### PR TITLE
build: aarch64: add -std=c++14 to fix build for latest ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ The library is optimized for the following GPUs:
 
 oneDNN supports systems meeting the following requirements:
 * Operating system with Intel 64 / Arm 64 / Power / IBMz architecture support
-* C++ compiler with C++11 standard support
+* C++ compiler with C++11 standard support (or C++14 for builds using Arm
+  Compute Library)
 * [CMake](https://cmake.org/download/) 2.8.11 or later
 * [Doxygen](http://www.doxygen.nl/download.html#srcbin) 1.8.5 or later
   to build the documentation

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -40,4 +40,6 @@ if(ACL_FOUND)
     message(STATUS "Arm Compute Library headers: ${ACL_INCLUDE_DIRS}")
 
     add_definitions(-DDNNL_AARCH64_USE_ACL)
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_EXTENSIONS OFF)
 endif()


### PR DESCRIPTION
# Description

This small change to ACL.cmake is needed for building with the latest development
branch of Arm Compute Library (build still works with release 20.11).
Also added `set(CMAKE_CXX_EXTENSIONS OFF)` to ensure the build uses `c++14` rather than `gnu++14`.

This is needed because Compute Library assumes c++14, but oneDNN does not.
That means there can be problems including arm_compute headers which assume support for c++14 features.

# Checklist

## Code-change submissions

- [N/A] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [N/A] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

### Bug fixes

- [N/A] Have you added relevant regression tests?
- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
