### PR TITLE
bfloat16: add operator+=(a) overload for float as argument type

### DIFF
--- a/src/common/bfloat16.hpp
+++ b/src/common/bfloat16.hpp
@@ -38,8 +38,8 @@ struct bfloat16_t {
 
     DNNL_API operator float() const;
 
-    bfloat16_t &operator+=(bfloat16_t a) {
-        (*this) = (float)(*this) + (float)a;
+    bfloat16_t &operator+=(const float a) {
+        (*this) = float {*this} + a;
         return *this;
     }
 };

--- a/tests/gtests/CMakeLists.txt
+++ b/tests/gtests/CMakeLists.txt
@@ -163,6 +163,7 @@ foreach(TEST_FILE ${PRIM_TEST_CASES_SRC})
 endforeach()
 
 add_subdirectory(api)
+add_subdirectory(internals)
 
 if(DNNL_GPU_RUNTIME STREQUAL "OCL")
     add_subdirectory(ocl)

--- a/tests/gtests/internals/CMakeLists.txt
+++ b/tests/gtests/internals/CMakeLists.txt
@@ -1,0 +1,27 @@
+#===============================================================================
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+set(TEST_EXE test_internals)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    append_if(WIN32 CMAKE_CXX_FLAGS "/fp:precise")
+    append_if(UNIX  CMAKE_CXX_FLAGS "-fp-model precise")
+endif()
+
+file(GLOB TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp)
+list(APPEND TEST_SOURCES ${MAIN_SRC_GTEST})
+
+register_exe(${TEST_EXE} "${TEST_SOURCES}" "test" "dnnl_gtest")

--- a/tests/gtests/internals/test_bfloat16.cpp
+++ b/tests/gtests/internals/test_bfloat16.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "dnnl_test_common.hpp"
+#include "gtest/gtest.h"
+
+#include "src/common/bfloat16.hpp"
+
+namespace dnnl {
+
+TEST(test_bfloat16_plus_float, TestDenormF32) {
+    const float denorm_f32 {FLT_MIN / 2.0f};
+    const bfloat16_t initial_value_bf16 {FLT_MIN};
+
+    bfloat16_t expect_bf16 {float {initial_value_bf16} + denorm_f32};
+    ASSERT_GT(float {expect_bf16}, float {initial_value_bf16});
+
+    bfloat16_t bf16_plus_equal_f32 = initial_value_bf16;
+    bf16_plus_equal_f32 += denorm_f32;
+    ASSERT_EQ(float {bf16_plus_equal_f32}, float {expect_bf16});
+
+    bfloat16_t bf16_plus_f32 = initial_value_bf16 + denorm_f32;
+    ASSERT_EQ(float {bf16_plus_f32}, float {expect_bf16});
+}
+
+} // namespace dnnl


### PR DESCRIPTION
Avoids a potentially lossy float-bfloat16-float round-trip for `b += a`,
when `a` is a 32-bit `float` and `b` is a `bfloat16_t`. Might yield a
significant performance improvement.
