### PR TITLE
all: bfloat16: initialize variables by T{} instead of integer constant 0

### DIFF
--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -150,7 +150,7 @@ void ref_pooling_fwd_t<data_type, acc_type>::execute_forward(
         parallel_nd(MB, OC, OD, OH, OW,
                 [&](int mb, int oc, int od, int oh, int ow) {
                     data_t *d = &dst[get_offset(dst_d, mb, oc, od, oh, ow)];
-                    d[0] = 0;
+                    d[0] = data_t {};
                     ker_avg(d, mb, oc, od, oh, ow);
                 });
     }
@@ -188,7 +188,7 @@ void ref_pooling_bwd_t<data_type>::execute_backward(
         for_(int ih = 0; ih < IH; ++ih)
         for (int iw = 0; iw < IW; ++iw) {
             const auto off = get_offset(diff_src_d, mb, oc, id, ih, iw);
-            diff_src[off] = data_type_t(0);
+            diff_src[off] = data_t {};
         }
     };
 

--- a/src/cpu/ref_resampling.cpp
+++ b/src/cpu/ref_resampling.cpp
@@ -104,7 +104,7 @@ void ref_resampling_fwd_t<data_type>::execute_forward(
                     auto id = linear_coeffs_t(od, FD, ID);
                     auto iw = linear_coeffs_t(ow, FW, IW);
                     auto ih = linear_coeffs_t(oh, FH, IH);
-                    data_t src_l[8] = {0};
+                    data_t src_l[8] {};
                     for_(int i = 0; i < 2; i++)
                     for_(int j = 0; j < 2; j++)
                     for (int k = 0; k < 2; k++) {

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -570,7 +570,7 @@ void copy_init_iter_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
         parallel_nd(
                 rnn.n_layer, rnn.n_dir, rnn.mb, [&](int lay, int dir, int b) {
                     for (int j = 0; j < rnn.sic; j++)
-                        ws_states_iter(lay + 1, dir, 0, b, j) = (src_data_t)0;
+                        ws_states_iter(lay + 1, dir, 0, b, j) = src_data_t {};
                     for (int j = 0; j < rnn.dhc; j++)
                         ws_states_iter_c(lay + 1, dir, 1, b, j) = 0.0f;
                 });

--- a/src/cpu/x64/gemm/amx/igemm_k.hpp
+++ b/src/cpu/x64/gemm/amx/igemm_k.hpp
@@ -108,7 +108,7 @@ public:
                     a_row_sum[i + ii + ti * um] += *b;
                 }
             } else {
-                *b = 0;
+                *b = a_t {};
             }
             b++;
         }
@@ -149,7 +149,7 @@ public:
                                         a_row_sum[i + ii + ti * um] += *b;
                                     }
                                 } else {
-                                    *b = 0;
+                                    *b = a_t {};
                                 }
                                 b++;
                             }
@@ -182,7 +182,7 @@ public:
                                 b_col_sum[i + ii] += *b;
                             }
                         } else {
-                            *b = 0;
+                            *b = b_t {};
                         }
                         b++;
                     }
@@ -215,7 +215,7 @@ public:
                                 b_col_sum[i + ii] += *b;
                             }
                         } else {
-                            *b = 0;
+                            *b = b_t {};
                         }
                         b++;
                     }

