### PR TITLE
cpu: aarch64: remove unused variable and fix no return function

### DIFF
--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -230,8 +230,7 @@ public:
         if (dstIdx == src2Idx) {
             assert(tmpIdx != srcIdx && tmpIdx != src2Idx);
 
-            mov(Xbyak_aarch64::ZRegD(tmp.getIdx()),
-                    Xbyak_aarch64::ZRegD(src2.getIdx()));
+            mov(Xbyak_aarch64::ZRegD(tmpIdx), Xbyak_aarch64::ZRegD(src2Idx));
             mov(dst, pred / Xbyak_aarch64::T_m, src);
             fdiv(dst, pred / Xbyak_aarch64::T_m, tmp);
         } else if (dstIdx == srcIdx) {

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -899,6 +899,7 @@ status_t jit_uni_i8i8_pooling_fwd_t<isa>::execute_forward(
                 p.dst_safe_access = dst_safe_access;
                 (*ker_)(&p);
             });
+    return status::success;
 }
 
 // Explicit instantiation only for supported <isa> values.


### PR DESCRIPTION
# Description

This PR fixes build error -Werror and no return of non-void function.

# Checklist

## Code-change submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [X] Have you formatted the code using clang-format?

