### PR TITLE
Improve reorder performance in single blocking format cases

### DIFF
--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include <assert.h>
+#include <numeric>
 
 #include "dnnl_debug.h"
 
@@ -23,6 +24,7 @@
 #include "common/nstl.hpp"
 #include "common/primitive.hpp"
 #include "common/type_helpers.hpp"
+#include "common/utils.hpp"
 
 #include "cpu/cpu_primitive.hpp"
 #include "cpu/cpu_reorder_pd.hpp"
@@ -45,6 +47,9 @@
 #ifdef _WIN32
 /* seems like s_addr is a reserved macro on Windows */
 #undef s_addr
+constexpr static bool is_windows = true;
+#else
+constexpr static bool is_windows = false;
 #endif
 
 using namespace Xbyak;
@@ -902,6 +907,324 @@ private:
     Zmm bf16_emu_reserv_4 = Zmm(19);
 };
 
+// Seperate class for no unroll/threading burden
+struct jit_single_blk_kernel : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_single_blk_kernel)
+    static bool applicable(const prb_t &p) {
+        using namespace data_type;
+
+        bool ok = p.ndims >= 2 && mayiuse(avx2)
+                && p.scale_type == scale_type_t::NONE
+                && utils::one_of(p.itype, f32) && utils::one_of(p.otype, f32)
+                && utils::everyone_is(0, p.ioff, p.ooff) && p.beta == 0.f;
+        if (!ok) return false;
+
+        int64_t n0 = p.nodes[0].n;
+        auto i0 = p.nodes[0].is;
+        auto o0 = p.nodes[0].os;
+        int64_t n1 = p.nodes[1].n;
+        auto i1 = p.nodes[1].is;
+        auto o1 = p.nodes[1].os;
+
+        /*
+         * for a transpose of plain to 8c case, nodes would be like:
+         *     n    is   os
+         *     m    1    8
+         *     8    m    1
+         * or
+         *     8    m    1
+         *     m    1    8
+         */
+        ok = (utils::one_of(n0, 8, 16) || utils::one_of(n1, 8, 16))
+                && ((i0 == 1 && o1 == 1 && n0 == i1 && o0 == n1)
+                        || (o0 == 1 && i1 == 1 && n0 == o1 && i0 == n1));
+        if (!ok) return false;
+
+        // Do not handle transpose of dimensions other than last 2
+        for (int i = 2; i < p.ndims; ++i) {
+            if (p.nodes[i].is != p.nodes[i].os) {
+                ok = false;
+                break;
+            }
+        }
+
+        return ok;
+    }
+
+    jit_single_blk_kernel(const tr::prb_t &prb)
+        : jit_generator()
+        , prb_(prb)
+        , ker_(nullptr)
+        , itype_sz(data_type_size(prb_.itype))
+        , otype_sz(data_type_size(prb_.otype))
+        , block_sz(prb.nodes[0].n) {
+        auto input_stride
+                = prb_.nodes[0].is != 1 ? prb_.nodes[0].is : prb_.nodes[1].is;
+        auto output_stride
+                = prb_.nodes[0].os != 1 ? prb_.nodes[0].os : prb_.nodes[1].os;
+
+        auto ker_off = getSize();
+        Label tail_processing;
+
+        preamble();
+        cmp(reg_ptr_tail, true);
+        je(tail_processing, T_NEAR);
+
+        if (block_sz == 8) {
+            gen_ker8x8(0, 0, input_stride, output_stride, 8, 8);
+            block_sz = 8;
+        } else if (block_sz == 16) {
+            gen_ker16x16_in_8x8(input_stride, output_stride);
+            block_sz = 16;
+        } else {
+            assert(!"unimplemented");
+        }
+
+        postamble();
+
+        L(tail_processing);
+
+        if (block_sz == 8) {
+            auto i_tail = input_stride % 8 != 0 ? input_stride % 8 : 8;
+            auto o_tail = output_stride % 8 != 0 ? output_stride % 8 : 8;
+            if (i_tail != o_tail) {
+                auto t_mask = i_tail == 8 ? o_tail : i_tail;
+                gen_setmask(t_mask);
+                gen_ker8x8(0, 0, input_stride, output_stride, i_tail, o_tail);
+            }
+        } else if (block_sz == 16) {
+            auto i_tail = input_stride % 16 != 0 ? input_stride % 16 : 16;
+            auto o_tail = output_stride % 16 != 0 ? output_stride % 16 : 16;
+            if (i_tail != o_tail) {
+                auto t_mask = i_tail == 16 ? o_tail : i_tail;
+                t_mask %= 8;
+                if (t_mask != 0) gen_setmask(t_mask);
+                gen_ker16x16_in_8x8(
+                        input_stride, output_stride, i_tail, o_tail);
+            }
+        } else {
+            assert(!"unimplemented");
+        }
+
+        postamble();
+
+        auto *ker_start = getCode();
+        this->ker_ = (decltype(ker_))(ker_start + ker_off);
+    }
+
+    void gen_loadu(const Ymm &ymm, const Address &addr, int size) {
+        Xmm xmm(ymm.getIdx());
+        switch (size) {
+            case 32: vmovups(ymm, addr); break;
+            case 16: vmovups(xmm, addr); break;
+            default: assert(!"unreachable");
+        }
+    }
+
+    void gen_storeu(const Address &addr, const Ymm &ymm, int size) {
+        Xmm xmm(ymm.getIdx());
+        switch (size) {
+            case 32: vmovups(addr, ymm); break;
+            case 16: vmovups(addr, xmm); break;
+            default: assert(!"unreachable");
+        }
+    }
+
+    void gen_maskloadu(
+            const Ymm &ymm, const Address &addr, const Ymm mask, int size) {
+        Xmm xmm(ymm.getIdx());
+        Xmm mask128(mask.getIdx());
+        switch (size) {
+            case 32: vmaskmovps(ymm, mask, addr); break;
+            case 16: vmaskmovps(xmm, mask128, addr); break;
+            default: assert(!"unreachable");
+        }
+    }
+
+    void gen_maskstoreu(
+            const Address &addr, const Ymm &ymm, const Ymm mask, int size) {
+        Xmm xmm(ymm.getIdx());
+        Xmm mask128(mask.getIdx());
+        switch (size) {
+            case 32: vmaskmovps(addr, mask, ymm); break;
+            case 16: vmaskmovps(addr, mask128, xmm); break;
+            default: assert(!"unreachable");
+        }
+    }
+
+    // Register allocation xmm0~11
+    void gen_transpose_8x8() {
+        constexpr int lane = 8;
+        for (int i = 0; i < lane / 2; i++) {
+            vunpcklps(Ymm(lane + i), Ymm(2 * i), Ymm(2 * i + 1));
+            vunpckhps(Ymm(i), Ymm(2 * i), Ymm(2 * i + 1));
+        }
+
+        const unsigned int lfloat = 0x44;
+        const unsigned int ufloat = 0xee;
+        for (int i = 0; i < lane / 2; i++) {
+            int j = i % 2 == 0 ? lane + i : i - 1;
+            vshufps(Ymm(lane / 2 + 2 * i), Ymm(j), Ymm(j + 1), lfloat);
+            vshufps(Ymm(lane / 2 + 2 * i + 1), Ymm(j), Ymm(j + 1), ufloat);
+        }
+
+        const unsigned int lquad = 0x20;
+        for (int i = 0; i < lane / 2; i++)
+            vperm2f128(Ymm(i), Ymm(lane / 2 + i), Ymm(lane + i), lquad);
+
+        const unsigned int uquad = 0x31;
+        for (int i = lane / 2; i < lane; i++)
+            vperm2f128(Ymm(i), Ymm(i), Ymm(lane / 2 + i), uquad);
+    }
+
+    // keep order nchw -> nChw()C
+    // or nChw()C -> nchw
+    void gen_setmask(int mask) {
+        // all 0, all 1
+        vxorps(ymm_tmp, ymm_tmp, ymm_tmp);
+        vpcmpeqd(ymm_mask, ymm_mask, ymm_mask);
+        // blend in
+        auto in_mask = -1 << mask;
+        vpblendd(ymm_mask, ymm_mask, ymm_tmp, in_mask);
+    }
+
+    // TODO: Mark parameter with type information
+    // XXX: !
+    // offset in byte offset
+    // stride in element number
+    //
+    // Gen specific 8x8 transform respect to certain tail condition
+    void gen_tr8x8(int i_off, int o_off, int input_stride, int output_stride,
+            int in_tail, int out_tail) {
+        constexpr int lane = 8;
+
+        if (in_tail == 0 || out_tail == 0) return;
+
+        for (int i = 0; i < out_tail; ++i) {
+            if (in_tail != lane) {
+                gen_maskloadu(Ymm(i),
+                        ptr[reg_ptr_in + i_off + i * input_stride * itype_sz],
+                        ymm_mask, lane * itype_sz);
+            } else {
+                gen_loadu(Ymm(i),
+                        ptr[reg_ptr_in + i_off + i * input_stride * itype_sz],
+                        lane * itype_sz);
+            }
+        }
+
+        gen_transpose_8x8();
+
+        for (int i = 0; i < in_tail; ++i) {
+            if (out_tail == lane) {
+                gen_storeu(
+                        ptr[reg_ptr_out + o_off + i * output_stride * otype_sz],
+                        Ymm(i), lane * otype_sz);
+            } else {
+                gen_maskstoreu(
+                        ptr[reg_ptr_out + o_off + i * output_stride * otype_sz],
+                        Ymm(i), ymm_mask, lane * otype_sz);
+            }
+        }
+    }
+
+    // tail: 0 ~ 8
+    // support: either in_tail or out_tail is not 8, but not both
+    void gen_ker8x8(int i_off, int o_off, int input_stride, int output_stride,
+            int in_tail, int out_tail) {
+        gen_tr8x8(i_off, o_off, input_stride, output_stride, in_tail, out_tail);
+    }
+
+    void gen_ker16x16_in_8x8(int input_stride, int output_stride) {
+        const auto lane = 16;
+        const auto sub_lane = lane / 2;
+        gen_tr8x8(0, 0, input_stride, output_stride, sub_lane, sub_lane);
+        gen_tr8x8(input_stride * sub_lane * itype_sz, sub_lane * otype_sz,
+                input_stride, output_stride, sub_lane, sub_lane);
+        gen_tr8x8(sub_lane * itype_sz, output_stride * sub_lane * otype_sz,
+                input_stride, output_stride, sub_lane, sub_lane);
+        gen_tr8x8((input_stride * sub_lane + sub_lane) * itype_sz,
+                (output_stride * sub_lane + sub_lane) * otype_sz, input_stride,
+                output_stride, sub_lane, sub_lane);
+    }
+
+    // tail can be 1 ~ 16, using avx2 for now
+    void gen_ker16x16_in_8x8(
+            int input_stride, int output_stride, int in_tail, int out_tail) {
+        constexpr auto lane = 16;
+        constexpr auto sub_lane = lane / 2;
+        auto tail = in_tail != lane ? in_tail : out_tail;
+
+        const auto l_tail = tail < sub_lane ? tail : sub_lane;
+        const auto u_tail = tail < sub_lane ? 0 : tail - sub_lane;
+
+        if (tail == in_tail) {
+            gen_tr8x8(0, 0, input_stride, output_stride, l_tail, sub_lane);
+            gen_tr8x8(input_stride * sub_lane * itype_sz, sub_lane * otype_sz,
+                    input_stride, output_stride, l_tail, sub_lane);
+            gen_tr8x8(sub_lane * itype_sz, output_stride * sub_lane * otype_sz,
+                    input_stride, output_stride, u_tail, sub_lane);
+            gen_tr8x8(itype_sz * (input_stride * sub_lane + sub_lane),
+                    otype_sz * (output_stride * sub_lane + sub_lane),
+                    input_stride, output_stride, u_tail, sub_lane);
+        } else {
+            gen_tr8x8(0, 0, input_stride, output_stride, sub_lane, l_tail);
+            gen_tr8x8(input_stride * sub_lane * itype_sz, sub_lane * otype_sz,
+                    input_stride, output_stride, sub_lane, u_tail);
+            gen_tr8x8(sub_lane * itype_sz, output_stride * sub_lane * itype_sz,
+                    input_stride, output_stride, sub_lane, l_tail);
+            gen_tr8x8(itype_sz * (input_stride * sub_lane + sub_lane),
+                    otype_sz * (output_stride * sub_lane + sub_lane),
+                    input_stride, output_stride, sub_lane, u_tail);
+        }
+    }
+
+    void operator()(const void *in, void *out, bool tail) const {
+        ker_(in, out, tail);
+    }
+
+private:
+    // 6 ~ 12
+    constexpr static int xmm_save_for_windows = is_windows ? 7 : 0;
+    constexpr static int xmm_save_start_from = 6;
+    constexpr static int xmm_width = 16;
+
+    void preamble() {
+        if (is_windows) {
+            sub(rsp, xmm_save_for_windows * xmm_width);
+            for (int i = 0; i < xmm_save_for_windows; ++i) {
+                movdqu(ptr[rsp + i * xmm_width],
+                        Xbyak::Xmm(xmm_save_start_from + i));
+            }
+        }
+    }
+
+    void postamble() {
+        if (is_windows) {
+            for (size_t i = 0; i < xmm_save_for_windows; ++i)
+                movdqu(Xbyak::Xmm(xmm_save_start_from + i),
+                        ptr[rsp + i * xmm_width]);
+            add(rsp, xmm_save_for_windows * xmm_width);
+        }
+        uni_vzeroupper();
+        ret();
+    }
+
+    const prb_t &prb_;
+    void (*ker_)(const void *, void *, bool tail);
+
+    int itype_sz;
+    int otype_sz;
+    int block_sz;
+
+    Reg64 reg_ptr_in = abi_param1;
+    Reg64 reg_ptr_out = abi_param2;
+    // Windows bool is 1-byte in register
+    Reg8 reg_ptr_tail = is_windows ? r8b : dl;
+
+    Ymm ymm_mask = ymm12;
+    Ymm ymm_tmp = ymm0;
+};
+
 status_t kernel_t::desc_init(
         kernel_t::desc_t &desc, const prb_t &prb, int ndims_ker_max) {
     desc.prb = prb;
@@ -1281,12 +1604,135 @@ private:
     tr::kernel_t *kernel_;
 };
 
