### PR TITLE
bug: build: ci: fix Clang builds for AArch64 CI.

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -42,6 +42,8 @@ steps:
   commands:
   - apt-get update && apt-get install -y sudo git build-essential cmake
   - .github/automation/env/clang.sh
+  - export CC=clang
+  - export CXX=clang++
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -98,7 +98,15 @@ elseif(UNIX OR MINGW)
     append(CMAKE_CCXX_NOEXCEPT_FLAGS "-fno-exceptions")
     # compiler specific settings
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(DEF_ARCH_OPT_FLAGS "-msse4.1")
+        if(DNNL_TARGET_ARCH STREQUAL "AARCH64")
+             set(DEF_ARCH_OPT_FLAGS "-O3")
+             # For native compilation tune for the host processor
+             if (CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
+                 append(DEF_ARCH_OPT_FLAGS "-mcpu=native")
+             endif()
+        elseif(DNNL_TARGET_ARCH STREQUAL "X64")
+             set(DEF_ARCH_OPT_FLAGS "-msse4.1")
+        endif()
         # Clang cannot vectorize some loops with #pragma omp simd and gets
         # very upset. Tell it that it's okay and that we love it
         # unconditionally.


### PR DESCRIPTION
# Description

This PR corrects a mistake in the AArch64 Drone CI Clang pipeline introduced in #694.

Currently the .drone.yaml config fails to set `CC=clang` and `CXX=clang++` causing the build and test to run with GCC (this can be seen in the existing logs, see [line 1090](https://cloud.drone.io/oneapi-src/oneDNN/8/2/2)).

In addition, AArch64 specific changes to `DEF_ARCH_OPT_FLAGS`, and disabling of `DNNL_ENABLE_JIT_PROFILING` added with #658 for GCC are replicated for the Clang build in `cmake/platform.cmake`.


# Checklist

## All Submissions

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally?
Unit tests pass with clang and gcc, but `test_benchdnn_bnorm_cpu` *failed* with clang build. This will need further investigation, and I would like to pursue as a separate issue. Fixing this bug will facilitate this. 

- [N/A] Have you formatted the code using clang-format?

Not applicable - yaml and cmake changes only.

## Bug fixes

- [x] Have you added relevant regression tests?
This PR enables Clang CI for AArch64.
- [x] Have you included information on how to reproduce the issue (either in a
      github issue or in this PR)?
