### PR TITLE
cpu: aarch64: add JIT implementation for convolution_f32

### DIFF
--- a/src/cpu/aarch64/cpu_barrier.cpp
+++ b/src/cpu/aarch64/cpu_barrier.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
-* Copyright 2020 FUJITSU LIMITED
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -98,8 +98,9 @@ void generate(jit_generator &code, Xbyak_aarch64::XReg reg_ctx,
 struct jit_t : public jit_generator {
 
     void generate() override {
+        this->preamble();
         simple_barrier::generate(*this, abi_param1, abi_param2);
-        ret();
+        this->postamble();
     }
 
     // TODO: Need to check status
@@ -107,6 +108,11 @@ struct jit_t : public jit_generator {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_t)
 };
+
+void barrier(ctx_t *ctx, int nthr) {
+    static jit_t j; // constructed during load
+    j(ctx, nthr);
+}
 
 } // namespace simple_barrier
 

--- a/src/cpu/aarch64/cpu_reducer.cpp
+++ b/src/cpu/aarch64/cpu_reducer.cpp
@@ -1,0 +1,597 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <assert.h>
+
+#include "dnnl_types.h"
+
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/platform.hpp"
+
+#include "cpu/aarch64/cpu_reducer.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace memory_tracking::names;
+
+void reduce_balancer_t::balance() {
+    using namespace nstl;
+    using namespace utils;
+
+    assert(nthr_ > 0 && job_size_ > 0 && njobs_ > 0 && reduction_size_ > 0);
+
+    const int job_complexity = 1;
+
+    const int min_njobs_per_group = max(1, njobs_ / nthr_);
+    const int max_njobs_per_group
+            = max(1, static_cast<int>(max_buffer_size_ / (nthr_ * job_size_)));
+
+    /* initial guess */
+    int ngroups = min(njobs_ / min_njobs_per_group, nthr_);
+    int nthr_per_group
+            = allow_nthr_in_group_ ? min(nthr_ / ngroups, reduction_size_) : 1;
+    int njobs_per_group_ub = div_up(njobs_, ngroups);
+
+    /* rough upper-bound estimation, will be fixed during brute force */
+    size_t thread_complexity_ub = (size_t)njobs_ * job_size_ * reduction_size_;
+
+    /* brute force parameters for the best balance... */
+    for (int c_njobs_per_group = min_njobs_per_group;
+            c_njobs_per_group < njobs_; ++c_njobs_per_group) {
+        /* current assumption */
+        int c_ngroups = min(njobs_ / c_njobs_per_group, nthr_);
+        int c_nthr_per_group = allow_nthr_in_group_
+                ? min(nthr_ / c_ngroups, reduction_size_)
+                : 1;
+        int c_njobs_per_group_ub = div_up(njobs_, c_ngroups);
+
+        if (c_nthr_per_group > 1 && c_njobs_per_group_ub > max_njobs_per_group)
+            continue;
+
+        int c_thread_reduction_ub = div_up(reduction_size_, c_nthr_per_group);
+        size_t c_group_size_ub = (size_t)job_size_ * c_njobs_per_group_ub;
+        size_t c_thread_complexity_ub = c_group_size_ub
+                * (job_complexity * c_thread_reduction_ub
+                        + (c_nthr_per_group != 1));
+
+        if (c_thread_complexity_ub < thread_complexity_ub) {
+            ngroups = c_ngroups;
+            nthr_per_group = c_nthr_per_group;
+            njobs_per_group_ub = c_njobs_per_group_ub;
+            thread_complexity_ub = c_thread_complexity_ub;
+        }
+    }
+
+    assert(njobs_per_group_ub <= max_njobs_per_group || nthr_per_group == 1);
+    assert(ngroups * nthr_per_group <= nthr_);
+    assert((size_t)njobs_per_group_ub * job_size_ * nthr_ <= max_buffer_size_
+            || nthr_per_group == 1); /* no reduction buffer overflow */
+    assert(IMPLICATION(!allow_nthr_in_group_, nthr_per_group == 1));
+
+    ngroups_ = ngroups;
+    nthr_per_group_ = nthr_per_group;
+    njobs_per_group_ub_ = njobs_per_group_ub;
+}
+
+/* reducer jit-ted driver */
+
+using namespace Xbyak_aarch64;
+
+template <impl::data_type_t data_type>
+struct reducer_2d_driver_t : public jit_generator {
+    using data_t = typename prec_traits<data_type>::type;
+
+    reducer_2d_driver_t(int n_src, size_t src_ld, size_t src_step,
+            size_t dst_step, bool nullify_dst)
+        : n_src_(n_src)
+        , src_ld_(src_ld)
+        , src_step_(src_step)
+        , dst_step_(dst_step)
+        , nullify_dst_(nullify_dst) {}
+    virtual void operator()(
+            data_t *dst, const data_t *srcs, size_t ny, size_t nx)
+            = 0;
+
+protected:
+    int n_src_;
+    size_t src_ld_, src_step_, dst_step_;
+    bool nullify_dst_;
+};
+
+template <impl::data_type_t data_type, cpu_isa_t isa>
+struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(reducer_2d_driver_f_s_32_t)
+
+    using data_t = typename prec_traits<data_type>::type;
+
+    void operator()(
+            data_t *dst, const data_t *srcs, size_t ny, size_t nx) override {
+        jit_generator::operator()(dst, srcs, ny, nx);
+    }
+
+    /* cpu specific part */
+    using Vmm = Xbyak_aarch64::ZRegS;
+
+    const int vlen = cpu_isa_traits<isa>::vlen;
+    const int typesize
+            = sizeof(typename dnnl::impl::prec_traits<data_type>::type);
+    XReg reg_dst = abi_param1;
+    XReg reg_src = abi_param2;
+    XReg reg_ny = abi_param3;
+    XReg reg_nx = abi_param4;
+
+    XReg reg_x = this->x19;
+    XReg reg_src_id = this->x20;
+    XReg reg_long_offt = this->x21;
+
+    XReg reg_tmp_imm = this->x29;
+    XReg reg_tmp_ptr = this->x30;
+
+    PReg preg_one = this->p3;
+    PReg preg_all = this->p4;
+
+    reducer_2d_driver_f_s_32_t(int n_src, size_t src_ld, size_t src_step,
+            size_t dst_step, bool nullify_dst)
+        : reducer_2d_driver_t<data_type>(
+                n_src, src_ld, src_step, dst_step, nullify_dst) {}
+
+    void uni_load(const Vmm &z1, const XReg &src, size_t off, int load_len) {
+        auto src_ptr = (off == 0) ? src : reg_tmp_ptr;
+        if (off != 0) this->add_imm(src_ptr, src, off, reg_tmp_imm);
+
+        if (load_len == typesize)
+            this->ld1w(z1, preg_one.s, ptr(src_ptr));
+        else if (load_len == vlen)
+            this->ld1w(z1, preg_all.s, ptr(src_ptr));
+        else
+            assert(!"unsupported");
+    }
+
+    void uni_store(const Vmm &z1, const XReg &dst, size_t off, int load_len) {
+        auto dst_ptr = (off == 0) ? dst : reg_tmp_ptr;
+        if (off != 0) this->add_imm(dst_ptr, dst, off, reg_tmp_imm);
+
+        if (load_len == typesize)
+            this->st1w(z1, preg_one.s, ptr(dst_ptr));
+        else if (load_len == vlen)
+            this->st1w(z1, preg_all.s, ptr(dst_ptr));
+        else
+            assert(!"unsupported");
+    }
+
+    void nullify_dst(int nloads, int load_len) {
+        UNUSED(load_len);
+        for (int i = 0; i < nloads; ++i)
+            this->fmov(Vmm(i)); // Zero clear
+        /* prefetches[dst] ? */
+    }
+
+    void load_dst(int nloads, int load_len) {
+        for (int i = 0; i < nloads; ++i)
+            uni_load(Vmm(i), reg_dst, i * load_len, load_len);
+    }
+
+    void store_dst(int nloads, int load_len) {
+        for (int i = 0; i < nloads; ++i)
+            uni_store(Vmm(i), reg_dst, i * load_len, load_len);
+    }
+
+    void accumulate(int nloads, int load_len, size_t base_off) {
+        for (int i = 0; i < nloads; ++i) {
+            size_t off = base_off + i * load_len;
+            uni_load(Vmm(cpu_isa_traits<isa>::n_vregs - 1), reg_src, off,
+                    load_len);
+            if (data_type == data_type::f32)
+                this->fadd(
+                        Vmm(i), Vmm(i), Vmm(cpu_isa_traits<isa>::n_vregs - 1));
+            else
+                this->add(
+                        Vmm(i), Vmm(i), Vmm(cpu_isa_traits<isa>::n_vregs - 1));
+        }
+    }
+
+    void loop_x() {
+        const int nloads[] = {cpu_isa_traits<isa>::n_vregs - 1, 1, 1};
+        const int nbranches = sizeof(nloads) / sizeof(nloads[0]);
+
+        const int load_len[nbranches] = {vlen, vlen, typesize};
+        Label loop_x_label[nbranches + 1];
+
+        this->ptrue(preg_all.b);
+        if (typesize == 4)
+            this->ptrue(preg_one.s, VL1);
+        else
+            assert(!"Unsupported typesize");
+
+        this->mov(reg_x, reg_nx);
+
+        for (int id = 0; id < nbranches; ++id) {
+            this->L(loop_x_label[id]);
+
+            this->cmp(reg_x, nloads[id] * load_len[id]);
+            this->b(LT, loop_x_label[id + 1]);
+
+            if (this->nullify_dst_)
+                nullify_dst(nloads[id], load_len[id]);
+            else
+                load_dst(nloads[id], load_len[id]);
+
+            if (nloads[id] > 1) {
+                Label loop_srcs;
+                this->mov_imm(reg_src_id, this->n_src_);
+                this->L(loop_srcs);
+
+                accumulate(nloads[id], load_len[id], 0);
+                this->add_imm(reg_src, reg_src, this->src_ld_ * typesize,
+                        reg_tmp_imm);
+
+                this->subs(reg_src_id, reg_src_id, 1); // dec
+                this->b(NE, loop_srcs);
+
+                size_t base_off
+                        = (size_t)this->n_src_ * this->src_ld_ * typesize;
+                this->sub_imm(reg_src, reg_src, base_off, reg_tmp_imm);
+            } else {
+                for (int src_id = 0; src_id < this->n_src_; ++src_id) {
+                    const size_t base_off
+                            = (size_t)src_id * this->src_ld_ * typesize;
+                    accumulate(nloads[id], load_len[id], base_off);
+                }
+            }
+
+            store_dst(nloads[id], load_len[id]);
+
+            this->add_imm(
+                    reg_src, reg_src, nloads[id] * load_len[id], reg_tmp_imm);
+            this->add_imm(
+                    reg_dst, reg_dst, nloads[id] * load_len[id], reg_tmp_imm);
+
+            this->sub_imm(reg_x, reg_x, nloads[id] * load_len[id], reg_tmp_imm);
+
+            this->b(loop_x_label[id]);
+        }
+
+        this->L(loop_x_label[nbranches]);
+
+        /* restore address registers */
+        this->sub(reg_src, reg_src, reg_nx);
+        this->sub(reg_dst, reg_dst, reg_nx);
+    }
+
+    void generate() override {
+        assert(isa == sve_512);
+
+        this->preamble();
+
+        this->lsl(reg_nx, reg_nx, 2);
+
+        Label ny_loop;
+        this->L(ny_loop);
+
+        loop_x();
+
+        this->add_imm(
+                reg_dst, reg_dst, this->dst_step_ * typesize, reg_tmp_imm);
+        this->add_imm(
+                reg_src, reg_src, this->src_step_ * typesize, reg_tmp_imm);
+
+        this->subs(reg_ny, reg_ny, 1); //dec(reg_ny);
+        this->b(NE, ny_loop); // jnz
+
+        this->postamble();
+    }
+};
+
+template <impl::data_type_t data_type>
+inline reducer_2d_driver_t<data_type> *create_reduce_2d_drv(int n_src,
+        size_t src_ld, size_t src_step, size_t dst_step, bool nullify_dst) {
+    if (mayiuse(sve_512))
+        return new reducer_2d_driver_f_s_32_t<data_type, sve_512>(
+                n_src, src_ld, src_step, dst_step, nullify_dst);
+    assert(!"unimplemented");
+    return nullptr;
+}
+
+/* cpu_reducer_t */
+
+template <impl::data_type_t data_type>
+void cpu_reducer_t<data_type>::conf_t::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad) const {
+    if (balancer_.nthr_per_group_ == 1) return;
+
+    const size_t space_size = balancer_.ngroups_
+            * (balancer_.nthr_per_group_ - 1)
+            * cpu_reducer_t<data_type>::space_per_thread(balancer_);
+    scratchpad.book<data_t>(key_reducer_space, space_size, PAGE_4K);
+    scratchpad.book<simple_barrier::ctx_t>(
+            key_reducer_space_bctx, balancer_.ngroups_);
+}
+
+template <impl::data_type_t data_type>
+cpu_reducer_t<data_type>::cpu_reducer_t(const conf_t &conf)
+    : conf_(conf), drv_(nullptr) {
+    if (balancer().nthr_per_group_ == 1) return;
+
+    drv_ = create_reduce_2d_drv<data_type>(balancer().nthr_per_group_ - 1,
+            space_per_thread(balancer()), 0, 0, false);
+}
+
+template <impl::data_type_t data_type>
+cpu_reducer_t<data_type>::~cpu_reducer_t() {
+    delete drv_;
+}
+
+template <impl::data_type_t data_type>
+status_t cpu_reducer_t<data_type>::create_kernel() {
+    return (drv_) ? drv_->create_kernel() : status::success;
+}
+
+template <impl::data_type_t data_type>
+typename cpu_reducer_t<data_type>::data_t *
+cpu_reducer_t<data_type>::get_local_ptr(int ithr, data_t *dst,
+        const memory_tracking::grantor_t &scratchpad) const {
+    const int id_in_grp = balancer().id_in_group(ithr);
+
+    /* threads 0 from each group writes directly to the destination */
+    if (id_in_grp == 0)
+        return dst + balancer().ithr_job_off(ithr) * balancer().job_size_;
+
+    const int grp_id = balancer().group_id(ithr);
+    const int offset_factor
+            = grp_id * (balancer().nthr_per_group_ - 1) + (id_in_grp - 1);
+
+    auto space = scratchpad.template get<data_t>(key_reducer_space);
+    return space + offset_factor * space_per_thread(balancer());
+}
+
+template <impl::data_type_t data_type>
+void cpu_reducer_t<data_type>::reduce_nolock(int ithr, data_t *dst,
+        const memory_tracking::grantor_t &scratchpad) const {
+    bool redundant_reduction
+            = balancer().nthr_per_group_ == 1 || balancer().idle(ithr);
+    if (redundant_reduction) return;
+
+#ifdef SIMPLE_IMPL
+    if (balancer().id_in_group(ithr) != 0)
+        return; /* only threads 0 do the reduction */
+
+    const int njobs_in_grp = balancer().ithr_njobs(ithr);
+    data_t *d = get_local_ptr(ithr, dst, scratchpad);
+    for (int id_in_grp = 1; id_in_grp < balancer().nthr_per_group_;
+            ++id_in_grp) {
+        const data_t *space = get_local_ptr(ithr + id_in_grp, dst, scratchpad);
+        for (size_t i = 0; i < (size_t)njobs_in_grp * balancer().job_size_; ++i)
+            d[i] += space[i];
+    }
+#else
+    using namespace utils;
+
+    const int id_in_grp = balancer().id_in_group(ithr);
+    const int njobs_in_grp = balancer().ithr_njobs(ithr);
+    const size_t cl = 64 / sizeof(data_t);
+
+    const size_t reduction_size = njobs_in_grp * balancer().job_size_;
+    size_t start {0}, end {0};
+    balance211(div_up(reduction_size, cl), balancer().nthr_per_group_,
+            id_in_grp, start, end);
+
+    if (start == end) return;
+
+    data_t *d = get_local_ptr(ithr - id_in_grp, dst, scratchpad) + start * cl;
+    const data_t *space
+            = get_local_ptr(ithr - id_in_grp + 1, dst, scratchpad) + start * cl;
+    const size_t len = nstl::min(end * cl, reduction_size) - start * cl;
+
+    (*drv_)(d, space, 1, len);
+#endif
+}
+
+template struct cpu_reducer_t<data_type::f32>;
+template struct cpu_reducer_t<data_type::s32>;
+
+/* cpu_reducer_2d_t */
+
+template <impl::data_type_t data_type>
+void cpu_reducer_2d_t<data_type>::conf_t::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad) const {
+    if (balancer_.nthr_per_group_ == 1) return;
+
+    const size_t space_size = balancer_.ngroups_ * balancer_.nthr_per_group_
+            * cpu_reducer_2d_t<data_type>::space_per_thread(balancer_);
+    scratchpad.book<data_t>(key_reducer_space, space_size);
+    scratchpad.book<simple_barrier::ctx_t>(
+            key_reducer_space_bctx, balancer_.ngroups_);
+}
+
+template <impl::data_type_t data_type>
+cpu_reducer_2d_t<data_type>::cpu_reducer_2d_t(const conf_t &conf)
+    : conf_(conf), drv_(nullptr) {
+    if (balancer().nthr_per_group_ == 1) return;
+
+    drv_ = create_reduce_2d_drv<data_type>(balancer().nthr_per_group_,
+            space_per_thread(balancer()), conf_.job_size_x_, conf_.dst_x_,
+            true);
+}
+
+template <impl::data_type_t data_type>
+cpu_reducer_2d_t<data_type>::~cpu_reducer_2d_t() {
+    delete drv_;
+}
+
+template <impl::data_type_t data_type>
+status_t cpu_reducer_2d_t<data_type>::create_kernel() {
+    return (drv_) ? drv_->create_kernel() : status::success;
+}
+
+template <impl::data_type_t data_type>
+typename cpu_reducer_2d_t<data_type>::data_t *
+cpu_reducer_2d_t<data_type>::get_local_ptr(
+        int ithr, const memory_tracking::grantor_t &scratchpad) const {
+    const int id_in_grp = balancer().id_in_group(ithr);
+    const int grp_id = balancer().group_id(ithr);
+    const int offset_factor = grp_id * balancer().nthr_per_group_ + id_in_grp;
+    auto space = scratchpad.template get<data_t>(key_reducer_space);
+    return space + offset_factor * space_per_thread(balancer());
+}
+
+template <impl::data_type_t data_type>
+int cpu_reducer_2d_t<data_type>::choose_x_blocking(
+        int nx, int ny, int nthr_per_grp) const {
+    // find x_blocking for better balance reducing work between threads
+    assert(conf_.x_block_ > 0 && nx > conf_.x_block_
+            && nx % conf_.x_block_ == 0);
+    int x_blocking = nx / conf_.x_block_;
+    int min_x_blocking
+            = utils::div_up(x_blocking, nstl::max(1, nthr_per_grp / ny));
+    while (true) {
+        if (x_blocking % 2 == 0 && x_blocking >= min_x_blocking * 2)
+            x_blocking /= 2;
+        else if (x_blocking % 3 == 0 && x_blocking >= min_x_blocking * 3)
+            x_blocking /= 3;
+        else
+            break;
+    }
+    if (x_blocking >= min_x_blocking * 4) x_blocking = 1;
+    x_blocking *= conf_.x_block_;
+    return x_blocking;
+}
+
+template <impl::data_type_t data_type>
+void cpu_reducer_2d_t<data_type>::reduce_block(const data_t *space_base,
+        data_t *dst, int job, int start_y, int start_x, int ny_start,
+        int nx_start, int ny_step, int nx_step) const {
+    data_t *d = dst + (start_y + ny_start) * conf_.dst_x_ + start_x + nx_start;
+    const data_t *space = space_base + (size_t)job * balancer().job_size_
+            + (size_t)ny_start * conf_.job_size_x_ + nx_start;
+#ifdef SIMPLE_IMPL
+    for (int idg = 0; idg < balancer().nthr_per_group_; ++idg) {
+        const data_t *w = &space[idg * space_per_thread(balancer())];
+        for (int y = 0; y < ny_step; ++y)
+            for (int x = 0; x < nx_step; ++x) {
+                d[y * conf_.dst_x_ + x]
+                        = (idg == 0 ? 0 : d[y * conf_.dst_x_ + x])
+                        + w[y * conf_.job_size_x_ + x];
+            }
+    }
+#else
+    (*drv_)(d, space, ny_step, nx_step);
+#endif
+}
+
+template <impl::data_type_t data_type>
+void cpu_reducer_2d_t<data_type>::reduce_nolock(int ithr, data_t *dst,
+        const memory_tracking::grantor_t &scratchpad) const {
+    bool redundant_reduction
+            = balancer().nthr_per_group_ == 1 || balancer().idle(ithr);
+    if (redundant_reduction) return;
+
+    const int id_in_grp = balancer().id_in_group(ithr);
+    const int njobs_in_grp = balancer().ithr_njobs(ithr);
+    const int njobs_x = utils::div_up(conf_.dst_x_, conf_.job_size_x_);
+    const int global_job_start = balancer().ithr_job_off(ithr);
+
+    const data_t *space_base = get_local_ptr(ithr - id_in_grp, scratchpad);
+
+    const int pr_grps = nstl::min(njobs_in_grp, balancer().nthr_per_group_);
+    const int pr_nthr_per_grp = balancer().nthr_per_group_ / pr_grps;
+
+    if (id_in_grp >= pr_grps * pr_nthr_per_grp) return; /* idle */
+
+    const int pr_my_grp = id_in_grp / pr_nthr_per_grp;
+    const int pr_my_id = id_in_grp % pr_nthr_per_grp;
+
+    int pr_job_start {0}, pr_job_end {0};
+    balance211(njobs_in_grp, pr_grps, pr_my_grp, pr_job_start, pr_job_end);
+
+    for (int j = pr_job_start; j < pr_job_end; ++j) {
+        const int global_job = global_job_start + j;
+        const int j_y = global_job / njobs_x;
+        const int j_x = global_job % njobs_x;
+        const int start_y = j_y * conf_.job_size_y_;
+        const int start_x = j_x * conf_.job_size_x_;
+        const int ny = nstl::min(conf_.dst_y_ - start_y, conf_.job_size_y_);
+        const int nx = nstl::min(conf_.dst_x_ - start_x, conf_.job_size_x_);
+        int x_blocking = choose_x_blocking(nx, ny, pr_nthr_per_grp);
+
+        int nxy_start {0}, nxy_end {0};
+        balance211(ny * nx / x_blocking, pr_nthr_per_grp, pr_my_id, nxy_start,
+                nxy_end);
+        if (nxy_start == nxy_end) continue;
+        nxy_start *= x_blocking;
+        nxy_end *= x_blocking;
+
+        int nxy = nxy_start;
+        if (nxy % nx != 0) {
+            int nx_step = nstl::min(nx - nxy % nx, nxy_end - nxy);
+            reduce_block(space_base, dst, j, start_y, start_x, nxy / nx,
+                    nxy % nx, 1, nx_step);
+            nxy += nx_step;
+        }
+        if ((nxy_end - nxy) > nx) {
+            int ny_step = (nxy_end - nxy) / nx;
+            reduce_block(space_base, dst, j, start_y, start_x, nxy / nx,
+                    nxy % nx, ny_step, nx);
+            nxy += nx * ny_step;
+        }
+        if ((nxy_end - nxy) > 0) {
+            reduce_block(space_base, dst, j, start_y, start_x, nxy / nx,
+                    nxy % nx, 1, nxy_end - nxy);
+        }
+    }
+}
+
+template struct cpu_reducer_2d_t<data_type::f32>;
+template struct cpu_reducer_2d_t<data_type::s32>;
+
+/* accumulator section */
+
+template <impl::data_type_t data_type>
+cpu_accumulator_1d_t<data_type>::cpu_accumulator_1d_t() : drv_(nullptr) {
+    drv_ = create_reduce_2d_drv<data_type>(1, 0, 0, 0, false);
+}
+
+template <impl::data_type_t data_type>
+cpu_accumulator_1d_t<data_type>::~cpu_accumulator_1d_t() {
+    delete drv_;
+}
+
+template <impl::data_type_t data_type>
+status_t cpu_accumulator_1d_t<data_type>::create_kernel() {
+    return drv_->create_kernel();
+}
+
+template <impl::data_type_t data_type>
+void cpu_accumulator_1d_t<data_type>::accumulate(
+        data_t *dst, const data_t *src, size_t size) {
+    (*drv_)(dst, src, 1, size);
+}
+
+template struct cpu_accumulator_1d_t<data_type::f32>;
+template struct cpu_accumulator_1d_t<data_type::s32>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/cpu_reducer.hpp
+++ b/src/cpu/aarch64/cpu_reducer.hpp
@@ -1,0 +1,357 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_CPU_REDUCER_HPP
+#define CPU_AARCH64_CPU_REDUCER_HPP
+
+#include <assert.h>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "dnnl_types.h"
+
+#include "cpu/aarch64/cpu_barrier.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+/** class to perform balancing over 3D array
+ *
+ * Conceptually the reduction happens according to the picture below:
+ *
+ *  <--job_size->
+ *  +-----------+   +-----------+           +-----------+  ^
+ *  |           |   |           |           |           |  |
+ *  |           |   |           |           |           |  |
+ *  |     1     |   |     2     |   . . .   |   njobs   |  | reduction_size
+ *  |           |   |           |           |           |  |
+ *  |           |   |           |           |           |  |
+ *  +-----------+   +-----------+           +-----------+  v
+ *
+ *    |   |   |       |   |   |               |   |   |
+ *    v   v   v       v   v   v               v   v   v
+ *  ===================================================== vertical reduction
+ *
+ *  +-----------+   +-----------+   . . .   +-----------+ result
+ *
+ * In a simple case the result must be contiguous in memory.
+ * @class cpu_reducer_t is an implementation.
+ *
+ * Threads are divided into groups. The groups are independent of each other.
+ * Each group may work on several jobs (the distribution is not uniform, since
+ * njobs might be not a multiple of groups). Threads within a group work on
+ * different parts of the reduction dimension. Thread 0 in each group is called
+ * master (@sa reduce_balancer_t::master()).
+ *
+ * If threading driver does not allow sync between sub-group of threads (e.g.
+ * TBB) the # of thread per group is enforced to be 1.
+ */
+struct reduce_balancer_t {
+    reduce_balancer_t() { init(1, 1, 1, 1, 0); } /* trivial balance */
+    reduce_balancer_t(int nthr, int job_size, int njobs, int reduction_size,
+            size_t max_buffer_size, bool lock_free = false) {
+        init(nthr, job_size, njobs, reduction_size, max_buffer_size, lock_free);
+    }
+
+    reduce_balancer_t &init(int nthr, int job_size, int njobs,
+            int reduction_size, size_t max_buffer_size,
+            bool lock_free = false) {
+        allow_nthr_in_group_ = lock_free ? true : dnnl_thr_syncable();
+        nthr_ = nthr;
+        job_size_ = job_size;
+        njobs_ = njobs;
+        reduction_size_ = reduction_size;
+        max_buffer_size_ = max_buffer_size;
+        balance();
+        return *this;
+    }
+
+    bool allow_nthr_in_group_;
+    int nthr_;
+    int job_size_, njobs_, reduction_size_;
+
+    int ngroups_; /** number of independent work (thread) groups */
+    int nthr_per_group_; /** number of threads within a single work group */
+    int njobs_per_group_ub_; /** the max # of jobs within a work group */
+
+    bool master(int ithr) const { return id_in_group(ithr) == 0; }
+    bool idle(int ithr) const { return ithr >= nthr_per_group_ * ngroups_; }
+
+    int group_id(int ithr) const { return ithr / nthr_per_group_; }
+    int id_in_group(int ithr) const { return ithr % nthr_per_group_; }
+
+    int grp_njobs(int grp) const {
+        if (grp >= ngroups_) return 0;
+        return njobs_ / ngroups_ + (grp < njobs_ % ngroups_);
+    }
+    int grp_job_off(int grp) const {
+        if (grp >= ngroups_) return njobs_;
+        return njobs_ / ngroups_ * grp + nstl::min(grp, njobs_ % ngroups_);
+    }
+
+    int ithr_njobs(int ithr) const { return grp_njobs(group_id(ithr)); }
+    int ithr_job_off(int ithr) const { return grp_job_off(group_id(ithr)); }
+
+private:
+    size_t max_buffer_size_;
+    void balance();
+};
+
+/** forward declaration of reduce driver */
+template <impl::data_type_t data_type>
+struct reducer_2d_driver_t;
+
+/** class to perform a reduction over 3D array
+ *
+ * Balancing is based on @class reduce_balancer_t.
+ * Restrictions: the result of the reduction must be contiguous in memory. *
+ * The reduction happens according to the picture below (once more):
+ *
+ *  <--job_size->
+ *  +-----------+   +-----------+           +-----------+  ^
+ *  |           |   |           |           |           |  |
+ *  |           |   |           |           |           |  |
+ *  |     1     |   |     2     |   . . .   |   njobs   |  | reduction_size
+ *  |           |   |           |           |           |  |
+ *  |           |   |           |           |           |  |
+ *  +-----------+   +-----------+           +-----------+  v
+ *
+ *    |   |   |       |   |   |               |   |   |
+ *    v   v   v       v   v   v               v   v   v
+ *  ===================================================== vertical reduction
+ *
+ *  +-----------+   +-----------+   . . .   +-----------+ (contiguous) result
+ *
+ * An example how work might be shared is shown below.
+ *
+ * In this example group 0 owns 2 (independent) jobs -- 2 big squares.
+ * The number of threads per group is also 2 (thread 0 of group 0 and thread 1
+ * of group 0). Master threads (i.e. threads with id 0 in corresponding group)
+ * from each group put the partial result directly into destination memory,
+ * while all the other threads with-in the group use workspace (on the picture
+ * the only thread 1). Once intermediate results obtained each group reduces
+ * corresponding part (own jobs) to the destination memory.
+ *
+ *  <-------   group 0   ------->
+ *
+ *  +-----------+   +-----------+  ^
+ *  |           |   |           |  | thread 0 of  reduces to the dest-memory
+ *  |           |   |           |  | group 0      +-----------+   +-----------+
+ *  |- - - - - -|   |- - - - - -|  X
+ *  |           |   |           |  | thread 1 of  reduces to workspace[tid=1]:
+ *  |           |   |           |  | group 0      +-----------+   +-----------+
+ *  +-----------+   +-----------+  v
+ *                                                  |   |   |       |   |   |
+ *                                                  v   v   v       v   v   v
+ *                                   ((barrier))  =============================
+ *
+ *                                  dest-memory:  +-----------+   +-----------+
+ */
+template <impl::data_type_t data_type>
+struct cpu_reducer_t {
+    typedef typename prec_traits<data_type>::type data_t;
+
+    struct conf_t {
+        conf_t() = default;
+        conf_t &init(const reduce_balancer_t &balancer) {
+            balancer_ = balancer;
+            return *this;
+        }
+
+        void init_scratchpad(memory_tracking::registrar_t &scratchpad) const;
+
+        reduce_balancer_t balancer_;
+    };
+
+    status_t create_kernel();
+
+    cpu_reducer_t(const conf_t &conf);
+    ~cpu_reducer_t();
+
+    /** initializes reducer.
+     * Must be called from a single thread prior to actual usage */
+    void init(const memory_tracking::grantor_t &scratchpad) const {
+        if (balancer().nthr_per_group_ == 1 || !dnnl_thr_syncable()) return;
+
+        auto bctx = scratchpad.template get<simple_barrier::ctx_t>(
+                memory_tracking::names::key_reducer_space_bctx);
+        for (int i = 0; i < balancer().ngroups_; ++i)
+            simple_barrier::ctx_init(&bctx[i]);
+    }
+
+    /** for given thread returns the pointer where to put partial results.
+     * Reduction destination @p dst must be provided as well (master threads
+     * from each group will use it for partial result to reduce memory
+     * pressure).
+     *
+     * @note: job offset is already applied by get_local_ptr(), which means all
+     *        threads should start writing from the very beginning of returned
+     *        address.
+     */
+    data_t *get_local_ptr(int ithr, data_t *dst,
+            const memory_tracking::grantor_t &scratchpad) const;
+
+    /** performs the reduction with built-in synchronization. */
+    void reduce(int ithr, data_t *dst,
+            const memory_tracking::grantor_t &scratchpad) const {
+        bool redundant_reduction
+                = balancer().nthr_per_group_ == 1 || balancer().idle(ithr);
+        if (redundant_reduction) return;
+
+        auto bctx = scratchpad.template get<simple_barrier::ctx_t>(
+                memory_tracking::names::key_reducer_space_bctx);
+        simple_barrier::barrier(
+                &bctx[balancer().group_id(ithr)], balancer().nthr_per_group_);
+
+        reduce_nolock(ithr, dst, scratchpad);
+    }
+
+    void reduce_nolock(int ithr, data_t *dst,
+            const memory_tracking::grantor_t &scratchpad) const;
+
+    const reduce_balancer_t &balancer() const { return conf_.balancer_; }
+
+private:
+    static size_t space_per_thread(const reduce_balancer_t &balancer) {
+        return balancer.njobs_per_group_ub_ * balancer.job_size_;
+    }
+
+    /* The scratchpad is organized as follows:
+     *
+     * data_t space[nthr_][njobs_per_group_ub_][jobs_size_];
+     * simple_barrier::ctx_t barriers[groups_]; */
+
+    const conf_t conf_;
+    reducer_2d_driver_t<data_type> *drv_;
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(cpu_reducer_t);
+};
+
+template <impl::data_type_t data_type>
+struct cpu_reducer_2d_t {
+    typedef typename prec_traits<data_type>::type data_t;
+
+    struct conf_t {
+        conf_t() = default;
+        conf_t &init(const reduce_balancer_t &balancer, int job_size_x,
+                int job_size_y, int x_block, int dst_x, int dst_y) {
+            balancer_ = balancer;
+            job_size_x_ = job_size_x;
+            job_size_y_ = job_size_y;
+            x_block_ = x_block;
+            dst_x_ = dst_x;
+            dst_y_ = dst_y;
+            return *this;
+        }
+
+        void init_scratchpad(memory_tracking::registrar_t &scratchpad) const;
+
+        reduce_balancer_t balancer_;
+        int job_size_x_, job_size_y_, x_block_, dst_x_, dst_y_;
+    };
+
+    status_t create_kernel();
+
+    cpu_reducer_2d_t(const conf_t &conf);
+    ~cpu_reducer_2d_t();
+
+    /** initializes reducer.
+     * Must be called from a single thread prior to actual usage */
+    void init(const memory_tracking::grantor_t &scratchpad) const {
+        if (balancer().nthr_per_group_ == 1 || !dnnl_thr_syncable()) return;
+
+        auto bctx = scratchpad.template get<simple_barrier::ctx_t>(
+                memory_tracking::names::key_reducer_space_bctx);
+        for (int i = 0; i < balancer().ngroups_; ++i)
+            simple_barrier::ctx_init(&bctx[i]);
+    }
+
+    /** for given thread returns the pointer where to put partial results */
+    data_t *get_local_ptr(
+            int ithr, const memory_tracking::grantor_t &scratchpad) const;
+
+    /** performs the reduction with built-in synchronization. */
+    void reduce(int ithr, data_t *dst,
+            const memory_tracking::grantor_t &scratchpad) const {
+        bool redundant_reduction
+                = balancer().nthr_per_group_ == 1 || balancer().idle(ithr);
+        if (redundant_reduction) return;
+
+        auto bctx = scratchpad.template get<simple_barrier::ctx_t>(
+                memory_tracking::names::key_reducer_space_bctx);
+        simple_barrier::barrier(
+                &bctx[balancer().group_id(ithr)], balancer().nthr_per_group_);
+
+        reduce_nolock(ithr, dst, scratchpad);
+    }
+
+    void reduce_nolock(int ithr, data_t *dst,
+            const memory_tracking::grantor_t &scratchpad) const;
+
+    const reduce_balancer_t &balancer() const { return conf_.balancer_; }
+
+private:
+    static size_t space_per_thread(const reduce_balancer_t &balancer) {
+        return balancer.njobs_per_group_ub_ * balancer.job_size_;
+    }
+
+    /* The scratchpad is organized as follows:
+     *
+     * data_t space[nthr_][njobs_per_group_ub_][jobs_size_];
+     * simple_barrier::ctx_t barriers[groups_]; */
+
+    const conf_t conf_;
+    reducer_2d_driver_t<data_type> *drv_;
+
+    int choose_x_blocking(int nx, int ny, int nthr_per_grp) const;
+    void reduce_block(const data_t *space_base, data_t *dst, int job,
+            int start_y, int start_x, int ny_start, int nx_start, int ny_step,
+            int nx_step) const;
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(cpu_reducer_2d_t);
+};
+
+/** simple 1d accumulator: y[:] += x[:] */
+template <impl::data_type_t data_type>
+struct cpu_accumulator_1d_t {
+    typedef typename prec_traits<data_type>::type data_t;
+
+    cpu_accumulator_1d_t();
+    ~cpu_accumulator_1d_t();
+    void accumulate(data_t *dst, const data_t *src, size_t size);
+
+    status_t create_kernel();
+
+    reducer_2d_driver_t<data_type> *drv_;
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(cpu_accumulator_1d_t);
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_op_imm_check.hpp
+++ b/src/cpu/aarch64/jit_op_imm_check.hpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef JIT_OP_IMM_CHECK_HPP
+#define JIT_OP_IMM_CHECK_HPP
+
+#define LDRMAX 255
+#define LDRMIN (-256)
+#define STRMAX 255
+#define STRMIN (-256)
+#define LD1RWMAX 252
+#define PRFMMAX 32760
+#define PRFMMIN 0
+#define PRFWMAX 31
+#define PRFWMIN (-32)
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+// Check the immediate value for LDR(vector) instruction
+//
+//   The imm9 in the LDR instruction is the optional signed immediate vector
+//   offset, in the range -256 to 255, defaulting to 0.
+template <typename T>
+bool ldr_imm_check(T ofs) {
+    int vlen = cpu_isa_traits<sve_512>::vlen;
+    int vlen_shift = cpu_isa_traits<sve_512>::vlen_shift;
+    int shifted_ofs = ofs >> vlen_shift;
+    return ((shifted_ofs) <= LDRMAX) && (shifted_ofs >= LDRMIN)
+            && ((ofs % vlen) == 0);
+}
+
+// Check the immediate value for SDR(vector) instruction
+//
+//   The imm9 in the STR instruction is the optional signed immediate vector
+//   offset, in the range -256 to 255, defaulting to 0.
+template <typename T>
+bool str_imm_check(T ofs) {
+    int vlen = cpu_isa_traits<sve_512>::vlen;
+    int vlen_shift = cpu_isa_traits<sve_512>::vlen_shift;
+    int shifted_ofs = ofs >> vlen_shift;
+    return ((shifted_ofs) <= STRMAX) && (shifted_ofs >= STRMIN)
+            && ((ofs % vlen) == 0);
+}
+
+// Check the immediate value for LD1RW instruction
+//
+//   The imm6 in the LD1RW instruction is the optional unsigned immediate byte
+//   offset, a multiple of 4 in the range 0 to 252, defaulting to 0.
+template <typename T>
+bool ld1rw_imm_check(T ofs) {
+    return ((ofs & 0x3) == 0) && (ofs <= LD1RWMAX) && (ofs >= 0);
+}
+
+// Check the immediate value for PRFM(immediate) instruction
+//
+//   The pimm in the PRFM instruction is the optional positive immediate byte
+//   offset, a multiple of 8 in the range 0 to 32760, defaulting to 0.
+template <typename T>
+bool prfm_imm_check(T ofs) {
+    return (ofs <= PRFMMAX) && (ofs >= PRFMMIN) && ((ofs & 0x7) == 0);
+}
+
+// Check the immediate value for PRFW(scalar plus immediate) instruction
+//
+//   The imm6 in the PRFW instruction is the optional signed immediate vector
+//   offset, in the range -32 to 31, defaulting to 0.
+template <typename T>
+bool prfw_imm_check(T ofs) {
+    int vlen = cpu_isa_traits<sve_512>::vlen;
+    int vlen_shift = cpu_isa_traits<sve_512>::vlen_shift;
+    int shifted_ofs = ofs >> vlen_shift;
+
+    return (shifted_ofs <= PRFWMAX) && (shifted_ofs >= PRFWMIN)
+            && ((ofs % vlen) == 0);
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+#endif

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,11 +30,250 @@ namespace aarch64 {
 
 enum class jit_memory_tag_kind_t { ncsp, nspc, blocked, undef };
 
+/* convolution */
+enum conv_version_t {
+    ver_unused,
+    ver_fma,
+};
+
+enum conv_loop_order_t {
+    loop_cgn,
+    loop_gnc,
+    loop_ngc,
+    loop_gncw,
+    loop_cwgn,
+    loop_ngcw,
+    loop_nhwcg,
+    loop_nwcg
+};
+
+enum conv_kernel_kind_t { embd_bcast, expl_bcast };
+
+enum conv_harness_t {
+    harness_2d_reduction,
+    harness_3d_reduction,
+    harness_mb_reduction,
+    harness_compute_full_spatial,
+    harness_nxc
+};
+
+enum {
+    FLAG_MB_FIRST = 1 << 0,
+    FLAG_MB_LAST = 1 << 1,
+    FLAG_OC_FIRST = 1 << 2,
+    FLAG_OC_LAST = 1 << 3,
+    FLAG_IC_FIRST = 1 << 4,
+    FLAG_IC_LAST = 1 << 5,
+    FLAG_SP_FIRST = 1 << 6,
+    FLAG_SP_LAST = 1 << 7,
+    FLAG_REDUCE_FIRST = 1 << 8,
+    FLAG_REDUCE_LAST = 1 << 9,
+    FLAG_ZERO_FILTER = 1 << 0, /* Controls whether the inner kernel skips
+                                   loading weights-data from memory; this
+                                   needs to happen on the first Group/16
+                                   iteration. */
+    FLAG_ZERO_BIAS = 1 << 1, /* Controls whether the inner kernel skip
+                               loading bias data from memory */
+    FLAG_COMPUTE_BIAS = 1 << 2, /* Controls bias computation during execution
+                                    pass */
+};
+
+struct jit_conv_conf_t {
+    prop_kind_t prop_kind;
+    conv_version_t ver;
+    conv_loop_order_t loop_order;
+    conv_harness_t harness;
+
+    int simd_w;
+    int ndims;
+    int mb;
+    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    int id, ih, iw, od, oh, ow;
+    int f_pad, l_pad, t_pad;
+    int back_pad, r_pad, b_pad;
+    int kd, kh, kw;
+    int stride_d, stride_h, stride_w;
+    int dilate_d, dilate_h, dilate_w;
+    format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
+    bool with_bias;
+    bool with_sum;
+    bool with_eltwise;
+    bool with_binary;
+
+    bool is_fused_conv;
+    int dw_conv_buffer_oc;
+
+    post_ops_t::entry_t::eltwise_t eltwise;
+    post_ops_t post_ops;
+
+    int nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b;
+
+    int idp, ihp, iwp, ohp, owp;
+    int nb_ic, ic_block;
+    int nb_oc, oc_block;
+    int nb_iw, iw_block;
+    int nb_ow, ow_block;
+    int nb_oc_blocking; /* used in jit kernels for nb_oc work blocking taking
+                           into account vector registers distribution */
+    int nb_oc_blocking_thr_chunk; /* used for distribution of nb_oc work
+                                      within threads */
+    int nb_ic_blocking, nb_ic_blocking_max; // blocking of nb_ic work
+    int nb_ic_L2;
+    int h_blocking;
+    int nb_oc_L2;
+    int ic_tail, oc_tail;
+    int ur_h, ur_w;
+    int ur_w_tail;
+    int ur_ic, ur_kw;
+    bool is_1stconv;
+    int nonblk_group_off;
+    /* fma sve512_core */
+    conv_kernel_kind_t kernel_kind;
+
+    int tr_iw, tr_ih;
+    int tr_kw, tr_kh;
+    int tr_src_num_guard_elems;
+
+    // Transpose buffer management
+    size_t tr_src_buf_size, tr_src_buf_count;
+    size_t tr_diff_dst_buf_size, tr_diff_dst_buf_count;
+    int nthr_mb_work;
+
+    /* 1st conv */
+    int tr_ld;
+    int kh_step;
+    /* sve_512_u8s8u8 */
+    int typesize_in;
+    int typesize_out;
+    int typesize_bia;
+    int typesize_acc;
+    int ic_nb1, ic_nb2;
+    int oc_nb1;
+    int ur_ow_max, ur_ow, ur_ow_tail;
+    int ur_ow_nsteps;
+    data_type_t bia_dt;
+    /* bf16 data-type for output */
+    data_type_t dst_dt;
+    data_type_t src_dt;
+    /* bf16 weights update */
+    data_type_t wei_dt;
+    data_type_t dsrc_dt;
+    data_type_t dwei_dt;
+    bool expl_bcast;
+    bool large_spatial, large_w_filter;
+    int is_oc_scale;
+    int max_regs_ur; // maximum accumulation registers
+    // dw conv
+    int nb_ch, ch_block, nb_ch_blocking;
+    bool is_depthwise, is_fast_depthwise, is_resrc_depthwise;
+    int aligned_threads;
+    // large spatial
+    int h_blk_size, oh_blk_size;
+    // s8s8 convolution
+    bool signed_input;
+    bool need_saturation;
+    float wei_adj_scale;
+    // zero-point compensation
+    bool src_zero_point;
+    bool dst_zero_point;
+    bool zp_src_is_common; // common, otherwise (TODO) per-channel
+
+    bool uses_permw_transposition;
+    bool transpose_src;
+    bool transpose_dst;
+    int ic_block_step;
+
+    bool is_hw_transp; // spatial dim height-width transposed
+};
+
+// calculates filter size taking into account dilation
+inline int calculate_extended_filter_size(int filter_size, int dilation) {
+    return (filter_size - 1) * (dilation + 1) + 1;
+}
+
 inline int calculate_end_padding(int start_padding, int dst_size, int src_size,
         int spatial_stride, int dilated_filter_size) {
     return (dst_size - 1) * spatial_stride + dilated_filter_size
             - (src_size + start_padding);
 }
+
+inline status_t init_tag(format_tag_t &tag, const memory_desc_wrapper &mdw,
+        const format_tag_t &tag_value) {
+    if (mdw.format_kind() == format_kind::any) return status::unimplemented;
+
+    tag = mdw.matches_one_of_tag(tag_value);
+    return tag == tag_value ? status::success : status::unimplemented;
+}
+
+struct jit_conv_call_s {
+    const void *src; /* hack, non-const for backward_data */
+    const void *dst; /* hack, non-const for forward */
+    const void *filt; /* hack, non-const for backward_weights */
+    const void *bias; /* hack, non-const for backward_bias */
+    const void *src_prf;
+    const void *dst_prf;
+    const void *filt_prf;
+    const void *bias_prf;
+    const void *scales;
+    const void *acc_s32;
+    const void *compensation;
+    const int32_t *zp_compensation;
+    const int32_t *src_zero_point;
+    const int32_t *dst_zero_point;
+    const void *tile_cfg;
+    const void *tile_cfg_tail;
+
+    // ptr to table of void * elements that are pointers to
+    // post_op binary src1 tensors
+    const void *post_ops_binary_rhs_arg_vec;
+    // logical (# of elems) offset to the processed output channel
+    // (for broadcasting [1,OC,1,1])
+    size_t oc_l_off;
+    const void *dst_orig; // pointer to dst memory (no offset)
+
+    size_t oc_l_off_prf;
+    const void *dst_orig_prf;
+
+    size_t kd_offset;
+    size_t kd_offset_prf;
+    size_t kh_offset;
+    size_t kh_offset_prf;
+    size_t os_index_begin;
+    size_t os_index_begin_prf;
+    size_t os_index_end;
+    size_t os_index_end_prf;
+    size_t kd_padding;
+    size_t kd_padding_prf;
+    size_t kh_padding;
+    size_t kh_padding_prf;
+    size_t iwb;
+    size_t iwb_prf;
+    size_t owb;
+    size_t owb_prf;
+    size_t kw_padding;
+    size_t channel;
+    size_t channel_prf;
+    size_t oc_blocks;
+    size_t ur_w;
+    size_t ur_str_w;
+    size_t ch_blocks;
+    size_t ch_blocks_prf;
+    size_t reduce_work;
+    size_t reduce_work_prf;
+    size_t load_work;
+    size_t load_work_prf;
+    size_t t_overflow;
+    size_t b_overflow;
+    size_t f_overflow;
+    size_t back_overflow;
+    size_t last_h;
+    size_t tail;
+    size_t current_iw;
+    size_t is_osb;
+    int flags;
+    int flags_prf;
+    int oc_flag;
+};
 
 struct jit_pool_conf_t {
     int ndims;

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
@@ -1,0 +1,4366 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/cpu_barrier.hpp"
+
+#include "cpu/aarch64/jit_sve_512_conv_kernel.hpp"
+#include "cpu/platform.hpp"
+
+#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_call_s, field))
+#define A64FX_L2_EFFECTIVE_CAPACITY ((666 - 128) * 1024)
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::format_tag;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+namespace {
+
+constexpr auto small_spatial = 14;
+unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
+unsigned int L2_cache_size = platform::get_per_core_cache_size(2);
+
+inline void pick_loop_order(jit_conv_conf_t &jcp) {
+    using namespace prop_kind;
+    assert(one_of(
+            jcp.prop_kind, forward_training, forward_inference, backward_data));
+    auto w = (jcp.prop_kind == backward_data) ? jcp.iw : jcp.ow;
+    auto h = (jcp.prop_kind == backward_data) ? jcp.ih : jcp.oh;
+
+    // The w in the loop order is currently ignored by 3D BWD_D
+    jcp.loop_order = (w <= small_spatial && h <= small_spatial) ? loop_cwgn
+                                                                : loop_gncw;
+    if (utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc)
+            && jcp.ngroups > 1 && jcp.oc < 16)
+        jcp.loop_order = loop_nhwcg;
+}
+
+inline status_t init_tag(format_tag_t &tag, memory_desc_t &md,
+        const memory_desc_wrapper &mdw, const format_tag_t tag_value) {
+    if (mdw.format_kind() == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(md, tag_value));
+        tag = tag_value;
+    } else {
+        tag = mdw.matches_one_of_tag(tag_value);
+    }
+
+    if (tag != tag_value) return status::unimplemented;
+
+    return status::success;
+}
+
+inline bool is_1stconv(const jit_conv_conf_t &jcp) {
+    if (mayiuse(sve_512))
+        return (jcp.ic < 16 && jcp.ngroups == 1);
+    else
+        return one_of(jcp.ic, 1, 3);
+}
+
+inline bool is_ow_threading_on(const jit_conv_conf_t &jcp) {
+    return (jcp.nb_ow > 1);
+}
+
+inline bool is_iw_threading_on(const jit_conv_conf_t &jcp) {
+    return (jcp.nb_iw > 1);
+}
+inline bool is_owb_prefetching(const jit_conv_conf_t &jcp) {
+    return false;
+}
+
+} // namespace
+
+void jit_sve_512_conv_fwd_kernel::prepare_output(int ur_w) {
+
+    auto zreg_out_s = [=](int i_ur, int i_oc) {
+        int idx = i_ur + i_oc * jcp.ur_w;
+        assert(idx < ker_reg_base_idx);
+        return ZRegS(idx);
+    };
+
+    int prev_out_ofs = -1;
+    for (int k = 0; k < jcp.nb_oc_blocking; k++)
+        for (int j = 0; j < ur_w; j++) {
+            fmov(zreg_out_s(j, k));
+            if (!is_owb_prefetching(jcp)) {
+                size_t aux_output_offset = get_output_offset(j, k);
+                std::string op = "LD";
+                if (j == 0) {
+                    prefetch(op, 2, reg_out_prf, aux_output_offset);
+                    add_imm(reg_tmp_addr, reg_out_prf, aux_output_offset,
+                            reg_tmp_imm);
+                } else {
+                    add_imm(reg_tmp_addr, reg_tmp_addr,
+                            aux_output_offset - prev_out_ofs, reg_tmp_imm);
+                    prefetch(op, 2, reg_tmp_addr, 0);
+                }
+                prev_out_ofs = aux_output_offset;
+            }
+        }
+}
+
+void jit_sve_512_conv_fwd_kernel::store_output(int ur_w) {
+
+    Label no_update_label, store_label, eltwise_label;
+
+    auto _test = [&](const int cond) { return tst(reg_channel, cond); };
+
+    auto zreg_tmp = [=](int idx) { return ZReg(idx); };
+    auto zreg_tmp_s = [=](int idx) { return ZRegS(idx); };
+
+    auto zreg_out = [=](int i_ur, int i_oc) {
+        int idx = i_ur + i_oc * jcp.ur_w;
+        assert(idx < ker_reg_base_idx);
+        return ZReg(idx);
+    };
+    auto zreg_out_s = [=](int i_ur, int i_oc) {
+        int idx = i_ur + i_oc * jcp.ur_w;
+        assert(idx < ker_reg_base_idx);
+        return ZRegS(idx);
+    };
+
+    ldr(reg_channel, ptr(abi_param1, GET_OFF(flags)));
+
+    if (jcp.with_bias) { ldr(reg_bias, ptr(abi_param1, GET_OFF(bias))); }
+
+    if (!jcp.with_sum) {
+        auto _jmp = [&](const Label &l) { return b(NE, l); };
+
+        _test(FLAG_IC_FIRST);
+        _jmp(no_update_label);
+    }
+
+    int reg_ofs = jcp.ur_w * jcp.nb_oc_blocking;
+    int num_regs = 32 - reg_ofs;
+    int prev_out_ofs = -1;
+
+    for (int k = 0; k < jcp.nb_oc_blocking; k++) {
+        for (int j = 0; j < ur_w; j++) {
+            size_t aux_output_offset = get_output_offset(j, k);
+            int idx = reg_ofs + ((j + k * ur_w) % num_regs);
+            if (j == 0) {
+                add_imm(reg_out_ofs, reg_out, aux_output_offset, reg_tmp_imm);
+                prev_out_ofs = aux_output_offset;
+                ldr(zreg_tmp(idx), ptr(reg_out_ofs));
+            } else if (ldr_imm_check(aux_output_offset - prev_out_ofs)) {
+                ldr(zreg_tmp(idx),
+                        ptr(reg_out_ofs,
+                                static_cast<int32_t>(VL_OFS(
+                                        aux_output_offset - prev_out_ofs))));
+            } else {
+                add_imm(reg_out_ofs, reg_out_ofs,
+                        aux_output_offset - prev_out_ofs, reg_tmp_imm);
+                prev_out_ofs = aux_output_offset;
+                ldr(zreg_tmp(idx), ptr(reg_out_ofs));
+            }
+        }
+        for (int j = 0; j < ur_w; j++) {
+            int idx = reg_ofs + ((j + k * ur_w) % num_regs);
+            fadd(zreg_out_s(j, k), zreg_out_s(j, k), zreg_tmp_s(idx));
+        }
+    }
+
+    if (!jcp.with_sum) {
+        b(eltwise_label);
+    } else {
+        auto _jmp = [&](const Label &l) { return b(EQ, l); };
+
+        // *Note 1
+        _test(FLAG_IC_FIRST);
+        _jmp(eltwise_label);
+    }
+
+    auto bias_load = [=](int bias_offset, int idx) {
+        int ofs = bias_offset;
+
+        if ((VL_OFS(ofs) < LDRMAX) && (VL_OFS(ofs) >= (-1 * LDRMAX))
+                && ((ofs & 0x3f) == 0)) {
+            ldr(zreg_tmp(idx),
+                    ptr(reg_bias, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            add_imm(reg_tmp_addr, reg_bias, ofs, reg_tmp_imm);
+            ldr(zreg_tmp(idx), ptr(reg_tmp_addr));
+        }
+    };
+
+    L(no_update_label);
+    if (jcp.with_bias) {
+        for (int k = 0; k < jcp.nb_oc_blocking; k++) {
+            int bias_offset = jcp.typesize_out * k * jcp.oc_block;
+            int idx = reg_ofs + (k % num_regs);
+            bias_load(bias_offset, idx);
+            for (int j = 0; j < ur_w; j++) {
+                fadd(zreg_out_s(j, k), zreg_out_s(j, k), zreg_tmp_s(idx));
+            }
+            int ofs = bias_offset + 256; // cache line size ?
+            std::string op = "LD";
+            prefetch(op, 2, reg_bias, ofs);
+        }
+    }
+
+    L(eltwise_label);
+    if (jcp.with_eltwise) {
+        tst(reg_channel, FLAG_IC_LAST);
+        b(EQ, store_label);
+
+#ifndef DISABLE_ELTWISE
+        if (ur_w == jcp.ur_w) {
+            eltwise_injector_->compute_vector_range(
+                    0, jcp.nb_oc_blocking * jcp.ur_w);
+        } else {
+            for (int k = 0; k < jcp.nb_oc_blocking; k++)
+                eltwise_injector_->compute_vector_range(
+                        k * jcp.ur_w, k * jcp.ur_w + ur_w);
+        }
+#else // #ifndef DISABLE_ELTWISE
+        assert(!"Error: with_eltwise is not supported");
+#endif // #ifndef DISABLE_ELTWISE
+    }
+    auto out_str = [=](int j, int k, int aux_output_offset, int prev_out_ofs) {
+        int ofs = aux_output_offset;
+
+        if (str_imm_check(ofs)) {
+            str(zreg_out(j, k),
+                    ptr(reg_out, static_cast<int32_t>(VL_OFS(ofs))));
+        } else if ((prev_out_ofs != -1) && str_imm_check(ofs - prev_out_ofs)) {
+            str(zreg_out(j, k),
+                    ptr(reg_tmp_addr,
+                            static_cast<int32_t>(VL_OFS(ofs - prev_out_ofs))));
+        } else {
+            if (prev_out_ofs == -1)
+                add_imm(reg_tmp_addr, reg_out, ofs, reg_tmp_imm);
+            else
+                add_imm(reg_tmp_addr, reg_tmp_addr, ofs - prev_out_ofs,
+                        reg_tmp_imm);
+            str(zreg_out(j, k), ptr(reg_tmp_addr));
+            prev_out_ofs = aux_output_offset;
+        }
+        return prev_out_ofs;
+    };
+
+    L(store_label);
+    prev_out_ofs = -1;
+    for (int k = 0; k < jcp.nb_oc_blocking; k++) {
+        for (int j = 0; j < ur_w; j++) {
+            size_t aux_output_offset = (size_t)typesize
+                    * ((size_t)k * jcp.od * jcp.oh * jcp.ow + j) * jcp.oc_block;
+
+            prev_out_ofs = out_str(j, k, aux_output_offset,
+                    prev_out_ofs); // <- reg_tmp_addr
+        }
+    }
+}
+
+void jit_sve_512_conv_fwd_kernel::compute_loop_fma_core(
+        int ur_w, int pad_l, int pad_r) {
+    int kw = jcp.kw;
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+    int nb_oc_block = jcp.nb_oc_blocking;
+    const bool is_source_layout_nxc = is_src_layout_nxc();
+    const bool icb_loop_in_compute_function = is_source_layout_nxc;
+    const int ic_tail = jcp.ic_tail;
+
+    Label kh_label, kd_label;
+
+    std::vector<Label> ic_tail_jmp(kw);
+    int shift_kernel_ptr
+            = jcp.typesize_in * jcp.kw * jcp.oc_block * jcp.ic_block;
+    int inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
+                                       : (!jcp.is_1stconv ? ic_block : 1);
+
+    int shift_input_ptr
+            = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mul;
+
+    if (one_of(jcp.ndims, 3, 4)) {
+        mov(aux_reg_inp, reg_inp);
+        add_imm(aux_reg_inp2, aux_reg_inp, 0x100, reg_tmp_imm);
+        add_imm(aux_reg_inp3, aux_reg_inp2, 0x100, reg_tmp_imm);
+        mov(aux_reg_ker, reg_ker);
+    }
+
+    if (jcp.ndims == 5) {
+        mov(reg_out_org, reg_out);
+        ldr(reg_ki, ptr(abi_param1, GET_OFF(kd_padding)));
+        if (icb_loop_in_compute_function) {
+            // need to continue with the same kernel pointer, but as
+            // aux_reg_ker_d == reg_ker we need to save its value and restore
+            // it after kd loop
+            mov(aux_reg_ker_d_org, aux_reg_ker_d);
+        } else {
+            mov(aux_reg_ker_d, aux_reg_ker_d_org);
+        }
+        mov(aux_reg_inp_d, reg_inp);
+
+        L(kd_label);
+        ldr(reg_kj, ptr(abi_param1, GET_OFF(kh_padding)));
+    } else {
+        mov(reg_kj, reg_kh);
+    }
+
+    if (jcp.ndims == 5) {
+        mov(aux_reg_inp, aux_reg_inp_d);
+        add_imm(aux_reg_inp2, aux_reg_inp, 0x100, reg_tmp_imm);
+        add_imm(aux_reg_inp3, aux_reg_inp2, 0x100, reg_tmp_imm);
+        mov(aux_reg_ker, aux_reg_ker_d);
+    }
+
+    auto zreg_inp_s = [=](int i_ic, int nb_x_blocking) {
+        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+        assert(idx < 31);
+        return ZRegS(idx);
+    };
+    auto zreg_out_s = [=](int i_ur, int i_oc) {
+        int idx = i_ur + i_oc * jcp.ur_w;
+        assert(idx < ker_reg_base_idx);
+        return ZRegS(idx);
+    };
+    auto zreg_wei = [=](int idx) {
+        assert(idx < 32);
+        return ZReg(idx);
+    };
+    auto zreg_wei_s = [=](int idx) {
+        assert(idx < 32);
+        return ZRegS(idx);
+    };
+
+    auto bcast_load = [&](int jj, int nb_oc_block, int aux_input_offset,
+                              int prev_ofs) {
+        if (ld1rw_imm_check(aux_input_offset)) {
+            ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                    ptr(aux_reg_inp, static_cast<int32_t>(aux_input_offset)));
+        } else if (ld1rw_imm_check(aux_input_offset - 0x100)) {
+            ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                    ptr(aux_reg_inp2,
+                            static_cast<int32_t>(aux_input_offset - 0x100)));
+        } else if (ld1rw_imm_check(aux_input_offset - 0x200)) {
+            ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                    ptr(aux_reg_inp3,
+                            static_cast<int32_t>(aux_input_offset - 0x200)));
+        } else {
+            if ((prev_ofs != -1)
+                    && ld1rw_imm_check(aux_input_offset - prev_ofs)) {
+
+                ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr,
+                                static_cast<int32_t>(
+                                        aux_input_offset - prev_ofs)));
+            } else {
+                int ofs;
+                if ((prev_ofs != -1) && ((aux_input_offset - prev_ofs) > 0)) {
+                    ofs = aux_input_offset - prev_ofs;
+                    add_imm(reg_prev_bcast_addr, reg_prev_bcast_addr, ofs,
+                            reg_tmp_imm);
+                } else {
+                    ofs = aux_input_offset;
+                    add_imm(reg_prev_bcast_addr, aux_reg_inp, ofs, reg_tmp_imm);
+                }
+
+                ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr));
+                prev_ofs = aux_input_offset;
+            }
+        }
+
+        return prev_ofs;
+    };
+
+    auto wei_load = [=](int aux_kernel_offset, int reg_idx, int prev_ofs) {
+        int ofs = aux_kernel_offset;
+
+        if (ldr_imm_check(ofs)) {
+            ldr(zreg_wei(reg_idx),
+                    ptr(aux_reg_ker, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            int ofs_tmp = ofs - prev_ofs;
+            if ((prev_ofs != -1) && ldr_imm_check(ofs_tmp)) {
+                ldr(zreg_wei(reg_idx),
+                        ptr(reg_prev_wei_addr,
+                                static_cast<int32_t>(VL_OFS(ofs_tmp))));
+            } else {
+                if ((prev_ofs != -1) && (ofs_tmp > 0)) {
+                    ofs_tmp = aux_kernel_offset - prev_ofs;
+                    add_imm(reg_prev_wei_addr, reg_prev_wei_addr, ofs_tmp,
+                            reg_tmp_imm);
+                } else {
+                    add_imm(reg_prev_wei_addr, aux_reg_ker, ofs, reg_tmp_imm);
+                }
+
+                ldr(zreg_wei(reg_idx), ptr(reg_prev_wei_addr));
+                prev_ofs = ofs;
+            }
+        }
+        return prev_ofs;
+    };
+
+    align(32);
+    L(kh_label);
+    {
+        int prev_bcast_ofs = -1;
+        int prev_wei_ofs = -1;
+        for (int ki = 0; ki < kw; ki++) {
+
+            int jj_start = get_ow_start(ki, pad_l);
+            int jj_end = get_ow_end(ur_w, ki, pad_r);
+
+            int wei_reg_ofs = nb_oc_block * jcp.ur_w;
+            wei_reg_ofs += ur_w >= 16 ? 1 : jj_end;
+            int num_regs4wei = 32 - wei_reg_ofs;
+            for (int ic = 0; ic < ic_block; ic++) {
+                if (ic_tail && ic >= ic_tail) {
+                    // if src has only tails to compute, skip early
+                    if (jcp.ic == ic_tail) {
+                        break;
+                    } else if (ic == ic_tail) {
+                        cmp_imm(reg_channel, ic_tail, reg_tmp_imm);
+                        b(EQ, ic_tail_jmp[ki]);
+                    }
+                }
+                int wei_count = 0;
+                for (int ii = 0; ii < nb_oc_block; ii++) {
+                    int reg_idx = wei_reg_ofs + ii;
+                    if (reg_idx >= 32) break;
+                    int aux_kernel_offset = jcp.typesize_in
+                            * (ii * jcp.nb_ic * jcp.kh * jcp.kw * jcp.kd
+                                            * ic_block * oc_block
+                                    + ki * ic_block * oc_block + ic * oc_block);
+
+                    wei_count++;
+                    if (jj_end - jj_start > 0) {
+                        prev_wei_ofs = wei_load(aux_kernel_offset,
+                                wei_reg_ofs + (ii % num_regs4wei),
+                                prev_wei_ofs);
+                    }
+                }
+
+                if ((jcp.kernel_kind == expl_bcast) && (ur_w < 16)) {
+                    for (int jj = jj_start; jj < jj_end; jj++) {
+                        size_t aux_input_offset
+                                = get_input_offset(ki, ic, jj, pad_l);
+                        prev_bcast_ofs = bcast_load(jj, nb_oc_block,
+                                aux_input_offset, prev_bcast_ofs);
+                    }
+                }
+
+                for (int ii = 0; ii < nb_oc_block; ii++) {
+                    int aux_kernel_offset = jcp.typesize_in
+                            * ((ii + wei_count) * jcp.nb_ic * jcp.kh * jcp.kw
+                                            * jcp.kd * ic_block * oc_block
+                                    + ki * ic_block * oc_block + ic * oc_block);
+
+                    for (int jj = jj_start; jj < jj_end; jj++)
+                        if (jcp.kernel_kind == expl_bcast) {
+                            if (ur_w >= 16) {
+                                size_t aux_input_offset
+                                        = get_input_offset(ki, ic, jj, pad_l);
+                                prev_bcast_ofs = bcast_load(0, nb_oc_block,
+                                        aux_input_offset, prev_bcast_ofs);
+
+                                fmla(zreg_out_s(jj, ii), reg_p_all_ones,
+                                        zreg_inp_s(0, nb_oc_block),
+                                        zreg_wei_s(wei_reg_ofs
+                                                + (ii % num_regs4wei)));
+
+                            } else {
+                                fmla(zreg_out_s(jj, ii), reg_p_all_ones,
+                                        zreg_inp_s(jj, nb_oc_block),
+                                        zreg_wei_s(wei_reg_ofs
+                                                + (ii % num_regs4wei)));
+                            }
+                        } else {
+                            assert(NULL);
+                        }
+
+                    if ((jj_end - jj_start > 0)
+                            && ((wei_count + ii) < nb_oc_block)) {
+                        prev_wei_ofs = wei_load(aux_kernel_offset,
+                                wei_reg_ofs + ((ii + wei_count) % num_regs4wei),
+                                prev_wei_ofs);
+                    }
+                }
+            }
+            L(ic_tail_jmp[ki]);
+        }
+
+        add_imm(aux_reg_ker, aux_reg_ker, shift_kernel_ptr, reg_tmp_imm);
+        add_imm(aux_reg_inp, aux_reg_inp, shift_input_ptr, reg_tmp_imm);
+        add_imm(aux_reg_inp2, aux_reg_inp, 0x100, reg_tmp_imm);
+        add_imm(aux_reg_inp3, aux_reg_inp2, 0x100, reg_tmp_imm);
+        sub(reg_kj, reg_kj, 1); //dec(reg_kj);
+        cmp(reg_kj, 0);
+        b(GT, kh_label);
+    }
+
+    if (jcp.ndims == 5) {
+        add_imm(aux_reg_inp_d, aux_reg_inp_d,
+                typesize * (jcp.dilate_d + 1) * jcp.ih * jcp.iw * inp_mul,
+                reg_tmp_imm);
+        const int ker_shift
+                = typesize * jcp.kw * jcp.kh * jcp.oc_block * jcp.ic_block;
+        add_imm(aux_reg_ker_d, aux_reg_ker_d, ker_shift, reg_tmp_imm);
+
+        sub(reg_ki, reg_ki, 1); //dec(reg_ki);
+        cmp(reg_ki, 0);
+        b(GT, kd_label);
+
+        if (icb_loop_in_compute_function) mov(aux_reg_ker_d, aux_reg_ker_d_org);
+        mov(reg_out, reg_out_org);
+    }
+}
+
+void jit_sve_512_conv_fwd_kernel::compute_loop(int ur_w, int pad_l, int pad_r) {
+
+    if (jcp.ndims == 5) mov(reg_oi_org, reg_oi);
+
+    prepare_output(ur_w);
+
+    Label skip_compute_loop;
+    if (jcp.ndims == 5) {
+        if ((jcp.dilate_d >= jcp.id)
+                || (jcp.kd - 1) * (jcp.dilate_d + 1)
+                        < nstl::max(jcp.f_pad, jcp.back_pad)) {
+            ldr(reg_kj, ptr(abi_param1, GET_OFF(kd_padding)));
+            cmp(reg_kj, 0);
+            b(LE, skip_compute_loop);
+        }
+    }
+    if ((jcp.dilate_h >= jcp.ih)
+            || (jcp.kh - 1) * (jcp.dilate_h + 1)
+                    < nstl::max(jcp.t_pad, jcp.b_pad)) {
+        ldr(reg_kj, ptr(abi_param1, GET_OFF(kh_padding)));
+        cmp(reg_kj, 0);
+        b(LE, skip_compute_loop);
+    }
+
+    Label ic_loop;
+    const bool generate_icb_loop = jcp.nb_ic > 1 && is_src_layout_nxc();
+    if (generate_icb_loop) {
+        mov(reg_inp_org, reg_inp);
+        mov(reg_ker_org, reg_ker);
+
+        ldr(reg_channel, ptr(param, GET_OFF(reduce_work)));
+        L(ic_loop);
+    }
+
+    if (jcp.ver == ver_fma)
+        if (jcp.is_1stconv && jcp.kernel_kind != expl_bcast)
+            assert(!"STOP:jcp.is_1stconv && jcp.kernel_kind != expl_bcast");
+        else if (jcp.kernel_kind == embd_bcast && jcp.nb_oc_blocking == 1)
+            assert(!"STOP:jcp.kernel_kind == embd_bcast && jcp.nb_oc_blocking "
+                    "== 1");
+        else {
+            compute_loop_fma_core(ur_w, pad_l, pad_r);
+        }
+    else
+        assert(!"unknown convolution version");
+
+    if (generate_icb_loop) {
+        assert(is_src_layout_nxc());
+        const int inp_shift = jcp.ic_block * jcp.typesize_in;
+        add_imm(reg_inp, reg_inp, inp_shift, reg_tmp_imm);
+        const int ker_shift = jcp.kd * jcp.kh * jcp.kw * jcp.ic_block
+                * jcp.oc_block * jcp.typesize_in;
+        add_imm(reg_ker, reg_ker, ker_shift, reg_tmp_imm);
+        sub_imm(reg_channel, reg_channel, jcp.ic_block, reg_tmp_imm);
+        b(GT, ic_loop);
+        mov(reg_ker, reg_ker_org);
+        mov(reg_inp, reg_inp_org);
+    }
+
+    L(skip_compute_loop);
+    store_output(ur_w);
+    if (jcp.ndims == 5) mov(reg_oi, reg_oi_org);
+}
+
+void jit_sve_512_conv_fwd_kernel::generate() {
+    int iw = jcp.iw;
+    int ow = jcp.ow;
+    int ow_block = jcp.ow_block;
+    int nb_ow = jcp.nb_ow;
+    int kw = jcp.kw;
+    int l_pad = jcp.l_pad;
+    int ur_w = jcp.ur_w;
+    int ur_w_tail = jcp.ur_w_tail;
+    int stride_w = jcp.stride_w;
+
+    int inp_mult = is_src_layout_nxc() ? jcp.ngroups * jcp.ic
+                                       : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    int inp_shift_pad = jcp.typesize_in * (ur_w * stride_w - l_pad) * inp_mult;
+    int inp_shift = jcp.typesize_in * ur_w * stride_w * inp_mult;
+    int inp_shift_pad_second_block = -1 * jcp.typesize_in * l_pad * inp_mult;
+    int out_shift = jcp.typesize_out * ur_w
+            * (is_dst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block);
+
+    preamble();
+    ldr(reg_inp, ptr(abi_param1, GET_OFF(src)));
+    ldr(reg_out, ptr(abi_param1, GET_OFF(dst)));
+    ldr(reg_ker, ptr(abi_param1, GET_OFF(filt)));
+    ldr(reg_kh, ptr(abi_param1, GET_OFF(kh_padding)));
+    if (jcp.ndims == 5) mov(aux_reg_ker_d_org, reg_ker);
+
+    int r_pad = nstl::max(0, jcp.r_pad);
+    int n_oi = ow / ur_w;
+    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+            calculate_extended_filter_size(kw, jcp.dilate_w));
+
+    ptrue(reg_p_all_ones.b);
+
+    if (!is_ow_threading_on(jcp)) { // nb_ow <= 1
+        // nb_ow is # of output width blocks ??
+
+        // ow is being processed as a whole - with left and right paddings
+        // n_oi is # of output width blocks ??
+        if (r_pad1 > 0) n_oi--;
+
+        if (ow == ur_w) {
+            ldr(reg_out_prf, ptr(abi_param1, GET_OFF(dst_prf)));
+            compute_loop(ur_w, l_pad, r_pad);
+        } else {
+            mov(reg_out_prf, reg_out);
+            if (n_oi == 0) {
+                add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+                compute_loop(ur_w, l_pad, r_pad1);
+                add_imm(reg_inp, reg_inp, inp_shift_pad, reg_tmp_imm);
+                add_imm(reg_out, reg_out, out_shift, reg_tmp_imm);
+                if (ur_w_tail != 0) {
+                    add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+                    compute_loop(ur_w_tail, 0, r_pad);
+                }
+            } else {
+                mov(reg_oi, 0);
+                if (l_pad > 0) {
+                    add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+                    compute_loop(ur_w, l_pad, 0);
+                    add_imm(reg_inp, reg_inp, inp_shift_pad, reg_tmp_imm);
+                    add_imm(reg_out, reg_out, out_shift, reg_tmp_imm);
+                    add_imm(reg_oi, reg_oi, 1, reg_tmp_imm); // increment
+                }
+                if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
+                    Label ow_loop_label;
+                    L(ow_loop_label);
+                    {
+                        add_imm(reg_out_prf, reg_out_prf, out_shift,
+                                reg_tmp_imm);
+                        compute_loop(ur_w, 0, 0);
+
+                        add_imm(reg_inp, reg_inp, inp_shift, reg_tmp_imm);
+                        add_imm(reg_out, reg_out, out_shift, reg_tmp_imm);
+                        add_imm(reg_oi, reg_oi, 1, reg_tmp_imm); //inc(reg_oi);
+                        cmp_imm(reg_oi, n_oi, reg_tmp_imm);
+
+                        b(LT, ow_loop_label);
+                    }
+                }
+                if (r_pad1 > 0) {
+                    add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+                    compute_loop(ur_w, 0, r_pad1);
+                    add_imm(reg_inp, reg_inp, inp_shift, reg_tmp_imm);
+                    add_imm(reg_out, reg_out, out_shift, reg_tmp_imm);
+                }
+                if (ur_w_tail != 0) {
+                    add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+                    compute_loop(ur_w_tail, 0, r_pad);
+                }
+            }
+        }
+    } else {
+        // ow block is only processed.
+        // Number of block is passed as parameter owb,
+        // and padding processing depends on this number.
+
+        Label end_label, last_oi_label, middle_ow_blocks_label, tail_label;
+        Label oi_loop_label, oi_loop_start_label, oi_loop_end_label;
+
+        assert(ow_block % ur_w == 0);
+        int n_oi_not_last_ow_block = ow_block / ur_w;
+        // to simplify code (and general regs usage),
+        // size of ow block must be >= 2 * ur_w
+        assert(n_oi_not_last_ow_block > 1);
+        int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
+        int n_oi_first_ow_block = n_oi_not_last_ow_block;
+
+        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
+
+        // prepare right padding
+        bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
+        bool first_ow_block_padded
+                = next_last_ow_block_padded && jcp.nb_ow == 2;
+        bool last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block > 0;
+
+        if (last_ow_block_padded)
+            n_oi_last_ow_block--;
+        else if (first_ow_block_padded)
+            n_oi_first_ow_block--;
+        else if (next_last_ow_block_padded)
+            n_oi_next_last_ow_block--;
+
+        ldr(reg_owb, ptr(abi_param1, GET_OFF(owb)));
+        cmp(reg_owb, 0); // is that the first ow-block ?
+        b(GT, middle_ow_blocks_label);
+
+        // the first ow block, compute left padding
+
+        mov(reg_oi, n_oi_first_ow_block);
+        mov(reg_out_prf, reg_out);
+
+        if (l_pad > 0) {
+            add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+            compute_loop(ur_w, l_pad, 0);
+            add_imm(reg_inp, reg_inp, inp_shift_pad, reg_tmp_imm);
+            add_imm(reg_out, reg_out, out_shift, reg_tmp_imm);
+            sub(reg_oi, reg_oi, 1); // decrement
+            cmp(reg_oi, 0);
+        }
+        b(oi_loop_label);
+
+        // middle or last ow block entry
+
+        L(middle_ow_blocks_label);
+
+        if (l_pad > 0) {
+            // just to consider left padding, not compute
+            add_imm(reg_inp, reg_inp, inp_shift_pad_second_block, reg_tmp_imm);
+        }
+
+        // set number of iteration for oi-loop
+        cmp_imm(reg_owb, jcp.nb_ow - 1, reg_tmp_imm); // last ow-block ?
+        mov(reg_oi, n_oi_last_ow_block);
+        b(EQ, oi_loop_label);
+        cmp_imm(reg_owb, jcp.nb_ow - 2, reg_tmp_imm); // next to last ow-block ?
+        mov(reg_oi, n_oi_next_last_ow_block);
+        b(EQ, oi_loop_label);
+        mov(reg_oi, n_oi_not_last_ow_block); // other middle ow-blocks
+
+        // oi loop w/o padding
+        L(oi_loop_label);
+        L(oi_loop_start_label);
+        cmp(reg_oi, 0);
+        b(LE, oi_loop_end_label);
+
+        add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+        compute_loop(ur_w, 0, 0);
+        add_imm(reg_inp, reg_inp, inp_shift, reg_tmp_imm);
+        add_imm(reg_out, reg_out, out_shift, reg_tmp_imm);
+        sub(reg_oi, reg_oi, 1); // dec(reg_oi);
+        cmp(reg_oi, 0);
+        b(oi_loop_start_label);
+        L(oi_loop_end_label);
+
+        ldr(reg_owb, ptr(abi_param1, GET_OFF(owb)));
+
+        cmp(reg_owb, 0); // first ow-block ?
+        if (first_ow_block_padded) {
+            b(EQ, last_oi_label);
+        } else {
+            b(EQ, end_label);
+        }
+        cmp_imm(reg_owb, jcp.nb_ow - 2, reg_tmp_imm); // next to last ow-block ?
+        b(LT, end_label);
+        if (next_last_ow_block_padded) {
+            b(EQ, last_oi_label);
+        } else {
+            b(EQ, end_label);
+        }
+        // that is last block
+        if (!last_ow_block_padded) { b(tail_label); }
+
+        // last oi block with right padding
+        L(last_oi_label);
+        add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+        compute_loop(ur_w, 0, r_pad1);
+        add_imm(reg_inp, reg_inp, inp_shift, reg_tmp_imm);
+        add_imm(reg_out, reg_out, out_shift, reg_tmp_imm);
+
+        ldr(reg_owb, ptr(abi_param1, GET_OFF(owb)));
+        cmp_imm(reg_owb, jcp.nb_ow - 1, reg_tmp_imm); // last ow_block?
+        b(LT, end_label);
+
+        L(tail_label);
+        if (ur_w_tail != 0) {
+            add_imm(reg_out_prf, reg_out_prf, out_shift, reg_tmp_imm);
+            compute_loop(ur_w_tail, 0, r_pad);
+        }
+        L(end_label);
+    }
+    postamble();
+
+    if (jcp.with_eltwise) {
+#ifndef DISABLE_ELTWISE
+        eltwise_injector_->prepare_table();
+        binCommit();
+#else // #ifndef DISABLE_ELTWISE
+        assert(!"Error: with_eltwise is not supported");
+#endif // #ifndef DISABLE_ELTWISE
+    }
+}
+
+bool jit_sve_512_conv_fwd_kernel::post_ops_ok(
+        jit_conv_conf_t &jcp, const primitive_attr_t &attr) {
+    const auto &p = attr.post_ops_;
+
+    auto is_eltwise = [&](int idx) { return p.entry_[idx].is_eltwise(); };
+    auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(); };
+
+    switch (p.len()) {
+        case 0: return true; // no post_ops
+        case 1: return is_eltwise(0) || is_sum(0); // sum OR eltwise
+        case 2: return is_sum(0) && is_eltwise(1); // sum -> eltwise
+        default: return false;
+    }
+
+    return false;
+}
+
+status_t jit_sve_512_conv_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, const primitive_attr_t &attr, int nthreads) {
+    using namespace prop_kind;
+
+    if (!mayiuse(sve_512)) { return status::unimplemented; }
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bias_d(&bias_md);
+
+    const int regs = 28;
+    const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
+    int ndims = src_d.ndims();
+
+    jcp = zero<decltype(jcp)>();
+    jcp.nthr = jcp.aligned_threads = nthreads;
+    jcp.ndims = ndims;
+    jcp.prop_kind = cd.prop_kind;
+    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    jcp.mb = src_d.dims()[0];
+    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc_without_padding = jcp.oc;
+    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = jcp.ic;
+    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
+    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
+    jcp.iw = src_d.dims()[ndims - 1];
+    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
+    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
+    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
+    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
+    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
+    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
+    jcp.stride_w = cd.strides[ndims - 3];
+
+    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
+    jcp.dilate_w = cd.dilates[ndims - 3];
+
+    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    jcp.r_pad = calculate_end_padding(
+            jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
+    jcp.b_pad = calculate_end_padding(
+            jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh);
+    jcp.back_pad = calculate_end_padding(
+            jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd);
+    bool kernel_outside_src = false || ext_kw <= jcp.l_pad
+            || ext_kw <= jcp.r_pad || ext_kh <= jcp.t_pad || ext_kh <= jcp.b_pad
+            || ext_kd <= jcp.f_pad || ext_kd <= jcp.back_pad;
+    if (kernel_outside_src) { return status::unimplemented; }
+
+    const auto dat_tag_nxc = pick(ndims - 3, nwc, nhwc, ndhwc);
+    const auto dat_tag_ncx = pick(ndims - 3, ncw, nchw, ncdhw);
+    const auto dat_tag_nCx16c = pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
+    auto curr_src_tag = src_d.matches_one_of_tag(
+            dat_tag_nxc, dat_tag_nCx16c, dat_tag_ncx);
+    auto curr_dst_tag = dst_d.matches_one_of_tag(dat_tag_nxc, dat_tag_nCx16c);
+    bool is_data_layout_nxc
+            = utils::everyone_is(dat_tag_nxc, curr_src_tag, curr_dst_tag);
+
+    /* 1st convolution check */
+    jcp.is_1stconv = is_1stconv(jcp);
+
+    /* Padding check (Channel) */
+    bool ok_to_pad_channels
+            = true && jcp.ngroups == 1 && src_d.data_type() == data_type::f32;
+
+    const int full_simd_w = cpu_isa_traits<sve_512>::vlen / typesize;
+    jcp.simd_w = full_simd_w;
+    jcp.oc_block = jcp.simd_w;
+    jcp.ic_block = jcp.is_1stconv ? jcp.ic : jcp.simd_w;
+
+    /* Channel padding */
+    if (ok_to_pad_channels) {
+        jcp.oc = rnd_up(jcp.oc, jcp.oc_block);
+        jcp.ic = rnd_up(jcp.ic, jcp.ic_block);
+    }
+
+    /* Input and output channels must be multiples of simd_w */
+    if (!(jcp.oc % jcp.oc_block == 0 && jcp.ic % jcp.ic_block == 0)) {
+        return status::unimplemented;
+    }
+    jcp.ic_tail = 0;
+    jcp.oc_tail = 0;
+
+    /* Post operation check */
+    if (!post_ops_ok(jcp, attr)) { return status::unimplemented; }
+
+    /* Eltwise operation check */
+    const auto &p = attr.post_ops_;
+    jcp.with_sum = p.find(primitive_kind::sum) != -1;
+    const int eltwise_ind = p.find(primitive_kind::eltwise);
+    jcp.with_eltwise = eltwise_ind != -1;
+    if (jcp.with_eltwise) {
+#ifndef DISABLE_ELTWISE
+        jcp.eltwise = p.entry_[eltwise_ind].eltwise;
+        if (jcp.eltwise.alg == alg_kind::eltwise_pow)
+            return status::unimplemented;
+        if (dst_d.data_type() == data_type::s32) return status::unimplemented;
+#else
+        return status::unimplemented;
+#endif
+    }
+
+    format_tag_t src_tag, dst_tag, wei_tag;
+
+    dst_tag = dat_tag_nCx16c;
+    src_tag = jcp.is_1stconv ? dat_tag_ncx : dat_tag_nCx16c;
+    wei_tag = pick(2 * ndims - 6 + with_groups, OIw16i16o, gOIw16i16o,
+            OIhw16i16o, gOIhw16i16o, OIdhw16i16o, gOIdhw16i16o);
+
+    if (src_md.format_kind == format_kind::any)
+        CHECK(memory_desc_init_by_tag(src_md, src_tag));
+    else if (curr_src_tag != src_tag)
+        return status::unimplemented;
+    jcp.src_tag = src_tag;
+
+    if (dst_md.format_kind == format_kind::any)
+        CHECK(memory_desc_init_by_tag(dst_md, dst_tag));
+    else if (curr_dst_tag != dst_tag)
+        return status::unimplemented;
+    jcp.dst_tag = dst_tag;
+
+    jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
+    if (jcp.with_bias) {
+        if (bias_d.format_kind() == format_kind::any)
+            CHECK(memory_desc_init_by_tag(bias_md, x));
+    }
+
+    if (mayiuse(sve_512) && src_d.data_type() == data_type::f32
+            && weights_d.data_type() == data_type::f32
+            && dst_d.data_type() == data_type::f32) {
+        jcp.ver = ver_fma;
+        jcp.typesize_in = typesize;
+        jcp.typesize_out = typesize;
+
+        if (jcp.is_1stconv) {
+            wei_tag = with_groups
+                    ? pick(ndims - 3, gOwi16o, gOhwi16o, gOdhwi16o)
+                    : pick(ndims - 3, Owi16o, Ohwi16o, Odhwi16o);
+        }
+    } else {
+        return status::unimplemented;
+    }
+
+    if (init_tag(jcp.wei_tag, weights_md, weights_d, wei_tag)
+            != status::success)
+        return status::unimplemented;
+
+    jcp.ur_w = nstl::min(jcp.ow, regs); // ur_w is min(output width, regs=28)
+
+    int n_oi = (jcp.ow / jcp.ur_w);
+    int r_pad = calculate_end_padding(
+            jcp.l_pad, jcp.ur_w * n_oi, jcp.iw, jcp.stride_w, ext_kw);
+    if (jcp.l_pad > 0 && r_pad > 0) n_oi--;
+
+    /* Grouped channel offset to support 'non-blocked data' format for
+     * convolution sizes with '(input_channel / ngroups) < simd' */
+    jcp.nonblk_group_off
+            = (jcp.ngroups > 1 && one_of(jcp.src_tag, ncw, nchw, ncdhw))
+            ? jcp.ic
+            : 1;
+
+    jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
+    jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
+    jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
+
+    jcp.ow_block = jcp.ow;
+
+    auto get_thr_eff = [=](int nb_oc_blocking, int ow_block) {
+        int nb_ow = div_up(jcp.ow, ow_block);
+        int nb_oc_chunks = div_up(jcp.nb_oc, nb_oc_blocking);
+        int work_amount = jcp.mb * jcp.oh * nb_oc_chunks * nb_ow;
+        float disbalance = (float)jcp.ow / rnd_up(jcp.ow, ow_block);
+        float thr_eff = disbalance * (float)work_amount
+                / rnd_up(work_amount, jcp.nthr);
+        return thr_eff;
+    };
+
+    auto get_ow_block = [=](int nb_oc_blocking, int ur_w, float &eff) {
+        int res_ow_block = jcp.ow;
+        eff = get_thr_eff(nb_oc_blocking, res_ow_block);
+
+        return res_ow_block;
+    };
+
+    if (jcp.ver == ver_fma && mayiuse(sve_512)) {
+        // These conditions define a set of shapes with 'ow = 1' which
+        // have a very limited optimization space for performance. Try
+        // to optimize by using a larger 'nb_oc_blocking' size.
+        bool expl_bcast_condition
+                = everyone_is(1, jcp.ngroups, jcp.mb, jcp.stride_h, jcp.ow,
+                          jcp.stride_w, jcp.id, jcp.od, jcp.kd, jcp.stride_d)
+                && jcp.iw == jcp.kw && jcp.nb_oc > 1
+                && everyone_is(0, jcp.l_pad, jcp.r_pad, jcp.dilate_w, jcp.f_pad,
+                        jcp.back_pad, jcp.dilate_d)
+                && jcp.oh >= 60 && jcp.kh >= 3;
+
+        if (jcp.mb == 1) {
+            unsigned int inp_size = jcp.mb * div_up(jcp.ih, jcp.stride_h)
+                    * div_up(jcp.iw, jcp.stride_w) * jcp.ic;
+            unsigned int wei_size = jcp.ic * jcp.oc * jcp.kh * jcp.kw;
+
+            // Estimate whether we need to limit the number of threads
+            // and calculate this number. Includes some heuristic.
+            int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+            int work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
+            int job_size_min = work_amount / nthreads;
+            int job_size_max = div_up(work_amount, nthreads);
+            int ch_max = rnd_up(jcp.oh, job_size_max);
+            int ch_min = (job_size_min == 0) ? jcp.oh
+                                             : rnd_up(jcp.oh, job_size_min);
+            bool not_aligned_max = ch_max % jcp.oh != 0 && ch_max / jcp.oh < 2
+                    && (jcp.oh != 8 || ch_max / jcp.oh > 1);
+            bool not_aligned_min = ch_min % jcp.oh != 0 && ch_min / jcp.oh < 2
+                    && (jcp.oh != 8 || ch_min / jcp.oh > 1);
+            bool eligible_case = (jcp.stride_h == 1 && jcp.stride_w == 1)
+                    || nthreads > oc_chunks;
+            if (jcp.loop_order == loop_cgn && oc_chunks > 1 && nthreads > 1
+                    && wei_size / inp_size > 24
+                    && (not_aligned_max || not_aligned_min) && eligible_case) {
+                // Try to find number of threads > nthreads / 2 such that
+                // oc_chunks is a multiple of nthreads, or nthreads is a
+                // multiple of oc_chunks. Otherwise, keep default value.
+                // TODO: implement a task-based alternative without throttling.
+                jcp.aligned_threads = jcp.nthr;
+                for (int i = jcp.nthr; i > jcp.nthr / 2; i--) {
+                    if (oc_chunks % i == 0 || i % oc_chunks == 0) {
+                        jcp.aligned_threads = i;
+                        break;
+                    }
+                }
+            }
+        }
+
+        const int max_nb_oc = 2;
+        {
+            jcp.kernel_kind = expl_bcast;
+            jcp.nb_ic_blocking = 1;
+            if (IMPLICATION(jcp.is_1stconv, jcp.mb >= 1)
+                    || expl_bcast_condition) {
+                float best_thr_eff = 0.f;
+                int best_nb_oc_blocking = 1;
+                for (int i = nstl::min(jcp.nb_oc, max_nb_oc); i > 0; i--) {
+                    if (jcp.nb_oc % i == 0) {
+                        if (expl_bcast_condition) {
+                            best_nb_oc_blocking = i;
+                            break;
+                        } else {
+                            float thr_eff;
+                            int ur_w = nstl::min(jcp.ow, 31 / (i + 1));
+                            get_ow_block(i, ur_w, thr_eff);
+                            if (thr_eff > 1.05f * best_thr_eff) {
+                                best_nb_oc_blocking = i;
+                                best_thr_eff = thr_eff;
+                            }
+                        }
+                    }
+                }
+                jcp.nb_oc_blocking = best_nb_oc_blocking;
+                jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                if (jcp.l_pad > jcp.ur_w) {
+                    jcp.nb_oc_blocking = 1;
+                    jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                }
+                if (jcp.l_pad >= 16) { jcp.ur_w = nstl::min(jcp.l_pad, 29); }
+            }
+        }
+    }
+
+    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+
+    bool args_ok = true && jcp.l_pad <= jcp.ur_w
+            && jcp.ic <= src_d.padded_dims()[1]
+            && jcp.oc <= dst_d.padded_dims()[1]
+            && jcp.ic <= weights_d.padded_dims()[with_groups + 1]
+            && jcp.oc <= weights_d.padded_dims()[with_groups + 0];
+    if (!args_ok) return status::unimplemented;
+
+    int r_pad_no_tail = nstl::max(0,
+            calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
+                    jcp.stride_w, ext_kw));
+    if (r_pad_no_tail > jcp.ur_w) return status::unimplemented;
+
+    pick_loop_order(jcp);
+
+    jcp.nb_ic_L2 = jcp.nb_ic;
+
+    float thr_eff;
+    jcp.ow_block = get_ow_block(jcp.nb_oc_blocking, jcp.ur_w, thr_eff);
+    jcp.nb_ow = div_up(jcp.ow, jcp.ow_block);
+
+    const int L2_size = platform::get_per_core_cache_size(2) / sizeof(float);
+
+    // Source and output data needs to fit in L2,
+    // leaving some space for weights and prefetching.
+    int h_L2 = int(((0.6f * L2_size) / jcp.simd_w
+                           - nstl::min(0, jcp.kh - jcp.stride_h) * jcp.iw)
+            / (jcp.stride_h * jcp.iw + jcp.ow));
+    jcp.h_blocking = nstl::max(1, nstl::min(jcp.oh, h_L2));
+
+    if (is_data_layout_nxc) {
+        // TODO: improve L2 blocking for large IC
+        const int nb_ic_theshold_L2 = 32;
+        if (jcp.nb_ic > nb_ic_theshold_L2 && jcp.nb_ic < 2 * nb_ic_theshold_L2)
+            jcp.nb_ic_L2 = div_up(jcp.nb_ic, 2);
+        else
+            jcp.nb_ic_L2 = nstl::min(nb_ic_theshold_L2, jcp.nb_ic);
+    }
+
+    // A rough check on code size
+    // TODO: come up with a tighter bound
+    {
+        const int max_code_size = 256 * 1024; // default size of jit generator
+        int mult = 1 + (jcp.l_pad > 0) + (r_pad > 0);
+        const float max_instruction_size = 15;
+        float ur_fac
+                = (float)jcp.kw * jcp.ic_block * jcp.nb_oc_blocking * jcp.ur_w;
+        float code_size = mult * ur_fac * max_instruction_size;
+        if (code_size > max_code_size) return status::unimplemented;
+    }
+
+    return status::success;
+}
+
+void jit_sve_512_conv_fwd_kernel::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
+
+    if (jcp.with_bias && jcp.oc != jcp.oc_without_padding)
+        scratchpad.book(key_conv_padded_bias, jcp.oc, jcp.typesize_out);
+}
+
+void jit_sve_512_conv_bwd_data_kernel_f32::prepare_output(int ur_w) {
+    auto zreg_out_s = [=](int i_ur, int i_oc) {
+        int idx = i_ur + i_oc * jcp.ur_w;
+        assert(idx < ker_reg_base_idx);
+        return ZRegS(idx);
+    };
+
+    long long int prev_ofs = 0;
+    for (int k = 0; k < jcp.nb_ic_blocking; k++) {
+        for (int j = 0; j < ur_w; j++) {
+            ZRegS zreg = zreg_out_s(j, k);
+            fmov(zreg);
+            size_t aux_src_offset = (size_t)typesize
+                    * ((size_t)k * jcp.ih * jcp.iw * jcp.id + j) * jcp.ic_block;
+
+            std::string op = "LD";
+            prev_ofs = prefetch(op, 2, reg_src_prf, aux_src_offset, prev_ofs);
+        }
+    }
+}
+
+void jit_sve_512_conv_bwd_data_kernel_f32::store_output(int ur_w) {
+
+    int num_used_zreg = 32 - ker_reg_base_idx;
+
+    auto zreg_tmp = [=](int idx) {
+        int zreg_idx = (idx % num_used_zreg) + ker_reg_base_idx;
+        return ZReg(zreg_idx);
+    };
+
+    auto zreg_tmp_s = [=](int idx) {
+        int zreg_idx = (idx % num_used_zreg) + ker_reg_base_idx;
+        return ZRegS(zreg_idx);
+    };
+
+    auto zreg_out = [=](int i_ur, int i_oc) {
+        int idx = i_ur + i_oc * jcp.ur_w;
+        assert(idx < ker_reg_base_idx);
+        return ZReg(idx);
+    };
+
+    auto zreg_out_s = [=](int i_ur, int i_oc) {
+        int idx = i_ur + i_oc * jcp.ur_w;
+        assert(idx < ker_reg_base_idx);
+        return ZRegS(idx);
+    };
+
+    auto out_load = [=](int aux_output_offset, int idx, int prev_ofs) {
+        int ofs = aux_output_offset;
+        if ((VL_OFS(ofs) < LDRMAX) && (VL_OFS(ofs) >= (-1 * LDRMAX))
+                && ((ofs & 0x3f) == 0)) {
+            ldr(zreg_tmp(idx), ptr(reg_src, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            int tmp_ofs = aux_output_offset - prev_ofs;
+
+            if (((tmp_ofs & 0x3f) == 0) && (VL_OFS(tmp_ofs) < LDRWMAX)
+                    && (tmp_ofs >= 0)) {
+                ldr(zreg_tmp(idx),
+                        ptr(reg_tmp_addr,
+                                static_cast<int32_t>(VL_OFS(tmp_ofs))));
+            } else {
+                add_imm(reg_tmp_addr, reg_src, ofs, reg_tmp_imm);
+                ldr(zreg_tmp(idx), ptr(reg_tmp_addr));
+                prev_ofs = ofs;
+            }
+        }
+        return prev_ofs;
+    };
+
+    auto out_str = [=](int j, int k, int aux_output_offset, int prev_ofs) {
+        int ofs = aux_output_offset;
+
+        if ((VL_OFS(ofs) < LDRMAX) && (VL_OFS(ofs) >= (-1 * LDRMAX))
+                && ((ofs & 0x3f) == 0)) {
+            str(zreg_out(j, k),
+                    ptr(reg_src, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            int tmp_ofs = aux_output_offset - prev_ofs;
+
+            if (((tmp_ofs & 0x3f) == 0) && (VL_OFS(tmp_ofs) < LDRWMAX)
+                    && (tmp_ofs >= 0)) {
+                str(zreg_out(j, k),
+                        ptr(reg_tmp_addr,
+                                static_cast<int32_t>(VL_OFS(tmp_ofs))));
+            } else {
+                add_imm(reg_tmp_addr, reg_src, ofs, reg_tmp_imm);
+                str(zreg_out(j, k), ptr(reg_tmp_addr));
+                prev_ofs = ofs;
+            }
+        }
+        return prev_ofs;
+    };
+
+    Label no_update_label;
+
+    ldr(reg_channel, ptr(param, GET_OFF(channel)));
+    cmp(reg_channel, 0);
+    b(EQ, no_update_label);
+    int prev_ofs = 0;
+    for (int k = 0; k < jcp.nb_ic_blocking; k++) {
+        for (int j = 0; j < ur_w; j++) {
+            int num_ldr = nstl::min(ur_w, num_used_zreg);
+            if (j == 0) {
+                for (int t = 0; t < num_ldr; t++) {
+                    size_t aux_src_offset = (size_t)typesize
+                            * ((size_t)k * jcp.ih * jcp.iw * jcp.id + j + t)
+                            * jcp.ic_block;
+                    prev_ofs = out_load(aux_src_offset, t, prev_ofs);
+                }
+            } else if (j < ur_w - num_ldr + 1) {
+                size_t aux_src_offset = (size_t)typesize
+                        * ((size_t)k * jcp.ih * jcp.iw * jcp.id + j + num_ldr
+                                - 1)
+                        * jcp.ic_block;
+                prev_ofs = out_load(aux_src_offset, j + num_ldr - 1, prev_ofs);
+            }
+            fadd(zreg_out_s(j, k), zreg_out_s(j, k), zreg_tmp_s(j));
+        }
+    }
+
+    L(no_update_label);
+    prev_ofs = 0;
+    for (int k = 0; k < jcp.nb_ic_blocking; k++) {
+        for (int j = 0; j < ur_w; j++) {
+            size_t aux_src_offset = (size_t)typesize
+                    * ((size_t)k * jcp.ih * jcp.iw * jcp.id + j) * jcp.ic_block;
+
+            prev_ofs = out_str(j, k, aux_src_offset, prev_ofs);
+        }
+    }
+}
+
+void jit_sve_512_conv_bwd_data_kernel_f32::compute_loop_fma(
+        int ur_w, int l_overflow, int r_overflow) {
+    Label kh_label, kd_label;
+    int kw = jcp.kw;
+    int ow = jcp.ow;
+
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+    int l_pad = jcp.l_pad;
+    int dilate_w = jcp.dilate_w + 1;
+    int stride_w = jcp.stride_w;
+    int stride_h = jcp.stride_h;
+
+    int ker_pipeline_depth = 2;
+    assert(ker_reg_base_idx + ker_pipeline_depth <= 31);
+    assert(oc_block >= ker_pipeline_depth);
+
+    int num_ker_loads = oc_block * kw;
+
+    auto zreg_ker = [=](int i_ic) {
+        assert(i_ic < ker_pipeline_depth);
+        assert((ker_reg_base_idx + i_ic) < 31);
+        return ZReg(ker_reg_base_idx + i_ic);
+    };
+    auto zreg_ker_s = [=](int i_ic) {
+        assert(i_ic < ker_pipeline_depth);
+        assert((ker_reg_base_idx + i_ic) < 31);
+        return ZRegS(ker_reg_base_idx + i_ic);
+    };
+    auto zreg_out_s = [=](int i_ur, int i_oc) {
+        int idx = (i_ur + i_oc * jcp.ur_w);
+        assert(idx < ker_reg_base_idx);
+        return ZRegS(idx);
+    };
+    auto zreg_in_s = [=](int idx) {
+        int num_used_zreg = ker_reg_base_idx + ker_pipeline_depth;
+        int zreg_idx = (idx % (32 - num_used_zreg)) + num_used_zreg;
+        assert(zreg_idx <= 31);
+        return ZRegS(zreg_idx);
+    };
+
+    auto bcast_load = [&](int aux_output_offset, int prev_ofs, int idx) {
+        int num_used_zreg = ker_reg_base_idx + ker_pipeline_depth;
+        int zreg_idx = (idx % (32 - num_used_zreg)) + num_used_zreg;
+        if (((aux_output_offset & 0x3) == 0) && (aux_output_offset < LDRWMAX)
+                && (aux_output_offset >= 0)) {
+            ld1rw(ZRegS(zreg_idx), reg_p_all_ones,
+                    ptr(aux_reg_dst, static_cast<int32_t>(aux_output_offset)));
+        } else {
+            int ofs = aux_output_offset - prev_ofs;
+            int ofs2 = aux_output_offset - (prev_ofs + 0x100);
+            int ofs3 = aux_output_offset - (prev_ofs + 0x200);
+            if (((ofs & 0x3) == 0) && (ofs < LDRWMAX) && (ofs >= 0)) {
+                ld1rw(ZRegS(zreg_idx), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr, static_cast<int32_t>(ofs)));
+            } else if (((ofs2 & 0x3) == 0) && (ofs2 < LDRWMAX) && (ofs2 >= 0)
+                    && (prev_ofs != 0)) {
+                ld1rw(ZRegS(zreg_idx), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr2, static_cast<int32_t>(ofs2)));
+            } else if (((ofs3 & 0x3) == 0) && (ofs3 < LDRWMAX) && (ofs3 >= 0)
+                    && (prev_ofs != 0)) {
+                ld1rw(ZRegS(zreg_idx), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr3, static_cast<int32_t>(ofs3)));
+            } else {
+                ofs = aux_output_offset;
+                add_imm(reg_prev_bcast_addr, aux_reg_dst, ofs, reg_tmp_imm);
+                add_imm(reg_prev_bcast_addr2, aux_reg_dst, ofs + 0x100,
+                        reg_tmp_imm);
+                add_imm(reg_prev_bcast_addr3, aux_reg_dst, ofs + 0x200,
+                        reg_tmp_imm);
+
+                ld1rw(ZRegS(zreg_idx), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr));
+                prev_ofs = ofs;
+            }
+        }
+        return prev_ofs;
+    };
+    auto ker_load = [=](int i, int aux_kernel_offset) {
+        int ofs = aux_kernel_offset;
+
+        if ((VL_OFS(ofs) < LDRMAX) && (VL_OFS(ofs) >= (-1 * LDRMAX))
+                && ((ofs & 0x3f) == 0)) {
+            ldr(zreg_ker(i),
+                    ptr(aux_reg_ker, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            add_imm(reg_tmp_addr, aux_reg_ker, ofs, reg_tmp_imm);
+            ldr(zreg_ker(i), ptr(reg_tmp_addr));
+        }
+    };
+
+    if (one_of(jcp.ndims, 3, 4)) {
+        mov(aux_reg_dst, reg_dst);
+        mov(aux_reg_ker, reg_ker);
+
+        mov(aux_reg_dst_prf, reg_dst_prf);
+        mov(aux_reg_ker_prf, reg_ker_prf);
+    }
+
+    if (jcp.ndims == 5) {
+        mov(reg_src_prf_org, reg_src_prf);
+        mov(reg_src_org, reg_src);
+
+        ldr(reg_ki, ptr(param, GET_OFF(kd_padding)));
+        mov(aux_reg_dst_d, reg_dst);
+        ldr(aux_reg_ker_d, ptr(param, GET_OFF(filt)));
+        mov(aux_reg_dst_d_prf, reg_dst_prf);
+        mov(aux_reg_ker_d_prf, reg_ker_prf);
+
+        L(kd_label);
+        ldr(reg_kj, ptr(param, GET_OFF(kh_padding)));
+    } else {
+        mov(reg_kj, reg_kh);
+    }
+
+    if (jcp.ndims == 5) {
+        mov(aux_reg_dst, aux_reg_dst_d);
+        mov(aux_reg_ker, aux_reg_ker_d);
+        mov(aux_reg_dst_prf, aux_reg_dst_d_prf);
+        mov(aux_reg_ker_prf, aux_reg_ker_d_prf);
+    }
+    int prev_ofs = 0;
+    L(kh_label);
+    {
+        int step = 0;
+        for (int ki = 0; ki < kw; ki++) {
+            for (int oc = 0; oc < oc_block; oc++) {
+                if (step == 0) {
+                    for (int i = 0; i < ker_pipeline_depth; i++) {
+                        int aux_kernel_offset = typesize
+                                * ((oc + i) * oc_block
+                                        + ki * ic_block * oc_block);
+                        ker_load(i, aux_kernel_offset);
+                    }
+                } else if (step < num_ker_loads - ker_pipeline_depth + 1) {
+                    int load_offset = ker_pipeline_depth - 1;
+                    int ker_load_reg_idx
+                            = (step + load_offset) % ker_pipeline_depth;
+                    int aux_kernel_offset = typesize
+                            * ((oc + load_offset) * oc_block
+                                    + ki * ic_block * oc_block);
+                    ker_load(ker_load_reg_idx, aux_kernel_offset);
+                }
+
+                auto zreg_kernel_s = zreg_ker_s(step % ker_pipeline_depth);
+
+                int jj_start = get_iw_start(ki, l_overflow);
+                int jj_end = get_iw_end(ur_w, ki, r_overflow);
+                assert(stride_w != 1
+                        || jj_start
+                                == nstl::max(0,
+                                        l_overflow - (kw - 1 - ki) * dilate_w));
+                assert(stride_w != 1
+                        || jj_end
+                                == ur_w
+                                        - nstl::max(
+                                                0, r_overflow - ki * dilate_w));
+
+                int bcast_idx = 0;
+                int bcast_pipeline_depth
+                        = 32 - (ker_reg_base_idx + ker_pipeline_depth);
+                int num_bcast_pipeline = nstl::min(
+                        ((jj_end - jj_start) / stride_w), bcast_pipeline_depth);
+                for (int jj = jj_start; jj < jj_end; jj += stride_w) {
+                    assert((jj + l_pad - ki * dilate_w) % stride_w == 0);
+                    if (num_bcast_pipeline > 1) {
+                        if (jj == jj_start) {
+                            for (int i = 0; i < num_bcast_pipeline; i++) {
+                                int jj_skip = jj + stride_w * i;
+                                int aux_dst_offset = typesize
+                                        * (((jj_skip + l_pad - ki * dilate_w)
+                                                   / stride_w)
+                                                        * jcp.oc_block
+                                                + oc);
+                                prev_ofs = bcast_load(aux_dst_offset, prev_ofs,
+                                        bcast_idx + i);
+                            }
+                        } else if (jj < jj_end
+                                        - (num_bcast_pipeline - 1) * stride_w) {
+                            int jj_skip
+                                    = jj + (num_bcast_pipeline - 1) * stride_w;
+                            int aux_dst_offset = typesize
+                                    * (((jj_skip + l_pad - ki * dilate_w)
+                                               / stride_w)
+                                                    * jcp.oc_block
+                                            + oc);
+                            prev_ofs = bcast_load(aux_dst_offset, prev_ofs,
+                                    bcast_idx + (num_bcast_pipeline - 1));
+                        }
+                    } else {
+                        int aux_dst_offset = typesize
+                                * (((jj + l_pad - ki * dilate_w) / stride_w)
+                                                * jcp.oc_block
+                                        + oc);
+                        prev_ofs = bcast_load(
+                                aux_dst_offset, prev_ofs, bcast_idx);
+                    }
+                    fmla(zreg_out_s(jj, 0), reg_p_all_ones, zreg_kernel_s,
+                            zreg_in_s(bcast_idx));
+                    bcast_idx++;
+                }
+                step++;
+            }
+        }
+
+        add_imm(aux_reg_ker, aux_reg_ker,
+                typesize * stride_h * kw * oc_block * ic_block, reg_tmp_imm);
+        sub_imm(aux_reg_dst, aux_reg_dst,
+                typesize * (jcp.dilate_h + 1) * ow * oc_block, reg_tmp_imm);
+        add_imm(aux_reg_ker_prf, aux_reg_ker_prf,
+                typesize * stride_h * kw * oc_block * ic_block, reg_tmp_imm);
+        sub_imm(aux_reg_dst_prf, aux_reg_dst_prf,
+                typesize * (jcp.dilate_h + 1) * ow * oc_block, reg_tmp_imm);
+        sub(reg_kj, reg_kj, 1);
+        cmp(reg_kj, 0);
+        b(GT, kh_label); //jg(kh_label, T_NEAR);
+    }
+    if (jcp.ndims == 5) {
+        sub_imm(aux_reg_dst_d, aux_reg_dst_d,
+                typesize * (jcp.dilate_d + 1) * jcp.oh * ow * ic_block,
+                reg_tmp_imm);
+        add_imm(aux_reg_ker_d, aux_reg_ker_d,
+                typesize * jcp.stride_d * jcp.kw * jcp.kh * oc_block * ic_block,
+                reg_tmp_imm);
+        sub_imm(aux_reg_dst_d_prf, aux_reg_dst_d_prf,
+                typesize * (jcp.dilate_d + 1) * jcp.oh * ow * ic_block,
+                reg_tmp_imm);
+        add_imm(aux_reg_ker_d_prf, aux_reg_ker_d_prf,
+                typesize * jcp.stride_d * jcp.kw * jcp.kh * oc_block * ic_block,
+                reg_tmp_imm);
+
+        sub(reg_ki, reg_ki, 1);
+        cmp(reg_ki, 0);
+        b(GT, kd_label); //jg(kd_label, T_NEAR);
+    }
+
+    if (jcp.ndims == 5) {
+        mov(reg_src, reg_src_org);
+        mov(reg_src_prf, reg_src_prf_org);
+    }
+}
+
+void jit_sve_512_conv_bwd_data_kernel_f32::compute_loop_fma_core(
+        int ur_w, int l_overflow, int r_overflow, int k_offset) {
+    int kw = jcp.kw;
+    int ow = jcp.ow;
+    int stride_w = jcp.stride_w;
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+    int nb_ic_block = jcp.nb_ic_blocking;
+    Label kh_label, kd_label;
+
+    const bool ddst_layout_nxc = is_ddst_layout_nxc();
+    int shift_ker_ptr = typesize * kw * oc_block * ic_block;
+    int oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    int shift_dst_ptr = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
+
+    const int oc_tail = jcp.oc_tail;
+    const int max_filter_size = 20;
+    Label oc_tail_jmp[max_filter_size];
+
+    auto kernel_offset = [=](int icb, int oc, int ki) {
+        int blk_idx = icb * jcp.kh * jcp.kw * jcp.kd + ki;
+        int blk_offset = blk_idx * jcp.oc_block * jcp.ic_block;
+        int oc_offset = oc * jcp.oc_block;
+        return typesize * (blk_offset + oc_offset);
+    };
+
+    auto zreg_inp_s = [=](int i_ic, int nb_x_blocking) {
+        int idx = (i_ic + nb_x_blocking * jcp.ur_w);
+        assert(idx < 31);
+        return ZRegS(idx);
+    };
+    auto zreg_out_s = [=](int i_ur, int i_oc) {
+        int idx = (i_ur + i_oc * jcp.ur_w);
+        assert(idx < ker_reg_base_idx);
+        return ZRegS(idx);
+    };
+    const int num_wei_reg = 2;
+    auto zreg_wei = [=](int idx) { return ZReg(31 - (idx % num_wei_reg)); };
+    auto zreg_wei_s = [=](int idx) { return ZRegS(31 - (idx % num_wei_reg)); };
+
+    auto bcast_load = [&](int jj, int nb_oc_block, int aux_output_offset,
+                              int prev_ofs, int jj_end) {
+        if (((aux_output_offset & 0x3) == 0) && (aux_output_offset < LDRWMAX)
+                && (aux_output_offset >= 0)) {
+            ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                    ptr(aux_reg_dst, static_cast<int32_t>(aux_output_offset)));
+        } else {
+            if ((prev_ofs > -1) && ((aux_output_offset - prev_ofs) > 0)
+                    && ((aux_output_offset - prev_ofs) < LDRWMAX)
+                    && (((aux_output_offset - prev_ofs) & 0x3) == 0)) {
+
+                ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr,
+                                static_cast<int32_t>(
+                                        aux_output_offset - prev_ofs)));
+
+            } else {
+                int ofs;
+                if ((prev_ofs > -1) && ((aux_output_offset - prev_ofs) > 0)) {
+                    ofs = aux_output_offset - prev_ofs;
+                    add_imm(reg_prev_bcast_addr, reg_prev_bcast_addr, ofs,
+                            reg_tmp_imm);
+
+                } else {
+                    ofs = aux_output_offset;
+                    add_imm(reg_prev_bcast_addr, aux_reg_dst, ofs, reg_tmp_imm);
+                }
+
+                ld1rw(zreg_inp_s(jj, nb_oc_block), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr));
+                prev_ofs = aux_output_offset;
+            }
+        }
+        return prev_ofs;
+    };
+
+    auto bcast_load_sw = [&](int jj, int nb_oc_block, int aux_output_offset,
+                                 int prev_ofs, int jj_end) {
+        if (((aux_output_offset & 0x3) == 0) && (aux_output_offset < LDRWMAX)
+                && (aux_output_offset >= 0)) {
+            ld1rw(zreg_inp_s(jj % stride_w, nb_oc_block), reg_p_all_ones,
+                    ptr(aux_reg_dst, static_cast<int32_t>(aux_output_offset)));
+        } else {
+            if ((prev_ofs > -1) && ((aux_output_offset - prev_ofs) > 0)
+                    && ((aux_output_offset - prev_ofs) < LDRWMAX)
+                    && (((aux_output_offset - prev_ofs) & 0x3) == 0)) {
+
+                ld1rw(zreg_inp_s(jj % stride_w, nb_oc_block), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr,
+                                static_cast<int32_t>(
+                                        aux_output_offset - prev_ofs)));
+
+            } else {
+                int ofs;
+                if ((prev_ofs > -1) && ((aux_output_offset - prev_ofs) > 0)) {
+                    ofs = aux_output_offset - prev_ofs;
+                    add_imm(reg_prev_bcast_addr, reg_prev_bcast_addr, ofs,
+                            reg_tmp_imm);
+
+                } else {
+                    ofs = aux_output_offset;
+                    add_imm(reg_prev_bcast_addr, aux_reg_dst, ofs, reg_tmp_imm);
+                }
+
+                ld1rw(zreg_inp_s(jj % stride_w, nb_oc_block), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr));
+                prev_ofs = aux_output_offset;
+            }
+        }
+        return prev_ofs;
+    };
+
+    auto wei_load = [=](int aux_kernel_offset, int idx) {
+        int ofs = aux_kernel_offset;
+
+        if ((VL_OFS(ofs) < LDRMAX) && (VL_OFS(ofs) >= (-1 * LDRMAX))) {
+            ldr(zreg_wei(idx),
+                    ptr(aux_reg_ker, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            add_imm(reg_tmp_addr, aux_reg_ker, ofs, reg_tmp_imm);
+            ldr(zreg_wei(idx), ptr(reg_tmp_addr));
+        }
+    };
+
+    if (one_of(jcp.ndims, 3, 4)) {
+        mov(aux_reg_dst, reg_dst);
+        mov(aux_reg_ker, reg_ker);
+    }
+
+    if (jcp.ndims == 5) {
+        mov(reg_src_prf_org, reg_src_prf);
+        mov(reg_src_org, reg_src);
+
+        ldr(reg_ki, ptr(param, GET_OFF(kd_padding)));
+        mov(aux_reg_dst_d, reg_dst);
+        ldr(aux_reg_ker_d, ptr(param, GET_OFF(filt)));
+
+        L(kd_label);
+        ldr(reg_kj, ptr(param, GET_OFF(kh_padding)));
+    } else {
+        mov(reg_kj, reg_kh);
+    }
+
+    if (jcp.ndims == 5) {
+        mov(aux_reg_dst, aux_reg_dst_d);
+        mov(aux_reg_ker, aux_reg_ker_d);
+    }
+
+    L(kh_label);
+    {
+        for (int ki = 0; ki < kw; ki++) { // kernel width
+            int prev_ofs = -1;
+
+            int jj_start = get_iw_start(ki, l_overflow);
+            int jj_end = get_iw_end(ur_w, ki, r_overflow);
+            for (int oc = 0; oc < oc_block; oc++) {
+                if (oc_tail && oc >= oc_tail) {
+                    // if src has only tails to compute, skip early
+                    if (jcp.oc == oc_tail)
+                        break;
+                    else if (oc == oc_tail) {
+                        cmp_imm(reg_channel, oc_tail, reg_tmp_imm);
+                        b(NE, oc_tail_jmp[ki]);
+                    }
+                }
+                if (stride_w == 1) {
+                    for (int jj = jj_start; jj < jj_end; jj += 1) {
+                        int aux_output_offset = get_dst_offset(jj, oc, ki);
+                        prev_ofs = bcast_load(jj, nb_ic_block,
+                                aux_output_offset, prev_ofs, jj_end);
+                    }
+                }
+                int wei_count = 0;
+                for (int ii = 0; ii < nb_ic_block; ii++) {
+                    if (jj_end - jj_start > 0) {
+                        if (nb_ic_block > 1) {
+                            if (ii == 0) {
+                                for (int t = 0; t < num_wei_reg; t++) {
+                                    int aux_kernel_offset = kernel_offset(
+                                            ii + t, oc, ki + k_offset);
+                                    wei_load(aux_kernel_offset, t);
+                                }
+                            } else if (ii < nb_ic_block - num_wei_reg + 1) {
+                                int aux_kernel_offset
+                                        = kernel_offset(ii + num_wei_reg - 1,
+                                                oc, ki + k_offset);
+                                wei_load(aux_kernel_offset,
+                                        wei_count + num_wei_reg - 1);
+                            }
+                        } else {
+                            int aux_kernel_offset
+                                    = kernel_offset(ii, oc, ki + k_offset);
+                            wei_load(aux_kernel_offset, wei_count);
+                        }
+                    }
+                    for (int jj = jj_start; jj < jj_end; jj += stride_w) {
+                        if (stride_w == 1) {
+                            fmla(zreg_out_s(jj, ii), reg_p_all_ones,
+                                    zreg_inp_s(jj, nb_ic_block),
+                                    zreg_wei_s(wei_count));
+                        } else {
+                            int aux_output_offset = get_dst_offset(jj, oc, ki);
+                            prev_ofs = bcast_load_sw(jj, nb_ic_block,
+                                    aux_output_offset, prev_ofs, jj_end);
+
+                            fmla(zreg_out_s(jj, ii), reg_p_all_ones,
+                                    zreg_inp_s(jj % stride_w, nb_ic_block),
+                                    zreg_wei_s(wei_count));
+                        }
+                    }
+                    wei_count++;
+                }
+            }
+            L(oc_tail_jmp[ki]);
+        }
+        add_imm(aux_reg_ker, aux_reg_ker, shift_ker_ptr, reg_tmp_imm);
+        assert(shift_dst_ptr >= 0);
+        sub_imm(aux_reg_dst, aux_reg_dst, shift_dst_ptr, reg_tmp_imm);
+        sub(reg_kj, reg_kj, 1);
+        cmp(reg_kj, 0);
+        b(GT, kh_label);
+    }
+
+    if (jcp.ndims == 5) {
+        sub_imm(aux_reg_dst_d, aux_reg_dst_d,
+                typesize * (jcp.dilate_d + 1) * jcp.oh * ow * ic_block,
+                reg_tmp_imm);
+        add_imm(aux_reg_ker_d, aux_reg_ker_d,
+                typesize * jcp.kw * jcp.kh * oc_block * ic_block, reg_tmp_imm);
+
+        sub(reg_ki, reg_ki, 1);
+        cmp(reg_ki, 0);
+        b(GT, kd_label);
+
+        mov(reg_src, reg_src_org);
+        mov(reg_src_prf, reg_src_prf_org);
+    }
+}
+
+inline void jit_sve_512_conv_bwd_data_kernel_f32::compute_loop(
+        int ur_w, int l_overflow, int r_overflow, int k_offset) {
+    if (jcp.ndims == 5) mov(reg_oi_org, reg_oi);
+
+    prepare_output(ur_w);
+
+    Label skip_compute_loop;
+    if (jcp.ndims == 5) {
+        ldr(reg_kj, ptr(param, GET_OFF(kd_padding)));
+        cmp(reg_kj, 0);
+        b(LE, skip_compute_loop);
+    }
+    ldr(reg_kj, ptr(param, GET_OFF(kh_padding)));
+    cmp(reg_kj, 0);
+    b(LE, skip_compute_loop);
+
+    const bool generate_ocb_loop = jcp.nb_oc > 1 && is_ddst_layout_nxc();
+    Label oc_loop;
+    if (generate_ocb_loop) {
+        mov(reg_dst_org, reg_dst);
+        mov(reg_ker_org, reg_ker);
+
+        ldr(reg_channel, ptr(param, GET_OFF(reduce_work)));
+        L(oc_loop);
+    }
+
+    if (jcp.ver == ver_fma)
+        if (jcp.nb_ic_blocking == 1)
+            compute_loop_fma(ur_w, l_overflow, r_overflow);
+        else
+            compute_loop_fma_core(ur_w, l_overflow, r_overflow, k_offset);
+
+    else
+        assert("!unknown convolution version");
+
+    if (generate_ocb_loop) {
+        add_imm(reg_dst, reg_dst, jcp.oc_block * typesize, reg_tmp_imm);
+        const int ker_shift = jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw
+                * jcp.ic_block * jcp.oc_block * typesize;
+        add_imm(reg_ker, reg_ker, ker_shift, reg_tmp_imm);
+        sub_imm(reg_channel, reg_channel, jcp.oc_block, reg_tmp_imm);
+        b(GT, oc_loop);
+
+        mov(reg_ker, reg_ker_org);
+        mov(reg_dst, reg_dst_org);
+    }
+
+    L(skip_compute_loop);
+    store_output(ur_w);
+    if (jcp.ndims == 5) mov(reg_oi, reg_oi_org);
+}
+
+void jit_sve_512_conv_bwd_data_kernel_f32::generate() {
+    int iw = jcp.iw;
+    int kw = jcp.kw;
+    int ur_w = jcp.ur_w;
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+    int nb_iw = jcp.nb_iw;
+    int iw_block = jcp.iw_block;
+    int ur_w_tail = jcp.ur_w_tail;
+    int dilate_w = jcp.dilate_w + 1;
+    int stride_w = jcp.stride_w;
+
+    int dst_shift = jcp.typesize_in * (ur_w / stride_w)
+            * (is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block);
+    int src_shift = jcp.typesize_out * ur_w
+            * (is_dsrc_layout_nxc() ? jcp.ngroups * jcp.ic : ic_block);
+
+    preamble();
+    ptrue(reg_p_all_ones.b);
+
+    ldr(reg_src, ptr(param, GET_OFF(src)));
+    ldr(reg_dst, ptr(param, GET_OFF(dst)));
+    ldr(reg_ker, ptr(param, GET_OFF(filt)));
+
+    ldr(reg_kh, ptr(param, GET_OFF(kh_padding)));
+    ldr(reg_src_prf, ptr(param, GET_OFF(src_prf)));
+    ldr(reg_dst_prf, ptr(param, GET_OFF(dst_prf)));
+    ldr(reg_ker_prf, ptr(param, GET_OFF(filt_prf)));
+
+    int l_overflow = nstl::max(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
+    int r_overflow = nstl::max(
+            0, ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad)) / stride_w);
+    int r_overflow_no_tail = nstl::max(0,
+            ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad + ur_w_tail))
+                    / stride_w);
+
+    int body_l_overflow = 0, body_r_overflow = 0;
+    int n_oi = iw / ur_w;
+    int head_n_oi = 0, body_n_oi = 0, pretail_n_oi = 0, tail_n_oi = 0;
+    int head_thread = 0, pretail_thread = 0, tail_thread = 0;
+    bool threaded = is_iw_threading_on(jcp);
+    Label head_label, body_label, pretail_label, tail_label, end_label;
+    assert(n_oi > 0);
+    if (r_overflow_no_tail > 0) n_oi--;
+    if (l_overflow > 0) n_oi--;
+    if (n_oi < 0) {
+        // l_overflow and r_overflow_no_tail are handled in the same
+        // compute_loop. Perform one iteration of body handling l_overflow and
+        // r_overflow_no_tail.
+        // TODO: Align other convolution kernels with this kernel. This version
+        // now uses r_overflow_no_tail instead of r_overflow in compute loop,
+        // this was done since when iw == ur_w, ur_w_tail == 0 and thus
+        // r_overflow_no_tail seems more appropriate
+        body_l_overflow = l_overflow;
+        body_r_overflow = r_overflow_no_tail;
+        n_oi = 1;
+        l_overflow = 0;
+        r_overflow_no_tail = 0;
+    }
+
+    if (!threaded) {
+        if (n_oi > 1) { mov_imm(reg_oi, n_oi); }
+    } else {
+        // Setup for threaded code generation, and jump into the correct
+        // portion of code for execution.
+        head_thread = 0;
+        tail_thread = nb_iw - 1;
+        pretail_thread = tail_thread;
+
+        int base_n_oi = iw_block / ur_w;
+        head_n_oi = l_overflow > 0 ? base_n_oi - 1 : base_n_oi;
+        tail_n_oi = (iw - iw_block * (nb_iw - 1)) / ur_w;
+        pretail_n_oi = tail_n_oi;
+        if (r_overflow_no_tail > 0) {
+            if (tail_n_oi > 0) {
+                pretail_n_oi--;
+                tail_n_oi = pretail_n_oi;
+            } else {
+                // pretail_thread and tail_thread are different
+                pretail_n_oi = base_n_oi - 1;
+                pretail_thread = tail_thread - 1;
+            }
+            if (head_thread == pretail_thread) {
+                head_n_oi--;
+                pretail_n_oi = 0;
+                tail_n_oi = 0;
+            }
+        }
+        body_n_oi = (head_thread < pretail_thread - 1) ? base_n_oi : 0;
+
+        // n_oi is used to determine how much control flow in the body portion
+        // of the code needs generated. As such, n_oi needs to be set to the
+        // maximum number of iterations it will be used the body code section.
+        n_oi = nstl::max(body_n_oi, head_n_oi);
+        n_oi = nstl::max(n_oi, pretail_n_oi);
+
+        assert(iw_block % ur_w == 0);
+        ldr(reg_iwb, ptr(param, GET_OFF(iwb)));
+
+        if (head_n_oi != 0) mov_imm(reg_oi, head_n_oi);
+        cmp_imm(reg_iwb, head_thread, reg_tmp_imm);
+        b(EQ, head_label);
+
+        cmp_imm(reg_iwb, pretail_thread, reg_tmp_imm);
+        if (pretail_n_oi == 0) {
+            b(EQ, pretail_label);
+        } else {
+            mov_imm(reg_oi, pretail_n_oi);
+            b(EQ, body_label);
+        }
+        if (pretail_thread != tail_thread) {
+            cmp_imm(reg_iwb, tail_thread, reg_tmp_imm);
+            b(EQ, tail_label);
+        }
+        if (body_n_oi != 0) {
+            mov_imm(reg_oi, body_n_oi);
+            b(body_label);
+        } else {
+            b(end_label);
+        }
+    }
+
+    L(head_label);
+    if (l_overflow > 0) {
+        compute_loop(ur_w, l_overflow, 0);
+        if (threaded && head_n_oi == 0 && head_thread != pretail_thread)
+            b(end_label);
+        else {
+            add_imm(reg_src, reg_src, src_shift, reg_tmp_imm);
+            add_imm(reg_dst, reg_dst, dst_shift, reg_tmp_imm);
+            add_imm(reg_src_prf, reg_src_prf, src_shift, reg_tmp_imm);
+            add_imm(reg_dst_prf, reg_dst_prf, dst_shift, reg_tmp_imm);
+        }
+    }
+
+    L(body_label);
+    if (n_oi > 0) {
+        Label ow_loop_label;
+        L(ow_loop_label);
+        {
+            compute_loop(ur_w, body_l_overflow, body_r_overflow);
+            if (n_oi > 1 || r_overflow_no_tail > 0 || ur_w_tail != 0) {
+                add_imm(reg_src, reg_src, src_shift, reg_tmp_imm);
+                add_imm(reg_src_prf, reg_src_prf, src_shift, reg_tmp_imm);
+                if (!jcp.large_w_filter) {
+                    add_imm(reg_dst, reg_dst, dst_shift, reg_tmp_imm);
+                    add_imm(reg_dst_prf, reg_dst_prf, dst_shift, reg_tmp_imm);
+                }
+            }
+            if (n_oi > 1) {
+                sub(reg_oi, reg_oi, 1);
+                cmp(reg_oi, 0);
+                b(GT, ow_loop_label);
+            }
+        }
+    }
+    if (threaded) {
+        ldr(reg_iwb, ptr(param, GET_OFF(iwb)));
+        cmp_imm(reg_iwb, pretail_thread, reg_tmp_imm);
+        b(NE, end_label);
+    }
+
+    L(pretail_label);
+    if (r_overflow_no_tail > 0) {
+        compute_loop(ur_w, 0, r_overflow_no_tail);
+        if (ur_w_tail != 0) {
+            if (threaded && tail_thread != pretail_thread) b(end_label);
+            add_imm(reg_src, reg_src, src_shift, reg_tmp_imm);
+            add_imm(reg_dst, reg_dst, dst_shift, reg_tmp_imm);
+            add_imm(reg_src_prf, reg_src_prf, src_shift, reg_tmp_imm);
+            add_imm(reg_dst_prf, reg_dst_prf, dst_shift, reg_tmp_imm);
+        }
+    }
+
+    L(tail_label);
+    if (ur_w_tail != 0) {
+        /* if 'filter-width > ur_w' then the main loop only partially computes
+         * width, ur_w_tail needs to offset the initial ur_w from the filter
+         * address. */
+        if (jcp.large_w_filter)
+            compute_loop(ur_w_tail, body_l_overflow, r_overflow - ur_w, ur_w);
+        else
+            compute_loop(ur_w_tail, 0, r_overflow);
+    }
+
+    L(end_label);
+
+    postamble();
+}
+
+status_t jit_sve_512_conv_bwd_data_kernel_f32::init_conf(jit_conv_conf_t &jcp,
+        const convolution_desc_t &cd, memory_desc_t &diff_src_md,
+        memory_desc_t &weights_md, memory_desc_t &diff_dst_md, int nthreads) {
+    if (!mayiuse(sve_512)) return status::unimplemented;
+
+    const memory_desc_wrapper diff_src_d(&diff_src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper diff_dst_d(&diff_dst_md);
+    jcp = zero<decltype(jcp)>();
+
+    const bool with_groups = weights_d.ndims() == diff_src_d.ndims() + 1;
+    int ndims = diff_src_d.ndims();
+
+    jcp.nthr = jcp.aligned_threads = nthreads;
+    jcp.ndims = ndims;
+    jcp.prop_kind = cd.prop_kind;
+
+    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    jcp.mb = diff_src_d.dims()[0];
+
+    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc_without_padding = jcp.oc;
+    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = jcp.ic;
+
+    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
+    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
+    jcp.iw = diff_src_d.dims()[ndims - 1];
+    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
+    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
+    jcp.ow = diff_dst_d.dims()[ndims - 1];
+
+    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
+    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
+    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+
+    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
+    jcp.l_pad = cd.padding[0][ndims - 3];
+
+    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
+    jcp.stride_w = cd.strides[ndims - 3];
+
+    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
+    jcp.dilate_w = cd.dilates[ndims - 3];
+    if ((jcp.dilate_w != 0 && jcp.stride_w != 1)
+            || (jcp.dilate_d != 0 && jcp.stride_d != 1)
+            || (jcp.dilate_h != 0 && jcp.stride_h != 1))
+        return status::unimplemented;
+
+    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    jcp.r_pad = calculate_end_padding(
+            jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
+    jcp.b_pad = calculate_end_padding(
+            jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh);
+    jcp.back_pad = calculate_end_padding(
+            jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd);
+    bool kernel_outside_src = false || ext_kw <= jcp.l_pad
+            || ext_kw <= jcp.r_pad || ext_kh <= jcp.t_pad || ext_kh <= jcp.b_pad
+            || ext_kd <= jcp.f_pad || ext_kd <= jcp.back_pad;
+    if (kernel_outside_src) return status::unimplemented;
+
+    jcp.aligned_threads = 0;
+    const auto dat_tag_nxc = pick(ndims - 3, nwc, nhwc, ndhwc);
+    const auto dat_tag_nCx4c = pick(ndims - 3, nCw4c, nChw4c, nCdhw4c);
+    const auto dat_tag_nCx8c = pick(ndims - 3, nCw8c, nChw8c, nCdhw8c);
+    const auto dat_tag_nCx16c = pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
+    auto curr_src_tag = diff_src_d.matches_one_of_tag(
+            dat_tag_nxc, dat_tag_nCx16c, dat_tag_nCx8c, dat_tag_nCx4c);
+    auto curr_dst_tag = diff_dst_d.matches_one_of_tag(
+            dat_tag_nxc, dat_tag_nCx16c, dat_tag_nCx8c, dat_tag_nCx4c);
+    bool is_data_layout_nxc
+            = utils::everyone_is(dat_tag_nxc, curr_src_tag, curr_dst_tag);
+    if (mayiuse(sve_512) && is_data_layout_nxc) return status::unimplemented;
+
+    jcp.is_1stconv = false;
+
+    bool ok_to_pad_channels = true && !is_data_layout_nxc && jcp.ngroups == 1
+            && diff_src_d.data_type() == data_type::f32;
+
+    const int full_simd_w = cpu_isa_traits<sve_512>::vlen / typesize;
+    jcp.simd_w = full_simd_w;
+
+    jcp.oc_block = jcp.simd_w;
+    jcp.ic_block = jcp.is_1stconv ? jcp.ic : jcp.simd_w;
+
+    if (ok_to_pad_channels) {
+        jcp.oc = rnd_up(jcp.oc, jcp.oc_block);
+        jcp.ic = rnd_up(jcp.ic, jcp.ic_block);
+    }
+
+    if (!IMPLICATION(!is_data_layout_nxc,
+                jcp.oc % jcp.oc_block == 0 && jcp.ic % jcp.ic_block == 0))
+        return status::unimplemented;
+    jcp.ic_tail = is_data_layout_nxc ? jcp.ic % jcp.simd_w : 0;
+    jcp.oc_tail = is_data_layout_nxc ? jcp.oc % jcp.simd_w : 0;
+
+    format_tag_t dat_tag, wei_tag;
+    const auto nxc_tag = pick(ndims - 3, nwc, nhwc, ndhwc);
+
+    if (jcp.simd_w == 8) {
+        assert(with_groups);
+        dat_tag = is_data_layout_nxc ? nxc_tag
+                                     : pick(ndims - 3, nCw8c, nChw8c, nCdhw8c);
+        wei_tag = pick(ndims - 3, gOIw8o8i, gOIhw8o8i, gOIdhw8o8i);
+    } else if (jcp.simd_w == 4) {
+        assert(with_groups);
+        dat_tag = is_data_layout_nxc ? nxc_tag
+                                     : pick(ndims - 3, nCw4c, nChw4c, nCdhw4c);
+        wei_tag = pick(ndims - 3, gOIw4o4i, gOIhw4o4i, gOIdhw4o4i);
+    } else {
+        dat_tag = is_data_layout_nxc
+                ? pick(ndims - 3, nwc, nhwc, ndhwc)
+                : pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
+        wei_tag = pick(2 * ndims - 6 + with_groups, OIw16o16i, gOIw16o16i,
+                OIhw16o16i, gOIhw16o16i, OIdhw16o16i, gOIdhw16o16i);
+    }
+
+    if (diff_src_md.format_kind == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(diff_src_md, dat_tag));
+    } else if (curr_src_tag != dat_tag)
+        return status::unimplemented;
+    jcp.src_tag = dat_tag;
+
+    if (diff_dst_md.format_kind == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(diff_dst_md, dat_tag));
+    } else if (curr_dst_tag != dat_tag)
+        return status::unimplemented;
+    jcp.dst_tag = dat_tag;
+
+    if (init_tag(jcp.wei_tag, weights_md, weights_d, wei_tag)
+            != status::success)
+        return status::unimplemented;
+
+    jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
+    jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
+
+    jcp.ur_w = jcp.stride_w;
+
+    int regs = 24;
+    if (jcp.iw <= regs)
+        jcp.ur_w = jcp.iw;
+    else {
+        for (int ur_w = regs; ur_w > 0; --ur_w)
+            if (ur_w % jcp.stride_w == 0) {
+                jcp.ur_w = ur_w;
+                break;
+            }
+    }
+    int l_overflow = nstl::max(
+            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
+    int r_overflow_no_tail = nstl::max(0,
+            ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                    - nstl::max(0, jcp.r_pad + jcp.iw % jcp.ur_w))
+                    / jcp.stride_w);
+    int n_oi = jcp.iw / jcp.ur_w;
+    if (r_overflow_no_tail > 0) n_oi--;
+
+    if (mayiuse(sve_512) && diff_dst_d.data_type() == data_type::f32
+            && weights_d.data_type() == data_type::f32
+            && diff_src_d.data_type() == data_type::f32) {
+        jcp.ver = ver_fma;
+        jcp.typesize_in = typesize;
+        jcp.typesize_out = typesize;
+    } else {
+        return status::unimplemented;
+    }
+
+    jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
+
+    bool large_code_size = (jcp.ur_w != jcp.ow)
+            && ((l_overflow <= 0 && n_oi > 0) || (l_overflow > 0 && n_oi > 1))
+            && (r_overflow_no_tail > 0) && (l_overflow > 0);
+    if (large_code_size) {
+        const int max_code_size = 24 * 1024;
+        const int num_ops_per_reg = 6 + jcp.oc_block * jcp.kw;
+        int mult = 1;
+        if (l_overflow > 0) mult += 1;
+        if (r_overflow_no_tail > 0) mult += 1;
+        for (int ur_w = jcp.ur_w; ur_w > regs / 2; --ur_w) {
+            if ((ur_w / jcp.stride_w) * mult * num_ops_per_reg * 9.2
+                    < max_code_size) {
+                if (ur_w % jcp.stride_w == 0) {
+                    jcp.ur_w = ur_w;
+                    break;
+                }
+            }
+        }
+    }
+
+    /* Support for large filter 'kw > 14' is only possible when ur_w is small
+     * (e.g ur_w = 1) because of register allocation (max_reg = 31) */
+    const int min_filter_size = 14;
+    /* Don't let JIT generate too big of a code which might result in an
+     * out-of-memory crash. */
+    const int max_filter_size = 20;
+
+    /* These conditions define a set of shapes with 'ow = 1' which
+     * have a very limited optimization space for performance.
+     * Optimize by using a targeted 'jcp.nb_ic_blocking' value. */
+    jcp.large_w_filter = jcp.kw >= min_filter_size && jcp.kw < max_filter_size
+            && jcp.ow == 1 && jcp.nb_ic > 1 && jcp.kw == jcp.iw
+            && jcp.stride_w == 1
+            && utils::everyone_is(0, jcp.dilate_d, jcp.dilate_h, jcp.dilate_w);
+
+    if (jcp.ver == ver_fma && mayiuse(sve_512)) {
+        int try_nb_ic_blocking = 2;
+        bool use_expl_bcast
+                = !(jcp.kw == 1 || (jcp.kw == 5 && jcp.iw < 8)
+                          || (jcp.kw < 5
+                                  && ((jcp.iw <= 5
+                                          || (jcp.iw > 8 && jcp.iw <= 13)))))
+                || jcp.stride_h > 1 || jcp.stride_d > 1;
+        if (use_expl_bcast && !jcp.large_w_filter) {
+            jcp.kernel_kind = embd_bcast;
+            jcp.ur_w = nstl::min(jcp.iw, 16);
+            jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
+            if (!(jcp.kw > 3 || (jcp.kw == 3 && jcp.ow > 8))
+                    && jcp.stride_h == 1 && jcp.stride_d == 1)
+                if (jcp.nb_ic % try_nb_ic_blocking == 0) {
+                    jcp.nb_ic_blocking = try_nb_ic_blocking;
+                    jcp.ur_w = 30 / (jcp.nb_ic_blocking + 1);
+                    if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+                }
+        } else {
+            jcp.kernel_kind = expl_bcast;
+            jcp.nb_oc_blocking = 1;
+            jcp.nb_ic_blocking = jcp.large_w_filter ? 2 : 4;
+            if (jcp.nb_ic < jcp.nb_ic_blocking) jcp.nb_ic_blocking = jcp.nb_ic;
+            if (jcp.nb_ic % jcp.nb_ic_blocking != 0)
+                for (int i = jcp.nb_ic_blocking; i > 0; i--)
+                    if (jcp.nb_ic % i == 0) {
+                        jcp.nb_ic_blocking = i;
+                        break;
+                    }
+            if (jcp.stride_w > 1) {
+                jcp.ur_w = 30 / (jcp.nb_ic_blocking + 1);
+            } else {
+                jcp.ur_w = 31 / (jcp.nb_ic_blocking + 1);
+            }
+            if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+        }
+    }
+    jcp.ur_w_tail = jcp.iw % jcp.ur_w;
+
+    auto is_iw_threading_applicable = [=]() { return one_of(jcp.ndims, 3, 4); };
+
+    auto get_thr_eff = [=](int nb_ic_blocking, int iw_block) {
+        // Cost heuristic for threading overhead. Determined using OMP.
+        const float iw_block_cost = 32.0;
+
+        int nb_iw = div_up(jcp.iw, iw_block);
+        int nb_ic_chunks = div_up(jcp.nb_ic, nb_ic_blocking);
+        int work_amount = jcp.mb * jcp.ih * nb_ic_chunks * nb_iw;
+        float disbalance = (float)jcp.iw / rnd_up(jcp.iw, iw_block);
+        float block_overhead = nstl::max(0.0f, 1.0f - iw_block_cost / iw_block);
+        float thr_eff = block_overhead * disbalance
+                * ((float)work_amount / rnd_up(work_amount, nthreads));
+        return thr_eff;
+    };
+
+    auto get_iw_block = [=](int nb_ic_blocking, int ur_w) {
+        int res_iw_block = jcp.iw;
+        if (!is_iw_threading_applicable()) return res_iw_block;
+
+        int max_nb_iw = div_up(jcp.iw, 2 * ur_w);
+        int iw_block_thr;
+        float eff;
+
+        if (jcp.ndims == 3) {
+            // Blocking optimization to prevent data from leaving cache This
+            // blocking optimization does not handle height blocking, so it does
+            // not apply to higher dimensions.
+            // TODO: Implement a more general optimization taking into account
+            // the height dimension.
+            int L2_part
+                    = (platform::get_per_core_cache_size(2) * 7 / 8) / typesize;
+            int size_diff_src_chunk = jcp.ic_block * nb_ic_blocking * ur_w;
+            int size_diff_dst_chunk = jcp.oc_block * ur_w;
+            int size_wei_chunk
+                    = jcp.ic_block * nb_ic_blocking * jcp.oc_block * jcp.kw;
+            int nurw_cache = (L2_part - 2 * size_wei_chunk)
+                    / (2 * size_diff_dst_chunk + 2 * size_diff_src_chunk);
+            // current design of generate() requires iw_block >= 2 * ur_w
+            int iw_block_cache = ur_w * nstl::max(2, nurw_cache);
+
+            iw_block_thr = iw_block_cache;
+        } else
+            iw_block_thr = jcp.iw;
+        eff = get_thr_eff(nb_ic_blocking, iw_block_thr);
+
+        // Search for most efficient threading over iw_blocks.
+        int start_nb_iw = div_up(jcp.iw, iw_block_thr);
+        for (int nb_iw = start_nb_iw; nb_iw <= max_nb_iw; nb_iw++) {
+            float eff_threshold = 0.98f;
+            if (eff > eff_threshold) break;
+            int iw_block
+                    = nstl::min(rnd_up(div_up(jcp.iw, nb_iw), ur_w), jcp.iw);
+            if (div_up(jcp.iw, iw_block) != nb_iw) continue;
+            float thr_eff = get_thr_eff(nb_ic_blocking, iw_block);
+            if (iw_block >= 2 * ur_w && thr_eff > eff) {
+                iw_block_thr = iw_block;
+                eff = thr_eff;
+            }
+        }
+        res_iw_block = nstl::min(jcp.iw, nstl::max(2 * ur_w, iw_block_thr));
+        return res_iw_block;
+    };
+
+    jcp.iw_block = get_iw_block(jcp.nb_ic_blocking, jcp.ur_w);
+    jcp.nb_iw = div_up(jcp.iw, jcp.iw_block);
+
+    if (l_overflow * jcp.stride_w > jcp.ur_w && !jcp.large_w_filter)
+        return status::unimplemented;
+    r_overflow_no_tail = nstl::max(0,
+            ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                    - nstl::max(0, jcp.r_pad + jcp.ur_w_tail))
+                    / jcp.stride_w);
+    bool tails_not_ok = false
+            /* maximum 1 ur_w block with r_overflow so far */
+            || r_overflow_no_tail * jcp.stride_w > jcp.ur_w
+            /* ur_w must be a multiple of stride */
+            || ((jcp.iw > jcp.ur_w) && (jcp.ur_w % jcp.stride_w != 0))
+            /* r_pad must not extend beyond ur_w_tail */
+            || ((jcp.iw > jcp.ur_w) && (jcp.r_pad + jcp.ur_w_tail < 0));
+    if (tails_not_ok) return status::unimplemented;
+
+    pick_loop_order(jcp);
+
+    jcp.nb_oc_L2 = jcp.nb_oc;
+
+    if (is_data_layout_nxc) {
+        // TODO: improve L2 blocking for large OC
+        const int nb_oc_theshold_L2 = 32;
+        if (jcp.nb_oc > nb_oc_theshold_L2 && jcp.nb_oc < 2 * nb_oc_theshold_L2)
+            jcp.nb_oc_L2 = div_up(jcp.nb_oc, 2);
+        else
+            jcp.nb_oc_L2 = nstl::min(nb_oc_theshold_L2, jcp.nb_oc);
+    }
+
+    bool args_ok = true && jcp.ic <= diff_src_d.padded_dims()[1]
+            && jcp.oc <= diff_dst_d.padded_dims()[1]
+            && jcp.ic <= weights_d.padded_dims()[with_groups + 1]
+            && jcp.oc <= weights_d.padded_dims()[with_groups + 0];
+    if (!args_ok) return status::unimplemented;
+
+    // A rough check on code size
+    // TODO: come up with a tighter bound
+    {
+        const int max_code_size = 256 * 1024; // default size of jit generator
+        int mult = 1 + (l_overflow > 0) + (r_overflow_no_tail > 0);
+        const float max_instruction_size = 15;
+        float ur_fac
+                = (float)jcp.kw * jcp.oc_block * jcp.nb_ic_blocking * jcp.ur_w;
+        float code_size = mult * ur_fac * max_instruction_size;
+        if (code_size > max_code_size && !jcp.large_w_filter)
+            return status::unimplemented;
+    }
+
+    return status::success;
+}
+
+void jit_sve_512_conv_bwd_data_kernel_f32::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
+    UNUSED(scratchpad);
+    UNUSED(jcp);
+}
+
+// Initialize static data members
+const int jit_sve_512_conv_bwd_weights_kernel_f32::max_ur_w = 28;
+const int jit_sve_512_conv_bwd_weights_kernel_f32::min_oh_reduce = 9;
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::od_step_comeback_pointers() {
+    Label kd_comeback_label;
+
+    /* 'depth' loop count bound by 'kd_work_size' */
+    mov(kj, reg_kd_count);
+    L(kd_comeback_label);
+    {
+        int inp_mult = is_src_layout_nxc()
+                ? jcp.ngroups * jcp.ic
+                : (jcp.is_1stconv ? 1 : jcp.ic_block);
+        int iw = jcp.iw;
+        sub_imm(reg_input, reg_input,
+                jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * iw * inp_mult,
+                reg_tmp_imm);
+        sub_imm(reg_kernel, reg_kernel,
+                jcp.typesize_out * jcp.kh * jcp.kw * jcp.ic_block
+                        * jcp.oc_block,
+                reg_tmp_imm);
+        sub(kj, kj, 1);
+        cmp(kj, 0);
+        b(GT, kd_comeback_label);
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::oh_step_comeback_pointers() {
+    Label kh_comeback_label, kd_comeback_label;
+    mov(kj, reg_kh);
+    L(kh_comeback_label);
+    {
+        int inp_mult = is_src_layout_nxc()
+                ? jcp.ngroups * jcp.ic
+                : (jcp.is_1stconv ? 1 : jcp.ic_block);
+        int iw = jcp.iw;
+        sub_imm(reg_input, reg_input,
+                jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mult,
+                reg_tmp_imm);
+        sub_imm(reg_kernel, reg_kernel,
+                jcp.typesize_out * jcp.kw * jcp.ic_block * jcp.oc_block,
+                reg_tmp_imm);
+        sub(kj, kj, 1);
+        cmp(kj, 0);
+        b(GT, kh_comeback_label);
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::compute_ic_block_step(int ur_w,
+        int pad_l, int pad_r, int ic_block_step, int input_offset,
+        int kernel_offset, int output_offset, bool input_wraparound) {
+
+    int kw = jcp.kw;
+    int iw = jcp.iw;
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+
+    auto load_ker = [=](int zreg_idx, int ofs, int pre_offset_ker) {
+        if (str_imm_check(ofs)) {
+            ldr(ZReg(zreg_idx),
+                    ptr(reg_kernel, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            if (pre_offset_ker >= 0 && str_imm_check(ofs - pre_offset_ker)) {
+                ldr(ZReg(zreg_idx),
+                        ptr(reg_pre_addr_ker,
+                                static_cast<int32_t>(
+                                        VL_OFS(ofs - pre_offset_ker))));
+            } else {
+                add_imm(reg_pre_addr_ker, reg_kernel, ofs, reg_tmp_imm);
+                ldr(ZReg(zreg_idx), ptr(reg_pre_addr_ker));
+                pre_offset_ker = ofs;
+            }
+        }
+        return pre_offset_ker;
+    };
+
+    int pre_offset_ker = -1;
+    for (int i_kw = 0; i_kw < kw; i_kw++) {
+        for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
+            pre_offset_ker = load_ker(i_kw * ic_block_step + i_ic,
+                    typesize * (i_kw * ic_block + i_ic) * jcp.oc_block
+                            + kernel_offset,
+                    pre_offset_ker);
+        }
+    }
+    int num_zregs4ker = kw * ic_block_step;
+    int num_zregs4out = 4;
+    num_zregs4out = (28 - num_zregs4ker) / num_zregs4ker
+            ? nstl::max(num_zregs4out
+                            + ((32 - num_zregs4out - num_zregs4ker)
+                                    % (num_zregs4ker)),
+                    4)
+            : nstl::max(32 - (num_zregs4ker + ic_block_step), 4);
+    int idata_reg_offset = num_zregs4ker + num_zregs4out;
+    int num_zregs4idata = 32 - idata_reg_offset;
+
+    int pre_offset_input = -1;
+    int offset_diff_inp = -1;
+    auto load_input = [&](size_t i_offset, int zreg_idx) {
+        unsigned int IMM_MASK12 = 0xfff;
+        unsigned long long int IMM_MASK24_12 = 0xfff000;
+        unsigned int IMM_MASK24 = 0xffffff;
+
+        assert(i_offset < (1LL << 31));
+        if (ld1rw_imm_check(i_offset)) {
+            // i_offset is smaller than the maximum value of ld1rw imm
+            ld1rw(ZRegS(idata_reg_offset + (zreg_idx % num_zregs4idata)),
+                    reg_p_all_ones,
+                    ptr(reg_input, static_cast<int32_t>(i_offset)));
+
+        } else if ((pre_offset_input >= 0)
+                && ld1rw_imm_check(i_offset - pre_offset_input)) {
+            // The offset from previous access address is smaller than the
+            // maximum value of ld1rw imm
+            ld1rw(ZRegS(idata_reg_offset + (zreg_idx % num_zregs4idata)),
+                    reg_p_all_ones,
+                    ptr(reg_pre_addr_input,
+                            static_cast<int32_t>(i_offset - pre_offset_input)));
+
+        } else if ((pre_offset_input >= 0) && (offset_diff_inp >= 0)
+                && (offset_diff_inp
+                        == ((long long int)i_offset - pre_offset_input))) {
+            add(reg_pre_addr_input, reg_pre_addr_input, reg_addr_diff_input);
+            ld1rw(ZRegS(idata_reg_offset + (zreg_idx % num_zregs4idata)),
+                    reg_p_all_ones, ptr(reg_pre_addr_input));
+            pre_offset_input = i_offset;
+        } else if (ld1rw_imm_check(i_offset & IMM_MASK12)
+                && !(i_offset & ~IMM_MASK24)) {
+            // i_offset can be represented by ld1rw imm and a 12-23 bit vaule
+            add_imm(reg_pre_addr_input, reg_input, (i_offset)&IMM_MASK24_12,
+                    reg_tmp_imm);
+            ld1rw(ZRegS(idata_reg_offset + (zreg_idx % num_zregs4idata)),
+                    reg_p_all_ones,
+                    ptr(reg_pre_addr_input,
+                            static_cast<int32_t>(i_offset & IMM_MASK12)));
+            pre_offset_input = i_offset - (i_offset & IMM_MASK12);
+
+        } else if ((pre_offset_input >= 0)
+                && ld1rw_imm_check((i_offset - pre_offset_input) & IMM_MASK12)
+                && !((i_offset - pre_offset_input) & ~IMM_MASK24)) {
+            // The offset from previous access address can be represented by
+            // ld1rw imm and a 12-23 bit value
+            add_imm(reg_pre_addr_input, reg_pre_addr_input,
+                    (i_offset - pre_offset_input) & IMM_MASK24_12, reg_tmp_imm);
+            ld1rw(ZRegS(idata_reg_offset + (zreg_idx % num_zregs4idata)),
+                    reg_p_all_ones,
+                    ptr(reg_pre_addr_input,
+                            static_cast<int32_t>((i_offset - pre_offset_input)
+                                    & IMM_MASK12)));
+            pre_offset_input
+                    = i_offset - ((i_offset - pre_offset_input) & IMM_MASK12);
+
+        } else {
+            // other cases
+            if ((pre_offset_input >= 0)
+                    && (((long long int)i_offset - pre_offset_input) >= 0)) {
+                if ((i_offset - pre_offset_input) > ADDMAX) {
+                    mov_imm(reg_addr_diff_input, i_offset - pre_offset_input);
+                    add(reg_pre_addr_input, reg_pre_addr_input,
+                            reg_addr_diff_input);
+                    offset_diff_inp = i_offset - pre_offset_input;
+                } else {
+                    add_imm(reg_pre_addr_input, reg_pre_addr_input,
+                            i_offset - pre_offset_input, reg_tmp_imm);
+                }
+            } else {
+                add_imm(reg_pre_addr_input, reg_input, i_offset, reg_tmp_imm);
+            }
+            ld1rw(ZRegS(idata_reg_offset + (zreg_idx % num_zregs4idata)),
+                    reg_p_all_ones, ptr(reg_pre_addr_input));
+            pre_offset_input = i_offset;
+        }
+        return;
+    };
+
+    int pre_offset_out = -1;
+    auto load_out = [&](int zreg_idx, int ofs) {
+        if (ldr_imm_check(ofs)) {
+            ldr(ZReg(zreg_idx),
+                    ptr(reg_output, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            if (pre_offset_out >= 0 && ldr_imm_check(ofs - pre_offset_out)) {
+                ldr(ZReg(zreg_idx),
+                        ptr(reg_pre_addr_out,
+                                static_cast<int32_t>(
+                                        VL_OFS(ofs - pre_offset_out))));
+            } else {
+                add_imm(reg_pre_addr_out, reg_output, ofs, reg_tmp_imm);
+                ldr(ZReg(zreg_idx), ptr(reg_pre_addr_out));
+                pre_offset_out = ofs;
+            }
+        }
+        return;
+    };
+
+    int pre_loaded_ur = 0;
+    /* 
+     * This loop generates the ld1rw instruction as much as possible
+     * before the loop that generates the fmla instruction.
+     */
+    for (int i_ur = 0; i_ur < ur_w; i_ur++) {
+        if ((idata_reg_offset - 1 + (i_ur + 1) * kw * ic_block_step) > 31)
+            break;
+        for (int i_kw = 0; i_kw < kw; i_kw++) {
+            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            if (i_iw < 0 || i_iw > get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r
+                    || get_iw_idx(i_ur, i_kw, jcp.l_pad) >= iw)
+                continue;
+
+            for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
+                if ((idata_reg_offset + i_ic) > 31) break;
+                size_t i_offset = get_full_src_offset(i_iw, i_ic, input_offset);
+                int zreg_idx = i_ic + (i_ur * kw + i_kw) * ic_block_step;
+                load_input(i_offset, zreg_idx);
+            }
+        }
+        pre_loaded_ur++;
+    }
+
+    for (int i_ur = 0; i_ur < ur_w; i_ur++) {
+        /*
+         * Generates ldr instructions to load output tensor data.
+         * The first iteration produces ldr instructions for the next iteration.
+         */
+        if (i_ur == 0) {
+            for (int ii = 0; ii < num_zregs4out; ii++) {
+                if (ur_w > ii) {
+
+                    load_out(kw * ic_block_step + (i_ur + ii) % num_zregs4out,
+                            typesize * (i_ur + ii) * oc_block + output_offset);
+                }
+            }
+        } else if ((i_ur + num_zregs4out - 1) < ur_w) {
+            load_out(kw * ic_block_step
+                            + (i_ur + num_zregs4out - 1) % num_zregs4out,
+                    typesize * (i_ur + num_zregs4out - 1) * oc_block
+                            + output_offset);
+        }
+
+        for (int i_kw = 0; i_kw < kw; i_kw++) {
+
+            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            if (!(i_iw < 0 || i_iw > get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r
+                        || get_iw_idx(i_ur, i_kw, jcp.l_pad) >= iw)) {
+
+                /*
+                 * If the previous loop does not generate ld1rw instructions,
+                 * the following routine generates.
+                 */
+                int pre_loaded_ic = 0;
+                if (pre_loaded_ur == 0) {
+                    for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
+                        if ((idata_reg_offset + i_ic) > 31) break;
+                        size_t i_offset
+                                = get_full_src_offset(i_iw, i_ic, input_offset);
+                        int zreg_idx
+                                = i_ic + (i_ur * kw + i_kw) * ic_block_step;
+                        load_input(i_offset, zreg_idx);
+                        pre_loaded_ic++;
+                    }
+                }
+
+                for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
+                    assert((i_kw * ic_block_step + i_ic) < 31);
+                    assert((kw * ic_block_step + (i_ur % num_zregs4out)) < 31);
+                    int zreg_idx = i_ic + (i_ur * kw + i_kw) * ic_block_step;
+                    fmla(ZRegS(i_kw * ic_block_step + i_ic), reg_p_all_ones,
+                            ZRegS(kw * ic_block_step + i_ur % num_zregs4out),
+                            ZRegS(idata_reg_offset
+                                    + (zreg_idx % num_zregs4idata)));
+                    if ((pre_loaded_ur == 0)
+                            && ((i_ic + pre_loaded_ic) < ic_block_step)) {
+                        size_t i_offset = get_full_src_offset(
+                                i_iw, i_ic + pre_loaded_ic, input_offset);
+                        int zreg_idx = i_ic + pre_loaded_ic
+                                + (i_ur * kw + i_kw) * ic_block_step;
+                        load_input(i_offset, zreg_idx);
+                    }
+                }
+            }
+
+            /*
+             * If the previous loop generates ld1rw instructions,
+             * the following routine generates ld1rw instructions for the next
+             * iteration.
+             */
+            if (pre_loaded_ur > 0) {
+                int i_iw4load = get_iw_idx(i_ur + pre_loaded_ur, i_kw, pad_l);
+                int unload_flag = (i_iw4load < 0
+                        || i_iw4load
+                                > get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r
+                        || get_iw_idx(i_ur + pre_loaded_ur, i_kw, jcp.l_pad)
+                                >= iw);
+
+                for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
+                    if ((idata_reg_offset + i_ic) > 31) break;
+                    if (unload_flag || (i_ur + pre_loaded_ur) >= ur_w) break;
+                    size_t i_offset = get_full_src_offset(
+                            i_iw4load, i_ic, input_offset);
+                    int zreg_idx = i_ic
+                            + ((i_ur + pre_loaded_ur) * kw + i_kw)
+                                    * ic_block_step;
+                    load_input(i_offset, zreg_idx);
+                }
+            }
+        }
+    }
+
+    auto store_ker = [=](int zreg_idx, int ofs, int pre_offset_ker) {
+        if (str_imm_check(ofs)) {
+            str(ZReg(zreg_idx),
+                    ptr(reg_kernel, static_cast<int32_t>(VL_OFS(ofs))));
+        } else {
+            if (pre_offset_ker >= 0 && str_imm_check(ofs - pre_offset_ker)) {
+                str(ZReg(zreg_idx),
+                        ptr(reg_pre_addr_ker,
+                                static_cast<int32_t>(
+                                        VL_OFS(ofs - pre_offset_ker))));
+            } else {
+                add_imm(reg_pre_addr_ker, reg_kernel, ofs, reg_tmp_imm);
+                str(ZReg(zreg_idx), ptr(reg_pre_addr_ker));
+                pre_offset_ker = ofs;
+            }
+        }
+        return pre_offset_ker;
+    };
+
+    pre_offset_ker = -1;
+    for (int i_kw = 0; i_kw < kw; i_kw++) {
+        for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
+            pre_offset_ker = store_ker(i_kw * ic_block_step + i_ic,
+                    typesize * (i_kw * ic_block + i_ic) * jcp.oc_block
+                            + kernel_offset,
+                    pre_offset_ker);
+        }
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32 ::
+        compute_oh_step_unroll_ow_icblock(int ic_block_step, int max_ur_w) {
+    UNUSED(max_ur_w);
+
+    Label kh_label, kd_label;
+
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+    const bool src_layout_nxc = is_src_layout_nxc();
+    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                 : (!jcp.is_1stconv ? ic_block : 1);
+    int iw = jcp.iw;
+    int r_pad = nstl::max(0, jcp.r_pad);
+    int l_pad = jcp.l_pad;
+
+    if (jcp.ndims == 5) {
+        L(kd_label);
+        mov(reg_input, aux_reg_input);
+        mov(reg_kernel, aux_reg_kernel);
+    }
+
+    const int ic_tail = jcp.ic_tail;
+    const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
+    mov(kj, reg_kh);
+    L(kh_label);
+    {
+        Label icb_block_label, icb_block_label_cb, ic_tail_loop, ic_tail_label;
+        if (generate_icb_loop || ic_tail) {
+            mov(reg_input_org, reg_input);
+            mov(reg_kernel_org, reg_kernel);
+            ldr(reg_icb, ptr(param, GET_OFF(reduce_work)));
+        }
+
+        if (ic_tail) {
+            cmp_imm(reg_icb, ic_block, reg_tmp_imm);
+            b(LT, ic_tail_loop);
+        }
+
+        const int ic_tail_loop_work = rnd_dn(ic_tail, ic_block_step);
+        Label icb_block_label_end;
+        L(icb_block_label);
+        for (int i_b_ic = 0; i_b_ic < jcp.ic_block; i_b_ic += ic_block_step) {
+            const int input_offset = jcp.typesize_in * i_b_ic;
+            compute_ic_block_step(jcp.ur_w, l_pad, r_pad, ic_block_step,
+                    input_offset, jcp.typesize_out * i_b_ic * jcp.oc_block, 0,
+                    i_b_ic + ic_block_step >= jcp.ic_block);
+            if (generate_icb_loop || ic_tail)
+                sub_imm(reg_icb, reg_icb, ic_block_step, reg_tmp_imm);
+            if (ic_tail && i_b_ic + ic_block_step == ic_tail_loop_work) {
+                cmp_imm(reg_icb, ic_block_step, reg_tmp_imm);
+                b(LT, icb_block_label_end);
+            }
+        }
+        L(icb_block_label_end);
+
+        const int input_icb_shift = jcp.typesize_in * ic_block;
+        const size_t kernel_icb_shift = (size_t)jcp.typesize_out * jcp.kd
+                * jcp.kh * jcp.kw * ic_block * oc_block;
+
+        if (generate_icb_loop) {
+            // icb loop supported for src in nxc layout only
+            assert(src_layout_nxc);
+            add_imm(reg_input, reg_input, input_icb_shift, reg_tmp_imm);
+            add_imm(reg_kernel, reg_kernel, kernel_icb_shift, reg_tmp_imm);
+            cmp_imm(reg_icb, ic_block, reg_tmp_imm);
+            b(GE, icb_block_label);
+        }
+
+        if (ic_tail) {
+            L(ic_tail_loop);
+            Label skip_ic_tail;
+            cmp(reg_icb, 0);
+            b(LE, skip_ic_tail);
+            if (ic_tail_loop_work) {
+                cmp_imm(reg_icb, ic_tail_loop_work, reg_tmp_imm);
+                b(GE, icb_block_label);
+                if (generate_icb_loop) {
+                    // compensate offset added in generate_icb_loop
+                    sub_imm(reg_input, reg_input, input_icb_shift, reg_tmp_imm);
+                    sub_imm(reg_kernel, reg_kernel, kernel_icb_shift,
+                            reg_tmp_imm);
+                }
+            }
+
+            L(ic_tail_label);
+            if (ic_tail % ic_block_step) {
+                cmp(reg_icb, 0);
+                b(LE, skip_ic_tail);
+                const int i_b_ic = ic_tail_loop_work;
+                const int input_offset = jcp.typesize_in * i_b_ic;
+                compute_ic_block_step(jcp.ur_w, l_pad, r_pad,
+                        ic_tail % ic_block_step, input_offset,
+                        jcp.typesize_out * i_b_ic * jcp.oc_block, 0);
+            }
+            L(skip_ic_tail);
+        }
+
+        if (generate_icb_loop || ic_tail) {
+            mov(reg_kernel, reg_kernel_org);
+            mov(reg_input, reg_input_org);
+        }
+
+        add_imm(reg_input, reg_input,
+                jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mul,
+                reg_tmp_imm);
+        add_imm(reg_kernel, reg_kernel,
+                jcp.typesize_out * jcp.kw * ic_block * oc_block, reg_tmp_imm);
+        subs(kj, kj, 1);
+        b(GT, kh_label);
+    }
+
+    if (jcp.ndims == 5) {
+        add_imm(aux_reg_input, aux_reg_input,
+                jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * iw * inp_mul,
+                reg_tmp_imm);
+        add_imm(aux_reg_kernel, aux_reg_kernel,
+                jcp.typesize_out * jcp.kh * jcp.kw * ic_block * oc_block,
+                reg_tmp_imm);
+        subs(ki, ki, 1);
+        b(GT, kd_label);
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32 ::compute_oh_step_unroll_ow(
+        int ic_block_step, int max_ur_w) {
+    Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
+    const bool src_layout_nxc = is_src_layout_nxc();
+    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                 : (!jcp.is_1stconv ? jcp.ic_block : 1);
+    const int ic_tail = jcp.ic_tail;
+    UNUSED(max_ur_w);
+
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+
+    int ow = jcp.ow;
+
+    int r_pad = nstl::max(0, jcp.r_pad);
+    int l_pad = jcp.l_pad;
+
+    if (jcp.ndims == 5) {
+        L(kd_label);
+        mov(reg_input, aux_reg_input);
+        mov(reg_kernel, aux_reg_kernel);
+    }
+
+    const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
+    mov(kj, reg_kh);
+    L(kh_label);
+    {
+        Label icb_block_label;
+        if (generate_icb_loop || ic_tail) {
+            mov(reg_input_org, reg_input);
+            mov(reg_kernel_org, reg_kernel);
+            ldr(reg_icb, ptr(param, GET_OFF(reduce_work)));
+        }
+
+        if (ic_tail) {
+            cmp_imm(reg_icb, ic_block, reg_tmp_imm);
+            b(LT, ic_tail_loop_label);
+        }
+
+        L(icb_block_label);
+        Label icb_block_label_end;
+        mov(b_ic, ic_block);
+        L(ic_block_label);
+        {
+            compute_ic_block_step(ow, l_pad, r_pad, ic_block_step, 0, 0, 0);
+            size_t inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
+                    ? (size_t)jcp.ih * jcp.iw * jcp.id
+                    : 1;
+            size_t input_offset
+                    = inp_icblk_stride * jcp.typesize_in * ic_block_step;
+            add_imm(reg_input, reg_input, input_offset, reg_tmp_imm);
+            add_imm(reg_kernel, reg_kernel,
+                    jcp.typesize_out * ic_block_step * oc_block, reg_tmp_imm);
+            sub_imm(b_ic, b_ic, ic_block_step, reg_tmp_imm);
+            if (generate_icb_loop || ic_tail)
+                sub_imm(reg_icb, reg_icb, ic_block_step, reg_tmp_imm);
+            cmp_imm(b_ic, ic_block_step, reg_tmp_imm);
+            b(GE, ic_block_label);
+        }
+        L(icb_block_label_end);
+
+        const int input_shift
+                = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mul;
+
+        if (generate_icb_loop || ic_tail) {
+            const size_t kernel_icb_shift = (size_t)jcp.typesize_out * jcp.kd
+                    * jcp.kh * jcp.kw * ic_block * oc_block;
+            if (generate_icb_loop) {
+                // icb loop supported for src in nxc layout only
+                assert(src_layout_nxc);
+                Label icb_loop_done;
+                add_imm(reg_kernel, reg_kernel,
+                        kernel_icb_shift
+                                - jcp.typesize_out * ic_block * oc_block,
+                        reg_tmp_imm);
+                cmp_imm(reg_icb, ic_block, reg_tmp_imm);
+                b(GE, icb_block_label);
+                L(icb_loop_done);
+            }
+
+            L(ic_tail_loop_label);
+            if (ic_tail) {
+                Label skip_ic_tail;
+                const int ic_tail_loop_work = rnd_dn(ic_tail, ic_block_step);
+                cmp(reg_icb, 0);
+                b(LE, skip_ic_tail);
+                mov(b_ic, reg_icb);
+                if (ic_tail_loop_work) {
+                    cmp_imm(reg_icb, ic_block_step, reg_tmp_imm);
+                    b(GE, ic_block_label);
+                    if (generate_icb_loop) {
+                        // compensate offset added in generate_icb_loop
+                        sub_imm(reg_kernel, reg_kernel,
+                                kernel_icb_shift
+                                        - jcp.typesize_out * ic_block
+                                                * oc_block,
+                                reg_tmp_imm);
+                    }
+                }
+
+                L(ic_tail_label);
+                if (ic_tail % ic_block_step) {
+                    cmp(reg_icb, 0);
+                    b(LE, skip_ic_tail);
+                    compute_ic_block_step(
+                            ow, l_pad, r_pad, ic_tail % ic_block_step, 0, 0, 0);
+                }
+                L(skip_ic_tail);
+            }
+
+            mov(reg_kernel, reg_kernel_org);
+            mov(reg_input, reg_input_org);
+
+            add_imm(reg_input, reg_input, input_shift, reg_tmp_imm);
+            add_imm(reg_kernel, reg_kernel,
+                    jcp.typesize_out * jcp.kw * ic_block * oc_block,
+                    reg_tmp_imm);
+
+        } else if (jcp.is_1stconv && !src_layout_nxc) {
+            size_t input_offset = (size_t)jcp.typesize_in * jcp.id * jcp.ih
+                    * jcp.iw * ic_block;
+            sub_imm(reg_input, reg_input, input_offset, reg_tmp_imm);
+            add_imm(reg_input, reg_input, input_shift, reg_tmp_imm);
+        } else {
+            add_imm(reg_input, reg_input,
+                    input_shift - jcp.typesize_in * jcp.ic_block, reg_tmp_imm);
+        }
+
+        if (!(generate_icb_loop || ic_tail))
+            add_imm(reg_kernel, reg_kernel,
+                    jcp.typesize_out * (jcp.kw - 1) * ic_block * oc_block,
+                    reg_tmp_imm);
+        subs(kj, kj, 1);
+        b(GT, kh_label);
+    }
+    if (jcp.ndims == 5) {
+        add_imm(aux_reg_input, aux_reg_input,
+                jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
+                        * inp_mul,
+                reg_tmp_imm);
+        add_imm(aux_reg_kernel, aux_reg_kernel,
+                jcp.typesize_out * jcp.kh * jcp.kw * ic_block * oc_block,
+                reg_tmp_imm);
+        subs(ki, ki, 1);
+        b(GT, kd_label);
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32 ::compute_oh_step_common(
+        int ic_block_step, int max_ur_w) {
+    using namespace nstl;
+    Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
+
+    const bool src_layout_nxc = is_src_layout_nxc();
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+
+    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    int r_pad = max(0, jcp.r_pad);
+    int l_pad = jcp.l_pad;
+    int ur_w = min(ow, max_ur_w);
+    int ur_w_trips = ow / ur_w;
+    int ur_w_tail = ow % ur_w;
+    if ((ur_w_tail == 0 && r_pad != 0) || (r_pad > 0 && r_pad >= ur_w_tail)) {
+        if (ur_w_trips > 1) {
+            ur_w_tail += ur_w;
+            ur_w_trips--;
+        } else {
+            ur_w_tail += (ur_w - ur_w / 2);
+            ur_w = ur_w / 2;
+        }
+    }
+
+    assert(l_pad <= max_ur_w);
+    int inp_mult = src_layout_nxc
+            ? jcp.ngroups * jcp.ic
+            : ((jcp.is_1stconv) ? 1
+                                : ic_block * (jcp.is_hw_transp ? jcp.iw : 1));
+    int out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
+    int input_comeback
+            = max((ur_w_trips * ur_w * jcp.stride_w - l_pad), 0) * inp_mult;
+    int output_comeback = ur_w_trips * ur_w * out_mult;
+    const int ic_tail = jcp.ic_tail;
+    const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
+
+    auto ic_loop = [=](int ic_block_step) {
+        Label ow_block_label, ic_block_inner_label;
+        int ur_w_blocks = ur_w_trips;
+
+        int l_pad_tail = max(l_pad - ur_w, 0);
+        L(ic_block_inner_label);
+        if (l_pad != 0) {
+            ur_w_blocks--;
+            compute_ic_block_step(ur_w, l_pad, 0, ic_block_step, 0, 0, 0);
+            int iw_offset = ur_w * jcp.stride_w - l_pad;
+            if (iw_offset > 0)
+                add_imm(reg_input, reg_input,
+                        jcp.typesize_in * iw_offset * inp_mult, reg_tmp_imm);
+            add_imm(reg_output, reg_output, jcp.typesize_in * ur_w * out_mult,
+                    reg_tmp_imm);
+        }
+
+        assert(IMPLICATION(l_pad_tail > 0, ur_w_blocks <= 1));
+        if (ur_w_blocks > 0) {
+            mov(reg_ur_w_trips, 0);
+            L(ow_block_label);
+            {
+                compute_ic_block_step(
+                        ur_w, l_pad_tail, 0, ic_block_step, 0, 0, 0);
+                add_imm(reg_input, reg_input,
+                        jcp.typesize_in * (ur_w * jcp.stride_w - l_pad_tail)
+                                * inp_mult,
+                        reg_tmp_imm);
+                add_imm(reg_output, reg_output,
+                        jcp.typesize_in * ur_w * out_mult, reg_tmp_imm);
+
+                add_imm(reg_ur_w_trips, reg_ur_w_trips, 1, reg_tmp_imm);
+                cmp_imm(reg_ur_w_trips, ur_w_blocks, reg_tmp_imm);
+                b(LT, ow_block_label);
+                l_pad_tail = max(l_pad_tail - ur_w, 0);
+            }
+        }
+
+        if (ur_w_tail > 0)
+            compute_ic_block_step(
+                    ur_w_tail, l_pad_tail, r_pad, ic_block_step, 0, 0, 0);
+
+        sub_imm(reg_output, reg_output, jcp.typesize_in * output_comeback,
+                reg_tmp_imm);
+    };
+
+    if (jcp.ndims == 5) {
+        L(kd_label);
+        mov(reg_input, aux_reg_input);
+        mov(reg_kernel, aux_reg_kernel);
+    }
+
+    mov(kj, reg_kh);
+    L(kh_label);
+    {
+        Label icb_block_label, icb_block_label_cb;
+        if (generate_icb_loop || ic_tail) {
+            mov(reg_input_org, reg_input);
+            mov(reg_kernel_org, reg_kernel);
+            ldr(reg_icb, ptr(param, GET_OFF(reduce_work)));
+        }
+
+        if (ic_tail) {
+            cmp_imm(reg_icb, ic_block, reg_tmp_imm);
+            b(LT, ic_tail_loop_label);
+        }
+
+        L(icb_block_label);
+        mov(b_ic, ic_block);
+        L(ic_block_label);
+        Label ic_block_label_end;
+        {
+            ic_loop(ic_block_step);
+            sub_imm(reg_input, reg_input, jcp.typesize_in * input_comeback,
+                    reg_tmp_imm);
+            int inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
+                    ? jcp.ih * jcp.iw * jcp.id
+                    : 1;
+            size_t input_offset
+                    = inp_icblk_stride * jcp.typesize_in * ic_block_step;
+            add_imm(reg_input, reg_input, input_offset, reg_tmp_imm);
+            add_imm(reg_kernel, reg_kernel,
+                    jcp.typesize_out * ic_block_step * oc_block, reg_tmp_imm);
+            sub_imm(b_ic, b_ic, ic_block_step, reg_tmp_imm);
+            if (generate_icb_loop || ic_tail)
+                sub_imm(reg_icb, reg_icb, ic_block_step, reg_tmp_imm);
+            cmp_imm(b_ic, ic_block_step, reg_tmp_imm);
+            b(GE, ic_block_label);
+        }
+        L(ic_block_label_end);
+
+        const int input_shift
+                = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mult;
+
+        if (generate_icb_loop || ic_tail) {
+            const size_t kernel_icb_loop_shift_bytes = (size_t)jcp.typesize_out
+                    * jcp.kd * jcp.kh * jcp.kw * ic_block * oc_block;
+
+            if (generate_icb_loop) {
+                // icb loop supported for src in nxc layout only
+                assert(src_layout_nxc);
+                add_imm(reg_kernel, reg_kernel,
+                        kernel_icb_loop_shift_bytes
+                                - jcp.typesize_out * ic_block * oc_block,
+                        reg_tmp_imm);
+
+                cmp_imm(reg_icb, ic_block, reg_tmp_imm);
+                b(GE, icb_block_label);
+            }
+
+            L(ic_tail_loop_label);
+            if (ic_tail) {
+                Label skip_ic_tail;
+                const int ic_tail_loop_work = rnd_dn(ic_tail, ic_block_step);
+                cmp(reg_icb, 0);
+                b(LE, skip_ic_tail);
+                mov(b_ic, reg_icb);
+                if (ic_tail_loop_work) {
+                    cmp_imm(reg_icb, ic_block_step, reg_tmp_imm);
+                    b(GE, ic_block_label);
+                    if (generate_icb_loop) {
+                        // compensate offset added in generate_icb_loop
+                        sub_imm(reg_kernel, reg_kernel,
+                                kernel_icb_loop_shift_bytes
+                                        - jcp.typesize_out * ic_block
+                                                * oc_block,
+                                reg_tmp_imm);
+                    }
+                }
+
+                L(ic_tail_label);
+                if (ic_tail % ic_block_step) {
+                    cmp(reg_icb, 0);
+                    b(LE, skip_ic_tail);
+                    ic_loop(ic_tail % ic_block_step);
+                }
+                L(skip_ic_tail);
+            }
+
+            mov(reg_kernel, reg_kernel_org);
+            mov(reg_input, reg_input);
+
+            add_imm(reg_input, reg_input, input_shift, reg_tmp_imm);
+            add_imm(reg_kernel, reg_kernel,
+                    jcp.typesize_out * jcp.kw * ic_block * oc_block,
+                    reg_tmp_imm);
+        } else if (jcp.is_1stconv && !src_layout_nxc) {
+            size_t input_offset = (size_t)jcp.typesize_in * jcp.id * jcp.ih
+                    * jcp.iw * ic_block;
+            sub_imm(reg_input, reg_input, input_offset, reg_tmp_imm);
+            add_imm(reg_input, reg_input, input_shift, reg_tmp_imm);
+        } else if (!jcp.is_hw_transp) {
+            add_imm(reg_input, reg_input,
+                    input_shift - jcp.typesize_in * ic_block, reg_tmp_imm);
+        }
+        if (!jcp.is_hw_transp && !(generate_icb_loop || ic_tail))
+            add_imm(reg_kernel, reg_kernel,
+                    jcp.typesize_out * (jcp.kw - 1) * ic_block * oc_block,
+                    reg_tmp_imm);
+        subs(kj, kj, 1);
+        b(GT, kh_label);
+    }
+    if (jcp.ndims == 5) {
+        add_imm(aux_reg_input, aux_reg_input,
+                jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
+                        * inp_mult,
+                reg_tmp_imm);
+        add_imm(aux_reg_kernel, aux_reg_kernel,
+                jcp.typesize_out * jcp.kh * jcp.kw * ic_block * oc_block,
+                reg_tmp_imm);
+        subs(ki, ki, 1);
+        b(GT, kd_label);
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32 ::compute_oh_step_disp() {
+    int ic_block_step;
+    if (jcp.kernel_kind == expl_bcast)
+        ic_block_step = jcp.kw <= 3 ? 4 : (jcp.kw <= 6 ? 2 : 1);
+    else
+        ic_block_step = jcp.kw <= 3 ? 8 : (jcp.kw <= 6 ? 4 : 2);
+
+    if (jcp.is_1stconv) {
+        bool large_code = jcp.kw >= 7 && (jcp.l_pad > 0 || jcp.t_pad > 0);
+        ic_block_step = (jcp.kw * jcp.ic_block <= 26 && !large_code)
+                ? jcp.ic_block
+                : 1;
+    }
+
+    bool too_large_to_unroll = (jcp.kw > 1 || jcp.kh > 1 || jcp.kd > 1)
+            && (jcp.stride_w > 1 || jcp.stride_h > 1 || jcp.stride_d > 1);
+
+    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    if (jcp.ndims == 5) {
+        /* NOTE: reg_kd_count = aux_reg_input = r12. The following order of
+         * 'movs' must be guaranteed. */
+        mov(ki, reg_kd_count);
+        mov(reg_kd_count_org, reg_kd_count);
+        mov(aux_reg_input, reg_input);
+        mov(aux_reg_kernel, reg_kernel);
+    }
+
+    if (jcp.kw <= 3 && ow <= 16 && !too_large_to_unroll)
+        compute_oh_step_unroll_ow_icblock(ic_block_step, max_ur_w);
+    else if (ow <= max_ur_w)
+        compute_oh_step_unroll_ow(ic_block_step, max_ur_w);
+    else
+        compute_oh_step_common(ic_block_step, max_ur_w);
+
+    if (jcp.ndims == 5) {
+        mov(reg_input, aux_reg_input);
+        mov(reg_kernel, aux_reg_kernel);
+        mov(reg_kd_count, reg_kd_count_org);
+        od_step_comeback_pointers();
+    } else {
+        oh_step_comeback_pointers();
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::maybe_zero_kernel() {
+    Label skip_zeroing, zeroing_loop;
+
+    ldr(reg_tmp, ptr(param, GET_OFF(channel)));
+    cmp(reg_tmp, 0);
+    b(EQ, skip_zeroing);
+
+    ZRegS zero = ZRegS(0);
+    eor(zero, reg_p_all_ones, zero); //vpxord(zero, zero, zero);
+
+    const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
+    const size_t kernel_block_bytes = (size_t)jcp.ic_block * jcp.oc_block
+            * jcp.kw * jcp.kh * jcp.kd * jcp.typesize_out;
+    Label icb_block_label, icb_block_label_cb;
+    if (generate_icb_loop) {
+        mov(reg_kernel_org, reg_kernel);
+
+        ldr(reg_icb, ptr(param, GET_OFF(reduce_work)));
+        L(icb_block_label);
+    }
+
+    mov(reg_tmp, 0);
+    L(zeroing_loop);
+    {
+        assert(jcp.oc_block * jcp.typesize_out
+                == cpu_isa_traits<sve_512>::vlen);
+        add(reg_ker_start_addr, reg_kernel, reg_tmp);
+        for (int ic1 = 0; ic1 < jcp.ic_block; ic1++) {
+            if (str_imm_check(ic1 * jcp.oc_block * jcp.typesize_out)) {
+                str(ZReg(0),
+                        ptr(reg_ker_start_addr,
+                                static_cast<int32_t>(VL_OFS(ic1 * jcp.oc_block
+                                        * jcp.typesize_out))));
+            } else {
+                add_imm(reg_add_tmp, reg_ker_start_addr,
+                        ic1 * jcp.oc_block * jcp.typesize_out, reg_tmp_imm);
+                str(ZReg(0), ptr(reg_add_tmp));
+            }
+        }
+
+        add_imm(reg_tmp, reg_tmp,
+                jcp.ic_block * jcp.oc_block * jcp.typesize_out, reg_tmp_imm);
+        cmp_imm(reg_tmp, kernel_block_bytes, reg_tmp_imm);
+        b(NE, zeroing_loop);
+    }
+    if (generate_icb_loop) {
+        add_imm(reg_kernel, reg_kernel, kernel_block_bytes, reg_tmp_imm);
+        sub_imm(reg_icb, reg_icb, jcp.ic_block, reg_tmp_imm);
+        cmp(reg_icb, 0);
+        b(GT, icb_block_label);
+
+        mov(reg_kernel, reg_kernel_org);
+    }
+
+    L(skip_zeroing);
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::bias_kernel_2d() {
+    assert(jcp.ndims == 4); // only supports 2d
+    Label skip_bias, bias_loop;
+
+    ldr(reg_tmp, ptr(param, GET_OFF(flags)));
+    ldr(reg_bias, ptr(param, GET_OFF(bias)));
+    tst(reg_tmp, reg_tmp);
+    b(NE, skip_bias);
+
+    ldr(ZReg(0), ptr(reg_bias));
+
+    mov_imm(reg_oi, jcp.ow);
+    mov(reg_tmp, 0);
+    L(bias_loop);
+    {
+        add(reg_add_tmp, reg_output, reg_tmp);
+        ldr(ZReg(1), ptr(reg_add_tmp));
+        fadd(ZRegS(0), ZRegS(0), ZRegS(1));
+        const int oc_stride
+                = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
+        add_imm(reg_tmp, reg_tmp, jcp.typesize_out * oc_stride, reg_tmp_imm);
+        subs(reg_oi, reg_oi, 1);
+        b(GT, bias_loop);
+    }
+    str(ZReg(0), ptr(reg_bias));
+
+    L(skip_bias);
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::bias_kernel_3d() {
+    assert(jcp.ndims == 5); // only supports 3d
+    Label skip_bias, bias_loop, skip_load_bias;
+
+    ldr(reg_tmp, ptr(param, GET_OFF(flags)));
+    tst(reg_tmp, reg_tmp);
+    b(NE, skip_bias);
+
+    ldr(reg_bias, ptr(param, GET_OFF(bias)));
+    ldr(reg_output, ptr(param, GET_OFF(dst)));
+    eor(ZRegS(1), reg_p_all_ones, ZRegS(1));
+
+    ldr(reg_tmp, ptr(param, GET_OFF(channel)));
+    cmp(reg_tmp, 0);
+    b(NE, skip_load_bias);
+    ldr(ZReg(1), ptr(reg_bias));
+
+    L(skip_load_bias);
+
+    ldr(reg_oi, ptr(param, GET_OFF(os_index_end)));
+    ldr(reg_tmp_imm, ptr(param, GET_OFF(os_index_begin)));
+    subs(reg_oi, reg_oi, reg_tmp_imm);
+    b(LE, skip_bias); // no iterations along depth dimension
+
+    const size_t oc_mult
+            = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
+    mov_imm(reg_tmp, oc_mult * jcp.ow * jcp.oh * jcp.typesize_out);
+    mul(reg_oi, reg_oi, reg_tmp);
+
+    mov(reg_tmp, 0);
+    L(bias_loop);
+    {
+        add(reg_add_tmp, reg_output, reg_tmp);
+        ldr(ZReg(0), ptr(reg_add_tmp));
+        fadd(ZRegS(1), ZRegS(1), ZRegS(0));
+        add_imm(reg_tmp, reg_tmp, oc_mult * jcp.typesize_out, reg_tmp_imm);
+        cmp(reg_tmp, reg_oi);
+        b(LT, bias_loop);
+    }
+    str(ZReg(1), ptr(reg_bias));
+
+    L(skip_bias);
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32 ::compute_oh_loop_common() {
+    assert(one_of(jcp.harness, harness_mb_reduction, harness_3d_reduction));
+    int b_pad = jcp.b_pad;
+    int t_pad = jcp.t_pad;
+    bool is_dilated = jcp.dilate_h != 0;
+    int dilate_h = jcp.dilate_h + 1;
+    int stride_h = jcp.stride_h;
+    const int inp_mult = is_src_layout_nxc()
+            ? jcp.ngroups * jcp.ic
+            : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    const int out_mult
+            = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
+    int iw = jcp.is_hw_transp ? 1 : jcp.iw;
+    Label oh_label, oh_label_end, oh_tpad_label, oh_tpad_tail_label,
+            oh_bpad_label, oh_bpad_label_end, oh_dilate_label_shift,
+            oh_dilate_label_noshift, oh_dilate_label_end;
+
+    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    int oh = jcp.is_hw_transp ? jcp.ow : jcp.oh;
+    int kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
+    int kh = jcp.is_hw_transp ? jcp.tr_kh : jcp.kh;
+    int ih = jcp.is_hw_transp ? jcp.tr_ih : jcp.ih;
+    int ihp = jcp.is_hw_transp ? jcp.tr_ih : jcp.ihp;
+
+    assert(IMPLICATION(jcp.is_hw_transp,
+            everyone_is(1, oh, stride_h, dilate_h)
+                    && everyone_is(0, b_pad, t_pad)));
+
+    mov(reg_kh, kh);
+    mov(reg_oj, 0);
+    /* Compute 'top' edge */
+    if (t_pad > 0) {
+        const int kh_range = 1 + (kh - 1) * dilate_h;
+        const int overflow = nstl::max(0, kh - div_up(t_pad + ih, dilate_h));
+        const int underflow = div_up(t_pad, dilate_h);
+        const int initial_inp_ker_overlap = kh - overflow - underflow;
+        mov_imm(reg_kh, initial_inp_ker_overlap);
+        add_imm(reg_kernel, reg_kernel,
+                jcp.typesize_out * underflow * kw * jcp.ic_block * jcp.oc_block,
+                reg_tmp_imm);
+        // generate loop to process kernel while it remains within t_pad + ih
+        if (kh_range < t_pad + ih) {
+            if (is_dilated) {
+                const int tail = t_pad % dilate_h;
+                const int shift = tail == 0 ? 0 : dilate_h - tail;
+                mov_imm(reg_tmp, shift);
+                if (tail != 0)
+                    add_imm(reg_input, reg_input,
+                            jcp.typesize_in * shift * iw * inp_mult,
+                            reg_tmp_imm);
+            }
+            L(oh_tpad_label);
+            {
+                cmp_imm(reg_oj, oh, reg_tmp_imm);
+                b(GE, oh_label_end);
+
+                compute_oh_step_disp();
+                add_imm(reg_output, reg_output, jcp.typesize_in * ow * out_mult,
+                        reg_tmp_imm);
+                if (is_dilated) {
+                    add_imm(reg_tmp, reg_tmp, 1, reg_tmp_imm);
+                    cmp_imm(reg_tmp, dilate_h, reg_tmp_imm);
+                    b(LT, oh_dilate_label_shift);
+                    // unshift input as new kernel element enters
+                    sub_imm(reg_input, reg_input,
+                            jcp.typesize_in * (dilate_h - 1) * iw * inp_mult,
+                            reg_tmp_imm);
+                    mov(reg_tmp, 0);
+                }
+                // kernel overlap only changes when (t_pad + oj) % dilate_h == 0
+                sub_imm(reg_kernel, reg_kernel,
+                        jcp.typesize_out * stride_h * kw * jcp.ic_block
+                                * jcp.oc_block,
+                        reg_tmp_imm);
+                add_imm(reg_kh, reg_kh, stride_h, reg_tmp_imm);
+                if (is_dilated) {
+                    b(oh_dilate_label_noshift);
+                    L(oh_dilate_label_shift);
+                    // shift input as old kernel element progresses
+                    add_imm(reg_input, reg_input,
+                            jcp.typesize_in * stride_h * iw * inp_mult,
+                            reg_tmp_imm);
+                    L(oh_dilate_label_noshift);
+                }
+                add_imm(reg_oj, reg_oj, 1, reg_tmp_imm);
+
+                // final number of kernel elements that overlap with input
+                const int final_inp_ker_overlap
+                        = nstl::min(kh, div_up(ih, dilate_h));
+                cmp_imm(reg_kh, final_inp_ker_overlap, reg_tmp_imm);
+                b(LT, oh_tpad_label);
+            }
+        }
+        // need second loop to process kernel if it is larger than the input
+        // (does not apply to dilations as they must have unit stride)
+        if (kh_range
+                >= ih + (t_pad % stride_h == 0 ? stride_h : t_pad % stride_h)) {
+            assert(!is_dilated);
+            mov_imm(reg_kh, ih);
+            L(oh_tpad_tail_label);
+            {
+                cmp_imm(reg_oj, oh, reg_tmp_imm);
+                b(GE, oh_label_end);
+
+                compute_oh_step_disp();
+                add_imm(reg_output, reg_output, jcp.typesize_in * ow * out_mult,
+                        reg_tmp_imm);
+                sub_imm(reg_kernel, reg_kernel,
+                        jcp.typesize_out * stride_h * kw * jcp.ic_block
+                                * jcp.oc_block,
+                        reg_tmp_imm);
+
+                add_imm(reg_oj, reg_oj, 1, reg_tmp_imm);
+                cmp_imm(reg_oj, nstl::min(utils::div_up(t_pad, stride_h), oh),
+                        reg_tmp_imm);
+                b(LT, oh_tpad_tail_label);
+            }
+        }
+        // correct any excess shifts to kernel and input
+        // (does not apply to dilations as they must have unit stride,
+        //  kernel must fit inside input, and padding is smaller than input)
+        if (t_pad <= oh * stride_h) {
+            // kernel has moved beyond padding (adjust for stride effects)
+            if (t_pad % stride_h != 0) {
+                assert(!is_dilated);
+                int inp_corr = stride_h - t_pad % stride_h;
+                add_imm(reg_kernel, reg_kernel,
+                        jcp.typesize_out * inp_corr * kw * jcp.ic_block
+                                * jcp.oc_block,
+                        reg_tmp_imm);
+                add_imm(reg_input, reg_input,
+                        jcp.typesize_in * inp_corr * iw * inp_mult,
+                        reg_tmp_imm);
+            }
+        } else {
+            // kernel still overlaps padding (complete reset)
+            assert(!is_dilated);
+            sub_imm(reg_kernel, reg_kernel,
+                    jcp.typesize_out * (t_pad - oh * stride_h) * kw
+                            * jcp.ic_block * jcp.oc_block,
+                    reg_tmp_imm);
+        }
+    }
+
+    const int oj_end_value = nstl::min(
+            oh, utils::div_up(ihp - b_pad - (kh - 1) * dilate_h, stride_h));
+    cmp_imm(reg_oj, oj_end_value, reg_tmp_imm);
+    b(GE, oh_label_end);
+
+    /* Compute middle block(s) */
+    mov_imm(reg_kh, kh);
+    L(oh_label);
+    {
+        compute_oh_step_disp();
+        add_imm(reg_input, reg_input,
+                jcp.typesize_in * stride_h * iw * inp_mult, reg_tmp_imm);
+        add_imm(reg_output, reg_output, jcp.typesize_in * ow * out_mult,
+                reg_tmp_imm);
+
+        add_imm(reg_oj, reg_oj, 1, reg_tmp_imm);
+        cmp_imm(reg_oj, oj_end_value, reg_tmp_imm);
+        b(LT, oh_label);
+    }
+    L(oh_label_end);
+
+    /* Compute bottom edge */
+    if (b_pad > 0) {
+        cmp(reg_oj, oh);
+        b(GE, oh_bpad_label_end);
+
+        if (is_dilated) {
+            mov_imm(reg_kh, kh - 1); // assumes unit stride for dilations
+            mov(reg_tmp, 0);
+        } else {
+            mov_imm(reg_kh, ihp - b_pad);
+            mov(reg_tmp, reg_oj);
+            mov_imm(reg_tmp_imm, stride_h);
+            mul(reg_tmp, reg_tmp, reg_tmp_imm);
+            sub(reg_kh, reg_kh, reg_tmp);
+        }
+        L(oh_bpad_label);
+        {
+            compute_oh_step_disp();
+            add_imm(reg_input, reg_input,
+                    jcp.typesize_in * stride_h * iw * inp_mult, reg_tmp_imm);
+            add_imm(reg_output, reg_output, jcp.typesize_in * ow * out_mult,
+                    reg_tmp_imm);
+            if (is_dilated) {
+                add_imm(reg_tmp, reg_tmp, 1, reg_tmp_imm);
+                cmp_imm(reg_tmp, dilate_h, reg_tmp_imm);
+                b(LT, oh_dilate_label_end);
+                mov(reg_tmp, 0);
+            }
+            subs_imm(reg_kh, reg_kh, stride_h, reg_tmp_imm);
+            b(LE, oh_bpad_label_end);
+            if (is_dilated) L(oh_dilate_label_end);
+
+            add_imm(reg_oj, reg_oj, 1, reg_tmp_imm);
+            cmp_imm(reg_oj, oh, reg_tmp_imm);
+            b(LT, oh_bpad_label);
+        }
+        L(oh_bpad_label_end);
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::compute_oh_loop_partial() {
+    assert(jcp.harness == harness_2d_reduction);
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+    const int inp_mult = is_src_layout_nxc()
+            ? jcp.ngroups * jcp.ic
+            : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    const int out_mult
+            = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
+    const int input_bottom_padding_overlap
+            = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
+
+    const size_t filter_shift = jcp.typesize_out * jcp.kw * ic_block * oc_block;
+    const size_t input_shift = jcp.typesize_in * jcp.iw * inp_mult;
+    const size_t output_shift = jcp.typesize_out * jcp.ow * out_mult;
+    ;
+
+    Label loop_begin_label, loop_end_label, common_block_label,
+            top_padding_end_label, bottom_padding_end_label,
+            bottom_padding_label;
+
+    if (jcp.with_bias) {
+        Label skip_zero_bias;
+        ldr(reg_bias, ptr(param, GET_OFF(bias)));
+        ldr(reg_tmp, ptr(param, GET_OFF(channel)));
+        tst(reg_tmp, reg_tmp);
+        b(EQ, skip_zero_bias);
+        ldr(reg_tmp, ptr(param, GET_OFF(flags)));
+        tst(reg_tmp, reg_tmp);
+        b(NE, skip_zero_bias);
+        eor(ZRegS(1), reg_p_all_ones.b, ZRegS(1));
+        str(ZReg(1),
+                ptr(reg_bias)); //vmovups(ptr[reg_bias], Zmm(1));
+        L(skip_zero_bias);
+    }
+
+    /* Offset filter position to adjust for top padding */
+    ldr(reg_tmp_imm, ptr(param, GET_OFF(kh_offset)));
+    add(reg_kernel, reg_kernel,
+            reg_tmp_imm); //add(reg_kernel, ptr[param + GET_OFF(kh_offset)]);
+
+    ldr(reg_oj, ptr(param, GET_OFF(os_index_begin)));
+    ldr(reg_kh, ptr(param, GET_OFF(kh_padding)));
+
+    cmp(reg_kh, 0);
+    b(LE, loop_end_label); // no iterations along kh
+    ldr(reg_tmp_imm, ptr(param, GET_OFF(os_index_end)));
+    cmp(reg_oj,
+            reg_tmp_imm); //cmp(reg_oj, ptr[param + GET_OFF(os_index_end)]);
+
+    b(GE, loop_end_label); // no iterations along height dimension
+
+    L(loop_begin_label);
+
+    if (jcp.with_bias) bias_kernel_2d();
+    compute_oh_step_disp();
+
+    /* Compute 'top' edge */
+    if (jcp.t_pad > 0) {
+
+        /* Check if within top padding region */
+        assert(div_up(jcp.t_pad, jcp.stride_h) >= 0
+                && div_up(jcp.t_pad, jcp.stride_h) < ADDMAX);
+        cmp_imm(reg_oj, div_up(jcp.t_pad, jcp.stride_h), reg_tmp_imm);
+        b(GE, top_padding_end_label);
+
+        /* Increment step counter and adjust filter position */
+        sub_imm(reg_kernel, reg_kernel, filter_shift * jcp.stride_h,
+                reg_tmp_imm);
+        add_imm(reg_kh, reg_kh, jcp.stride_h, reg_tmp_imm);
+
+        /* Final number of kernel elements that overlap with input */
+        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        mov_imm(reg_tmp_imm, inp_ker_overlap);
+        cmp(reg_kh, reg_tmp_imm);
+
+        b(LE, common_block_label);
+
+        /* Correct any excess shifts to kernel and input */
+        if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
+            /* Filter has moved beyond padding (adjust for stride effects) */
+            if (jcp.t_pad % jcp.stride_h != 0) {
+                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add_imm(reg_kernel, reg_kernel, filter_shift * inp_corr,
+                        reg_tmp_imm);
+                add_imm(reg_input, reg_input, input_shift * inp_corr,
+                        reg_tmp_imm);
+            }
+        } else {
+            /* Filter still overlaps padding (complete reset) */
+            sub_imm(reg_kernel, reg_kernel,
+                    (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift,
+                    reg_tmp_imm);
+        }
+
+        /* Apply correction */
+        mov_imm(reg_kh, inp_ker_overlap);
+        b(common_block_label);
+
+        L(top_padding_end_label);
+    }
+
+    /* Compute 'bottom' edge */
+    if (jcp.b_pad > 0) {
+
+        /* Check if within bottom padding region */
+        assert((input_bottom_padding_overlap - 1) >= 0
+                && (input_bottom_padding_overlap - 1) < ADDMAX);
+        cmp_imm(reg_oj, input_bottom_padding_overlap - 1, reg_tmp_imm);
+        b(LT, bottom_padding_end_label);
+        b(GT, bottom_padding_label);
+
+        /* Execute overlap correction between the filter and the initial
+         * bottom padding region. */
+        mov_imm(reg_kh,
+                jcp.ih + jcp.t_pad
+                        - input_bottom_padding_overlap * jcp.stride_h);
+        b(bottom_padding_end_label);
+
+        L(bottom_padding_label);
+        subs_imm(reg_kh, reg_kh, jcp.stride_h, reg_tmp_imm);
+        b(LE, loop_end_label);
+
+        L(bottom_padding_end_label);
+    }
+
+    /* Compute middle block */
+    add_imm(reg_input, reg_input, input_shift * jcp.stride_h, reg_tmp_imm);
+
+    /* Execute common block and loop */
+    L(common_block_label);
+    add_imm(reg_output, reg_output, output_shift, reg_tmp_imm);
+
+    add_imm(reg_oj, reg_oj, 1, reg_tmp_imm);
+    ldr(reg_tmp_imm, ptr(param, GET_OFF(os_index_end)));
+    cmp(reg_oj,
+            reg_tmp_imm); //cmp(reg_oj, ptr[param + GET_OFF(os_index_end)]);
+
+    b(LT, loop_begin_label);
+
+    L(loop_end_label);
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::compute_od_loop_partial() {
+    assert(jcp.harness == harness_3d_reduction);
+    int ic_block = jcp.ic_block;
+    int oc_block = jcp.oc_block;
+    const int inp_mult = is_src_layout_nxc()
+            ? jcp.ngroups * jcp.ic
+            : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    const int out_mult
+            = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
+    int iw = jcp.iw;
+    int ow = jcp.ow;
+    const int input_backpad_overlap
+            = div_up(jcp.id + jcp.f_pad - (jcp.kd - 1), jcp.stride_d);
+
+    const size_t filter_shift
+            = jcp.typesize_out * jcp.kh * jcp.kw * ic_block * oc_block;
+    const size_t input_shift = jcp.typesize_in * jcp.ih * iw * inp_mult;
+    const size_t output_shift = jcp.typesize_in * jcp.oh * ow * out_mult;
+
+    Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
+            backpad_end_label, backpad_label;
+
+    if (jcp.with_bias) bias_kernel_3d();
+
+    /* initially offset 'kd' by f_pad */
+    ldr(reg_tmp_imm, ptr(param, GET_OFF(kd_offset)));
+    add(reg_kernel, reg_kernel, reg_tmp_imm);
+
+    ldr(reg_input_d, ptr(param, GET_OFF(src)));
+    ldr(reg_output_d, ptr(param, GET_OFF(dst)));
+    ldr(reg_d_index, ptr(param, GET_OFF(os_index_begin)));
+    ldr(reg_kd_count, ptr(param, GET_OFF(kd_padding)));
+
+    cmp(reg_kd_count, 0);
+    b(LE, loop_end_label); // no iterations along kd
+    ldr(reg_tmp_imm, ptr(param, GET_OFF(os_index_end)));
+    cmp(reg_d_index, reg_tmp_imm);
+    b(GE, loop_end_label); // no iterations along depth dimension
+
+    L(d_loop_label);
+
+    mov(reg_input, reg_input_d);
+    mov(reg_output, reg_output_d);
+
+    mov(reg_input_d_org, reg_input_d);
+    mov(reg_output_d_org, reg_output_d);
+    mov(reg_d_index_org, reg_d_index);
+
+    compute_oh_loop_common();
+
+    mov(reg_d_index, reg_d_index_org);
+    mov(reg_output_d, reg_output_d_org);
+    mov(reg_input_d, reg_input_d_org);
+
+    /* Compute 'front' edge */
+    if (jcp.f_pad > 0) {
+
+        /* Check if within fpad region */
+        cmp_imm(reg_d_index, div_up(jcp.f_pad, jcp.stride_d), reg_tmp_imm);
+        b(GE, fpad_end_label);
+
+        /* Fpad steps */
+        sub_imm(reg_kernel, reg_kernel, filter_shift * jcp.stride_d,
+                reg_tmp_imm);
+        add_imm(reg_kd_count, reg_kd_count, jcp.stride_d, reg_tmp_imm);
+
+        /* Final number of kernel elements that overlap with input */
+        const int inp_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        cmp_imm(reg_kd_count, inp_ker_overlap, reg_tmp_imm);
+        b(LE, common_block_label);
+
+        /* Correct any excess shifts to kernel and input */
+        if (jcp.f_pad <= jcp.od * jcp.stride_d) {
+            /* Filter has moved beyond padding (adjust for stride effects) */
+            if (jcp.f_pad % jcp.stride_d != 0) {
+                int inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                add_imm(reg_kernel, reg_kernel, filter_shift * inp_corr,
+                        reg_tmp_imm);
+                add_imm(reg_input_d, reg_input_d, input_shift * inp_corr,
+                        reg_tmp_imm);
+            }
+        } else {
+            /* Filter still overlaps padding (complete reset) */
+            sub_imm(reg_kernel, reg_kernel,
+                    (jcp.f_pad - jcp.od * jcp.stride_d) * filter_shift,
+                    reg_tmp_imm);
+        }
+
+        /* Apply correction */
+        mov_imm(reg_kd_count, inp_ker_overlap);
+        b(common_block_label);
+
+        L(fpad_end_label);
+    }
+
+    /* Compute bottom edge */
+    if (jcp.back_pad > 0) {
+
+        /* Check if within back_pad region */
+        cmp_imm(reg_d_index, input_backpad_overlap - 1, reg_tmp_imm);
+        b(LT, backpad_end_label);
+        b(GT, backpad_label);
+
+        /* Execute overlap correction between the filter and the initial
+         * back_pad region. */
+        mov_imm(reg_kd_count,
+                jcp.id + jcp.f_pad - input_backpad_overlap * jcp.stride_d);
+        b(backpad_end_label);
+
+        L(backpad_label);
+        subs_imm(reg_kd_count, reg_kd_count, jcp.stride_d, reg_tmp_imm);
+        b(LE, loop_end_label);
+
+        L(backpad_end_label);
+    }
+
+    /* Compute middle block */
+    add_imm(reg_input_d, reg_input_d, input_shift * jcp.stride_d, reg_tmp_imm);
+
+    /* Execute common block and loop */
+    L(common_block_label);
+    add_imm(reg_output_d, reg_output_d, output_shift, reg_tmp_imm);
+    add_imm(reg_d_index, reg_d_index, 1, reg_tmp_imm);
+    ldr(reg_tmp_imm, ptr(param, GET_OFF(os_index_end)));
+    cmp(reg_d_index, reg_tmp_imm);
+    b(LT, d_loop_label);
+
+    L(loop_end_label);
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::compute_loop() {
+
+    maybe_zero_kernel();
+
+    switch (jcp.harness) {
+        case harness_2d_reduction: compute_oh_loop_partial(); break;
+        case harness_3d_reduction: compute_od_loop_partial(); break;
+        case harness_mb_reduction: compute_oh_loop_common(); break;
+        case harness_nxc: break;
+        default: assert(!"Invalid harness type");
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::generate_kernel() {
+    preamble();
+    ptrue(reg_p_all_ones.b);
+
+    ldr(reg_input, ptr(param, GET_OFF(src)));
+    ldr(reg_output, ptr(param, GET_OFF(dst)));
+    ldr(reg_kernel, ptr(param, GET_OFF(filt)));
+
+    compute_loop();
+
+    postamble();
+}
+
+status_t jit_sve_512_conv_bwd_weights_kernel_f32::init_conf(
+        jit_conv_conf_t &jcp, const convolution_desc_t &cd,
+        memory_desc_t &src_md, memory_desc_t &diff_weights_md,
+        memory_desc_t &diff_bias_md, memory_desc_t &diff_dst_md, int nthreads) {
+    if (!mayiuse(sve_512)) return status::unimplemented;
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper diff_weights_d(&diff_weights_md);
+    const memory_desc_wrapper diff_bias_d(&diff_bias_md);
+    const memory_desc_wrapper diff_dst_d(&diff_dst_md);
+
+    const bool with_groups = diff_weights_d.ndims() == src_d.ndims() + 1;
+    int ndims = src_d.ndims();
+
+    jcp = zero<decltype(jcp)>();
+
+    jcp.simd_w = cpu_isa_traits<sve_512>::vlen / typesize;
+    jcp.nthr = jcp.aligned_threads = nthreads;
+    jcp.ndims = ndims;
+    jcp.prop_kind = cd.prop_kind;
+
+    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
+    jcp.mb = src_d.dims()[0];
+
+    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc_without_padding = jcp.oc;
+    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = jcp.ic;
+
+    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
+    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
+    jcp.iw = src_d.dims()[ndims - 1];
+    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
+    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
+    jcp.ow = diff_dst_d.dims()[ndims - 1];
+
+    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
+    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
+    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+
+    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
+    jcp.l_pad = cd.padding[0][ndims - 3];
+
+    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
+    jcp.stride_w = cd.strides[ndims - 3];
+
+    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
+    jcp.dilate_w = cd.dilates[ndims - 3];
+
+    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+
+    bool ok = true
+            // general condition to simplify dilations
+            && IMPLICATION(jcp.dilate_d != 0, jcp.stride_d == 1)
+            && IMPLICATION(jcp.dilate_h != 0, jcp.stride_h == 1)
+            // special condition to simplify dilations in compute_oh_loop_common
+            && IMPLICATION(jcp.dilate_h != 0, ext_kh <= jcp.ih);
+    if (!ok) return status::unimplemented;
+
+    jcp.r_pad = nstl::max(0,
+            calculate_end_padding(
+                    jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
+    jcp.b_pad = nstl::max(0,
+            calculate_end_padding(
+                    jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
+    jcp.back_pad = nstl::max(0,
+            calculate_end_padding(
+                    jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
+
+    /* XXX: currently, does not support dilation_d > 0 */
+    if (ndims == 5)
+        if (jcp.dilate_d > 0) return status::unimplemented;
+
+    /* Set bounds for large filter 'kw > 14' support and optimized JIT
+     * implementation for small output-width 'ow = 1' */
+    const int min_filter_size = 14;
+    const int max_filter_size = 20;
+    const auto dat_tag_nxc = pick(ndims - 3, nwc, nhwc, ndhwc);
+    const auto dat_tag_ncx = pick(ndims - 3, ncw, nchw, ncdhw);
+    const auto dat_tag_nCx16c = pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
+    auto curr_src_tag = src_d.matches_one_of_tag(
+            dat_tag_nxc, dat_tag_nCx16c, dat_tag_ncx);
+    auto curr_dst_tag
+            = diff_dst_d.matches_one_of_tag(dat_tag_nxc, dat_tag_nCx16c);
+    bool is_data_layout_nxc
+            = utils::everyone_is(dat_tag_nxc, curr_src_tag, curr_dst_tag);
+    if (mayiuse(sve_512) && is_data_layout_nxc) return status::unimplemented;
+
+    /* Optimization: when `output-width == 1' deploy a special case of the
+     * JIT-Kernel by unrolling with regards to height instead of width for
+     * the source and filter tensors. The JIT-Kernel also transposes the
+     * strides for the input and filter memory access. */
+    jcp.is_hw_transp = false;
+    /* TODO: support hw-transpose optimization */
+    /*
+    jcp.is_hw_transp = !is_data_layout_nxc && ndims == 4
+            && jcp.kw >= min_filter_size && jcp.kw < max_filter_size
+            && jcp.ow == 1 && jcp.kw == jcp.iw
+            && everyone_is(1, jcp.stride_w, jcp.stride_h)
+            && everyone_is(0, jcp.dilate_h, jcp.dilate_w)
+            && everyone_is(0, jcp.l_pad, jcp.t_pad, jcp.r_pad, jcp.b_pad);
+
+    if (jcp.is_hw_transp) {
+        jcp.tr_kw = jcp.kh;
+        jcp.tr_kh = jcp.kw;
+        jcp.tr_iw = jcp.ih;
+        jcp.tr_ih = jcp.iw;
+    }
+    */
+
+    jcp.ihp = jcp.ih + jcp.t_pad + jcp.b_pad;
+    jcp.iwp = jcp.iw + jcp.l_pad + jcp.r_pad;
+    jcp.ohp = jcp.oh;
+    jcp.owp = jcp.ow;
+    jcp.aligned_threads = 0;
+
+    /* check for the 1st convolution */
+    jcp.is_1stconv = is_1stconv(jcp);
+
+    jcp.oc_block = jcp.simd_w;
+
+    bool ok_to_pad_channels = true && !is_data_layout_nxc && jcp.ngroups == 1
+            && src_d.data_type() == data_type::f32;
+
+    if (ok_to_pad_channels) jcp.oc = rnd_up(jcp.oc, jcp.simd_w);
+
+    if (!IMPLICATION(!is_data_layout_nxc, jcp.oc % jcp.oc_block == 0))
+        return status::unimplemented;
+
+    jcp.ic_tail = is_data_layout_nxc ? jcp.ic % jcp.simd_w : 0;
+    jcp.oc_tail = is_data_layout_nxc ? jcp.oc % jcp.simd_w : 0;
+
+    auto dst_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_nCx16c;
+    auto wei_tag = with_groups
+            ? pick(ndims - 3, gOIw16i16o, gOIhw16i16o, gOIdhw16i16o)
+            : pick(ndims - 3, OIw16i16o, OIhw16i16o, OIdhw16i16o);
+
+    if (diff_dst_md.format_kind == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(diff_dst_md, dst_tag));
+    } else if (curr_dst_tag != dst_tag)
+        return status::unimplemented;
+    jcp.dst_tag = dst_tag;
+
+    /* conditions on bias memory */
+    jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
+    if (jcp.with_bias) {
+        if (diff_bias_d.format_kind() == format_kind::any)
+            CHECK(memory_desc_init_by_tag(diff_bias_md, x));
+    }
+
+    jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
+
+    /* kernel applicability check wrt boundaries
+     * the conditions are quite general across the kernels we have,
+     * but ideally the check should belong to a specific kernel... */
+    const int max_pad_h = ext_kh / 2;
+    const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
+            && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
+            && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd
+            && IMPLICATION(jcp.f_pad > 0, jcp.kd < jcp.id + jcp.f_pad)
+            && jcp.l_pad <= max_ur_w && jcp.r_pad <= max_ur_w;
+    if (!boundaries_ok) return status::unimplemented;
+
+    /* yet another common check */
+    if (!jcp.is_hw_transp && jcp.kw > 13) return status::unimplemented;
+
+    /* setting register strategy */
+    const int unroll_dim = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    for (int ur_w = nstl::min(max_ur_w, unroll_dim); ur_w > 0; --ur_w) {
+        if (unroll_dim % ur_w == 0) {
+            jcp.ur_w = ur_w;
+            break;
+        }
+    }
+
+    if (jcp.is_1stconv) {
+        auto src_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_ncx;
+        if (src_d.format_kind() == format_kind::any) {
+            CHECK(memory_desc_init_by_tag(src_md, src_tag));
+        } else {
+            // if `ic == 1`, then `nxc` and `ncx` are effectively equivalent
+            if (jcp.ic == 1 && one_of(curr_src_tag, dat_tag_nxc, dat_tag_ncx))
+                src_tag = curr_src_tag;
+            if (curr_src_tag != src_tag) return status::unimplemented;
+        }
+        jcp.src_tag = src_tag;
+
+        const bool src_ok = true
+                && utils::everyone_is(data_type::f32, src_d.data_type(),
+                        diff_weights_d.data_type(), diff_dst_d.data_type())
+                && IMPLICATION(!is_data_layout_nxc,
+                        (one_of(jcp.ic, 1, 2, 3, 4, 5, 6, 7, 8)
+                                && jcp.ngroups == 1));
+        if (!src_ok) return status::unimplemented;
+
+        jcp.ver = ver_fma;
+        jcp.ic_block = jcp.ic;
+
+        wei_tag = with_groups ? pick(ndims - 3, gOwi16o, gOhwi16o, gOdhwi16o)
+                              : pick(ndims - 3, Owi16o, Ohwi16o, Odhwi16o);
+
+        if (init_tag(jcp.wei_tag, diff_weights_md, diff_weights_d, wei_tag)
+                != status::success)
+            return status::unimplemented;
+
+        jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
+    } else {
+        auto src_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_nCx16c;
+        if (src_md.format_kind == format_kind::any) {
+            CHECK(memory_desc_init_by_tag(src_md, src_tag));
+        } else if (curr_src_tag != src_tag)
+            return status::unimplemented;
+        jcp.src_tag = src_tag;
+
+        if (init_tag(jcp.wei_tag, diff_weights_md, diff_weights_d, wei_tag)
+                != status::success)
+            return status::unimplemented;
+
+        jcp.ic_block = jcp.simd_w;
+        if (ok_to_pad_channels) jcp.ic = rnd_up(jcp.ic, jcp.ic_block);
+        jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
+        if (mayiuse(sve_512)
+                && utils::everyone_is(data_type::f32, src_d.data_type(),
+                        diff_weights_d.data_type(), diff_dst_d.data_type())) {
+            jcp.ver = ver_fma;
+        } else {
+            return status::unimplemented;
+        }
+    }
+
+    if (jcp.ver == ver_fma) {
+        jcp.typesize_in = typesize;
+        jcp.typesize_out = typesize;
+    } else
+        return status::unimplemented;
+
+    bool use_nxc_harness = false;
+    if (is_data_layout_nxc && jcp.ver == ver_fma) {
+        dim_t kernel_size
+                = jcp.ic * jcp.oc * jcp.kd * jcp.kh * jcp.kw * jcp.typesize_out;
+        dim_t src_size
+                = jcp.mb * jcp.ic * jcp.id * jcp.ih * jcp.iw * jcp.typesize_in;
+        dim_t diff_dst_size
+                = jcp.mb * jcp.oc * jcp.id * jcp.ih * jcp.iw * jcp.typesize_in;
+        dim_t data_size = src_size + diff_dst_size;
+
+        // The advantage of the nxc kernel is cache traversal, this comes at a
+        // cost of extra work updating the weights buffers more often. As such,
+        // if everything fits in cache, this kernel is at a disadvantage to the
+        // inner loop over ow. More optimizing/balancing is required to
+        // determine when this is needed for multidimensional kernels because
+        // the data reuses within the kernel height/depth dimension make the
+        // computation more computationally bound and cache traversal advantage
+        // less important. Due to the current blocked weights format, the
+        // weights and the data buffers cannot both be traversed optimally, so
+        // for performance, the weights must fit in cache.
+        use_nxc_harness
+                = (data_size / nthreads + kernel_size > L2_cache_size / 3)
+                && (jcp.oc % jcp.simd_w == 0) && (jcp.ic % jcp.simd_w == 0)
+                && jcp.kw > 1 && ndims == 3
+                && (kernel_size < L2_cache_size / 2);
+    }
+
+    jcp.harness = use_nxc_harness
+            ? harness_nxc
+            : ndims == 5 ? harness_3d_reduction : harness_mb_reduction;
+    if (jcp.dilate_h == 0 && jcp.ndims == 4 && jcp.oh > min_oh_reduce
+            && jcp.ver == ver_fma && !jcp.is_hw_transp && !is_data_layout_nxc)
+        jcp.harness = harness_2d_reduction; // 2d harness with oh reduction
+    bool args_ok = true
+            && IMPLICATION(!is_data_layout_nxc,
+                    jcp.ic % jcp.ic_block == 0 && jcp.oc % jcp.oc_block == 0)
+            && jcp.ic <= src_d.padded_dims()[1]
+            && jcp.oc <= diff_dst_d.padded_dims()[1]
+            && jcp.ic <= diff_weights_d.padded_dims()[with_groups + 1]
+            && jcp.oc <= diff_weights_d.padded_dims()[with_groups + 0];
+    if (!args_ok) return status::unimplemented;
+
+    int nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b;
+    if (jcp.harness == harness_nxc) {
+        // The harness_nxc is quite different from the other kernels. The
+        // init_conf function should probably be refactored so that it calls
+        // functions along the line of tune_nxc, tun_4fma, tune_fma which
+        // independently tune the kernels for each implementation with tuning
+        // common to multiple implementations performed by helper functions.
+        // This will help maintainability and help prevent the different
+        // implementations from stepping on each other.
+        int zmm_regs = 32;
+
+        // Block by ic and kw in the compute kernel to decrease loads from the
+        // src buffer
+        jcp.ur_ic = 2 - jcp.ic % 2;
+        jcp.ur_kw = 1;
+        if (jcp.stride_w == jcp.dilate_w + 1) {
+            jcp.ur_kw = jcp.kw;
+            if (jcp.kw > 7) {
+                // Blocking by kw is more effective than by ic in the compute
+                // kernel since neighbor kw operations share src data
+                jcp.ur_ic = 1;
+                if (jcp.kw > zmm_regs / (jcp.ur_ic + 1))
+                    jcp.ur_kw = jcp.kw % (zmm_regs / (jcp.ur_ic + 1));
+            }
+        }
+
+        // Unroll by ow to decrease updates to diff_weights. In practice, this
+        // should be approximately 1/4 - 1/2 of the zmm registers
+        jcp.ur_ow = nstl::min(
+                (zmm_regs - jcp.ur_kw * jcp.ur_ic) / (jcp.ur_ic + 1), jcp.ow);
+
+        int work_amount_base = jcp.mb * jcp.od * jcp.oh;
+        int ow_iter = div_up(jcp.ow, jcp.ur_ow);
+        int nthr_ow = nstl::min(
+                jcp.nthr / math::gcd(work_amount_base, jcp.nthr), ow_iter);
+        int ow_block = div_up(ow_iter, nthr_ow) * jcp.ur_ow;
+
+        jcp.ow_block = ow_block;
+        jcp.nb_ow = div_up(jcp.ow, jcp.ow_block);
+
+        // Choose a simple parallelization method. A more advance may need made
+        // later
+        int work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow;
+        nthr_mb = nstl::min(jcp.nthr, work_amount);
+        nthr_g = 1;
+        nthr_oc_b = 1;
+        nthr_ic_b = 1;
+        nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
+    } else { // balancing
+        balance(jcp, nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b, jcp.nthr);
+    }
+
+    jcp.nthr = nthr;
+    jcp.nthr_mb = nthr_mb;
+    jcp.nthr_g = nthr_g;
+    jcp.nthr_oc_b = nthr_oc_b;
+    jcp.nthr_ic_b = nthr_ic_b;
+
+    jcp.kernel_kind = embd_bcast;
+    if (is_data_layout_nxc && jcp.stride_w == 1 && jcp.dilate_w == 0
+            && !jcp.is_1stconv) {
+        jcp.kernel_kind = expl_bcast;
+    }
+
+    jcp.nb_ic_blocking_max = 1;
+    if (is_data_layout_nxc && (jcp.ow > max_ur_w || jcp.ndims == 5)) {
+        assert(!jcp.is_hw_transp);
+        jcp.nb_ic_blocking_max = nstl::min(8, div_up(jcp.nb_ic, jcp.nthr_ic_b));
+    }
+
+    return status::success;
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
+    if (jcp.nthr_mb > 1) {
+        const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+                * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
+        const int bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
+        const size_t wei_bia_reduction_size = wei_size + bia_size;
+
+        scratchpad.book(key_conv_wei_bia_reduction,
+                wei_bia_reduction_size * (jcp.nthr_mb - 1), jcp.typesize_out);
+        scratchpad.book<simple_barrier::ctx_t>(
+                key_conv_wei_bia_reduction_bctx, 1);
+    }
+
+    if (jcp.with_bias && jcp.oc_without_padding % jcp.oc_block != 0) {
+        const size_t nelems_padded_bias
+                = jcp.ngroups * utils::rnd_up(jcp.oc, jcp.oc_block);
+        scratchpad.book(
+                key_conv_padded_bias, nelems_padded_bias, jcp.typesize_out);
+    }
+}
+
+void jit_sve_512_conv_bwd_weights_kernel_f32::balance(const jit_conv_conf_t &j,
+        int &nthr_, int &nthr_mb_, int &nthr_g_, int &nthr_oc_b_,
+        int &nthr_ic_b_, int nthreads) {
+    nthr_ = nthr_mb_ = nthr_g_ = nthr_oc_b_ = nthr_ic_b_ = 1;
+
+    if (nthreads < j.ngroups) {
+        /* simplification... fortunately it doesn't hurt much */
+        nthr_ = nthr_g_ = nthreads;
+        return;
+    }
+
+    nthr_g_ = j.ngroups;
+    const int nthr = nthreads / nthr_g_;
+
+    const int ih = j.is_hw_transp ? j.tr_ih : j.ih;
+    const int oh = j.is_hw_transp ? j.ow : j.oh;
+
+    int ih_reduce = j.harness == harness_2d_reduction ? ih : 1;
+    int oh_reduce = j.harness == harness_2d_reduction ? oh : 1;
+    int ih_no_reduce = j.harness == harness_2d_reduction ? 1 : ih;
+    int oh_no_reduce = j.harness == harness_2d_reduction ? 1 : oh;
+    int nthr_oh_reduce = nstl::max(1, oh_reduce / min_oh_reduce);
+
+    auto calc_mem_cost = [=](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
+        /* calculate per thread memory cost (read/write). high level optimizer
+         * tries to minimize memory consumption. few notes:
+         *  (n1) unclear why, but that essentially helps first convolution...
+         *  (n2) assuming the reduction over minibatch is always there:
+         *    - instead of 8 it should be 5 here (write ~= 2 read):
+         *      kernel: temporal workspace 1 write
+         *      reduction: 1 read from workspace and 1 write to the diff_wei
+         *    - but experiments showed 8 works better than 5 or 6... */
+        const dim_t src_coef = 1;
+        const dim_t dst_coef = 1;
+        const dim_t wei_coef = 8;
+        const dim_t iw = j.is_hw_transp ? j.tr_iw : j.iw;
+        const dim_t ow = j.is_hw_transp ? j.oh : j.ow;
+
+        return 0
+                + src_coef * div_up(j.mb * ih_reduce, nthr_mb)
+                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_ic, nthr_ic_b)
+                * j.ic_block * ih_no_reduce * iw * j.id / j.stride_d
+                / j.stride_h / j.stride_w /* (n1) */
+                + dst_coef * div_up(j.mb * oh_reduce, nthr_mb)
+                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_oc, nthr_oc_b)
+                * j.oc_block * oh_no_reduce * ow * j.od
+                + wei_coef /* (n2) */
+                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_oc, nthr_oc_b)
+                * div_up(j.nb_ic, nthr_ic_b) * j.kh * j.kw * j.kd * j.ic_block
+                * j.oc_block;
+    };
+
+    dim_t best_mem_cost = calc_mem_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
+
+    /* step 1: find the best thread distribution with lowest memory cost */
+    const int nthr_mb_max = nstl::min(nthr, j.mb * j.od * nthr_oh_reduce);
+    for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
+        const int nthr_par = nthr / nthr_mb;
+        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
+            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+
+            dim_t mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
+            if (mem_cost <= best_mem_cost) {
+                best_mem_cost = mem_cost;
+                nthr_mb_ = nthr_mb;
+                nthr_oc_b_ = nthr_oc_b;
+                nthr_ic_b_ = nthr_ic_b;
+            }
+        }
+    }
+
+    if (nthr_mb_ > nthreads / 2 && nthr_mb_ < nthreads)
+        nthr_mb_ = nstl::min(j.mb * j.od * nthr_oh_reduce, nthreads);
+    nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
+
+    assert(nthr_ <= nthreads);
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
@@ -1,0 +1,628 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_SVE_CONV_KERNEL_HPP
+#define CPU_AARCH64_JIT_SVE_CONV_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+#define DISABLE_ELTWISE
+#ifndef DISABLE_ELTWISE
+#include "cpu/aarch64/jit_uni_eltwise_injector.hpp"
+#endif // #ifndef DISABLE_ELTWISE
+
+#include "cpu/aarch64/jit_op_imm_check.hpp"
+
+#define LDRWMAX 252
+#define ADDMAX 4095
+/* Get vector offsets, ofs / VL(VL: 512bits = 64Bytes) */
+#define VL_OFS(ofs) ((ofs) >> 6)
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct jit_sve_512_conv_fwd_kernel : public jit_generator {
+
+    jit_sve_512_conv_fwd_kernel(
+            const jit_conv_conf_t &ajcp, const primitive_attr_t &attr)
+        : jcp(ajcp)
+        , attr_(attr)
+#ifndef DISABLE_ELTWISE
+        , eltwise_injector_(nullptr)
+#endif // #ifndef DISABLE_ELTWISE
+    {
+
+        if (jcp.with_eltwise)
+#ifndef DISABLE_ELTWISE
+            eltwise_injector_ = new jit_uni_eltwise_injector_f32<sve_512>(
+                    this, jcp.eltwise);
+#else // #ifndef DISABLE_ELTWISE
+            assert(!"Error: Generation of eltwise_injector in not supported");
+#endif // #ifndef DISABLE_ELTWISE
+    }
+
+    ~jit_sve_512_conv_fwd_kernel() {
+#ifndef DISABLE_ELTWISE
+        delete eltwise_injector_;
+#endif // #ifndef DISABLE_ELTWISE
+    }
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_512_conv_fwd_kernel)
+
+    jit_conv_conf_t jcp;
+    const primitive_attr_t &attr_;
+
+    static bool post_ops_ok(jit_conv_conf_t &jcp, const primitive_attr_t &attr);
+    static status_t init_conf(jit_conv_conf_t &jcp,
+            const convolution_desc_t &cd, memory_desc_t &src_pd,
+            memory_desc_t &weights_pd, memory_desc_t &dst_pd,
+            memory_desc_t &bias_pd, const primitive_attr_t &attr, int nthreads);
+    static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+            const jit_conv_conf_t &jcp);
+
+private:
+    using reg64_t = const XReg;
+    enum {
+        typesize = sizeof(float),
+        ker_reg_base_idx = 28,
+    };
+
+    const PReg reg_p_all_ones = p2;
+
+    reg64_t param = abi_param1;
+    reg64_t reg_inp = x1; // src base addr (2d)
+    reg64_t reg_ker = x2; // ker base addr (2d)
+    reg64_t aux_reg_ker_d = x2; // ker addr (3d)
+    reg64_t reg_out = x3; // dst base addr (2d)
+    reg64_t reg_ki = x3; // d-dim loop var? (3d)
+    reg64_t reg_owb = x5; // num of ow-block
+    reg64_t reg_out_prf = x6; // addr for prefetch
+
+    reg64_t aux_reg_inp = x7; // src addr (main loop)
+    reg64_t aux_reg_inp2 = x24; // src addr (main loop)
+    reg64_t aux_reg_inp3 = x25; // src addr (main loop)
+    reg64_t reg_out_ofs = x7; // dst addr (store_output)
+    reg64_t aux_reg_ker = x8; // ker addr (main loop)
+    reg64_t reg_channel = x9; // reduce workload
+    reg64_t reg_bias = x10; // bias addr (prepare_out)
+
+    reg64_t aux_reg_inp_d = x11; // src addr (3d)
+    reg64_t reg_oi = x11;
+
+    reg64_t reg_kh = x12; // ker h size
+    reg64_t reg_kj = x13; // ker h workload
+
+    /* Temporary registers for ARM insts */
+    reg64_t reg_tmp_addr = x14;
+    reg64_t reg_prev_bcast_addr = x15;
+    reg64_t reg_prev_wei_addr = x16;
+    reg64_t reg_tmp_imm = x17;
+
+    reg64_t reg_out_org = x18; // dst base addr (3d)
+    reg64_t reg_oi_org = x19; // base oi (3d)
+    reg64_t aux_reg_ker_d_org = x20;
+    reg64_t reg_ker_org = x21; // ker base addr (3d)
+    reg64_t reg_inp_org = x29; // src base addr (3d)
+
+    void prefetch(
+            const std::string prfop, int level, reg64_t in, long long int ofs) {
+        bool for_load;
+        if (prfop == "LD") {
+            for_load = true;
+        } else if (prfop == "ST") {
+            for_load = false;
+        } else {
+            assert(!"invalid prfop");
+        }
+
+        bool cacheline_aligned = ((ofs & 0xFF) == 0) ? true : false;
+        if (cacheline_aligned == true) {
+            Prfop op = PLDL1KEEP;
+            switch (level) {
+                case 1: op = (for_load == true) ? PLDL1KEEP : PSTL1KEEP; break;
+                case 2: op = (for_load == true) ? PLDL2KEEP : PSTL2KEEP; break;
+                case 3: op = (for_load == true) ? PLDL3KEEP : PSTL3KEEP; break;
+                default: assert(!"invalid prfop"); break;
+            }
+
+            if ((ofs <= PRFMMAX) && (ofs >= 0)) {
+                prfm(op, ptr(in, static_cast<int32_t>(ofs)));
+            } else {
+                add_imm(reg_tmp_addr, in, ofs, reg_tmp_imm);
+                prfm(op, ptr(reg_tmp_addr));
+            }
+        } else {
+            PrfopSve op_sve = PLDL1KEEP_SVE;
+            switch (level) {
+                case 1:
+                    op_sve = (for_load == true) ? PLDL1KEEP_SVE : PSTL1KEEP_SVE;
+                    break;
+                case 2:
+                    op_sve = (for_load == true) ? PLDL2KEEP_SVE : PSTL2KEEP_SVE;
+                    break;
+                case 3:
+                    op_sve = (for_load == true) ? PLDL3KEEP_SVE : PSTL3KEEP_SVE;
+                    break;
+                default: assert(!"invalid level"); break;
+            }
+
+            if ((VL_OFS(ofs) <= PRFWMAX)
+                    && (VL_OFS(ofs) >= (-1 * PRFWMAX - 1))) {
+                prfw(op_sve, reg_p_all_ones,
+                        ptr(in, static_cast<int32_t>(VL_OFS(ofs))));
+            } else {
+                add_imm(reg_tmp_addr, in, ofs, reg_tmp_imm);
+                prfw(op_sve, reg_p_all_ones, ptr(reg_tmp_addr));
+            }
+        }
+    }
+
+#ifndef DISABLE_ELTWISE
+    jit_uni_eltwise_injector_f32<sve_512> *eltwise_injector_;
+#endif // #ifndef DISABLE_ELTWISE
+
+    inline void prepare_output(int ur_w);
+    inline void store_output(int ur_w);
+    inline void compute_loop_fma_core(int ur_w, int pad_l, int pad_r);
+    inline void compute_loop(int ur_w, int pad_l, int pad_r);
+
+    void generate() override;
+
+    inline size_t get_output_offset(int oi, int n_oc_block) {
+        const bool is_nxc_layout = is_dst_layout_nxc();
+        size_t ow_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
+        size_t ocb_str = is_nxc_layout
+                ? jcp.oc_block
+                : (size_t)jcp.od * jcp.oh * jcp.ow * jcp.oc_block;
+
+        return jcp.typesize_out * (n_oc_block * ocb_str + oi * ow_str);
+    }
+
+    inline size_t get_input_offset(int ki, int ic, int oi, int pad_l) {
+        const bool is_nxc_layout = is_src_layout_nxc();
+        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic
+                                      : (!jcp.is_1stconv ? jcp.ic_block : 1);
+        size_t ic_str = !jcp.is_1stconv || is_nxc_layout
+                ? 1
+                : (size_t)jcp.iw * jcp.ih * jcp.id;
+        size_t iw_idx = ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
+
+        return jcp.typesize_in * (iw_idx * iw_str + ic * ic_str);
+    }
+
+    inline int get_kernel_offset(
+            int ki, int ic, int n_oc_block, int ker_number) {
+        return jcp.typesize_in * jcp.oc_block
+                * (n_oc_block * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw
+                                * jcp.kd
+                        + (ic + ker_number) + ki * jcp.ic_block);
+    }
+
+    inline int get_ow_start(int ki, int pad_l) {
+        return nstl::max(0,
+                utils::div_up(pad_l - ki * (jcp.dilate_w + 1), jcp.stride_w));
+    }
+
+    inline int get_ow_end(int ur_w, int ki, int pad_r) {
+        return ur_w
+                - nstl::max(0,
+                        utils::div_up(
+                                pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1),
+                                jcp.stride_w));
+    }
+    inline bool is_src_layout_nxc() {
+        return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+    inline bool is_dst_layout_nxc() {
+        return utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+};
+
+struct jit_sve_512_conv_bwd_data_kernel_f32 : public jit_generator {
+
+    jit_sve_512_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
+        : jcp(ajcp) {}
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_512_conv_bwd_data_kernel_f32)
+    jit_conv_conf_t jcp;
+    void (*jit_ker_)(jit_conv_call_s *);
+
+    static status_t init_conf(jit_conv_conf_t &jcp,
+            const convolution_desc_t &cd, memory_desc_t &diff_src_d,
+            memory_desc_t &weights_d, memory_desc_t &diff_dst_d, int nthreads);
+    static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+            const jit_conv_conf_t &jcp);
+
+private:
+    using reg64_t = const XReg;
+    enum {
+        typesize = sizeof(float),
+    };
+    int ker_reg_base_idx = (jcp.nb_ic_blocking == 1) ? 16 : 24;
+
+    reg64_t param = abi_param1;
+    reg64_t reg_dst = x1;
+    reg64_t reg_ker = x2;
+    reg64_t reg_src = x3;
+
+    reg64_t reg_dst_prf = x23;
+    reg64_t reg_ker_prf = x5;
+    reg64_t reg_src_prf = x6;
+    reg64_t reg_iwb = x24;
+
+    reg64_t aux_reg_dst = x7;
+    reg64_t aux_reg_ker = x8;
+
+    reg64_t aux_reg_dst_prf = x9;
+    reg64_t aux_reg_ker_prf = x10;
+
+    reg64_t aux_reg_dst_d_prf = x6;
+    reg64_t aux_reg_dst_d = x11;
+    reg64_t aux_reg_ker_d_prf = x12;
+    reg64_t aux_reg_ker_d = x2;
+    reg64_t reg_ki = x3;
+
+    reg64_t reg_kj = x13;
+    reg64_t reg_oi = x11;
+    reg64_t reg_kh = x12;
+
+    reg64_t reg_channel = x9;
+
+    reg64_t reg_tmp = x14;
+    reg64_t reg_long_offt = x7;
+
+    /* Temporary registers for ARM insts */
+    reg64_t reg_prev_bcast_addr = x15;
+    reg64_t reg_prev_bcast_addr2 = x17;
+    reg64_t reg_prev_bcast_addr3 = x21;
+    reg64_t reg_tmp_imm = x16;
+    reg64_t reg_tmp_addr = x18;
+
+    reg64_t reg_src_prf_org = x19;
+    reg64_t reg_src_org = x20;
+    reg64_t reg_oi_org = x25;
+    reg64_t reg_dst_org = x22;
+    reg64_t reg_ker_org = x26;
+    reg64_t reg_input_org = x22;
+    reg64_t reg_kernel_org = x26;
+
+    const PReg reg_p_all_ones = p2;
+
+    long long int prefetch(const std::string prfop, int level, reg64_t in,
+            long long int ofs, long long int prev_ofs) {
+        bool for_load;
+        if (prfop == "LD") {
+            for_load = true;
+        } else if (prfop == "ST") {
+            for_load = false;
+        } else {
+            assert(!"invalid prfop");
+        }
+
+        bool cacheline_alinged = ((ofs & 0xFF) == 0) ? true : false;
+        if (cacheline_alinged == true) {
+            Prfop op = PLDL1KEEP;
+            switch (level) {
+                case 1: op = (for_load == true) ? PLDL1KEEP : PSTL1KEEP; break;
+                case 2: op = (for_load == true) ? PLDL2KEEP : PSTL2KEEP; break;
+                case 3: op = (for_load == true) ? PLDL3KEEP : PSTL3KEEP; break;
+                default: assert(!"invalid prfop"); break;
+            }
+
+            long long int tmp_ofs = ofs - prev_ofs;
+            if ((ofs <= PRFMMAX) && (ofs >= 0)) {
+                prfm(op, ptr(in, static_cast<int32_t>(ofs)));
+            } else if ((tmp_ofs <= PRFMMAX) && (tmp_ofs >= 0)) {
+                prfm(op, ptr(reg_tmp_addr, static_cast<int32_t>(tmp_ofs)));
+            } else {
+                add_imm(reg_tmp_addr, in, ofs, reg_tmp_imm);
+                prfm(op, ptr(reg_tmp_addr));
+                prev_ofs = ofs;
+            }
+        } else {
+            PrfopSve op_sve = PLDL1KEEP_SVE;
+            switch (level) {
+                case 1:
+                    op_sve = (for_load == true) ? PLDL1KEEP_SVE : PSTL1KEEP_SVE;
+                    break;
+                case 2:
+                    op_sve = (for_load == true) ? PLDL2KEEP_SVE : PSTL2KEEP_SVE;
+                    break;
+                case 3:
+                    op_sve = (for_load == true) ? PLDL3KEEP_SVE : PSTL3KEEP_SVE;
+                    break;
+                default: assert(!"invalid prfop"); break;
+            }
+
+            long long int tmp_ofs = ofs - prev_ofs;
+            if ((VL_OFS(ofs) <= PRFWMAX)
+                    && (VL_OFS(ofs) >= (-1 * PRFWMAX - 1))) {
+                prfw(op_sve, reg_p_all_ones,
+                        ptr(in, static_cast<int32_t>(VL_OFS(ofs))));
+            } else if ((VL_OFS(tmp_ofs) <= PRFWMAX)
+                    && (VL_OFS(tmp_ofs) >= (-1 * PRFWMAX - 1))) {
+                prfw(op_sve, reg_p_all_ones,
+                        ptr(reg_tmp_addr,
+                                static_cast<int32_t>(VL_OFS(tmp_ofs))));
+            } else {
+                add_imm(reg_tmp_addr, in, ofs, reg_tmp_imm);
+                prfw(op_sve, reg_p_all_ones, ptr(reg_tmp_addr));
+                prev_ofs = ofs;
+            }
+        }
+        return prev_ofs;
+    }
+
+    ZReg reg_wei = ZReg(31);
+
+    inline void prepare_output(int ur_w);
+    inline void store_output(int ur_w);
+    inline void compute_loop_fma(int ur_w, int l_overflow, int r_overflow);
+    inline void compute_loop_fma_core(
+            int ur_w, int l_overflow, int r_overflow, int k_offset);
+    inline void compute_loop(
+            int ur_w, int l_overflow, int r_overflow, int k_offset = 0);
+    void generate() override;
+
+    inline int get_iw_start(int ki, int l_overflow) {
+        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+                + l_overflow * jcp.stride_w
+                - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
+        while (res < 0)
+            res += jcp.stride_w;
+
+        return res;
+    }
+
+    inline int get_iw_end(int ur_w, int ki, int r_overflow) {
+        if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
+            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
+        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+                + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
+        while (res < 0)
+            res += jcp.stride_w;
+
+        return ur_w - res;
+    }
+
+    inline size_t get_diff_src_offset(int iw, int icb) {
+        const bool is_nxc_layout = is_dsrc_layout_nxc();
+        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
+        size_t icb_str = is_nxc_layout
+                ? jcp.ic_block
+                : (size_t)jcp.id * jcp.ih * jcp.iw * jcp.ic_block;
+
+        return typesize * (icb * icb_str + iw * iw_str);
+    }
+
+    inline ptrdiff_t get_dst_offset(int iw, int oc, int kw) {
+        ptrdiff_t ow
+                = (iw + jcp.l_pad - kw * (jcp.dilate_w + 1)) / jcp.stride_w;
+        ptrdiff_t ow_str
+                = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
+
+        return typesize * (ow * ow_str + oc);
+    };
+
+    inline bool is_dsrc_layout_nxc() {
+        return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+    inline bool is_ddst_layout_nxc() {
+        return utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+};
+
+struct jit_sve_512_conv_bwd_weights_kernel_f32 : public jit_generator {
+
+    jit_sve_512_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
+        : jcp(ajcp) {}
+
+    void generate() override {
+        if (jcp.harness != harness_nxc) {
+            generate_kernel();
+        } else {
+            assert(!"none microkernel");
+        }
+    }
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_512_conv_bwd_weights_kernel_f32)
+
+    static status_t init_conf(jit_conv_conf_t &jcp,
+            const convolution_desc_t &cd, memory_desc_t &src_md,
+            memory_desc_t &diff_weights_md, memory_desc_t &diff_bias_md,
+            memory_desc_t &diff_dst_md, int nthreads);
+    static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+            const jit_conv_conf_t &jcp);
+
+    jit_conv_conf_t jcp;
+
+private:
+    using reg64_t = const XReg;
+    enum { typesize = sizeof(float) };
+    static const int max_ur_w;
+    static const int min_oh_reduce;
+
+    reg64_t param = abi_param1;
+    reg64_t reg_input = x1;
+    reg64_t reg_kernel = x2;
+    reg64_t reg_output = x3;
+    reg64_t b_ic = x20;
+    reg64_t kj = x5;
+    reg64_t reg_kh = x6;
+    reg64_t reg_ur_w_trips = x7;
+    reg64_t reg_oj = x8;
+    reg64_t reg_tmp = x10;
+    reg64_t reg_icb = x9;
+
+    reg64_t ki = x11;
+    reg64_t reg_kd_count = x12;
+    reg64_t reg_oi = x12;
+    reg64_t reg_d_index = x13;
+    reg64_t reg_input_d = x8;
+    reg64_t reg_output_d = x9;
+    reg64_t aux_reg_input = x12;
+    reg64_t aux_reg_kernel = x13;
+    reg64_t reg_bias = x9;
+    reg64_t reg_oc_tail = x10;
+
+    /* Temporary registers */
+    reg64_t reg_add_tmp = x14;
+    reg64_t reg_tmp_imm = x15;
+
+    reg64_t reg_kd_count_org = x16;
+    reg64_t reg_input_d_org = x17;
+    reg64_t reg_output_d_org = x18;
+    reg64_t reg_d_index_org = x19;
+
+    reg64_t reg_input_org = x24;
+    reg64_t reg_kernel_org = x22;
+    reg64_t reg_output_org = x23;
+
+    reg64_t reg_pre_addr_input = x25;
+    reg64_t reg_pre_addr_out = x26;
+    reg64_t reg_pre_addr_ker = x26;
+    reg64_t reg_ker_start_addr = x27;
+    reg64_t reg_addr_diff_input = x28;
+
+    const PReg reg_p_all_ones = p2;
+
+    void prefetch(
+            const std::string prfop, int level, reg64_t in, long long int ofs) {
+        bool for_load;
+        if (prfop == "LD") {
+            for_load = true;
+        } else if (prfop == "ST") {
+            for_load = false;
+        } else {
+            assert(!"invalid prfop");
+        }
+
+        bool cacheline_alinged = ((ofs & 0xFF) == 0) ? true : false;
+        if (cacheline_alinged == true) {
+            Prfop op;
+            switch (level) {
+                case 1: op = (for_load == true) ? PLDL1KEEP : PSTL1KEEP; break;
+                case 2: op = (for_load == true) ? PLDL2KEEP : PSTL2KEEP; break;
+                case 3: op = (for_load == true) ? PLDL3KEEP : PSTL3KEEP; break;
+                default: assert(!"invalid prfop"); break;
+            }
+
+            if ((ofs <= PRFMMAX) && (ofs >= 0)) {
+                prfm(op, ptr(in, static_cast<int32_t>(ofs)));
+            } else {
+                add_imm(reg_add_tmp, in, ofs, reg_tmp_imm);
+                prfm(op, ptr(reg_add_tmp));
+            }
+        } else {
+            PrfopSve op_sve;
+            switch (level) {
+                case 1:
+                    op_sve = (for_load == true) ? PLDL1KEEP_SVE : PSTL1KEEP_SVE;
+                    break;
+                case 2:
+                    op_sve = (for_load == true) ? PLDL2KEEP_SVE : PSTL2KEEP_SVE;
+                    break;
+                case 3:
+                    op_sve = (for_load == true) ? PLDL3KEEP_SVE : PSTL3KEEP_SVE;
+                    break;
+                default: assert(!"invalid prfop"); break;
+            }
+
+            if ((VL_OFS(ofs) <= PRFWMAX)
+                    && (VL_OFS(ofs) >= (-1 * PRFWMAX - 1))) {
+                prfw(op_sve, reg_p_all_ones,
+                        ptr(in, static_cast<int32_t>(VL_OFS(ofs))));
+            } else {
+                add_imm(reg_add_tmp, in, ofs, reg_tmp_imm);
+                prfw(op_sve, reg_p_all_ones, ptr(reg_add_tmp));
+            }
+        }
+    }
+
+    inline void bias_kernel_2d();
+    inline void bias_kernel_3d();
+    inline void maybe_zero_kernel();
+    inline void compute_oh_step_unroll_ow_icblock(
+            int ic_block_step, int max_ur_w);
+    inline void od_step_comeback_pointers();
+    inline void oh_step_comeback_pointers();
+    inline void compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w);
+    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
+            int ic_block_step, int input_offset, int kernel_offset,
+            int output_offset, bool input_wraparound = false);
+    inline void compute_oh_step_common(int ic_block_step, int max_ur_w);
+    inline void compute_oh_step_disp();
+    inline void compute_oh_loop_common();
+    inline void compute_oh_loop_partial();
+    inline void compute_od_loop_partial();
+
+    inline bool compute_full_spat_loop();
+    inline bool flat_4ops_compute();
+
+    inline void compute_loop();
+    inline bool is_src_layout_nxc() {
+        return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+    inline bool is_ddst_layout_nxc() {
+        return utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+
+    inline ptrdiff_t get_full_src_offset(
+            int i_iw, int i_ic, ptrdiff_t input_offset) {
+        const bool is_nxc_layout = is_src_layout_nxc();
+        const size_t w_shift_st
+                = (jcp.is_hw_transp ? jcp.iw : 1) * jcp.ic_block;
+        ptrdiff_t w_shift = is_nxc_layout ? jcp.ngroups * jcp.ic
+                                          : (jcp.is_1stconv ? 1 : w_shift_st);
+        ptrdiff_t ic_shift = (jcp.is_1stconv && !is_nxc_layout
+                        ? (ptrdiff_t)jcp.ih * jcp.iw * jcp.id
+                        : 1);
+
+        ptrdiff_t local_input_offset = i_iw * w_shift + i_ic * ic_shift;
+        return input_offset + typesize * local_input_offset;
+    };
+
+    inline int get_iw_idx(int ow, int kw, int l_pad) {
+        return ow * jcp.stride_w + kw * (jcp.dilate_w + 1) - l_pad;
+    }
+
+    void generate_kernel();
+
+    static void balance(const jit_conv_conf_t &j, int &nthr, int &nthr_mb,
+            int &nthr_g, int &nthr_oc_b, int &nthr_ic_b, int nthreads);
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_sve_512_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_convolution.cpp
@@ -1,0 +1,1858 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/jit_sve_512_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+using namespace nstl;
+
+using jit_conv_ker_t = void (*)(jit_conv_call_s *);
+
+#define PIPELINE(field) \
+    do { \
+        p.field = p.field##_prf; \
+        p.field##_prf = field; \
+    } while (0)
+
+inline void jit_conv_ker_pipeline(jit_conv_ker_t ker, jit_conv_call_s &p,
+        const void *src, const void *dst, const void *filt, const void *bias,
+        int channel, int kh_padding, int reduce_work, int load_work) {
+    PIPELINE(src);
+    PIPELINE(dst);
+    PIPELINE(filt);
+    PIPELINE(bias);
+    PIPELINE(channel);
+    // non-positive value of kh_padding is allowed, in this case kernel must
+    // skip computation part and initialize output by zeroes
+    PIPELINE(kh_padding);
+    PIPELINE(reduce_work);
+    PIPELINE(load_work);
+
+    if (p.src) ker(&p);
+}
+// The special case for the driver with ow-parallelization (FWD)
+inline void jit_conv_ker_pipeline_ow_thr(jit_conv_ker_t ker, jit_conv_call_s &p,
+        const void *src, const void *dst, const void *filt, const void *bias,
+        int channel, int kh_padding, int owb, int reduce_work, int load_work,
+        int flags) {
+    PIPELINE(owb);
+    PIPELINE(flags);
+    jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
+            reduce_work, load_work);
+}
+// The special case for the driver with iw-parallelization (BWD)
+inline void jit_conv_ker_pipeline_iw_thr(jit_conv_ker_t ker, jit_conv_call_s &p,
+        const void *src, const void *dst, const void *filt, const void *bias,
+        int channel, int kh_padding, int iwb, int reduce_work, int load_work) {
+    PIPELINE(iwb);
+
+    jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
+            reduce_work, load_work);
+}
+
+inline void jit_sve_512_conv_3d_ker_pipeline(jit_conv_ker_t ker,
+        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        const void *bias, int channel, int kh_padding, int kd_padding,
+        int reduce_work, int load_work) {
+    PIPELINE(src);
+    PIPELINE(dst);
+    PIPELINE(filt);
+    PIPELINE(bias);
+    PIPELINE(channel);
+    // non-positive value of both kd_padding and kh_padding is allowed, in this
+    // case kernel must skip computation part and initialize output by zeroes
+    PIPELINE(kh_padding);
+    PIPELINE(kd_padding);
+    PIPELINE(reduce_work);
+    PIPELINE(load_work);
+
+    if (p.src) ker(&p);
+}
+// The special case for the driver with ow-parallelization (FWD)
+// TODO: implement it for BWD_D and BWD_W too
+inline void jit_sve_512_conv_3d_ker_pipeline_ow_thr(jit_conv_ker_t ker,
+        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        const void *bias, int channel, int kh_padding, int kd_padding, int owb,
+        int reduce_work, int load_work, int flags) {
+    PIPELINE(owb);
+    PIPELINE(flags);
+
+    jit_sve_512_conv_3d_ker_pipeline(ker, p, src, dst, filt, bias, channel,
+            kh_padding, kd_padding, reduce_work, load_work);
+}
+
+inline void jit_conv_ker_pipeline_bwd_w(jit_conv_ker_t ker, jit_conv_call_s &p,
+        const void *src, const void *dst, const void *filt, const void *bias,
+        int channel, int kh_padding, size_t reduce_work, size_t load_work) {
+    jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
+            reduce_work, load_work);
+}
+
+void jit_sve_512_conv_2d_ker_bwd_w_pipeline(jit_conv_ker_t ker,
+        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        const void *bias, int channel, int os_index_begin, int os_index_end,
+        int kh_padding /* kh_work_size */, size_t kh_offset, size_t reduce_work,
+        size_t load_work) {
+    PIPELINE(src);
+    PIPELINE(dst);
+    PIPELINE(filt);
+    PIPELINE(bias);
+    PIPELINE(channel);
+    PIPELINE(os_index_begin);
+    PIPELINE(os_index_end);
+    // non-positive value of kh_padding is allowed, in this case kernel must
+    // skip kw loop computation and initialize output by zeroes
+    PIPELINE(kh_padding);
+    PIPELINE(kh_offset);
+    PIPELINE(reduce_work);
+    PIPELINE(load_work);
+
+    if (p.src) ker(&p);
+}
+
+void jit_sve_512_conv_3d_ker_bwd_w_pipeline(jit_conv_ker_t ker,
+        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        const void *bias, int channel, int os_index_begin, int os_index_end,
+        int kd_padding /* kd_work_size */, size_t kd_offset, size_t reduce_work,
+        size_t load_work) {
+    PIPELINE(src);
+    PIPELINE(dst);
+    PIPELINE(filt);
+    PIPELINE(bias);
+    PIPELINE(channel);
+    PIPELINE(os_index_begin);
+    PIPELINE(os_index_end);
+    // non-positive value of kd_padding is allowed, in this case kernel must
+    // skip kh loop computation and initialize output by zeroes
+    PIPELINE(kd_padding);
+    PIPELINE(kd_offset);
+    PIPELINE(reduce_work);
+    PIPELINE(load_work);
+
+    if (p.src) ker(&p);
+}
+#define wht_blk_off(d, g, ...) \
+    (pd()->with_groups() ? (d).blk_off((g), __VA_ARGS__) \
+                         : (d).blk_off(__VA_ARGS__))
+
+template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+void jit_sve_512_convolution_fwd_t<src_type, wei_type,
+        dst_type>::prepare_padded_bias(const dst_data_t *&bias,
+        const memory_tracking::grantor_t &scratchpad) const {
+    if (!pd()->wants_padded_bias()) return;
+
+    auto padded_bias
+            = scratchpad.template get<dst_data_t>(key_conv_padded_bias);
+    utils::array_copy(padded_bias, bias, pd()->jcp_.oc_without_padding);
+    utils::array_set(padded_bias + pd()->jcp_.oc_without_padding, (dst_data_t)0,
+            pd()->jcp_.oc - pd()->jcp_.oc_without_padding);
+    bias = padded_bias;
+}
+
+template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+void jit_sve_512_convolution_fwd_t<src_type, wei_type,
+        dst_type>::execute_forward_1d(const exec_ctx_t &ctx) const {
+    auto src = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto bias = CTX_IN_MEM(const dst_data_t *, DNNL_ARG_BIAS);
+    auto dst = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+
+    prepare_padded_bias(bias, ctx.get_scratchpad_grantor());
+
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = pd()->jcp_;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+    assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
+
+    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    int g_blocking = 1;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    int nthr = jcp.aligned_threads;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        int start {0}, end {0}, start_copy;
+        balance211(work_amount, nthr, ithr, start, end);
+        start_copy = start;
+
+        auto par_conv = jit_conv_call_s();
+        size_t src_c_stride = src_d.blk_off(0, 1);
+        size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
+
+        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+            start = start_copy;
+            int n {0}, gg {0}, occ {0}, owb {0};
+
+            if (jcp.loop_order == loop_cwgn) {
+                int dummy {0};
+                nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
+                        nb_groups, n, jcp.mb, dummy, 1);
+            } else if (jcp.loop_order == loop_gncw) {
+                int dummy {0};
+                nd_iterator_init(start, gg, nb_groups, n, jcp.mb, occ,
+                        oc_chunks, owb, jcp.nb_ow, dummy, 1);
+            } else if (jcp.loop_order == loop_nhwcg) {
+                nd_iterator_init(start, n, jcp.mb, owb, jcp.nb_ow, occ,
+                        oc_chunks, gg, nb_groups);
+            } else {
+                assert(!"unsupported loop order");
+            }
+
+            while (start < end) {
+                int ocb = occ * jcp.nb_oc_blocking;
+                int g = gg * g_blocking;
+                int g_ocb = g * jcp.nb_oc + ocb;
+                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+
+                int ow_s = owb * jcp.ow_block;
+                int iw_s = ow_s * jcp.stride_w;
+                const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
+                const int oc_off_idx = is_dst_layout_nxc
+                        ? g * jcp.oc + ocb * jcp.oc_block
+                        : g_ocb;
+                auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, ow_s);
+                const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
+                const int ic_off_idx = is_src_layout_nxc
+                        ? g * jcp.ic + icb_l2 * jcp.ic_block
+                        : g_icb + icb_l2;
+                auto src_w = src + src_d.blk_off(n, ic_off_idx, iw_s);
+                auto wht_w = weights + wht_blk_off(weights_d, g, ocb, icb_l2);
+                auto bias_w = bias ? bias
+                                + oc_off_idx
+                                        * (is_dst_layout_nxc ? 1 : jcp.oc_block)
+                                   : nullptr;
+
+                int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                        jcp.oc, jcp.nb_oc_blocking * jcp.oc_block);
+                int ic_work = icb_step * jcp.ic_block;
+                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                    int flags = 0;
+                    if (icb == 0) flags |= FLAG_IC_FIRST;
+                    if (icb + curr_nb_ic >= jcp.nb_ic) {
+                        flags |= FLAG_IC_LAST;
+                        ic_work = utils::this_block_size(icb * jcp.ic_block,
+                                jcp.ic, icb_step * jcp.ic_block);
+                    }
+                    jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv, src_w,
+                            dst_w, wht_w, bias_w, icb, 1, owb, ic_work, oc_work,
+                            flags);
+
+                    src_w += src_c_stride;
+                    wht_w += wht_ic_stride;
+                }
+                if (jcp.loop_order == loop_cwgn) {
+                    int dummy {0};
+                    nd_iterator_jump(start, end, occ, oc_chunks, owb, jcp.nb_ow,
+                            gg, nb_groups, n, jcp.mb, dummy, 1);
+                } else if (jcp.loop_order == loop_gncw) {
+                    int dummy {0};
+                    nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, occ,
+                            oc_chunks, owb, jcp.nb_ow, dummy, 1);
+                } else if (jcp.loop_order == loop_nhwcg) {
+                    ++start;
+                    nd_iterator_step(n, jcp.mb, owb, jcp.nb_ow, occ, oc_chunks,
+                            gg, nb_groups);
+                } else {
+                    assert(!"unsupported loop order");
+                }
+            }
+        }
+
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_conv_ker_pipeline_ow_thr(
+                jit_ker, par_conv, src, dst, weights, bias, 0, 0, 0, 0, 0, 0);
+    });
+}
+
+template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+void jit_sve_512_convolution_fwd_t<src_type, wei_type,
+        dst_type>::execute_forward_2d(const exec_ctx_t &ctx) const {
+    auto src = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto bias = CTX_IN_MEM(const dst_data_t *, DNNL_ARG_BIAS);
+    auto dst = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+
+    prepare_padded_bias(bias, ctx.get_scratchpad_grantor());
+
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = pd()->jcp_;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+    assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
+
+    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    int g_blocking = 1;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    int nthr = jcp.aligned_threads;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        int start {0}, end {0}, start_copy;
+        balance211(work_amount, nthr, ithr, start, end);
+        start_copy = start;
+
+        auto par_conv = jit_conv_call_s();
+        size_t src_h_stride = src_d.blk_off(0, 0, 1);
+        size_t src_c_stride = src_d.blk_off(0, 1);
+        size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
+        size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
+        size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
+
+        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+            start = start_copy;
+            int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+
+            if (jcp.loop_order == loop_cwgn)
+                nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
+                        nb_groups, n, jcp.mb, oh_s, jcp.oh);
+            else if (jcp.loop_order == loop_gncw)
+                nd_iterator_init(start, gg, nb_groups, n, jcp.mb, occ,
+                        oc_chunks, owb, jcp.nb_ow, oh_s, jcp.oh);
+            else if (jcp.loop_order == loop_nhwcg)
+                nd_iterator_init(start, n, jcp.mb, oh_s, jcp.oh, owb, jcp.nb_ow,
+                        occ, oc_chunks, gg, nb_groups);
+            else
+                assert(!"unsupported loop order");
+
+            while (start < end) {
+                int ocb = occ * jcp.nb_oc_blocking;
+                int g = gg * g_blocking;
+                int g_ocb = g * jcp.nb_oc + ocb;
+                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+
+                int work_rem = end - start;
+
+                int ow_s = owb * jcp.ow_block;
+                int iw_s = ow_s * jcp.stride_w;
+                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                if (jcp.loop_order == loop_nhwcg)
+                    oh_e = oh_s + 1; //step instead
+
+                for (int oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
+                    int ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
+                    const bool is_dst_layout_nxc
+                            = jcp.dst_tag == format_tag::nhwc;
+                    const int oc_off_idx = is_dst_layout_nxc
+                            ? g * jcp.oc + ocb * jcp.oc_block
+                            : g_ocb;
+                    auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, oh_b, ow_s);
+                    const bool is_src_layout_nxc
+                            = jcp.src_tag == format_tag::nhwc;
+                    const int ic_off_idx = is_src_layout_nxc
+                            ? g * jcp.ic + icb_l2 * jcp.ic_block
+                            : g_icb + icb_l2;
+                    auto src_w = src + src_d.blk_off(n, ic_off_idx, ih_b, iw_s);
+                    auto wht_w
+                            = weights + wht_blk_off(weights_d, g, ocb, icb_l2);
+
+                    int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                    int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                    auto bias_w = bias ? bias
+                                    + oc_off_idx
+                                            * (is_dst_layout_nxc ? 1
+                                                                 : jcp.oc_block)
+                                       : nullptr;
+                    const int oc_work
+                            = utils::this_block_size(ocb * jcp.oc_block, jcp.oc,
+                                    jcp.nb_oc_blocking * jcp.oc_block);
+                    int ic_work = icb_step * jcp.ic_block;
+                    for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
+                        int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                        int flags = 0;
+                        if (icb == 0) flags |= FLAG_IC_FIRST;
+                        if (icb + curr_nb_ic >= jcp.nb_ic) {
+                            flags |= FLAG_IC_LAST;
+                            ic_work = utils::this_block_size(icb * jcp.ic_block,
+                                    jcp.ic, icb_step * jcp.ic_block);
+                        }
+                        auto src_c = src_w;
+                        auto dst_c = dst_w;
+                        for (int oj = oh_b, ij = ih_b;
+                                oj < min(oh_e, oh_b + jcp.h_blocking);
+                                ++oj, ij += jcp.stride_h) {
+                            int dilate_h = jcp.dilate_h + 1;
+                            int i_t_overflow = div_up(max(0, -ij), dilate_h);
+                            int i_b_overflow = div_up(
+                                    max(0,
+                                            ij - jcp.ih
+                                                    + (jcp.kh - 1) * dilate_h
+                                                    + 1),
+                                    dilate_h);
+                            int kh_padding = nstl::max(
+                                    0, jcp.kh - i_t_overflow - i_b_overflow);
+
+                            auto aux_src = src_c
+                                    + i_t_overflow * dilate_h * src_h_stride;
+                            auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
+
+                            jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv,
+                                    aux_src, dst_c, aux_wht, bias_w, icb,
+                                    kh_padding, owb, ic_work, oc_work, flags);
+
+                            src_c += src_h_stride * jcp.stride_h;
+                            dst_c += dst_h_stride;
+                        }
+                        src_w += src_c_stride;
+                        wht_w += wht_ic_stride;
+                    }
+                }
+
+                if (jcp.loop_order == loop_cwgn)
+                    nd_iterator_jump(start, end, occ, oc_chunks, owb, jcp.nb_ow,
+                            gg, nb_groups, n, jcp.mb, oh_s, jcp.oh);
+                else if (jcp.loop_order == loop_gncw)
+                    nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, occ,
+                            oc_chunks, owb, jcp.nb_ow, oh_s, jcp.oh);
+                else if (jcp.loop_order == loop_nhwcg) {
+                    ++start;
+                    nd_iterator_step(n, jcp.mb, oh_s, jcp.oh, owb, jcp.nb_ow,
+                            occ, oc_chunks, gg, nb_groups);
+                } else
+                    assert(!"unsupported loop order");
+            }
+        }
+
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_conv_ker_pipeline_ow_thr(
+                jit_ker, par_conv, src, dst, weights, bias, 0, 0, 0, 0, 0, 0);
+    });
+}
+
+template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+void jit_sve_512_convolution_fwd_t<src_type, wei_type,
+        dst_type>::execute_forward_3d(const exec_ctx_t &ctx) const {
+    auto src = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto bias = CTX_IN_MEM(const dst_data_t *, DNNL_ARG_BIAS);
+    auto dst = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+
+    prepare_padded_bias(bias, ctx.get_scratchpad_grantor());
+
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = pd()->jcp_;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+    assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
+
+    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    int g_blocking = 1;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount
+            = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
+    int nthr = jcp.nthr;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        int start {0}, end {0}, start_copy;
+        balance211(work_amount, nthr, ithr, start, end);
+        start_copy = start;
+
+        auto par_conv = jit_conv_call_s();
+        size_t src_d_stride = src_d.blk_off(0, 0, 1);
+        size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);
+        size_t src_c_stride = src_d.blk_off(0, 1);
+        size_t dst_h_stride = dst_d.blk_off(0, 0, 0, 1);
+        size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
+        size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
+        size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
+
+        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+            start = start_copy;
+            int n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
+
+            if (jcp.loop_order == loop_cwgn)
+                nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
+                        nb_groups, n, jcp.mb, od_s, jcp.od, oh_s, jcp.oh);
+            else if (jcp.loop_order == loop_gncw)
+                nd_iterator_init(start, gg, nb_groups, n, jcp.mb, occ,
+                        oc_chunks, owb, jcp.nb_ow, od_s, jcp.od, oh_s, jcp.oh);
+            else if (jcp.loop_order == loop_nhwcg)
+                nd_iterator_init(start, n, jcp.mb, od_s, jcp.od, oh_s, jcp.oh,
+                        owb, jcp.nb_ow, occ, oc_chunks, gg, nb_groups);
+            else
+                assert(!"unsupported loop order");
+
+            while (start < end) {
+                int ocb = occ * jcp.nb_oc_blocking;
+                int g = gg * g_blocking;
+                int g_ocb = g * jcp.nb_oc + ocb;
+                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+
+                int work_rem = end - start;
+                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                int ow_s = owb * jcp.ow_block;
+                int iw_s = ow_s * jcp.stride_w;
+                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                if (jcp.loop_order == loop_nhwcg)
+                    oh_e = oh_s + 1; //step instead
+
+                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
+
+                int dilate_d = jcp.dilate_d + 1;
+                int d_t_overflow = div_up(max(0, -id_s), dilate_d);
+                int d_b_overflow = div_up(
+                        max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                        dilate_d);
+                int kd_padding
+                        = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
+                const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
+                const int oc_off_idx = is_dst_layout_nxc
+                        ? g * jcp.oc + ocb * jcp.oc_block
+                        : g_ocb;
+                auto dst_w
+                        = dst + dst_d.blk_off(n, oc_off_idx, od_s, oh_s, ow_s);
+                const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
+                const int ic_off_idx = is_src_layout_nxc
+                        ? g * jcp.ic + icb_l2 * jcp.ic_block
+                        : g_icb + icb_l2;
+                auto src_w = src
+                        + src_d.blk_off(n, ic_off_idx, id_s, ih_s, iw_s)
+                        + d_t_overflow * dilate_d * src_d_stride;
+                auto wht_w = weights + wht_blk_off(weights_d, g, ocb, icb_l2)
+                        + d_t_overflow * wht_d_stride;
+                auto bias_w = bias ? bias
+                                + oc_off_idx
+                                        * (is_dst_layout_nxc ? 1 : jcp.oc_block)
+                                   : nullptr;
+
+                const int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                        jcp.oc, jcp.nb_oc_blocking * jcp.oc_block);
+                int ic_work = icb_step * jcp.ic_block;
+                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                    int flags = 0;
+                    if (icb == 0) flags |= FLAG_IC_FIRST;
+                    if (icb + curr_nb_ic >= jcp.nb_ic) {
+                        flags |= FLAG_IC_LAST;
+                        ic_work = utils::this_block_size(icb * jcp.ic_block,
+                                jcp.ic, icb_step * jcp.ic_block);
+                    }
+                    auto src_c = src_w;
+                    auto dst_c = dst_w;
+                    for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                            ++oj, ij += jcp.stride_h) {
+                        int dilate_h = jcp.dilate_h + 1;
+                        int i_t_overflow = div_up(max(0, -ij), dilate_h);
+                        int i_b_overflow = div_up(
+                                max(0,
+                                        ij - jcp.ih + (jcp.kh - 1) * dilate_h
+                                                + 1),
+                                dilate_h);
+                        int kh_padding = nstl::max(
+                                0, jcp.kh - i_t_overflow - i_b_overflow);
+                        jit_sve_512_conv_3d_ker_pipeline_ow_thr(jit_ker,
+                                par_conv,
+                                src_c + i_t_overflow * dilate_h * src_h_stride,
+                                dst_c, wht_w + i_t_overflow * wht_h_stride,
+                                bias_w, icb, kh_padding, kd_padding, owb,
+                                ic_work, oc_work, flags);
+
+                        src_c += src_h_stride * jcp.stride_h;
+                        dst_c += dst_h_stride;
+                    }
+                    src_w += src_c_stride;
+                    wht_w += wht_ic_stride;
+                }
+
+                if (jcp.loop_order == loop_cwgn)
+                    nd_iterator_jump(start, end, occ, oc_chunks, owb, jcp.nb_ow,
+                            gg, nb_groups, n, jcp.mb, od_s, jcp.od, oh_s,
+                            jcp.oh);
+                else if (jcp.loop_order == loop_gncw)
+                    nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, occ,
+                            oc_chunks, owb, jcp.nb_ow, od_s, jcp.od, oh_s,
+                            jcp.oh);
+                else if (jcp.loop_order == loop_nhwcg) {
+                    ++start;
+                    nd_iterator_step(n, jcp.mb, od_s, jcp.od, oh_s, jcp.oh, owb,
+                            jcp.nb_ow, occ, oc_chunks, gg, nb_groups);
+                } else
+                    assert(!"unsupported loop order");
+            }
+        }
+
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_sve_512_conv_3d_ker_pipeline_ow_thr(jit_ker, par_conv, src, dst,
+                weights, bias, 0, 0, 0, 0, 0, 0, 0);
+    });
+}
+
+template struct jit_sve_512_convolution_fwd_t<data_type::f32>;
+
+template <data_type_t diff_dst_type, data_type_t wei_type,
+        data_type_t diff_src_type>
+void jit_sve_512_convolution_bwd_data_t<diff_dst_type, wei_type,
+        diff_src_type>::execute_backward_data_1d(const exec_ctx_t &ctx) const {
+    auto diff_dst = CTX_IN_MEM(const diff_dst_data_t *, DNNL_ARG_DIFF_DST);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto diff_src = CTX_OUT_MEM(diff_src_data_t *, DNNL_ARG_DIFF_SRC);
+
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = pd()->jcp_;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+
+    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    int g_blocking = 1;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
+    int nthr = jcp.nthr;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        int start {0}, end {0}, start_copy;
+        balance211(work_amount, nthr, ithr, start, end);
+        start_copy = start;
+
+        auto par_conv = jit_conv_call_s();
+        size_t diff_dst_c_stride = diff_dst_d.blk_off(0, 1);
+        size_t wht_oc_stride = wht_blk_off(weights_d, 0, 1);
+
+        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+            start = start_copy;
+            int n {0}, gg {0}, icc {0}, iwb {0};
+            if (jcp.loop_order == loop_cwgn) {
+                int dummy {0};
+                nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
+                        nb_groups, n, jcp.mb, dummy, 1);
+            } else if (jcp.loop_order == loop_gncw) {
+                int dummy {0};
+                nd_iterator_init(start, gg, nb_groups, n, jcp.mb, icc,
+                        ic_chunks, iwb, jcp.nb_iw, dummy, 1);
+            } else if (jcp.loop_order == loop_nhwcg) {
+                nd_iterator_init(start, n, jcp.mb, iwb, jcp.nb_iw, icc,
+                        ic_chunks, gg, nb_groups);
+            } else {
+                assert(!"unsupported loop order");
+            }
+
+            while (start < end) {
+                int icb = icc * jcp.nb_ic_blocking;
+                int g = gg * g_blocking;
+                int g_icb = g * jcp.nb_ic + icb;
+                int g_ocb = g * jcp.nb_oc;
+                int iw_s = iwb * jcp.iw_block;
+                int ow_s = iw_s / jcp.stride_w;
+
+                const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nwc;
+                const int ic_off_idx = is_dsrc_layout_nxc
+                        ? g * jcp.ic + icb * jcp.ic_block
+                        : g_icb;
+                auto diff_src_w
+                        = diff_src + diff_src_d.blk_off(n, ic_off_idx, iw_s);
+                const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nwc;
+                const int oc_off_idx = is_ddst_layout_nxc
+                        ? g * jcp.oc + ocb_l2 * jcp.oc_block
+                        : g_ocb + ocb_l2;
+                auto diff_dst_w
+                        = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, ow_s);
+                auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
+
+                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const int load_work = utils::this_block_size(icb * jcp.ic_block,
+                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
+                int reduce_work = ocb_step * jcp.oc_block;
+                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                    if (ocb + curr_nb_oc >= jcp.nb_oc) {
+                        reduce_work = utils::this_block_size(ocb * jcp.oc_block,
+                                jcp.oc, ocb_step * jcp.oc_block);
+                    }
+
+                    jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src_w,
+                            diff_dst_w, wht_w, 0, ocb, 1, iwb, reduce_work,
+                            load_work);
+                    diff_dst_w += diff_dst_c_stride;
+                    wht_w += wht_oc_stride;
+                }
+
+                if (jcp.loop_order == loop_cwgn) {
+                    int dummy {0};
+                    nd_iterator_jump(start, end, icc, ic_chunks, iwb, jcp.nb_iw,
+                            gg, nb_groups, n, jcp.mb, dummy, 1);
+                } else if (jcp.loop_order == loop_gncw) {
+                    int dummy {0};
+                    nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, icc,
+                            ic_chunks, iwb, jcp.nb_iw, dummy, 1);
+                } else if (jcp.loop_order == loop_nhwcg) {
+                    ++start;
+                    nd_iterator_step(n, jcp.mb, iwb, jcp.nb_iw, icc, ic_chunks,
+                            gg, nb_groups);
+                } else {
+                    assert(!"unsupported loop order");
+                }
+            }
+        }
+
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src, diff_dst,
+                weights, 0, 0, 0, 0, 0, 0);
+    });
+}
+
+template <data_type_t diff_dst_type, data_type_t wei_type,
+        data_type_t diff_src_type>
+void jit_sve_512_convolution_bwd_data_t<diff_dst_type, wei_type,
+        diff_src_type>::execute_backward_data_2d(const exec_ctx_t &ctx) const {
+    auto diff_dst = CTX_IN_MEM(const diff_dst_data_t *, DNNL_ARG_DIFF_DST);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto diff_src = CTX_OUT_MEM(diff_src_data_t *, DNNL_ARG_DIFF_SRC);
+
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = pd()->jcp_;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+
+    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    int g_blocking = 1;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+    int nthr = jcp.nthr;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        int start {0}, end {0}, start_copy;
+        balance211(work_amount, nthr, ithr, start, end);
+        start_copy = start;
+
+        auto par_conv = jit_conv_call_s();
+        size_t diff_src_h_stride = diff_src_d.blk_off(0, 0, 1);
+        size_t diff_dst_h_stride = diff_dst_d.blk_off(0, 0, 1);
+        size_t diff_dst_c_stride = diff_dst_d.blk_off(0, 1);
+        size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
+        size_t wht_oc_stride = wht_blk_off(weights_d, 0, 1);
+
+        bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
+
+        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+            start = start_copy;
+            int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+
+            if (jcp.loop_order == loop_cwgn) {
+                nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
+                        nb_groups, n, jcp.mb, ih_s, jcp.ih);
+            } else if (jcp.loop_order == loop_gncw) {
+                nd_iterator_init(start, gg, nb_groups, n, jcp.mb, icc,
+                        ic_chunks, iwb, jcp.nb_iw, ih_s, jcp.ih);
+            } else if (jcp.loop_order == loop_nhwcg) {
+                nd_iterator_init(start, n, jcp.mb, ih_s, jcp.ih, iwb, jcp.nb_iw,
+                        icc, ic_chunks, gg, nb_groups);
+            } else
+                assert(!"unsupported loop order");
+
+            while (start < end) {
+                int icb = icc * jcp.nb_ic_blocking;
+                int g = gg * g_blocking;
+                int g_icb = g * jcp.nb_ic + icb;
+                int g_ocb = g * jcp.nb_oc;
+
+                int work_rem = end - start;
+                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                if (jcp.loop_order == loop_nhwcg)
+                    ih_e = ih_s + 1; //step instead
+                int iw_s = iwb * jcp.iw_block;
+                int ow_s = iw_s / jcp.stride_w;
+                const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nhwc;
+                const int ic_off_idx = is_dsrc_layout_nxc
+                        ? g * jcp.ic + icb * jcp.ic_block
+                        : g_icb;
+                auto diff_src_w
+                        = diff_src + diff_src_d.blk_off(n, ic_off_idx, 0, iw_s);
+                const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
+                const int oc_off_idx = is_ddst_layout_nxc
+                        ? g * jcp.oc + ocb_l2 * jcp.oc_block
+                        : g_ocb + ocb_l2;
+                auto diff_dst_w
+                        = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, 0, ow_s);
+                auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
+
+                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const int load_work = utils::this_block_size(icb * jcp.ic_block,
+                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
+                int reduce_work = ocb_step * jcp.oc_block;
+                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                    if (ocb + curr_nb_oc >= jcp.nb_oc) {
+                        reduce_work = utils::this_block_size(ocb * jcp.oc_block,
+                                jcp.oc, ocb_step * jcp.oc_block);
+                    }
+                    for (int ij = ih_s; ij < ih_e; ++ij) {
+                        int oj, k_len, k_lo;
+                        if (is_fast_path) { // dilate == 0 && stride == 1
+                            int i_t_overflow
+                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
+                            int i_b_overflow
+                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            k_len = jcp.kh - i_t_overflow - i_b_overflow;
+                            k_lo = i_b_overflow;
+                            oj = ij + jcp.t_pad - i_b_overflow;
+                        } else if (jcp.dilate_h != 0) { // stride == 1
+                            int dilate_h = jcp.dilate_h + 1;
+                            // Note: use div_up to account for "holes" in filter
+                            int i_t_overflow
+                                    = div_up(max(0,
+                                                     (jcp.kh - 1) * dilate_h
+                                                             - ij - jcp.t_pad),
+                                            dilate_h);
+                            int i_b_overflow = div_up(
+                                    max(0,
+                                            (jcp.kh - 1) * dilate_h + 1 - jcp.ih
+                                                    + ij - jcp.b_pad),
+                                    dilate_h);
+                            k_len = jcp.kh - i_t_overflow - i_b_overflow;
+                            k_lo = i_b_overflow;
+                            oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
+                        } else { // dilate == 0
+                            int i_t_overflow = max(0,
+                                    (jcp.kh - 1 - ij - jcp.t_pad)
+                                            / jcp.stride_h);
+                            int i_b_overflow = max(0,
+                                    (jcp.kh - jcp.ih + ij - jcp.b_pad)
+                                            / jcp.stride_h);
+                            int overflow_kh_hi = jcp.kh - 1
+                                    - modulo(jcp.ih - 1 + jcp.b_pad - ij,
+                                            jcp.stride_h);
+                            int overflow_kh_lo
+                                    = (ij + jcp.t_pad) % jcp.stride_h;
+
+                            k_len = (overflow_kh_hi - overflow_kh_lo)
+                                            / jcp.stride_h
+                                    + 1 - i_t_overflow - i_b_overflow;
+                            k_lo = overflow_kh_lo + i_b_overflow * jcp.stride_h;
+                            oj = (ij + jcp.t_pad - k_lo) / jcp.stride_h;
+                        }
+
+                        jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv,
+                                diff_src_w + ij * diff_src_h_stride,
+                                diff_dst_w + oj * diff_dst_h_stride,
+                                wht_w + k_lo * wht_h_stride, 0, ocb, k_len, iwb,
+                                reduce_work, load_work);
+                    }
+                    diff_dst_w += diff_dst_c_stride;
+                    wht_w += wht_oc_stride;
+                }
+
+                if (jcp.loop_order == loop_cwgn) {
+                    nd_iterator_jump(start, end, icc, ic_chunks, iwb, jcp.nb_iw,
+                            gg, nb_groups, n, jcp.mb, ih_s, jcp.ih);
+                } else if (jcp.loop_order == loop_gncw) {
+                    nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, icc,
+                            ic_chunks, iwb, jcp.nb_iw, ih_s, jcp.ih);
+                } else if (jcp.loop_order == loop_nhwcg) {
+                    ++start;
+                    nd_iterator_step(n, jcp.mb, ih_s, jcp.ih, iwb, jcp.nb_iw,
+                            icc, ic_chunks, gg, nb_groups);
+                } else
+                    assert(!"unsupported loop order");
+            }
+        }
+
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src, diff_dst,
+                weights, 0, 0, 0, 0, 0, 0);
+    });
+}
+
+template <data_type_t diff_dst_type, data_type_t wei_type,
+        data_type_t diff_src_type>
+void jit_sve_512_convolution_bwd_data_t<diff_dst_type, wei_type,
+        diff_src_type>::execute_backward_data_3d(const exec_ctx_t &ctx) const {
+    auto diff_dst = CTX_IN_MEM(const diff_dst_data_t *, DNNL_ARG_DIFF_DST);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto diff_src = CTX_OUT_MEM(diff_src_data_t *, DNNL_ARG_DIFF_SRC);
+
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = pd()->jcp_;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+
+    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    int g_blocking = 1;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+    int nthr = jcp.nthr;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        int start {0}, end {0}, start_copy;
+        balance211(work_amount, nthr, ithr, start, end);
+        start_copy = start;
+
+        auto par_conv = jit_conv_call_s();
+        size_t diff_src_h_stride = diff_src_d.blk_off(0, 0, 0, 1);
+        size_t diff_src_d_stride = diff_src_d.blk_off(0, 0, 1);
+        size_t diff_dst_h_stride = diff_dst_d.blk_off(0, 0, 0, 1);
+        size_t diff_dst_d_stride = diff_dst_d.blk_off(0, 0, 1);
+        size_t diff_dst_c_stride = diff_dst_d.blk_off(0, 1);
+        size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
+        size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
+        size_t wht_oc_stride = wht_blk_off(weights_d, 0, 1);
+
+        bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
+        bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
+
+        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+            start = start_copy;
+            int n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
+            // Input width threading is not currently implemented for 3d, so it
+            // is not included in the iterator.
+            if (jcp.loop_order == loop_cwgn)
+                nd_iterator_init(start, icc, ic_chunks, gg, nb_groups, n,
+                        jcp.mb, id_s, jcp.id, ih_s, jcp.ih);
+            else if (jcp.loop_order == loop_gncw)
+                nd_iterator_init(start, gg, nb_groups, n, jcp.mb, icc,
+                        ic_chunks, id_s, jcp.id, ih_s, jcp.ih);
+            else if (jcp.loop_order == loop_nhwcg)
+                nd_iterator_init(start, n, jcp.mb, id_s, jcp.id, ih_s, jcp.ih,
+                        icc, ic_chunks, gg, nb_groups);
+            else
+                assert(!"unsupported loop order");
+
+            while (start < end) {
+                int icb = icc * jcp.nb_ic_blocking;
+                int g = gg * g_blocking;
+                int g_icb = g * jcp.nb_ic + icb;
+                int g_ocb = g * jcp.nb_oc;
+
+                int work_rem = end - start;
+                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                if (jcp.loop_order == loop_nhwcg)
+                    ih_e = ih_s + 1; //step instead
+                int d_len = 0, d_lo = 0, d_oj = 0;
+                if (is_fast_path_d) { // dilate == 0 && stride == 1
+                    int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                    int d_b_overflow
+                            = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                    d_len = jcp.kd - d_t_overflow - d_b_overflow;
+                    d_lo = d_b_overflow;
+                    d_oj = id_s + jcp.f_pad - d_b_overflow;
+                } else if (jcp.dilate_d != 0) { // stride == 1
+                    int dilate_d = jcp.dilate_d + 1;
+                    // Note: use div_up to account for "holes" in filter
+                    int d_t_overflow = div_up(
+                            max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                            dilate_d);
+                    int d_b_overflow = div_up(
+                            max(0,
+                                    (jcp.kd - 1) * dilate_d + 1 - jcp.id + id_s
+                                            - jcp.back_pad),
+                            dilate_d);
+                    d_len = jcp.kd - d_t_overflow - d_b_overflow;
+                    d_lo = d_b_overflow;
+                    d_oj = id_s + jcp.f_pad - d_b_overflow * dilate_d;
+                } else { // dilate == 0
+                    int d_t_overflow = max(
+                            0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
+                    int d_b_overflow = max(0,
+                            (jcp.kd - jcp.id + id_s - jcp.back_pad)
+                                    / jcp.stride_d);
+                    int overflow_kd_hi = jcp.kd - 1
+                            - modulo(jcp.id - 1 + jcp.back_pad - id_s,
+                                    jcp.stride_d);
+                    int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+
+                    d_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
+                            - d_t_overflow - d_b_overflow;
+                    d_lo = overflow_kd_lo + d_b_overflow * jcp.stride_d;
+                    d_oj = (id_s + jcp.f_pad - d_lo) / jcp.stride_d;
+                }
+
+                const bool is_dsrc_layout_nxc
+                        = jcp.src_tag == format_tag::ndhwc;
+                const int ic_off_idx = is_dsrc_layout_nxc
+                        ? g * jcp.ic + icb * jcp.ic_block
+                        : g_icb;
+                auto diff_src_w = diff_src + diff_src_d.blk_off(n, ic_off_idx)
+                        + id_s * diff_src_d_stride;
+                const bool is_ddst_layout_nxc
+                        = jcp.dst_tag == format_tag::ndhwc;
+                const int oc_off_idx = is_ddst_layout_nxc
+                        ? g * jcp.oc + ocb_l2 * jcp.oc_block
+                        : g_ocb + ocb_l2;
+                auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_off_idx)
+                        + d_oj * diff_dst_d_stride;
+                auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb)
+                        + d_lo * wht_d_stride;
+
+                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const int load_work = utils::this_block_size(icb * jcp.ic_block,
+                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
+                int reduce_work = ocb_step * jcp.oc_block;
+                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                    if (ocb + curr_nb_oc >= jcp.nb_oc) {
+                        reduce_work = utils::this_block_size(ocb * jcp.oc_block,
+                                jcp.oc, ocb_step * jcp.oc_block);
+                    }
+                    for (int ij = ih_s; ij < ih_e; ++ij) {
+                        int oj, k_len, k_lo;
+                        if (is_fast_path_h) { // dilate == 0 && stride == 1
+                            int i_t_overflow
+                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
+                            int i_b_overflow
+                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            k_len = jcp.kh - i_t_overflow - i_b_overflow;
+                            k_lo = i_b_overflow;
+                            oj = ij + jcp.t_pad - i_b_overflow;
+                        } else if (jcp.dilate_h != 0) { // stride == 1
+                            int dilate_h = jcp.dilate_h + 1;
+                            // Note: use div_up to account for "holes" in filter
+                            int i_t_overflow
+                                    = div_up(max(0,
+                                                     (jcp.kh - 1) * dilate_h
+                                                             - ij - jcp.t_pad),
+                                            dilate_h);
+                            int i_b_overflow = div_up(
+                                    max(0,
+                                            (jcp.kh - 1) * dilate_h + 1 - jcp.ih
+                                                    + ij - jcp.b_pad),
+                                    dilate_h);
+                            k_len = jcp.kh - i_t_overflow - i_b_overflow;
+                            k_lo = i_b_overflow;
+                            oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
+                        } else { // dilate == 0
+                            int i_t_overflow = max(0,
+                                    (jcp.kh - 1 - ij - jcp.t_pad)
+                                            / jcp.stride_h);
+                            int i_b_overflow = max(0,
+                                    (jcp.kh - jcp.ih + ij - jcp.b_pad)
+                                            / jcp.stride_h);
+                            int overflow_kh_hi = jcp.kh - 1
+                                    - modulo(jcp.ih - 1 + jcp.b_pad - ij,
+                                            jcp.stride_h);
+                            int overflow_kh_lo
+                                    = (ij + jcp.t_pad) % jcp.stride_h;
+
+                            k_len = (overflow_kh_hi - overflow_kh_lo)
+                                            / jcp.stride_h
+                                    + 1 - i_t_overflow - i_b_overflow;
+                            k_lo = overflow_kh_lo + i_b_overflow * jcp.stride_h;
+                            oj = (ij + jcp.t_pad - k_lo) / jcp.stride_h;
+                        }
+                        assert(k_len >= 0);
+
+                        jit_sve_512_conv_3d_ker_pipeline(jit_ker, par_conv,
+                                diff_src_w + ij * diff_src_h_stride,
+                                diff_dst_w + oj * diff_dst_h_stride,
+                                wht_w + k_lo * wht_h_stride, 0, ocb, k_len,
+                                d_len, reduce_work, load_work);
+                    }
+                    diff_dst_w += diff_dst_c_stride;
+                    wht_w += wht_oc_stride;
+                }
+
+                if (jcp.loop_order == loop_cwgn)
+                    nd_iterator_jump(start, end, icc, ic_chunks, gg, nb_groups,
+                            n, jcp.mb, id_s, jcp.id, ih_s, jcp.ih);
+                else if (jcp.loop_order == loop_gncw)
+                    nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, icc,
+                            ic_chunks, id_s, jcp.id, ih_s, jcp.ih);
+                else if (jcp.loop_order == loop_nhwcg) {
+                    ++start;
+                    nd_iterator_step(n, jcp.mb, id_s, jcp.id, ih_s, jcp.ih, icc,
+                            ic_chunks, gg, nb_groups);
+                } else
+                    assert(!"unsupported loop order");
+            }
+        }
+
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_sve_512_conv_3d_ker_pipeline(jit_ker, par_conv, diff_src, diff_dst,
+                weights, 0, 0, 1, 1, 0, 0);
+    });
+}
+
+template struct jit_sve_512_convolution_bwd_data_t<data_type::f32>;
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+status_t jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::init(engine_t *engine) {
+    const auto &j = pd()->jcp_;
+
+    nthr_ = j.nthr;
+    nthr_mb_ = j.nthr_mb;
+    nthr_g_ = j.nthr_g;
+    nthr_oc_b_ = j.nthr_oc_b;
+    nthr_ic_b_ = j.nthr_ic_b;
+
+    CHECK(safe_ptr_assign(
+            kernel_, new jit_sve_512_conv_bwd_weights_kernel_f32(j)));
+    CHECK(kernel_->create_kernel());
+
+    if (nthr_mb_ > 1) {
+        CHECK(safe_ptr_assign(
+                acc_ker_, new cpu_accumulator_1d_t<diff_weights_type>()));
+        CHECK(acc_ker_->create_kernel());
+    }
+
+    CHECK(safe_ptr_assign(reducer_bias_,
+            new cpu_reducer_t<diff_weights_type>(pd()->reducer_bia_conf_)));
+    CHECK(reducer_bias_->create_kernel());
+    return status::success;
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+struct jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::thread_info_t {
+    const src_data_t *src;
+    const diff_dst_data_t *diff_dst;
+    const diff_weights_data_t *diff_weights;
+    diff_weights_data_t *diff_bias;
+
+    const memory_tracking::grantor_t scratchpad;
+
+    src_data_t *tr_src;
+    simple_barrier::ctx_t *tr_src_bctx;
+
+    diff_dst_data_t *tr_diff_dst;
+    simple_barrier::ctx_t *tr_diff_dst_bctx;
+
+    diff_weights_data_t *wei_bia_reduction;
+    simple_barrier::ctx_t *wei_bia_reduction_bctx;
+
+    int ithr;
+    int ithr_ic_b, ithr_oc_b, ithr_g, ithr_mb;
+    int ithr_but_oc;
+    int ithr_but_ic;
+
+    int img_start = 0, img_end = 0, img_work;
+    int g_start = 0, g_end = 0, g_work;
+    int oc_b_start = 0, oc_b_end = 0, oc_b_work;
+    int ic_b_start = 0, ic_b_end = 0, ic_b_work;
+
+    thread_info_t(const jit_sve_512_convolution_bwd_weights_t *self,
+            const exec_ctx_t &ctx, int ithr)
+        : scratchpad(ctx.get_scratchpad_grantor()), ithr(ithr) {
+        diff_dst = CTX_IN_MEM(const diff_dst_data_t *, DNNL_ARG_DIFF_DST);
+        src = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+        diff_weights
+                = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_WEIGHTS);
+        const auto &jcp = self->kernel_->jcp;
+        const bool is_bias_padded = self->pd()->with_bias()
+                && jcp.oc_without_padding % jcp.oc_block != 0;
+        diff_bias = is_bias_padded
+                ? scratchpad.template get<diff_weights_data_t>(
+                        key_conv_padded_bias)
+                : CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
+
+        tr_src = scratchpad.template get<src_data_t>(key_conv_tr_src);
+        tr_src_bctx = scratchpad.template get<simple_barrier::ctx_t>(
+                key_conv_tr_src_bctx);
+
+        tr_diff_dst = scratchpad.template get<diff_dst_data_t>(
+                key_conv_tr_diff_dst);
+        tr_diff_dst_bctx = scratchpad.template get<simple_barrier::ctx_t>(
+                key_conv_tr_diff_dst_bctx);
+
+        wei_bia_reduction = scratchpad.template get<diff_weights_data_t>(
+                key_conv_wei_bia_reduction);
+        wei_bia_reduction_bctx = scratchpad.template get<simple_barrier::ctx_t>(
+                key_conv_wei_bia_reduction_bctx);
+
+        ithr_ic_b = ithr % self->nthr_ic_b_;
+        ithr_oc_b = ithr / self->nthr_ic_b_ % self->nthr_oc_b_;
+        ithr_g = ithr / self->nthr_ic_b_ / self->nthr_oc_b_ % self->nthr_g_;
+        ithr_mb = ithr / self->nthr_ic_b_ / self->nthr_oc_b_ / self->nthr_g_;
+
+        ithr_but_oc = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_ic_b_
+                + ithr_ic_b;
+
+        ithr_but_ic = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_oc_b_
+                + ithr_oc_b;
+
+        /* reduction dimension */
+        int oh_reduce = jcp.harness == harness_2d_reduction ? jcp.oh : 1;
+        balance211(jcp.mb * jcp.od * oh_reduce, self->nthr_mb_, ithr_mb,
+                img_start, img_end);
+        img_work = img_end - img_start;
+
+        /* independent dimensions */
+        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        g_work = g_end - g_start;
+
+        balance211(
+                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        oc_b_work = oc_b_end - oc_b_start;
+
+        balance211(
+                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        ic_b_work = ic_b_end - ic_b_start;
+    }
+};
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::compute_diff_weights(const thread_info_t *ti)
+        const {
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
+
+    const auto &jcp = kernel_->jcp;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw * jcp.kd;
+
+    diff_weights_data_t *diff_wei = ti->ithr_mb == 0
+            ? (diff_weights_data_t *)ti->diff_weights
+            : ti->wei_bia_reduction + (ti->ithr_mb - 1) * wei_size;
+    const bool is_src_layout_nxc = utils::one_of(
+            jcp.src_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+    int ic_b_step = jcp.nb_ic_blocking_max;
+    int icb_work = ti->ic_b_end - ti->ic_b_start;
+    if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
+        ic_b_step = utils::div_up(icb_work, 2);
+
+    for (int img = ti->img_start; img < ti->img_end; ++img) {
+        auto p = jit_conv_call_s();
+
+        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
+                format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+        for_(int g = ti->g_start; g < ti->g_end; ++g)
+        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+                ic_b += ic_b_step) {
+            const int _oc = g * jcp.nb_oc + oc_b;
+            const int _ic = g * jcp.nb_ic + ic_b;
+            const int ic_to_compute = this_block_size(
+                    ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
+            const int oc_to_compute = this_block_size(
+                    oc_b * jcp.oc_block, max_oc, jcp.oc_block);
+
+            const int ic_off_idx = is_src_layout_nxc
+                    ? g * jcp.ic + ic_b * jcp.ic_block
+                    : _ic;
+            const int oc_off_idx = is_ddst_layout_nxc
+                    ? g * jcp.oc + oc_b * jcp.oc_block
+                    : _oc;
+
+            jit_conv_ker_pipeline_bwd_w(jit_ker, p,
+                    &ti->src[src_d.blk_off(img, ic_off_idx)],
+                    &ti->diff_dst[diff_dst_d.blk_off(img, oc_off_idx)],
+                    diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b), 0,
+                    (img == ti->img_start), 0, ic_to_compute, oc_to_compute);
+        }
+
+        const int _oc = ti->g_start * jcp.nb_oc + ti->oc_b_start;
+        const int _ic = ti->g_start * jcp.nb_ic + ti->ic_b_start;
+        const int ic_off_idx = is_src_layout_nxc
+                ? ti->g_start * jcp.ic + ti->ic_b_start * jcp.ic_block
+                : _ic;
+        const int oc_off_idx = is_ddst_layout_nxc
+                ? ti->g_start * jcp.oc + ti->oc_b_start * jcp.oc_block
+                : _oc;
+        // This call is required only to finalize pipeline with paramaters
+        // set on the last iteration of loop above. Only valid pointers make
+        // sense here as call parameters to avoid execution of prefetch
+        // instructions with nullptr, other parameters are not used in real
+        // jit call here
+        jit_conv_ker_pipeline_bwd_w(jit_ker, p,
+                &ti->src[src_d.blk_off(img + 1, ic_off_idx)],
+                &ti->diff_dst[diff_dst_d.blk_off(img + 1, oc_off_idx)],
+                diff_wei
+                        + wht_blk_off(diff_weights_d, ti->g_start,
+                                ti->oc_b_start, ti->ic_b_start),
+                0, 0, 0, 0, 0);
+    }
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::compute_diff_weights_2d(const thread_info_t *ti)
+        const {
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
+
+    const auto &jcp = kernel_->jcp;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw;
+
+    diff_weights_data_t *diff_wei = ti->ithr_mb == 0
+            ? (diff_weights_data_t *)ti->diff_weights
+            : ti->wei_bia_reduction + (ti->ithr_mb - 1) * wei_size;
+    diff_weights_data_t *diff_bia = ti->ithr_mb == 0
+            ? (diff_weights_data_t *)ti->diff_bias
+            : ti->wei_bia_reduction + (nthr_mb_ - 1) * wei_size
+                    + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
+
+    int img {0}, oh_s {0};
+    int img_start = ti->img_start, img_end = ti->img_end;
+    nd_iterator_init(img_start, img, jcp.mb, oh_s, jcp.oh);
+    const int img_first = img;
+
+    int ic_b_step = jcp.nb_ic_blocking_max;
+    int icb_work = ti->ic_b_end - ti->ic_b_start;
+    if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
+        ic_b_step = utils::div_up(icb_work, 2);
+    while (img_start < img_end) {
+        auto p = jit_conv_call_s();
+
+        int work_rem = img_end - img_start;
+        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        const int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const int kh_top_overflow = nstl::max(0, -ih_s);
+        const int kh_bottom_overflow = nstl::max(0, ih_s - jcp.ih + jcp.kh);
+        int kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
+        int kh_padding_offset = nstl::min(jcp.kh - 1, kh_top_overflow) * jcp.kw
+                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        auto src_h = ti->src + src_d.blk_off(img, 0, ih_s + kh_top_overflow);
+        auto diff_dst_h = ti->diff_dst + diff_dst_d.blk_off(img, 0, oh_s);
+
+        const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
+        const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
+        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        for_(int g = ti->g_start; g < ti->g_end; ++g)
+        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+                ic_b += ic_b_step) {
+            const int _oc = g * jcp.nb_oc + oc_b;
+            const int _ic = g * jcp.nb_ic + ic_b;
+            const int ic_to_compute = this_block_size(
+                    ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
+            const int oc_to_compute = this_block_size(
+                    oc_b * jcp.oc_block, max_oc, jcp.oc_block);
+            const int ic_off_idx = is_src_layout_nxc
+                    ? g * jcp.ic + ic_b * jcp.ic_block
+                    : _ic;
+            const int oc_off_idx = is_ddst_layout_nxc
+                    ? g * jcp.oc + oc_b * jcp.oc_block
+                    : _oc;
+            auto src = src_h + src_d.blk_off(0, ic_off_idx);
+            auto diff_dst = diff_dst_h + diff_dst_d.blk_off(0, oc_off_idx);
+
+            jit_sve_512_conv_2d_ker_bwd_w_pipeline(jit_ker, p, src, diff_dst,
+                    diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
+                    diff_bia + _oc * jcp.oc_block, (img == img_first), oh_s,
+                    oh_e, kh_padding, kh_padding_offset, ic_to_compute,
+                    oc_to_compute);
+
+            p.flags = ic_b == 0 ? 0 : 1;
+        }
+
+        const int _oc = ti->g_start * jcp.nb_oc + ti->oc_b_start;
+        const int _ic = ti->g_start * jcp.nb_ic + ti->ic_b_start;
+        const int ic_off_idx = is_src_layout_nxc
+                ? ti->g_start * jcp.ic + ti->ic_b_start * jcp.ic_block
+                : _ic;
+        const int oc_off_idx = is_ddst_layout_nxc
+                ? ti->g_start * jcp.oc + ti->oc_b_start * jcp.oc_block
+                : _oc;
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_sve_512_conv_2d_ker_bwd_w_pipeline(jit_ker, p,
+                ti->src + src_d.blk_off(img + 1, ic_off_idx),
+                ti->diff_dst + diff_dst_d.blk_off(img + 1, oc_off_idx),
+                diff_wei
+                        + wht_blk_off(diff_weights_d, ti->g_start,
+                                ti->oc_b_start, ti->ic_b_start),
+                diff_bia + _oc * jcp.oc_block, 0, 0, 0, 0, 0, 0, 0);
+        nd_iterator_jump(img_start, img_end, img, jcp.mb, oh_s, jcp.oh);
+    }
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::compute_diff_weights_3d(const thread_info_t *ti)
+        const {
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
+
+    const auto &jcp = kernel_->jcp;
+    const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw * jcp.kd;
+
+    diff_weights_data_t *diff_wei = ti->ithr_mb == 0
+            ? (diff_weights_data_t *)ti->diff_weights
+            : ti->wei_bia_reduction + (ti->ithr_mb - 1) * wei_size;
+    diff_weights_data_t *diff_bia = ti->ithr_mb == 0
+            ? (diff_weights_data_t *)ti->diff_bias
+            : ti->wei_bia_reduction + (nthr_mb_ - 1) * wei_size
+                    + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
+
+    const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
+    const int inp_mult = is_src_layout_nxc
+            ? jcp.ngroups * jcp.ic
+            : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    const int input_step = jcp.ih * jcp.iw * inp_mult;
+    const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
+    const int output_step = jcp.ow * jcp.oh
+            * (is_ddst_layout_nxc ? jcp.ngroups * jcp.oc : jcp.oc_block);
+    int img {0}, od_s {0};
+    int img_start = ti->img_start, img_end = ti->img_end;
+    nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
+    const int img_first = img;
+
+    int ic_b_step = jcp.nb_ic_blocking_max;
+    int icb_work = ti->ic_b_end - ti->ic_b_start;
+    if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
+        ic_b_step = utils::div_up(icb_work, 2);
+
+    while (img_start < img_end) {
+        auto p = jit_conv_call_s();
+
+        int work_rem = img_end - img_start;
+        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        const int id_s = od_s * jcp.stride_d;
+        const int ik_overlap = nstl::max(0, id_s - jcp.f_pad);
+        const int kd_front_pad = nstl::max(0, jcp.f_pad - id_s);
+        const int kd_back_pad
+                = nstl::max(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
+        int kd_pad_off = nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw
+                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+
+        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+
+        for_(int g = ti->g_start; g < ti->g_end; ++g)
+        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+                ic_b += ic_b_step) {
+            const int _oc = g * jcp.nb_oc + oc_b;
+            const int _ic = g * jcp.nb_ic + ic_b;
+
+            const int ic_to_compute = this_block_size(
+                    ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
+            const int oc_to_compute = this_block_size(
+                    oc_b * jcp.oc_block, max_oc, jcp.oc_block);
+
+            const int ic_off_idx = is_src_layout_nxc
+                    ? g * jcp.ic + ic_b * jcp.ic_block
+                    : _ic;
+            const int oc_off_idx = is_ddst_layout_nxc
+                    ? g * jcp.oc + oc_b * jcp.oc_block
+                    : _oc;
+            auto src = &ti->src[src_d.blk_off(img, ic_off_idx)
+                    + ik_overlap * input_step];
+            auto dst = &ti->diff_dst[diff_dst_d.blk_off(img, oc_off_idx)
+                    + od_s * output_step];
+
+            jit_sve_512_conv_3d_ker_bwd_w_pipeline(jit_ker, p, src, dst,
+                    diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
+                    diff_bia + _oc * 16, (img == img_first), od_s, od_e,
+                    jcp.kd - kd_front_pad - kd_back_pad, kd_pad_off,
+                    ic_to_compute, oc_to_compute);
+
+            p.flags = ic_b == 0 ? 0 : 1;
+        }
+
+        const int _oc = ti->g_start * jcp.nb_oc + ti->oc_b_start;
+        const int _ic = ti->g_start * jcp.nb_ic + ti->ic_b_start;
+        const int ic_off_idx = is_src_layout_nxc
+                ? ti->g_start * jcp.ic + ti->ic_b_start * jcp.ic_block
+                : _ic;
+        const int oc_off_idx = is_ddst_layout_nxc
+                ? ti->g_start * jcp.oc + ti->oc_b_start * jcp.oc_block
+                : _oc;
+        // This call is required only to finalize pipeline with paramaters set
+        // on the last iteration of loop above. Only valid pointers make sense
+        // here as call parameters to avoid execution of prefetch instructions
+        // with nullptr, other parameters are not used in real jit call here
+        jit_sve_512_conv_3d_ker_bwd_w_pipeline(jit_ker, p,
+                &ti->src[src_d.blk_off(img + 1, ic_off_idx)],
+                &ti->diff_dst[diff_dst_d.blk_off(img + 1, oc_off_idx)],
+                diff_wei
+                        + wht_blk_off(diff_weights_d, ti->g_start,
+                                ti->oc_b_start, ti->ic_b_start),
+                diff_bia, 0, 0, 0, 0, 0, 0, 0);
+        nd_iterator_jump(img_start, img_end, img, jcp.mb, od_s, jcp.od);
+    }
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::reduce_diff_weights(const thread_info_t *ti) const {
+    const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
+
+    const auto &jcp = kernel_->jcp;
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw;
+    /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
+    if (dnnl_thr_syncable())
+        simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
+
+    const int ic_b_kh_work = ti->ic_b_work * jcp.kh;
+    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+
+    int start {0}, end {0};
+    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
+    if (start == end) return;
+
+    for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
+        int w = start;
+        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
+                ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
+        while (w < end) {
+            const int g = ti->g_start + sub_g_start;
+            const int oc_b = ti->oc_b_start + sub_oc_b_start;
+            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
+            const int kh = sub_ic_b_kh_start % jcp.kh;
+
+            const int acc_size
+                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+                    * jcp.kw * jcp.ic_block * jcp.oc_block;
+
+            const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kh);
+
+            diff_weights_data_t *d
+                    = (diff_weights_data_t *)ti->diff_weights + off;
+            diff_weights_data_t *s
+                    = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
+
+            acc_ker_->accumulate(d, s, acc_size);
+
+            nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
+                    ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
+        }
+    }
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::reduce_diff_weights_3d(const thread_info_t *ti)
+        const {
+    const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
+
+    const auto &jcp = kernel_->jcp;
+    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
+
+    /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
+    if (dnnl_thr_syncable())
+        simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
+
+    const int ic_b_kh_work = ti->ic_b_work * jcp.kd;
+    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+
+    int start {0}, end {0};
+    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
+    if (start == end) return;
+
+    for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
+        int w = start;
+        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
+                ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
+        while (w < end) {
+            const int g = ti->g_start + sub_g_start;
+            const int oc_b = ti->oc_b_start + sub_oc_b_start;
+            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
+            const int kd = sub_ic_b_kh_start % jcp.kd;
+
+            const int acc_size
+                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+                    * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.kh;
+
+            const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kd);
+            diff_weights_data_t *d
+                    = (diff_weights_data_t *)ti->diff_weights + off;
+            diff_weights_data_t *s
+                    = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
+            acc_ker_->accumulate(d, s, acc_size);
+
+            nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
+                    ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
+        }
+    }
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::compute_diff_bias(const thread_info_t *ti) const {
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+
+    auto rb = this->reducer_bias_;
+    assert(nthr_ == rb->balancer().nthr_);
+
+    const auto reducer_bia_scratchpad
+            = memory_tracking::grantor_t(ti->scratchpad, prefix_reducer_bia);
+
+    const auto &jcp = kernel_->jcp;
+
+    const int b_job_start = rb->balancer().ithr_job_off(ti->ithr);
+    const int b_njobs = rb->balancer().ithr_njobs(ti->ithr);
+
+    if (b_njobs == 0) return;
+
+    /* reduction dimension */
+    int img_start {0}, img_end {0};
+    balance211(jcp.mb, rb->balancer().nthr_per_group_,
+            rb->balancer().id_in_group(ti->ithr), img_start, img_end);
+
+    /* jobs */
+    int g_start {0}, ocb_start {0};
+    nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
+    for (int img = img_start; img < img_end; ++img) {
+        int g = g_start, ocb = ocb_start;
+        for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
+            const size_t _oc = g * jcp.nb_oc + ocb;
+            const int max_oc
+                    = this_block_size(ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
+
+            const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
+                    format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+            const int oc_off_idx = is_ddst_layout_nxc
+                    ? g * jcp.oc + ocb * jcp.oc_block
+                    : _oc;
+            const diff_dst_data_t *d_dst
+                    = &ti->diff_dst[diff_dst_d.blk_off(img, oc_off_idx)];
+            diff_weights_data_t *d_bias
+                    = rb->get_local_ptr(
+                              ti->ithr, ti->diff_bias, reducer_bia_scratchpad)
+                    + b_job_loc * rb->balancer().job_size_;
+
+            if (img == img_start)
+                for (int o = 0; o < jcp.oc_block; ++o)
+                    d_bias[o] = 0;
+            for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
+                PRAGMA_OMP_SIMD()
+                for (int o = 0; o < max_oc; ++o)
+                    d_bias[o] += d_dst[o];
+                d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
+                                            : jcp.oc_block;
+            }
+
+            nd_iterator_step(g, jcp.ngroups, ocb, jcp.nb_oc);
+        }
+    }
+
+    if (dnnl_thr_syncable())
+        rb->reduce(ti->ithr, ti->diff_bias, reducer_bia_scratchpad);
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::reduce_diff_bias(const thread_info_t *ti) const {
+    const auto &jcp = kernel_->jcp;
+
+    const size_t wei_size = (size_t)jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
+    const int bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
+    const diff_weights_data_t *diff_bias_ws
+            = ti->wei_bia_reduction + (size_t)(nthr_mb_ - 1) * wei_size;
+
+    if (dnnl_thr_syncable() && nthr_mb_ > 1) dnnl_thr_barrier();
+
+    if (ti->ithr == 0) {
+        for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
+            acc_ker_->accumulate(ti->diff_bias, diff_bias_ws, bia_size);
+            diff_bias_ws += bia_size;
+        }
+    }
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::prepare_scratchpad_data(const exec_ctx_t &ctx)
+        const {
+    auto scratchpad = ctx.get_scratchpad_grantor();
+
+    if (dnnl_thr_syncable() && nthr_mb_ > 1) {
+        simple_barrier::ctx_init(scratchpad.template get<simple_barrier::ctx_t>(
+                key_conv_wei_bia_reduction_bctx));
+    }
+
+    const auto reducer_bia_scratchpad
+            = memory_tracking::grantor_t(scratchpad, prefix_reducer_bia);
+    auto rb = this->reducer_bias_;
+    rb->init(reducer_bia_scratchpad);
+}
+
+template <data_type_t src_type, data_type_t diff_dst_type,
+        data_type_t diff_weights_type>
+void jit_sve_512_convolution_bwd_weights_t<src_type, diff_dst_type,
+        diff_weights_type>::execute_backward_weights(const exec_ctx_t &ctx)
+        const {
+    prepare_scratchpad_data(ctx);
+
+#if DNNL_THR_SYNC == 1
+    parallel(nthr_, [&](const int ithr, const int nthr) {
+        assert(nthr_ == nthr);
+
+        thread_info_t thread_info(this, ctx, ithr);
+
+        switch (pd()->jcp_.harness) {
+            case harness_2d_reduction:
+                compute_diff_weights_2d(&thread_info);
+                if (nthr_mb_ > 1) reduce_diff_weights(&thread_info);
+                if (pd()->with_bias()) reduce_diff_bias(&thread_info);
+                break;
+            case harness_3d_reduction:
+                compute_diff_weights_3d(&thread_info);
+                if (nthr_mb_ > 1) reduce_diff_weights_3d(&thread_info);
+                if (pd()->with_bias()) reduce_diff_bias(&thread_info);
+                break;
+            case harness_mb_reduction:
+                compute_diff_weights(&thread_info);
+                if (nthr_mb_ > 1) reduce_diff_weights(&thread_info);
+                if (pd()->with_bias()) compute_diff_bias(&thread_info);
+                break;
+            default: assert(!"Invalid harness type");
+        }
+    });
+#else
+    parallel(nthr_, [&](const int ithr, const int nthr) {
+        thread_info_t thread_info(this, ctx, ithr);
+        switch (pd()->jcp_.harness) {
+            case harness_2d_reduction:
+                compute_diff_weights_2d(&thread_info);
+                break;
+            case harness_3d_reduction:
+                compute_diff_weights_3d(&thread_info);
+                break;
+            case harness_mb_reduction:
+                compute_diff_weights(&thread_info);
+                if (pd()->with_bias()) compute_diff_bias(&thread_info);
+                break;
+            default: assert(!"Invalid harness type");
+        }
+    });
+
+    parallel(nthr_, [&](const int ithr, const int nthr) {
+        thread_info_t thread_info(this, ctx, ithr);
+        if (nthr_mb_ > 1) {
+            switch (pd()->jcp_.harness) {
+                case harness_mb_reduction:
+                case harness_2d_reduction:
+                    reduce_diff_weights(&thread_info);
+                    break;
+                case harness_nxc:
+                case harness_3d_reduction:
+                    reduce_diff_weights_3d(&thread_info);
+                    break;
+                default: assert(!"Invalid harness type");
+            }
+        }
+        if (pd()->with_bias()) {
+            switch (pd()->jcp_.harness) {
+                case harness_2d_reduction:
+                case harness_3d_reduction:
+                    reduce_diff_bias(&thread_info);
+                    break;
+                case harness_nxc:
+                case harness_mb_reduction: {
+                    auto rb = this->reducer_bias_;
+                    assert(nthr == rb->balancer().nthr_);
+                    if (rb->balancer().ithr_njobs(ithr) == 0) return;
+                    const auto reducer_bia_scratchpad
+                            = memory_tracking::grantor_t(
+                                    thread_info.scratchpad, prefix_reducer_bia);
+                    rb->reduce_nolock(thread_info.ithr, thread_info.diff_bias,
+                            reducer_bia_scratchpad);
+                } break;
+                default: assert(!"Invalid harness type");
+            }
+        }
+    });
+#endif
+
+    /* TODO: put that into compute_diff_bias() */
+    auto &jcp = pd()->jcp_;
+    if (pd()->with_bias() && jcp.oc_without_padding % jcp.oc_block != 0) {
+        auto diff_bias = ctx.get_scratchpad_grantor()
+                                 .template get<const diff_weights_data_t>(
+                                         key_conv_padded_bias);
+        auto diff_bias_in
+                = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
+        const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+        const int stride = jcp.oc_without_padding;
+        for (int g = 0; g < jcp.ngroups; ++g) {
+            utils::array_copy(diff_bias_in + g * stride,
+                    diff_bias + g * padded_stride, stride);
+        }
+    }
+}
+
+template struct jit_sve_512_convolution_bwd_weights_t<data_type::f32>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_sve_512_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_convolution.hpp
@@ -1,0 +1,275 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_SVE_CONVOLUTION_HPP
+#define CPU_AARCH64_JIT_SVE_CONVOLUTION_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/cpu_barrier.hpp"
+#include "cpu/aarch64/cpu_reducer.hpp"
+#include "cpu/cpu_convolution_pd.hpp"
+
+#include "cpu/aarch64/jit_sve_512_conv_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <impl::data_type_t src_type, impl::data_type_t wei_type = src_type,
+        impl::data_type_t dst_type = src_type>
+struct jit_sve_512_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), jcp_() {}
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", sve_512, ""),
+                jit_sve_512_convolution_fwd_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && is_fwd()
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(src_type, wei_type, dst_type, dst_type,
+                            data_type::undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, dst_type)
+                    && !has_zero_dim_memory();
+            if (!ok) return status::unimplemented;
+
+            status_t status = jit_sve_512_conv_fwd_kernel::init_conf(jcp_,
+                    *desc(), src_md_, weights_md_, dst_md_, bias_md_, *attr(),
+                    dnnl_get_max_threads());
+            if (status != status::success) return status;
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_sve_512_conv_fwd_kernel::init_scratchpad(scratchpad, jcp_);
+
+            return status;
+        }
+
+        jit_conv_conf_t jcp_;
+    };
+
+    jit_sve_512_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    typedef typename prec_traits<src_type>::type src_data_t;
+    typedef typename prec_traits<wei_type>::type wei_data_t;
+    typedef typename prec_traits<dst_type>::type dst_data_t;
+
+    status_t init(engine_t *engine) override {
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_sve_512_conv_fwd_kernel(pd()->jcp_, *pd()->attr())));
+        return kernel_->create_kernel();
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        if (pd()->ndims() == 3)
+            execute_forward_1d(ctx);
+        else if (pd()->ndims() == 4)
+            execute_forward_2d(ctx);
+        else if (pd()->ndims() == 5)
+            execute_forward_3d(ctx);
+        else
+            assert(false);
+
+        if (pd()->wants_zero_pad_dst())
+            ctx.memory(DNNL_ARG_DST)->zero_pad(ctx.stream());
+
+        return status::success;
+    }
+
+private:
+    void prepare_padded_bias(const dst_data_t *&bias,
+            const memory_tracking::grantor_t &scratchpad) const;
+    void execute_forward_1d(const exec_ctx_t &ctx) const;
+    void execute_forward_2d(const exec_ctx_t &ctx) const;
+    void execute_forward_3d(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_sve_512_conv_fwd_kernel> kernel_;
+};
+
+template <impl::data_type_t diff_dst_type,
+        impl::data_type_t wei_type = diff_dst_type,
+        impl::data_type_t diff_src_type = diff_dst_type>
+struct jit_sve_512_convolution_bwd_data_t : public primitive_t {
+    struct pd_t : public cpu_convolution_bwd_data_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const convolution_fwd_pd_t *hint_fwd_pd)
+            : cpu_convolution_bwd_data_pd_t(adesc, attr, hint_fwd_pd), jcp_() {}
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", sve_512, ""),
+                jit_sve_512_convolution_bwd_data_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && desc()->prop_kind == prop_kind::backward_data
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(diff_src_type, wei_type,
+                            data_type::undef, diff_dst_type, data_type::undef)
+                    && attr()->has_default_values() && !has_zero_dim_memory();
+            if (!ok) return status::unimplemented;
+
+            status_t status = jit_sve_512_conv_bwd_data_kernel_f32::init_conf(
+                    jcp_, *desc(), diff_src_md_, weights_md_, diff_dst_md_,
+                    dnnl_get_max_threads());
+            if (status != status::success) return status;
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_sve_512_conv_bwd_data_kernel_f32::init_scratchpad(
+                    scratchpad, jcp_);
+
+            return status::success;
+        }
+
+        jit_conv_conf_t jcp_;
+    };
+
+    jit_sve_512_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
+
+    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits<wei_type>::type wei_data_t;
+    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+
+    status_t init(engine_t *engine) override {
+        CHECK(safe_ptr_assign(
+                kernel_, new jit_sve_512_conv_bwd_data_kernel_f32(pd()->jcp_)));
+        return kernel_->create_kernel();
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        if (pd()->ndims() == 3)
+            execute_backward_data_1d(ctx);
+        else if (pd()->ndims() == 4)
+            execute_backward_data_2d(ctx);
+        else if (pd()->ndims() == 5)
+            execute_backward_data_3d(ctx);
+        else
+            assert(false);
+        return status::success;
+    }
+
+private:
+    void execute_backward_data_1d(const exec_ctx_t &ctx) const;
+    void execute_backward_data_2d(const exec_ctx_t &ctx) const;
+    void execute_backward_data_3d(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_sve_512_conv_bwd_data_kernel_f32> kernel_;
+};
+
+template <impl::data_type_t src_type,
+        impl::data_type_t diff_dst_type = src_type,
+        impl::data_type_t diff_weights_type = src_type>
+struct jit_sve_512_convolution_bwd_weights_t : public primitive_t {
+    struct pd_t : public cpu_convolution_bwd_weights_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const convolution_fwd_pd_t *hint_fwd_pd)
+            : cpu_convolution_bwd_weights_pd_t(adesc, attr, hint_fwd_pd)
+            , jcp_() {}
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", sve_512, ""),
+                jit_sve_512_convolution_bwd_weights_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && desc()->prop_kind == prop_kind::backward_weights
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(src_type, diff_weights_type,
+                            diff_weights_type, diff_dst_type, data_type::undef)
+                    && attr()->has_default_values() && !has_zero_dim_memory();
+            if (!ok) return status::unimplemented;
+
+            status_t status
+                    = jit_sve_512_conv_bwd_weights_kernel_f32::init_conf(jcp_,
+                            *desc(), src_md_, diff_weights_md_, diff_bias_md_,
+                            diff_dst_md_, dnnl_get_max_threads());
+            if (status != status::success) return status;
+
+            init_balancers();
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_sve_512_conv_bwd_weights_kernel_f32::init_scratchpad(
+                    scratchpad, jcp_);
+
+            auto reducer_bia_scratchpad = memory_tracking::registrar_t(
+                    scratchpad, memory_tracking::names::prefix_reducer_bia);
+            reducer_bia_conf_.init_scratchpad(reducer_bia_scratchpad);
+
+            return status;
+        }
+
+        jit_conv_conf_t jcp_;
+        typename cpu_reducer_t<diff_weights_type>::conf_t reducer_bia_conf_;
+
+    private:
+        void init_balancers() {
+            const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
+            if (with_bias()) {
+                reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
+                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_oc, jcp_.mb,
+                        max_buffer_size, true));
+            }
+        }
+    };
+
+    jit_sve_512_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
+
+    typedef typename prec_traits<src_type>::type src_data_t;
+    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits<diff_weights_type>::type diff_weights_data_t;
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_backward_weights(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_backward_weights(const exec_ctx_t &ctx) const;
+    void prepare_scratchpad_data(const exec_ctx_t &ctx) const;
+    struct thread_info_t;
+    void compute_diff_weights(const thread_info_t *) const;
+    void compute_diff_weights_2d(const thread_info_t *) const;
+    void compute_diff_weights_3d(const thread_info_t *) const;
+    void reduce_diff_weights(const thread_info_t *) const;
+    void reduce_diff_weights_3d(const thread_info_t *) const;
+    void compute_diff_bias(const thread_info_t *) const;
+    void reduce_diff_bias(const thread_info_t *) const;
+
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    int nthr_, nthr_mb_, nthr_g_, nthr_oc_b_, nthr_ic_b_;
+
+    jit_sve_512_conv_bwd_weights_kernel_f32 *kernel_;
+    cpu_accumulator_1d_t<diff_weights_type> *acc_ker_;
+    cpu_reducer_t<diff_weights_type> *reducer_bias_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2021 Intel Corporation
 * Copyright 2020 Arm Ltd. and affiliates
+* Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,6 +57,9 @@ using namespace dnnl::impl::cpu::aarch64;
 #include "cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp"
 #include "cpu/x64/jit_uni_x8s8s32x_convolution.hpp"
 using namespace dnnl::impl::cpu::x64;
+#elif DNNL_AARCH64
+#include "cpu/aarch64/jit_sve_512_convolution.hpp"
+using namespace dnnl::impl::cpu::aarch64;
 #endif
 
 namespace dnnl {
@@ -103,6 +107,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_sse41_1x1_convolution_fwd_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_fwd_t)
         CPU_INSTANCE_X64(jit_sse41_convolution_fwd_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
         CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
         CPU_INSTANCE(gemm_convolution_fwd_t)
         CPU_INSTANCE(ref_convolution_fwd_t<f32>)
@@ -141,6 +146,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_avx2_1x1_convolution_bwd_data_t)
         CPU_INSTANCE_X64(jit_sse41_dw_convolution_bwd_data_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_bwd_data_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_convolution_bwd_data_t<f32>)
         CPU_INSTANCE(gemm_convolution_bwd_data_t)
         CPU_INSTANCE(ref_convolution_bwd_data_t<f32, f32, f32, f32>)
         nullptr,
@@ -174,6 +180,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_avx2_1x1_convolution_bwd_weights_t)
         CPU_INSTANCE_X64(jit_sse41_dw_convolution_bwd_weights_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_bwd_weights_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_convolution_bwd_weights_t<f32>)
         CPU_INSTANCE(gemm_convolution_bwd_weights_t)
         CPU_INSTANCE(ref_convolution_bwd_weights_t<f32, f32, f32, f32>)
         nullptr,

--- a/tests/gtests/test_iface_attr.cpp
+++ b/tests/gtests/test_iface_attr.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
-* Copyright 2017-2020 Intel Corporation
+* Copyright 2017-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -408,6 +409,9 @@ HANDLE_EXCEPTIONS_FOR_TEST_F(attr_test_t, DepthwiseFusion) {
     auto engine_kind = get_test_engine_kind();
     SKIP_IF(engine_kind != engine::kind::cpu,
             "Depthwise fusion is only supported on CPU engine");
+#if DNNL_AARCH64
+    SKIP_IF(true, "Depthwise fusion is not supported on AArch64 at this time");
+#endif
 
     engine e {engine_kind, 0};
 


### PR DESCRIPTION
# Description

This PR adds JIT support of convolution_f32 for AArch64.
It includes JIT implementation for SVE 512.

Related RFC #841
Related PR #850

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
  - "benchdnn --conv --batch=inputs/conv/test_conv_ci" is OK. 
  - "test_conv_all" is OK. ~~still running...~~ : (The test_conv_gpu outputted 200 unimplemented.)

- [x] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

There is no need to make a new tests for this PR,
since we can use the existing gtests and benchdnn for this PR.
