### PR TITLE
rfc: oneDNN v2 API

### DIFF
--- a/rfcs/20200717-onednn-v2/README.md
+++ b/rfcs/20200717-onednn-v2/README.md
@@ -1,0 +1,138 @@
+# oneDNN v2.0 Changes
+
+The objective of this RFC is to discuss the changes in the upcoming oneDNN
+v2.0, which will introduce the support for DPC++ programming model.
+The plan is to merge
+[`dev-v2`](https://github.com/oneapi-src/oneDNN/tree/dev-v2) branch into
+[`master`](https://github.com/oneapi-src/oneDNN/tree/master). The exact date
+is TBD, but would probably happen around October 2020.
+
+One of the goals is to make v2.0 API backwards compatible with v1.x as much as
+possible, ideally not breaking the existing code at all. There is no such goal
+with respect to the backwards compatibility with `dev-v2` branch though
+(`2021.1-betaXX` releases).
+
+## 1. Executive Summary Of The Changes
+
+1. The header files are split into runtime-agnostic and runtime-specific
+   versions. The interoperability API with RT objects is only possible through
+   runtime-specific header files. The changes are **incompatible** with the
+   existing integration of Thread Pool, OpenCL, and DPC++.
+
+   | Headers                                             | API For                | Namespace (applicable for C++ header files only) |
+   | :--                                                 | :--                    | :--                                              |
+   | `dnnl_types.h`, `dnnl.h`, `dnnl.hpp`                | Common and RT-agnostic | `dnnl`                                           |
+   | `dnnl_sycl_types.h`, `dnnl_sycl.h`, `dnnl_sycl.hpp` | SYCL-specific          | `dnnl::sycl`                                     |
+   | `dnnl_ocl.h`, `dnnl_ocl.hpp`                        | OpenCL specific        | `dnnl::ocl`                                      |
+   | `dnnl_threadpool.h`, `dnnl_threadpool.hpp`          | Thread pool specific   | `dnnl::threadpool`                               |
+
+2. Stream attributes are removed. This should affect only the integration with
+   Thread Pool.
+
+3. Stream flag `stream::flags::default_order` is removed.
+
+4. Some simplifications for RT-specific object constructors. For instance,
+   there is no need to pass `engine::kind` to engine constructor that takes
+   OpenCL device as an argument.
+
+5. For DPC++ users:
+   - Default buffer-based API is replaced with device USM;
+   - Memory kind (USM or buffers) is now controlled using memory constructor
+     and not `DNNL_USE_SYCL_BUFFERS`;
+
+No changes are expected to the distribution model: there will be still many
+configurations. We anticipate the need to add one more configuration:
+`cpu_omp_gpu_dpcpp`.
+
+### 1.1. API Preview
+
+On can make a quick comparison of the current (v1.x and `dev-v2`) API and the
+proposed one by checking the [api-simplified](api-simplified/) directory.
+
+## 2. Discussion
+
+For simplicity, the discussions on different aspects of the changes are split
+in the following files:
+
+1. [General v2 API](general-v2-api.md)
+   - The most interesting part the describes the changes to the general API in
+     details.
+2. [USM and Buffer Support](usm-and-buffer-support.md)
+   - Options and challenges in supporting DPC++ USM and Buffers.
+3. [Changing `stream::flags::default_order` Behavior](changing-stream-flags-default-order-behavior.md)
+   - Just as the name says.
+
+## 3. Dropped Ideas
+
+The discussion on the API change took quite some time. During it we considered
+multiple options, reflected on them, and changed our decisions. The following
+documents discuss some of the options that we decided not to proceed with:
+
+1. [Dropped Ideas: API Classes](dropped-ideas-api-classes.md)
+   - Initially we wanted to introduce `api` enum class to the API, to be able
+     to choose between different runtimes within a fixed configuration. For
+     instance, for DPC++ CPU configuration one could still create an enigne
+     with Native C++ API. However, after quite some discussions we decided this
+     idea brings very small value and should wait till better times (e.g. when
+     oneDNN decides to enalbe plugin system, in which case a user needs a way
+     to specify the runtime during engine construction).
+
+2. [API Mockups](history/api-mockups/)
+   - Mostly made by Roma (@rsdubtso). He considered several different
+     approaches how organize the interoperability API (e.g. oneDNN <-> SYCL).
+     The option 1 is the most simple one and essentially used in this RFC.
+     Options 2 - 4, are probably more C++-like, but seem overcomplicated and
+     less flexible for future (and even current) changes. For instance,
+     `dnnl::sycl::memory_kind` memory parameter doesn't interplay nicely with
+     `dnnl::interop::memory` structure. However, it is worth admitting that
+     the [option 3a](history/api-mockups/option3a/) enforces different API/RT
+     to be quite consistent.
+
+## 4. Updates To This RFC
+
+- 20/08/06. After the discussion between Eugene (@echeresh) and Evarist
+  (@emfomenk), the RFC changed as follows:
+  - Decided to disallow supporting multiple runtimes for one library
+    configuration. Specifically, before RFC suggested to support native (C++)
+    CPU along with DPC++ CPU runtime for `cpu_dpcpp_gpu_dpcpp`. The rationale
+    is that the usefulness of this feature is questionable at this moment,
+    given that we don't support plugin model and there are very low chances
+    people would like to mix two runtimes for CPU.
+  - As a consequence, `api` enum is dropped altogether -- there won't be any
+    benefit of having it exposed in the API. That essentially means that the
+    API corresponds to the configuration the library was built with. This is
+    exactly what oneDNN v1.x and `dev-v2` were about.
+  - This also solves the problem with the "default" api/runtime in engine
+    constructor and with the name of api/runtime enum too.
+  - The previous definition of the API where there was an `api` enum is
+    documented in [Dropped Ideas: API Classes](dropped-ideas-api-classes.md).
+
+- 20/08/05. After a discussion with Eugene (@echeresh), Mourad (@mgouicem),
+  Denis (@densamoilov), Igor (@igorsafo), and Evarist (@emfomenk), the RFC
+  changed as follows:
+  - The engine constructor without `api` parameter was default to the runtime
+    according the priorities instead of always assuming `api::c`. For DPC++
+    configuration with native C++ CPU support, the suggestion was to default to
+    `api::c` and not `api::sycl` for backward compatibility reasons. This
+    approach allows creating GPU engine with `engine(kind::gpu, 0)`, as before
+    RFC prohibited this (because the `api` was assumed `c`).
+  - Thread-pool was suggested to be dropped from `api` enum as it doesn't bring
+    any value.
+  - There was a discussion about name for `api` enum: whether it should be
+    named `api` or `runtime`.
+    - The name `runtime` better reflects the reality, and has future
+      extensibility if oneDNN will switch to plug-in based system. Runtime
+      also is primary, while API is secondary (depends on runtime).
+    - The name `api` with less values seemed more user-friendly.
+    - We didn't come to a conclusion, those the majority leaned towards
+      `api` mostly due to its simplicity from user's point of view.
+  - Briefly discussed removing `memory_kind` from engine creation to memory
+    creation, allowing mixing different kinds of memory for a single primitive.
+    Agreed on proceeding this way. This simplifies the API, its concepts, it is
+    more flexible, and in future, if buffers are de-prioritized / dropped,
+    there would be minimum changes to the API (essentially 0).
+
+
+---
+
+EOD

--- a/rfcs/20200717-onednn-v2/README.md
+++ b/rfcs/20200717-onednn-v2/README.md
@@ -139,6 +139,11 @@ documents discuss some of the options that we decided not to proceed with:
   called `dnnl::sycl_interop::get_memory_kind()` as subject can be guessed by
   the first argument name.
 
+- 20/09/17. Remove `usm_device` and `usm_shared` in favor of simple `usm` for
+  `sycl_interop::memory_kind`. Justification: simpler API and in most of the
+  cases the type of USM is not that important. For the cases where the type of
+  USM is important users could use `sycl::get_pointer_type()`.
+
 
 ---
 

--- a/rfcs/20200717-onednn-v2/README.md
+++ b/rfcs/20200717-onednn-v2/README.md
@@ -22,9 +22,9 @@ with respect to the backwards compatibility with `dev-v2` branch though
    | Headers                                             | API For                | Namespace (applicable for C++ header files only) |
    | :--                                                 | :--                    | :--                                              |
    | `dnnl_types.h`, `dnnl.h`, `dnnl.hpp`                | Common and RT-agnostic | `dnnl`                                           |
-   | `dnnl_sycl_types.h`, `dnnl_sycl.h`, `dnnl_sycl.hpp` | SYCL-specific          | `dnnl::sycl`                                     |
-   | `dnnl_ocl.h`, `dnnl_ocl.hpp`                        | OpenCL specific        | `dnnl::ocl`                                      |
-   | `dnnl_threadpool.h`, `dnnl_threadpool.hpp`          | Thread pool specific   | `dnnl::threadpool`                               |
+   | `dnnl_sycl_types.h`, `dnnl_sycl.h`, `dnnl_sycl.hpp` | SYCL-specific          | `dnnl::sycl_interop`                             |
+   | `dnnl_ocl.h`, `dnnl_ocl.hpp`                        | OpenCL specific        | `dnnl::ocl_interop`                              |
+   | `dnnl_threadpool.h`, `dnnl_threadpool.hpp`          | Thread pool specific   | `dnnl::threadpool_interop`                       |
 
 2. Stream attributes are removed. This should affect only the integration with
    Thread Pool.
@@ -131,6 +131,13 @@ documents discuss some of the options that we decided not to proceed with:
     Agreed on proceeding this way. This simplifies the API, its concepts, it is
     more flexible, and in future, if buffers are de-prioritized / dropped,
     there would be minimum changes to the API (essentially 0).
+
+- 20/09/09. After we discovered the issue with namespace clashing, we renamed
+  `dnnl::sycl` (and other) namespaces to `dnnl::sycl_interop`. Along with that
+  we also simplified the names of the interoperability functions. For instance,
+  instead of `dnnl::sycl_interop::memory_get_memory_kind()` the function is now
+  called `dnnl::sycl_interop::get_memory_kind()` as subject can be guessed by
+  the first argument name.
 
 
 ---

--- a/rfcs/20200717-onednn-v2/api-simplified/v1_dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v1_dnnl.hpp
@@ -1,0 +1,95 @@
+namespace dnnl {
+
+struct engine : public handle<dnnl_engine_t> {
+    enum class kind {
+        any = dnnl_any_engine,
+        cpu = dnnl_cpu,
+        gpu = dnnl_gpu,
+    };
+
+    static size_t get_count(kind akind);
+
+    engine(kind akind, size_t index);
+    kind get_kind() const;
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    engine(kind akind, cl_device_id device, cl_context context);
+    cl_context get_ocl_context() const;
+    cl_device_id get_ocl_device() const;
+#endif
+
+#if DNNL_WITH_SYCL
+    engine(kind akind, const cl::sycl::device &dev, const cl::sycl::context &ctx);
+    cl::sycl::context DNNL_API get_sycl_context() const;
+    cl::sycl::device DNNL_API get_sycl_device() const;
+#endif
+};
+
+struct stream : public handle<dnnl_stream_t> {
+    enum class flags : unsigned {
+        default_order = dnnl_stream_default_order,
+        in_order = dnnl_stream_default_order,
+        out_of_order = dnnl_stream_out_of_order,
+        default_flags = dnnl_stream_default_flags,
+    };
+
+    stream(const engine &aengine, flags aflags = flags::default_flags,
+            const stream_attr &attr = stream_attr());
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    stream(const engine &aengine, cl_command_queue queue);
+    cl_command_queue get_ocl_command_queue() const;
+#endif
+
+#if DNNL_WITH_SYCL
+    stream(const engine &aengine, cl::sycl::queue &queue);
+    cl::sycl::queue DNNL_API get_sycl_queue() const;
+#endif
+
+    stream &wait();
+};
+
+struct memory : public handle<dnnl_memory_t> {
+    memory(const desc &md, const engine &aengine, void *handle);
+    memory(const desc &md, const engine &aengine);
+
+    desc get_desc() const;
+    engine get_engine() const;
+
+    void *get_data_handle() const;
+
+    void set_data_handle(void *handle, const stream &astream) const;
+    void set_data_handle(void *handle) const;
+
+    template <typename T = void> T *map_data() const;
+    void unmap_data(void *mapped_ptr) const;
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    cl_mem get_ocl_mem_object() const;
+    void set_ocl_mem_object(cl_mem mem_object);
+#endif
+
+#if DNNL_WITH_SYCL && defined(DNNL_USE_SYCL_BUFFERS)
+    template <typename T, int ndims = 1>
+    memory(const desc &md, const engine &aengine, cl::sycl::buffer<T, ndims> &buf);
+
+    template <typename T, int ndims = 1>
+    cl::sycl::buffer<T, ndims> get_sycl_buffer(size_t *offset = nullptr) const;
+
+    template <typename T, int ndims>
+    void set_sycl_buffer(cl::sycl::buffer<T, ndims> &buf);
+#endif
+};
+
+struct primitive : public handle<dnnl_primitive_t> {
+    void execute(const stream &astream,
+            const std::unordered_map<int, memory> &args) const;
+
+#ifdef DNNL_SYCL_DPCPP
+    cl::sycl::event DNNL_API execute_sycl(const stream &astream,
+            const std::unordered_map<int, memory> &args,
+            const std::vector<cl::sycl::event> &deps = {}) const;
+#endif
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl.hpp
@@ -1,0 +1,60 @@
+namespace dnnl {
+
+struct engine : public handle<dnnl_engine_t> {
+    enum class kind {
+        any = dnnl_any_engine,
+        cpu = dnnl_cpu,
+        gpu = dnnl_gpu,
+    };
+
+    static size_t get_count(kind akind);
+
+    engine(kind akind, size_t index = 0);
+
+    kind get_kind() const;
+    api get_api() const;
+};
+
+struct stream : public handle<dnnl_stream_t> {
+    // Based on Eugene's proposal for dropping `stream::flags::default_order`:
+    // ../changing-stream-flags-default-order-behavior.md
+    enum class flags : unsigned {
+        in_order = dnnl_stream_default_order,
+        out_of_order = dnnl_stream_out_of_order,
+        default_flags = in_order,
+    };
+
+    // stream_attr are dropped
+    stream(const engine &aengine, flags aflags = flags::default_flags);
+    stream &wait();
+};
+
+struct memory : public handle<dnnl_memory_t> {
+    // May fail if handle != NONE / ALLOCATE and engine's memory model
+    // doesn't support pointers (e.g. in case of OpenCL).
+    memory(const desc &md, const engine &aengine,
+            void *handle = DNNL_MEMORY_ALLOCATE);
+    // This ctor requires only engine to be alive along with memory, the stream
+    // is only used to perform zero padding, if necessary, and is discarded
+    // afterwards.
+    memory(const desc &md, const stream &astream,
+            void *handle = DNNL_MEMORY_ALLOCATE);
+
+    desc get_desc() const;
+    engine get_engine() const;
+
+    // Works only when memory buffer is represented by pure pointer.
+    void *get_data_handle() const;
+    void set_data_handle(void *handle) const;
+    void set_data_handle(void *handle, const stream &astream) const;
+
+    template <typename T = void> T *map_data() const;
+    void unmap_data(void *mapped_ptr) const;
+};
+
+struct primitive : public handle<dnnl_primitive_t> {
+    void execute(const stream &astream,
+            const std::unordered_map<int, memory> &args) const;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_ocl.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_ocl.hpp
@@ -1,0 +1,33 @@
+#include <CL/cl.hpp>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+namespace ocl_interop {
+
+// ======
+// Engine
+// ======
+
+// Note that engine::kind is dropped.
+engine make_engine(cl_device_id &dev, cl_context &ctx);
+cl_device_id get_device(const engine &e);
+cl_context get_context(const engine &e);
+
+// ======
+// Stream
+// ======
+
+// Note, that stream_flags are dropped.
+stream make_stream(const engine &e, cl_command_queue &queue);
+cl_command_queue get_command_queue(const stream &s);
+
+// ======
+// Memory
+// ======
+
+void set_mem_object(memory &m, cl_mem mem_object);
+cl_mem get_mem_object(const memory &m);
+
+} // namespace ocl_interop
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_sycl.hpp
@@ -6,8 +6,7 @@ namespace dnnl {
 namespace sycl_interop {
 
 enum class memory_kind { // maybe memory_model is better name?
-    usm_device, // default for SYCL-agnostic engine creation
-    usm_shared,
+    usm, // default for SYCL-agnostic engine creation (use device usm)
     buffer,
 };
 
@@ -35,6 +34,8 @@ cl::sycl::queue get_queue(const stream &s);
 // ======
 
 // for mkind == buffer, handle could only be DNNL_MEMORY_{ALLOCATE,NONE}
+// for mkind == usm && handle == DNNL_MEMORY_ALLOCATE use device USM.
+// for mkind == usm, handle could be USM of any kind.
 memory make_memory(const desc &md, const engine &aengine, memory_kind mkind,
         void *handle = DNNL_MEMORY_ALLOCATE);
 memory make_memory(const desc &md, const engine &astream, memory_kind mkind,

--- a/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_sycl.hpp
@@ -1,0 +1,69 @@
+#include <CL/sycl.hpp>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+namespace sycl {
+
+enum class memory_kind { // maybe memory_model is better name?
+    usm_device, // default for SYCL-agnostic engine creation
+    usm_shared,
+    buffer,
+};
+
+// ======
+// Engine
+// ======
+
+// Note that engine::kind is dropped.
+engine engine_create(const cl::sycl::device &dev, const cl::sycl::context &ctx);
+cl::sycl::device engine_get_device(const engine &e);
+cl::sycl::context engine_get_context(const engine &e);
+
+// ======
+// Stream
+// ======
+
+// Note, that stream_flags are dropped.
+// So far seems they could be derived from queue (for DPC++ and OpenCL and
+// could be assumed `in_order` for ThreadPool), so could dropped.
+stream stream_create(const engine &e, cl::sycl::queue &queue);
+cl::sycl::queue stream_get_queue(const stream &s);
+
+// ======
+// Memory
+// ======
+
+// for mkind == buffer, handle could only be DNNL_MEMORY_{ALLOCATE,NONE}
+memory memory_create(const desc &md, const engine &aengine, memory_kind mkind,
+        void *handle = DNNL_MEMORY_ALLOCATE);
+memory memory_create(const desc &md, const engine &astream, memory_kind mkind,
+        void *handle = DNNL_MEMORY_ALLOCATE);
+
+// memory_kind could be changed during the lifetime, by setting the USM handle
+// or SYCL buffer
+memory_kind memory_get_memory_kind(const memory &amemory);
+
+// memory_kind == buffer implied
+template <typename T, int ndims>
+memory memory_create(const desc &md, const engine &aengine,
+        cl::sycl::buffer<T, ndims> buf, stream &s);
+
+template <typename T, int ndims>
+void memory_set_data_handle(memory &m, cl::sycl::buffer<T, ndims> b);
+template <typename T, int ndims>
+void memory_set_data_handle(memory &m, cl::sycl::buffer<T, ndims> b, stream &s);
+template <typename T, int ndims = 1>
+cl::sycl::buffer<T, ndims> memory_get_sycl_buffer(const memory &m);
+
+// ==========
+// Primitives
+// ==========
+
+cl::sycl::event primitive_execute(
+        const primitive &p, const stream &s,
+        const std::unordered_map<int, memory> &args,
+        const std::vector<cl::sycl::event> &dependencies = {});
+
+} // namespace sycl
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_sycl.hpp
@@ -3,7 +3,7 @@
 #include "dnnl.hpp"
 
 namespace dnnl {
-namespace sycl {
+namespace sycl_interop {
 
 enum class memory_kind { // maybe memory_model is better name?
     usm_device, // default for SYCL-agnostic engine creation
@@ -16,9 +16,9 @@ enum class memory_kind { // maybe memory_model is better name?
 // ======
 
 // Note that engine::kind is dropped.
-engine engine_create(const cl::sycl::device &dev, const cl::sycl::context &ctx);
-cl::sycl::device engine_get_device(const engine &e);
-cl::sycl::context engine_get_context(const engine &e);
+engine make_engine(const cl::sycl::device &dev, const cl::sycl::context &ctx);
+cl::sycl::device get_device(const engine &e);
+cl::sycl::context get_context(const engine &e);
 
 // ======
 // Stream
@@ -27,43 +27,46 @@ cl::sycl::context engine_get_context(const engine &e);
 // Note, that stream_flags are dropped.
 // So far seems they could be derived from queue (for DPC++ and OpenCL and
 // could be assumed `in_order` for ThreadPool), so could dropped.
-stream stream_create(const engine &e, cl::sycl::queue &queue);
-cl::sycl::queue stream_get_queue(const stream &s);
+stream make_stream(const engine &e, cl::sycl::queue &queue);
+cl::sycl::queue get_queue(const stream &s);
 
 // ======
 // Memory
 // ======
 
 // for mkind == buffer, handle could only be DNNL_MEMORY_{ALLOCATE,NONE}
-memory memory_create(const desc &md, const engine &aengine, memory_kind mkind,
+memory make_memory(const desc &md, const engine &aengine, memory_kind mkind,
         void *handle = DNNL_MEMORY_ALLOCATE);
-memory memory_create(const desc &md, const engine &astream, memory_kind mkind,
+memory make_memory(const desc &md, const engine &astream, memory_kind mkind,
         void *handle = DNNL_MEMORY_ALLOCATE);
 
 // memory_kind could be changed during the lifetime, by setting the USM handle
 // or SYCL buffer
-memory_kind memory_get_memory_kind(const memory &amemory);
+memory_kind get_memory_kind(const memory &amemory);
 
 // memory_kind == buffer implied
 template <typename T, int ndims>
-memory memory_create(const desc &md, const engine &aengine,
-        cl::sycl::buffer<T, ndims> buf, stream &s);
+memory make_memory(const desc &md, const engine &aengine,
+        cl::sycl::buffer<T, ndims> buf);
+template <typename T, int ndims>
+memory make_memory(const desc &md, const stream &astream,
+        cl::sycl::buffer<T, ndims> buf);
 
 template <typename T, int ndims>
-void memory_set_data_handle(memory &m, cl::sycl::buffer<T, ndims> b);
+void set_buffer(memory &m, cl::sycl::buffer<T, ndims> b);
 template <typename T, int ndims>
-void memory_set_data_handle(memory &m, cl::sycl::buffer<T, ndims> b, stream &s);
+void set_buffer(memory &m, cl::sycl::buffer<T, ndims> b, stream &s);
 template <typename T, int ndims = 1>
-cl::sycl::buffer<T, ndims> memory_get_sycl_buffer(const memory &m);
+cl::sycl::buffer<T, ndims> get_buffer(const memory &m);
 
 // ==========
 // Primitives
 // ==========
 
-cl::sycl::event primitive_execute(
+cl::sycl::event execute(
         const primitive &p, const stream &s,
         const std::unordered_map<int, memory> &args,
         const std::vector<cl::sycl::event> &dependencies = {});
 
-} // namespace sycl
+} // namespace sycl_interop
 } // namespace dnnl

--- a/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_threadpool.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_threadpool.hpp
@@ -1,0 +1,27 @@
+#include "dnnl.hpp"
+#include "dnnl_threadpool_iface.hpp"
+
+namespace dnnl {
+namespace threadpool {
+
+// option 1a (preferable, but breaks backwards compatibility)
+// The flags are dropped, the `in_order` is assumed.
+stream stream_create(const engine &e, threadpool_iface *threadpool);
+threadpool_iface *stream_get_threadpool(const stream &s);
+
+#if 0
+// option 1b (preferable, but breaks backwards compatibility)
+// the flags are preserved
+stream stream_create(const engine &e, threadpool_iface *threadpool,
+        stream::flags aflags = flags::default_flags);
+threadpool_iface *stream_get_threadpool(const stream &s);
+
+
+// option 2 (keep stream_attr, mimics current API)
+void stream_attr_set_threadpool(stream_attr &sa, threadpool_iface *threadpool,
+        stream::flags aflags = flags::default_flags);
+threadpool_iface *stream_attr_get_threadpool(const stream_attr &sa);
+#endif
+
+} // namespace threadpool
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_threadpool.hpp
+++ b/rfcs/20200717-onednn-v2/api-simplified/v2_dnnl_threadpool.hpp
@@ -2,26 +2,26 @@
 #include "dnnl_threadpool_iface.hpp"
 
 namespace dnnl {
-namespace threadpool {
+namespace threadpool_interop {
 
 // option 1a (preferable, but breaks backwards compatibility)
 // The flags are dropped, the `in_order` is assumed.
-stream stream_create(const engine &e, threadpool_iface *threadpool);
-threadpool_iface *stream_get_threadpool(const stream &s);
+stream make_stream(const engine &e, threadpool_iface *threadpool);
+threadpool_iface *get_threadpool(const stream &s);
 
 #if 0
 // option 1b (preferable, but breaks backwards compatibility)
 // the flags are preserved
-stream stream_create(const engine &e, threadpool_iface *threadpool,
+stream make_stream(const engine &e, threadpool_iface *threadpool,
         stream::flags aflags = flags::default_flags);
-threadpool_iface *stream_get_threadpool(const stream &s);
+threadpool_iface *get_threadpool(const stream &s);
 
 
 // option 2 (keep stream_attr, mimics current API)
-void stream_attr_set_threadpool(stream_attr &sa, threadpool_iface *threadpool,
+void set_threadpool(stream_attr &sa, threadpool_iface *threadpool,
         stream::flags aflags = flags::default_flags);
-threadpool_iface *stream_attr_get_threadpool(const stream_attr &sa);
+threadpool_iface *get_threadpool(const stream_attr &sa);
 #endif
 
-} // namespace threadpool
+} // namespace threadpool_interop
 } // namespace dnnl

--- a/rfcs/20200717-onednn-v2/changing-stream-flags-default-order-behavior.md
+++ b/rfcs/20200717-onednn-v2/changing-stream-flags-default-order-behavior.md
@@ -1,0 +1,114 @@
+# Changing `stream::flags::default_order` behavior
+
+> This is a shameless copy of RFC made by Eugene (@echeresh) to keep all oneDNN
+> v2 related suggestions in one place.
+
+## Background
+
+Currently stream flags are defined as a bitmask:
+
+```c++
+enum class flags : unsigned {
+    /// Default order execution. Either in-order or out-of-order depending
+    /// on the engine runtime.
+    default_order = dnnl_stream_default_order,
+    /// In-order execution.
+    in_order = dnnl_stream_default_order,
+    /// Out-of-order execution.
+    out_of_order = dnnl_stream_out_of_order,
+    /// Default stream configuration.
+    default_flags = dnnl_stream_default_flags,
+};
+```
+
+The default order was introduced to support DPC++/SYCL. SYCL queues always
+behave as out-of-order (SYCL 1.2.1 standard), and the SYCL runtime handles
+dependencies automatically via accessors. `stream::flags::default_order` was
+introduced specifically to match this behavior. `default_order` is in-order for
+OpenCL, and out-of-order for DPC++/SYCL.
+
+This helped to have API consistency and (kind of) consistency in behavior
+across different runtimes. The consistency in behavior is that the
+default-constructed stream does not require dependency handling on the user
+side:
+
+```c++
+stream s(eng, stream::flags::default_order);
+```
+
+## Problem
+
+The default order definition is vague, and its behavior is, in fact,
+inconsistent across runtimes.
+
+## Proposal
+
+This RFC suggests the following changes for 2.0 version:
+
+1. Make `flags::default_flags` equal to `flags::in_order` (in-order semantics by default)
+2. Remove `flags::default_order`
+
+This would make the behavior fully consistent across runtimes for the stream
+constructed by default.
+
+### Native CPU and OpenCL
+
+Native CPU streams (OpenMP, TBB, sequential, threadpool) are always in-order.
+OpenCL GPU streams are in-order by default (aligned with the current oneDNN behavior).
+
+### DPC++/SYCL
+
+oneDNN provides support for oneAPI DPC++ compiler (official, referred here as
+"DPC++") and for ComputeCpp (unofficial, being used by frameworks while
+they have not moved to DPC++ yet, referred here as "SYCL"). oneAPI
+DPC++ compiler relies on DPC++ with its extensions, ComputeCpp relies
+on SYCL 1.2.1 standard.
+
+Recently DPC++ introduced an extension for in-order behavior for queues:
+[OrderedQueue](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/OrderedQueue/OrderedQueue_v2.adoc).
+This extension (queue property) can be used with `flags::in_order`.
+
+SYCL 1.2.1 does not support in-order behavior but it can be emulated using
+explicit `queue::wait()`. This is the current behavior of oneDNN streams with
+`flags::in_order` for DPC++/SYCL runtimes - in-order behavior is emulated via
+explicit synchronization.
+
+## Next steps
+
+Apply the following changes in `dev-v2` branch:
+
+- Update API:
+    - Remove `flags::default_order`
+    - Make `flags::default_flags` equal to `flags::in_order`
+    - Apply similar changes for C and C++ API
+- Update the implementation:
+    - Use the ordered queue for DPC++ for `flags::in_order`
+    - Emulate in-order behavior for ComputeCpp for `flags::in_order`
+
+## Further discussion and comments
+
+The above proposal breaks backward compatibility in oneDNN 2.0. Though there is
+another option which does not break backward compatibility:
+
+- Keep `flags::default_order` and `flags::default_flags` but make it clear in
+  the documentation that the default order is the same as `flags::in_order`
+- Update implementation to treat `flags::default_order` and `flags::in_order` the same way
+
+This keeps binary/API compatibility but slightly changes the default behavior.
+
+One more thing to mention is that C++ API have a bug in the definition of
+`flags::in_order`:
+
+```c++
+enum class flags : unsigned {
+    ...
+    /// In-order execution.
+    in_order = dnnl_stream_default_order,
+    ...
+};
+```
+
+`flags::in_order` is defined as `dnnl_stream_default_order`. This means that
+now there is no way to create a truly in-order stream with C++ API (e.g. this
+might be useful with DPC++ USM). However this can be easily fixed as it
+requires changes in `dnnl.hpp` header only.

--- a/rfcs/20200717-onednn-v2/dropped-ideas-api-classes.md
+++ b/rfcs/20200717-onednn-v2/dropped-ideas-api-classes.md
@@ -1,0 +1,282 @@
+# Dropped Ideas: API Classes
+
+The proposed library API could be found in
+[history/api-simplified-rev0](history/api-simplified-rev0/) directory.
+
+## 1. API Classes
+
+It was suggested to bring a new enum `dnnl::api` (or, maybe better
+`dnnl::api_class`, and maybe make it `engine` sub-class), which names the API
+classes we support. For native C/C++ API the enum contains `api::c`. Exactly
+this API class is fully defined in `dnnl.hpp`, and only engine kind supported
+by this API is CPU. It was also suggested that for DPC++ library configuration
+(`dnnl_cpu_dpcpp_gpu_dpcpp`) it is allowed to create engine with native C API.
+This will allow supporting native C++ applications as well as DPC++
+applications within a single configuration.
+
+The list of `dnnl::api` values:
+
+| `dnnl::api`       | API to work with | Memory buffer representation                        |
+| :--               | :--              | :--                                                 |
+| `api::c`          | Native C/C++     | `void *`                                            |
+| `api::sycl`       | DPC++            | Further dispatch based on `dnnl::sycl::memory_kind` |
+| `api::ocl`        | OpenCL           | `cl_mem`                                            |
+
+The API class is closely related to the engine. Engine class would then have a
+new query: `dnnl::api engine::get_api() const;`. This is also the reason why
+`api` should probably belong to the `engine` class.
+
+## 2. Engine
+
+There would be 3 ways to create an engine:
+
+``` cpp
+// =============
+// dnnl_$api.hpp
+// =============
+
+// 1. The most advance, API-specific way of creating an engine that accepts
+// API/RT-specific input arguments. Example below for DPC++ (similar of OCL):
+dnnl::engine dnnl::sycl::engine_create(engine::kind, memory_kind,
+        const cl::sycl::device &dev, const cl::sycl::context &ctx);
+// The memory_kind is discussed below.
+
+// =============
+// dnnl.hpp
+// =============
+
+// 2. New way of creating engine. If `api` != `api::c`, the extra parameters
+// appeared in `dnnl_$api.hpp` will used some default parameters, that should
+// be documented on the corresponding API-related page.
+auto eng = engine(engine::kind, dnnl::api, index);
+
+// Example:
+// engine(engine::kind::cpu, dnnl::api::sycl, 0) will use
+// `memory_kind::usm_device` and create device and context underneath.
+
+// 3. oneDNN v1.x compatible way
+auto eng = engine(engine::kind, index); // same as engine(engine::kind, api::c, index);
+```
+
+DPC++ engine will have (mostly for completeness) one extra constructor:
+``` cpp
+// =============
+// dnnl_sycl.hpp
+// =============
+
+dnnl::engine dnnl::sycl::engine_create(engine::kind, memory_kind = memory_kind::usm_device);
+```
+
+Which will create device and context underneath. Exactly this version will be
+used by `dnnl::engine(engine::kind::xpu, api::sycl, index);` that lives in
+`dnnl.hpp`.
+
+The proposed API breaks backwards compatibility with OpenCL.
+``` cpp
+auto eng = engine(engine::kind::gpu, 0); // which is the same as
+auto eng = engine(engine::kind::gpu, api::c, 0); // will always fail
+```
+
+One could create OpenCL engine in two ways:
+``` cpp
+auto eng = engine(engine::kind::gpu, api::ocl, 0); // dnnl.hpp
+auto eng = dnnl::ocl::engine_create(engine::kind::gpu, ocl_dev, ocl_ctx); // dnnl_ocl.hpp
+```
+
+## Discussion: Default For Engine Constructor w/o API
+
+As it is mentioned above the RFC suggests making
+`engine(engine::kind::xpu, index)` constructor be an equivalent of
+`engine(engine::kind::xpu, api::c, index);`, which in particularly means:
+- No matter what, `engine(engine::kind::gpu, index)` will always fail
+- ThreadPool, OpenCL and DPC++ users will always have to explicitly pass the
+  desired API to the constructor.
+
+While this behavior is very explicit, it might be inconvenient for non-C++-API
+users.
+
+Eugene suggests the alternative approach: make the API-agnostic engine
+constructor to pick the first suitable version that is satisfies the
+requirements. For instance, if the library is built with OpenCL support,
+the `engine(engine::kind::gpu, 0)` will create OpenCL engine. User can verify
+that by querying the `api` with `engine::get_api()` method.
+
+There are 3 obvious benefits:
+1. The API is "more" backwards compatible with v1.x version
+2. For the well known configurations (e.g. `cpu_omp_gpu_ocl`) a user gets what
+   they want by default (simpler API).
+3. It would be very convenient for the testing, as we don't need to care much
+   about properly picked runtime (anyways we don't have multiple API at the
+   same time in our current building system).
+
+The drawbacks:
+1. If the wrong configuration is loaded, the behavior would be unexpected
+   (could be mitigated by user, if desired, by explicitly setting the API in
+   the constructor, i.e. `engine(engine::kind::xpu, desired_api, 0);` instead
+   of `engine(engine::kind::xpu, 0)`).
+2. Less explicit behavior wrt multiple APIs if supported.
+   - For instance, if we support both C++ and DPC++ APIs for CPU (say, for
+     `cpu_dpcpp_gpu_dpcpp` configuration), it is unclear whether DPC++ is
+     prioritized of C++ or vice versa.
+3. Probably, this approach doesn't scale well if we are to support more APIs.
+   Though we probably envision any beyond what we currently have.
+
+If we go this route an open question if we should enumerate one engine kind
+(say, CPU) with different API with this API-agnostic constructor, or we should
+just allow creating one. I.e.:
+
+``` cpp
+engine(engine::kind::cpu, 0) --> engine(engine::kind::xpu, api::dpcpp, 0)
+engine(engine::kind::cpu, 1) --> engine(engine::kind::xpu, api::c, 0)
+
+// vs
+
+engine(engine::kind::cpu, 0) --> engine(engine::kind::xpu, api::dpcpp, 0)
+engine(engine::kind::cpu, 1) --> error, not such engine
+// to create CPU engine with C, one needs explicitly call:
+// engine(engine::kind::xpu, api::c, 0)
+```
+
+One of the concerns about the alternative approach is that when people use
+oneDNN they typically know what API they are using (as they use all the
+interoperability features). So, with that, I think, the clarity / explicitness
+of choosing the API outweighs the usefulness of the default dispatching.
+
+## Discussion: Alternative to API Enum Class -- Runtime Enum Class
+
+Eugene suggested to avoid using overloaded word API (or API class) and reuse
+`runtime_kind` that we use internally in the library:
+
+``` cpp
+enum class runtime_kind {
+    native = 0x1000,
+    ocl = 0x2000,
+    sycl = 0x4000,
+    threadpool = 0x8000,
+    seq = native | 0x1,
+    omp = native | 0x2,
+    tbb = native | 0x4,
+};
+```
+
+After a second thought I think this could be a possible and actually quite nice
+solution. The sketch of the API and its semantics is shown below.
+
+``` cpp
+namespace dnnl {
+
+enum class runtime_kind {
+    // interfaces
+    c = 0x1000, // instead of native
+    ocl = 0x2000,
+    sycl = 0x4000,
+
+    // extra runtime specifications, not a part of specification
+    seq = 0x1,
+    omp = 0x2,
+    tbb = 0x4,
+    threadpool = 0x8,
+};
+
+struct engine {
+    // rkind must specify the interface {c, ocl, sycl}, and could or could not
+    // specify extra runtime specification. The portable code should not make
+    // any assumption on the extra runtime specifications.
+    engine(engine::kind ekind, runtime_kind rkind, ...);
+
+    // returns the runtime kind. For `rkind` that was used at engine creation,
+    // it is guaranteed that `get_kind() & rkind == rkind`.
+    // However, the returned runtime_kind could contain additional information,
+    // e.g. for engine created with `runtime_kind::c`, the returned value
+    // could be `runtime_kind::c | runtime_kind::omp` (in future, even
+    // `runtime_kind::c | runtime_kind::omp | runtime_kind::omp_rt_intel`).
+    runtime_kind get_runtime_kind() const;
+};
+
+} // namespace dnnl
+```
+
+Consider few use cases:
+
+1. Portable way to create CPU engine for C/C++ API
+   ``` cpp
+   auto eng = engine(engine::kind::cpu, runtime_kind::c, 0);
+   assert(eng.get_runtime_kind() & runtime_kind::c == runtime_kind::c);
+   // not portable code, but could be handy
+   if (eng.get_runtime_kind() & runtime_kind::omp) {
+       // omp specific code
+   }
+   ```
+
+2. Non-portable way to create an engine that will use OMP RT. The creation may
+   fail if the library was built with TBB:
+   ``` cpp
+   // a strong desire to use OMP, ok to fail...
+   auto eng = engine(engine::kind::cpu, runtime_kind::c | runtime_kind::omp, 0);
+   ```
+
+3. Could be possible now if we want to support that:
+   ``` cpp
+   // even though the configuration is dnnl_cpu_omp we could support external
+   // thread pool, if we really want to.
+   auto eng = engine(engine::kind::cpu,
+           runtime_kind::c | runtime_kind::threadpool, 0);
+    ```
+
+4. There would be a way to use sequential oneDNN even if it comes with OMP:
+   ``` cpp
+   // configuration cpu_iomp
+   // a user wants sequential version
+   auto eng = engine(engine::kind::cpu, runtime_kind::c | runtime_kind::seq, 0);
+   ```
+
+5. Get what is underlying parallelization runtime for DPC++:
+   ``` cpp
+   auto eng = engine(engine::kind::cpu, runtime_kind::sycl, 0);
+
+   print(eng.get_runtime_kind());
+   // cpu_dpcpp_tbb will print: runtime_kind::sycl | runtime_kind::tbb
+   // cpu_dpcpp_omp will print: runtime_kind::sycl | runtime_kind::omp
+   ```
+
+I think as of today, there is little value in exposing these extra flags
+(compared to just exposing the _API_). However, the approach gives the
+following advantages:
+1. We could (at least in theory) support more configurations in a single
+   bundle, like forcing:
+   - sequential version for OMP or TBB configurations,
+   - having threadpool for OMP or TBB configurations;
+2. Use can query extra information if that would be of any help. For instance,
+   even though the API is DPC++, a user can find out that the runtime used for
+   parallelization is OMP.
+3. This approach will allow us support plugin model, where depending on the
+   chosen runtime flags oneDNN common (core) library will load the proper
+   engine plugin.
+
+In my opinion, however, implementing all this will be an overkill, and probably
+not feasible at this moment (for instance, I am not sure how easy it would be
+to support sequential mode for the library built with OMP). With that, I still
+vote for having an `api` (maybe better api_class) enum class, and extend the
+when we decide to proceed with plugin model.
+
+- The intermediate solution will be to use `runtime_kind` name and implement
+  only meaningful part, e.g.:
+  ``` cpp
+  enum class runtime_kind {
+      // interfaces
+      c = 0x1000, // instead of native
+      ocl = 0x2000,
+      sycl = 0x4000,
+
+      // extra runtime specifications, not a part of specification
+      threadpool = 0x8, // should it be an interface actually?..
+  };
+  ```
+  I.e. do not bring OMP, TBB, SEQ to the list, and extend it when time comes.
+  The downside is that with this definition users could be confused with our
+  cmake options `-DDNNL_CPU_RUNTIME=OMP` and `-DDNNL_GPU_RUNTIME=DPCPP`.
+
+
+---
+
+EOD

--- a/rfcs/20200717-onednn-v2/general-v2-api.md
+++ b/rfcs/20200717-onednn-v2/general-v2-api.md
@@ -1,0 +1,401 @@
+# General v2 API
+
+The discussion here will mostly focus on C++ API (`dnnl*.hpp`). Where important
+the C API will be mentioned explicitly. Otherwise, the assumption that
+statements made relate to both C and C++ APIs.
+
+
+## 1. API Mock-up
+
+Please check simplified [API directory](api-simplified/), which focuses on
+C++ API only:
+- Current version [`dnnl.hpp`](api-simplified/v1_dnnl.hpp)
+- Suggested v2 version:
+  - [`dnnl.hpp`](api-simplified/v2_dnnl.hpp)
+  - [`dnnl_sycl.hpp`](api-simplified/v2_dnnl_sycl.hpp)
+  - [`dnnl_threadpool.hpp`](api-simplified/v2_dnnl_threadpool.hpp)
+
+
+## 2. Basis Principals
+
+1. Currently the main `dnnl.hpp` _dynamically_ adds or modifies the functions
+   depending on the API/RT the library was built with, by looking at
+   `dnnl_config.h`. We suggest to split the headers into API/RT agnostic and
+   API/RT dependent parts. A user will be responsible to include and call
+   special functions that provide interoperability API between DNNL and API/RT,
+   e.g. SYCL.
+   - The library shipped could always include all of the headers, which reduces
+     the divergence between the configurations.
+   - The approach is generally less fragile.
+   - Better alignment with potential future support for plugin-based model
+     (see also C++-API over C-API).
+
+2. C++ API is fully based on C API. DPC++ objects are passed by address casted
+   to a `(const) void *`.
+
+   Rationale:
+   - The approach makes it more difficult to break ABI, as the only entry point
+     to the library will be C-based (living in `dnnl*.h` files).
+   - (weak argument) The approach is better aligned with plugin-model, if ever
+     decide to go this route.
+   - We could put all symbols to the library regardless of the API/RT it was
+     built with. In this case even if user tries to call OpenCL-specific API
+     with the library that was built w/o its support, the function with
+     gracefully return `status::unimplemented` or so. This will make different
+     application to "work" with arbitrary oneDNN library (meaning that they
+     won't crash at load time due to undefined symbols). However, I think
+     seeing the issue at run time make it easier to debug, so suggest to not
+     implement this, at least at the beginning.
+
+   This will require proper and thorough documenting the C-API (mostly for the
+   DPC++ C++ counterpart), as the types would be erased. E.g. instead of an
+   address on a SYCL buffer the API will take `void *`. As C-API for DPC++ is
+   merely an implementation detail (entry point), we should encourage our users
+   to avoid using it (at least for DPC++).
+
+   Example:
+   ``` cpp
+   // ===========
+   // dnnl_sycl.h
+   // ===========
+
+   // ...
+   // @param sycl_dev_ptr Address of a SYCL device object casted to `void *`.
+   // @param sycl_ctx_ptr Address of a SYCL context object casted to `void *`.
+   // ...
+   // @note
+   //     Since the function signature takes `void *` instead of some of the
+   //     parameters (type erasure), the compiler won't be able to check that
+   //     the arguments are passed correctly. The users are encouraged to use
+   //     the corresponding C++ API instead.
+   dnnl_status_t dnnl_sycl_engine_create(dnnl_engine_t *engine,
+           void *sycl_dev_ptr, void *sycl_ctx_ptr); // <-- type erasure
+
+   // =============
+   // dnnl_sycl.hpp
+   // =============
+   namespace dnnl {
+   namespace sycl {
+   inline engine engine_create(cl::sycl::device dev, cl::sycl::context ctx) {
+     dnnl_engine_t e = nullptr;
+     dnnl::error(
+         dnnl_sycl_engine_create(&e, /* type erasure */ &dev, /* type erasure */ &ctx),
+         "cannot create engine"
+     );
+     return dnnl::engine(e);
+   }
+   } // namespace sycl
+   } // namespace dnnl
+   ```
+
+
+## 3. Suggested API
+
+As it is mentioned above, it is suggested to split oneDNN API into
+API/RT-agnostic that would continue living in `dnnl.hpp`, and interoperability
+API going to `dnnl_$api.hpp` header file. Only API-specific headers are allowed
+to make API-specific includes, e.g. only `dnnl_sycl.hpp` is allowed to include
+`CL/sycl.hpp`. Luckily, the interoperability API is limited to creating few
+oneDNN objects, such as engine, stream, and memory, and querying those.
+
+
+### 3.1. Engine
+
+There would be 2 ways to create an engine:
+
+``` cpp
+// =================
+// dnnl_$runtime.hpp
+// =================
+
+// 1. The most advance, runtime-specific way of creating an engine that accepts
+// API/RT-specific input arguments. Example below for DPC++ (similar for OCL).
+dnnl::engine dnnl::sycl::engine_create(
+        const cl::sycl::device &dev, const cl::sycl::context &ctx);
+
+// ========
+// dnnl.hpp
+// ========
+
+// 2. oneDNN v1.x compatible way
+auto eng = engine(engine::kind, index);
+
+// 2.a. In oneDNN v2.x the default value for index is 0:
+auto eng = engine(engine::kind); // index = 0
+```
+
+Just like in oneDNN v1.x and `dev-v2` branch, the engine created with the
+second (API/RT-agnostic way) would depend on the library configuration. Say,
+for `cpu_dpcpp_gpu_dpcpp` configuration the engine will be backed up by DPC++.
+
+Notice, there is no `engine::kind` argument in `dnnl::sycl::engine_create()`
+(same for OpenCL). The assumption is that the kind could be derived from the
+input device.
+
+
+### 3.2. Stream
+
+1. The stream story is pretty similar to engine's one: the `dnnl_$runtime.hpp`
+   header will contain the constructors that could accept the runtime-specific
+   objects. Examples:
+   ``` cpp
+   // =============
+   // dnnl_sycl.hpp
+   // =============
+   stream stream_create(const engine &e, cl::sycl::queue &queue);
+
+   // ===================
+   // dnnl_threadpool.hpp
+   // ===================
+
+   stream stream_create(const engine &e, threadpool_iface *threadpool);
+   ```
+
+2. Since thread pool now deserves a separate header file we suggest to get rid
+   of stream attributes, and pass the thread pool pointer directly to the
+   stream constructor.
+
+   - The biggest concern is a broken API, though the hope is that no one
+     actually uses `stream_attr`, except for TF with Eigen thread pool. But
+     given that the proposal anyways break the thread pool, that should be
+     fine.
+
+3. The stream flags are also dropped from the RT-specific constructors, as they
+   could be derived from the corresponding RT objects (e.g. `sycl::queue`).
+   - For DPC++ and OpenCL the order could be derived from the queue properties.
+     The assumption that if the queue is `out_of_order`, no one would want to
+     _simulate_ it is in-order, by passing us the corresponding flag. If they
+     do, they could call `stream::wait()` on their own after each API call.
+   - For Thread Pool the assumption that (just like regular C++ API) only
+     in-order streams will be supported.
+   - If really necessary we extend the constructors by returning back the flags
+     with default value equals `stream::flags::default_flags` which will
+     preserve API/ABI backwards compatibility.
+   - On the other hand, since flags could contain (in future) extra meaning,
+     such as enabling profiling (not quite relevant as this flag cannot be used
+     for the already created queue), it could be safer to include them in the
+     API. We also could make a semantic check on the flags and input queue:
+     - `flags::out_of_order` and out-of-order queue is a valid combination
+     - `flags::out_of_order` and in-order queue is a valid combination
+     - `flags::in_order` and out-of-order queue is *not* a valid combination
+
+   The suggestion is to drop the stream flags for RT-specific API. Of course,
+   the flags stay in RT-agnostic constructor (`dnnl.hpp`).
+
+
+### 3.3. Memory
+
+1. Memory now has an extra constructor
+   ``` cpp
+   // dnnl.hpp
+   dnnl::memory(const desc &md, const stream &astream, void *handle);
+   ```
+   That uses stream to do zero padding, if necessary. This could also be handy
+   to properly _pin_ the memory.
+
+2. Similarly to engine and stream objects, RT-specific headers will provide the
+   interoperable API. For instance, to create a memory with sycl buffers, one
+   will use on of the following functions:
+   ``` cpp
+    template <typename T, int ndims>
+    memory memory_create(const desc &md, const engine &aengine,
+            cl::sycl::buffer<T, ndims> buf, stream &s);
+
+    template <typename T, int ndims>
+    void memory_set_data_handle(memory &m, cl::sycl::buffer<T, ndims> b);
+   ```
+
+3. For DPC++ the [USM and Buffers Support](usm-and-buffer-support.md) discusses
+   the support for buffers and USM. Assuming we choose to go with the suggested
+   approach (that is supporting both USM and buffers at memory creation,
+   allowing user to mix those at a primitive execution), the DPC++ specific
+   header defines `dnnl::sycl::memory_kind` enum class, that declares different
+   kinds of memory (device USM, shared USM, and buffers).
+   - A memory object created through RT-agnostic API (`dnnl.hpp`) will use
+     _device USM_ as an option that gives the best performance and usability.
+
+
+The relevant piece of the `dnnl_sycl.hpp`:
+
+``` cpp
+namespace dnnl {
+namespace sycl {
+
+enum class memory_kind { // maybe memory_model is better name?
+    usm_device, // default for SYCL-agnostic engine creation
+    usm_shared,
+    buffer,
+};
+
+// for mkind == buffer, handle could only be DNNL_MEMORY_{ALLOCATE,NONE}
+memory memory_create(const desc &md, const engine &aengine, memory_kind mkind,
+        void *handle = DNNL_MEMORY_ALLOCATE);
+memory memory_create(const desc &md, const engine &astream, memory_kind mkind,
+        void *handle = DNNL_MEMORY_ALLOCATE);
+
+// API for sycl buffers The `memory_kind == buffer` is implied.
+template <typename T, int ndims>
+memory memory_create(const desc &md, const engine &aengine,
+        cl::sycl::buffer<T, ndims> buf, stream &s);
+
+// memory_kind could be changed during the lifetime, by setting the USM handle
+// or SYCL buffer
+memory_kind memory_get_memory_kind(const memory &amemory);
+
+} // namespace sycl
+} // namespace dnnl
+```
+
+
+### 3.4. Primitive Execution
+
+DPC++ and OpenCL potentially might need to support events at the execution API.
+For this purpose, the interoperability API is used:
+``` cpp
+// =============
+// dnnl_sycl.hpp
+// =============
+cl::sycl::event dnnl::sycl::primitive_execute(const primitive &p,
+        const stream &s, const std::unordered_map<int, memory> &args,
+        const std::vector<cl::sycl::event> &dependencies = {});
+
+// Similarly for dnnl_ocl.hpp, which we currently don't have, as only support
+// in-order queues. Could add later, if required.
+```
+
+The `dnnl::primitive::execute()` function that lives in `dnnl.hpp` will assume
+that there are no dependencies for the given primitive, and that the resulting
+event is unused. That should work fine for the in-order streams or with
+manual `stream::wait()` calls from a user side.
+
+
+### 3.5 API Classes (NOT TO BE IMPLEMENTED)
+
+> This is a brief introduction to the idea that is **not** suggested to be
+> implemented and included here mostly due to the significance of it. More
+> implementation details could be read in
+> [Dropped Ideas: API Classes](dropped-ideas-api-classes.md).
+
+It was suggested to introduce a new enum `dnnl::api`, which names the API
+classes the library supports. For native C/C++ API the enum contains `api::c`.
+Exactly this API class is fully defined in `dnnl.hpp`, and only engine kind
+supported by this API is CPU. It was also suggested that for DPC++ library
+configuration (`dnnl_cpu_dpcpp_gpu_dpcpp`) it is allowed to create engine with
+native C API.  This will allow supporting native C++ applications as well as
+DPC++ applications within a single configuration.
+
+The list of `dnnl::api` values would be:
+
+| `dnnl::api`       | API to work with | Memory buffer representation                        |
+| :--               | :--              | :--                                                 |
+| `api::c`          | Native C/C++     | `void *`                                            |
+| `api::sycl`       | DPC++            | Further dispatch based on `dnnl::sycl::memory_kind` |
+| `api::ocl`        | OpenCL           | `cl_mem`                                            |
+
+The engine constructor in `dnnl.hpp` is to be extended with a new parameter:
+``` cpp
+struct engine {
+    engine(engine::kind akind, dnnl::api aapi, size_t index);
+
+    dnnl::api get_api() const;
+};
+```
+
+As mentioned above, that would allow creating native C++ CPU engine for the
+DPC++ library configuration. With such API we could easily enable plugin system
+in the library: `api` indicates what plugin to load.
+
+However, after some discussions we decided that:
+1. We are not going to enable plugin system any time soon;
+2. The `api` doesn't bring any value except for allowing creating native C++
+   CPU engine for DPC++ build. In turn, we see no much value in having this
+   ability. It seems that users would either use only DPC++ on CPU or only
+   native C++. For the latter group (which is, e.g. some frameworks) we need to
+   provide the corresponding configuration anyways, say `cpu_gomp_gpu_dpcpp`.
+
+With that in mind we decided to not pursue adding the `api` enum and keep it
+for future extensions, if we get the corresponding requests. The plugin system,
+which seems to be much more valuable and possible in the future, requires much
+more than just adding the `api` enum anyways, so there would be very little
+value in adding it right away.
+
+
+## 4. Discussion
+
+
+### 4.1. Library Configurations
+
+The proposed API is very similar to the current API (except for small technical
+details). In particular, the API doesn't change anything with respect to the
+way the library is shipped in the binary forms.
+
+Given we received multiple asks to support Native C++ CPU along with DPC++ GPU,
+we anticipate the need to ship the following configuration:
+- `cpu_gomp`
+- `cpu_iomp`
+- `cpu_tbb`
+- `cpu_iomp_gpu_dpcpp`
+- `cpu_dpcpp_gpu_dpcpp`
+
+Frameworks are also welcome to build the library from sources (just like they
+do now), in which case an arbitrary configuration could be chosen.
+
+
+### 4.2. Trade-offs
+
+1. Multi-GPU systems. The API doesn't help with specifying the type of the GPU
+   that will be picked when engine is created. For instance, if a system has
+   both iGPU and dGPU, what `dnnl::engine(engine::kind::gpu, 0)` will pick?
+   Internally we probably could create a priority list, e.g. make dGPU be more
+   preferable than iGPU. That could be handy for the testing. Alternatively, we
+   could just rely on `gpu_selector{}` mechanism that DPC++ has, and maybe ask
+   to provide an environment control over the default selector to be able to
+   control what oneDNN chooses. Finally, we could just make our tests more
+   advanced to pick a proper GPU (via option, or just implicitly), and ask
+   users to use the advanced API where our engine is created with SYCL device.
+
+
+### 4.3. Incompatible Changes: v1.x and v2.x
+
+1. **Native C++** API
+   - Stream attributes are dropped as unused. Mostly affects TF thread pool
+     integration, as it is unlikely anyone else uses stream attributes.
+
+2. **ThreadPool** API
+   - Same as above + the way to create a stream with thread pool attached
+     happens by including `dnnl_threadpool.hpp` header file and calling
+     ``` cpp
+     dnnl::threadpool::create_stream(const engine &e, threadpool_iface *thread_pool);
+     ```
+
+3. **OpenCL** API
+   - Same as bullet 1, and the way engine, stream, and memory are created with
+     the corresponding CL objects: instead of constructors a free functions
+     that live in a separate `dnnl_ocl.hpp` header file should be used.
+
+
+### 4.4. Incompatible Changes: `dev-v2` (v2.0-betaX) and v2.x
+
+Since `dev-v2` essentially based on v1.x the incompatible changes repeat the
+one above.
+
+1. **DPC++** API
+   - Constructors with SYCL objects are migrated to `dnnl_sycl.hpp` into a free
+     functions, like `dnnl::sycl::engine_create(dev, ctx)` with slightly
+     different parameters.
+   - The default memory kind switched from buffers to device USM.
+   - There is no more control between buffers and USM via
+     `DNNL_USE_SYCL_BUFFERS` macro. The control happens through passing the
+     desired memory kind to memory creation: `dnnl::sycl::memory_create(...)`.
+   - Primitive execution that has dependencies and returns a SYCL event is
+     moved to a separate function `dnnl::sycl::primitive_execute(...)`.
+
+
+### 4.5. Feedback from Frameworks
+
+TBA.
+
+
+---
+
+EOD

--- a/rfcs/20200717-onednn-v2/history/api-mockups/MORE.md
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/MORE.md
@@ -1,0 +1,86 @@
+# Additions To The Main [README.md](README.md)
+
+## 1. Core API: Universal vs Narrow
+
+> **Assumption** We move the RT-specific interop API into separate headers,
+>  e.g. `dnnl_sycl.hpp`, `dnnl_ocl.h`.
+
+The RT-agnostic API is called Core API. Essentially, this is `dnnl.h{,pp}` and
+`dnnl_types.h`.
+
+### Question
+
+Should interop API interact with the library through the C Core API (by using
+type-erased generic-enough functions) or should directly go to the library?
+
+#### Option 1. Interop API (and C++ Core API) goes through C Core API
+
+``` cpp
+// dnnl_sycl.hpp
+#include "dnnl.h" // for dnnl_memory_create_generic()
+namespace dnnl {
+memory make_memory(dnnl::engine e, cl::sycl::buffer buf) {
+    unsigned flags = dnnl_sycl_memory_kind_usm;
+    dnnl_memory_create_generic(e.get(), flags, (void*)&buf);
+    ...
+    return mem;
+}
+} // namespace dnnl
+```
+
+Advantages:
+1. If a "wrong" `libdnnl.so` was loaded, the application won't crash, but
+   gracefully reports an issue on creating an engine (for that case when
+   initially an application was built against oneDNN w/ SYCL, but then was run
+   with oneDNN w/o SYCL).
+   - This advantage, however, could be seen as disadvantage too, as linking or
+     runtime issue could help understanding earlier that something goes wrong.
+2. Assuming the C Core API is "stable" (i.e. doesn't often change) this model
+   more or less guaranties that the final user application will use only one
+   oneDNN library (even if several copies are loaded).
+3. Minor. Less chance to break backwards compatibility, as oneDNN C++ API
+   doesn't directly use the library, but through C API: the ABI surface is
+   tangible.
+4. If we decide to implement plugin model in future, this approach, in theory,
+   would not require users to link against plugins themselves, as the whole
+   communication will happen through the main API (code library).
+
+#### Option 2. Interop API can directly go to the library
+
+   ``` cpp
+// dnnl_sycl.hpp
+namespace dnnl {
+memory make_memory(dnnl::engine e, cl::sycl::buffer buf);
+} // namespace dnnl
+
+// src/sycl/cxxapi/memory.cpp
+dnnl::memory dnnl::make_memory(dnnl::engine e, cl::sycl::buffer buf) {
+    ...
+}
+```
+
+Advantages:
+1. See the 1st advantage of the Option 1.
+2. Future proof: there is more flexibility to add more RT-specific stuff in
+   future as there is no need to adjust the Core API.
+
+
+## More Questions
+
+1. We have `dnnl_cpu_omp` configuration and code that works with it, running
+   with the assumption that default stream is in-order (even more, actually,
+   **blocking**) and `data_handle` for memory is just a pointer. We now replace
+   the library with `dnnl_cpu_dpcpp`. Do we expect the same source code to
+   continue working? Without rebuilding? With rebuilding?
+   - If we do, that might make us require from user to create SYCL engine not
+     as `engine(kind::cpu, 0)` as it is now, but with something like
+     `engine(api_kind::sycl, kind::cpu, 0)`. This is, however, doesn't aligned
+     well with GPU and OCL...
+   - This also will make the testing more complex, as we need to specify the
+     RT. We may have something line `DNNL_OVERRIDE_DEFAULT_RT={CPP,OCL,SYCL}`
+     and set this environment variable during our testing, but still.
+
+
+---
+
+EOD

--- a/rfcs/20200717-onednn-v2/history/api-mockups/README.md
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/README.md
@@ -1,0 +1,54 @@
+# oneDNN interoperability API mockups
+
+> See also: [MORE.md](MORE.md).
+
+Here interoperability API means functions to
+* create oneDNN objects from runtime-native objects,
+* retrieve runtime-native objects from oneDNN objects,
+* setting runtime-native objects underlying oneDNN objects.
+
+The requirement to all the proposal is to keep the main `dnnl.hpp` free from
+runtime-specific includes.
+
+## Common API semantics update
+
+### USM and SYCL buffers
+
+Currently oneDNN requires a compile-time switch to enable USM. This should go
+away. But there is still a question what a memory object constructed without a
+handle should contain: a SYCL buffer or an USM pointer, and, if it is the
+latter, whether the USM pointer should have a shared or device class.
+
+* Option 1: a memory object constructed without a handle should contain a SYCL
+  buffer. This option ensures oneDNN behavior is compatible between DPC++ and
+  ComputeCPP which does not support USM (at least yet...). It also would work
+  well regardless of whether the default queue is in or out of order. The
+  downside of this option is that USM-based code will have to always provide
+  pointers.
+
+* Option 2a: a memory object constructed without handle should contain a
+  device-specific USM pointer. This option makes SYCL GPU and SYCL CPU behave
+  in fashion very similar to traditional CPU with respect to memory allocation.
+  Alignment with respect to execution is only realized for in-order queues. The
+  downside of this option is that buffers-based code will have to always use
+  interoperability API and that out-of-order queues will require special
+  handling.
+
+* Option 2b: a memory object constructed without handle should contain a shared
+  USM pointer. It may be an upgrade from 2a or, probably, the decision to
+  allocate device-specific or shared pointer by default can be based on the
+  capabilities of the HW underlying the engine.
+
+## Runtime API options
+
+*Option 1* introduces separate `dnnl::<runtime>` namespaces which contain all
+the necessary interoperability functions. The interoperability functions are
+unique to each runtime and are declared in separate header files.
+
+*Option 2* adds interoperability functions as very generic templates that can
+be later specialized inside the library.
+
+*Option 3* and *Option 3a* implement interoperability in a way similar to
+SYCL. Each runtime introduces separate header file with type traits mapping
+oneDNN types to runtime-specific types, and the main `dnnl.hpp` file declares
+interoperability functions templated with a runtime parameter.

--- a/rfcs/20200717-onednn-v2/history/api-mockups/compile_flags.txt
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/compile_flags.txt
@@ -1,0 +1,3 @@
+-std=c++11
+-I.
+-I/nfs/pdx/disks/mkl_mirror/NN/tools/dpc++/20200601_rls/lnx/compiler/latest/linux/include/sycl/

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option1/dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option1/dnnl.hpp
@@ -1,0 +1,58 @@
+// Inspiration:
+//
+// https://github.com/KhronosGroup/SYCL-Shared/blob/master/proposals/sycl_generalization.md
+//
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+
+// No runtime-specific headers.
+
+namespace dnnl {
+
+struct engine {
+    enum class kind { cpu, gpu };
+
+    engine();
+
+    // Common API constructor. Interpretation of idx is implementation and
+    // kind-specific, but needs to be firmly defined.
+    engine(kind k, int idx);
+
+    kind get_kind();
+};
+
+struct stream {};
+
+struct memory {
+    struct desc {};
+
+    memory();
+
+    // Common API constructor that may fail if a runtime underlying the engine
+    // does not support pointers. SYCL GPU engines default to allocating USM
+    // memory.
+    memory(const desc &d, const engine &e, const stream &s, void *handle = 0);
+
+    // Common API way to retrieve the underlying storage. May fail if the
+    // runtime or this parcitular memory object does not use pointers to store
+    // data.
+    void *get_data_handle();
+
+    // Common API way to set the underlying storage. May fail if the runtime
+    // does not use pointers to store data.
+    void set_data_handle(void *handle, const stream &s);
+};
+
+struct primitive {
+    void execute(const stream &s, const memory &src, const memory &dst) const;
+    void execute(
+            const stream &s, const std::unordered_map<int, memory> &args) const;
+};
+
+#define DNNL_ARG_SRC 0
+#define DNNL_ARG_DST 1
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option1/dnnl_ocl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option1/dnnl_ocl.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+
+#include <CL/cl.h>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+namespace ocl {
+
+engine engine_create(engine::kind kind, cl_device_id dev, cl_context ctx);
+cl_device_id engine_get_device(const engine &e);
+cl_context engine_get_context(const engine &e);
+
+stream stream_create(const engine &e, cl_command_queue queue);
+cl_command_queue stream_get_queue(const stream &s);
+
+memory memory_create(cl_mem mem_object);
+void memory_set_data_handle(memory &m, cl_mem mem_object);
+cl_mem memory_get_data_handle(const memory &m);
+
+cl_event execute(const primitive &p, const stream &s,
+        const std::unordered_map<int, memory> &args,
+        const std::vector<cl_event> &dependencies = {});
+
+} // namespace ocl
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option1/dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option1/dnnl_sycl.hpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <CL/sycl.hpp>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+namespace sycl {
+
+engine engine_create(engine::kind kind, const cl::sycl::device &dev,
+        const cl::sycl::context &ctx);
+cl::sycl::device engine_get_device(const engine &e);
+cl::sycl::context engine_get_context(const engine &e);
+
+stream stream_create(const engine &e, cl::sycl::queue &queue);
+cl::sycl::queue stream_get_queue(const stream &s);
+
+template <typename T, int ndims>
+memory memory_create(cl::sycl::buffer<T, ndims> buf, stream &s);
+template <typename T, int ndims>
+void memory_set_data_handle(memory &m, cl::sycl::buffer<T, ndims> b, stream &s);
+template <typename T, int ndims>
+cl::sycl::buffer<T, ndims> memory_get_data_handle(const memory &m);
+
+cl::sycl::event execute(const primitive &p, const stream &s,
+        const std::unordered_map<int, memory> &args,
+        const std::vector<cl::sycl::event> &dependencies = {});
+
+} // namespace sycl
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option1/test.cpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option1/test.cpp
@@ -1,0 +1,31 @@
+#include "dnnl.hpp"
+#include "dnnl_sycl.hpp"
+
+int main(int argc, char **argv) {
+    dnnl::memory m;
+    dnnl::engine e;
+    dnnl::stream s;
+    dnnl::primitive p;
+
+    float *ptr = new float[100];
+    cl::sycl::buffer<float, 1> buf(cl::sycl::range<1>(100));
+
+    m.set_data_handle(ptr, s);
+    dnnl::sycl::memory_set_data_handle(m, buf, s);
+
+    buf = dnnl::sycl::memory_get_data_handle<float, 1>(m);
+    ptr = static_cast<decltype(ptr)>(m.get_data_handle());
+
+    auto d = dnnl::sycl::engine_get_device(e);
+    auto c = dnnl::sycl::engine_get_context(e);
+
+    e = dnnl::sycl::engine_create(e.get_kind(), d, c);
+
+    auto q = dnnl::sycl::stream_get_queue(s);
+    s = dnnl::sycl::stream_create(e, q);
+
+    std::unordered_map<int, dnnl::memory> args
+            = {{DNNL_ARG_SRC, m}, {DNNL_ARG_DST, m}};
+    auto ev = dnnl::sycl::execute(p, s, args);
+    ev = dnnl::sycl::execute(p, s, args, {ev});
+}

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option2/dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option2/dnnl.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+
+// No runtime-specific headers.
+
+namespace dnnl {
+
+struct engine {
+    enum class kind { cpu, gpu };
+
+    engine();
+
+    // Common API constructor. Interpretation of idx is implementation and
+    // kind-specific, but needs to be firmly defined.
+    engine(kind k, int idx);
+
+    kind get_kind();
+};
+
+struct stream {};
+
+struct memory {
+    struct desc {};
+
+    memory();
+
+    // Common API constructor that may fail if a runtime underlying the engine
+    // does not support pointers. SYCL GPU engines default to allocating USM
+    // memory.
+    memory(const desc &d, const engine &e, const stream &s, void *handle = 0);
+
+    // Common API way to retrieve the underlying storage. May fail if the
+    // runtime or this particular memory object does not use pointers to store
+    // data.
+    void *get_data_handle();
+
+    // Common API way to set the underlying storage. May fail if the runtime
+    // does not use pointers to store data.
+    void set_data_handle(void *handle, const stream &s);
+};
+
+struct primitive {
+    void execute(const stream &s, const memory &src, const memory &dst) const;
+    void execute(
+            const stream &s, const std::unordered_map<int, memory> &args) const;
+};
+
+#define DNNL_ARG_SRC 0
+#define DNNL_ARG_DST 1
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option2/dnnl_interop.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option2/dnnl_interop.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "dnnl.hpp"
+
+// A separate header for exposition purposes. All things here may be declared
+// in dnnl.hpp.
+
+namespace dnnl {
+
+// Memory factory.
+template <typename... Args>
+memory make(const engine &e, const stream &s, Args &&... args);
+
+// Returns the underlying memory storage object. Throws if the underlying
+// memory storage object has a different type.
+template <typename RuntimeT, typename... Args>
+RuntimeT get_native(const memory &m, Args &&... args);
+
+// Sets the underlying memory storage object. Throws if the memory object does
+// not support this type of object.
+template <typename... Args>
+void set_native(memory &m, const stream &s, Args &&... args);
+
+// Engine factory.
+template <typename... Args>
+engine make(engine::kind kind, Args &&... args);
+
+// Returns the device or the context underlying an engine. Throws on type
+// mismatch.
+template <typename RuntimeT, typename... Args>
+RuntimeT get_native(const engine &e, Args &&... args);
+
+// Stream factory.
+template <typename... Args>
+stream make(const engine &e, Args &&... args);
+
+// Returns the queue underlying a stream. Throws if there is none.
+template <typename RuntimeT, typename... Args>
+RuntimeT get_native(const stream &s, Args &&... args);
+
+// Executes a primitive.
+template <typename EventT>
+EventT execute(const primitive &p, const stream &s,
+        const std::unordered_map<int, memory> &args,
+        const std::vector<EventT> &dependencies = {});
+
+// Executes a primitive. Standalone function for consistency. Should belong to
+// dnnl.hpp
+void execute(const primitive &p, const stream &s,
+        const std::unordered_map<int, memory> &args);
+
+// Executes a 'reorder'.
+template <typename EventT>
+EventT execute(const primitive &p, const stream &s, const memory &src,
+        memory &dst, const std::vector<EventT> &dependencies = {});
+
+// Executes a 'reorder'. Standalone function for consistency. Should belong to
+// dnnl.hpp
+void execute(const primitive &p, const stream &s, const memory &src,
+        memory &dst);
+}

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option2/test.cpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option2/test.cpp
@@ -1,0 +1,44 @@
+#include <type_traits>
+
+#include <CL/sycl.hpp> // Only in the user's code
+
+#include "dnnl.hpp"
+#include "dnnl_interop.hpp"
+
+int main(int argc, char **argv) {
+    dnnl::memory m;
+    dnnl::engine e;
+    dnnl::stream s;
+    dnnl::primitive p;
+
+    float *ptr = new float[100];
+    cl::sycl::buffer<float, 1> buf(cl::sycl::range<1>(100));
+
+    m.set_data_handle(ptr, s);
+    dnnl::set_native(m, s, buf);
+
+    // XXX: we would need overloads for all the types and dimensions?
+    buf = dnnl::get_native<decltype(buf)>(m);
+
+    ptr = static_cast<decltype(ptr)>(m.get_data_handle());
+    ptr = dnnl::get_native<decltype(ptr)>(m);
+
+    auto d = dnnl::get_native<cl::sycl::device>(e);
+    auto c = dnnl::get_native<cl::sycl::context>(e);
+
+    auto e1 = dnnl::make(e.get_kind(), d, c);
+    static_assert(std::is_same<decltype(e1), decltype(e)>::value, "OK");
+
+    auto q = dnnl::get_native<cl::sycl::queue>(s);
+    auto s1 = dnnl::make(e, q);
+    static_assert(std::is_same<decltype(s1), decltype(s)>::value, "OK");
+
+    std::unordered_map<int, dnnl::memory> args
+            = {{DNNL_ARG_SRC, m}, {DNNL_ARG_DST, m}};
+    auto ev = dnnl::execute<cl::sycl::event>(p, s, args);
+    auto ev1 = dnnl::execute<cl::sycl::event>(p, s, args, {ev});
+    auto ev2 = dnnl::execute(p, s, args, std::vector<decltype(ev)>({ev}));
+    static_assert(std::is_same<cl::sycl::event, decltype(ev)>::value, "OK");
+    static_assert(std::is_same<decltype(ev1), decltype(ev)>::value, "OK");
+    static_assert(std::is_same<decltype(ev2), decltype(ev)>::value, "OK");
+}

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3/dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3/dnnl.hpp
@@ -1,0 +1,153 @@
+// Inspiration:
+//
+// https://github.com/KhronosGroup/SYCL-Shared/blob/master/proposals/sycl_generalization.md
+//
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+#include <unordered_map>
+
+// No runtime-specific headers.
+
+namespace dnnl {
+
+enum class runtime {
+    seq,
+    omp,
+    tbb,
+    threadpool,
+    ocl,
+    sycl, // collides with the namespace, unfortunately...
+};
+
+// Interop trait that maps a (runtime, dnnl type) pair to a runtime-specific
+// type via ::type
+template <runtime name, typename object>
+struct interop;
+
+struct engine {
+    enum class kind { cpu, gpu };
+
+    engine();
+
+    // Common API constructor. Interpretation of idx is implementation and
+    // kind-specific, but needs to be firmly defined.
+    engine(kind k, int idx);
+
+    // Returns runtime associated with the engine.
+    runtime get_runtime();
+
+    kind get_kind();
+
+    // Returns the underlying runtime-specific object. Throws if none is
+    // available.
+    template <runtime name>
+    typename interop<name, engine>::type get_native() const;
+};
+
+// Runtime-specific engine factory.
+template <runtime name>
+engine make_from_native(
+        engine::kind k, typename interop<name, engine>::type native);
+
+struct stream {
+    stream();
+
+    stream(const engine &e);
+
+    // Returns the underlying runtime-specific object. Throws if none is
+    // available.
+    template <runtime name>
+    typename interop<name, stream>::type get_native() const;
+};
+
+// Runtime-specific memory factory.
+template <runtime name>
+stream make_from_native(
+        const engine &e, const typename interop<name, stream>::type native);
+
+struct memory {
+    struct desc {};
+
+    memory();
+
+    desc get_desc();
+
+    // Common API constructor that may fail if a runtime underlying the engine
+    // does not support pointers. SYCL GPU engines default to allocating USM
+    // memory.
+    memory(const desc &d, const engine &e, const stream &s, void *handle = 0);
+
+    // Common API way to retrieve the underlying storage. May fail if the
+    // runtime or this parcitular memory object does not use pointers to store
+    // data.
+    void *get_data_handle();
+
+    // Common API way to set the underlying storage. May fail if the runtime
+    // does not use pointers to store data.
+    void set_data_handle(void *handle, const stream &s);
+
+    // Templated runtime-specific way to retrieve the underlying storage. May
+    // fail if this particular memory object uses a different runtime or uses
+    // pointers to store data.
+    template <runtime name>
+    typename interop<name, memory>::type get_native() const;
+
+    // Templated runtime-specific way to retrieve the underlying storage. May
+    // fail if this particular memory object uses a different runtime or uses
+    // pointers to store data.
+    template <runtime name, typename T = uint8_t, int dims = 1>
+    typename interop<name, memory>::template typed_type<T, dims>
+    get_native() const;
+
+    // Templated and typed runtime-specific way to set the underlying storage.
+    // May fail if this particular memory object uses a different runtime.
+    template <runtime name>
+    void set_native(
+            typename interop<name, memory>::type handle, const stream &s);
+
+    // Templated and typed runtime-specific way to set the underlying storage.
+    // May fail if this particular memory object uses a different runtime.
+    template <runtime name, typename T, int dims>
+    void set_native(
+            typename interop<name, memory>::template typed_type<T, dims> handle,
+            const stream &s);
+};
+
+// Runtime-specific memory factory.
+template <runtime name>
+memory make_from_native(const memory::desc &d, const engine &e,
+        const typename interop<name, memory>::type handle);
+
+// Runtime-specific typed memory factory.
+template <runtime name, typename T, int dims>
+memory make_from_native(const memory::desc &d, const engine &e,
+        const typename interop<name, memory>::template typed_type<T, dims>
+                handle);
+
+struct primitive {
+    void execute(const stream &s, const memory &src, const memory &dst) const;
+    void execute(
+            const stream &s, const std::unordered_map<int, memory> &args) const;
+};
+
+// Runtime-specific execute functions.
+template <runtime name>
+typename interop<name, stream>::event execute(const primitive &p,
+        const stream &s, const std::unordered_map<int, memory> &args,
+        const std::vector<typename interop<name, stream>::event> &dependencies
+        = {});
+
+// Runtime-specific reorder execute function.
+template <runtime name>
+typename interop<name, stream>::event execute(const primitive &p,
+        const stream &s, const memory &src, const memory &dst,
+        const std::vector<typename interop<name, stream>::event> &dependencies
+        = {});
+
+#define DNNL_ARG_SRC 0
+#define DNNL_ARG_DST 1
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3/dnnl_ocl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3/dnnl_ocl.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <utility>
+#include <CL/cl.h>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+
+template <>
+struct interop<dnnl::runtime::ocl, engine> {
+    // Have to use a tuple to return two values.
+    using type = std::pair<cl_device_id, cl_context>;
+};
+
+template <>
+struct interop<dnnl::runtime::ocl, stream> {
+    using type = cl_command_queue;
+    using event = cl_event; // XXX not so nice :(
+};
+
+template <>
+struct interop<dnnl::runtime::ocl, memory> {
+    using type = std::pair<cl_mem, size_t>;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3/dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3/dnnl_sycl.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <utility>
+#include <CL/sycl.hpp>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+
+template <>
+struct interop<dnnl::runtime::sycl, engine> {
+    // Have to use a tuple to return two values.
+    using type = std::pair<cl::sycl::device, cl::sycl::context>;
+};
+
+template <>
+struct interop<dnnl::runtime::sycl, stream> {
+    using type = cl::sycl::queue;
+    using event = cl::sycl::event; // XXX not so nice :(
+};
+
+template <>
+struct interop<dnnl::runtime::sycl, memory> {
+    template <typename T, int dims>
+    using typed_type = std::pair<cl::sycl::buffer<T, dims>, size_t>;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3/test.cpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3/test.cpp
@@ -1,0 +1,52 @@
+#include <utility>
+#include <type_traits>
+
+#include "dnnl.hpp"
+#include "dnnl_sycl.hpp"
+
+int main() {
+    dnnl::memory m;
+    dnnl::engine e;
+    dnnl::stream s;
+    dnnl::primitive p;
+
+    float *ptr = new float[100];
+    cl::sycl::buffer<float, 2> buf(cl::sycl::range<2>(10, 10));
+
+    m.set_data_handle(ptr, s);
+    auto span = std::make_pair(buf, size_t(0));
+    m.set_native<dnnl::runtime::sycl>(span, s);
+
+    auto span1 = m.get_native<dnnl::runtime::sycl>();
+    static_assert(
+            std::is_same<decltype(span1),
+                    std::pair<cl::sycl::buffer<uint8_t, 1>, size_t>>::value,
+            "OK");
+
+    auto span2 = m.get_native<dnnl::runtime::sycl, float, 2>();
+    static_assert(std::is_same<decltype(span2), decltype(span)>::value, "OK");
+
+    // XXX it is not clear that a memory is being created
+    m = dnnl::make_from_native<dnnl::runtime::sycl>(m.get_desc(), e, span1);
+
+    auto dc = e.get_native<dnnl::runtime::sycl>();
+    static_assert(
+            std::is_same<decltype(dc.first), cl::sycl::device>::value, "OK");
+    static_assert(
+            std::is_same<decltype(dc.second), cl::sycl::context>::value, "OK");
+
+    // XXX it is not clear that an engine is being created
+    auto e1 = dnnl::make_from_native<dnnl::runtime::sycl>(e.get_kind(), dc);
+    static_assert(std::is_same<decltype(e1), decltype(e)>::value, "OK");
+
+    auto q = s.get_native<dnnl::runtime::sycl>();
+    auto s1 = dnnl::make_from_native<dnnl::runtime::sycl>(e, q);
+    static_assert(std::is_same<decltype(s1), decltype(s)>::value, "OK");
+
+    std::unordered_map<int, dnnl::memory> args
+            = {{DNNL_ARG_SRC, m}, {DNNL_ARG_DST, m}};
+    auto ev = dnnl::execute<dnnl::runtime::sycl>(p, s, args);
+    auto ev1 = dnnl::execute<dnnl::runtime::sycl>(p, s, args, {ev});
+    static_assert(std::is_same<cl::sycl::event, decltype(ev)>::value, "OK");
+    static_assert(std::is_same<decltype(ev1), decltype(ev)>::value, "OK");
+}

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3a/dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3a/dnnl.hpp
@@ -1,0 +1,145 @@
+// Inspiration:
+//
+// https://github.com/KhronosGroup/SYCL-Shared/blob/master/proposals/sycl_generalization.md
+//
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+#include <unordered_map>
+
+// No runtime_class-specific headers.
+
+namespace dnnl {
+
+enum class runtime_class {
+    cpu,
+    ocl,
+    sycl, // collides with the namespace, unfortunately...
+};
+
+// Interop trait that maps a (runtime_class, dnnl type) pair to a
+// runtime_class-specific type via ::type
+template <runtime_class name>
+struct interop;
+
+struct engine {
+    enum class kind { cpu, gpu };
+
+    engine();
+
+    // Common API constructor. Interpretation of idx is implementation and
+    // kind-specific, but needs to be firmly defined.
+    engine(kind k, int idx);
+
+    // Returns runtime_class associated with the engine.
+    runtime_class get_runtime();
+
+    kind get_kind();
+
+    // Returns the underlying runtime_class-specific object. Throws if none is
+    // available.
+    template <runtime_class name>
+    typename interop<name>::engine get_native() const;
+};
+
+// Runtime_class-specific engine factory.
+template <runtime_class name>
+engine make_from_native(engine::kind k, typename interop<name>::engine native);
+
+struct stream {
+    stream();
+
+    stream(const engine &e);
+
+    // Returns the underlying runtime_class-specific object. Throws if none is
+    // available.
+    template <runtime_class name>
+    typename interop<name>::stream get_native() const;
+};
+
+// Runtime_class-specific memory factory.
+template <runtime_class name>
+stream make_from_native(
+        const engine &e, const typename interop<name>::stream native);
+
+struct memory {
+    struct desc {};
+
+    memory();
+
+    desc get_desc();
+
+    // Common API constructor that may fail if a runtime_class underlying the
+    // engine does not support pointers. SYCL GPU engines default to allocating
+    // USM memory.
+    memory(const desc &d, const engine &e, const stream &s, void *handle = 0);
+
+    // Common API way to retrieve the underlying storage. May fail if the
+    // runtime_class or this parcitular memory object does not use pointers to
+    // store data.
+    void *get_data_handle();
+
+    // Common API way to set the underlying storage. May fail if the
+    // runtime_class does not use pointers to store data.
+    void set_data_handle(void *handle, const stream &s);
+
+    // Templated runtime_class-specific way to retrieve the underlying storage.
+    // May fail if this particular memory object uses a different runtime_class
+    // or uses pointers to store data.
+    template <runtime_class name>
+    typename interop<name>::memory get_native() const;
+
+    // Templated runtime_class-specific way to retrieve the underlying storage.
+    // May fail if this particular memory object uses a different runtime_class
+    // or uses pointers to store data.
+    template <runtime_class name, typename T = uint8_t, int dims = 1>
+    typename interop<name>::template memory<T, dims> get_native() const;
+
+    // Templated and typed runtime_class-specific way to set the underlying
+    // storage. May fail if this particular memory object uses a different
+    // runtime_class.
+    template <runtime_class name>
+    void set_native(typename interop<name>::memory handle, const stream &s);
+
+    // Templated and typed runtime_class-specific way to set the underlying
+    // storage. May fail if this particular memory object uses a different
+    // runtime_class.
+    template <runtime_class name, typename T, int dims>
+    void set_native(typename interop<name>::template memory<T, dims> handle,
+            const stream &s);
+};
+
+// Runtime_class-specific memory factory.
+template <runtime_class name>
+memory make_from_native(const memory::desc &d, const engine &e,
+        const typename interop<name>::memory handle);
+
+// Runtime_class-specific typed memory factory.
+template <runtime_class name, typename T, int dims>
+memory make_from_native(const memory::desc &d, const engine &e,
+        const typename interop<name>::template memory<T, dims> handle);
+
+struct primitive {
+    void execute(const stream &s, const memory &src, const memory &dst) const;
+    void execute(
+            const stream &s, const std::unordered_map<int, memory> &args) const;
+};
+
+// Runtime_class-specific execute functions.
+template <runtime_class name>
+typename interop<name>::event execute(const primitive &p, const stream &s,
+        const std::unordered_map<int, memory> &args,
+        const std::vector<typename interop<name>::event> &dependencies = {});
+
+// Runtime_class-specific reorder execute function.
+template <runtime_class name>
+typename interop<name>::event execute(const primitive &p, const stream &s,
+        const memory &src, const memory &dst,
+        const std::vector<typename interop<name>::event> &dependencies = {});
+
+#define DNNL_ARG_SRC 0
+#define DNNL_ARG_DST 1
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3a/dnnl_ocl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3a/dnnl_ocl.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <utility>
+#include <CL/cl.h>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+
+template <>
+struct interop<dnnl::runtime_class::ocl> {
+    using engine = std::pair<cl_device_id, cl_context>;
+    using stream = cl_command_queue;
+    using event = cl_event;
+    using memory = std::pair<cl_mem, size_t>;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3a/dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3a/dnnl_sycl.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <utility>
+#include <CL/sycl.hpp>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+
+template <>
+struct interop<dnnl::runtime_class::sycl> {
+    using engine = std::pair<cl::sycl::device, cl::sycl::context>;
+    using stream = cl::sycl::queue;
+    using event = cl::sycl::event;
+    template <typename T, int dims>
+    using memory = std::pair<cl::sycl::buffer<T, dims>, size_t>;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3a/test_ocl.cpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3a/test_ocl.cpp
@@ -1,0 +1,48 @@
+#include <utility>
+#include <type_traits>
+
+#include "dnnl.hpp"
+#include "dnnl_ocl.hpp"
+
+int main() {
+    dnnl::memory m;
+    dnnl::engine e;
+    dnnl::stream s;
+    dnnl::primitive p;
+
+    float *ptr = new float[100];
+    cl_mem buf;
+
+    m.set_data_handle(ptr, s);
+    auto span = std::make_pair(buf, size_t(0));
+    m.set_native<dnnl::runtime_class::ocl>(span, s);
+
+    auto span1 = m.get_native<dnnl::runtime_class::ocl>();
+    static_assert(
+            std::is_same<decltype(span1), std::pair<cl_mem, size_t>>::value,
+            "OK");
+
+    // XXX it is not clear that a memory is being created
+    m = dnnl::make_from_native<dnnl::runtime_class::ocl>(
+            m.get_desc(), e, span1);
+
+    auto dc = e.get_native<dnnl::runtime_class::ocl>();
+    static_assert(std::is_same<decltype(dc.first), cl_device_id>::value, "OK");
+    static_assert(std::is_same<decltype(dc.second), cl_context>::value, "OK");
+
+    // XXX it is not clear that an engine is being created
+    auto e1 = dnnl::make_from_native<dnnl::runtime_class::ocl>(
+            e.get_kind(), dc);
+    static_assert(std::is_same<decltype(e1), decltype(e)>::value, "OK");
+
+    auto q = s.get_native<dnnl::runtime_class::ocl>();
+    auto s1 = dnnl::make_from_native<dnnl::runtime_class::ocl>(e, q);
+    static_assert(std::is_same<decltype(s1), decltype(s)>::value, "OK");
+
+    std::unordered_map<int, dnnl::memory> args
+            = {{DNNL_ARG_SRC, m}, {DNNL_ARG_DST, m}};
+    auto ev = dnnl::execute<dnnl::runtime_class::ocl>(p, s, args);
+    auto ev1 = dnnl::execute<dnnl::runtime_class::ocl>(p, s, args, {ev});
+    static_assert(std::is_same<cl_event, decltype(ev)>::value, "OK");
+    static_assert(std::is_same<decltype(ev1), decltype(ev)>::value, "OK");
+}

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option3a/test_sycl.cpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option3a/test_sycl.cpp
@@ -1,0 +1,54 @@
+#include <utility>
+#include <type_traits>
+
+#include "dnnl.hpp"
+#include "dnnl_sycl.hpp"
+
+int main() {
+    dnnl::memory m;
+    dnnl::engine e;
+    dnnl::stream s;
+    dnnl::primitive p;
+
+    float *ptr = new float[100];
+    cl::sycl::buffer<float, 2> buf(cl::sycl::range<2>(10, 10));
+
+    m.set_data_handle(ptr, s);
+    auto span = std::make_pair(buf, size_t(0));
+    m.set_native<dnnl::runtime_class::sycl>(span, s);
+
+    auto span1 = m.get_native<dnnl::runtime_class::sycl>();
+    static_assert(
+            std::is_same<decltype(span1),
+                    std::pair<cl::sycl::buffer<uint8_t, 1>, size_t>>::value,
+            "OK");
+
+    auto span2 = m.get_native<dnnl::runtime_class::sycl, float, 2>();
+    static_assert(std::is_same<decltype(span2), decltype(span)>::value, "OK");
+
+    // XXX it is not clear that a memory is being created
+    m = dnnl::make_from_native<dnnl::runtime_class::sycl>(
+            m.get_desc(), e, span1);
+
+    auto dc = e.get_native<dnnl::runtime_class::sycl>();
+    static_assert(
+            std::is_same<decltype(dc.first), cl::sycl::device>::value, "OK");
+    static_assert(
+            std::is_same<decltype(dc.second), cl::sycl::context>::value, "OK");
+
+    // XXX it is not clear that an engine is being created
+    auto e1 = dnnl::make_from_native<dnnl::runtime_class::sycl>(
+            e.get_kind(), dc);
+    static_assert(std::is_same<decltype(e1), decltype(e)>::value, "OK");
+
+    auto q = s.get_native<dnnl::runtime_class::sycl>();
+    auto s1 = dnnl::make_from_native<dnnl::runtime_class::sycl>(e, q);
+    static_assert(std::is_same<decltype(s1), decltype(s)>::value, "OK");
+
+    std::unordered_map<int, dnnl::memory> args
+            = {{DNNL_ARG_SRC, m}, {DNNL_ARG_DST, m}};
+    auto ev = dnnl::execute<dnnl::runtime_class::sycl>(p, s, args);
+    auto ev1 = dnnl::execute<dnnl::runtime_class::sycl>(p, s, args, {ev});
+    static_assert(std::is_same<cl::sycl::event, decltype(ev)>::value, "OK");
+    static_assert(std::is_same<decltype(ev1), decltype(ev)>::value, "OK");
+}

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option4/dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option4/dnnl.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+#include <unordered_map>
+
+namespace dnnl {
+
+enum class api_class { cpp, ocl, sycl, };
+
+struct engine {
+    enum class kind { cpu, gpu };
+
+    engine();
+    engine(kind k, int idx);
+    engine(api_class a, kind k, int idx); // to create pure c++ for dpcpp build
+
+    api_class get_api_class() const;
+    kind get_kind() const;
+
+    // API-specific ctor:
+    // - engine(kind k, cl::sycl::device, cl::sycl::context)
+    template<typename... Args> engine(kind k, Args &&... args);
+
+    // API-specific getter:
+    // - engine::get_api_object<cl::sycl::device>()
+    template<typename T> T get_api_object() const;
+};
+
+struct stream {
+    stream();
+    stream(const engine &e);
+};
+
+using memory_flags_t = dnnl_memory_flags_t; // unsigned
+namespace memory_flags {
+    unsigned skip_zero_pad = 0x1;
+}
+
+struct memory {
+    struct desc {};
+
+    memory();
+
+    desc get_desc() const;
+
+    // backwards compatibility:
+    // memory(const desc &d, const engine &e, void *handle = DNNL_MEM_ALLOCATE);
+
+    memory(const desc &d, const engine &e, void *handle = DNNL_MEM_ALLOCATE);
+    memory(const desc &d, const stream &s, void *handle = DNNL_MEM_ALLOCATE);
+    memory(const desc &d, const engine &e, unsigned flags, void *handle = DNNL_MEM_ALLOCATE);
+    memory(const desc &d, const stream &s, unsigned flags, void *handle = DNNL_MEM_ALLOCATE);
+
+    // Common API way to retrieve the underlying storage. May fail if the
+    // api_class or this particular memory object does not use pointers to
+    // store data.
+    void *get_data_handle();
+
+    // Common API way to set the underlying storage. May fail if the
+    // api_class does not use pointers to store data.
+    void set_data_handle(void *handle);
+    void set_data_handle(void *handle, const stream &s);
+
+};
+
+struct primitive {
+    void execute(const stream &s, const memory &src, const memory &dst) const;
+    void execute(const stream &s, const std::unordered_map<int, memory> &args) const;
+
+    template <typename T>
+    T execute(const stream &s, const memory &src, const memory &dst, const std::vector<T> &deps) const;
+    template <typename T>
+    T execute(const stream &s, const std::unordered_map<int, memory> &args, const std::vector<T> &deps) const;
+};
+
+#define DNNL_ARG_SRC 0
+#define DNNL_ARG_DST 1
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option4/dnnl_ocl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option4/dnnl_ocl.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <utility>
+#include <CL/cl.h>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+
+template <>
+struct interop<dnnl::runtime_class::ocl> {
+    using engine = std::pair<cl_device_id, cl_context>;
+    using stream = cl_command_queue;
+    using event = cl_event;
+    using memory = std::pair<cl_mem, size_t>;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option4/dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option4/dnnl_sycl.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <utility>
+#include <CL/sycl.hpp>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+
+// engine
+template<> inline engine::engine(kind k, cl::sycl::device dev, cl::sycl::context ctx);
+template<> inline cl::sycl::device engine::get_api_object() const;
+template<> inline cl::sycl::context engine::get_api_object() const;
+
+// memory
+
+template <> memory(const desc &d, const engine &e, void *handle = DNNL_MEM_ALLOCATE);
+template <> memory(const desc &d, const stream &s, void *handle = DNNL_MEM_ALLOCATE);
+template <> memory(const desc &d, const engine &e, unsigned flags, void *handle = DNNL_MEM_ALLOCATE);
+template <> memory(const desc &d, const stream &s, unsigned flags, void *handle = DNNL_MEM_ALLOCATE);
+
+
+
+// primitive execution
+template<> inline cl::sycl::event primitive::execute(const stream &s, const memory &src, const memory &dst, const std::vector<cl::sycl::event> &deps) const;
+template<> inline cl::sycl::event primitive::execute(const stream &s, const std::unordered_map<int, memory> &args, const std::vector<cl::sycl::event> &deps) const;
+
+template <>
+struct interop<dnnl::runtime_class::sycl> {
+    using engine = std::pair<cl::sycl::device, cl::sycl::context>;
+    using stream = cl::sycl::queue;
+    using event = cl::sycl::event;
+    template <typename T, int dims>
+    using memory = std::pair<cl::sycl::buffer<T, dims>, size_t>;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option4/test_ocl.cpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option4/test_ocl.cpp
@@ -1,0 +1,48 @@
+#include <utility>
+#include <type_traits>
+
+#include "dnnl.hpp"
+#include "dnnl_ocl.hpp"
+
+int main() {
+    dnnl::memory m;
+    dnnl::engine e;
+    dnnl::stream s;
+    dnnl::primitive p;
+
+    float *ptr = new float[100];
+    cl_mem buf;
+
+    m.set_data_handle(ptr, s);
+    auto span = std::make_pair(buf, size_t(0));
+    m.set_native<dnnl::runtime_class::ocl>(span, s);
+
+    auto span1 = m.get_native<dnnl::runtime_class::ocl>();
+    static_assert(
+            std::is_same<decltype(span1), std::pair<cl_mem, size_t>>::value,
+            "OK");
+
+    // XXX it is not clear that a memory is being created
+    m = dnnl::make_from_native<dnnl::runtime_class::ocl>(
+            m.get_desc(), e, span1);
+
+    auto dc = e.get_native<dnnl::runtime_class::ocl>();
+    static_assert(std::is_same<decltype(dc.first), cl_device_id>::value, "OK");
+    static_assert(std::is_same<decltype(dc.second), cl_context>::value, "OK");
+
+    // XXX it is not clear that an engine is being created
+    auto e1 = dnnl::make_from_native<dnnl::runtime_class::ocl>(
+            e.get_kind(), dc);
+    static_assert(std::is_same<decltype(e1), decltype(e)>::value, "OK");
+
+    auto q = s.get_native<dnnl::runtime_class::ocl>();
+    auto s1 = dnnl::make_from_native<dnnl::runtime_class::ocl>(e, q);
+    static_assert(std::is_same<decltype(s1), decltype(s)>::value, "OK");
+
+    std::unordered_map<int, dnnl::memory> args
+            = {{DNNL_ARG_SRC, m}, {DNNL_ARG_DST, m}};
+    auto ev = dnnl::execute<dnnl::runtime_class::ocl>(p, s, args);
+    auto ev1 = dnnl::execute<dnnl::runtime_class::ocl>(p, s, args, {ev});
+    static_assert(std::is_same<cl_event, decltype(ev)>::value, "OK");
+    static_assert(std::is_same<decltype(ev1), decltype(ev)>::value, "OK");
+}

--- a/rfcs/20200717-onednn-v2/history/api-mockups/option4/test_sycl.cpp
+++ b/rfcs/20200717-onednn-v2/history/api-mockups/option4/test_sycl.cpp
@@ -1,0 +1,29 @@
+#include <utility>
+#include <type_traits>
+
+#include "dnnl.hpp"
+#include "dnnl_sycl.hpp"
+
+int main() {
+    dnnl::memory::desc md;
+    dnnl::memory m;
+    dnnl::engine e;
+    dnnl::stream s;
+    dnnl::primitive p;
+
+    float *ptr = new float[100];
+    cl::sycl::buffer<float, 2> buf(cl::sycl::range<2>(10, 10));
+
+    m = dnnl::memory(md, e);
+    m = dnnl::memory(md, e, ptr); // USM
+    m = dnnl::memory(md, e, no_zero_pad | allocate_usm_shared);
+    m = dnnl::memory(md, e, no_zero_pad, ptr);
+    m = dnnl::memory(md, s, ptr);
+    m = dnnl::memory(md, s, no_zero_pad, ptr); // ???
+
+    m = dnnl::memory(md, e, buf); // Buffer
+
+    m.set_data_handle(ptr);
+    m.set_data_handle(s, ptr);
+    m.set_data_handle(e, no_zero_pad, buf);
+}

--- a/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v1_dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v1_dnnl.hpp
@@ -1,0 +1,95 @@
+namespace dnnl {
+
+struct engine : public handle<dnnl_engine_t> {
+    enum class kind {
+        any = dnnl_any_engine,
+        cpu = dnnl_cpu,
+        gpu = dnnl_gpu,
+    };
+
+    static size_t get_count(kind akind);
+
+    engine(kind akind, size_t index);
+    kind get_kind() const;
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    engine(kind akind, cl_device_id device, cl_context context);
+    cl_context get_ocl_context() const;
+    cl_device_id get_ocl_device() const;
+#endif
+
+#if DNNL_WITH_SYCL
+    engine(kind akind, const cl::sycl::device &dev, const cl::sycl::context &ctx);
+    cl::sycl::context DNNL_API get_sycl_context() const;
+    cl::sycl::device DNNL_API get_sycl_device() const;
+#endif
+};
+
+struct stream : public handle<dnnl_stream_t> {
+    enum class flags : unsigned {
+        default_order = dnnl_stream_default_order,
+        in_order = dnnl_stream_default_order,
+        out_of_order = dnnl_stream_out_of_order,
+        default_flags = dnnl_stream_default_flags,
+    };
+
+    stream(const engine &aengine, flags aflags = flags::default_flags,
+            const stream_attr &attr = stream_attr());
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    stream(const engine &aengine, cl_command_queue queue);
+    cl_command_queue get_ocl_command_queue() const;
+#endif
+
+#if DNNL_WITH_SYCL
+    stream(const engine &aengine, cl::sycl::queue &queue);
+    cl::sycl::queue DNNL_API get_sycl_queue() const;
+#endif
+
+    stream &wait();
+};
+
+struct memory : public handle<dnnl_memory_t> {
+    memory(const desc &md, const engine &aengine, void *handle);
+    memory(const desc &md, const engine &aengine);
+
+    desc get_desc() const;
+    engine get_engine() const;
+
+    void *get_data_handle() const;
+
+    void set_data_handle(void *handle, const stream &astream) const;
+    void set_data_handle(void *handle) const;
+
+    template <typename T = void> T *map_data() const;
+    void unmap_data(void *mapped_ptr) const;
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    cl_mem get_ocl_mem_object() const;
+    void set_ocl_mem_object(cl_mem mem_object);
+#endif
+
+#if DNNL_WITH_SYCL && defined(DNNL_USE_SYCL_BUFFERS)
+    template <typename T, int ndims = 1>
+    memory(const desc &md, const engine &aengine, cl::sycl::buffer<T, ndims> &buf);
+
+    template <typename T, int ndims = 1>
+    cl::sycl::buffer<T, ndims> get_sycl_buffer(size_t *offset = nullptr) const;
+
+    template <typename T, int ndims>
+    void set_sycl_buffer(cl::sycl::buffer<T, ndims> &buf);
+#endif
+};
+
+struct primitive : public handle<dnnl_primitive_t> {
+    void execute(const stream &astream,
+            const std::unordered_map<int, memory> &args) const;
+
+#ifdef DNNL_SYCL_DPCPP
+    cl::sycl::event DNNL_API execute_sycl(const stream &astream,
+            const std::unordered_map<int, memory> &args,
+            const std::vector<cl::sycl::event> &deps = {}) const;
+#endif
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v2_dnnl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v2_dnnl.hpp
@@ -1,0 +1,80 @@
+namespace dnnl {
+
+// Maybe put under engine?
+// Maybe call api_class to avoid overloading the word API?..
+enum class api { c, sycl, ocl, threadpool };
+
+struct engine : public handle<dnnl_engine_t> {
+    enum class kind {
+        any = dnnl_any_engine,
+        cpu = dnnl_cpu,
+        gpu = dnnl_gpu,
+    };
+
+    static size_t get_count(kind akind, api aapi = c);
+
+    // For non-c api:
+    // 1. Creation may fail if api is not supported
+    // 2. The extra parameters in the equivalent dnnl::$api::make_engine(..)
+    //    are implementation specific (but documented). The rule of thumb to
+    //    choose parameters so that user's code continue working with as small
+    //    changes, as possible.
+    //    For instance, for DPCPP the memory model will be USM (but device?).
+    //
+    // For api::c one engine with kind != kind::cpu cannot be created.
+    engine(kind akind, size_t index, api aapi = c);
+    kind get_kind() const;
+    api get_api() const;
+
+    // It could also be useful to add the following query, that would return
+    // true if the underlying memory model could be represented with `void *`:
+    // - api::c || api::threadpool                          true
+    // - api::sycl && memory_kind = usm_{device,shared}     true
+    // - api::sycl && memory_kind = buffer                  false
+    // - api::ocl                                           false
+    bool is_memory_kind_pointer_based() const;
+};
+
+struct stream : public handle<dnnl_stream_t> {
+    // Based on Eugene's proposal for `stream::flags`
+    enum class flags : unsigned {
+        in_order = dnnl_stream_default_order,
+        out_of_order = dnnl_stream_out_of_order,
+        default_flags = in_order,
+    };
+
+    // stream_attr are dropped
+    stream(const engine &aengine, flags aflags = flags::default_flags);
+    stream &wait();
+};
+
+struct memory : public handle<dnnl_memory_t> {
+    // May fail if handle != NONE / ALLOCATE and engine's memory model
+    // doesn't support pointers (i.e. api=c or api=sycl && USM).
+    // For DPCPP may fail if pointer doesn't correspond to the memory_kind.
+    memory(const desc &md, const engine &aengine, void *handle);
+    memory(const desc &md, const engine &aengine);
+    // This ctor requires only engine to be alive along with memory, the stream
+    // is only used to perform zero padding, if necessary, and is discarded
+    // afterwards.
+    memory(const desc &md, const stream &astream, void *handle);
+
+    desc get_desc() const;
+    engine get_engine() const;
+
+    // Works only when memory buffer is represented by pure pointer, i.e.
+    // engine::is_memory_kind_pointer_based() == true.
+    void *get_data_handle() const;
+    void set_data_handle(void *handle, const stream &astream) const;
+    void set_data_handle(void *handle) const;
+
+    template <typename T = void> T *map_data() const;
+    void unmap_data(void *mapped_ptr) const;
+};
+
+struct primitive : public handle<dnnl_primitive_t> {
+    void execute(const stream &astream,
+            const std::unordered_map<int, memory> &args) const;
+};
+
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v2_dnnl_sycl.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v2_dnnl_sycl.hpp
@@ -1,0 +1,46 @@
+#include <CL/sycl.hpp>
+
+#include "dnnl.hpp"
+
+namespace dnnl {
+namespace sycl {
+
+enum class memory_kind { // maybe memory_model is better name?
+    usm_device, // default for SYCL-agnostic engine creation
+    usm_shared,
+    buffer,
+};
+
+// api = api::sycl is implied
+engine engine_create(
+        engine::kind kind, memory_kind model = memory_kind::usm_device);
+// Do we actually need kind here?
+engine engine_create(engine::kind kind, memory_kind model,
+        const cl::sycl::device &dev, const cl::sycl::context &ctx);
+cl::sycl::device engine_get_device(const engine &e);
+cl::sycl::context engine_get_context(const engine &e);
+memory_kind engine_get_memory_kind(const engine &e);
+
+// Do we need flags?
+// So far seems they could be derived from queue (for DPC++ and OpenCL and
+// could be assumed `in_order` for ThreadPool), so could dropped.
+stream stream_create(const engine &e, cl::sycl::queue &queue);
+cl::sycl::queue stream_get_queue(const stream &s);
+
+template <typename T, int ndims>
+memory memory_create(const desc &md, const engine &aengine,
+        cl::sycl::buffer<T, ndims> buf, stream &s);
+
+template <typename T, int ndims>
+void memory_set_data_handle(memory &m, cl::sycl::buffer<T, ndims> b, stream &s);
+template <typename T, int ndims>
+cl::sycl::buffer<T, ndims> memory_get_data_handle(const memory &m);
+template <typename T, int ndims = 1>
+cl::sycl::buffer<T, ndims> memory_get_sycl_buffer(const memory &m);
+
+cl::sycl::event primitive_execute(const primitive &p, const stream &s,
+        const std::unordered_map<int, memory> &args,
+        const std::vector<cl::sycl::event> &dependencies = {});
+
+} // namespace sycl
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v2_dnnl_threadpool.hpp
+++ b/rfcs/20200717-onednn-v2/history/api-simplified-rev0/v2_dnnl_threadpool.hpp
@@ -1,0 +1,27 @@
+#include "dnnl.hpp"
+#include "dnnl_threadpool_iface.hpp"
+
+namespace dnnl {
+namespace threadpool {
+
+// option 1 (preferable, but breaks backwards compatibility)
+// The flags are dropped, the `in_order` is assumed.
+stream stream_create(const engine &e, threadpool_iface *threadpool);
+threadpool_iface *stream_get_threadpool(const stream &s);
+
+#if 0
+// option 1 (preferable, but breaks backwards compatibility)
+// the flags are preserved
+stream stream_create(const engine &e, threadpool_iface *threadpool,
+        stream::flags aflags = flags::default_flags);
+threadpool_iface *stream_get_threadpool(const stream &s);
+
+
+// option 2 (keep stream_attr, mimics current API)
+void stream_attr_set_threadpool(stream_attr &sa, threadpool_iface *threadpool,
+        stream::flags aflags = flags::default_flags);
+threadpool_iface *stream_attr_get_threadpool(const stream_attr &sa);
+#endif
+
+} // namespace threadpool
+} // namespace dnnl

--- a/rfcs/20200717-onednn-v2/usm-and-buffer-support.md
+++ b/rfcs/20200717-onednn-v2/usm-and-buffer-support.md
@@ -1,0 +1,274 @@
+# USM and Buffers Support
+
+## Current State
+
+Currently, `dev-v2` supports both USM and Buffer interfaces for the built
+library. On API level the dispatch happens using `DNNL_USE_DPCPP_USM` macro
+that changes the behavior of `dnnl::memory` constructor:
+``` cpp
+dnnl::memory::memory(const desc &md, const engine &engine, void *ahandle)
+#ifdef DNNL_USE_DPCPP_USM
+        : memory(with_sycl_tag {}, md, engine, ahandle, /* use_usm = */ true) {}
+#else
+        : memory(with_sycl_tag {}, md, engine, ahandle, /* use_usm = */ false) {}
+#endif
+```
+
+On the implementation side, the USM and buffers are easily translated to the
+OpenCL kernel argument using:
+- `cgh.set_arg(..., usm_ptr)` for USM, and
+- `cgh.set_arg(..., accessor)` for buffers;
+
+This easy translation, in particular, allows transparently mixing USM and
+buffer objects within one kernel. It is worth mentioning, that if we use SYCL
+kernels (instead of OpenCL), that translation wouldn't be that trivial, as
+memory objects are passed directly to SYCL kernels (as arguments), and cannot
+be set independently as in case of attached `cl_mem` as an argument to a
+kernel. If we want to make our kernels work with arbitrary combination of USM
+and buffers we will:
+1. Either have our kernels templated by the kind of each input memory object,
+   and instantiate them for each and every possible combination;
+2. Or ask compiler team to introduce a method similar to `cfg.set_arg(...)`
+   that will allow alleviate the difference between USM and buffers, and allow
+   the dispatching at runtime, rather than at compile time.
+   - Currently, there is no convenient way of doing that even from the SYCL
+     standard point of view.
+3. Or implement a wrapper that would allow encapsulating an accessor (buffer)
+   and USM, and dispatch between those in the kernel based on the type the
+   wrapper was created with.
+
+The 1st option is highly discouraging, as it will increase the time of library
+compilation and its size for no good reason. The latter 2nd is unlikely to
+happen as well, as I don't think we have good enough driver to convince
+compiler team to implement the feature. The 3rd option seems feasible even
+though it makes the programming a little more difficult + may have overhead at
+runtime. See the [Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers)
+for the possible implementation.
+
+Throughout this section the assumption is that idea in the
+[Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers) will work as
+intended. However, original the RFC was written in the assumption that that
+won't be the case. To document the discussion for this scenario there will be
+hidden snippets of text under "What if
+[Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers) doesn't work" title.
+
+## Options to Support USM and Buffers in v2.0
+
+For some of the options below the following enum is used:
+``` cpp
+// dnnl_sycl.hpp
+namespace dnnl {
+namespace sycl {
+enum class memory_kind {
+    buffer,
+    usm_shared,
+    usm_device,
+};
+} // namespace sycl
+} // namespace dnnl
+```
+
+The options:
+
+1. A choice between USM and buffers happens at compile time.
+
+   The obvious benefits are:
+   - Smaller size of the library: kernels work with one type of memory kind;
+   - Simpler implementation: macros or templates will allow to write linear
+     code with no branches for USM vs buffers;
+
+   The cons:
+   - The least flexible option for a user.
+   - Yet another configuration. Will need to decide what configuration to ship
+     in binary form.
+     - If we take this route, probably USM as it is used by the majority of
+       our users, namely frameworks.
+
+2. Allow using USM or buffers, but primitive execution should only use one
+   flavor (i.e. mixing is not allowed). There are different levels of enforcing
+   the policy:
+   - Just state the requirement in the documentation, and check that all input
+     and output memory objects are of the same kind;
+   - Extend engine constructor with the flag that would indicate the flavor
+     a user wants to use, e.g.:
+     ``` cpp
+     auto eng_cpu_buf = dnnl::engine(kind::cpu, memory_kind::buffer, 0);
+     auto eng_gpu_usm = dnnl::engine(kind::gpu, memory_kind::usm_device, 0);
+     ```
+   - Introduce a global control (not attached to the engine) to select memory
+     kind: `dnnl::sycl::set_memory_kind(memory_kind::buffer)` and corresponding
+     environment variable duplicating the setter.
+
+   <details><summary>What if [Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers) doesn't work</summary><p>
+   It is worth mentioning that the all these options above lead to at least 2x
+   number of kernels in object files, as they should be prepared to work with
+   either kind of memory.
+
+   The biggest issue with the first option is that primitives could be
+   configured to use internally allocated scratchpad (which uses either buffer
+   or USM). The thing is that at primitive creation time, when the scratchpad
+   needs to be allocated, there is no information on what kind of memory a user
+   uses. This means that the options are:
+   - We switch to lazy allocation, that happens at execution, rather than at
+     creation, when the memory kind is clear;
+   - We implement DPC++ kernels in a way they could mix different kinds of
+     memory for scratchpad and the rest inputs / outputs.
+
+   The 3rd options is conceptually the same as the 2nd one, but makes it much
+   easier to control what kind of memory is used. The only drawback (that seems
+   to be quite sever) is that it is global switch. I think we should avoid
+   global states for the library.
+
+   Both these options seem quite unpleasant. The latter will lead to another 3x
+   factor for the number of kernels, as now they should support the following
+   combinations (say if scratchpad is allocated internally we always use USM):
+   1. Input/output use USM, scratchpad USM;
+   2. Input/output use buffers, scratchpad allocated internally using USM;
+   3. Input/output use buffers, scratchpad provided by a user, hence buffer;
+
+   Hence, if we decide to go with this overall option (supporting both kinds at
+   run-time, but fixed for primitive run) attaching the restriction to the
+   engine (or primitive attribute?) is the way to go.
+   </p></details>
+
+
+3. Allow mixing USM and buffers in the API in any way a user wants.
+   - For instance,
+     ``` cpp
+     eltwise::execute({{SRC, mem(..., usm_ptr_a)}, {DST, mem(..., buffer_b)}});
+     ```
+   - Pros:
+     - Maximum flexibility for users;
+     - Scratchpad, that was created as `memory(scrachpad_desc, engine)` will
+       work regardless whether it is backed up by USM or buffer.
+     - No API restrictions (hence, potentially the less amount of changes to
+       behavior);
+   - Cons:
+     - Such flexibility enlarges the changes to shoot in the foot;
+     - (minor, can be fixed) Memory object creation without specifying user's
+       USM or buffer makes it unclear, what to expect inside;
+
+   <details><summary>What if [Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers) doesn't work</summary><p>
+   More Cons:
+
+   - Very difficult to implement due to SYCL kernel limitations described above;
+   - Library size, and cache size (assuming we use templated approach);
+   </p></details>
+
+
+## Proposal and Discussion
+
+Assuming we will develop the majority of kernels in DPC++ the only feasible
+options seem to be:
+1. Make a choice at the library compile time;
+   - Intel binary version will be built with USM support;
+
+2. **(Fallback recommended option)**
+   Make memory kind an option for engine constructor;
+   - All memory allocations through oneDNN API will comply to the engine option;
+
+3. **(Recommended option)**
+   Allow arbitrary mixing of the USM and buffers.
+   - The kind of memory used during memory object could be either specified
+     using a flag:
+     ``` cpp
+     auto mem = dnnl::sycl::make_memory(engine, md, memory_kind::buffer);
+     ```
+   - For default constructor pick the default option. Assuming that USM is
+     generally more user-frindly than buffers, the suggestion is to default to
+     USM. This is also well aligned with the Native C++ API, that works with
+     pointers. Futhermore, it is suggested to use specifically device USM, as
+     opposite to shared USM, as the former gives better performance and is also
+     aligned with the fact library's memory objects are attached to engine
+     (device).
+
+In my opinion, since buffers are first-class citizens of DPC++ we should
+properly support them. That's why option 1 doesn't seem really feasible.
+
+If we can easily support both USM and buffer in the code
+([Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers)), we should go
+with option 3, as it is the most flexible, has less impact on the API, and
+doesn't cost us much.
+
+<details><summary>What if [Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers) doesn't work</summary><p>
+
+Option 3 is not an option anymore -- need to generate to many kernels (for each
+combination of USM and buffers for every kernel).
+
+The second option looks nice. It gives the flexibility to a user, and also
+somehow solves the issue of differentiating between different kinds of USM:
+
+``` cpp
+auto eng_cpu_buf = dnnl::engine(kind::cpu, memory_kind::buffer, 0);
+auto cpu_mem(eng_cpu_buf, md); // use buffer
+
+auto eng_gpu_usm = dnnl::engine(kind::gpu, memory_kind::usm_shared, 0);
+auto gpu_mem(eng_gpu_usm, md); // shared USM
+float *x = (float *)gpu_mem.get_data_handle();
+x[0] = 1; // oK, as it is shared USM
+```
+
+However, the price is twice the number of kernels.
+
+The usefulness of mixing the kinds of memory is also questionable.
+
+On the other hand, option 1 means having yet another configuration, and if we
+even decide to support both in the library, that would require an incompatible
+changes (because before the kind of memory would have been implied).
+
+The table of downsides:
+
+| Built time option (option 1)                 | Engine flag (option 2 **recommended as a fallback**)                  |
+| :--                                          | :--                                                                   |
+| One more configuration <br> Less flexibility | Questionable usefulness <br> Slightly more complicated implementation |
+
+We don't expect many (any?) will mix buffers and USM, so simplifying the API
+accordingly is acceptable. Subjectively, asking to pass an extra argument to
+engine (`memory_kind::usm_device`) is not that big of a hassle.
+
+</p></details>
+
+
+## Appendix A. Wrapper to Handle USM and Buffers.
+
+Denis suggested the following way of encapsulating USM and buffers to handle
+both types in a single kernel:
+
+``` cpp
+buffer_u8_t &dummy_buffer() {
+    thread_local buffer_u8_t instance(1);
+    return instance;
+}
+
+struct sycl_memory_arg_t {
+    static constexpr auto rw_mode_t = cl::sycl::access::mode::read_write;
+    using acc_t = cl::sycl::accessor<uint8_t, 1, rw_mode_t,
+          cl::sycl::access::target::global_buffer>;
+
+    sycl_memory_arg_t(void *usm, cl::sycl::handler &cgh)
+        : usm(usm), acc(dummy_buffer().get_access<rw_mode_t>(cgh)) {}
+    sycl_memory_arg_t(const acc_t &acc) : usm(nullptr), acc(acc) {}
+
+    // std::variant would be a better option, but it is not yet supported
+    void *usm;
+    acc_t acc;
+};
+
+struct kernel_t {
+    binary_kernel_t(sycl_memory_arg_t mem_arg) : mem_arg_(mem_arg) {}
+
+    void operator()() {
+        void *ptr = mem_arg_.usm
+                  ? mem_arg_.usm
+                  : (void *)mem_arg_.acc.get_pointer().get();
+        // work with ptr...
+    }
+
+private:
+    sycl_memory_arg_t mem_arg_;
+};
+```
+
+---
+
+EOD

--- a/rfcs/20200717-onednn-v2/usm-and-buffer-support.md
+++ b/rfcs/20200717-onednn-v2/usm-and-buffer-support.md
@@ -58,13 +58,13 @@ For some of the options below the following enum is used:
 ``` cpp
 // dnnl_sycl.hpp
 namespace dnnl {
-namespace sycl {
+namespace sycl_interop {
 enum class memory_kind {
     buffer,
     usm_shared,
     usm_device,
 };
-} // namespace sycl
+} // namespace sycl_interop
 } // namespace dnnl
 ```
 
@@ -96,8 +96,8 @@ The options:
      auto eng_gpu_usm = dnnl::engine(kind::gpu, memory_kind::usm_device, 0);
      ```
    - Introduce a global control (not attached to the engine) to select memory
-     kind: `dnnl::sycl::set_memory_kind(memory_kind::buffer)` and corresponding
-     environment variable duplicating the setter.
+     kind: `dnnl::sycl_interop::set_memory_kind(memory_kind::buffer)` and
+     corresponding environment variable duplicating the setter.
 
    <details><summary>What if [Appendix A](#appendix-a-wrapper-to-handle-usm-and-buffers) doesn't work</summary><p>
    It is worth mentioning that the all these options above lead to at least 2x
@@ -172,7 +172,7 @@ options seem to be:
    - The kind of memory used during memory object could be either specified
      using a flag:
      ``` cpp
-     auto mem = dnnl::sycl::make_memory(engine, md, memory_kind::buffer);
+     auto mem = dnnl::sycl_interop::make_memory(md, engine, memory_kind::buffer);
      ```
    - For default constructor pick the default option. Assuming that USM is
      generally more user-frindly than buffers, the suggestion is to default to


### PR DESCRIPTION
# Description

An RFC on the API changes for the upcoming [oneDNN v2.0](https://github.com/oneapi-src/oneDNN/milestone/7).

[Rendered document](https://github.com/emfomenk/mkl-dnn/tree/emfomenk/rfcs/v2-general-api/rfcs/20200717-onednn-v2#onednn-v20-changes).

The executive summary could be found [here](https://github.com/emfomenk/mkl-dnn/tree/emfomenk/rfcs/v2-general-api/rfcs/20200717-onednn-v2#1-executive-summary-of-the-changes). The API mock up: [link](https://github.com/emfomenk/mkl-dnn/blob/emfomenk/rfcs/v2-general-api/rfcs/20200717-onednn-v2/api-simplified). 

In general, the changes are very modest.
- For oneDNN v1.x users there are very few incompatible changes (listed [here](https://github.com/emfomenk/mkl-dnn/blob/emfomenk/rfcs/v2-general-api/rfcs/20200717-onednn-v2/general-v2-api.md#43-incompatible-changes-v1x-and-v2x)).
- For oneDNN v2.x-beta users, there changes are noticeable but should be manageable (listed [here](https://github.com/emfomenk/mkl-dnn/blob/emfomenk/rfcs/v2-general-api/rfcs/20200717-onednn-v2/general-v2-api.md#44-incompatible-changes-dev-v2-v20-betax-and-v2x)).

Many people contributed to the RFC.
I would like to say special thanks to @echeresh, @rsdubtso, @densamoilov, @sbogusev, and @mgouicem!
