### PR TITLE
gpu: Fix compilation errors in NVIDIA GPUs with cuDNN 8

### DIFF
--- a/src/gpu/nvidia/cudnn_conv_inner_product_impl.hpp
+++ b/src/gpu/nvidia/cudnn_conv_inner_product_impl.hpp
@@ -297,20 +297,13 @@ struct cudnn_conv_inner_product_fwd_impl_t
 
             // perf_results are sorted ascending by compute time, so the first suitable
             // algorithm found is the one with best performance
-            bool found_algo = false;
-            for (int i = 0; !found_algo && i < returned_algo_count; i++) {
+            for (int i = 0; i < returned_algo_count; i++) {
                 if (perf_results[i].status == CUDNN_STATUS_SUCCESS
                         && perf_results[i].memory < free_memory) {
 
-                    found_algo = true;
                     algo_ = perf_results[i].algo;
+                    break;
                 }
-            }
-
-            if (!found_algo) {
-                std::cout << "Not suitable algorithm for convolution found"
-                          << std::endl;
-                return status::runtime_error;
             }
         } else {
             algo_ = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
@@ -533,20 +526,13 @@ struct cudnn_conv_inner_product_bwd_data_impl_t
 
         // perf_results are sorted ascending by compute time, so the first suitable
         // algorithm found is the one with best performance
-        bool found_algo = false;
-        for (int i = 0; !found_algo && i < returned_algo_count; i++) {
+        for (int i = 0; i < returned_algo_count; i++) {
             if (perf_results[i].status == CUDNN_STATUS_SUCCESS
                     && perf_results[i].memory < free_memory) {
 
-                found_algo = true;
                 algo_ = perf_results[i].algo;
+                break;
             }
-        }
-
-        if (!found_algo) {
-            std::cout << "Not suitable algorithm for convolution bwd found"
-                      << std::endl;
-            return status::runtime_error;
         }
 
         // Allocate the workspace from the algorithm selection, if applicable.
@@ -714,21 +700,13 @@ struct cudnn_conv_inner_product_bwd_weights_impl_t
 
         // perf_results are sorted ascending by compute time, so the first suitable
         // algorithm found is the one with best performance
-        bool found_algo = false;
-        for (int i = 0; !found_algo && i < returned_algo_count; i++) {
+        for (int i = 0; i < returned_algo_count; i++) {
             if (perf_results[i].status == CUDNN_STATUS_SUCCESS
                     && perf_results[i].memory < free_memory) {
 
-                found_algo = true;
                 algo_ = perf_results[i].algo;
+                break;
             }
-        }
-
-        if (!found_algo) {
-            std::cout
-                    << "Not suitable algorithm for convolution bwd filter found"
-                    << std::endl;
-            return status::runtime_error;
         }
 
         // Allocate the workspace from the algorithm selection, if applicable.

--- a/src/gpu/nvidia/cudnn_conv_inner_product_impl.hpp
+++ b/src/gpu/nvidia/cudnn_conv_inner_product_impl.hpp
@@ -512,8 +512,9 @@ struct cudnn_conv_inner_product_bwd_data_impl_t
 
         // Inner product can choose whatever algorithm it prefers.
         int num_algos = 0, returned_algo_count = 0;
-        CHECK(CUDNN_EXECUTE_FUNC_S(cudnnGetConvolutionForwardAlgorithmMaxCount,
-                handle, &num_algos));
+        CHECK(CUDNN_EXECUTE_FUNC_S(
+                cudnnGetConvolutionBackwardDataAlgorithmMaxCount, handle,
+                &num_algos));
         std::vector<cudnnConvolutionBwdDataAlgoPerf_t> perf_results(num_algos);
 
         CUDNN_EXECUTE_FUNC(cudnnGetConvolutionBackwardDataAlgorithm_v7, handle,


### PR DESCRIPTION
# Description

The current version does not build with cudDNN 8 since there are some changes in the API. Building with cuDNN 8 results in a failure, as I described in issue #885.

Deprecated calls in cuDNN 8 used in oneDNN:
- cudnnGetConvolutionBackwardDataAlgorithm
- cudnnGetConvolutionBackwardFilterAlgorithm
- cudnnGetConvolutionForwardAlgorithm

All of them were replaced by `_v7` calls. They could have been replaced by cuddnFind... counterparts, but because they do not behave in the same way, I decided to use the `_v7` functions. API changed, and now cuDNN functions return a list of the possible algorithms to choose instead of returning the fastest one. Therefore, I implemented a simple algorithm to choose the fastest suitable algorithm from the list.

Because `_v7` functions build successfully with cuDNN 7, I did not write any conditional to check the version of cuDNN; both cuDNN 7 and 8 builds successfully with the same code.

I am unable to run the tests for GPU with an untouched master branch, so I did not include any new test.

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [ ] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?