### PR TITLE
ci: adds ACL build to CI on aarch64.

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -16,6 +16,23 @@
 # *******************************************************************************
 
 kind: pipeline
+name: Ubuntu16+ACL
+
+platform:
+  arch: arm64
+
+steps:
+- name: gcc-test+ACL
+  image: ubuntu:16.04
+  commands:
+  - apt-get update && apt-get install -y git build-essential cmake scons
+  - .github/automation/build_acl.sh  --version 20.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
+  - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
+
+---
+
+kind: pipeline
 name: Ubuntu16
 
 platform:
@@ -49,6 +66,25 @@ steps:
 
 ---
 kind: pipeline
+name: Ubuntu18-clang+ACL
+
+platform:
+  arch: arm64
+
+steps:
+- name: clang-test+ACL
+  image: ubuntu:18.04
+  commands:
+  - apt-get update && apt-get install -y sudo git build-essential cmake scons
+  - .github/automation/env/clang.sh
+  - export CC=clang
+  - export CXX=clang++
+  - .github/automation/build_acl.sh  --version 20.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
+  - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
+
+---
+kind: pipeline
 name: Ubuntu18
 
 platform:
@@ -60,4 +96,20 @@ steps:
   commands:
   - apt-get update && apt-get install -y git build-essential cmake
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build
+  - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
+
+---
+kind: pipeline
+name: Ubuntu18+ACL
+
+platform:
+  arch: arm64
+
+steps:
+- name: gcc-test+ACL
+  image: ubuntu:18.04
+  commands:
+  - apt-get update && apt-get install -y git build-essential cmake scons
+  - .github/automation/build_acl.sh  --version 20.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report

--- a/.github/automation/build.sh
+++ b/.github/automation/build.sh
@@ -16,6 +16,7 @@
 # limitations under the License.
 #===============================================================================
 
+
 while [[ $# -gt 0 ]]; do
     key="$1"
 
@@ -28,6 +29,9 @@ while [[ $# -gt 0 ]]; do
         ;;
         --source-dir)
         SORUCE_DIR="$2"
+        ;;
+        --acl-dir)
+        ACL_DIR="$2"
         ;;
         --build-dir)
         BUILD_DIR="$2"
@@ -42,7 +46,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=${BUILD_MODE} -DDNNL_BUILD_FOR_CI=ON -DDNNL_WERROR=ON"
-
 CPU_RUNTIME="NONE"
 GPU_RUNTIME="NONE"
 
@@ -57,12 +60,20 @@ elif [ "${BUILD_THREADING}" == "ocl" ]; then
     echo "Info: Setting DNNL_GPU_RUNTIME to OCL..."
     CPU_RUNTIME="OMP"
     GPU_RUNTIME="OCL"
-else 
+else
     echo "Error unknown threading: ${BUILD_THREADING}"
     exit 1
 fi
 
 CMAKE_OPTIONS="${CMAKE_OPTIONS} -DDNNL_CPU_RUNTIME=${CPU_RUNTIME} -DDNNL_GPU_RUNTIME=${GPU_RUNTIME}"
+
+# Enable Compute Library backend if a location for the built library is given
+# NOTE: only for AArch64 builds.
+if [ ! -z ${ACL_DIR} ]; then
+  export ACL_ROOT_DIR=$ACL_DIR
+  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DDNNL_AARCH64_USE_ACL=ON"
+  echo "Info: Building with Arm Compute Library backend for Aarch64..."
+fi
 
 if [ "$(uname)" == "Linux" ]; then
     MAKE_OP="-j$(grep -c processor /proc/cpuinfo)"

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -1,0 +1,65 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2020 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Compute Library build defaults
+ACL_VERSION="v20.08"
+ACL_DIR="${PWD}/ComputeLibrary"
+ACL_ARCH="arm64-v8a"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)
+        ACL_VERSION="v$2"
+        shift
+        ;;
+        --arch)
+        ACL_ARCH="$2"
+        shift
+        ;;
+        --root-dir)
+        ACL_DIR="$2"
+        shift
+        ;;
+        *)
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+readonly ACL_REPO="https://github.com/ARM-software/ComputeLibrary.git"
+MAKE_NP="-j$(grep -c processor /proc/cpuinfo)"
+
+git clone $ACL_REPO $ACL_DIR
+cd $ACL_DIR
+git checkout $ACL_VERSION
+
+# The STRINGIFY macro used in Version.h conflicts with a existing macro
+# in oneDNN. This will generate a warning on compilation.
+# When buildng with -Werror (as is the case for CI builds) this
+# will cause the build to fail. The following line re-names the
+# Compute Library macro to avoid the conflict.
+
+sed -i -e 's/STRINGIFY/ARM_COMPUTE_STRINGIFY/g' arm_compute/core/Version.h
+
+scons $MAKE_NP Werror=0 debug=0 neon=1 gles_compute=0 embed_kernels=0 \
+  os=linux arch=$ACL_ARCH build=native
+
+exit $?


### PR DESCRIPTION
# Description

Recent work (#820) added Arm Compute Library as an optional dependency for Aarch64 builds. This is currently absent from the AArch64 CI running on Drone CI.

This PR implements additional stages in `.drone.yml` which build oneDNN against Compute Library and run the CI.
An additional shell script, `build_acl.sh` has been added to clone and build Compute Library.
_Note: due to a clash of macro names between oneDNN and Compute Library (specifically STRINGIFY), the oneDNN build will fail with -Werror, as used for CI runs. To avoid this, STRINGIFY in Compute Library is renamed before the build.
This clash will be corrected in a future Compute Library release._

# Checklist

## Code-change submissions

- [ X ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [ not applicable ] Have you formatted the code using clang-format?

### New features

- [ not applicable ] Have you added relevant tests?
- [ X ] Have you provided motivation for adding a new feature?

### Bug fixes

- [ not applicable ] Have you added relevant regression tests?
- [ not applicable ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

