### PR TITLE
cpu: aarch64: add JIT implementation for pooling

### DIFF
--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -92,7 +92,11 @@ struct cpu_isa_traits<isa_all> {
 
 template <>
 struct cpu_isa_traits<asimd> {
-    typedef Xbyak_aarch64::VReg4S Vmm;
+    typedef Xbyak_aarch64::VReg TReg;
+    typedef Xbyak_aarch64::VReg16B TRegB;
+    typedef Xbyak_aarch64::VReg8H TRegH;
+    typedef Xbyak_aarch64::VReg4S TRegS;
+    typedef Xbyak_aarch64::VReg2D TRegD;
     static constexpr int vlen_shift = 4;
     static constexpr int vlen = 16;
     static constexpr int n_vregs = 32;
@@ -103,7 +107,11 @@ struct cpu_isa_traits<asimd> {
 
 template <>
 struct cpu_isa_traits<sve_512> {
-    typedef Xbyak_aarch64::ZRegS Vmm;
+    typedef Xbyak_aarch64::ZReg TReg;
+    typedef Xbyak_aarch64::ZRegB TRegB;
+    typedef Xbyak_aarch64::ZRegH TRegH;
+    typedef Xbyak_aarch64::ZRegS TRegS;
+    typedef Xbyak_aarch64::ZRegD TRegD;
     static constexpr int vlen_shift = 6;
     static constexpr int vlen = 64;
     static constexpr int n_vregs = 32;

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -115,6 +115,10 @@ public:
     const Xbyak_aarch64::PReg P_MSB_384 = p14;
     const Xbyak_aarch64::PReg P_ALL_ONE = p15;
 
+    const std::vector<Xbyak_aarch64::XReg> x_tmp_vec
+            = {X_TMP_0, X_TMP_1, X_TMP_2, X_TMP_3, X_TMP_4};
+    const int x_tmp_vec_size = x_tmp_vec.size();
+
     const Xbyak_aarch64::XReg param1 = abi_param1;
     constexpr static size_t translator_stack_offset = 1024 * 128;
     constexpr static uint32_t DUMMY_IDX = 99;

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_PRIMITIVE_CONF_HPP
+#define CPU_AARCH64_JIT_PRIMITIVE_CONF_HPP
+
+#include <stdint.h>
+
+#include "common/primitive_attr.hpp"
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+enum class jit_memory_tag_kind_t { ncsp, nspc, blocked, undef };
+
+inline int calculate_end_padding(int start_padding, int dst_size, int src_size,
+        int spatial_stride, int dilated_filter_size) {
+    return (dst_size - 1) * spatial_stride + dilated_filter_size
+            - (src_size + start_padding);
+}
+
+struct jit_pool_conf_t {
+    int ndims;
+    int mb, c, c_without_padding;
+    int id, ih, iw, od, oh, ow;
+    int stride_d, stride_h, stride_w;
+    int kd, kh, kw;
+    int f_pad, t_pad, l_pad;
+    alg_kind_t alg;
+    bool is_training;
+    bool pad_w_is_null;
+    bool is_backward;
+    bool simple_alg;
+    bool is_c_padded;
+    data_type_t ind_dt;
+
+    int c_block, c_tail, nb_c;
+    int ur_bc, ur_bc_tail;
+    int ur_c, ur_c_tail;
+    int ur;
+    size_t tail[4];
+    bool safe_c_tail;
+    data_type_t src_dt;
+    data_type_t dst_dt;
+
+    int dt_size;
+    bool is_bf16;
+    jit_memory_tag_kind_t tag_kind;
+    bool is_plain() const {
+        return (tag_kind == jit_memory_tag_kind_t::ncsp
+                || tag_kind == jit_memory_tag_kind_t::nspc);
+    }
+
+    cpu_isa_t isa;
+    post_ops_t post_ops;
+    bool with_postops;
+    bool with_eltwise;
+    bool with_binary;
+};
+
+struct jit_pool_call_s {
+    const void *src;
+    const void *dst;
+    const void *indices;
+    const void *src_prf;
+    const void *dst_prf;
+    const void *indices_prf;
+    const void *post_ops_binary_rhs_arg_vec;
+    size_t c_elem_off;
+    size_t zero_ih;
+    size_t zero_id;
+    const void *zero_ptr;
+    size_t kd_padding;
+    size_t kh_padding;
+    size_t kh_padding_shift;
+    size_t kd_padding_shift;
+    size_t kw_padding;
+    const void *init_value;
+    float ker_area_h;
+    size_t ur_bc; // contains number of channel blocks to processing
+    size_t b_c; // contains number of channel blocks already processed
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
@@ -1,0 +1,910 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include "cpu/aarch64/jit_uni_i8i8_pooling.hpp"
+#include <math.h>
+
+#include "common/dnnl_thread.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+static inline dim_t get_offset(
+        const memory_desc_wrapper &mdw, int n, int c, int d, int h, int w) {
+    switch (mdw.ndims()) {
+        case 3: return mdw.blk_off(n, c, w);
+        case 4: return mdw.blk_off(n, c, h, w);
+        case 5: return mdw.blk_off(n, c, d, h, w);
+        default: assert(!"Invalid tensor dimension in pooling");
+    }
+    return 0;
+}
+
+using namespace Xbyak_aarch64;
+
+using namespace dnnl::impl::utils;
+using namespace dnnl::impl::types;
+using namespace alg_kind;
+
+#define GET_OFF(field) offsetof(call_params_t, field)
+
+struct call_params_t {
+    const char *src_i8;
+    const char *dst_i8;
+    size_t kd_range;
+    size_t kh_range;
+    size_t kw_range;
+    float idivider;
+    const char *src_safe_access;
+    const char *dst_safe_access;
+};
+
+template <cpu_isa_t isa>
+struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_i8i8_pooling_fwd_ker_t)
+
+    using TReg = typename cpu_isa_traits<isa>::TReg;
+
+    VReg xreg(int idx) const { return VReg(idx); }
+    ZReg yreg(int idx) const { return ZReg(xreg(idx).getIdx()); }
+    TReg vreg(int idx) const { return TReg(xreg(idx).getIdx()); }
+    XReg reg_param = x0;
+    XReg reg_ptr_src_i8 = x4;
+    XReg reg_ptr_dst_i8 = x5;
+    XReg reg_ptr_maskmovdqu_dst = x3;
+
+    XReg reg_kd_index = x0;
+    XReg reg_kh_index = x11;
+    XReg reg_kw_index = x10;
+    XReg reg_kd = x14;
+    XReg reg_kh = x13;
+    XReg reg_kw = x12;
+    XReg c_iter = x15; // shared with reg_mask; only used after mask init
+
+    XReg aux_reg_src_d
+            = x2; // shared with reg_tmp; loaded before each accum loop, unused during store
+    XReg aux_reg_src_h = x7;
+    XReg aux_reg_src_w = x1;
+
+    XReg reg_tmp = x2; // only used during mask init and store
+    XReg reg_src_safe_access = x9;
+    XReg reg_dst_safe_access = x1;
+
+    XReg reg_mask = x15; // only used during mask init
+
+    PReg k_cmp_mask = p7;
+    PReg mask(int idx) { return PReg(6 - idx); } /* 6, 5, 4, 3 */
+
+    PReg p_all_zero = p0;
+    PReg p_512 = p2;
+    PReg p_tmp0 = p1;
+
+    VReg xmm_tmp = xreg(0); // temp to init vreg_tmp
+    TReg vreg_tmp = vreg(0); // max pooling : holds minimum values for data_type
+    TReg vreg_zeros = vreg(1);
+
+    ZReg z_tmp0 = z24;
+
+    int post_op_tail_opmask_idx_ = -1;
+    jit_pool_conf_t jpp;
+
+    enum : int { max_vidx_base = 2 };
+    //"avg" pool uses more registers for unrolling.
+    enum : int { avg_vidx_base = 2 };
+
+    TReg max_base_vr(int idx) const { return vreg(max_vidx_base + idx); }
+    TReg avg_base_vr(int idx) const { return vreg(avg_vidx_base + idx); }
+
+    size_t sizeof_src_dt() const { return data_type_size(jpp.src_dt); }
+    size_t sizeof_dst_dt() const { return data_type_size(jpp.dst_dt); }
+
+    /* max pooling */
+    TReg vreg_src(int idx) const {
+        return max_base_vr(idx);
+    } // [0    .. ur_c-1]
+    TReg vreg_dst(int idx) const {
+        return max_base_vr(jpp.ur_c + idx);
+    } // [ur_c .. 2*ur_c-1]
+
+    /* avg pooling */
+    // s32 used for processing of s8/u8 data
+    // thus we need to take into account ratio of sizes s32/i8 = 4
+    static constexpr data_type_t avg_proc_dt = data_type::s32;
+    enum : int {
+        s32_to_i8_ratio = sizeof(typename prec_traits<avg_proc_dt>::type)
+                / sizeof(typename prec_traits<data_type::u8>::type),
+        max_num_ll = s32_to_i8_ratio,
+        mmx_msk_base_reg = 3
+    };
+
+    TReg vreg_src_s32(int jj, int ll) {
+        return avg_base_vr(3 * max_num_ll * jj + ll + 0 * max_num_ll);
+    } // ll: 0..4 [0..3]
+
+    TReg vreg_dst_s32(int jj, int ll) {
+        return avg_base_vr(3 * max_num_ll * jj + ll + 1 * max_num_ll);
+    } // ll: 0..4 [4..7]
+
+    TReg vreg_dst_f32(int jj, int ll) {
+        return avg_base_vr(3 * max_num_ll * jj + ll + 2 * max_num_ll);
+    } // ll: 0..4 [8..11]
+
+    static bool post_ops_ok(jit_pool_conf_t &jpp, const primitive_attr_t &attr,
+            const memory_desc_wrapper &dst_d);
+
+    void init_tmp_reg();
+    void init_mask();
+
+    void load_vreg_mask_q(int ll) {};
+
+    void load_src_max_op(
+            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+    void load_src_avg_op(
+            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+    void load_src(int jj, int ll, int c_tail);
+
+    void store_dst_max_op(
+            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+    void store_dst_avg_op(
+            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+    void store_dst(int jj, int ll, int c_tail);
+
+    void compute_avg_step(int ur_c, int c_tail);
+    void compute_max_op(const int jj);
+    void compute_max_step(int ur_c, int c_tail);
+    void compute_step(int ur_c, int c_tail);
+
+    void compute_c_block();
+    void generate() override;
+
+    static status_t init_conf(jit_pool_conf_t &jpp, const pooling_pd_t *ppd);
+
+    jit_uni_i8i8_pooling_fwd_ker_t(
+            const jit_pool_conf_t &jpp_, const memory_desc_t *dst_md)
+        : jit_generator(nullptr, MAX_CODE_SIZE, true), jpp(jpp_) {}
+};
+
+template <>
+void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::load_src_max_op(
+        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+    using namespace data_type;
+
+    if (masked) {
+        if (jpp.src_dt == s32) {
+            add_imm(X_DEFAULT_ADDR, aux_reg_src_w, offset, X_TMP_0);
+            zip1(p_tmp0.b, mask(0).b, p_all_zero.b);
+            zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+            ld1w(z_tmp0.s, p_tmp0 / T_z, ptr(X_DEFAULT_ADDR));
+            mov(vreg_src(jj).s, p_tmp0 / T_m, z_tmp0.s);
+        } else {
+            add_imm(X_DEFAULT_ADDR, aux_reg_src_w, offset, X_TMP_0);
+            ld1b(z_tmp0.b, mask(0) / T_z, ptr(X_DEFAULT_ADDR));
+            mov(vreg_src(jj).b, mask(0) / T_m, z_tmp0.b);
+        }
+    } else {
+        add_imm(X_DEFAULT_ADDR, aux_reg_src_w, offset, X_TMP_0);
+        ldr(vreg_src(jj), ptr(X_DEFAULT_ADDR));
+    }
+};
+
+template <>
+void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::load_src_avg_op(
+        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+    using namespace data_type;
+
+    const TReg &vr_src = vreg_src_s32(jj, ll);
+
+    switch (jpp.src_dt) {
+        case s32:
+            add_imm(X_DEFAULT_ADDR, aux_reg_src_w, offset * data_type_size(s32),
+                    X_TMP_0);
+            if (masked) {
+                zip1(p_tmp0.b, mask(ll).b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                ld1w(z_tmp0.s, p_tmp0 / T_z, ptr(X_DEFAULT_ADDR));
+                mov(vr_src.s, p_tmp0 / T_m, z_tmp0.s);
+            } else {
+                ldr(vr_src, ptr(X_DEFAULT_ADDR));
+            }
+            break;
+        case s8:
+            add_imm(X_DEFAULT_ADDR, aux_reg_src_w, offset, X_TMP_0);
+            if (masked) {
+                zip1(p_tmp0.b, mask(ll).b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                // use p_tmp, uzp1 can be eliminate.
+                ld1b(z_tmp0.s, p_tmp0 / T_z, ptr(X_DEFAULT_ADDR));
+                sxtb(vr_src.s, p_tmp0 / T_m, z_tmp0.s);
+            } else {
+                ld1b(z_tmp0.s, p_512 / T_z, ptr(X_DEFAULT_ADDR));
+                sxtb(vr_src.s, p_512 / T_m, z_tmp0.s);
+            }
+            break;
+        case u8:
+            add_imm(X_DEFAULT_ADDR, aux_reg_src_w, offset, X_TMP_0);
+            if (masked) {
+                zip1(p_tmp0.b, mask(ll).b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                // use p_tmp, uzp1 can be eliminate.
+                ld1b(z_tmp0.s, p_tmp0 / T_z, ptr(X_DEFAULT_ADDR));
+                uxtb(vr_src.s, p_tmp0 / T_m, z_tmp0.s);
+            } else {
+                ldr(QReg(z_tmp0.getIdx()), ptr(X_DEFAULT_ADDR));
+                zip1(z_tmp0.b, z_tmp0.b, z_tmp0.b);
+                zip1(z_tmp0.h, z_tmp0.h, z_tmp0.h);
+                uxtb(vr_src.s, p_512 / T_m, z_tmp0.s);
+            }
+            break;
+        default: assert(!"unsupported src data type");
+    }
+};
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(int jj, int ll, int c_tail) {
+    using namespace data_type;
+
+    int c_block = jpp.c_block;
+    int ur_c = jpp.ur_c;
+
+    switch (jpp.alg) {
+        case pooling_max: {
+            auto offset = jj * c_block * sizeof_src_dt();
+            bool masked = jj == ur_c - 1 && c_tail;
+            load_src_max_op(jj, ll, offset, masked, jpp.tail[0]);
+            break;
+        }
+        case pooling_avg_include_padding:
+        case pooling_avg_exclude_padding: {
+            auto offset = (ll * (c_block / max_num_ll) + jj * c_block)
+                    * sizeof_src_dt();
+            bool masked = jj == ur_c - 1 && c_tail;
+            load_src_avg_op(jj, ll, offset, masked, jpp.tail[ll]);
+            break;
+        }
+        default: assert(!"unsupported algorithm");
+    }
+}
+
+template <>
+void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::store_dst_max_op(
+        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+    using namespace data_type;
+
+    if (masked) {
+        switch (jpp.src_dt) {
+            case s32:
+                add_imm(X_DEFAULT_ADDR, reg_ptr_dst_i8, offset, X_TMP_0);
+                zip1(p_tmp0.b, mask(0).b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                st1w(vreg_dst(jj).s, p_tmp0, ptr(X_DEFAULT_ADDR));
+                break;
+            case s8:
+            case u8:
+                add_imm(X_DEFAULT_ADDR, reg_ptr_dst_i8, offset, X_TMP_0);
+                st1b(vreg_dst(jj).b, mask(0), ptr(X_DEFAULT_ADDR));
+                break;
+            default: assert(!"unsupported src data type");
+        }
+    } else {
+        add_imm(X_DEFAULT_ADDR, reg_ptr_dst_i8, offset, X_TMP_0);
+        str(vreg_dst(jj), ptr(X_DEFAULT_ADDR));
+    }
+}
+
+template <>
+void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::store_dst_avg_op(
+        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+    using namespace data_type;
+
+    // Don't generate useless code
+    if (masked && !msk) return;
+
+    const TReg &vr_dst = vreg_dst_s32(jj, ll);
+    switch (jpp.dst_dt) {
+        case s32:
+            add_imm(X_DEFAULT_ADDR, reg_ptr_dst_i8, offset, X_TMP_0);
+            if (masked) {
+                zip1(p_tmp0.b, mask(ll).b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                st1w(vr_dst.s, p_tmp0, ptr(X_DEFAULT_ADDR));
+            } else {
+                str(vr_dst, ptr(X_DEFAULT_ADDR));
+            }
+            break;
+        case s8:
+            add_imm(X_DEFAULT_ADDR, reg_ptr_dst_i8, offset, X_TMP_0);
+            if (masked) {
+                mov(z_tmp0.d, vr_dst.d);
+                smin(z_tmp0.s, 127);
+                smax(z_tmp0.s, -128);
+                zip1(p_tmp0.b, mask(ll).b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                st1b(z_tmp0.s, p_tmp0, ptr(X_DEFAULT_ADDR));
+            } else {
+                mov(z_tmp0.d, vr_dst.d);
+                smin(z_tmp0.s, 127);
+                smax(z_tmp0.s, -128);
+                st1b(z_tmp0.s, p_512, ptr(X_DEFAULT_ADDR));
+            }
+            break;
+        case u8:
+            add_imm(X_DEFAULT_ADDR, reg_ptr_dst_i8, offset, X_TMP_0);
+            if (masked) {
+                mov(z_tmp0.d, vr_dst.d);
+                umin(z_tmp0.s, 255);
+                zip1(p_tmp0.b, mask(ll).b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                st1b(z_tmp0.s, p_tmp0, ptr(X_DEFAULT_ADDR));
+            } else {
+                mov(z_tmp0.d, vr_dst.d);
+                umin(z_tmp0.s, 255);
+                st1b(z_tmp0.s, p_512, ptr(X_DEFAULT_ADDR));
+            }
+            break;
+        default: assert(!"unsupported dst data_type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::store_dst(
+        int jj, int ll, int c_tail) {
+    using namespace data_type;
+
+    int c_block = jpp.c_block;
+    int ur_c = jpp.ur_c;
+
+    switch (jpp.alg) {
+        case pooling_max: {
+            auto offset = jj * c_block * sizeof_dst_dt();
+            bool masked = jj == ur_c - 1 && c_tail;
+            store_dst_max_op(jj, ll, offset, masked, jpp.tail[ll]);
+            break;
+        }
+        case pooling_avg_include_padding:
+        case pooling_avg_exclude_padding: {
+            auto offset = (ll * (c_block / max_num_ll) + jj * c_block)
+                    * sizeof_dst_dt();
+            bool masked = jj == ur_c - 1 && c_tail;
+            store_dst_avg_op(jj, ll, offset, masked, jpp.tail[ll]);
+            break;
+        }
+        default: assert(!"unsupported pooling algorithm");
+    }
+}
+
+template <>
+void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::compute_max_op(const int jj) {
+    using namespace data_type;
+
+    // Compare
+    switch (jpp.src_dt) {
+        case s32:
+            cmplt(k_cmp_mask.s, p_512 / T_z, vreg_dst(jj).s, vreg_src(jj).s);
+            break;
+        case s8:
+            cmplt(k_cmp_mask.b, p_512 / T_z, vreg_dst(jj).b, vreg_src(jj).b);
+            break;
+        case u8:
+            cmpls(k_cmp_mask.b, p_512 / T_z, vreg_dst(jj).b, vreg_src(jj).b);
+            break;
+        default: assert(!"unsupported src data type");
+    }
+
+    // move max values into vreg_dst
+    if (jpp.src_dt == s32) {
+        sel(vreg_dst(jj).s, k_cmp_mask / T_m, vreg_src(jj).s, vreg_dst(jj).s);
+    } else {
+        sel(vreg_dst(jj).b, k_cmp_mask / T_m, vreg_src(jj).b, vreg_dst(jj).b);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
+        int ur_c, int c_tail) {
+    Label l_kd, l_kh, l_kw;
+
+    int ih = jpp.ih;
+    int iw = jpp.iw;
+    int c = jpp.c;
+
+    for (int jj = 0; jj < ur_c; jj++) {
+        mov(vreg_dst(jj).d, vreg_tmp.d);
+    }
+
+    mov(aux_reg_src_d, reg_ptr_src_i8);
+    eor(reg_kd_index, reg_kd_index, reg_kd_index);
+    L(l_kd);
+    {
+        mov(aux_reg_src_h, aux_reg_src_d);
+        eor(reg_kh_index, reg_kh_index, reg_kh_index);
+        L(l_kh);
+        {
+            mov(aux_reg_src_w, aux_reg_src_h);
+            eor(reg_kw_index, reg_kw_index, reg_kw_index);
+            L(l_kw);
+            {
+                for (int jj = 0; jj < ur_c; jj++) {
+                    load_src(jj, 0, c_tail);
+                    compute_max_op(jj);
+                }
+                add(aux_reg_src_w, aux_reg_src_w, c * sizeof_src_dt());
+                adds(reg_kw_index, reg_kw_index, 1);
+                cmp(reg_kw_index, reg_kw);
+                b(LT, l_kw);
+            }
+            add_imm(aux_reg_src_h, aux_reg_src_h, iw * c * sizeof_src_dt(),
+                    X_TMP_0);
+            adds(reg_kh_index, reg_kh_index, 1);
+            cmp(reg_kh_index, reg_kh);
+            b(LT, l_kh);
+        }
+        add_imm(aux_reg_src_d, aux_reg_src_d, ih * iw * c * sizeof_src_dt(),
+                X_TMP_0);
+        adds(reg_kd_index, reg_kd_index, 1);
+        cmp(reg_kd_index, reg_kd);
+        b(LT, l_kd);
+    }
+
+    for (int jj = 0; jj < ur_c; jj++)
+        store_dst(jj, 0, c_tail);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
+        int ur_c, int c_tail) {
+    using namespace data_type;
+
+    Label l_kd, l_kh, l_kw;
+
+    int ih = jpp.ih;
+    int iw = jpp.iw;
+    int c = jpp.c;
+
+    const int num_ll = data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt);
+
+    for (int jj = 0; jj < ur_c; jj++) {
+        for (int ll = 0; ll < num_ll; ll++) {
+            bool masked = jj == ur_c - 1 && c_tail;
+            size_t msk = jpp.tail[ll];
+            if (!(masked && !msk)) {
+                // Clearing of src reg is not needed as they are written before read
+                eor(vreg_dst_s32(jj, ll).d, vreg_dst_s32(jj, ll).d,
+                        vreg_dst_s32(jj, ll).d);
+            }
+        }
+    }
+
+    mov(aux_reg_src_d, reg_ptr_src_i8);
+    eor(reg_kd_index, reg_kd_index, reg_kd_index);
+    L(l_kd);
+    {
+        mov(aux_reg_src_h, aux_reg_src_d);
+        eor(reg_kh_index, reg_kh_index, reg_kh_index);
+        L(l_kh);
+        {
+            mov(aux_reg_src_w, aux_reg_src_h);
+            eor(reg_kw_index, reg_kw_index, reg_kw_index);
+            L(l_kw);
+            {
+                for (int jj = 0; jj < ur_c; jj++) {
+                    for (int ll = 0; ll < num_ll; ll++) {
+                        bool masked = jj == ur_c - 1 && c_tail;
+                        size_t msk = jpp.tail[ll];
+                        if (!(masked && !msk)) {
+                            load_src(jj, ll, c_tail);
+                            add(vreg_dst_s32(jj, ll).s, vreg_dst_s32(jj, ll).s,
+                                    vreg_src_s32(jj, ll).s);
+                        }
+                    }
+                }
+                add(aux_reg_src_w, aux_reg_src_w, c * sizeof_src_dt());
+                adds(reg_kw_index, reg_kw_index, 1);
+                cmp(reg_kw_index, reg_kw);
+                b(LT, l_kw);
+            }
+            add_imm(aux_reg_src_h, aux_reg_src_h, iw * c * sizeof_src_dt(),
+                    X_TMP_0);
+            adds(reg_kh_index, reg_kh_index, 1);
+            cmp(reg_kh_index, reg_kh);
+            b(LT, l_kh);
+        }
+        add_imm(aux_reg_src_d, aux_reg_src_d, ih * iw * c * sizeof_src_dt(),
+                X_TMP_0);
+        adds(reg_kd_index, reg_kd_index, 1);
+        cmp(reg_kd_index, reg_kd);
+        b(LT, l_kd);
+    }
+
+    static constexpr int vlen_size_elem
+            = cpu_isa_traits<isa>::vlen / sizeof(float);
+    const auto reg_tmp_postops = XReg(15);
+
+    if (jpp.with_binary) {
+        mov_imm(X_TMP_0,
+                static_cast<int64_t>(
+                        static_cast<int8_t>(ur_c * num_ll * vlen_size_elem)));
+        mul(reg_tmp_postops, c_iter, X_TMP_0);
+    }
+
+    for (int jj = 0; jj < ur_c; jj++) {
+        for (int ll = 0; ll < num_ll; ll++) {
+            const bool masked = jj == ur_c - 1 && c_tail;
+            const size_t msk = jpp.tail[ll];
+            if (!(masked && !msk)) {
+                const auto &reg_dst_f32 = vreg_dst_f32(jj, ll);
+                const auto &reg_dst_s32 = vreg_dst_s32(jj, ll);
+                scvtf(reg_dst_f32.s, p_512 / T_m, reg_dst_s32.s);
+                fmad(reg_dst_f32.s, p_512 / T_m, vreg_tmp.s, vreg_zeros.s);
+
+                frinti(reg_dst_s32.s, p_512 / T_m, reg_dst_f32.s);
+                fcvtzs(reg_dst_s32.s, p_512 / T_m, reg_dst_s32.s);
+
+                store_dst(jj, ll, c_tail);
+            }
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_step(int ur_c, int c_tail) {
+    switch (jpp.alg) {
+        case pooling_max: compute_max_step(ur_c, c_tail); break;
+        case pooling_avg_include_padding:
+        case pooling_avg_exclude_padding: compute_avg_step(ur_c, c_tail); break;
+        default: assert(!"unsupported pooling algorithm");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_c_block() {
+    Label l_main_loop;
+
+    int nb_c = jpp.nb_c;
+    int c_block = jpp.c_block;
+    int ur_c = jpp.ur_c;
+    int ur_c_tail = jpp.ur_c_tail;
+    int c_steps = nb_c / ur_c;
+    int c_tail = jpp.c_tail;
+
+    eor(c_iter, c_iter, c_iter);
+    if (c_steps > 0) {
+        L(l_main_loop);
+        {
+            compute_step(ur_c, 0);
+            add(reg_ptr_src_i8, reg_ptr_src_i8,
+                    ur_c * c_block * sizeof_src_dt());
+            add(reg_ptr_dst_i8, reg_ptr_dst_i8,
+                    ur_c * c_block * sizeof_dst_dt());
+            adds(c_iter, c_iter, 1);
+            mov_imm(X_TMP_0, c_steps);
+            cmp(c_iter, X_TMP_0);
+            b(LT, l_main_loop);
+        }
+    }
+
+    if (ur_c_tail != 0) { compute_step(ur_c_tail, c_tail); }
+}
+
+template <>
+void jit_uni_i8i8_pooling_fwd_ker_t<sve_512>::init_mask() {
+    using namespace data_type;
+
+    sub(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 8 * max_num_ll);
+
+    for (int ll = 0; ll < max_num_ll; ll++) {
+        mov_imm(reg_mask, jpp.tail[ll]);
+        str(reg_mask, ptr(X_TRANSLATOR_STACK, 8 * ll));
+    }
+    for (int ll = 0; ll < max_num_ll; ll++) {
+        ldr(PReg(mask(ll)), ptr(X_TRANSLATOR_STACK));
+        add(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 8);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_tmp_reg() {
+    using namespace data_type;
+
+    switch (jpp.alg) {
+        case pooling_avg_include_padding:
+        case pooling_avg_exclude_padding:
+            add_imm(X_DEFAULT_ADDR, reg_param,
+                    offsetof(call_params_t, idivider), X_TMP_0);
+            ldr(reg_tmp, ptr(X_DEFAULT_ADDR));
+            bic(xmm_tmp.b16, xmm_tmp.b16, xmm_tmp.b16);
+            mov(xmm_tmp.d[0], reg_tmp);
+
+            dup(vreg_tmp.s, ZRegS(xmm_tmp.getIdx())[0]);
+            break;
+        case pooling_max:
+            switch (jpp.src_dt) {
+                case s32:
+                    mov_imm(reg_tmp, nstl::numeric_limits<int32_t>::lowest());
+                    break;
+                case s8:
+                    mov_imm(reg_tmp, nstl::numeric_limits<int8_t>::lowest());
+                    break;
+                case u8:
+                    mov(reg_tmp, nstl::numeric_limits<uint8_t>::lowest());
+                    break;
+                default: assert(!"unsupported src data_type");
+            }
+
+            bic(xmm_tmp.b16, xmm_tmp.b16, xmm_tmp.b16);
+            mov(xmm_tmp.d[0], reg_tmp);
+            if (jpp.src_dt == s32) {
+                dup(vreg_tmp.s, ZRegS(xmm_tmp.getIdx())[0]);
+            } else if (mayiuse(sve_512)) {
+                dup(ZRegB(vreg_tmp.getIdx()), ZRegB(xmm_tmp.getIdx())[0]);
+            } else {
+                assert(!"unreachable");
+            }
+            break;
+        default: assert(!"unsupported pooling algorithm");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::generate() {
+    preamble();
+
+    ptrue(p_512.b);
+    pfalse(p_all_zero.b);
+
+    add_imm(X_DEFAULT_ADDR, reg_param, offsetof(call_params_t, src_i8),
+            X_TMP_0);
+    ldr(reg_ptr_src_i8, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, offsetof(call_params_t, dst_i8),
+            X_TMP_0);
+    ldr(reg_ptr_dst_i8, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, offsetof(call_params_t, kd_range),
+            X_TMP_0);
+    ldr(reg_kd, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, offsetof(call_params_t, kh_range),
+            X_TMP_0);
+    ldr(reg_kh, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, offsetof(call_params_t, kw_range),
+            X_TMP_0);
+    ldr(reg_kw, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, offsetof(call_params_t, src_safe_access),
+            X_TMP_0);
+    ldr(reg_src_safe_access, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, offsetof(call_params_t, dst_safe_access),
+            X_TMP_0);
+    ldr(reg_dst_safe_access, ptr(X_DEFAULT_ADDR));
+
+    eor(VReg16B(vreg_zeros.getIdx()), VReg16B(vreg_zeros.getIdx()),
+            VReg16B(vreg_zeros.getIdx()));
+
+    init_mask();
+    init_tmp_reg();
+
+    compute_c_block();
+
+    postamble();
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
+        jit_pool_conf_t &jpp, const pooling_pd_t *ppd) {
+    if (!mayiuse(isa)) return status::unimplemented;
+
+    const auto &pd = *ppd->desc();
+    const memory_desc_wrapper src_d(ppd->src_md());
+    const memory_desc_wrapper dst_d(ppd->dst_md());
+    const int ndims = src_d.ndims();
+    const bool is_1d = ndims == 3;
+    const bool is_3d = ndims == 5;
+
+    jpp.mb = src_d.dims()[0];
+    jpp.c = src_d.dims()[1];
+
+    jpp.id = is_3d ? src_d.dims()[ndims - 3] : 1;
+    jpp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
+    jpp.iw = src_d.dims()[ndims - 1];
+
+    jpp.od = is_3d ? dst_d.dims()[ndims - 3] : 1;
+    jpp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
+    jpp.ow = dst_d.dims()[ndims - 1];
+
+    jpp.stride_d = is_3d ? pd.strides[ndims - 5] : 1;
+    jpp.stride_h = is_1d ? 1 : pd.strides[ndims - 4];
+    jpp.stride_w = pd.strides[ndims - 3];
+
+    jpp.kd = is_3d ? pd.kernel[ndims - 5] : 1;
+    jpp.kh = is_1d ? 1 : pd.kernel[ndims - 4];
+    jpp.kw = pd.kernel[ndims - 3];
+
+    jpp.f_pad = is_3d ? pd.padding[0][ndims - 5] : 0;
+    jpp.t_pad = is_1d ? 0 : pd.padding[0][ndims - 4];
+    jpp.l_pad = pd.padding[0][ndims - 3];
+
+    int back_pad = calculate_end_padding(
+            jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
+    int bottom_pad = calculate_end_padding(
+            jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
+    int right_pad = calculate_end_padding(
+            jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
+
+    if (jpp.f_pad >= jpp.kd || jpp.t_pad >= jpp.kh || jpp.l_pad >= jpp.kw
+            || back_pad >= jpp.kd || bottom_pad >= jpp.kh
+            || right_pad >= jpp.kw)
+        return status::unimplemented;
+
+    jpp.alg = pd.alg_kind;
+
+    jpp.src_dt = pd.src_desc.data_type;
+    jpp.dst_dt = pd.dst_desc.data_type;
+
+    // data_type items per one vreg on the <isa>
+    //     isa == sve_512 : 64 bytes -> 64 for s8/u8, 16 for s32
+    int simd_w = cpu_isa_traits<isa>::vlen / data_type_size(jpp.src_dt);
+
+    /* Verify that vlen-sized memory access happens within the tensor's
+     * size, otherwise load/store will always spill outside the memory
+     * boundary.*/
+    bool safe_load_n_store = IMPLICATION(utils::one_of(isa, sve_512),
+            jpp.mb * jpp.c * nstl::min(jpp.id, jpp.od)
+                            * nstl::min(jpp.ih, jpp.oh)
+                            * nstl::min(jpp.iw, jpp.ow)
+                    >= simd_w);
+    if (!safe_load_n_store) return status::unimplemented;
+
+    jpp.c_block = simd_w;
+    jpp.c_tail = jpp.c % jpp.c_block;
+    jpp.nb_c = jpp.c / jpp.c_block;
+    jpp.ur_c = 1;
+    jpp.ur_c_tail = jpp.c_tail != 0;
+
+    size_t tail_mask = (1ULL << jpp.c_tail) - 1;
+
+    /* If channel_size is bigger than vlen, we can safely assume there is no
+     * underflow of memory boundary, so always perform c_tail and save
+     * a couple of compute cycles*/
+    jpp.safe_c_tail = jpp.c_tail > 0 && jpp.c >= simd_w;
+
+    switch (jpp.alg) {
+        case pooling_max:
+            jpp.tail[0] = tail_mask;
+            jpp.tail[1] = 0;
+            jpp.tail[2] = 0;
+            jpp.tail[3] = 0;
+            break;
+        case pooling_avg_include_padding:
+        case pooling_avg_exclude_padding: {
+            // avg_proc_dt (s32) defines granularity (because u8/s8 processed as s32)
+            // sve_512 : 16
+            const size_t msk_gran
+                    = cpu_isa_traits<isa>::vlen / data_type_size(avg_proc_dt);
+            const size_t msk_msk = (1ULL << msk_gran) - 1;
+            size_t m = tail_mask;
+            for (size_t ll = 0; ll < max_num_ll; ll++) {
+                jpp.tail[ll] = m & msk_msk;
+                m = m >> msk_gran;
+            }
+            break;
+        }
+        default: return status::unimplemented;
+    }
+
+    if (!post_ops_ok(jpp, *ppd->attr(), dst_d)) return status::unimplemented;
+
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+bool jit_uni_i8i8_pooling_fwd_ker_t<isa>::post_ops_ok(jit_pool_conf_t &jpp,
+        const primitive_attr_t &attr, const memory_desc_wrapper &dst_d) {
+    const auto &post_ops = attr.post_ops_;
+    const auto &entries = post_ops.entry_;
+    jpp.with_postops = false;
+    jpp.with_eltwise = false;
+    jpp.with_binary = false;
+
+    return entries.empty() ? true : false;
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_i8i8_pooling_fwd_t<isa>::pd_t::jit_conf() {
+    return jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(jpp_, this);
+}
+
+template <cpu_isa_t isa>
+jit_uni_i8i8_pooling_fwd_t<isa>::jit_uni_i8i8_pooling_fwd_t(const pd_t *apd)
+    : primitive_t(apd), ker_(nullptr) {}
+
+template <cpu_isa_t isa>
+jit_uni_i8i8_pooling_fwd_t<isa>::~jit_uni_i8i8_pooling_fwd_t() = default;
+
+template <cpu_isa_t isa>
+status_t jit_uni_i8i8_pooling_fwd_t<isa>::init(engine_t *engine) {
+    CHECK(safe_ptr_assign(ker_,
+            new jit_uni_i8i8_pooling_fwd_ker_t<isa>(
+                    pd()->jpp_, pd()->invariant_dst_md())));
+    return ker_->create_kernel();
+}
+
+template <cpu_isa_t isa>
+void jit_uni_i8i8_pooling_fwd_t<isa>::execute_forward(
+        const exec_ctx_t &ctx) const {
+    auto src_i8 = CTX_IN_MEM(const char *, DNNL_ARG_SRC);
+    auto dst_i8 = CTX_OUT_MEM(char *, DNNL_ARG_DST);
+
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+
+    const auto &jpp = pd()->jpp_;
+    /* Calculate when the memory-access will happen outisde of the memory
+     * boundary, if so, compute a safe memory access. */
+    const auto src_safe_access = reinterpret_cast<char *>(
+            reinterpret_cast<ptrdiff_t>(src_i8 + src_d.size() - 1)
+            - (cpu_isa_traits<isa>::vlen - 1));
+
+    const auto dst_safe_access = reinterpret_cast<char *>(
+            reinterpret_cast<ptrdiff_t>(dst_i8 + dst_d.size() - 1)
+            - (cpu_isa_traits<isa>::vlen - 1));
+
+    parallel_nd(
+            jpp.mb, jpp.od, jpp.oh, jpp.ow, [&](int n, int od, int oh, int ow) {
+                const int id = nstl::max(od * jpp.stride_d - jpp.f_pad, 0);
+                const int ih = nstl::max(oh * jpp.stride_h - jpp.t_pad, 0);
+                const int iw = nstl::max(ow * jpp.stride_w - jpp.l_pad, 0);
+
+                const int kd_start
+                        = nstl::max(0, jpp.f_pad - od * jpp.stride_d);
+                const int kd_end = nstl::min(
+                        jpp.kd, jpp.id + jpp.f_pad - od * jpp.stride_d);
+                const int kh_start
+                        = nstl::max(0, jpp.t_pad - oh * jpp.stride_h);
+                const int kh_end = nstl::min(
+                        jpp.kh, jpp.ih + jpp.t_pad - oh * jpp.stride_h);
+                const int kw_start
+                        = nstl::max(0, jpp.l_pad - ow * jpp.stride_w);
+                const int kw_end = nstl::min(
+                        jpp.kw, jpp.iw + jpp.l_pad - ow * jpp.stride_w);
+
+                auto p = call_params_t();
+                p.src_i8 = &src_i8[get_offset(src_d, n, 0, id, ih, iw)
+                        * src_d.data_type_size()];
+                p.dst_i8 = &dst_i8[get_offset(dst_d, n, 0, od, oh, ow)
+                        * dst_d.data_type_size()];
+                p.kd_range = (size_t)(kd_end - kd_start);
+                p.kh_range = (size_t)(kh_end - kh_start);
+                p.kw_range = (size_t)(kw_end - kw_start);
+                p.idivider = 1.0f
+                        / ((jpp.alg == pooling_avg_exclude_padding)
+                                        ? p.kd_range * p.kh_range * p.kw_range
+                                        : jpp.kd * jpp.kh * jpp.kw);
+                p.src_safe_access = src_safe_access;
+                p.dst_safe_access = dst_safe_access;
+                (*ker_)(&p);
+            });
+}
+
+// Explicit instantiation only for supported <isa> values.
+//
+template struct jit_uni_i8i8_pooling_fwd_ker_t<sve_512>;
+template struct jit_uni_i8i8_pooling_fwd_t<sve_512>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
@@ -1,0 +1,100 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_I8I8_POOLING_HPP
+#define CPU_AARCH64_JIT_UNI_I8I8_POOLING_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/cpu_pooling_pd.hpp"
+
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa>
+struct jit_uni_i8i8_pooling_fwd_ker_t;
+
+template <cpu_isa_t isa>
+struct jit_uni_i8i8_pooling_fwd_t : public primitive_t {
+    struct pd_t : public cpu_pooling_fwd_pd_t {
+        using cpu_pooling_fwd_pd_t::cpu_pooling_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_int:", isa, ""),
+                jit_uni_i8i8_pooling_fwd_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && mayiuse(isa) && utils::one_of(ndims(), 3, 4, 5)
+                    && set_default_params() == status::success
+                    && desc()->prop_kind == prop_kind::forward_inference
+                    && utils::one_of(desc()->alg_kind, alg_kind::pooling_max,
+                            alg_kind::pooling_avg_include_padding,
+                            alg_kind::pooling_avg_exclude_padding)
+                    && utils::one_of(src_md()->data_type, data_type::s32,
+                            data_type::s8, data_type::u8)
+                    && src_md()->data_type == dst_md()->data_type
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops)
+                    && memory_desc_matches_one_of_tag(*src_md(),
+                               format_tag::nwc, format_tag::nhwc,
+                               format_tag::ndhwc)
+                            != format_tag::undef
+                    && memory_desc_matches_one_of_tag(*dst_md(),
+                               format_tag::nwc, format_tag::nhwc,
+                               format_tag::ndhwc)
+                            != format_tag::undef
+                    && !is_dilated();
+            if (!ok) return status::unimplemented;
+
+            return jit_conf();
+        }
+
+        jit_pool_conf_t jpp_;
+
+    protected:
+        status_t jit_conf();
+    };
+
+    jit_uni_i8i8_pooling_fwd_t(const pd_t *apd);
+    ~jit_uni_i8i8_pooling_fwd_t();
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_forward(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_uni_i8i8_pooling_fwd_ker_t<isa>> ker_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -1,0 +1,1075 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+* Copyright 2018 YANDEX LLC
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/nstl.hpp"
+#include "common/utils.hpp"
+#include "cpu/cpu_pooling_pd.hpp"
+
+#include "cpu/aarch64/jit_uni_pool_kernel.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace alg_kind;
+
+#define GET_OFF(field) offsetof(jit_pool_call_s, field)
+
+template <cpu_isa_t isa>
+jit_uni_pool_kernel<isa>::~jit_uni_pool_kernel() = default;
+
+template <cpu_isa_t isa>
+jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
+        const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md)
+    : jpp(ajpp) {}
+
+template <cpu_isa_t isa>
+status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
+        memory_tracking::registrar_t &scratchpad, const pooling_pd_t *ppd,
+        int nthreads) {
+
+    const auto &pd = *ppd->desc();
+    const memory_desc_wrapper src_d(
+            ppd->is_fwd() ? ppd->src_md() : ppd->diff_src_md());
+    const memory_desc_wrapper dst_d(
+            ppd->is_fwd() ? ppd->dst_md() : ppd->diff_dst_md());
+
+    const int ndims = src_d.ndims();
+
+    jpp.is_training = pd.prop_kind == prop_kind::forward_training;
+    jpp.is_backward = pd.prop_kind == prop_kind::backward_data;
+
+    jpp.id = (ndims == 5) ? src_d.dims()[2] : 1;
+    jpp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
+    jpp.iw = src_d.dims()[ndims - 1];
+    jpp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
+    jpp.ow = dst_d.dims()[ndims - 1];
+    jpp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
+
+    jpp.ndims = ndims;
+    jpp.mb = src_d.dims()[0];
+    jpp.c_without_padding = src_d.dims()[1];
+    jpp.c_block = 16;
+
+    jpp.alg = pd.alg_kind;
+
+    using namespace format_tag;
+    const auto blocked_fmt_tag = utils::one_of(isa, sve_512)
+            ? utils::pick(ndims - 3, nCw16c, nChw16c, nCdhw16c)
+            : utils::pick(ndims - 3, nCw8c, nChw8c, nCdhw8c);
+
+    // src_d.data_type() is equal to dst_d.data_type(). This is checked in init
+    auto ncsp_fmt_tag = format_tag::undef;
+
+    const unsigned int L3_cache_size_per_core
+            = platform::get_per_core_cache_size(3);
+    const size_t block_size
+            = ((size_t)jpp.id * jpp.ih * jpp.iw + jpp.od * jpp.oh * jpp.ow)
+            * jpp.c_block * types::data_type_size(src_d.data_type());
+
+    const bool forward_ncsp_allowed = !jpp.is_backward
+            && jpp.c_without_padding > 3
+            && ((jpp.ih > 1 && jpp.iw > 1
+                        && block_size <= L3_cache_size_per_core)
+                    || src_d.data_type() == data_type::bf16);
+
+    const bool backward_ncsp_allowed = jpp.is_backward
+            && ((jpp.ih > 1 && jpp.iw > 1 && jpp.c_without_padding > 1
+                        && block_size <= L3_cache_size_per_core)
+                    || (src_d.data_type() == data_type::bf16
+                            && !(jpp.alg == pooling_max
+                                    && block_size > L3_cache_size_per_core)));
+
+    ncsp_fmt_tag = ((forward_ncsp_allowed || backward_ncsp_allowed)
+                           && isa == sve_512 && ndims <= 5)
+            ? utils::pick(ndims - 3, ncw, nchw, ncdhw)
+            : format_tag::undef;
+
+    const auto nspc_fmt_tag = (ndims <= 5)
+            ? utils::pick(ndims - 3, nwc, nhwc, ndhwc)
+            : format_tag::undef;
+
+    const auto fmt_tag = src_d.matches_one_of_tag(
+            blocked_fmt_tag, ncsp_fmt_tag, nspc_fmt_tag);
+
+    if (!dst_d.matches_tag(fmt_tag)) return status::unimplemented;
+
+    if (fmt_tag == ncsp_fmt_tag) {
+        // transform input to blocked f32, call f32 jit, transform result to
+        // plain output
+        jpp.is_bf16 = false;
+        jpp.dt_size = types::data_type_size(data_type::f32);
+        jpp.tag_kind = jit_memory_tag_kind_t::ncsp;
+    } else {
+        jpp.is_bf16 = (src_d.data_type() == data_type::bf16
+                && dst_d.data_type() == data_type::bf16);
+        jpp.dt_size = types::data_type_size(src_d.data_type());
+        jpp.tag_kind = (fmt_tag == nspc_fmt_tag)
+                ? jit_memory_tag_kind_t::nspc
+                : jit_memory_tag_kind_t::blocked;
+    }
+
+    jpp.isa = isa;
+
+    const bool args_ok = true && mayiuse(isa) && (fmt_tag != format_tag::undef)
+            && jpp.is_bf16 == false
+            && utils::one_of(pd.alg_kind, pooling_max,
+                    pooling_avg_include_padding, pooling_avg_exclude_padding);
+    if (!args_ok) return status::unimplemented;
+
+    jpp.c = jpp.tag_kind == jit_memory_tag_kind_t::blocked
+            ? utils::rnd_up(jpp.c_without_padding, jpp.c_block)
+            : jpp.c_without_padding;
+    if (jpp.tag_kind == jit_memory_tag_kind_t::blocked)
+        assert(src_d.padded_dims()[1] == jpp.c);
+    jpp.nb_c = utils::div_up(jpp.c, jpp.c_block);
+    jpp.c_tail = jpp.c_without_padding % jpp.c_block;
+    jpp.is_c_padded = jpp.tag_kind == jit_memory_tag_kind_t::blocked
+            && src_d.padded_dims()[1] != jpp.c_without_padding;
+
+    jpp.stride_d = (ndims == 5) ? pd.strides[0] : 1;
+    jpp.stride_h = (ndims == 3) ? 1 : pd.strides[ndims - 4];
+    jpp.stride_w = pd.strides[ndims - 3];
+    jpp.kd = (ndims == 5) ? pd.kernel[0] : 1;
+    jpp.kh = (ndims == 3) ? 1 : pd.kernel[ndims - 4];
+    jpp.kw = pd.kernel[ndims - 3];
+
+    jpp.f_pad = (ndims == 5) ? pd.padding[0][0] : 0;
+    jpp.t_pad = (ndims == 3) ? 0 : pd.padding[0][ndims - 4];
+    jpp.l_pad = pd.padding[0][ndims - 3];
+
+    const int back_pad = calculate_end_padding(
+            jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
+    const int bottom_pad = calculate_end_padding(
+            jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
+    const int right_pad = calculate_end_padding(
+            jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
+
+    if (jpp.f_pad >= jpp.kd || jpp.t_pad >= jpp.kh || jpp.l_pad >= jpp.kw
+            || back_pad >= jpp.kd || bottom_pad >= jpp.kh
+            || right_pad >= jpp.kw)
+        return status::unimplemented;
+
+    jpp.ind_dt = ppd->workspace_md() ? ppd->workspace_md()->data_type
+                                     : data_type::undef;
+
+    jpp.simple_alg = jpp.is_training
+            || IMPLICATION(jpp.is_backward, jpp.kd <= jpp.stride_d);
+
+    jpp.ur = 0;
+    if (jpp.alg == pooling_max) {
+        jpp.ur = 16;
+
+        if (jpp.is_training)
+            jpp.ur = 9;
+        else if (jpp.is_backward)
+            jpp.ur = 6;
+    } else {
+        if (jpp.is_backward)
+            jpp.ur = 12;
+        else
+            jpp.ur = 24;
+    }
+    // select jpp.ur_bc
+    if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
+        auto min_ur_w = nstl::max(1, utils::div_up(jpp.l_pad, jpp.stride_w));
+        int min_ur_w1 = utils::div_up(right_pad, jpp.stride_w);
+        if (min_ur_w < min_ur_w1) { min_ur_w = min_ur_w1; }
+        jpp.ur_bc = nstl::min(jpp.nb_c, nstl::max(1, jpp.ur / min_ur_w));
+        //take into account threading - to have enough work for parallelization
+        float best_eff = 0;
+        for (int ur_bc = jpp.ur_bc; ur_bc > 0; ur_bc--) {
+
+            const auto nb2_c = utils::div_up(jpp.nb_c, ur_bc);
+            auto work = jpp.is_backward
+                    ? (ndims == 5 && jpp.simple_alg ? jpp.od : 1)
+                    : (ndims == 5 ? jpp.od : jpp.oh);
+            work *= jpp.mb * nb2_c;
+            auto eff = (float)work / utils::rnd_up(work, nthreads);
+            if (eff > best_eff) {
+
+                best_eff = eff;
+                jpp.ur_bc = ur_bc;
+            }
+            if (eff > 0.9) break; // Heuristic threshold
+        }
+
+        jpp.ur_bc_tail = jpp.nb_c % jpp.ur_bc;
+    } else {
+        jpp.ur_bc = 1;
+        jpp.ur_bc_tail = 0;
+    }
+    auto ur_w = nstl::min(jpp.ow, jpp.ur / jpp.ur_bc);
+    if (utils::div_up(jpp.l_pad, jpp.stride_w) > ur_w)
+        return status::unimplemented;
+    if (utils::div_up(right_pad, jpp.stride_w) > ur_w)
+        return status::unimplemented;
+
+    // scratchpad for c_block slice of input and/or output
+    using namespace memory_tracking::names;
+    const int nscr = nstl::min(dnnl_get_max_threads(), jpp.mb * jpp.nb_c);
+    if (jpp.tag_kind == jit_memory_tag_kind_t::ncsp) {
+        scratchpad.book(key_pool_src_plain2blocked_cvt,
+                jpp.c_block * jpp.id * jpp.ih * jpp.iw * nscr, jpp.dt_size);
+        scratchpad.book(key_pool_dst_plain2blocked_cvt,
+                jpp.c_block * jpp.od * jpp.oh * jpp.ow * nscr, jpp.dt_size);
+        scratchpad.book<uint32_t>(key_pool_ind_plain2blocked_cvt,
+                jpp.c_block * jpp.od * jpp.oh * jpp.ow * nscr);
+    }
+
+    const auto attr = *ppd->attr();
+    if (!post_ops_ok(jpp, attr, dst_d)) return status::unimplemented;
+
+    return status::success;
+}
+
+static int reg_ind(int shift, int bc, int j, int ur_bc, int ur_w) noexcept {
+    return shift * ur_bc * ur_w + bc * ur_w + j;
+};
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::prepare_tail_mask() {
+    size_t c_tail_mask = (1ULL << jpp.c_tail) - 1ULL;
+    /* PRegS(k_c_tail_mask) keeps flags in the context
+           of 8-bit elements. */
+    mov_imm(X_TMP_0, c_tail_mask);
+    sub(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 8);
+    str(X_TMP_0, ptr(X_TRANSLATOR_STACK));
+    ldr(PReg(k_c_tail_mask), ptr(X_TRANSLATOR_STACK));
+    add(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 8);
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::put_one_in_vmm() {
+    mov_imm(tmp_gpr, 1);
+    uni_broadcast_reg_val(tmp_gpr.getIdx(), vmm_one.getIdx());
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::uni_broadcast_reg_val(
+        const int reg_idx, const int vmm_idx) {
+    ptrue(p_tmp0.d, VL2);
+    mov(ZRegD(vmm_idx), p_tmp0 / T_m, 0);
+    ptrue(p_tmp0.d, VL1);
+    mov(ZRegD(vmm_idx), p_tmp0 / T_m, XReg(reg_idx));
+
+    dup(ZRegS(vmm_idx), ZRegS(vmm_idx)[0]);
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::push_vmm_val(const int idx) {
+    using TReg = typename cpu_isa_traits<isa>::TReg;
+    TReg val_to_store(idx);
+    XReg rsp = sp;
+    sub_imm(XReg(idx), XReg(idx), val_to_store.getBit(), X_TMP_0);
+
+    str(val_to_store, ptr(rsp));
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::pop_vmm_val(const int idx) {
+    using TReg = typename cpu_isa_traits<isa>::TReg;
+    TReg val_to_load(idx);
+    XReg rsp = sp;
+
+    ldr(val_to_load, ptr(rsp));
+    add_imm(x9, x9, val_to_load.getBit(), X_TMP_0);
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::load(const int idx, const xreg_t &reg_ptr,
+        const int offset, const bool is_c_tail_proccessing) {
+    if (is_c_tail_proccessing && !jpp.is_c_padded) {
+        add_imm(X_DEFAULT_ADDR, reg_ptr, offset, X_TMP_0);
+        zip1(p_tmp0.b, k_c_tail_mask.b, p_all_zero.b);
+        zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+        ld1w(ZRegS(idx), p_tmp0 / T_z, ptr(X_DEFAULT_ADDR));
+    } else {
+        add_imm(X_DEFAULT_ADDR, reg_ptr, offset, X_TMP_0);
+        ld1w(ZRegS(idx), p_lsb / T_z, ptr(X_DEFAULT_ADDR));
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::store(const int idx,
+        const xreg_t &reg_ptr, const int offset,
+        const bool is_c_tail_proccessing) {
+    if (is_c_tail_proccessing && !jpp.is_c_padded) {
+        add_imm(X_DEFAULT_ADDR, reg_ptr, offset, X_TMP_0);
+        zip1(p_tmp0.b, k_c_tail_mask.b, p_all_zero.b);
+        zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+        st1w(ZRegS(idx), p_tmp0, ptr(X_DEFAULT_ADDR));
+    } else {
+        add_imm(X_DEFAULT_ADDR, reg_ptr, offset, X_TMP_0);
+        st1w(ZRegS(idx), p_lsb, ptr(X_DEFAULT_ADDR));
+    }
+}
+
+template <cpu_isa_t isa>
+bool jit_uni_pool_kernel<isa>::post_ops_ok(jit_pool_conf_t &jpp,
+        const primitive_attr_t &attr, const memory_desc_wrapper &dst_d) {
+    const auto &post_ops = attr.post_ops_;
+    const auto &entries = post_ops.entry_;
+    jpp.with_postops = false;
+    jpp.with_eltwise = false;
+    jpp.with_binary = false;
+
+    /* At this time, post_op is not supported. */
+    return post_ops.len() ? false : true;
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::maybe_recalculate_divisor(
+        int jj, int ur_w, int pad_l, int pad_r, bool with_c_tail_proccessing) {
+    if (jpp.alg == pooling_avg_exclude_padding) {
+        int kw = jpp.kw;
+        int stride_w = jpp.stride_w;
+
+        int non_zero_kw = kw;
+        non_zero_kw -= nstl::max(0, pad_l - jj * stride_w);
+        non_zero_kw -= nstl::max(0, pad_r - (ur_w - 1 - jj) * stride_w);
+
+        if (non_zero_kw != prev_kw) {
+            mov_imm(tmp_gpr, float2int((float)non_zero_kw));
+
+            ptrue(p_tmp0.d, VL2);
+            mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, 0);
+            ptrue(p_tmp0.d, VL1);
+            mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, tmp_gpr);
+
+            dup(vmm_tmp.s, ZRegS(xmm_tmp.getIdx())[0]);
+
+            fmul(vmm_tmp.s, vmm_tmp.s, vmm_ker_area_h);
+            prev_kw = non_zero_kw;
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
+        int pad_r, bool with_c_tail_proccessing) {
+
+    auto iw = jpp.iw;
+    auto kw = jpp.kw;
+    auto stride_w = jpp.stride_w;
+    auto c_block = jpp.c_block;
+    auto dt_size = jpp.dt_size;
+    const int c_off
+            = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
+    Label kd_label, kh_label;
+
+    const auto is_tail_processing = [&](int bc) {
+        return with_c_tail_proccessing && bc == (ur_bc - 1);
+    };
+
+    for (int jj = 0; jj < ur_w; jj++) {
+        if (jpp.is_backward)
+            maybe_recalculate_divisor(
+                    jj, ur_w, pad_l, pad_r, with_c_tail_proccessing);
+        for (int bci = 0; bci < ur_bc; bci++) {
+            const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
+            auto accvr = vreg(accr_i);
+            if (jpp.is_backward) {
+                auto output_offset = dt_size * (jj * c_off + bci * c_block);
+                load(accvr.getIdx(), xreg_output, output_offset,
+                        is_tail_processing(bci));
+                fdiv(accvr.s, p_512, vmm_tmp.s);
+            } else {
+                eor(accvr.d, accvr.d, accvr.d);
+            }
+        }
+    }
+
+    if (jpp.simple_alg && jpp.ndims == 5) {
+        str(reg_input, pre_ptr(X_TRANSLATOR_STACK, -8));
+        str(reg_output, pre_ptr(X_TRANSLATOR_STACK, -8));
+
+        mov(aux_reg_input_d, reg_input);
+
+        add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(kd_padding), X_TMP_0);
+        ldr(ki, ptr(X_DEFAULT_ADDR));
+        L(kd_label);
+
+        mov(aux_reg_input, aux_reg_input_d);
+    } else {
+        mov(aux_reg_input, reg_input);
+    }
+
+    eor(kj, kj, kj);
+    L(kh_label);
+    {
+        for (int ki = 0; ki < kw; ki++) {
+            int jj_start = nstl::max(0, utils::div_up(pad_l - ki, stride_w));
+            int jj_end = ur_w
+                    - utils::div_up(
+                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+
+            for_(int jj = jj_start; jj < jj_end; jj++)
+            for (int bci = 0; bci < ur_bc; bci++) {
+                const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).s;
+                const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
+                auto inpvr = vreg(inpr_i);
+                int aux_input_offset
+                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
+                if (aux_input_offset >= iw * c_off) continue;
+                int input_offset = dt_size * aux_input_offset;
+                if (jpp.is_backward) {
+                    auto inpyr = yreg(inpr_i);
+                    load(reg_idx(inpr_i), aux_xreg_input, input_offset,
+                            is_tail_processing(bci));
+
+                    fadd(inpvr.s, inpvr.s, accvr);
+                    store(reg_idx(inpr_i), aux_reg_input, input_offset,
+                            is_tail_processing(bci));
+                } else {
+                    if (is_tail_processing(bci)) {
+                        load(vmm_tmp_1.getIdx(), aux_xreg_input, input_offset,
+                                is_tail_processing(bci));
+                        fadd(accvr, accvr, vmm_tmp_1);
+                    } else {
+                        add_imm(X_DEFAULT_ADDR, aux_reg_input, input_offset,
+                                X_TMP_0);
+                        ldr(z_tmp0, ptr(X_DEFAULT_ADDR));
+                        fadd(accvr, accvr, z_tmp0.s);
+                    }
+                }
+            }
+        }
+        add_imm(aux_reg_input, aux_reg_input, (jpp.dt_size * iw * c_off),
+                X_TMP_0);
+        adds(kj, kj, 1);
+        cmp(kj, reg_kh);
+        b(LT, kh_label);
+    }
+
+    if (jpp.simple_alg && jpp.ndims == 5) {
+        add_imm(aux_reg_input_d, aux_reg_input_d,
+                (jpp.dt_size * jpp.ih * iw * c_off), X_TMP_0);
+        subs(ki, ki, 1);
+        mov_imm(X_TMP_0, 0);
+        cmp(ki, X_TMP_0);
+        b(GT, kd_label);
+        ldr(reg_output, post_ptr(X_TRANSLATOR_STACK, 8));
+        ldr(reg_input, post_ptr(X_TRANSLATOR_STACK, 8));
+    }
+
+    if (!jpp.is_backward) {
+        for (int jj = 0; jj < ur_w; jj++) {
+            maybe_recalculate_divisor(
+                    jj, ur_w, pad_l, pad_r, with_c_tail_proccessing);
+            for (int bci = 0; bci < ur_bc; bci++) {
+                const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
+                const auto accvr = vreg(accr_i);
+                fdiv(accvr.s, p_512, vmm_tmp.s);
+            }
+        }
+
+        for (int jj = 0; jj < ur_w; jj++) {
+            for (int bci = 0; bci < ur_bc; bci++) {
+                const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
+                const auto output_offset
+                        = dt_size * (jj * c_off + bci * c_block);
+                store(reg_idx(accr_i), xreg_output, output_offset,
+                        is_tail_processing(bci));
+            }
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
+        int pad_l, int pad_r, bool with_c_tail_proccessing) {
+    int iw = jpp.iw;
+    int kw = jpp.kw;
+    int stride_w = jpp.stride_w;
+    int c_block = jpp.c_block;
+    const int c_off
+            = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
+    Label kd_label, kh_label;
+
+    auto is_tail_processing = [&](int bc) {
+        return with_c_tail_proccessing && bc == (ur_bc - 1);
+    };
+
+    mov_imm(tmp_gpr, float2int(nstl::numeric_limits<float>::lowest()));
+
+    ptrue(p_tmp0.d, VL2);
+    mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, 0);
+    ptrue(p_tmp0.d, VL1);
+    mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, tmp_gpr);
+
+    dup(vmm_tmp.s, ZRegS(xmm_tmp.getIdx())[0]);
+
+    for_(int jj = 0; jj < ur_w; jj++)
+    for (int bci = 0; bci < ur_bc; bci++) {
+        const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).d;
+        mov(accvr, vmm_tmp.d);
+
+        if (jpp.is_training) {
+            const auto indvr = vreg(reg_ind(2, bci, jj, ur_bc, ur_w)).d;
+
+            eor(indvr, indvr, indvr);
+        }
+    }
+    if (jpp.is_training) {
+
+        ptrue(p_tmp0.d, VL2);
+        mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, 0);
+        ptrue(p_tmp0.d, VL1);
+        mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, reg_k_shift);
+
+        dup(vmm_k_offset, ZRegS(xmm_tmp.getIdx())[0]);
+    }
+    if (jpp.ndims == 5) {
+
+        str(reg_input, pre_ptr(X_TRANSLATOR_STACK, -8));
+
+        str(reg_output, pre_ptr(X_TRANSLATOR_STACK, -8));
+
+        mov(aux_reg_input_d, reg_input);
+
+        add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(kd_padding), X_TMP_0);
+        ldr(ki, ptr(X_DEFAULT_ADDR));
+        L(kd_label);
+
+        mov(aux_reg_input, aux_reg_input_d);
+    } else {
+
+        mov(aux_reg_input, reg_input);
+    }
+
+    eor(kj, kj, kj);
+    L(kh_label);
+    {
+        for (int ki = 0; ki < kw; ki++) {
+            int jj_start
+                    = nstl::max(0, utils::div_up(pad_l - ki, stride_w)); //test
+            int jj_end = ur_w
+                    - utils::div_up(
+                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+            for_(int jj = jj_start; jj < jj_end; jj++)
+            for (int bci = 0; bci < ur_bc; bci++) {
+                const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).s;
+                const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
+                const auto inpvr = vreg(inpr_i).s;
+                const auto indvr = vreg(reg_ind(2, bci, jj, ur_bc, ur_w)).s;
+                const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
+                int aux_input_offset
+                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
+                if (aux_input_offset >= iw * c_off) continue;
+                int input_offset = jpp.dt_size * aux_input_offset;
+                load(reg_idx(inpr_i), aux_xreg_input, input_offset,
+                        is_tail_processing(bci));
+
+                fcmlt(k_store_mask.s, p_512 / T_z, accvr, inpvr);
+                sel(accvr, k_store_mask / T_m, inpvr, accvr);
+                if (jpp.is_training) {
+                    sel(indvr, k_store_mask / T_m, vmm_k_offset, indvr);
+                }
+            }
+            if (jpp.is_training) add(vmm_k_offset, vmm_k_offset, vmm_one);
+        }
+
+        add_imm(aux_reg_input, aux_reg_input, (jpp.dt_size * iw * c_off),
+                X_TMP_0);
+        adds(kj, kj, 1);
+        cmp(kj, reg_kh);
+        b(LT, kh_label);
+    }
+
+    if (jpp.ndims == 5) {
+        add_imm(aux_reg_input_d, aux_reg_input_d,
+                (jpp.dt_size * jpp.ih * iw * c_off), X_TMP_0);
+        if (jpp.is_training) {
+            add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(kd_padding_shift),
+                    X_TMP_0);
+            ldr(tmp_gpr, ptr(X_DEFAULT_ADDR));
+
+            ptrue(p_tmp0.d, VL2);
+            mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, 0);
+            ptrue(p_tmp0.d, VL1);
+            mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, tmp_gpr);
+
+            dup(vmm_tmp.s, ZRegS(xmm_tmp.getIdx())[0]);
+            add(vmm_k_offset, vmm_k_offset, vmm_tmp.s);
+        }
+
+        subs(ki, ki, 1);
+        mov_imm(X_TMP_0, 0);
+        cmp(ki, X_TMP_0);
+        b(GT, kd_label);
+        ldr(reg_output, post_ptr(X_TRANSLATOR_STACK, 8));
+        ldr(reg_input, post_ptr(X_TRANSLATOR_STACK, 8));
+    }
+
+    for_(int jj = 0; jj < ur_w; jj++)
+    for (int bci = 0; bci < ur_bc; bci++) {
+        const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
+        const auto output_offset = jpp.dt_size * (jj * c_off + bci * c_block);
+        store(reg_idx(accr_i), xreg_output, output_offset,
+                is_tail_processing(bci));
+
+        if (jpp.is_training) {
+            const size_t step_index = (jj * c_off + bci * c_block)
+                    * types::data_type_size(jpp.ind_dt);
+
+            const auto indr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
+            auto vr = vreg(indr_i);
+            if (jpp.ind_dt == data_type::u8) {
+                auto xr = xreg(indr_i);
+                if (is_tail_processing(bci)) {
+                    if (jpp.is_c_padded) {
+                        add_imm(X_DEFAULT_ADDR, reg_index, step_index, X_TMP_0);
+                        zip1(p_tmp0.b, k_c_tail_mask.b, p_all_zero.b);
+                        zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                        not_(p_tmp0.b, P_ALL_ONE / T_z, p_tmp0.b);
+                        mov(z_tmp0.d, vr.d);
+                        mov(z_tmp0.s, p_tmp0 / T_m, 0);
+                        umin(z_tmp0.s, 255);
+                        //			std::cout << __LINE__ << std::endl;
+                        st1b(z_tmp0.s, p_512, ptr(X_DEFAULT_ADDR));
+                    } else {
+                        add_imm(X_DEFAULT_ADDR, reg_index, step_index, X_TMP_0);
+                        mov(z_tmp0.d, vr.d);
+                        umin(z_tmp0.s, 255);
+                        zip1(p_tmp0.b, k_c_tail_mask.b, p_all_zero.b);
+                        zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                        //			std::cout << __LINE__ << std::endl;
+                        st1b(z_tmp0.s, p_tmp0, ptr(X_DEFAULT_ADDR));
+                    }
+                } else {
+                    add_imm(X_DEFAULT_ADDR, reg_index, step_index, X_TMP_0);
+                    mov(z_tmp0.d, vr.d);
+                    umin(z_tmp0.s, 255);
+                    //		    std::cout << __LINE__ << std::endl;
+                    st1b(z_tmp0.s, p_512, ptr(X_DEFAULT_ADDR));
+                }
+            } else {
+                store(vr.getIdx(), xreg_index, step_index,
+                        is_tail_processing(bci));
+            }
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
+        int pad_l, int pad_r, bool with_c_tail_proccessing) {
+
+    int iw = jpp.iw;
+    int kw = jpp.kw;
+    int stride_w = jpp.stride_w;
+    int c_block = jpp.c_block;
+    const int c_off
+            = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
+    Label kd_label, kh_label;
+
+    const auto is_tail_processing = [&](int bc) {
+        return with_c_tail_proccessing && bc == (ur_bc - 1);
+    };
+
+    for_(int jj = 0; jj < ur_w; jj++)
+    for (int bci = 0; bci < ur_bc; bci++) {
+        const auto outr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
+        auto out_offset = jpp.dt_size * (jj * c_off + bci * c_block);
+        load(reg_idx(outr_i), xreg_output, out_offset, is_tail_processing(bci));
+        const size_t step_index = (jj * c_off + bci * c_block)
+                * types::data_type_size(jpp.ind_dt);
+
+        const auto indr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
+        auto indvr = vreg(indr_i);
+        if (jpp.ind_dt == data_type::u8) {
+            auto indxr = xreg(indr_i);
+            if (is_tail_processing(bci) && !jpp.is_c_padded) {
+                add_imm(X_DEFAULT_ADDR, reg_index, step_index, X_TMP_0);
+                ld1b(indvr.b, k_c_tail_mask / T_z, ptr(X_DEFAULT_ADDR));
+                zip1(indvr.b, indvr.b, z_tmp0.b);
+                zip1(indvr.h, indvr.h, z_tmp0.h);
+                zip1(p_tmp0.b, k_c_tail_mask.b, p_all_zero.b);
+                zip1(p_tmp0.h, p_tmp0.h, p_all_zero.h);
+                uxtb(indvr.s, p_tmp0 / T_m, indvr.s);
+            } else {
+                add_imm(X_DEFAULT_ADDR, reg_index, step_index, X_TMP_0);
+                ldr(QReg(z_tmp0.getIdx()), ptr(X_DEFAULT_ADDR));
+                zip1(z_tmp0.b, z_tmp0.b, z_tmp0.b);
+                zip1(z_tmp0.h, z_tmp0.h, z_tmp0.h);
+                uxtb(indvr.s, p_512 / T_m, z_tmp0.s);
+            }
+        } else {
+            load(indvr.getIdx(), xreg_index, step_index,
+                    is_tail_processing(bci));
+        }
+    }
+    ptrue(p_tmp0.d, VL2);
+    mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, 0);
+    ptrue(p_tmp0.d, VL1);
+    mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, reg_k_shift);
+    dup(vmm_k_offset, ZRegS(xmm_tmp.getIdx())[0]);
+
+    if (jpp.simple_alg && jpp.ndims == 5) {
+        str(reg_input, pre_ptr(X_TRANSLATOR_STACK, -8));
+        str(reg_output, pre_ptr(X_TRANSLATOR_STACK, -8));
+        mov(aux_reg_input_d, reg_input);
+
+        add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(kd_padding), X_TMP_0);
+        ldr(ki, ptr(X_DEFAULT_ADDR));
+
+        add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(kd_padding_shift), X_TMP_0);
+        ldr(reg_kd_pad_shift, ptr(X_DEFAULT_ADDR));
+        L(kd_label);
+
+        mov(aux_reg_input, aux_reg_input_d);
+    } else {
+
+        mov(aux_reg_input, reg_input);
+    }
+
+    eor(kj, kj, kj);
+
+    L(kh_label);
+    {
+        for (int ki = 0; ki < kw; ki++) {
+            int jj_start = nstl::max(0, utils::div_up(pad_l - ki, stride_w));
+            int jj_end = ur_w
+                    - utils::div_up(
+                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+            for_(int jj = jj_start; jj < jj_end; jj++)
+            for (int bci = 0; bci < ur_bc; bci++) {
+                const auto outvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).d;
+                const auto indvr = vreg(reg_ind(1, bci, jj, ur_bc, ur_w)).s;
+                const auto inpr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
+                const auto inpvr = vreg(inpr_i).s;
+                const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
+                int aux_inp_offset
+                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
+                if (aux_inp_offset >= iw * c_off) continue;
+                int inp_offset = jpp.dt_size * aux_inp_offset;
+                load(reg_idx(inpr_i), aux_xreg_input, inp_offset,
+                        is_tail_processing(bci));
+                auto indzr = zreg(inpr_i);
+                auto indyr = yreg(inpr_i);
+
+                cmpeq(k_store_mask.s, p_lsb / T_z, indvr, vmm_k_offset);
+
+                not_(p_tmp0.b, P_ALL_ONE.b, k_store_mask.b);
+
+                mov(vmm_tmp.d, outvr);
+                mov(vmm_tmp.s, p_tmp0 / T_m, 0);
+                fadd(inpvr, inpvr, vmm_tmp.s);
+
+                store(inpvr.getIdx(), aux_xreg_input, inp_offset,
+                        is_tail_processing(bci));
+            }
+
+            add(vmm_k_offset, vmm_k_offset, vmm_one);
+        }
+        add_imm(aux_reg_input, aux_reg_input, (jpp.dt_size * iw * c_off),
+                X_TMP_0);
+        adds(kj, kj, 1);
+        cmp(kj, reg_kh);
+        b(LT, kh_label);
+    }
+    if (jpp.simple_alg && jpp.ndims == 5) {
+        add_imm(aux_reg_input_d, aux_reg_input_d,
+                (jpp.dt_size * jpp.ih * iw * c_off), X_TMP_0);
+
+        mov(tmp_gpr, reg_kd_pad_shift);
+
+        ptrue(p_tmp0.d, VL2);
+        mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, 0);
+        ptrue(p_tmp0.d, VL1);
+        mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, tmp_gpr);
+
+        dup(vmm_tmp.s, ZRegS(xmm_tmp.getIdx())[0]);
+
+        add(vmm_k_offset, vmm_k_offset, vmm_tmp.s);
+        subs(ki, ki, 1);
+        mov_imm(X_TMP_0, 0);
+        cmp(ki, X_TMP_0);
+        b(GT, kd_label);
+        ldr(reg_output, post_ptr(X_TRANSLATOR_STACK, 8));
+
+        ldr(reg_input, post_ptr(X_TRANSLATOR_STACK, 8));
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel<isa>::zero_diff_src(
+        int ur_bc, bool with_c_tail_proccessing) {
+    const int c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
+            ? jpp.c
+            : jpp.c_block;
+
+    Label l_skip, l_ih_loop, l_id_loop;
+
+    auto is_tail_processing = [&](int bc) {
+        return with_c_tail_proccessing && bc == (ur_bc - 1);
+    };
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(zero_id), X_TMP_0);
+    ldr(reg_zero_id, ptr(X_DEFAULT_ADDR));
+
+    mov_imm(X_TMP_0, 0);
+    cmp(reg_zero_id, X_TMP_0);
+
+    b(EQ, l_skip);
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(zero_ih), X_TMP_0);
+    ldr(reg_zero_ih, ptr(X_DEFAULT_ADDR));
+
+    mov_imm(X_TMP_0, 0);
+    cmp(reg_zero_ih, X_TMP_0);
+
+    b(EQ, l_skip);
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(zero_ptr), X_TMP_0);
+    ldr(reg_zero_ptr, ptr(X_DEFAULT_ADDR));
+
+    TReg vzero = vmm_tmp;
+    eor(vzero.d, vzero.d, vzero.d);
+
+    const int width_size = jpp.iw * c_off * jpp.dt_size;
+
+    auto aux_reg_zero_ptr = tmp_gpr;
+
+    L(l_id_loop);
+    {
+        mov(aux_reg_zero_ptr, reg_zero_ptr);
+        mov(aux_reg_zero_ih, reg_zero_ih);
+        L(l_ih_loop);
+        {
+            const int step = c_off * jpp.dt_size;
+
+            // TODO: maybe a big code generated here
+            for_(int i = 0; i < width_size; i += step)
+            for (int bci = 0; bci < ur_bc; bci++) {
+                const int offs = i + bci * jpp.c_block * jpp.dt_size;
+                store(vzero.getIdx(), xreg_zero_ptr, offs,
+                        is_tail_processing(bci));
+            }
+            add_imm(reg_zero_ptr, reg_zero_ptr, width_size, X_TMP_0);
+            subs(aux_reg_zero_ih, aux_reg_zero_ih, 1);
+            b(NE, l_ih_loop);
+        }
+        mov(reg_zero_ptr, aux_reg_zero_ptr);
+        add_imm(reg_zero_ptr, reg_zero_ptr, (width_size * jpp.ih), X_TMP_0);
+        subs(reg_zero_id, reg_zero_id, 1);
+        b(NE, l_id_loop);
+    }
+
+    L(l_skip);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel<isa>::generate() {
+
+    this->preamble();
+
+    Label idx_table;
+
+    int ow = jpp.ow;
+    int iw = jpp.iw;
+    int kw = jpp.kw;
+    int kh = jpp.kh;
+    int c_block = jpp.c_block;
+    int stride_w = jpp.stride_w;
+    int l_pad = jpp.l_pad;
+    const int c_off
+            = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
+
+    int vlen = cpu_isa_traits<isa>::vlen;
+
+    ptrue(p_512.b);
+    pfalse(p_all_zero.b);
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(src), X_TMP_0);
+    ldr(reg_input, ptr(X_DEFAULT_ADDR));
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(dst), X_TMP_0);
+    ldr(reg_output, ptr(X_DEFAULT_ADDR));
+    if (jpp.alg == pooling_max && (jpp.is_training || jpp.is_backward)) {
+        add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(indices), X_TMP_0);
+        ldr(reg_index, ptr(X_DEFAULT_ADDR));
+    }
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(kh_padding), X_TMP_0);
+    ldr(reg_kh, ptr(X_DEFAULT_ADDR));
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(kh_padding_shift), X_TMP_0);
+    ldr(reg_k_shift, ptr(X_DEFAULT_ADDR));
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(ker_area_h), X_TMP_0);
+    ldr(reg_ker_area_h, ptr(X_DEFAULT_ADDR));
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(ur_bc), X_TMP_0);
+    ldr(reg_nbc, ptr(X_DEFAULT_ADDR));
+
+    int r_pad
+            = nstl::max(0, calculate_end_padding(l_pad, ow, iw, stride_w, kw));
+
+    auto process_oi = [&](int ur_w, int ur_bc, int lpad, int rpad,
+                              bool with_c_tail_proccessing,
+                              bool inc_reg = true) {
+        step(ur_w, ur_bc, lpad, rpad, with_c_tail_proccessing);
+
+        if (!inc_reg) return;
+
+        auto dt_size = jpp.dt_size;
+        add_imm(reg_input, reg_input,
+                (dt_size * (ur_w * stride_w - lpad) * c_off), X_TMP_0);
+        add_imm(reg_output, reg_output, (dt_size * ur_w * c_off), X_TMP_0);
+
+        if (jpp.alg == pooling_max && (jpp.is_training || jpp.is_backward)) {
+            auto ind_dt_size = types::data_type_size(jpp.ind_dt);
+            add_imm(reg_index, reg_index, ((ur_w * c_off) * ind_dt_size),
+                    X_TMP_0);
+        }
+    };
+
+    auto perform_ker = [&](int ur_bc, bool with_c_tail_processing) {
+        prev_kw = 0; // re-initialize this value for avg steps
+
+        if (jpp.is_backward && jpp.simple_alg)
+            zero_diff_src(ur_bc, with_c_tail_processing);
+
+        if (jpp.alg == pooling_avg_exclude_padding) {
+            // vmm_ker_area_h and vmm_c_tail_mask are stored in one register
+            // so when vmm_c_tail_mask is used we need to load vmm_ker_area_h
+            // exactly where this information is needed with the
+            // vmm_c_tail_mask information being saved first
+            uni_broadcast_reg_val(
+                    reg_ker_area_h.getIdx(), vmm_ker_area_h.getIdx());
+        }
+
+        if (jpp.alg == pooling_avg_include_padding) {
+            mov_imm(tmp_gpr, float2int((float)(kw * kh * jpp.kd)));
+
+            ptrue(p_tmp0.d, VL2);
+            mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, 0);
+            ptrue(p_tmp0.d, VL1);
+            mov(ZRegD(xmm_tmp.getIdx()), p_tmp0 / T_m, tmp_gpr);
+
+            dup(vmm_tmp.s, ZRegS(xmm_tmp.getIdx())[0]);
+        }
+
+        if (jpp.alg == pooling_max && (jpp.is_training || jpp.is_backward)) {
+            // The same situation as above(vmm_ker_area_h).
+            put_one_in_vmm();
+        }
+
+        auto ur_w = nstl::min(jpp.ow, jpp.ur / jpp.ur_bc);
+        auto ur_w_tail = jpp.ow % ur_w;
+
+        int n_oi = ow / ur_w;
+        int r_pad1
+                = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w, kw);
+        if (r_pad1 > 0) n_oi--;
+
+        if (l_pad > 0) {
+            n_oi--;
+            if (n_oi < 0 && r_pad1 > 0)
+                process_oi(ur_w, ur_bc, l_pad, r_pad1, with_c_tail_processing);
+            else
+                process_oi(ur_w, ur_bc, l_pad, 0, with_c_tail_processing);
+        }
+
+        eor(oi_iter, oi_iter, oi_iter);
+        if (n_oi > 0) {
+            Label ow_loop;
+            L(ow_loop);
+            {
+                process_oi(ur_w, ur_bc, 0, 0, with_c_tail_processing);
+
+                adds(oi_iter, oi_iter, 1);
+                mov_imm(X_TMP_0, n_oi);
+                cmp(oi_iter, X_TMP_0);
+                b(LT, ow_loop);
+            }
+        }
+
+        if (r_pad1 > 0 && n_oi >= 0)
+            process_oi(ur_w, ur_bc, 0, r_pad1, with_c_tail_processing);
+
+        if (ur_w_tail != 0)
+            process_oi(
+                    ur_w_tail, ur_bc, 0, r_pad, with_c_tail_processing, false);
+    };
+    Label ur_bc_tail_label, c_tail_processing_label, finish_label;
+
+    if (jpp.ur_bc_tail > 0) {
+        mov_imm(X_TMP_0, jpp.ur_bc);
+        cmp(reg_nbc, X_TMP_0);
+        b(NE, ur_bc_tail_label);
+    } else if (jpp.c_tail != 0) {
+        // ur_bc contains number of channel blocks to processing
+        // b_c contains number of channel blocks already processed
+        // If reg_nbc + tmp_gpr == jpp.nb_c then this is
+        // information that probably channel tail processing will be needed.
+        /* get mem address */
+        add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(b_c), X_TMP_0);
+        ldr(tmp_gpr, ptr(X_DEFAULT_ADDR));
+        add(tmp_gpr, tmp_gpr, reg_nbc);
+        mov_imm(X_TMP_0, jpp.nb_c);
+        cmp(tmp_gpr, X_TMP_0);
+        b(Xbyak_aarch64::EQ, c_tail_processing_label);
+    }
+
+    perform_ker(jpp.ur_bc, false);
+
+    if (jpp.ur_bc_tail > 0) {
+        bl(finish_label);
+
+        // If ur_bc_tail exists then we know that this is
+        // last set of blocks to process and we need
+        // care of c tail processing if number of channels
+        // is not divided by number of channels in block
+        L(ur_bc_tail_label);
+
+        if (jpp.c_tail != 0) prepare_tail_mask();
+        perform_ker(jpp.ur_bc_tail, jpp.c_tail != 0);
+
+        L(finish_label);
+
+    } else if (jpp.c_tail != 0) {
+        bl(finish_label);
+
+        L(c_tail_processing_label);
+
+        prepare_tail_mask();
+        perform_ker(jpp.ur_bc, true);
+
+        L(finish_label);
+    }
+
+    this->postamble();
+}
+
+template struct jit_uni_pool_kernel<sve_512>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.hpp
@@ -1,0 +1,180 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+* Copyright 2018 YANDEX LLC
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_POOL_KERNEL_HPP
+#define CPU_AARCH64_JIT_UNI_POOL_KERNEL_HPP
+
+#include <cfloat>
+#include <functional>
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa>
+struct jit_uni_pool_kernel : public jit_generator {
+
+    jit_uni_pool_kernel(
+            const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md);
+    jit_pool_conf_t jpp;
+    ~jit_uni_pool_kernel();
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_pool_kernel)
+
+    static status_t init_conf(jit_pool_conf_t &jbp,
+            memory_tracking::registrar_t &scratchpad, const pooling_pd_t *ppd,
+            int nthreads);
+
+private:
+    using TReg = typename cpu_isa_traits<isa>::TReg;
+    using TRegS = typename cpu_isa_traits<isa>::TRegS;
+
+    int vmm_idx_upper_bound() const noexcept { return 31; }
+
+    int reg_idx(int idx) const noexcept { return vmm_idx_upper_bound() - idx; }
+
+    VReg xreg(int idx) const noexcept { return VReg(reg_idx(idx)); }
+    ZReg yreg(int idx) const noexcept { return ZReg(reg_idx(idx)); }
+    ZReg zreg(int idx) const noexcept { return ZReg(reg_idx(idx)); }
+    TReg vreg(int idx) const noexcept { return TReg(reg_idx(idx)); }
+
+    VReg vmm_mask = VReg(0);
+    ZReg ymm_tmp_1 = ZReg(0);
+    TRegS vmm_tmp_1 = TRegS(0);
+
+    TReg vmm_c_tail_mask = TReg(2);
+
+    VReg xmm_ker_area_h = VReg(2);
+    VReg xmm_one = VReg(2);
+    VReg xmm_tmp = VReg(3);
+
+    TRegS vmm_ker_area_h = TRegS(2);
+    TRegS vmm_one = TRegS(2);
+    TReg vmm_tmp = TReg(3);
+    ZReg ymm_tmp = ZReg(3);
+
+    TRegS vmm_k_offset = TRegS(1);
+
+    inline uint32_t reg_idx() {
+        if (!jpp.is_backward) {
+            return (jpp.is_training) ? 4 : 1;
+        } else
+            return 4;
+    }
+
+    ZReg z_tmp0 = z4;
+
+    PReg k_c_tail_mask = p4;
+    PReg k_mask_cvt = p5;
+    PReg k_store_mask = p6;
+
+    /* Caution: Chose predicate registers not used by x64's implementation. */
+    PReg p_all_zero = p0;
+    PReg p_512 = p2;
+    PReg p_tmp0 = p3;
+    PReg p_lsb = p2;
+
+    using xreg_t = const XReg;
+    xreg_t reg_param = x0;
+    xreg_t reg_input = x4;
+    xreg_t aux_reg_input = x5;
+    xreg_t reg_index = x10;
+    xreg_t reg_output = x12;
+    xreg_t reg_kd_pad_shift = x13;
+
+    xreg_t kj = x14;
+    xreg_t oi_iter = x15;
+    xreg_t reg_kh = x7;
+    xreg_t reg_k_shift = x3;
+    xreg_t tmp_gpr = x6;
+    xreg_t reg_ker_area_h = x2;
+    xreg_t reg_nbc = x1;
+
+    xreg_t reg_zero_ptr = x5;
+    xreg_t reg_zero_id = x13;
+    xreg_t reg_zero_ih = x14;
+    xreg_t aux_reg_zero_ih = x15;
+    xreg_t ki = x12;
+    xreg_t aux_reg_input_d = x4;
+
+    xreg_t aux_xreg_input = x5;
+    xreg_t xreg_output = x12;
+    xreg_t xreg_index = x10;
+    xreg_t xreg_zero_ptr = x5;
+
+    int prev_kw;
+
+    void prepare_tail_mask();
+    void put_one_in_vmm();
+    void uni_broadcast_reg_val(const int reg_idx, const int vmm_idx);
+    void push_vmm_val(const int idx);
+    void pop_vmm_val(const int idx);
+    void load(const int idx, const xreg_t &reg_ptr, const int offset,
+            const bool is_c_tail_proccessing);
+    void store(const int idx, const xreg_t &reg_ptr, const int offset,
+            const bool is_c_tail_proccessing);
+
+    void maybe_recalculate_divisor(int jj, int ur_w, int pad_l, int pad_r,
+            bool with_c_tail_proccessing);
+    void avg_step(int ur_w, int ur_bc, int pad_l, int pad_r,
+            bool with_c_tail_proccessing);
+    void max_step_fwd(int ur_w, int ur_bc, int pad_l, int pad_r,
+            bool with_c_tail_proccessing);
+    void max_step_bwd(int ur_w, int ur_bc, int pad_l, int pad_r,
+            bool with_c_tail_proccessing);
+
+    void zero_diff_src(int ur_bc, bool with_c_tail_proccessing);
+
+    void step(int ur_w, int ur_bc, int pad_l, int pad_r,
+            bool with_c_tail_proccessing) {
+        if (jpp.alg == alg_kind::pooling_max) {
+            if (jpp.is_backward)
+                max_step_bwd(
+                        ur_w, ur_bc, pad_l, pad_r, with_c_tail_proccessing);
+            else
+                max_step_fwd(
+                        ur_w, ur_bc, pad_l, pad_r, with_c_tail_proccessing);
+        } else
+            avg_step(ur_w, ur_bc, pad_l, pad_r, with_c_tail_proccessing);
+    }
+
+    void generate() override;
+
+    static bool post_ops_ok(jit_pool_conf_t &jpp, const primitive_attr_t &attr,
+            const memory_desc_wrapper &dst_d);
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -1,0 +1,1228 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <functional>
+#include <new>
+#include "dnnl_types.h"
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/aarch64/jit_uni_pooling.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace jit_uni_pooling_utils {
+
+struct trans_wrapper_t {
+    trans_wrapper_t(data_type_t inp_dt, dim_t inp_str, data_type_t out_dt,
+            dim_t out_str, dim_t ysize, dim_t xsize)
+        : inp_dt_size_(types::data_type_size(inp_dt))
+        , out_dt_size_(types::data_type_size(out_dt))
+        , inp_str_(inp_str)
+        , out_str_(out_str)
+        , nb_x_(xsize / 8)
+        , nb_y_(ysize / 8)
+        , x_tail_(xsize % 8)
+        , y_tail_(ysize % 8) {
+        using namespace cpu::aarch64::tr;
+
+        auto create_ker = [=](dim_t ys, dim_t y_inp_str, dim_t y_out_str,
+                                  dim_t xs, dim_t x_inp_str, dim_t x_out_str) {
+            tr::prb_t prb;
+            kernel_t::desc_t desc;
+
+            prb.ndims = 2;
+            prb.ioff = 0;
+            prb.ooff = 0;
+            prb.scale_type = scale_type_t::NONE;
+            prb.beta = 0;
+            prb.nodes[0].ss = prb.nodes[1].ss = 1;
+
+            prb.itype = inp_dt;
+            prb.otype = out_dt;
+
+            prb.nodes[0].n = ys;
+            prb.nodes[0].is = y_inp_str;
+            prb.nodes[0].os = y_out_str;
+
+            prb.nodes[1].n = xs;
+            prb.nodes[1].is = x_inp_str;
+            prb.nodes[1].os = x_out_str;
+
+            kernel_t::desc_init(desc, prb, 2);
+            return kernel_t::create(desc);
+        };
+
+        if (nb_x_ * nb_y_ > 0)
+            ker_.reset(create_ker(8, inp_str_, 1, 8, 1, out_str_));
+
+        if (x_tail_)
+            ker_x_tail_.reset(create_ker(8, inp_str_, 1, x_tail_, 1, out_str_));
+
+        if (y_tail_)
+            ker_y_tail_.reset(
+                    create_ker(y_tail_, inp_str_, 1, xsize, 1, out_str_));
+    }
+
+    status_t create_kernel() {
+        if (ker_) CHECK(ker_->create_kernel());
+        if (ker_x_tail_) CHECK(ker_x_tail_->create_kernel());
+        if (ker_y_tail_) CHECK(ker_y_tail_->create_kernel());
+        return status::success;
+    }
+
+    void exec(const void *inp, void *out) {
+        dim_t x_blocked = nb_x_ * 8;
+        dim_t y_blocked = nb_y_ * 8;
+
+        auto call_ker = [&](tr::kernel_t &ker, dim_t inp_y, dim_t inp_x,
+                                dim_t out_y, dim_t out_x) {
+            tr::call_param_t cp;
+            cp.scale = nullptr;
+
+            dim_t inp_off = (inp_y * inp_str_ + inp_x) * inp_dt_size_;
+            dim_t out_off = (out_y * out_str_ + out_x) * out_dt_size_;
+            cp.in = (uint8_t *)inp + inp_off;
+            cp.out = (uint8_t *)out + out_off;
+            (ker)(&cp);
+        };
+
+        for (dim_t by = 0; by < nb_y_; by++) {
+            for (dim_t bx = 0; bx < nb_x_; bx++)
+                call_ker(*ker_, 8 * by, 8 * bx, 8 * bx, 8 * by);
+
+            if (x_tail_)
+                call_ker(*ker_x_tail_, 8 * by, x_blocked, x_blocked, 8 * by);
+        }
+        if (y_tail_) call_ker(*ker_y_tail_, y_blocked, 0, 0, y_blocked);
+    }
+
+    ~trans_wrapper_t() = default;
+
+private:
+    std::unique_ptr<tr::kernel_t> ker_;
+    std::unique_ptr<tr::kernel_t> ker_x_tail_;
+    std::unique_ptr<tr::kernel_t> ker_y_tail_;
+
+    const size_t inp_dt_size_;
+    const size_t out_dt_size_;
+
+    const dim_t inp_str_;
+    const dim_t out_str_;
+    const dim_t nb_x_;
+    const dim_t nb_y_;
+    const dim_t x_tail_;
+    const dim_t y_tail_;
+};
+
+struct trans_context_t {
+    std::unique_ptr<trans_wrapper_t> src_trans_ = nullptr;
+    std::unique_ptr<trans_wrapper_t> src_tail_trans_ = nullptr;
+    std::unique_ptr<trans_wrapper_t> ind_trans_ = nullptr;
+    std::unique_ptr<trans_wrapper_t> ind_tail_trans_ = nullptr;
+    std::unique_ptr<trans_wrapper_t> dst_trans_ = nullptr;
+    std::unique_ptr<trans_wrapper_t> dst_tail_trans_ = nullptr;
+    status_t create_kernel() {
+        if (src_trans_) CHECK(src_trans_->create_kernel());
+        if (src_tail_trans_) CHECK(src_tail_trans_->create_kernel());
+        if (ind_trans_) CHECK(ind_trans_->create_kernel());
+        if (ind_tail_trans_) CHECK(ind_tail_trans_->create_kernel());
+        if (dst_trans_) CHECK(dst_trans_->create_kernel());
+        if (dst_tail_trans_) CHECK(dst_tail_trans_->create_kernel());
+        return status::success;
+    }
+};
+
+static void trans_exec(trans_wrapper_t *trans, trans_wrapper_t *trans_tail,
+        dim_t cs, const void *inp, void *out, dim_t c_block) {
+
+    if (cs == c_block)
+        trans->exec(inp, out);
+    else
+        trans_tail->exec(inp, out);
+};
+
+template <typename src_data_t, typename dst_data_t>
+struct transpose_ncsp_to_block_fmt_t {
+    transpose_ncsp_to_block_fmt_t(trans_wrapper_t *transposer,
+            trans_wrapper_t *transposer_tail, const src_data_t *src_nscp_base,
+            const memory_desc_wrapper &src_nscp_desc,
+            dst_data_t *__restrict dst_blocked_base, dim_t block_size,
+            const jit_pool_conf_t &jpp, std::size_t offset_multiplier = 1u)
+        : transposer_(transposer)
+        , transposer_tail_(transposer_tail)
+        , c_without_padding_(jpp.c_without_padding)
+        , c_block_(jpp.c_block)
+        , src_nscp_base_(src_nscp_base)
+        , src_nscp_desc_(src_nscp_desc)
+        , dst_blocked_base_(dst_blocked_base)
+        , block_size_(block_size)
+        , offset_multiplier_(offset_multiplier) {}
+
+    void operator()(std::size_t ithr, int n, int b_c) const {
+        const dim_t cs
+                = nstl::min(c_without_padding_ - b_c * c_block_, c_block_);
+        const src_data_t *src_nscp = src_nscp_base_
+                + src_nscp_desc_.blk_off(n, b_c * c_block_, 0)
+                        * offset_multiplier_;
+        dst_data_t *dst_blocked
+                = dst_blocked_base_ + ithr * block_size_ * offset_multiplier_;
+        trans_exec(transposer_, transposer_tail_, cs, src_nscp, dst_blocked,
+                c_block_);
+    }
+
+private:
+    trans_wrapper_t *transposer_;
+    trans_wrapper_t *transposer_tail_;
+    const int c_without_padding_;
+    const int c_block_;
+    const src_data_t *src_nscp_base_;
+    const memory_desc_wrapper &src_nscp_desc_;
+    dst_data_t *__restrict dst_blocked_base_;
+    const dim_t block_size_;
+    std::size_t offset_multiplier_;
+};
+
+template <typename src_data_t, typename dst_data_t>
+struct transpose_block_fmt_to_ncsp_t {
+
+    transpose_block_fmt_to_ncsp_t(trans_wrapper_t *transposer,
+            trans_wrapper_t *transposer_tail,
+            const src_data_t *__restrict src_blocked_base, dim_t block_size,
+            dst_data_t *dst_ncsp_base, const memory_desc_wrapper &dst_nscp_desc,
+            const jit_pool_conf_t &jpp, std::size_t offset_multiplier = 1u)
+        : transposer_(transposer)
+        , transposer_tail_(transposer_tail)
+        , c_without_padding_(jpp.c_without_padding)
+        , c_block_(jpp.c_block)
+        , src_blocked_base_(src_blocked_base)
+        , block_size_(block_size)
+        , dst_ncsp_base_(dst_ncsp_base)
+        , dst_nscp_desc_(dst_nscp_desc)
+        , offset_multiplier_(offset_multiplier) {}
+
+    void operator()(std::size_t ithr, int n, int b_c) const {
+        const dim_t cs
+                = nstl::min(c_without_padding_ - b_c * c_block_, c_block_);
+        const src_data_t *src_blocked
+                = src_blocked_base_ + ithr * block_size_ * offset_multiplier_;
+        dst_data_t *dst_ncsp = dst_ncsp_base_
+                + dst_nscp_desc_.blk_off(n, b_c * c_block_, 0)
+                        * offset_multiplier_;
+        trans_exec(transposer_, transposer_tail_, cs, src_blocked, dst_ncsp,
+                c_block_);
+    }
+
+private:
+    trans_wrapper_t *transposer_;
+    trans_wrapper_t *transposer_tail_;
+    const int c_without_padding_;
+    const int c_block_;
+    const src_data_t *__restrict src_blocked_base_;
+    const dim_t block_size_;
+    dst_data_t *dst_ncsp_base_;
+    const memory_desc_wrapper &dst_nscp_desc_;
+    std::size_t offset_multiplier_;
+};
+
+template <typename wsp_data_t, impl::data_type_t d_type>
+class transpose_facade_base_t {
+public:
+    transpose_facade_base_t(const jit_pool_conf_t &jpp,
+            const memory_desc_wrapper &src_d, const memory_desc_wrapper &dst_d,
+            const memory_desc_wrapper &indices_d, const char *indices,
+            const data_type_t wsp_dt, const exec_ctx_t &ctx)
+        : src_sp_(static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw)
+        , dst_sp_(static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow)
+        , src_slice_(src_sp_ * jpp.c_block)
+        , dst_slice_(dst_sp_ * jpp.c_block)
+        , transpose_src_(jpp.tag_kind == jit_memory_tag_kind_t::ncsp)
+        , transpose_dst_(jpp.tag_kind == jit_memory_tag_kind_t::ncsp)
+        , src_d_(src_d)
+        , dst_d_(dst_d)
+        , indices_d_(indices_d)
+        , ind_dt_size_(
+                  indices ? types::data_type_size(indices_d_.data_type()) : 0)
+        , cvt_slice_src_wsp_(nullptr)
+        , cvt_slice_dst_wsp_(nullptr)
+        , cvt_slice_ind_wsp_(nullptr)
+        , execute_transpose_input_(nullptr)
+        , execute_transpose_output_(nullptr) {
+
+        auto scratchpad = ctx.get_scratchpad_grantor();
+
+        if (transpose_src_)
+            cvt_slice_src_wsp_ = scratchpad.template get<wsp_data_t>(
+                    memory_tracking::names::key_pool_src_plain2blocked_cvt);
+
+        if (transpose_dst_) {
+            cvt_slice_dst_wsp_ = scratchpad.template get<wsp_data_t>(
+                    memory_tracking::names::key_pool_dst_plain2blocked_cvt);
+            cvt_slice_ind_wsp_ = scratchpad.template get<char>(
+                    memory_tracking::names::key_pool_ind_plain2blocked_cvt);
+        }
+    }
+
+    inline bool should_transpose_src() const noexcept { return transpose_src_; }
+    inline bool should_transpose_dst() const noexcept { return transpose_dst_; }
+
+    const void *get_src_addr(
+            std::size_t ithr, int ih, const jit_pool_conf_t &jpp) const {
+        const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
+        return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block]);
+    }
+
+    const void *get_dst_addr(
+            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+        const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
+        return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block]);
+    }
+
+    const void *get_indices_addr(
+            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+        const char *const wsp
+                = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
+        return static_cast<const void *>(
+                &wsp[oh * jpp.ow * jpp.c_block * ind_dt_size_]);
+    }
+
+    const void *get_src_addr_3d(std::size_t ithr, int id, int ih,
+            const jit_pool_conf_t &jpp) const {
+        const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
+        return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block
+                + id * jpp.ih * jpp.iw * jpp.c_block]);
+    }
+
+    const void *get_dst_addr_3d(std::size_t ithr, int od, int oh,
+            const jit_pool_conf_t &jpp) const {
+        const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
+        return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block
+                + od * jpp.oh * jpp.ow * jpp.c_block]);
+    }
+
+    const void *get_indices_addr_3d(std::size_t ithr, int od, int oh,
+            const jit_pool_conf_t &jpp) const {
+        const char *const wsp
+                = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
+        return static_cast<const void *>(
+                &wsp[oh * jpp.ow * jpp.c_block * ind_dt_size_
+                        + od * jpp.oh * jpp.ow * jpp.c_block * ind_dt_size_]);
+    }
+
+    void execute_transpose_input(std::size_t ithr, int n, int b_c) const {
+        execute_transpose_input_(ithr, n, b_c);
+    }
+
+    void execute_transpose_output(std::size_t ithr, int n, int b_c) const {
+        execute_transpose_output_(ithr, n, b_c);
+    }
+
+protected:
+    const dim_t src_sp_;
+    const dim_t dst_sp_;
+    const dim_t src_slice_;
+    const dim_t dst_slice_;
+
+    const bool transpose_src_;
+    const bool transpose_dst_;
+
+    const memory_desc_wrapper &src_d_;
+    const memory_desc_wrapper &dst_d_;
+    const memory_desc_wrapper &indices_d_;
+    const size_t ind_dt_size_;
+
+    wsp_data_t *__restrict cvt_slice_src_wsp_;
+    wsp_data_t *__restrict cvt_slice_dst_wsp_;
+    char *__restrict cvt_slice_ind_wsp_;
+
+    std::function<void(std::size_t, int, int)> execute_transpose_input_;
+    std::function<void(std::size_t, int, int)> execute_transpose_output_;
+};
+
+template <typename data_t, typename wsp_data_t, impl::data_type_t d_type>
+class fwd_pooling_transpose_facade_t
+    : public transpose_facade_base_t<wsp_data_t, d_type> {
+public:
+    fwd_pooling_transpose_facade_t(const jit_pool_conf_t &jpp,
+            trans_context_t *trans_ctx, const memory_desc_wrapper &src_d,
+            const memory_desc_wrapper &dst_d,
+            const memory_desc_wrapper &indices_d, const data_type_t wsp_dt,
+            const data_t *src, data_t *dst, char *indices,
+            const exec_ctx_t &ctx)
+        : transpose_facade_base_t<wsp_data_t, d_type>(
+                jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx) {
+
+        if (this->should_transpose_src()) {
+            this->execute_transpose_input_
+                    = transpose_ncsp_to_block_fmt_t<data_t, wsp_data_t>(
+                            trans_ctx->src_trans_.get(),
+                            trans_ctx->src_tail_trans_.get(), src, this->src_d_,
+                            this->cvt_slice_src_wsp_, this->src_slice_, jpp);
+        }
+
+        if (this->should_transpose_dst()) {
+            using namespace std::placeholders;
+            this->execute_transpose_output_ = std::bind(
+                    [=](const transpose_block_fmt_to_ncsp_t<wsp_data_t, data_t>
+                                    &trans_dst,
+                            transpose_block_fmt_to_ncsp_t<char, char>
+                                    &trans_indices,
+                            std::size_t ithr, int n, int b_c) {
+                        trans_dst(ithr, n, b_c);
+                        if (indices) trans_indices(ithr, n, b_c);
+                    },
+                    transpose_block_fmt_to_ncsp_t<wsp_data_t, data_t>(
+                            trans_ctx->dst_trans_.get(),
+                            trans_ctx->dst_tail_trans_.get(),
+                            this->cvt_slice_dst_wsp_, this->dst_slice_, dst,
+                            this->dst_d_, jpp, 1u),
+                    transpose_block_fmt_to_ncsp_t<char, char>(
+                            trans_ctx->ind_trans_.get(),
+                            trans_ctx->ind_tail_trans_.get(),
+                            this->cvt_slice_ind_wsp_, this->dst_slice_, indices,
+                            this->indices_d_, jpp, this->ind_dt_size_),
+                    _1, _2, _3);
+        }
+    }
+};
+
+template <typename data_t, typename wsp_data_t, impl::data_type_t d_type>
+class bwd_pooling_transpose_facade_t
+    : public transpose_facade_base_t<wsp_data_t, d_type> {
+public:
+    bwd_pooling_transpose_facade_t(const jit_pool_conf_t &jpp,
+            trans_context_t *trans_ctx, const memory_desc_wrapper &src_d,
+            const memory_desc_wrapper &dst_d,
+            const memory_desc_wrapper &indices_d, const data_type_t wsp_dt,
+            data_t *src, const data_t *dst, const char *indices,
+            const exec_ctx_t &ctx)
+        : transpose_facade_base_t<wsp_data_t, d_type>(
+                jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx)
+        , c_tail_(jpp.c_without_padding % jpp.c_block) {
+
+        if (this->should_transpose_src())
+            this->execute_transpose_output_
+                    = transpose_block_fmt_to_ncsp_t<wsp_data_t, data_t>(
+                            trans_ctx->src_trans_.get(),
+                            trans_ctx->src_tail_trans_.get(),
+                            this->cvt_slice_src_wsp_, this->src_slice_, src,
+                            this->src_d_, jpp, 1u);
+
+        if (this->should_transpose_dst()) {
+            using namespace std::placeholders;
+
+            this->execute_transpose_input_ = std::bind(
+                    [=](const transpose_ncsp_to_block_fmt_t<data_t, wsp_data_t>
+                                    &trans_dst,
+                            transpose_ncsp_to_block_fmt_t<char, char>
+                                    &trans_indices,
+                            std::size_t ithr, int n, int b_c) {
+                        trans_dst(ithr, n, b_c);
+                        if (indices) trans_indices(ithr, n, b_c);
+                    },
+                    transpose_ncsp_to_block_fmt_t<data_t, wsp_data_t>(
+                            trans_ctx->dst_trans_.get(),
+                            trans_ctx->dst_tail_trans_.get(), dst, this->dst_d_,
+                            this->cvt_slice_dst_wsp_, this->dst_slice_, jpp),
+                    transpose_ncsp_to_block_fmt_t<char, char>(
+                            trans_ctx->ind_trans_.get(),
+                            trans_ctx->ind_tail_trans_.get(), indices,
+                            this->indices_d_, this->cvt_slice_ind_wsp_,
+                            this->dst_slice_, jpp, this->ind_dt_size_),
+                    _1, _2, _3);
+        }
+    }
+
+    inline bool should_fill_input_c_tail_with_zeros() const noexcept {
+        return this->should_transpose_dst() && c_tail_ != 0;
+    }
+
+    void fill_input_c_tail_with_zeros(
+            std::size_t ithr, const jit_pool_conf_t &jpp) const {
+
+        wsp_data_t *__restrict wsp_ptr
+                = this->cvt_slice_dst_wsp_ + ithr * this->dst_slice_;
+        for_(dim_t s = 0; s < this->dst_sp_; s++)
+        for (dim_t c = c_tail_; c < jpp.c_block; c++)
+            wsp_ptr[s * jpp.c_block + c] = 0.f;
+
+        char *__restrict ind_ptr = this->cvt_slice_ind_wsp_
+                + ithr * this->dst_slice_ * this->ind_dt_size_;
+        for_(dim_t s = 0; s < this->dst_sp_; s++)
+        for_(dim_t c = c_tail_; c < jpp.c_block; c++)
+        for (size_t i = 0; i < this->ind_dt_size_; i++)
+            ind_ptr[(s * jpp.c_block + c) * this->ind_dt_size_ + i] = 0;
+    }
+
+private:
+    const dim_t c_tail_;
+};
+
+} // namespace jit_uni_pooling_utils
+
+template <cpu_isa_t isa, impl::data_type_t d_type>
+jit_uni_pooling_fwd_t<isa, d_type>::jit_uni_pooling_fwd_t(const pd_t *apd)
+    : primitive_t(apd), kernel_(nullptr), trans_ctx_(nullptr) {}
+
+template <cpu_isa_t isa, impl::data_type_t d_type>
+status_t jit_uni_pooling_fwd_t<isa, d_type>::init(engine_t *engine) {
+
+    CHECK(safe_ptr_assign(kernel_,
+            new jit_uni_pool_kernel<isa>(
+                    pd()->jpp_, pd()->invariant_dst_md())));
+
+    if (pd()->jpp_.tag_kind == jit_memory_tag_kind_t::ncsp)
+        CHECK(init_ncsp_trans_ctx());
+    return kernel_->create_kernel();
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+status_t jit_uni_pooling_fwd_t<isa, d_type>::init_ncsp_trans_ctx() {
+    using namespace dnnl::impl;
+    using namespace jit_uni_pooling_utils;
+
+    const auto &jpp = pd()->jpp_;
+    trans_ctx_ = utils::make_unique<trans_context_t>();
+    const dim_t src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
+    const dim_t dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
+    const auto res = std::div(jpp.c_without_padding, jpp.c_block);
+    const dim_t &nb_c = res.quot;
+    const dim_t &c_tail = res.rem;
+    const memory_desc_wrapper indices_d = pd()->workspace_md();
+    const bool have_indices = indices_d.data_type() != data_type::undef;
+    static constexpr auto wsp_dt = wsp_dt_;
+
+    if (nb_c) {
+        trans_ctx_->src_trans_ = utils::make_unique<trans_wrapper_t>(
+                d_type, src_sp, wsp_dt, jpp.c_block, jpp.c_block, src_sp);
+        trans_ctx_->dst_trans_ = utils::make_unique<trans_wrapper_t>(
+                wsp_dt, jpp.c_block, d_type, dst_sp, dst_sp, jpp.c_block);
+        if (have_indices)
+            trans_ctx_->ind_trans_ = utils::make_unique<trans_wrapper_t>(
+                    indices_d.data_type(), jpp.c_block, indices_d.data_type(),
+                    dst_sp, dst_sp, jpp.c_block);
+    }
+
+    if (c_tail) {
+        trans_ctx_->src_tail_trans_ = utils::make_unique<trans_wrapper_t>(
+                d_type, src_sp, wsp_dt, jpp.c_block, c_tail, src_sp);
+        trans_ctx_->dst_tail_trans_ = utils::make_unique<trans_wrapper_t>(
+                wsp_dt, jpp.c_block, d_type, dst_sp, dst_sp, c_tail);
+        if (have_indices)
+            trans_ctx_->ind_tail_trans_ = utils::make_unique<trans_wrapper_t>(
+                    indices_d.data_type(), jpp.c_block, indices_d.data_type(),
+                    dst_sp, dst_sp, c_tail);
+    }
+
+    return trans_ctx_->create_kernel();
+}
+
+template <cpu_isa_t isa, impl::data_type_t d_type>
+jit_uni_pooling_fwd_t<isa, d_type>::~jit_uni_pooling_fwd_t() = default;
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(const data_t *src,
+        data_t *dst, char *indices, const exec_ctx_t &ctx) const {
+
+    const memory_desc_wrapper src_d = pd()->src_md();
+    const memory_desc_wrapper dst_d = pd()->dst_md();
+    const memory_desc_wrapper indices_d = pd()->workspace_md();
+    const auto ind_dt_size
+            = indices ? types::data_type_size(indices_d.data_type()) : 0;
+    const auto &jpp = pd()->jpp_;
+
+    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using namespace jit_uni_pooling_utils;
+
+    const auto transpose_facade
+            = fwd_pooling_transpose_facade_t<data_t, wsp_data_t, d_type>(jpp,
+                    trans_ctx_.get(), src_d, dst_d, indices_d, wsp_dt_, src,
+                    dst, indices, ctx);
+
+    const auto trans_src = transpose_facade.should_transpose_src();
+    const auto trans_dst = transpose_facade.should_transpose_dst();
+
+    const auto ker = [&](std::size_t ithr, int n, int b_c, int oh, int ur_bc) {
+        assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
+        auto arg = jit_pool_call_s();
+
+        const int ij = oh * jpp.stride_h;
+        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
+        const int i_b_overflow
+                = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
+        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
+        const int c_off
+                = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
+                                                                 : 1)
+                * b_c;
+        const int c_elem_off = jpp.c_block * b_c;
+
+        if (trans_src)
+            arg.src = transpose_facade.get_src_addr(ithr, ih, jpp);
+        else
+            arg.src = static_cast<const void *>(
+                    &src[src_d.blk_off(n, c_off, ih)]);
+
+        if (trans_dst)
+            arg.dst = transpose_facade.get_dst_addr(ithr, oh, jpp);
+        else
+            arg.dst = static_cast<const void *>(
+                    &dst[dst_d.blk_off(n, c_off, oh)]);
+
+        if (indices) {
+            if (trans_dst)
+                arg.indices = transpose_facade.get_indices_addr(ithr, oh, jpp);
+            else {
+                const size_t ind_off = indices_d.blk_off(n, c_off, oh);
+                arg.indices = static_cast<const void *>(
+                        &indices[ind_off * ind_dt_size]);
+            }
+        }
+        arg.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
+        arg.kh_padding_shift = i_t_overflow * jpp.kw;
+        arg.ker_area_h = static_cast<float>(jpp.kh
+                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+        arg.ur_bc = ur_bc;
+        arg.b_c = b_c;
+        arg.c_elem_off = c_elem_off;
+        (*kernel_)(&arg);
+    };
+
+    if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
+        const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+        parallel_nd(jpp.mb, jpp.oh, nb2_c, [&](int n, int oh, int b2_c) {
+            const auto b_c = b2_c * jpp.ur_bc;
+            const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+            ker(0, n, b_c, oh, ur_bc);
+        });
+    } else {
+        if (trans_src || trans_dst) {
+            // ncsp format
+            parallel_nd_ext(0, jpp.mb, jpp.nb_c,
+                    [&](int ithr, int nthr, int n, int b_c) {
+                        if (trans_src)
+                            transpose_facade.execute_transpose_input(
+                                    ithr, n, b_c);
+                        for (int oh = 0; oh < jpp.oh; ++oh)
+                            ker(ithr, n, b_c, oh, 1);
+                        if (trans_dst)
+                            transpose_facade.execute_transpose_output(
+                                    ithr, n, b_c);
+                    });
+        } else {
+            // nChw16c, nChw8c format
+            parallel(0, [&](std::size_t ithr, std::size_t nthr) {
+                const std::size_t work_amount
+                        = static_cast<std::size_t>(jpp.mb) * jpp.nb_c * jpp.oh;
+                if (ithr >= work_amount) return;
+
+                std::size_t start {0}, end {0};
+                int n {0}, b_c {0}, oh {0};
+
+                balance211(work_amount, nthr, ithr, start, end);
+                utils::nd_iterator_init(
+                        start, n, jpp.mb, b_c, jpp.nb_c, oh, jpp.oh);
+
+                for (std::size_t iwork = start; iwork < end; ++iwork) {
+                    ker(ithr, n, b_c, oh, 1);
+                    utils::nd_iterator_step(
+                            n, jpp.mb, b_c, jpp.nb_c, oh, jpp.oh);
+                }
+            });
+        }
+    }
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(const data_t *src,
+        data_t *dst, char *indices, const exec_ctx_t &ctx) const {
+
+    const auto &jpp = pd()->jpp_;
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper indices_d(pd()->workspace_md());
+    const size_t ind_dt_size
+            = indices ? types::data_type_size(indices_d.data_type()) : 0;
+
+    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using namespace jit_uni_pooling_utils;
+    static constexpr int first_ithr = 0;
+
+    const auto transpose_facade
+            = fwd_pooling_transpose_facade_t<data_t, wsp_data_t, d_type>(jpp,
+                    trans_ctx_.get(), src_d, dst_d, indices_d, wsp_dt_, src,
+                    dst, indices, ctx);
+
+    const auto trans_src = transpose_facade.should_transpose_src();
+    const auto trans_dst = transpose_facade.should_transpose_dst();
+
+    auto ker = [&](int n, int b_c, int od, int oh, int id, int d_t_overflow,
+                       int d_b_overflow, int ur_bc, int ithr) {
+        assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
+        auto arg = jit_pool_call_s();
+
+        const int ij = oh * jpp.stride_h;
+        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
+        const int i_b_overflow
+                = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
+        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const int c_off
+                = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
+                                                                 : 1)
+                * b_c;
+
+        if (trans_src)
+            arg.src = transpose_facade.get_src_addr_3d(ithr, id, ih, jpp);
+        else
+            arg.src = &src[src_d.blk_off(n, c_off, id, ih)];
+
+        if (trans_dst)
+            arg.dst = transpose_facade.get_dst_addr_3d(ithr, od, oh, jpp);
+        else
+            arg.dst = &dst[dst_d.blk_off(n, c_off, od, oh)];
+
+        if (indices) {
+            if (trans_dst) {
+                arg.indices = transpose_facade.get_indices_addr_3d(
+                        ithr, od, oh, jpp);
+            } else {
+                const size_t ind_off = indices_d.blk_off(n, c_off, od, oh);
+                arg.indices = &indices[ind_off * ind_dt_size];
+            }
+        }
+
+        arg.kd_padding = jpp.kd - d_t_overflow - d_b_overflow;
+        arg.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
+        arg.kh_padding_shift
+                = i_t_overflow * jpp.kw + d_t_overflow * jpp.kw * jpp.kh;
+        arg.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
+        arg.ker_area_h = (float)(jpp.kh
+                                 - nstl::max(0,
+                                         oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                                 - jpp.ih)
+                                 - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+                * (jpp.kd
+                        - nstl::max(0,
+                                od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
+                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+
+        arg.ur_bc = ur_bc;
+        arg.b_c = b_c;
+        arg.c_elem_off = jpp.c_block * b_c;
+        (*kernel_)(&arg);
+    };
+
+    if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
+        const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+        parallel_nd(jpp.mb, jpp.od, nb2_c, [&](int n, int od, int b2_c) {
+            const auto b_c = b2_c * jpp.ur_bc;
+            const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+
+            const int ik = od * jpp.stride_d;
+            const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
+            const int d_b_overflow
+                    = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
+            const int id = nstl::max(ik - jpp.f_pad, 0);
+            for (int oh = 0; oh < jpp.oh; ++oh) {
+                ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, ur_bc,
+                        first_ithr);
+            }
+        });
+    } else {
+        if (trans_src || trans_dst) {
+            parallel_nd_ext(0, jpp.mb, jpp.nb_c,
+                    [&](int ithr, int nthr, int n, int b_c) {
+                        if (trans_src)
+                            transpose_facade.execute_transpose_input(
+                                    ithr, n, b_c);
+
+                        for (int od = 0; od < jpp.od; ++od) {
+                            const int ik = od * jpp.stride_d;
+                            const int d_t_overflow
+                                    = nstl::max(0, jpp.f_pad - ik);
+                            const int d_b_overflow
+                                    = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad)
+                                    - jpp.id;
+                            const int id = nstl::max(ik - jpp.f_pad, 0);
+                            for (int oh = 0; oh < jpp.oh; ++oh) {
+                                ker(n, b_c, od, oh, id, d_t_overflow,
+                                        d_b_overflow, 1, ithr);
+                            }
+                        }
+
+                        if (trans_dst)
+                            transpose_facade.execute_transpose_output(
+                                    ithr, n, b_c);
+                    });
+        } else {
+            parallel_nd(jpp.mb, jpp.nb_c, jpp.od, [&](int n, int b_c, int od) {
+                const int ik = od * jpp.stride_d;
+                const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
+                const int d_b_overflow
+                        = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
+                const int id = nstl::max(ik - jpp.f_pad, 0);
+                for (int oh = 0; oh < jpp.oh; ++oh) {
+                    ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
+                            first_ithr);
+                }
+            });
+        }
+    }
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+jit_uni_pooling_bwd_t<isa, d_type>::jit_uni_pooling_bwd_t(const pd_t *apd)
+    : primitive_t(apd)
+    , kernel_(utils::make_unique<jit_uni_pool_kernel<isa>>(
+              pd()->jpp_, pd()->invariant_dst_md()))
+    , trans_ctx_(nullptr) {}
+
+template <cpu_isa_t isa, data_type_t d_type>
+jit_uni_pooling_bwd_t<isa, d_type>::~jit_uni_pooling_bwd_t() = default;
+
+template <cpu_isa_t isa, data_type_t d_type>
+status_t jit_uni_pooling_bwd_t<isa, d_type>::init_ncsp_trans_ctx() {
+    using namespace dnnl::impl;
+    using namespace jit_uni_pooling_utils;
+
+    const auto &jpp = pd()->jpp_;
+    trans_ctx_ = utils::make_unique<trans_context_t>();
+    const dim_t diff_src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
+    const dim_t diff_dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
+    const auto res = std::div(jpp.c_without_padding, jpp.c_block);
+    const dim_t &nb_c = res.quot;
+    const dim_t &c_tail = res.rem;
+    const memory_desc_wrapper indices_d = pd()->workspace_md();
+    const bool have_indices = indices_d.data_type() != data_type::undef;
+    static constexpr auto wsp_dt = wsp_dt_;
+
+    if (nb_c) {
+        trans_ctx_->dst_trans_ = utils::make_unique<trans_wrapper_t>(d_type,
+                diff_dst_sp, wsp_dt, jpp.c_block, jpp.c_block, diff_dst_sp);
+        trans_ctx_->src_trans_ = utils::make_unique<trans_wrapper_t>(wsp_dt,
+                jpp.c_block, d_type, diff_src_sp, diff_src_sp, jpp.c_block);
+        if (have_indices)
+            trans_ctx_->ind_trans_ = utils::make_unique<trans_wrapper_t>(
+                    indices_d.data_type(), diff_dst_sp, indices_d.data_type(),
+                    jpp.c_block, jpp.c_block, diff_dst_sp);
+    }
+    if (c_tail) {
+        trans_ctx_->dst_tail_trans_ = utils::make_unique<trans_wrapper_t>(
+                d_type, diff_dst_sp, wsp_dt, jpp.c_block, c_tail, diff_dst_sp);
+        trans_ctx_->src_tail_trans_ = utils::make_unique<trans_wrapper_t>(
+                wsp_dt, jpp.c_block, d_type, diff_src_sp, diff_src_sp, c_tail);
+        if (have_indices)
+            trans_ctx_->ind_tail_trans_ = utils::make_unique<trans_wrapper_t>(
+                    indices_d.data_type(), diff_dst_sp, indices_d.data_type(),
+                    jpp.c_block, c_tail, diff_dst_sp);
+    }
+
+    return trans_ctx_->create_kernel();
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+status_t jit_uni_pooling_bwd_t<isa, d_type>::init(engine_t *engine) {
+    if (pd()->jpp_.tag_kind == jit_memory_tag_kind_t::ncsp)
+        CHECK(init_ncsp_trans_ctx());
+    return kernel_->create_kernel();
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
+        const data_t *diff_dst, const char *indices, data_t *diff_src,
+        const exec_ctx_t &ctx) const {
+
+    using namespace jit_uni_pooling_utils;
+    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+
+    const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper indices_d(pd()->workspace_md());
+    const size_t ind_dt_size
+            = indices ? types::data_type_size(indices_d.data_type()) : 0;
+    const auto &jpp = pd()->jpp_;
+    const auto transpose_facade
+            = jit_uni_pooling_utils::bwd_pooling_transpose_facade_t<data_t,
+                    wsp_data_t, d_type>(jpp, trans_ctx_.get(), diff_src_d,
+                    diff_dst_d, indices_d, wsp_dt_, diff_src, diff_dst, indices,
+                    ctx);
+
+    auto get_first_ih = [&](int oh) {
+        return nstl::min(nstl::max(oh * jpp.stride_h - jpp.t_pad, 0), jpp.ih);
+    };
+
+    auto get_last_ih = [&](int oh) {
+        return nstl::min(
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+    };
+    const auto ker = [&](int ithr, int n, int b_c, int oh, int ur_bc) {
+        auto arg = jit_pool_call_s();
+
+        const int ih = get_first_ih(oh);
+        assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
+        assert(pd()->ndims() != 3 || utils::everyone_is(0, ih, oh));
+
+        const auto c_off = jpp.is_plain() ? b_c * jpp.c_block : b_c;
+        if (transpose_facade.should_transpose_src())
+            arg.src = transpose_facade.get_src_addr(ithr, ih, jpp);
+        else
+            arg.src = &diff_src[diff_src_d.blk_off(n, c_off, ih)];
+
+        if (transpose_facade.should_transpose_dst())
+            arg.dst = transpose_facade.get_dst_addr(ithr, oh, jpp);
+        else
+            arg.dst = &diff_dst[diff_dst_d.blk_off(n, c_off, oh)];
+
+        if (indices) {
+            if (transpose_facade.should_transpose_dst())
+                arg.indices = transpose_facade.get_indices_addr(ithr, oh, jpp);
+
+            else {
+                const size_t ind_off = indices_d.blk_off(n, c_off, oh);
+                arg.indices = &indices[ind_off * ind_dt_size];
+            }
+        }
+
+        const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+        const int zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
+
+        arg.zero_id = 1;
+        arg.zero_ih = zero_ih_end - zero_ih_start;
+        if (transpose_facade.should_transpose_src())
+            arg.zero_ptr
+                    = transpose_facade.get_src_addr(ithr, zero_ih_start, jpp);
+        else
+            arg.zero_ptr
+                    = &diff_src[diff_src_d.blk_off(n, c_off, zero_ih_start, 0)];
+
+        const int i_t_overflow = nstl::max(0, jpp.t_pad - oh * jpp.stride_h);
+        const int i_b_overflow
+                = nstl::max(jpp.ih, oh * jpp.stride_h + jpp.kh - jpp.t_pad)
+                - jpp.ih;
+        arg.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
+        arg.kh_padding_shift = i_t_overflow * jpp.kw;
+        arg.ker_area_h = static_cast<float>(jpp.kh
+                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+
+        arg.ur_bc = ur_bc;
+        arg.b_c = b_c;
+        (*kernel_)(&arg);
+    };
+
+    auto process_block = [&](int ithr, int n, int b_c, int ur_bc) {
+        if (transpose_facade.should_transpose_dst())
+            transpose_facade.execute_transpose_input(ithr, n, b_c);
+
+        for (int oh = 0; oh < jpp.oh; ++oh)
+            ker(ithr, n, b_c, oh, ur_bc);
+
+        if (transpose_facade.should_transpose_src())
+            transpose_facade.execute_transpose_output(ithr, n, b_c);
+    };
+
+    parallel(0, [&](int ithr, int nthr) {
+        const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+        const std::size_t work_amount
+                = static_cast<std::size_t>(jpp.mb) * nb2_c;
+        if (static_cast<std::size_t>(ithr) >= work_amount) return;
+
+        if (transpose_facade.should_fill_input_c_tail_with_zeros())
+            transpose_facade.fill_input_c_tail_with_zeros(ithr, jpp);
+
+        std::size_t start {0}, end {0};
+        balance211(work_amount, nthr, ithr, start, end);
+        int n {0}, b2_c {0};
+        utils::nd_iterator_init(start, n, jpp.mb, b2_c, nb2_c);
+        for (size_t iwork = start; iwork < end; ++iwork) {
+            const auto b_c = b2_c * jpp.ur_bc;
+            const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+
+            process_block(ithr, n, b_c, ur_bc);
+            utils::nd_iterator_step(n, jpp.mb, b2_c, nb2_c);
+        }
+    });
+}
+
+template <cpu_isa_t isa, data_type_t d_type>
+void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
+        const data_t *diff_dst, const char *indices, data_t *diff_src,
+        const exec_ctx_t &ctx) const {
+    const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper indices_d(pd()->workspace_md());
+    const size_t ind_dt_size
+            = indices ? types::data_type_size(indices_d.data_type()) : 0;
+
+    const auto &jpp = pd()->jpp_;
+
+    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using namespace jit_uni_pooling_utils;
+    static constexpr int first_ithr = 0;
+
+    const auto transpose_facade
+            = bwd_pooling_transpose_facade_t<data_t, wsp_data_t, d_type>(jpp,
+                    trans_ctx_.get(), diff_src_d, diff_dst_d, indices_d,
+                    wsp_dt_, diff_src, diff_dst, indices, ctx);
+
+    const auto trans_src = transpose_facade.should_transpose_src();
+    const auto trans_dst = transpose_facade.should_transpose_dst();
+
+    auto get_last_ih = [&](int oh) {
+        return nstl::min(
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+    };
+
+    auto get_last_id = [&](int od) {
+        return nstl::min(
+                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, 0), jpp.id);
+    };
+
+    auto ker = [&](int n, int b_c, int od, int oh, int id, int d_t_overflow,
+                       int d_b_overflow, bool zero_inp, int kd, int ur_bc,
+                       int ithr) {
+        auto arg = jit_pool_call_s();
+
+        const int ij = oh * jpp.stride_h;
+        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
+        const int i_b_overflow
+                = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
+        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const int c_off
+                = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
+                                                                 : 1)
+                * b_c;
+
+        if (trans_src)
+            arg.src = transpose_facade.get_src_addr_3d(ithr, id + kd, ih, jpp);
+        else
+            arg.src = (const void *)&diff_src[diff_src_d.blk_off(
+                    n, c_off, id + kd, ih)];
+
+        if (trans_dst)
+            arg.dst = transpose_facade.get_dst_addr_3d(ithr, od, oh, jpp);
+        else
+            arg.dst = (const void
+                            *)&diff_dst[diff_dst_d.blk_off(n, c_off, od, oh)];
+
+        if (indices) {
+            if (trans_dst) {
+                arg.indices = transpose_facade.get_indices_addr_3d(
+                        ithr, od, oh, jpp);
+            } else {
+                const size_t ind_off = indices_d.blk_off(n, c_off, od, oh);
+                arg.indices = (const void *)&indices[ind_off * ind_dt_size];
+            }
+        }
+
+        if (zero_inp) {
+            const int zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
+            const int zero_id_end
+                    = (od == jpp.od - 1) ? jpp.id : get_last_id(od);
+
+            arg.zero_id = zero_id_end - zero_id_start;
+
+            const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+            const int zero_ih_end
+                    = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
+            arg.zero_ih = zero_ih_end - zero_ih_start;
+
+            if (trans_src)
+                arg.zero_ptr = transpose_facade.get_src_addr_3d(
+                        ithr, zero_id_start, zero_ih_start, jpp);
+            else
+                arg.zero_ptr = &diff_src[diff_src_d.blk_off(
+                        n, c_off, zero_id_start, zero_ih_start, 0)];
+        } else {
+            arg.zero_id = 0;
+            arg.zero_ih = 0;
+        }
+
+        arg.kd_padding = jpp.kd - d_t_overflow - d_b_overflow;
+        arg.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
+        arg.kh_padding_shift = i_t_overflow * jpp.kw
+                + d_t_overflow * jpp.kw * jpp.kh + kd * jpp.kw * jpp.kh;
+        arg.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
+        arg.ker_area_h = (float)(jpp.kh
+                                 - nstl::max(0,
+                                         oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                                 - jpp.ih)
+                                 - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+                * (jpp.kd
+                        - nstl::max(0,
+                                od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
+                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+
+        arg.ur_bc = ur_bc;
+        arg.b_c = b_c;
+        (*kernel_)(&arg);
+    };
+
+    auto process_simple = [&](int n, int b_c, int od, int ur_bc, int ithr) {
+        const int ik = od * jpp.stride_d;
+        const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
+        const int d_b_overflow
+                = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
+        const int id = nstl::max(ik - jpp.f_pad, 0);
+
+        for (int oh = 0; oh < jpp.oh; ++oh) {
+            ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, true, 0, ur_bc,
+                    ithr);
+        }
+    };
+
+    if (jpp.simple_alg) {
+        if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
+            const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+            parallel_nd(jpp.mb, jpp.od, nb2_c, [&](int n, int od, int b2_c) {
+                const auto b_c = b2_c * jpp.ur_bc;
+                const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+                process_simple(n, b_c, od, ur_bc, first_ithr);
+            });
+        } else {
+            assert(jpp.ur_bc == 1);
+            if (trans_src || trans_dst) {
+                parallel_nd_ext(0, jpp.mb, jpp.nb_c,
+                        [&](int ithr, int nthr, int n, int b_c) {
+                            if (trans_src)
+                                transpose_facade.execute_transpose_input(
+                                        ithr, n, b_c);
+                            for (int od = 0; od < jpp.od; ++od) {
+                                process_simple(n, b_c, od, 1, ithr);
+                            }
+                            if (trans_dst)
+                                transpose_facade.execute_transpose_output(
+                                        ithr, n, b_c);
+                        });
+            } else {
+                parallel_nd(
+                        jpp.mb, jpp.nb_c, jpp.od, [&](int n, int b_c, int od) {
+                            process_simple(n, b_c, od, 1, first_ithr);
+                        });
+            }
+        }
+    } else {
+        const data_t zero_val = 0;
+        if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
+            const size_t chunk_size = (size_t)jpp.ih * jpp.iw * jpp.c;
+            parallel_nd(jpp.mb, jpp.id, [&](int n, int id) {
+                const size_t offset = ((size_t)n * jpp.id + id) * chunk_size;
+                PRAGMA_OMP_SIMD()
+                for (size_t idx = 0; idx < chunk_size; ++idx)
+                    diff_src[offset + idx] = zero_val;
+            });
+        } else {
+            if (!trans_src) {
+                const size_t chunk_size
+                        = (size_t)jpp.id * jpp.ih * jpp.iw * jpp.c_block;
+                parallel_nd_ext(0, jpp.mb, jpp.nb_c,
+                        [&](int ithr, int nthr, int n, int b_c) {
+                            const size_t offset
+                                    = ((size_t)n * jpp.nb_c + b_c) * chunk_size;
+                            PRAGMA_OMP_SIMD()
+                            for (size_t idx = 0; idx < chunk_size; ++idx)
+                                diff_src[offset + idx] = zero_val;
+                        });
+            }
+        }
+
+        const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+        if (trans_src || trans_dst) {
+            parallel_nd_ext(
+                    0, jpp.mb, nb2_c, [&](int ithr, int nthr, int n, int b2_c) {
+                        const auto b_c = b2_c * jpp.ur_bc;
+
+                        if (trans_dst) {
+                            transpose_facade.execute_transpose_input(
+                                    ithr, n, b_c);
+
+                            size_t block_size = jpp.c_block * jpp.id * jpp.ih
+                                    * jpp.iw * jpp.dt_size;
+
+                            const void *src = transpose_facade.get_src_addr_3d(
+                                    ithr, 0, 0, jpp);
+                            std::memset((void *)src, zero_val, block_size);
+                        }
+
+                        for (int kd = 0; kd < jpp.kd; ++kd) {
+                            const auto ur_bc
+                                    = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+                            for (int od = 0; od < jpp.od; ++od) {
+                                const int ik = od * jpp.stride_d;
+                                const int d_t_overflow
+                                        = nstl::max(0, jpp.f_pad - ik);
+                                const int d_b_overflow
+                                        = nstl::max(jpp.id,
+                                                  ik + jpp.kd - jpp.f_pad)
+                                        - jpp.id;
+                                if (kd >= jpp.kd - d_t_overflow - d_b_overflow)
+                                    continue;
+                                const int id = nstl::max(ik - jpp.f_pad, 0);
+                                for (int oh = 0; oh < jpp.oh; ++oh) {
+                                    ker(n, b_c, od, oh, id, d_t_overflow,
+                                            d_b_overflow, false, kd, ur_bc,
+                                            ithr);
+                                }
+                            }
+                        }
+
+                        if (trans_src)
+                            transpose_facade.execute_transpose_output(
+                                    ithr, n, b_c);
+                    });
+        } else {
+            for (int kd = 0; kd < jpp.kd; ++kd) {
+                parallel_nd(jpp.mb, nb2_c, [&](int n, int b2_c) {
+                    const auto b_c = b2_c * jpp.ur_bc;
+                    const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+                    for (int od = 0; od < jpp.od; ++od) {
+                        const int ik = od * jpp.stride_d;
+                        const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
+                        const int d_b_overflow
+                                = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad)
+                                - jpp.id;
+                        if (kd >= jpp.kd - d_t_overflow - d_b_overflow)
+                            continue;
+                        const int id = nstl::max(ik - jpp.f_pad, 0);
+                        for (int oh = 0; oh < jpp.oh; ++oh) {
+                            ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow,
+                                    false, kd, ur_bc, first_ithr);
+                        }
+                    }
+                });
+            }
+        }
+    }
+}
+
+template struct jit_uni_pooling_fwd_t<sve_512, data_type::f32>;
+template struct jit_uni_pooling_bwd_t<sve_512, data_type::f32>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_uni_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_pooling.hpp
@@ -1,0 +1,183 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef CPU_AARCH64_JIT_UNI_POOLING_HPP
+#define CPU_AARCH64_JIT_UNI_POOLING_HPP
+
+#include <assert.h>
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/jit_uni_pool_kernel.hpp"
+#include "cpu/aarch64/jit_uni_reorder.hpp"
+#include "cpu/cpu_pooling_pd.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace jit_uni_pooling_utils {
+struct trans_wrapper_t;
+struct trans_context_t;
+} // namespace jit_uni_pooling_utils
+
+template <cpu_isa_t isa, impl::data_type_t d_type>
+struct jit_uni_pooling_fwd_t : public primitive_t {
+    struct pd_t : public cpu_pooling_fwd_pd_t {
+        using cpu_pooling_fwd_pd_t::cpu_pooling_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
+                jit_uni_pooling_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace utils;
+
+            const bool ok = true && set_default_params() == status::success
+                    && is_fwd() && !has_zero_dim_memory()
+                    && everyone_is(
+                            d_type, src_md()->data_type, dst_md()->data_type)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, d_type)
+                    && !is_dilated();
+            if (!ok) return status::unimplemented;
+
+            const bool is_training
+                    = desc_.prop_kind == prop_kind::forward_training;
+            if (desc()->alg_kind == alg_kind::pooling_max && is_training)
+                init_default_ws();
+
+            auto scratchpad = scratchpad_registry().registrar();
+            return jit_uni_pool_kernel<isa>::init_conf(
+                    jpp_, scratchpad, this, dnnl_get_max_threads());
+        }
+
+        jit_pool_conf_t jpp_;
+    };
+
+    explicit jit_uni_pooling_fwd_t(const pd_t *apd);
+    jit_uni_pooling_fwd_t(jit_uni_pooling_fwd_t &&) = default;
+    jit_uni_pooling_fwd_t &operator=(jit_uni_pooling_fwd_t &&) = default;
+    ~jit_uni_pooling_fwd_t();
+
+    using data_t = typename prec_traits<d_type>::type;
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+        auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+        auto ws = CTX_OUT_MEM(char *, DNNL_ARG_WORKSPACE);
+
+        if (pd()->ndims() == 5)
+            execute_forward_3d(src, dst, ws, ctx);
+        else
+            execute_forward(src, dst, ws, ctx);
+
+        return status::success;
+    }
+
+private:
+    void execute_forward(const data_t *src, data_t *dst, char *indices,
+            const exec_ctx_t &ctx) const;
+    void execute_forward_3d(const data_t *src, data_t *dst, char *indices,
+            const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t init_ncsp_trans_ctx();
+
+    std::unique_ptr<jit_uni_pool_kernel<isa>> kernel_;
+    std::unique_ptr<jit_uni_pooling_utils::trans_context_t> trans_ctx_;
+    static constexpr data_type_t wsp_dt_ = data_type::f32;
+};
+
+template <cpu_isa_t isa, impl::data_type_t d_type>
+struct jit_uni_pooling_bwd_t : public primitive_t {
+    struct pd_t : public cpu_pooling_bwd_pd_t {
+        using cpu_pooling_bwd_pd_t::cpu_pooling_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit:", jpp_.isa, ""),
+                jit_uni_pooling_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace utils;
+
+            const bool ok = true && set_default_params() == status::success
+                    && !is_fwd() && !has_zero_dim_memory()
+                    && everyone_is(d_type, diff_src_md()->data_type,
+                            diff_dst_md()->data_type)
+                    && attr()->has_default_values() && !is_dilated();
+            if (!ok) return status::unimplemented;
+
+            if (desc()->alg_kind == alg_kind::pooling_max) {
+                init_default_ws();
+                if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;
+            }
+            auto scratchpad = scratchpad_registry().registrar();
+            return jit_uni_pool_kernel<isa>::init_conf(
+                    jpp_, scratchpad, this, dnnl_get_max_threads());
+        }
+
+        jit_pool_conf_t jpp_;
+    };
+
+    explicit jit_uni_pooling_bwd_t(const pd_t *apd);
+    jit_uni_pooling_bwd_t(jit_uni_pooling_bwd_t &&) = default;
+    jit_uni_pooling_bwd_t &operator=(jit_uni_pooling_bwd_t &&) = default;
+    ~jit_uni_pooling_bwd_t();
+
+    using data_t = typename prec_traits<d_type>::type;
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        auto diff_dst = CTX_IN_MEM(const data_t *, DNNL_ARG_DIFF_DST);
+        auto ws = CTX_IN_MEM(const char *, DNNL_ARG_WORKSPACE);
+        auto diff_src = CTX_OUT_MEM(data_t *, DNNL_ARG_DIFF_SRC);
+
+        if (pd()->ndims() == 5)
+            execute_backward_3d(diff_dst, ws, diff_src, ctx);
+        else
+            execute_backward(diff_dst, ws, diff_src, ctx);
+
+        return status::success;
+    }
+
+private:
+    void execute_backward(const data_t *diff_dst, const char *indices,
+            data_t *diff_src, const exec_ctx_t &ctx) const;
+    void execute_backward_3d(const data_t *diff_dst, const char *indices,
+            data_t *diff_src, const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t init_ncsp_trans_ctx();
+
+    std::unique_ptr<jit_uni_pool_kernel<isa>> kernel_;
+    std::unique_ptr<jit_uni_pooling_utils::trans_context_t> trans_ctx_;
+    static constexpr data_type_t wsp_dt_ = data_type::f32;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -1238,10 +1238,6 @@ private:
     ZReg z_tmp6 = z26;
     ZReg z_tmp7 = z27;
 
-    const std::vector<XReg> x_tmp_vec
-            = {X_TMP_0, X_TMP_1, X_TMP_2, X_TMP_3, X_TMP_4};
-    constexpr static int x_tmp_vec_size = 5;
-
     const std::vector<ZReg> z_tmp_vec
             = {z_tmp0, z_tmp1, z_tmp2, z_tmp3, z_tmp4, z_tmp5, z_tmp6, z_tmp7};
     constexpr static int z_tmp_vec_size = 8;

--- a/src/cpu/cpu_pooling_list.cpp
+++ b/src/cpu/cpu_pooling_list.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2020 Intel Corporation
+* Copyright 2020 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,6 +25,10 @@
 #include "cpu/x64/jit_uni_i8i8_pooling.hpp"
 #include "cpu/x64/jit_uni_pooling.hpp"
 using namespace dnnl::impl::cpu::x64;
+#elif DNNL_AARCH64
+#include "cpu/aarch64/jit_uni_i8i8_pooling.hpp"
+#include "cpu/aarch64/jit_uni_pooling.hpp"
+using namespace dnnl::impl::cpu::aarch64;
 #endif
 
 namespace dnnl {
@@ -50,6 +55,8 @@ const pd_create_f impl_list[] = {
         CPU_INSTANCE_X64(jit_uni_pooling_bwd_t<avx, f32>)
         CPU_INSTANCE_X64(jit_uni_pooling_fwd_t<sse41, f32>)
         CPU_INSTANCE_X64(jit_uni_pooling_bwd_t<sse41, f32>)
+        CPU_INSTANCE_AARCH64(jit_uni_pooling_fwd_t<sve_512, f32>)
+        CPU_INSTANCE_AARCH64(jit_uni_pooling_bwd_t<sve_512, f32>)
         CPU_INSTANCE(nchw_pooling_fwd_t<bf16>)
         CPU_INSTANCE(nchw_pooling_bwd_t<bf16>)
         CPU_INSTANCE(nchw_pooling_fwd_t<f32>)
@@ -66,6 +73,7 @@ const pd_create_f impl_list[] = {
         CPU_INSTANCE_X64(jit_uni_i8i8_pooling_fwd_t<avx512_core>)
         CPU_INSTANCE_X64(jit_uni_i8i8_pooling_fwd_t<avx2>)
         CPU_INSTANCE_X64(jit_uni_i8i8_pooling_fwd_t<sse41>)
+        CPU_INSTANCE_AARCH64(jit_uni_i8i8_pooling_fwd_t<sve_512>)
         CPU_INSTANCE(ref_pooling_fwd_t<s32>)
         CPU_INSTANCE(ref_pooling_fwd_t<s8, s32>)
         CPU_INSTANCE(ref_pooling_fwd_t<u8, s32>)


### PR DESCRIPTION
# Description

This PR adds JIT support of pooling for AArch64.
It includes JIT implementation for SVE 512.
Related RFC https://github.com/oneapi-src/oneDNN/pull/841
Related PR https://github.com/oneapi-src/oneDNN/pull/850
# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [x] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

There is no need to add a new tests for this PR,
since we can use the existing gtests and benchdnn for this PR.