### PR TITLE
cpu: make local zero_val const, to avoid internal compiler error vs2019

### DIFF
--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -423,7 +423,7 @@ void im2col(const conv_gemm_conf_t &jcp, const data_type_t *__restrict im,
     const int first_ow = ss % jcp.ow;
     const int last_ow = (ss + sb - 1) % jcp.ow;
 
-    auto zero_val = (data_t)0;
+    const data_t zero_val = 0;
 
     if (jcp.outer_threading) {
         if (sw == 1) {


### PR DESCRIPTION
Declared the local variable `zero_val` within the function body of
`im2col` const, to avoid the following error from a Release build of
Visual Studio 2019 version 16.7.1 (compiler version 19.27.29111 for x64):

> D:\oneDNN\src\cpu\gemm_convolution_utils.cpp(401): fatal error C1001: Internal compiler error.
> (compiler file 'd:\agent\_work\7\s\src\vctools\Compiler\Utc\src\p2\main.c', line 195)
>  To work around this problem, try simplifying or changing the program near the locations listed above.
> If possible please provide a repro here: https://developercommunity.visualstudio.com
> Please choose the Technical Support command on the Visual C++
>  Help menu, or open the Technical Support help file for more information
>   CL!RaiseException()+0x69
>   CL!RaiseException()+0x69
>   CL!CloseTypeServerPDB()+0x22e6b
>   CL!CloseTypeServerPDB()+0xcd30a
> Done building project "dnnl_cpu.vcxproj" -- FAILED.

Related compiler problem report: "VS2019 Internal compiler error using
__restrict keyword in Release build"
https://developercommunity.visualstudio.com/content/problem/1145942/vs2019-internal-compiler-error-using-restrict-keyw.html