+struct jit_blk_reorder_t : public primitive_t {
+    struct pd_t : public cpu_reorder_pd_t {
+        using cpu_reorder_pd_t::cpu_reorder_pd_t;
+        DECLARE_COMMON_PD_T("jit:blk", jit_blk_reorder_t);
+
+        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
+                const primitive_attr_t *attr, engine_t *src_engine,
+                const memory_desc_t *src_md, engine_t *dst_engine,
+                const memory_desc_t *dst_md) {
+            auto prb = tr::prb_t();
+
+            status_t prb_init_status = prb_init(prb, *src_md, *dst_md, attr);
+            if (prb_init_status != status::success) return prb_init_status;
+
+            DEBUG({
+                printf("init : ");
+                prb_dump(prb);
+            });
+            // Sort the prb array in increasing sizes of the output stride
+            prb_normalize(prb);
+            DEBUG({
+                printf("norm : ");
+                prb_dump(prb);
+            });
+            /* Combine the variables, which appear together on both
+             * sides of the reorder */
+            prb_simplify(prb);
+            DEBUG({
+                printf("smpl : ");
+                prb_dump(prb);
+            });
+            prb_tile_normalize(prb);
+            DEBUG({
+                printf("tile : ");
+                prb_dump(prb);
+            });
+
+            if (!tr::jit_single_blk_kernel::applicable(prb)) {
+                return status::unimplemented;
+            }
+
+            auto _pd = new pd_t(attr, src_engine->kind(), src_md,
+                    dst_engine->kind(), dst_md);
+            if (_pd == nullptr) return status::out_of_memory;
+            if (_pd->init(engine, src_engine, dst_engine) != status::success) {
+                delete _pd;
+                return status::unimplemented;
+            }
+            _pd->prb_ = prb;
+            _pd->init_scratchpad_md();
+            return safe_ptr_assign<reorder_pd_t>(*reorder_pd, _pd);
+        }
+
+        tr::prb_t prb_;
+
+    private:
+        // Swap last two nodes, put block 4, 8, 16 nodes to first
+        static void prb_tile_normalize(tr::prb_t &p) {
+            if (!utils::one_of(p.nodes[0].n, 8ul, 16ul)
+                    && utils::one_of(p.nodes[1].n, 8ul, 16ul)) {
+                nstl::swap(p.nodes[0], p.nodes[1]);
+            }
+        }
+    };
+
+    jit_blk_reorder_t(const pd_t *apd) : primitive_t(apd) {
+        kernel_ = utils::make_unique<tr::jit_single_blk_kernel>(pd()->prb_);
+    }
+
+    size_t n(int d) const {
+        assert(d < pd()->prb_.ndims);
+        return (int)pd()->prb_.nodes[d].n;
+    }
+    ptrdiff_t is(int d) const {
+        assert(d < pd()->prb_.ndims);
+        return pd()->prb_.nodes[d].is;
+    }
+    ptrdiff_t os(int d) const {
+        assert(d < pd()->prb_.ndims);
+        return pd()->prb_.nodes[d].os;
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        auto in = CTX_IN_MEM(const char *, DNNL_ARG_FROM);
+        auto out = CTX_OUT_MEM(char *, DNNL_ARG_TO);
+
+        // kernel handle 2-dimension tiles, a tail is possible
+        auto &prb = this->pd()->prb_;
+        ptrdiff_t BH = 1;
+        for (int i = 2; i < prb.ndims; ++i) {
+            BH *= prb.nodes[i].n;
+        }
+
+        auto block_sz = n(0);
+        auto n1 = n(1);
+        auto i1 = is(1);
+        auto o1 = os(1);
+        auto FL = (n1 + block_sz - 1) / block_sz;
+        auto bh_stride = BH == 1 ? 0 : is(2);
+
+        auto itype_sz = data_type_size(pd()->prb_.itype);
+        auto otype_sz = data_type_size(pd()->prb_.otype);
+
+        parallel_nd(BH, FL, [&](dim_t bh, dim_t fl) {
+            auto fl_b = fl * block_sz;
+            auto bh_b = bh_stride * bh;
+            auto *i = in + (bh_b + fl_b * i1) * itype_sz;
+            auto *o = out + (bh_b + fl_b * o1) * otype_sz;
+            (*kernel_)(i, o, n1 - fl_b < block_sz);
+        });
+
+        return status::success;
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::unique_ptr<tr::jit_single_blk_kernel> kernel_;
+};
+
 status_t jit_uni_reorder_create(reorder_pd_t **reorder_pd, engine_t *engine,
         const primitive_attr_t *attr, engine_t *src_engine,
         const memory_desc_t *src_md, engine_t *dst_engine,
         const memory_desc_t *dst_md) {
-    return jit_uni_reorder_t::pd_t::create(
+    auto ret = jit_blk_reorder_t::pd_t::create(
             reorder_pd, engine, attr, src_engine, src_md, dst_engine, dst_md);
+    if (status::success != ret)
+        ret = jit_uni_reorder_t::pd_t::create(reorder_pd, engine, attr,
+                src_engine, src_md, dst_engine, dst_md);
+    return ret;
 }
 
 } // namespace x64


### PR DESCRIPTION
# Description

  Cache blocking heuristic for uni reorder was hard to fix in general, even with cache blocking done right, its complexity O(n^2) still quite high for cache reside cases. for example, when reorder from blocking format, write complexity killed the performance. This implementation use 8x8 or 16x16 SIMD transpose to deal with reorder, generally improve reorder performance in nchw <--> nChw(X)c cases, and both directions can have comparable performance.
# Checklist

## Code-change submissions

- [ ✅] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [✅] Have you formatted the code using clang-format?

### New features

- [No need ] Have you added relevant tests?
- [ No need] Have you provided motivation for adding a new feature?

### Bug fixes

- [No need ] Have you added relevant regression tests?
- [No need?] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
