### PR TITLE
src: cpu: aarch64: remove debug prints

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -947,7 +947,6 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         add_imm(x_ptr_out_off, x_ptr_out_off, o_step * otype_sz, X_TMP_0);
 
         if (prb_.scale_type == scale_type_t::MANY) {
-            std::cout << "scale" << std::endl;
             add_imm(reg_off_scale, reg_off_scale, s_step * stype_sz, X_TMP_0);
             add_imm(x_ptr_scale_off, x_ptr_scale_off, s_step * stype_sz,
                     X_TMP_0);

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64_util.h
@@ -89,8 +89,6 @@ public:
       sveLen_ = static_cast<sveLen_t>(prctl(51));
 #endif
     }
-
-    std::cout << type_ << std::endl;
   }
 #undef SYS_REG_FIELD
 


### PR DESCRIPTION
# Description

This is a small fixup for the issue mentioned in #871 (an odd number printed when the first primitive descriptor is created on Aarch64).