### PR TITLE
benchdnn: fix float to int32_t conversion behaviour

### DIFF
--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -189,7 +189,8 @@ inline float saturate_and_round(float val) {
     const float dt_max = max_dt(dt);
     const float dt_min = (float)dnnl::impl::nstl::numeric_limits<
             typename prec_traits<dt>::type>::lowest();
-    if (dt == dnnl_s32 && val >= max_dt(dnnl_s32)) return max_dt(dnnl_s32);
+    if (dt == dnnl_s32 && val >= max_dt(dnnl_s32))
+        return BENCHDNN_S32_TO_F32_SAT_CONST;
     if (val > dt_max) val = dt_max;
     if (val < dt_min) val = dt_min;
     return mxcsr_cvt(val);


### PR DESCRIPTION
# Description

There is a rounding behaviour mismatch between oneDNN and ref_reorder of benchdnn.

- Every simple_reorder uses `2147483520` as the upper bound of int32 value. The reason is explained in [type_helpers.hpp](https://github.com/oneapi-src/oneDNN/blob/4387cd6c5ff9e19934a566256dec8ed0b0095a07/src/common/type_helpers.hpp#L128).
- On the other hand, [ref_reorder()](https://github.com/oneapi-src/oneDNN/blob/4387cd6c5ff9e19934a566256dec8ed0b0095a07/tests/benchdnn/reorder/reorder.cpp#L117) of benchdnn only rounds dst values at last.

## Example test pattern

`./benchdnn --reorder --skip-impl="ref:simple" --sdt=s32 --ddt=f32 --stag=aBx8b --dtag=aBx8b --attr-oscale=common:4.29497e+09 1x17x9x5`

### Input value

Below is the summry of input value calculation of this bug.

```c++
int32_t input_value = (int32_t) (float(numeric_limits<int32_t>::max()));
```

The float value `(float(numeric_limits<int32_t>::max()))` is over int32_t range.
In this case, cast to int32_t result is compiler dependent.

- On aarch64 environment, this example generates `0x7fffffff` as input and the test fails.
- On x64 environment, this example generates `0x80000000` and the test passes.

## oneDNN on aarch64 environment

```bash
fx700-01-05.local /home/kawakami/mkldnn/oneDNN/build/tests/benchdnn% DNNL_VERBOSE=1 ./benchdnn --reorder --skip-impl="ref:simple" --sdt=s32 --ddt=f32 --stag=aBx8b --dtag=aBx8b --attr-oscale=common:4.29497e+09 1x17x9x5
dnnl_verbose,info,oneDNN v2.0.0 (commit 8d623ef7a6ff4f188079725700a963fc24922527)
dnnl_verbose,info,cpu,runtime:OpenMP
dnnl_verbose,info,cpu,isa:AArch64 SVE (512 bits)
dnnl_verbose,info,gpu,runtime:none
dnnl_verbose,info,prim_template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
dnnl_verbose,exec,cpu,reorder,simple:any,undef,src_s32::blocked:abcd:f0 dst_s32:p:blocked:aBcd8b:f0,,,1x17x9x5,0.916016
dnnl_verbose,exec,cpu,reorder,jit:uni,undef,src_s32:p:blocked:aBcd8b:f0 dst_f32:p:blocked:aBcd8b:f0,oscale:0:4.29497e+09;,,1x17x9x5,0.902832
dnnl_verbose,exec,cpu,reorder,simple:any,undef,src_f32:p:blocked:aBcd8b:f0 dst_f32::blocked:abcd:f0,,,1x17x9x5,0.907959
[   6][0x0x1x1] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  13][0x0x2x3] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  20][0x0x4x0] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  27][0x0x5x2] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  34][0x0x6x4] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  41][0x0x8x1] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  48][0x1x0x3] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  55][0x1x2x0] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
[  62][0x1x3x2] exp_f32:9.22338e+18 exp:9.22338e+18 got:9.22338e+18 diff:1.09951e+12 rdiff:1.19209e-07
@@@ error [int reorder::doit(const reorder::prb_t*, res_t*):412]: 'cmp.compare(dst_dt_out_fmt_ref, dst_dt_out_fmt_out, prb->attr, res, dst_engine)' -> 1
0:FAILED (errors:109 total:765) __REPRO: --reorder --skip-impl=ref:simple --sdt=s32 --ddt=f32 --stag=aBx8b --dtag=aBx8b --attr-oscale=common:4.29497e+09 1x17x9x5
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 failed:1 listed:0
```

The output of first reorder is limited below `2147483520 (=0x7fffff80)` and it is used for the second input.
The final result becomes slightly, `(0x7fffffff - 0x7fffff80) * scale`, less than the true value. 

## ref_reorder of benchdnn

Only if the data type of output is int32, the output is rounded to `2147483520 (=0x7fffff80)`. 
The example above does not hit this condition, because the output data type is f32.


# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [N/A] Have you added relevant regression tests?
- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
