### PR TITLE
bug: testing: dissables Packed GEMM test for non-x86 targets

### DIFF
--- a/tests/gtests/test_gemm_common.hpp
+++ b/tests/gtests/test_gemm_common.hpp
@@ -1234,6 +1234,9 @@ protected:
         bool pack = (p.pack_params.pack_a || p.pack_params.pack_b);
         SKIP_IF(get_test_engine_kind() == engine::kind::gpu && pack,
                 "GPU does not support packed GEMM.");
+#ifndef DNNL_X86_64
+        SKIP_IF(pack, "Packed GEMM does not support non-x86 CPUs.");
+#endif
         SKIP_IF((p.alpha != 1.f || p.igemm_params.oa() != 0
                         || p.igemm_params.ob() != 0)
                         && pack,


### PR DESCRIPTION
# Description

Following on from the discussion in #678, this PR disables the Packed GEMM tests for non x86 targets.

Fixes #678 

# Checklist

## All Submissions

- [partial] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally?
Note, owing to the scope of the changes, full benchdnn tests have not been run. Passes unit tests and validation on AArch64 builds as shown here: https://cloud.drone.io/nSircombe/mkl-dnn/10
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests?
Demo CI for AArch64 discussed in #679 defend against regression.
- [x] Have you included information on how to reproduce the issue (either in a
      github issue or in this PR)?
