### PR TITLE
cpu: aarch64: support hw transpose optimization for convolution_f32

### DIFF
--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
@@ -2435,15 +2435,16 @@ void jit_sve_512_conv_bwd_weights_kernel_f32::oh_step_comeback_pointers() {
     mov(kj, reg_kh);
     L(kh_comeback_label);
     {
+        int kw = jcp.is_hw_transp ? 1 : jcp.kw;
         int inp_mult = is_src_layout_nxc()
                 ? jcp.ngroups * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
-        int iw = jcp.iw;
+        int iw = jcp.is_hw_transp ? 1 : jcp.iw;
         sub_imm(reg_input, reg_input,
                 jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mult,
                 reg_tmp_imm);
         sub_imm(reg_kernel, reg_kernel,
-                jcp.typesize_out * jcp.kw * jcp.ic_block * jcp.oc_block,
+                jcp.typesize_out * kw * jcp.ic_block * jcp.oc_block,
                 reg_tmp_imm);
         sub(kj, kj, 1);
         cmp(kj, 0);
@@ -2876,7 +2877,8 @@ void jit_sve_512_conv_bwd_weights_kernel_f32 ::compute_oh_step_unroll_ow(
     int ic_block = jcp.ic_block;
     int oc_block = jcp.oc_block;
 
-    int ow = jcp.ow;
+    int inp_icb_sp_stride = jcp.is_hw_transp ? 1 : jcp.iw;
+    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
 
     int r_pad = nstl::max(0, jcp.r_pad);
     int l_pad = jcp.l_pad;
@@ -2925,8 +2927,8 @@ void jit_sve_512_conv_bwd_weights_kernel_f32 ::compute_oh_step_unroll_ow(
         }
         L(icb_block_label_end);
 
-        const int input_shift
-                = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mul;
+        const int input_shift = jcp.typesize_in * (jcp.dilate_h + 1)
+                * inp_icb_sp_stride * inp_mul;
 
         if (generate_icb_loop || ic_tail) {
             const size_t kernel_icb_shift = (size_t)jcp.typesize_out * jcp.kd
@@ -2992,7 +2994,7 @@ void jit_sve_512_conv_bwd_weights_kernel_f32 ::compute_oh_step_unroll_ow(
                     input_shift - jcp.typesize_in * jcp.ic_block, reg_tmp_imm);
         }
 
-        if (!(generate_icb_loop || ic_tail))
+        if (!jcp.is_hw_transp && !(generate_icb_loop || ic_tail))
             add_imm(reg_kernel, reg_kernel,
                     jcp.typesize_out * (jcp.kw - 1) * ic_block * oc_block,
                     reg_tmp_imm);

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
@@ -598,10 +598,9 @@ private:
     inline ptrdiff_t get_full_src_offset(
             int i_iw, int i_ic, ptrdiff_t input_offset) {
         const bool is_nxc_layout = is_src_layout_nxc();
-        const size_t w_shift_st
-                = (jcp.is_hw_transp ? jcp.iw : 1) * jcp.ic_block;
-        ptrdiff_t w_shift = is_nxc_layout ? jcp.ngroups * jcp.ic
-                                          : (jcp.is_1stconv ? 1 : w_shift_st);
+        const size_t w_shift_st = (jcp.is_hw_transp ? jcp.iw : 1)
+                * (jcp.is_1stconv ? 1 : jcp.ic_block);
+        ptrdiff_t w_shift = is_nxc_layout ? jcp.ngroups * jcp.ic : w_shift_st;
         ptrdiff_t ic_shift = (jcp.is_1stconv && !is_nxc_layout
                         ? (ptrdiff_t)jcp.ih * jcp.iw * jcp.id
                         : 1);


### PR DESCRIPTION
# Description

This PR is support the hw transpose optimization for aarch64/convolution_f32 JIT.
Using the same method as JIT for AVX_512.

    /* Optimization: when `output-width == 1' deploy a special case of the
     * JIT-Kernel by unrolling with regards to height instead of width for
     * the source and filter tensors. The JIT-Kernel also transposes the
     * strides for the input and filter memory access. */

Related RFC #841
Related PR #931

## Performance impact:
Using FX700 with A64FX(2GHz),
% ./tests/benchdnn/benchdnn --conv --mode=P --dir=BWD_WB --cfg=f32_full mb7ic128ih102iw19oc256oh100ow1kh3kw19ph0pw0n"small-spatial:3"
  w/o this optimization : 21.3855 ms average, using gemm:ref
  with the optimization : 2.39671 ms average, using jit:sve_512

# Checklist

## Code-change submissions

- [N/A] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
 Some patterns using "gemm:ref" was failed.
- [x] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

There is no need to make a new tests for this PR,
since we can use the existing gtests and benchdnn for this PR.
