### PR TITLE
build: document DNNL_BLAS_VENDOR and add support for Free ArmPL.

### DIFF
--- a/cmake/FindBLAS.cmake
+++ b/cmake/FindBLAS.cmake
@@ -569,6 +569,15 @@ if(BLA_VENDOR MATCHES "Arm" OR BLA_VENDOR STREQUAL "All")
      set(BLAS_armpl_LIB "${BLAS_armpl_LIB}_mp")
    endif()
 
+   # Arm Performance Libraries contains Fortran code and must be linked against libgfortran for a GCC build.
+   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+     message(STATUS "gfortran")
+     set(BLAS_armpl_LIB "${BLAS_armpl_LIB};gfortran")
+   endif()
+
+   # Link against libamath, provided with ArmPL, which contains AArch64 optimised implementations of math.h functions.
+   set(BLAS_armpl_LIB "${BLAS_armpl_LIB};amath;m")
+
    if(NOT BLAS_LIBRARIES)
     check_blas_libraries(
       BLAS_LIBRARIES

--- a/cmake/FindBLAS.cmake
+++ b/cmake/FindBLAS.cmake
@@ -571,7 +571,6 @@ if(BLA_VENDOR MATCHES "Arm" OR BLA_VENDOR STREQUAL "All")
 
    # Arm Performance Libraries contains Fortran code and must be linked against libgfortran for a GCC build.
    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-     message(STATUS "gfortran")
      set(BLAS_armpl_LIB "${BLAS_armpl_LIB};gfortran")
    endif()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -204,6 +204,6 @@ set(DNNL_BLAS_VENDOR "NONE" CACHE STRING
         (https://www.openblas.net)
       - ARMPL
         Arm Performance Libraries
-        (https://developer.arm.com/tools-and-software/server-and-hpc/compile/arm-compiler-for-linux/arm-performance-libraries)
+        (https://developer.arm.com/tools-and-software/server-and-hpc/downloads/arm-performance-libraries)
       - ANY
         FindBLAS will search default library paths for a known BLAS installation.")

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -16,9 +16,10 @@ oneDNN supports the following build-time options.
 | DNNL_ENABLE_PRIMITIVE_CACHE | **ON**, OFF                         | Enables [primitive cache](@ref dev_guide_primitive_cache)
 | DNNL_ENABLE_MAX_CPU_ISA     | **ON**, OFF                         | Enables [CPU dispatcher controls](@ref dev_guide_cpu_dispatcher_control)
 | DNNL_VERBOSE                | **ON**, OFF                         | Enables [verbose mode](@ref dev_guide_verbose)
+| DNNL_BLAS_VENDOR            | **NONE**, ARMPL                     | Defines an external BLAS library to link to for GEMM-like operations
 
-All other building options that can be found in CMake files are dedicated for
-the development/debug purposes and are subject to change without any notice.
+All other building options or values that can be found in CMake files are intended for
+development/debug purposes and are subject to change without notice.
 Please avoid using them.
 
 ## Common options
@@ -115,6 +116,21 @@ TBB plus more:
   responsible for balancing the static decomposition from the previous item
   across available worker threads.
 
+#### Vendor BLAS libraries
+oneDNN can use a standard BLAS library for GEMM operations.
+The `DNNL_BLAS_VENDOR` build option controls BLAS library selection, and
+defaults to `NONE`. For AArch64 builds with GCC, use the
+[Arm Performance Libraries](https://developer.arm.com/tools-and-software/server-and-hpc/downloads/arm-performance-libraries):
+
+~~~sh
+$ cmake -DDNNL_BLAS_VENDOR=ARMPL ..
+~~~
+
+Additional options available for development/debug purposes. These options are
+subject to change without notice, see
+[`cmake/options.cmake`](https://github.com/oneapi-src/oneDNN/blob/master/cmake/options.cmake)
+for details.
+
 ## GPU Options
 Intel Processor Graphics is supported by oneDNN GPU engine. GPU engine
 is disabled in the default build configuration.
@@ -129,5 +145,5 @@ OpenCL runtime requires Intel(R) SDK for OpenCL\* applications. You can
 explicitly specify the path to the SDK using `-DOPENCLROOT` CMake option.
 
 ~~~sh
-cmake -DDNNL_GPU_RUNTIME=OCL -DOPENCLROOT=/path/to/opencl/sdk ..
+$ cmake -DDNNL_GPU_RUNTIME=OCL -DOPENCLROOT=/path/to/opencl/sdk ..
 ~~~


### PR DESCRIPTION
# Description

This PR updates the work simplify vendor BLAS based builds on AArch64 contained in #741 

1. Documentation is updated to detail the `DNNL_BLAS_VENDOR` option.
In the list of options, only `NONE` and `ARMPL` are given as values for `DNNL_BLAS_VENDOR`.  A new sub-section "Vendor BLAS Libraries" has been added with further details - this also lists `MKL`, `OPENBLAS` and `ANY` as permitted values for debug / development. These are already mentioned in `cmake/options.cmake`, so could be omitted from the docs here if the preference is not to list such development options.

2. Updates FindBLAS to work with the free version of Arm Performance Libraries
When linking to `libarmpl_lp64_mp.so` there is now an explicit dependence on `libgfortran` - this was not required in subscription product, as this shipped with the required compiler and libs, and the ArmPL library was already linked to the appropriate Fortran library.
libamath, part of ArmPL, providing AArch64 optimised implementations of common math.h functions, is also linked.

# Checklist

## Code-change submissions

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
_Partial: gtests pass, full benchdnn suite hasn't been re-run with these changes to the build system. For the scope of these changes, will this be required (noting that it does slightly alter the lib. dependencies in the `DNNL_BLAS_VENDOR=ARMPL` case._
- [ ] Have you formatted the code using clang-format?
_Not Applicable: no changes to src cover but clang-format_

### New features

- [ ] Have you added relevant tests? _Not Applicable_.
- [ ] Have you provided motivation for adding a new feature? _Not Applicable._

### Bug fixes

- [ ] Have you added relevant regression tests? _Not Applicable._
- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)? _Not Applicable._

