### PR TITLE
IDIV hurts performance of loop

### DIFF
--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -334,8 +334,10 @@ inline bool nd_iterator_step() {
 template <typename U, typename W, typename... Args>
 inline bool nd_iterator_step(U &x, const W &X, Args &&... tuple) {
     if (nd_iterator_step(utils::forward<Args>(tuple)...)) {
-        x = (x + 1) % X;
-        return x == 0;
+        if (++x - X == 0) {
+            x = 0;
+            return true;
+        }
     }
     return false;
 }
@@ -358,8 +360,10 @@ template <typename U, typename W, typename Y, typename... Args>
 inline bool nd_iterator_jump(
         U &cur, const U end, W &x, const Y &X, Args &&... tuple) {
     if (nd_iterator_jump(cur, end, utils::forward<Args>(tuple)...)) {
-        x = (x + 1) % X;
-        return x == 0;
+        if (++x - X == 0) {
+            x = 0;
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
Signed-off-by: caozhong <zhong.z.cao@intel.com>

# Description

IDIV slows down tight loop. In one of my poking, loop suffers extreme stall. Observable in VTune and tests

Before patch:
perf,cpu,--reorder --sdt=f32 --ddt=f32 --stag=nChw8c --dtag=nchw 1x256x14x14,5.0176e-05,0.0151367,3.31485,0.0164791,3.04482
perf,cpu,--reorder --sdt=f32 --ddt=f32 --stag=nChw16c --dtag=nchw 1x256x14x14,5.0176e-05,0.00805664,6.22791,0.00891358,5.62917

After patch:
perf,cpu,--reorder --sdt=f32 --ddt=f32 --stag=nChw8c --dtag=nchw 1x256x14x14,5.0176e-05,0.00756836,6.62971,0.00818725,6.12856
perf,cpu,--reorder --sdt=f32 --ddt=f32 --stag=nChw16c --dtag=nchw 1x256x14x14,5.0176e-05,0.00683594,7.34003,0.0074625,6.72375

8c have 1/4 instructions compare to 16c in inner loop.