### PR TITLE
cpu: aarch64: Add support for ACL-based indirect convolution

### DIFF
--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -32,6 +32,21 @@ endif()
 find_package(ACL REQUIRED)
 
 if(ACL_FOUND)
+    file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)
+    if ("${ACL_VERSION_FILE}" STREQUAL "")
+        message(WARNING "Build may fail: Could not determine ACL version (minimum required is v20.11)")
+    else()
+        file(READ ${ACL_VERSION_FILE} ACL_VERSION_STRING)
+        string(REGEX MATCH "v[0-9]+\\.[0-9]+" ACL_VERSION ${ACL_VERSION_STRING})
+        if (${ACL_VERSION} VERSION_EQUAL "0.0")
+            # Unreleased ACL versions come with version string "v0.0-unreleased", and may not be compatible with oneDNN.
+            # It is recommended to use the latest release of ACL.
+            message(WARNING "Build may fail: Using unreleased ACL version (minimum required is v20.11)")
+        elseif(${ACL_VERSION} VERSION_LESS "20.11")
+            message(FATAL_ERROR "Detected ACL version ${ACL_VERSION}, but minimum required is v20.11")
+        endif()
+    endif()
+
     list(APPEND EXTRA_SHARED_LIBS ${ACL_LIBRARIES})
 
     include_directories(${ACL_INCLUDE_DIRS})

--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -85,8 +85,9 @@ cmake .. \
          -DDNNL_AARCH64_USE_ACL=ON \
          <extra build options>
 ~~~
-Using ACL versions above 20.11 may require the `-DCMAKE_CXX_STANDARD=14`
-and `-DCMAKE_CXX_EXTENSIONS=OFF` flags to be passed.
+Only ACL versions 20.11 or above are supported. Using ACL versions above	
+20.11 may require the `-DCMAKE_CXX_STANDARD=14` and `-DCMAKE_CXX_EXTENSIONS=OFF`
+flags to be passed.
 
 #### Build and Install the Library
 

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -157,6 +157,9 @@ independently of oneDNN.
 For a debug build of oneDNN it is advisable to specify a Compute Library build
 which has also been built with debug enabled.
 
+@warning
+oneDNN is only compatible with Compute Library builds v20.11 or later.
+
 #### Vendor BLAS libraries
 oneDNN can use a standard BLAS library for GEMM operations.
 The `DNNL_BLAS_VENDOR` build option controls BLAS library selection, and

--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Arm Ltd. and affiliates
+* Copyright 2020-2021 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -243,6 +243,40 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
         acp.weights_info,
         acp.dilation_info,
         acp.act_info);
