### PR TITLE
Fix libsysinfo detection on BSDs because libsysinfo is an external library there.

### DIFF
--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -31,12 +31,16 @@ static size_t get_cpu_ram_size() {
     GlobalMemoryStatusEx(&s);
     return s.ullTotalPhys;
 }
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
 #include <unistd.h>
 #include <sys/sysctl.h>
 
 static size_t get_cpu_ram_size() {
+#ifdef __APPLE__
     int query_ram[] = {CTL_HW, HW_MEMSIZE};
+#else
+    int query_ram[] = {CTL_HW, HW_PHYSMEM};
+#endif
     int query_ram_len = sizeof(query_ram) / sizeof(*query_ram);
     size_t totalram = 0;
     size_t length = sizeof(totalram);


### PR DESCRIPTION

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## All Submissions

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally?
- [ ] Have you formatted the code using clang-format?

## New features

- [ ] Have you added relevant tests?
- [ ] Have you provided motivation for adding a new feature?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      github issue or in this PR)?
