### PR TITLE
fixup: rfc: openvino int8 pipeline support (#765)

### DIFF
--- a/rfcs/20200428-openvino-int8-support/README.md
+++ b/rfcs/20200428-openvino-int8-support/README.md
@@ -339,7 +339,10 @@ typedef enum {
 
 /* Allocating 5 bits for multiple post ops support. This arg will be used as a
  * prefix to an actual argument. */
-#define DNNL_ARG_ATTR_MULTIPLE_POST_OP 2 << 13 /* 16384 */
+#define DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE 2 << 13 /* 16384 */
+
+#define DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) \
+    (DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE * ((idx) + 1))
 
 
 /* dnnl.h */


### PR DESCRIPTION
# Description

This is a small fixup for the RFC "Openvino int8 pipeline support (#765)". This change simplifies the way memory is provided to execute() when multiple post ops are used. Implementation already uses new approach (commit: db23af2edd518e6c0d90716d50a28c607ce67719).

