### PR TITLE
Fix NVIDIA backend link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ is enabled:
 >
 > NVIDIA GPU support is experimental. General information, build instructions
 > and implementation limitations is available in
-> [NVIDIA backend readme](https://github.com/oneapi-src/oneDNN/blob/master/src/gpu/NVIDIA/README.md).
+> [NVIDIA backend readme](https://github.com/oneapi-src/oneDNN/blob/dev-v2/src/gpu/nvidia/README.md).
 
 ### Runtime Dependencies
 


### PR DESCRIPTION
# Fix NVIDIA backend link in README.md

Old README points to wrong location in master branch, new link points to the correct README location.

