### PR TITLE
examples: properly call sycl::queue::memcpy

### DIFF
--- a/examples/example_utils.hpp
+++ b/examples/example_utils.hpp
@@ -191,7 +191,7 @@ inline void read_from_dnnl_memory(void *handle, dnnl::memory &mem) {
             } else {
                 auto sycl_queue
                         = dnnl::sycl_interop::get_queue(dnnl::stream(eng));
-                sycl_queue.memcpy(src_ptr, handle, size).wait();
+                sycl_queue.memcpy(handle, src_ptr, size).wait();
             }
         }
         return;


### PR DESCRIPTION
# Description

Signature of memcpy is:
```c++
class queue {
  ...
  public:
    ...
    event memcpy(void* dest, const void* src, size_t num_bytes);
};
```

the parameters in `example_utils.hpp` are in opposite order.