--- a/src/cpu/x64/gemm/gemm_info.cpp
+++ b/src/cpu/x64/gemm/gemm_info.cpp
@@ -136,7 +136,7 @@ gemm_info_t<a_t, b_t, c_t>::gemm_info_t(const char *transA, const char *transB,
 
     constexpr bool is_int8 = utils::one_of(
             data_traits<a_t>::data_type, data_type::s8, data_type::u8);
-    if (is_int8) this->ao = oa ? *oa : a_t(0);
+    if (is_int8) this->ao = oa ? *oa : a_t {};
     prepare_bo<b_t>(this->bo, ob);
 
     if (offsetC != NULL) {

--- a/src/cpu/x64/gemm/gemm_pack.cpp
+++ b/src/cpu/x64/gemm/gemm_pack.cpp
@@ -140,8 +140,8 @@ static dnnl_status_t gemm_pack_driver(const char *identifier,
         const dim_t *K, const float *alpha, const dim_t *lda, const dim_t *ldb,
         const void *src, gemm_pack_storage_t *pack_dst, bool measure_only) {
 
-    a_dt oa = 0;
-    b_dt ob = 0;
+    a_dt oa {};
+    b_dt ob {};
 
     const a_dt *a = nullptr;
     const b_dt *b = nullptr;

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -564,7 +564,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
             // jit_gemm_convolution_utils::im2col_3d() requires external
             // data initialization by zeroes
             for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
-                _col[i] = (src_data_t)0;
+                _col[i] = src_data_t {};
         }
         int g {0}, n {0}, od {0}, nb_os {0};
         size_t start = 0, end = 0;
@@ -1158,7 +1158,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             const bool outer_padding = jcp.os_nb_block == 1;
             if (outer_padding && is_problem_3d) {
                 for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
-                    _col[i] = (src_data_t)0;
+                    _col[i] = src_data_t {};
             }
 
             acc_data_t *weights_reduce_base

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -1821,7 +1821,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::prepare_scratchpad_data(
         for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
             src_data_t *ts = &tr_src[ithr * jcp.tr_src_buf_size];
             for (int i = 0; i < jcp.tr_src_num_guard_elems; ++i)
-                ts[i] = 0;
+                ts[i] = src_data_t {};
         }
 
         if (dnnl_thr_syncable() && jcp.nthr_oc_b > 1) {

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -936,7 +936,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             });
         }
     } else {
-        const data_t zero_val = 0;
+        const data_t zero_val {};
         if (jpp.tag_kind == jptg_nspc) {
             const size_t chunk_size = (size_t)jpp.ih * jpp.iw * jpp.c;
             parallel_nd(jpp.mb, jpp.id, [&](int n, int id) {

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -288,7 +288,7 @@ static inline data_t set_value(
         const bool fill = in_group == ((group % 1637) % group_size);
         return fill ? static_cast<data_t>(
                        mean + deviation * sinf(float(index % 37)))
-                    : data_t {0};
+                    : data_t {};
     } else if (data_traits<data_t>::data_type == memory::data_type::s32
             || data_traits<data_t>::data_type == memory::data_type::s8) {
         return data_t(index * 13 % 21 - 10);

--- a/tests/gtests/test_eltwise.cpp
+++ b/tests/gtests/test_eltwise.cpp
@@ -100,7 +100,7 @@ T linear_bwd(T dd, T s, A alpha, A beta) {
 
 template <typename T, typename A>
 T bounded_relu_fwd(T s, A alpha) {
-    s = s > 0 ? s : T(0);
+    s = s > 0 ? s : T {};
     return s > alpha ? T(alpha) : s;
 }
 
@@ -195,7 +195,7 @@ void check_eltwise_fwd(const eltwise_test_params &p, const memory::desc &md,
     memory::dim n = n_elems(md);
     for (memory::dim i = 0; i < n; ++i) {
         data_t s = src_data[i];
-        data_t ref_d = 0;
+        data_t ref_d {};
         switch (p.alg_kind) {
             case algorithm::eltwise_relu: ref_d = relu_fwd(s, p.alpha); break;
             case algorithm::eltwise_tanh: ref_d = tanh_fwd(s); break;
@@ -226,7 +226,7 @@ void compare_eltwise_fwd(const eltwise_test_params &p, const memory::desc &md,
     data_t eps;
     if (data_traits<data_t>::data_type == memory::data_type::s8
             || data_traits<data_t>::data_type == memory::data_type::s32)
-        eps = 0;
+        eps = data_t {};
     else
         eps = static_cast<data_t>(
                 (data_traits<data_t>::data_type == memory::data_type::f16
@@ -272,7 +272,7 @@ void check_eltwise_bwd(const eltwise_test_params &p, const memory::desc &md,
     for (memory::dim i = 0; i < n; ++i) {
         data_t ref_s = src_data[data_mdw.off_l(i)];
         data_t ref_dd = diff_dst_data[diff_data_mdw.off_l(i)];
-        data_t ref_ds = 0;
+        data_t ref_ds {};
         switch (p.alg_kind) {
             case algorithm::eltwise_relu:
                 ref_ds = relu_bwd(ref_dd, ref_s, p.alpha);
@@ -371,7 +371,7 @@ protected:
         memory dst(*data_desc, eng);
         memory ref_dst(*data_desc, eng);
 
-        data_t data_median = data_t(0);
+        data_t data_median {};
         data_t data_deviation = (p.alg_kind == algorithm::eltwise_elu
                                         || p.alg_kind == algorithm::eltwise_exp)
                         || (p.alg_kind == algorithm::eltwise_swish)
@@ -408,7 +408,7 @@ protected:
         memory diff_src(diff_data_desc, eng);
         memory diff_dst(diff_data_desc, eng);
 
-        data_t data_median = data_t(0);
+        data_t data_median {};
         data_t data_deviation = p.alg_kind == algorithm::eltwise_elu
                 ? data_t(1.0)
                 : p.alg_kind == algorithm::eltwise_square ? data_t(6.0)

--- a/tests/gtests/test_gemm_common.hpp
+++ b/tests/gtests/test_gemm_common.hpp
@@ -510,7 +510,7 @@ void fill_matrices(const test_params &p, const mapper_t &mapper_m,
     if (oc_mem.get_size() == 0) return;
 
     if (p.igemm_params.nonzero_oc) {
-        fill_data<c_dt>(p.size_oc(), oc_mem.get(), (c_dt)1, (c_dt)0);
+        fill_data<c_dt>(p.size_oc(), oc_mem.get(), (c_dt)1, c_dt {});
         if (p.oc_is_R()) {
             extend_matrix_cols<c_dt>(oc_mem, 0, 1, p.N, p.N, mapper_n);
         } else if (p.oc_is_C()) {
@@ -519,7 +519,7 @@ void fill_matrices(const test_params &p, const mapper_t &mapper_m,
     } else {
         auto oc = map_memory<c_dt>(oc_mem);
         for (int64_t i = 0; i < p.size_oc(); i++)
-            oc[i] = 0;
+            oc[i] = c_dt {};
     }
 }
 

--- a/tests/gtests/test_logsoftmax.cpp
+++ b/tests/gtests/test_logsoftmax.cpp
@@ -186,7 +186,7 @@ protected:
         auto test_with_given_fill = [&](data_t mean, data_t var) {
             // Fill the logsoftmax backward diffs
             fill_data<data_t>(diff_data_desc.get_size() / sizeof(data_t),
-                    diff_dst, data_t(0), data_t(1));
+                    diff_dst, data_t {}, data_t(1));
             check_zero_tail<data_t>(1, diff_dst);
 
             logsoftmax.execute(strm,

--- a/tests/gtests/test_softmax.cpp
+++ b/tests/gtests/test_softmax.cpp
@@ -185,7 +185,7 @@ protected:
         auto test_with_given_fill = [&](data_t mean, data_t var) {
             // Fill the softmax backward diffs
             fill_data<data_t>(diff_data_desc.get_size() / sizeof(data_t),
-                    diff_dst, data_t(0), data_t(1));
+                    diff_dst, data_t {}, data_t(1));
             check_zero_tail<data_t>(1, diff_dst);
 
             softmax.execute(strm,


### PR DESCRIPTION
Obviously for any scalar type `T`, the expression `T{}` is equal to zero.
However, `bfloat16_t bf16 = 0` calls a rather expensive converting
constructor, `bfloat16_t(float)`, whereas its defaulted default
constructor `bfloat16_t()` is inline, and (implicitly) `constexpr` and
`noexcept`.

This commit replaces initialization by a constant zero integer by `{}`
(value-initialization), and assignment of zero by assignment of a
value-initialized object `T{}`, whenever `bfloat16_t` is involved.