### PR TITLE
sycl: interop: make cpu stream

### DIFF
--- a/src/sycl/capi/capi_stream.cpp
+++ b/src/sycl/capi/capi_stream.cpp
@@ -29,8 +29,7 @@ using namespace dnnl::impl;
 
 status_t dnnl_sycl_interop_stream_create(
         stream_t **stream, engine_t *engine, void *queue) {
-    bool args_ok = true && !utils::any_null(stream, engine, queue)
-            && engine->kind() == engine_kind::gpu;
+    bool args_ok = true && !utils::any_null(stream, engine, queue);
     if (!args_ok) return status::invalid_arguments;
 
     auto *sycl_engine

--- a/tests/gtests/sycl/api/test_stream.cpp
+++ b/tests/gtests/sycl/api/test_stream.cpp
@@ -98,6 +98,22 @@ TEST_F(sycl_stream_test, BasicInterop) {
 #endif
 }
 
+TEST_F(sycl_stream_test, BasicInteropCPU) {
+    cl_device_id cpu_ocl_dev = find_ocl_device(CL_DEVICE_TYPE_CPU);
+    SKIP_IF(!cpu_ocl_dev, "CPU device not found.");
+
+    queue cpu_sycl_queue(cpu_selector {});
+    SKIP_IF(!cpu_sycl_queue.get_device().is_cpu(), "CPU-only device not found");
+
+    {
+        auto cpu_eng = sycl_interop::make_engine(
+                cpu_sycl_queue.get_device(), cpu_sycl_queue.get_context());
+        auto s = sycl_interop::make_stream(cpu_eng, cpu_sycl_queue);
+        auto sycl_queue = sycl_interop::get_queue(s);
+        EXPECT_EQ(sycl_queue, cpu_sycl_queue);
+    }
+}
+
 TEST_F(sycl_stream_test, InteropIncompatibleQueue) {
     SKIP_IF(!eng, "GPU device not found.");
 


### PR DESCRIPTION
# Description

- improve `sycl_interop::make_stream` to support create a stream with CPU SYCL Queue.
- add test case
- improve sycl interop example to create engine and stream with user provided queue.

Fixes # (github issue)

# Checklist

## Code-change submissions

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [ ] Have you formatted the code using clang-format?

### New features

- [ ] Have you added relevant tests?
- [ ] Have you provided motivation for adding a new feature?

### Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
