### PR TITLE
ci: aarch64: update Compute Library version

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -27,7 +27,7 @@ steps:
   image: ubuntu:16.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 20.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 20.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -80,7 +80,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 20.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 20.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -111,7 +111,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 20.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 20.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -18,7 +18,7 @@
 # *******************************************************************************
 
 # Compute Library build defaults
-ACL_VERSION="v20.08"
+ACL_VERSION="v20.11"
 ACL_DIR="${PWD}/ComputeLibrary"
 ACL_ARCH="arm64-v8a"
 
@@ -50,14 +50,6 @@ MAKE_NP="-j$(grep -c processor /proc/cpuinfo)"
 git clone $ACL_REPO $ACL_DIR
 cd $ACL_DIR
 git checkout $ACL_VERSION
-
-# The STRINGIFY macro used in Version.h conflicts with a existing macro
-# in oneDNN. This will generate a warning on compilation.
-# When buildng with -Werror (as is the case for CI builds) this
-# will cause the build to fail. The following line re-names the
-# Compute Library macro to avoid the conflict.
-
-sed -i -e 's/STRINGIFY/ARM_COMPUTE_STRINGIFY/g' arm_compute/core/Version.h
 
 scons $MAKE_NP Werror=0 debug=0 neon=1 gles_compute=0 embed_kernels=0 \
   os=linux arch=$ACL_ARCH build=native


### PR DESCRIPTION
# Description                                                                                                                                                                                                                                                                   
 
This PR updates the version of Arm Compute Library used in the DroneCI
pipelines, introduced with #853, to the latest release
[20.11](https://arm-software.github.io/ComputeLibrary/v20.11/).
 
With 20.11, the `STRINGIFY` macro present in previous Compute Library releases
has been renamed, and no longer conflicts with oneDNN. As a result, the
work-around implemented [previously](https://github.com/oneapi-src/oneDNN/blob/7bd73fb5297425e3d38a80a49559f55fdbad2d8c/.github/automation/build_acl.sh#L60)
is no longer required.
 
# Checklist
 
## Code-change submissions
 
- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [N/A] Have you formatted the code using clang-format?
 
### New features
 
- [N/A] Have you added relevant tests?
- [X] Have you provided motivation for adding a new feature?
 
### Bug fixes
 
- [N/A] Have you added relevant regression tests?
- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
