### PR TITLE
cpu: aarch64: reorder: fix SEGV and misuse of temporally register

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -1061,14 +1061,17 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
     }
 
     void cvt_z_b_s(const int startIdx, const int regNum) {
-        dup(z_tmp0.b, 0);
+        assert(z_tmp7.getIdx() < startIdx
+                || startIdx + regNum - 1 < z_tmp7.getIdx());
+
+        dup(z_tmp7.b, 0);
         for (int i = startIdx; i < startIdx + regNum; i++) {
             ZRegB tmp(i);
-            zip1(tmp, tmp, z_tmp0.b);
+            zip1(tmp, tmp, z_tmp7.b);
         }
         for (int i = startIdx; i < startIdx + regNum; i++) {
             ZRegH tmp(i);
-            zip1(tmp, tmp, z_tmp0.h);
+            zip1(tmp, tmp, z_tmp7.h);
         }
     }
 
@@ -1082,7 +1085,10 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
     }
 
     void cvt_z_s32_s8(const int startIdx, const int regNum) {
-        dup(z_tmp0.s, 0);
+        assert(z_tmp7.getIdx() < startIdx
+                || startIdx + regNum - 1 < z_tmp7.getIdx());
+
+        dup(z_tmp7.s, 0);
 
         for (int i = startIdx; i < startIdx + regNum; i++) {
             smin(ZRegS(i), 127);
@@ -1092,11 +1098,11 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         }
         for (int i = startIdx; i < startIdx + regNum; i++) {
             ZRegH z(i);
-            uzp1(z, z, z_tmp0.h);
+            uzp1(z, z, z_tmp7.h);
         }
         for (int i = startIdx; i < startIdx + regNum; i++) {
             ZRegB z(i);
-            uzp1(z, z, z_tmp0.b);
+            uzp1(z, z, z_tmp7.b);
         }
     }
 
@@ -1120,13 +1126,15 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
     }
 
     void cvt_z_s32_u8(const int startIdx, const int regNum) {
-        dupm(z_tmp0.s, 255);
+        assert(z_tmp7.getIdx() < startIdx
+                || startIdx + regNum - 1 < z_tmp7.getIdx());
+        dupm(z_tmp7.s, 255);
 
         for (int i = startIdx; i < startIdx + regNum; i++)
             smax(ZRegS(i), 0);
 
         for (int i = startIdx; i < startIdx + regNum; i++)
-            smin(ZRegS(i), p_512 / T_m, z_tmp0.s);
+            smin(ZRegS(i), p_512 / T_m, z_tmp7.s);
 
         for (int i = startIdx; i < startIdx + regNum; i++) {
             ZRegH z(i);


### PR DESCRIPTION
# Description

This PR fixes bugs of AArch64 JIT reorder (SEGV and miscalculation) for the pattern below.

```bash
./benchdnn --reorder --skip-impl="ref:simple" --sdt=f32 --ddt=s8 --stag=abx --dtag=abx --attr-oscale="per_dim_1:0.125*" --attr-post-ops="'sum'" 2x64x1x1
```


Fixes # (github issue)

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?

If the test below is run
```
./benchdnn --reorder --batch=inputs/reorder/test_reorder_all 
```
, the two test patterns below is FAILED, and the others are PASSED.

```
[   6][0x0x1x1] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  13][0x0x2x3] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  20][0x0x4x0] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  27][0x0x5x2] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  34][0x0x6x4] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  41][0x0x8x1] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  48][0x1x0x3] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  55][0x1x2x0] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  62][0x1x3x2] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
22379:FAILED (errors:109 total:765) __REPRO: --reorder --skip-impl="ref:simple" --sdt=s32 --ddt=f32 --stag=aBx4b --dtag=aBx4b --attr-oscale=common:4.29497e+09 1x17x9x5
[   6][0x0x1x1] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  13][0x0x2x3] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  20][0x0x4x0] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  27][0x0x5x2] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  34][0x0x6x4] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  41][0x0x8x1] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  48][0x1x0x3] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  55][0x1x2x0] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
[  62][0x1x3x2] exp_f32:9.22337e+18 exp:9.22337e+18 got:9.22337e+18 diff:5.49756e+11 rdiff:5.96046e-08
22385:FAILED (errors:109 total:765) __REPRO: --reorder --skip-impl="ref:simple" --sdt=s32 --ddt=f32 --stag=aBx8b --dtag=aBx8b --attr-oscale=common:4.29497e+09 1x17x9x5
```

It seems `exp_f` of these two FAILED has some calculatoin error reported on https://github.com/oneapi-src/oneDNN/pull/951

- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you added relevant regression tests?

Benchdnn already includes the tests.

```
./benchdnn --reorder --batch=inputs/reorder/test_reorder_all
```

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

```bash
# Run this pattern on AArch64
./benchdnn --reorder --skip-impl="ref:simple" --sdt=f32 --ddt=s8 --stag=abx --dtag=abx --attr-oscale="per_dim_1:0.125*" --attr-post-ops="'sum'" 2x64x1x1
```


