### PR TITLE
bug: do not error on overaligned types in AArch64 build.

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -141,6 +141,8 @@ elseif(UNIX OR MINGW)
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         if(TARGET_ARCH STREQUAL "AARCH64")
              set(DEF_ARCH_OPT_FLAGS "-O3 -mcpu=native")
+             # Avoid error on overaligned type in jit_avx512_common_convolution_winograd.cpp
+             append_if(DNNL_WERROR CMAKE_CCXX_FLAGS "-Wno-error=attributes")
              set(DNNL_ENABLE_JIT_PROFILING CACHE BOOL "OFF" FORCE)
              message(WARNING "AArch64 build, DNNL_ENABLE_JIT_PROFILING is OFF")
         else()


### PR DESCRIPTION
# Description

As discussed in #679, building `/src/cpu/jit_avx512_common_convolution_winograd.cpp` on AArch64 with `-Werror` causes a build failure as a result of the warning about over aligned types.

To reproduce (building with GCC 9.2 on AArch64, RHEL 8)...

```
mkdir build
cd build
cmake -DDNNL_WERROR=ON ..
make -j
```

Results in errors of the form:

```
src/cpu/jit_avx512_common_convolution_winograd.cpp: In function ‘void dnnl::impl::cpu::input_transform_data(int, const dnnl::impl::cpu::jit_conv_winograd_conf_t&, float*, float*, bool)’:
src/cpu/jit_avx512_common_convolution_winograd.cpp:434:46: warning: requested alignment 64 is larger than 16 [-Wattributes]
  434 |     alignas(64) float Iw[alpha][alpha][simd_w];
      |                                              ^
```

...builds without `-DDNNL_WERROR=ON` run to completion (with warnings).

On AArch64 NEON targets, `alignas(max_align_t)` is 16, not 64. 
Behaviour of over aligned types in C++11 is (I believe) implementation defined. However, this warning does not lead to any run-time issues, as the AVX512 JIT Winograd kernel is not used in AArch64 execution.

This PR relaxes the -Werror for this particular warning, so that a native CI validation build on AArch64 is possible. This change was made in the demo Drone CI setup discussed in #679, and will be needed for planned PR to implement the Drone CI config in #679.

# Checklist

## All Submissions

- [] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally?
Partial: `make test` passes on x86 and AArch64 locally. Given the scope of the change, full benchdnn tests have not been run.
- [] Have you formatted the code using clang-format?
Not applicable: no src changes (cmake only)

## New features

- [ ] Have you added relevant tests?
Not applicable.

- [x] Have you provided motivation for adding a new feature?

## Bug fixes

- [ ] Have you added relevant regression tests?
Drone CI PR (to follow) will test as part of AArch64 builds.
- [x] Have you included information on how to reproduce the issue (either in a
      github issue or in this PR)?
