### PR TITLE
cpu: aarch64: change DNNL_JIT_PROFILE default value to 2

### DIFF
--- a/doc/performance_considerations/profilers.md
+++ b/doc/performance_considerations/profilers.md
@@ -23,8 +23,8 @@ variable can be used to manage integration with performance profilers.
 
 | Environment variable | Value            | Description                                                            | x64            | AArch64
 | :---                 | :---             | :---                                                                   | :---           | :---
-| DNNL_JIT_PROFILE     | 1                | Enables VTune Amplifier integration                                    | **x(default)** | **N/A(default)**
-|                      | 2                | Enables basic Linux perf integration                                   | x              | x
+| DNNL_JIT_PROFILE     | 1                | Enables VTune Amplifier integration                                    | **x(default)** | N/A
+|                      | 2                | Enables basic Linux perf integration                                   | x              | **x(default)**
 |                      | 6                | Enables Linux perf integration with JIT dump output                    | x              | x
 |                      | 14               | Enables Linux perf integration with JIT dump output and TSC timestamps | x              | N/A
 

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2020 Intel Corporation
+* Copyright 2018-2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -152,7 +152,11 @@ bool get_jit_dump() {
     return jit_dump.get();
 }
 
+#if DNNL_AARCH64
+static setting_t<unsigned> jit_profiling_flags {DNNL_JIT_PROFILE_LINUX_PERFMAP};
+#else
 static setting_t<unsigned> jit_profiling_flags {DNNL_JIT_PROFILE_VTUNE};
+#endif
 unsigned get_jit_profiling_flags() {
     if (!jit_profiling_flags.initialized()) {
         jit_profiling_flags.set(


### PR DESCRIPTION
# Description

This PR change the default value of DNNL_JIT_PROFILE on AArch64 into `2 (Enables basic Linux perf integration)`, because `1 (Enables VTune Amplifier integration)` is meaningless for AArch64 and outputs warning messages. https://github.com/oneapi-src/oneDNN/blob/63c8b5ce84b0be266d1edad0420390f2e131cb29/src/cpu/jit_utils/jit_utils.cpp#L93-L96.