+    // clang-format on
+    if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
+        return status::unimplemented;
+    }
+
+    return status::success;
+}
+
+status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, const convolution_desc_t &cd,
+        const primitive_attr_t &attr) {
+    // Indirect convolution results in slowdown for low thread count or 1x1
+    // kernels, so fall back to GEMM-based convolution in these cases
+    if (one_of(true, weights_md.dims[2] == 1, // kh
+                weights_md.dims[3] == 1, // kw
+                dnnl_get_max_threads() < 28)) {
+        return status::unimplemented;
+    }
+
+    CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
+
+    // clang-format off
+    // NOTE: indirect convolution method supports only nhwc layout.
+    auto acl_st = arm_compute::NEGEMMConv2d::validate(
+        &acp.src_info,
+        &acp.wei_info,
+        acp.with_bias ? &acp.bia_info : nullptr,
+        &acp.dst_info,
+        arm_compute::Conv2dInfo(acp.padstride_info,
+                                acp.dilation_info,
+                                acp.act_info,
+                                false,
+                                1));
     // clang-format on
     if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
         return status::unimplemented;

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Arm Ltd. and affiliates
+* Copyright 2020-2021 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,6 +56,11 @@ struct acl_conv_conf_t {
 namespace acl_convolution_utils {
 
 status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, const convolution_desc_t &cd,
+        const primitive_attr_t &attr);
+
+status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
         const primitive_attr_t &attr);

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+* Copyright 2021 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
+        const exec_ctx_t &ctx) const {
+    status_t status = status::success;
+    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+    auto bia_base = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
+    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+
+    bool with_bias = pd()->acp_.with_bias;
+
+    // Retrieve primitive resource and configured Compute Library objects
+    auto *acl_resource
+            = ctx.get_resource_mapper()->get<acl_indirect_gemm_resource_t>(
+                    this);
+    acl_obj_t<arm_compute::NEGEMMConv2d> &acl_indirect_gemm_obj
+            = acl_resource->get_acl_obj();
+
+    acl_indirect_gemm_obj.src_tensor.allocator()->import_memory(
+            const_cast<data_t *>(src_base));
+    acl_indirect_gemm_obj.wei_tensor.allocator()->import_memory(
+            const_cast<data_t *>(wei_base));
+    acl_indirect_gemm_obj.dst_tensor.allocator()->import_memory(dst_base);
+
+    // Retrieve extra bias memory from the scratchpad and copy from user memory
+    if (with_bias) {
+        const auto scratchpad = ctx.get_scratchpad_grantor();
+        data_t *bia_memory = scratchpad.template get<data_t>(
+                memory_tracking::names::key_none);
+        size_t oc = acl_indirect_gemm_obj.bia_tensor.info()->tensor_shape()[0];
+        std::memcpy(bia_memory, bia_base, oc * sizeof(data_t));
+        acl_indirect_gemm_obj.bia_tensor.allocator()->import_memory(bia_memory);
+    }
+
+    acl_indirect_gemm_obj.conv.run();
+
+    acl_indirect_gemm_obj.src_tensor.allocator()->free();
+    acl_indirect_gemm_obj.wei_tensor.allocator()->free();
+    acl_indirect_gemm_obj.dst_tensor.allocator()->free();
+    if (with_bias) { acl_indirect_gemm_obj.bia_tensor.allocator()->free(); }
+
+    return status;
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -1,0 +1,176 @@
+/*******************************************************************************
+* Copyright 2021 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_INDIRECT_GEMM_CONVOLUTION_HPP
+#define CPU_AARCH64_ACL_INDIRECT_GEMM_CONVOLUTION_HPP
+
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/acl_convolution_utils.hpp"
+
+#include "cpu/cpu_convolution_pd.hpp"
+
+#include "arm_compute/runtime/FunctionDescriptors.h"
+#include "arm_compute/runtime/NEON/NEFunctions.h"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct acl_indirect_gemm_resource_t : public resource_t {
+
+    acl_indirect_gemm_resource_t()
+        : acl_obj_(utils::make_unique<acl_obj_t<arm_compute::NEGEMMConv2d>>()) {
+    }
+
+    status_t configure(const acl_conv_conf_t &acp) {
+        if (!acl_obj_) return status::out_of_memory;
+
+        // Init Compute Library tensors based on info from descriptor
+        acl_obj_->src_tensor.allocator()->init(acp.src_info);
+        acl_obj_->wei_tensor.allocator()->init(acp.wei_info);
+        acl_obj_->dst_tensor.allocator()->init(acp.dst_info);
+        acl_obj_->bia_tensor.allocator()->init(acp.bia_info);
+
+        // clang-format off
+        acl_obj_->conv.configure(
+            &acl_obj_->src_tensor,
+            &acl_obj_->wei_tensor,
+            acp.with_bias ? &acl_obj_->bia_tensor : nullptr,
+            &acl_obj_->dst_tensor,
+            arm_compute::Conv2dInfo(acp.padstride_info,
+                                    acp.dilation_info,
+                                    acp.act_info,
+                                    false,
+                                    1));
+        // clang-format on
+
+        return status::success;
+    }
+
+    acl_obj_t<arm_compute::NEGEMMConv2d> &get_acl_obj() const {
+        return *acl_obj_;
+    }
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_indirect_gemm_resource_t);
+
+private:
+    std::unique_ptr<acl_obj_t<arm_compute::NEGEMMConv2d>> acl_obj_;
+
+}; // acl_indirect_gemm_resource_t
+
+struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
+
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), acp_() {}
+
+        DECLARE_COMMON_PD_T("indirect_gemm:acl",
+                acl_indirect_gemm_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            using smask_t = primitive_attr_t::skip_mask_t;
+
+            bool ok = is_fwd()
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(data_type::f32, data_type::f32,
+                            data_type::f32, data_type::f32, undef)
+                    && !has_zero_dim_memory()
+                    && attr()->has_default_values(
+                            smask_t::post_ops, data_type::f32)
+                    && post_ops_ok();
+            if (!ok) return status::unimplemented;
+
+            auto conf_status = acl_convolution_utils::init_conf_indirect_gemm(
+                    acp_, src_md_, weights_md_, dst_md_, bias_md_, *desc(),
+                    *attr());
+            if (conf_status != status::success) return status::unimplemented;
+
+            // Number of threads in Compute Library is set by OMP_NUM_THREADS
+            // dnnl_get_max_threads() == OMP_NUM_THREADS
+            arm_compute::Scheduler::get().set_num_threads(
+                    dnnl_get_max_threads());
+
+            // TODO: remove dependence on scratchpad memory
+            // Using user provided memory for the biases currently segfaults
+            if (acp_.with_bias) {
+                auto scratchpad = scratchpad_registry().registrar();
+                const size_t bia_mem_sz_ = acp_.bia_info.tensor_shape()[0];
+                scratchpad.template book<data_t>(
+                        memory_tracking::names::key_none, bia_mem_sz_);
+            }
+
+            return status::success;
+        }
+
+        acl_conv_conf_t acp_;
+
+    protected:
+        bool post_ops_ok() const {
+            using namespace data_type;
+            using namespace alg_kind;
+            auto const &po = attr()->post_ops_;
+            auto is_eltwise
+                    = [&](int idx) { return po.entry_[idx].is_eltwise(); };
+
+            bool eltwise_ok = false;
+            // Compute Library supports only one eltwise post-op
+            if (po.len() == 1 && is_eltwise(0)) {
+                const auto act_type = po.entry_[0].eltwise.alg;
+                eltwise_ok = acl_convolution_utils::acl_act_ok(act_type);
+            }
+
+            return eltwise_ok || (po.len() == 0);
+        }
+    };
+
+    acl_indirect_gemm_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const override {
+        if (mapper.has_resource(this)) return status::success;
+
+        auto r = utils::make_unique<acl_indirect_gemm_resource_t>();
+        if (!r) return status::out_of_memory;
+
+        // Configure the resource based on information from primitive descriptor
+        auto st = r->configure(pd()->acp_);
+        if (st == status::success) { mapper.add(this, std::move(r)); }
+
+        return st;
+    }
+
+    typedef typename prec_traits<data_type::f32>::type data_t;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_INDIRECT_GEMM_CONVOLUTION_HPP

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2021 Intel Corporation
-* Copyright 2020 Arm Ltd. and affiliates
+* Copyright 2020-2021 Arm Ltd. and affiliates
 * Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,7 @@
 
 #if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
 #include "cpu/aarch64/acl_gemm_convolution.hpp"
+#include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
 #include "cpu/aarch64/acl_winograd_convolution.hpp"
 using namespace dnnl::impl::cpu::aarch64;
 #endif
@@ -112,6 +113,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_avx2_convolution_fwd_t)
         CPU_INSTANCE_X64(jit_sse41_convolution_fwd_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
+        CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
         CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
         CPU_INSTANCE(gemm_convolution_fwd_t)
         CPU_INSTANCE(ref_convolution_fwd_t<f32>)


### PR DESCRIPTION
# Description

This PR introduces support for [indirect convolution](https://arxiv.org/pdf/1907.02129.pdf) algorithm for two-dimensional convolutions on AArch64 with the help of Arm Compute Library routines. Implementation follows the same approach as was detailed in RFC [#795](https://github.com/oneapi-src/oneDNN/pull/795). This indirect implementation provides 10% - 40% speedup for FP32 on ResNet50 shapes compared to `acl_gemm_convolution_fwd_t`, especially at high core counts.

## Outline

The key changes are listed below:

- New `acl_indirect_gemm_convolution.cpp/.hpp` files added in `src/cpu/aarch64` directory;
- New implementation `acl_indirect_gemm_convolution_fwd_t` added in `src/cpu/cpu_convolution_list.cpp`;
- This implementation supports only `NHWC` memory layout, respective launch heuristics introduced in `init_conf_indirect_gemm()` function located in `acl_convolution_utils.cpp`.

# Checklist

## Code-change submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
pass locally?

- [X] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?

- [X] Have you provided motivation for adding a new feature?

### Bug fixes

- [N/A] Have you added relevant regression tests?

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
