### PR TITLE
Enabling the support of `acdb` memory layout on AArch64

### DIFF
--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -101,8 +101,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
                 const typename pd_t::base_class *hint_fwd_pd)
             : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), acp_() {}
 
-        DECLARE_COMMON_PD_T(GEMM_IMPL_STR, acl_gemm_convolution_fwd_t,
-                USE_GLOBAL_SCRATCHPAD);
+        DECLARE_COMMON_PD_T(
+                "gemm:acl", acl_gemm_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
         status_t init(engine_t *engine) {
             bool ok = true && is_fwd()


### PR DESCRIPTION
# Description

This PR introduces minor modifications to enable the support of NHWC (`acdb`) memory layout on AArch64. At the moment it is not supported, because Arm Compute Library requires use of the same tags for all three tensors. Such a layout leads to 20% - 40% speedup on AArch64 compared to the default `abcd` for the use-cases like ResNet50 and VGG19.

The relevant changes are introduced in acl\_gemm\_convolution\_utils.cpp. Also the value of GEMM\_IMPL\_STR was changed to "gemm:acl" in acl\_gemm\_convolution.hpp, which allows to track the calls to ACL with `DNNL_VERBOSE=2`.

# Checklist

## Code-change submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [X] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [X] Have you provided motivation for adding a new feature?

### Bug fixes

- [N/A] Have you added relevant regression tests?
- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
