### PR TITLE
cpu: aarch64: add JIT implementation for 1x1 convolution_fp32

### DIFF
--- a/src/cpu/aarch64/cpu_barrier.hpp
+++ b/src/cpu/aarch64/cpu_barrier.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
-* Copyright 2020 FUJITSU LIMITED
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ void barrier(ctx_t *ctx, int nthr);
  *   reg_nnthr -- read-only register with the # of synchronizing threads
  */
 void generate(jit_generator &code, Xbyak_aarch64::XReg reg_ctx,
-        Xbyak_aarch64::XReg reg_nthr);
+        Xbyak_aarch64::XReg reg_nthr, bool usedAsFunc = false);
 
 } // namespace simple_barrier
 

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -34,6 +34,7 @@ enum class jit_memory_tag_kind_t { ncsp, nspc, blocked, undef };
 enum conv_version_t {
     ver_unused,
     ver_fma,
+    ver_sve_512,
 };
 
 enum conv_loop_order_t {
@@ -48,6 +49,15 @@ enum conv_loop_order_t {
 };
 
 enum conv_kernel_kind_t { embd_bcast, expl_bcast };
+
+enum conv_1x1_loop_order_t {
+    loop_rbl,
+    loop_rlb,
+    loop_lbr,
+    loop_lrb,
+    loop_blr,
+    loop_brl
+};
 
 enum conv_harness_t {
     harness_2d_reduction,
@@ -183,6 +193,8 @@ struct jit_conv_conf_t {
     bool transpose_dst;
     int ic_block_step;
 
+    cpu_isa_t isa;
+
     bool is_hw_transp; // spatial dim height-width transposed
 };
 
@@ -273,6 +285,114 @@ struct jit_conv_call_s {
     int flags;
     int flags_prf;
     int oc_flag;
+};
+
+struct jit_dw_conv_call_s {
+    const void *input;
+    const void *output;
+    const void *filter;
+    const void *bias;
+    size_t kh_count;
+    size_t oh_count;
+    size_t oh_index;
+    size_t filter_pad_off;
+    unsigned char
+            exec_flags; /* Flags passed by driver execution to inner kernel */
+};
+
+struct jit_1x1_conv_conf_t {
+    prop_kind_t prop_kind;
+    conv_version_t ver;
+
+    int ndims;
+    int mb;
+    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    int id, ih, iw, od, oh, ow;
+    int f_pad, t_pad, l_pad;
+    int kd, kh, kw;
+    int stride_d, stride_h, stride_w;
+    format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
+    bool with_bias;
+    bool with_sum;
+    bool with_eltwise;
+    bool with_binary;
+    bool with_dw_conv;
+
+    post_ops_t post_ops;
+    post_ops_t::entry_t::eltwise_t eltwise;
+
+    int is, os;
+    int ic_block, oc_block;
+
+    int ur, ur_tail;
+
+    int reduce_dim, reduce_block, nb_reduce, nb_reduce_blocking,
+            nb_reduce_blocking_max;
+    int load_dim, load_block, nb_load, nb_load_blocking, nb_load_blocking_max,
+            nb_load_chunk;
+    int bcast_dim, bcast_block, nb_bcast, nb_bcast_blocking,
+            nb_bcast_blocking_max;
+
+    int reduce_loop_unroll, reduce_loop_bcast_step, reduce_loop_load_step;
+    int load_loop_load_step, load_loop_iter_step;
+    int bcast_loop_output_step, bcast_loop_output_substep;
+    int bcast_loop_bcast_step, bcast_loop_bcast_substep;
+    int fma_step;
+    int load_grp_count;
+    conv_1x1_loop_order_t loop_order;
+    bool use_vmovntps;
+    /* sve512 core */
+    bool expl_bcast;
+    int typesize_in;
+    int typesize_out;
+    int typesize_bia;
+    int typesize_acc;
+    /* 4fma */
+    bool transpose_src;
+    int tr_is;
+    int nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b;
+    int is_oc_scale;
+    data_type_t bia_dt;
+    data_type_t dst_dt;
+    bool signed_input;
+    float wei_adj_scale;
+    // zero-point compensation
+    bool src_zero_point;
+    bool dst_zero_point;
+    bool zp_src_is_common; // common, otherwise (TODO) per-channel
+
+    cpu_isa_t isa;
+    bool uses_permw_transposition;
+};
+
+struct jit_1x1_conv_call_s {
+    const void *bcast_data;
+    const void *load_data;
+    const void *output_data;
+    const void *bias_data; // used in forward and backward_weights only
+    const void *acc_s32;
+    const void *scales;
+    const void *compensation;
+    const void *store_buffer;
+    const int32_t *zp_compensation;
+    const int32_t *src_zero_point;
+    const int32_t *dst_zero_point;
+
+    // ptr to table of void * elements that are pointers to
+    // post_op binary src1 tensors
+    const void *post_ops_binary_rhs_arg_vec;
+    // logical (# of elems) offset to the processed output channel
+    // (for broadcasting [1,OC,1,1])
+    size_t oc_l_off;
+    const void *dst_orig; // pointer to dst memory (not offseted)
+
+    size_t load_dim;
+    size_t bcast_dim;
+    size_t reduce_dim;
+
+    size_t output_stride; // used in backward_weights only
+
+    size_t first_last_flag;
 };
 
 struct jit_pool_conf_t {

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
@@ -1,0 +1,1234 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <assert.h>
+#include <float.h>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/cpu_barrier.hpp"
+#include "cpu/platform.hpp"
+
+#include "cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp"
+
+#include "cpu/aarch64/jit_uni_1x1_conv_utils.hpp"
+
+#define GET_OFF(field) \
+    static_cast<int32_t>(offsetof(jit_1x1_conv_call_s, field))
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::format_tag;
+using namespace dnnl::impl::prop_kind;
+using namespace dnnl::impl::utils;
+
+void jit_sve_512_1x1_conv_kernel::bcast_loop(int load_loop_blk) {
+
+    mov(aux1_reg_bcast_data, reg_bcast_data);
+    mov(aux_reg_bcast_data, reg_bcast_data);
+    mov(aux_reg_output_data, reg_output_data);
+    mov(reg_bcast_loop_iter, reg_bcast_loop_work);
+
+    Label bcast_loop;
+    Label bcast_loop_tail;
+    Label large_tail;
+
+    cmp_imm(reg_bcast_loop_iter, jcp.bcast_block, reg_tmp_imm);
+    b(LT, bcast_loop_tail);
+
+    L(bcast_loop);
+    {
+        assert(jcp.bcast_block % jcp.ur == 0);
+        int num_substeps = jcp.bcast_block / jcp.ur;
+        assert(num_substeps > 0 && num_substeps < 10);
+        for (int i = 0; i < num_substeps; i++) {
+            if (i + 1 == num_substeps) L(large_tail);
+            reduce_loop(load_loop_blk, jcp.ur, i, false);
+            if (i < num_substeps - 1) {
+                add_imm(aux1_reg_bcast_data, aux1_reg_bcast_data,
+                        jcp.bcast_loop_bcast_substep, reg_tmp_imm);
+                add_imm(aux_reg_output_data, aux_reg_output_data,
+                        jcp.bcast_loop_output_substep, reg_tmp_imm);
+            } else {
+                add_imm(aux1_reg_bcast_data, aux1_reg_bcast_data,
+                        jcp.bcast_loop_bcast_step
+                                - (num_substeps - 1)
+                                        * jcp.bcast_loop_bcast_substep,
+                        reg_tmp_imm);
+                add_imm(aux_reg_output_data, aux_reg_output_data,
+                        jcp.bcast_loop_output_step
+                                - (num_substeps - 1)
+                                        * jcp.bcast_loop_output_substep,
+                        reg_tmp_imm);
+            }
+            subs_imm(reg_bcast_loop_iter, reg_bcast_loop_iter, jcp.ur,
+                    reg_tmp_imm);
+        }
+        cmp_imm(reg_bcast_loop_iter, jcp.bcast_block, reg_tmp_imm);
+        b(GE, bcast_loop);
+    }
+
+    L(bcast_loop_tail);
+    if (jcp.ur_tail) {
+        Label bcast_loop_tail_out;
+        if (jcp.ur_tail >= jcp.ur) {
+            cmp_imm(reg_bcast_loop_iter, jcp.ur, reg_tmp_imm);
+            b(GE, large_tail);
+        }
+        if (jcp.ur_tail % jcp.ur) {
+            cmp(reg_bcast_loop_iter, 0);
+            b(LE, bcast_loop_tail_out);
+            reduce_loop(load_loop_blk, jcp.ur_tail % jcp.ur, 0, true);
+            L(bcast_loop_tail_out);
+        }
+    }
+}
+
+void jit_sve_512_1x1_conv_kernel::reduce_loop(
+        int load_loop_blk, int ur, int substep, bool wraparound) {
+
+    const bool out_layout_nxc = is_out_layout_nxc(jcp);
+    const bool load_layout_nxc = is_load_layout_nxc(jcp);
+    const bool bcast_layout_nxc = is_bcast_layout_nxc(jcp);
+    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+
+    auto vreg_sum = [=]() { return ZReg(31); };
+    auto vreg_sum_s = [=]() { return ZRegS(31); };
+
+    auto vreg_load = [=](int i_load, int i_fma) {
+        return ZReg(utils::rnd_up(ur * load_loop_blk, jcp.fma_step)
+                + jcp.fma_step * i_load + i_fma);
+    };
+    auto vreg_load_s = [=](int i_load, int i_fma) {
+        return ZRegS(utils::rnd_up(ur * load_loop_blk, jcp.fma_step)
+                + jcp.fma_step * i_load + i_fma);
+    };
+
+    auto vreg_accum = [=](int i_load, int i_ur) {
+        return ZReg(i_ur * load_loop_blk + i_load);
+    };
+    auto vreg_accum_s = [=](int i_load, int i_ur) {
+        return ZRegS(i_ur * load_loop_blk + i_load);
+    };
+
+    auto bias_load = [=](int i_load, int i_ur) {
+        int ofs = jcp.typesize_out * jcp.oc_block * i_load;
+        if (ldr_imm_check(ofs)) {
+            ldr(vreg_accum(i_load, i_ur),
+                    ptr(reg_bias_data, static_cast<int32_t>(VL64_OFS(ofs))));
+        } else {
+            add_imm(reg_tmp_ofs, reg_bias_data, ofs, reg_tmp_imm);
+            ldr(vreg_accum(i_load, i_ur), ptr(reg_tmp_ofs));
+        }
+    };
+
+    auto bcast_load = [=](int i_reduce, int i_ur, int prev_ofs, int bcast_idx) {
+        assert(i_ur < jcp.ur);
+        assert(i_reduce <= jcp.reduce_loop_unroll);
+        int ofs;
+        if (one_of(jcp.prop_kind, forward_training, forward_inference,
+                    backward_data)) {
+            assert(jcp.reduce_loop_unroll == jcp.reduce_block);
+            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
+                                                    : jcp.reduce_loop_unroll;
+            ofs = (i_reduce == jcp.reduce_loop_unroll)
+                    ? (jcp.bcast_dim + i_ur) * reduce_mul
+                    : i_ur * reduce_mul + i_reduce;
+        } else {
+            int rmul = bcast_layout_nxc ? jcp.ic : jcp.ic_block;
+            ofs = i_reduce * rmul + i_ur;
+        }
+
+        ofs = jcp.typesize_in * ofs;
+        int tmp_ofs = ofs;
+        if (ld1rw_imm_check(ofs)) {
+            ld1rw(ZRegS(bcast_idx), reg_p_all_ones,
+                    ptr(aux_reg_bcast_data, static_cast<int32_t>(ofs)));
+        } else {
+            if ((prev_ofs != -1) && ld1rw_imm_check(ofs - prev_ofs)) {
+                ld1rw(ZRegS(bcast_idx), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr,
+                                static_cast<int32_t>((ofs - prev_ofs))));
+            } else {
+                if ((prev_ofs != -1) && ((ofs - prev_ofs) >= 0)) {
+                    ofs = ofs - prev_ofs;
+                    add_imm(reg_prev_bcast_addr, reg_prev_bcast_addr, ofs,
+                            reg_tmp_imm);
+                } else {
+                    add_imm(reg_prev_bcast_addr, aux_reg_bcast_data, ofs,
+                            reg_tmp_imm);
+                }
+                prev_ofs = tmp_ofs;
+
+                ld1rw(ZRegS(bcast_idx), reg_p_all_ones,
+                        ptr(reg_prev_bcast_addr));
+            }
+        }
+        return prev_ofs;
+    };
+
+    auto load_load = [=](int i_reduce, int i_load, int i_fma) {
+        int ofs;
+        int u0 = i_reduce % jcp.reduce_loop_unroll;
+        int u1 = i_reduce / jcp.reduce_loop_unroll;
+        int lmul = jcp.load_block
+                * (load_layout_nxc ? 1
+                                   : utils::rnd_up(
+                                           jcp.reduce_dim, jcp.reduce_block));
+        int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
+        ofs = i_load * lmul + u0 * rmul;
+        ofs = u1 * jcp.reduce_loop_load_step + jcp.typesize_in * ofs;
+
+        if (ldr_imm_check(ofs)) {
+            ofs = VL64_OFS(ofs);
+            ldr(vreg_load(i_load, i_fma),
+                    ptr(aux_reg_load_data, static_cast<int32_t>(ofs)));
+        } else {
+            add_imm(reg_tmp_ofs, aux_reg_load_data, ofs, reg_tmp_imm);
+            ldr(vreg_load(i_load, i_fma), ptr(reg_tmp_ofs));
+        }
+    };
+
+    auto out_load = [=](int i_load, int i_ur, int prev_ofs) {
+        int ofs, ofs_tmp;
+        int bwd_iload
+                = (i_load != 0) && one_of(jcp.prop_kind, backward_weights);
+        auto r = (bwd_iload) ? reg_tmp_ofs : aux_reg_output_data;
+
+        if (one_of(jcp.prop_kind, forward_training, forward_inference,
+                    backward_data)) {
+            int i_load_shift = out_layout_nxc
+                    ? jcp.load_block
+                    : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
+                            * jcp.load_block;
+            int i_ur_shift = out_layout_nxc ? jcp.load_dim : jcp.load_block;
+            ofs = (i_load * i_load_shift + i_ur * i_ur_shift)
+                    * jcp.typesize_out;
+        } else {
+            ofs = jcp.typesize_out * jcp.load_block * i_ur;
+        }
+
+        ofs_tmp = ofs;
+
+        if (bwd_iload) mov(r, i_load);
+        if (ldr_imm_check(ofs)) {
+            if (bwd_iload) madd(r, r, reg_output_stride, aux_reg_output_data);
+            ldr(vreg_sum(), ptr(r, static_cast<int32_t>(VL64_OFS(ofs))));
+        } else {
+            if ((prev_ofs != -1) && ((ofs - prev_ofs) > 0)
+                    && (VL64_OFS(ofs - prev_ofs) <= LDRMAX)) {
+                if (bwd_iload)
+                    madd(r, r, reg_output_stride, reg_prev_out_addr);
+                else
+                    r = reg_prev_out_addr;
+                ldr(vreg_sum(),
+                        ptr(r, static_cast<int32_t>(VL64_OFS(ofs - prev_ofs))));
+            } else {
+                if ((prev_ofs != -1) && ((ofs - prev_ofs) > 0)) {
+                    ofs = ofs - prev_ofs;
+                    add_imm(reg_prev_out_addr, reg_prev_out_addr, ofs,
+                            reg_tmp_imm);
+                } else {
+                    add_imm(reg_prev_out_addr, aux_reg_output_data, ofs,
+                            reg_tmp_imm);
+                }
+                if (bwd_iload)
+                    madd(r, r, reg_output_stride, reg_prev_out_addr);
+                else
+                    r = reg_prev_out_addr;
+                ldr(vreg_sum(), ptr(r));
+
+                prev_ofs = ofs_tmp;
+            }
+        }
+        return prev_ofs;
+    };
+
+    auto out_str = [=](int i_load, int i_ur, int prev_ofs) {
+        int ofs, ofs_tmp;
+        int bwd_iload
+                = (i_load != 0) && one_of(jcp.prop_kind, backward_weights);
+        auto r = (bwd_iload) ? reg_tmp_ofs : aux_reg_output_data;
+        if (one_of(jcp.prop_kind, forward_training, forward_inference,
+                    backward_data)) {
+            ofs = (i_load * jcp.bcast_dim + i_ur) * jcp.load_block
+                    * jcp.typesize_out;
+        } else {
+            ofs = jcp.typesize_out * jcp.load_block * i_ur;
+        }
+        ofs_tmp = ofs;
+
+        if (bwd_iload) mov(r, i_load);
+        if (str_imm_check(ofs)) {
+            if (bwd_iload) madd(r, r, reg_output_stride, aux_reg_output_data);
+            str(vreg_accum(i_load, i_ur),
+                    ptr(r, static_cast<int32_t>(VL64_OFS(ofs))));
+        } else {
+            if ((prev_ofs != -1) && str_imm_check(ofs - prev_ofs)) {
+                if (bwd_iload)
+                    madd(r, r, reg_output_stride, reg_prev_out_addr);
+                else
+                    r = reg_prev_out_addr;
+                str(vreg_accum(i_load, i_ur),
+                        ptr(r, static_cast<int32_t>(VL64_OFS(ofs - prev_ofs))));
+            } else {
+                if ((prev_ofs != -1) && ((ofs - prev_ofs) > 0)) {
+                    ofs = ofs - prev_ofs;
+                    add_imm(reg_prev_out_addr, reg_prev_out_addr, ofs,
+                            reg_tmp_imm);
+                } else {
+                    add_imm(reg_prev_out_addr, aux_reg_output_data, ofs,
+                            reg_tmp_imm);
+                }
+                if (bwd_iload)
+                    madd(r, r, reg_output_stride, reg_prev_out_addr);
+                else
+                    r = reg_prev_out_addr;
+                str(vreg_accum(i_load, i_ur), ptr(r));
+
+                prev_ofs = ofs_tmp;
+            }
+        }
+        return prev_ofs;
+    };
+
+    auto prefetch_output = [=](int i_load, int i_ur) {
+        int ofs;
+        int bwd_iload
+                = (i_load != 0) && one_of(jcp.prop_kind, backward_weights);
+        auto r = (bwd_iload) ? reg_tmp_ofs : aux_reg_output_data;
+        if (one_of(jcp.prop_kind, forward_training, forward_inference,
+                    backward_data)) {
+            ofs = (i_load * jcp.bcast_dim + i_ur) * jcp.load_block
+                    * jcp.typesize_out;
+        } else {
+            ofs = jcp.typesize_out * jcp.load_block * i_ur;
+        }
+        std::string op = "LD";
+        prefetch(op, 2, r, ofs);
+    };
+
+    auto init = [=]() {
+        Label init_done;
+        Label init_zero;
+
+        if (jcp.with_sum) {
+            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                    prefetch_output(i_load, i_ur);
+                }
+            }
+        }
+
+        if (jcp.with_bias
+                && one_of(jcp.prop_kind, forward_training, forward_inference)) {
+
+            tst(reg_reduce_pos_flag, FLAG_REDUCE_FIRST);
+            b(EQ, init_zero);
+
+            for (int i_load = 0; i_load < load_loop_blk; i_load++)
+                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                    bias_load(i_load, i_ur);
+                }
+            b(init_done);
+        }
+
+        L(init_zero);
+        /* Zero clear */
+        for (int i_load = 0; i_load < load_loop_blk; ++i_load)
+            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                fmov(vreg_accum_s(i_load, i_ur));
+            }
+        L(init_done);
+    };
+
+    auto store = [=]() {
+        Label store_noadd;
+        if (!jcp.with_sum) {
+            tst(reg_reduce_pos_flag, FLAG_REDUCE_FIRST);
+            b(NE, store_noadd);
+        }
+
+        int prev_ofs = -1;
+        for (int i_ur = 0; i_ur < ur; ++i_ur)
+            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                auto r = vreg_accum_s(i_load, i_ur);
+                prev_ofs = out_load(i_load, i_ur, prev_ofs);
+                fadd(r, r, vreg_sum_s());
+            }
+
+        L(store_noadd);
+        if (jcp.with_eltwise) {
+#ifndef DISABLE_ELTWISE
+            Label store_noeltwise;
+            tst(reg_reduce_pos_flag, FLAG_REDUCE_LAST);
+            b(EQ, store_noeltwise);
+            eltwise_injector_->compute_vector_range(0, ur * load_loop_blk);
+            L(store_noeltwise);
+#else
+            assert(!"fused eltwise error!");
+#endif
+        }
+
+        prev_ofs = -1;
+        for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                prev_ofs = out_str(i_load, i_ur, prev_ofs);
+            }
+        }
+    };
+
+    auto fma_block = [=](bool last_block) {
+        assert(jcp.reduce_loop_unroll % jcp.fma_step == 0);
+
+        int reduce_step = jcp.fma_step;
+        int prev_bcast_ofs = -1;
+        assert(reduce_dim_tail % reduce_step == 0);
+
+        const int i_reduce_end = reduce_dim_tail && last_block
+                ? reduce_dim_tail
+                : jcp.reduce_loop_unroll;
+
+        int bcast_reg_ofs = utils::rnd_up(ur * load_loop_blk, jcp.fma_step)
+                + jcp.fma_step * load_loop_blk;
+        int num_bcast_regs = 32 - bcast_reg_ofs;
+        int bcast_reg_idx = 0;
+
+        for (int i_reduce = 0; i_reduce < i_reduce_end;
+                i_reduce += reduce_step) { // IC
+            for (int i_load = 0; i_load < load_loop_blk; ++i_load) { // OC
+                for (int i_fma = 0; i_fma < jcp.fma_step; i_fma++) {
+                    load_load(i_reduce + i_fma, i_load, i_fma);
+                }
+            }
+
+            int bcast_reg_startidx = bcast_reg_idx % num_bcast_regs;
+            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                if (i_ur >= num_bcast_regs) break;
+                prev_bcast_ofs = bcast_load(i_reduce, i_ur, prev_bcast_ofs,
+                        bcast_reg_ofs + (bcast_reg_idx % num_bcast_regs));
+                bcast_reg_idx++;
+            }
+
+            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+
+                for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                    fmla(vreg_accum_s(i_load, i_ur), reg_p_all_ones,
+                            vreg_load_s(i_load, 0),
+                            ZRegS(bcast_reg_ofs
+                                    + ((bcast_reg_startidx + i_ur)
+                                            % num_bcast_regs)));
+                }
+                if ((num_bcast_regs + i_ur) < ur) {
+                    prev_bcast_ofs = bcast_load(i_reduce, num_bcast_regs + i_ur,
+                            prev_bcast_ofs,
+                            bcast_reg_ofs + (bcast_reg_idx % num_bcast_regs));
+                    bcast_reg_idx++;
+                }
+            }
+        }
+    };
+    Label reduce_loop;
+    Label reduce_loop_tail;
+
+    mov(aux_reg_load_data, reg_load_data);
+
+    mov(aux_reg_bcast_data, aux1_reg_bcast_data);
+    init();
+
+    mov(reduce_loop_iter, reg_reduce_loop_work);
+    subs_imm(reduce_loop_iter, reduce_loop_iter, jcp.reduce_loop_unroll,
+            reg_tmp_imm);
+    b(LE, reduce_loop_tail);
+
+    align(32);
+    L(reduce_loop);
+    {
+        fma_block(false);
+        add_imm(aux_reg_bcast_data, aux_reg_bcast_data,
+                jcp.reduce_loop_bcast_step, reg_tmp_imm);
+        add_imm(aux_reg_load_data, aux_reg_load_data, jcp.reduce_loop_load_step,
+                reg_tmp_imm);
+        subs_imm(reduce_loop_iter, reduce_loop_iter, jcp.reduce_loop_unroll,
+                reg_tmp_imm);
+        b(GT, reduce_loop);
+    }
+
+    L(reduce_loop_tail);
+    fma_block(true);
+
+    store();
+}
+
+void jit_sve_512_1x1_conv_kernel::generate() {
+    preamble();
+
+    /* All 1 predicate register */
+    ptrue(reg_p_all_ones.b);
+
+    /* Pointers indicate weight, input, and output data */
+    ldr(reg_bcast_data, ptr(abi_param1, GET_OFF(bcast_data))); // Input
+    ldr(reg_load_data, ptr(abi_param1, GET_OFF(load_data))); // Weight
+    ldr(reg_output_data, ptr(abi_param1, GET_OFF(output_data))); // Output
+
+    /* Pointer indicates bias data if the layer has bias option */
+    if (jcp.with_bias) ldr(reg_bias_data, ptr(abi_param1, GET_OFF(bias_data)));
+
+    /* Get workloads of each loop */
+    ldr(reg_load_loop_work, ptr(abi_param1, GET_OFF(load_dim)));
+    ldr(reg_bcast_loop_work, ptr(abi_param1, GET_OFF(bcast_dim)));
+    ldr(reg_reduce_loop_work, ptr(abi_param1, GET_OFF(reduce_dim)));
+
+    /* A flag for controlling reduce loop */
+    ldr(reg_reduce_pos_flag, ptr(abi_param1, GET_OFF(first_last_flag)));
+
+    if (one_of(jcp.prop_kind, forward_training, forward_inference))
+        mov(reg_relu_ns, reinterpret_cast<size_t>(&jcp.eltwise.alpha));
+
+    if (jcp.prop_kind == backward_weights)
+        ldr(reg_output_stride, ptr(abi_param1, GET_OFF(output_stride)));
+
+    auto load_loop_body = [=](int load_loop_blk) {
+        subs_imm(reg_load_loop_work, reg_load_loop_work,
+                load_loop_blk * jcp.load_loop_iter_step, reg_tmp_imm);
+
+        bcast_loop(load_loop_blk);
+        add_imm(reg_load_data, reg_load_data,
+                load_loop_blk * jcp.load_loop_load_step, reg_tmp_imm);
+        switch (jcp.prop_kind) {
+            case forward_training:
+            case forward_inference:
+                add_imm(reg_bias_data, reg_bias_data,
+                        load_loop_blk * jcp.load_block * jcp.typesize_out,
+                        reg_tmp_imm);
+                add_imm(reg_output_data, reg_output_data,
+                        load_loop_blk * jcp.load_block * jcp.typesize_out
+                                * (is_out_layout_nxc(jcp)
+                                                ? 1
+                                                : (jcp.with_dw_conv
+                                                                ? jcp.ow
+                                                                : jcp.bcast_dim)),
+                        reg_tmp_imm);
+                break;
+            case backward_data:
+                add_imm(reg_output_data, reg_output_data,
+                        load_loop_blk * jcp.load_block * jcp.typesize_out
+                                * (is_out_layout_nxc(jcp) ? 1 : jcp.bcast_dim),
+                        reg_tmp_imm);
+                break;
+            case backward_weights:
+                for (int i_load = 0; i_load < load_loop_blk; i_load++)
+                    add(reg_output_data, reg_output_data, reg_output_stride);
+                break;
+            default: assert(!"invalid prop_kind");
+        }
+    };
+
+    const int simd_w = cpu_isa_traits<sve_512>::vlen / sizeof(float);
+
+    Label load_loop_blk[7];
+
+    // with an implicit load_loop_block {6, 5, 4, 3, 2,  1}
+    static const int ur_cases_bcast[] = {2, 5, 6, 9, 14, 32};
+
+    const int size_ur_cases = sizeof(ur_cases_bcast);
+
+    const int *ur_cases = ur_cases_bcast;
+    const int num_ur_cases = size_ur_cases / sizeof(*ur_cases);
+
+    for (int ur_idx = num_ur_cases - 1; ur_idx > 0; ur_idx--) {
+        int label_idx = num_ur_cases - ur_idx - 1;
+        if (jcp.nb_load > label_idx && jcp.ur <= ur_cases[ur_idx]) {
+            cmp_imm(reg_load_loop_work, simd_w * (label_idx + 1), reg_tmp_imm);
+            b(LE, load_loop_blk[label_idx]);
+        }
+    }
+
+    for (int ur_idx = 0; ur_idx < num_ur_cases; ur_idx++) {
+        int label_idx = num_ur_cases - ur_idx - 1;
+        if (jcp.nb_load > label_idx && jcp.ur <= ur_cases[ur_idx]) {
+            L(load_loop_blk[label_idx]);
+            {
+                if (label_idx == 0) {
+                    cmp(reg_load_loop_work, 0);
+                    b(LE, load_loop_blk[num_ur_cases]);
+                }
+                load_loop_body(label_idx + 1);
+                if (label_idx - 1 > 0) {
+                    cmp_imm(reg_load_loop_work, 2 * label_idx * simd_w,
+                            reg_tmp_imm);
+                    b(EQ, load_loop_blk[label_idx - 1]);
+                }
+                cmp_imm(reg_load_loop_work, label_idx * simd_w, reg_tmp_imm);
+                b(GT, load_loop_blk[label_idx]);
+            }
+            for (int idx = label_idx - 1; idx > 0; --idx) {
+                cmp_imm(reg_load_loop_work, simd_w * (idx + 1), reg_tmp_imm);
+                b(EQ, load_loop_blk[idx]);
+            }
+            if (ur_idx < num_ur_cases - 2) {
+                cmp_imm(reg_load_loop_work, simd_w, reg_tmp_imm);
+                b(LE, load_loop_blk[0]);
+            }
+        }
+    }
+    L(load_loop_blk[num_ur_cases]);
+
+    postamble();
+    if (jcp.with_eltwise) {
+#ifndef DISABLE_ELTWISE
+        eltwise_injector_->prepare_table();
+        binCommit();
+#else
+        assert(!"fused eltwise error");
+#endif
+    }
+}
+
+bool jit_sve_512_1x1_conv_kernel::post_ops_ok(
+        jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr) {
+
+    const auto &p = attr.post_ops_;
+
+    auto is_eltwise = [&](int idx) { return p.entry_[idx].is_eltwise(); };
+    auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(); };
+    auto is_convolution
+            = [&](int idx) { return p.entry_[idx].is_convolution(); };
+
+    int dw_idx = p.find(primitive_kind::convolution);
+    int len = dw_idx != -1 ? dw_idx + 1 : p.len();
+
+    switch (len) {
+        case 0: return true; // no post_ops
+        case 1: // eltwise OR sum OR Convolution
+            return is_eltwise(0) || is_sum(0) || is_convolution(0);
+        case 2: // sum -> eltwise OR eltwise -> convolution
+            return (is_sum(0) && is_eltwise(1))
+                    || (is_eltwise(0) && is_convolution(1));
+        default: return false;
+    }
+
+    return false;
+}
+
+status_t jit_sve_512_1x1_conv_kernel::init_conf(jit_1x1_conv_conf_t &jcp,
+        const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
+        const memory_desc_wrapper &weights_d, const memory_desc_wrapper &dst_d,
+        const primitive_attr_t &attr, int nthreads, bool reduce_src) {
+
+    /* arch check */
+    if (!mayiuse(sve_512)) return status::unimplemented;
+
+    jcp.nthr = nthreads;
+
+    const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
+    const int simd_w = cpu_isa_traits<sve_512>::vlen / sizeof(float);
+    const int ndims = src_d.ndims();
+    /* Forward_[training, inference], backward_[data, weight] */
+    jcp.prop_kind = cd.prop_kind;
+
+    /* Check group option */
+    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    /* Batchsize */
+    jcp.mb = src_d.dims()[0];
+    /* Channel */
+    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = jcp.oc_without_padding;
+    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = jcp.ic_without_padding;
+    /* D, H, W */
+    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
+    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
+    jcp.iw = src_d.dims()[ndims - 1];
+    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
+    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
+    jcp.ow = dst_d.dims()[ndims - 1];
+    /* Kernel size */
+    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
+    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
+    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    /* padding params */
+    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
+    jcp.l_pad = cd.padding[0][ndims - 3];
+    /* stride params */
+    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
+    jcp.stride_w = cd.strides[ndims - 3];
+    /* bias info */
+    jcp.with_bias = pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.format_kind,
+                            format_kind::undef, cd.diff_bias_desc.format_kind)
+            != format_kind::undef;
+
+    /* Spatials */
+    jcp.os = jcp.od * jcp.oh * jcp.ow;
+    jcp.is = jcp.id * jcp.ih * jcp.iw;
+    jcp.tr_is = rnd_up(jcp.is, 4);
+
+    if (!post_ops_ok(jcp, attr)) return status::unimplemented;
+
+    /* Depthwise conv check */
+    const auto &p = attr.post_ops_;
+    const int dw_conv_ind = p.find(primitive_kind::convolution);
+    jcp.with_dw_conv = dw_conv_ind != -1;
+
+    /* Post operation check */
+    // Using dw_conv_ind as upper-bound below, as post-ops after it will be
+    // handled in depthwise convolution.
+    jcp.with_sum = p.find(primitive_kind::sum, 0, dw_conv_ind) != -1;
+    const int eltwise_ind = p.find(primitive_kind::eltwise, 0, dw_conv_ind);
+    jcp.with_eltwise = eltwise_ind != -1;
+    if (jcp.with_eltwise) {
+#ifndef DISABLE_ELTWISE
+        jcp.eltwise = p.entry_[eltwise_ind].eltwise;
+        if (jcp.eltwise.alg == alg_kind::eltwise_pow)
+            return status::unimplemented;
+        if (dst_d.data_type() == data_type::s32) return status::unimplemented;
+#else
+        return status::unimplemented;
+#endif
+    }
+
+    /* Data format check */
+    const auto dat_tag_nxc = pick(ndims - 3, nwc, nhwc, ndhwc);
+    const auto dat_tag_nCx16c = pick(ndims - 3, nCw16c, nChw16c, nCdhw16c);
+    jcp.src_tag = src_d.matches_one_of_tag(dat_tag_nxc, dat_tag_nCx16c);
+    jcp.dst_tag = dst_d.matches_one_of_tag(dat_tag_nxc, dat_tag_nCx16c);
+    bool is_data_layout_nxc
+            = utils::everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
+    auto required_dat_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_nCx16c;
+
+    if (is_data_layout_nxc) return status::unimplemented;
+
+    /* Channel padding check */
+    bool ok_to_pad_channels
+            = true && jcp.ngroups == 1 && src_d.data_type() == data_type::f32;
+
+    /* Input and output must be multiple of simd_w */
+    if (ok_to_pad_channels) {
+        jcp.oc = rnd_up(jcp.oc, simd_w);
+        jcp.ic = rnd_up(jcp.ic, simd_w);
+    }
+
+    bool args_ok = true && jcp.ngroups == 1 && jcp.src_tag == required_dat_tag
+            && jcp.dst_tag == required_dat_tag
+            && (jcp.oc % simd_w == 0 && jcp.ic % simd_w == 0) && jcp.f_pad == 0
+            && jcp.t_pad == 0 && jcp.l_pad == 0 && jcp.stride_w == 1
+            && jcp.stride_h == 1 && jcp.stride_d == 1 && jcp.kd == 1
+            && jcp.kh == 1 && jcp.kw == 1 && jcp.ow == jcp.iw
+            && jcp.oh == jcp.ih && jcp.od == jcp.id; // enforce rpad=0
+    if (!args_ok) return status::unimplemented;
+
+    /* Channel blocking size is simd_w */
+    jcp.ic_block = jcp.oc_block = simd_w;
+
+    jcp.ver = ver_sve_512;
+    if (everyone_is(data_type::f32, src_d.data_type(), weights_d.data_type(),
+                dst_d.data_type())) {
+        const int is_bwd_d = jcp.prop_kind == backward_data;
+        /* Set weight data layout tag */
+        format_tag_t wei_tag = with_groups
+                ? pick(2 * ndims - 6 + is_bwd_d, gOIw16i16o, gIOw16o16i,
+                        gOIhw16i16o, gIOhw16o16i, gOIdhw16i16o, gIOdhw16o16i)
+                : pick(2 * ndims - 6 + is_bwd_d, OIw16i16o, IOw16o16i,
+                        OIhw16i16o, IOhw16o16i, OIdhw16i16o, IOdhw16o16i);
+
+        jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
+        if (jcp.wei_tag != wei_tag) return status::unimplemented;
+
+        jcp.fma_step = 1;
+        jcp.typesize_in = sizeof(prec_traits<data_type::f32>::type);
+        jcp.typesize_out = sizeof(prec_traits<data_type::f32>::type);
+    } else {
+        // TODO: currently, only support fp32
+        return status::unimplemented;
+    }
+
+    /* once all the formats are set, check the padding consistency */
+    args_ok = true && jcp.ic <= src_d.padded_dims()[1]
+            && jcp.oc <= dst_d.padded_dims()[1]
+            && jcp.ic <= weights_d.padded_dims()[with_groups + 1]
+            && jcp.oc <= weights_d.padded_dims()[with_groups + 0];
+    if (!args_ok) return status::unimplemented;
+
+    // TODO: Optimize bellow params
+    const int SMALL_SPATIAL = 10;
+    const int BIG_SPATIAL = 65;
+    const int BIG_LOAD_DIM = (jcp.reduce_dim >= 512) ? 256 : 512;
+
+    int load_blocking {0};
+    int load_blocking_max {0};
+    int bcast_blocking {0};
+    int bcast_blocking_max {0};
+    int reduce_blocking {0};
+    int reduce_blocking_max {0};
+
+    jcp.load_grp_count = 1;
+
+    // TODO: mov check funcs into platform files
+    const int L1_capacity
+            = platform::get_per_core_cache_size(1) / sizeof(float);
+    const int L2_size = platform::get_per_core_cache_size(2) / sizeof(float);
+    const int L2_capacity = (L2_size * 3) / 4;
+
+    /* FWD, BWD data */
+    if (one_of(jcp.prop_kind, forward_training, forward_inference,
+                backward_data)) {
+
+        if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
+            /* Forward */
+            if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+            jcp.reduce_dim = jcp.ic; // src channel
+            jcp.reduce_block = jcp.ic_block; // src simd_w
+
+            jcp.load_dim = jcp.oc; // dst channel
+            jcp.load_block = jcp.oc_block; // dst simd_W
+
+            jcp.bcast_dim = jcp.is; // src H*W
+        } else {
+            /* Backward data */
+            jcp.reduce_dim = jcp.oc; // src channel
+            jcp.reduce_block = jcp.oc_block; // src simd_w
+
+            jcp.load_dim = jcp.ic; // dst channel
+            jcp.load_block = jcp.ic_block; // dst simd_w
+
+            jcp.bcast_dim = jcp.os; // src H*W
+        }
+
+        /* # of consecutive channel elements  */
+        jcp.reduce_loop_unroll = jcp.reduce_block;
+
+        /* Offset to move to the next 16 input channel elements with the same H*W position */
+        jcp.reduce_loop_bcast_step
+                = jcp.reduce_loop_unroll * jcp.bcast_dim * jcp.typesize_in;
+
+        /* Offset: 16o*16i (filter) */
+        jcp.reduce_loop_load_step
+                = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
+
+        /* Offset: I/16 * 16o */
+        jcp.load_loop_load_step
+                = (utils::rnd_up(jcp.reduce_dim, jcp.reduce_block))
+                * jcp.load_block * jcp.typesize_in;
+
+        /* adjusting registry blocking */
+        int max_regs, min_regs, size_threshold, ur_step;
+
+        /* spatial : H*D of dst */
+        const int spatial
+                = (one_of(jcp.prop_kind, forward_training, forward_inference))
+                ? jcp.od * jcp.oh // forward
+                : jcp.id * jcp.ih; // backward
+
+        max_regs = 9; // max # of ur_w
+        min_regs = 6; // min # of ur_w
+        size_threshold = 14;
+        ur_step = 1; // step size of ur_w param checking
+        jcp.ur = 1;
+
+        /*
+         *  H*D of dst  > SMALL_SPATIAL
+         */
+        if (jcp.load_dim > 128 && jcp.load_dim < BIG_LOAD_DIM
+                && spatial > SMALL_SPATIAL && spatial < BIG_SPATIAL
+                && jcp.reduce_dim < 256) {
+            max_regs = 6;
+            min_regs = 5;
+        }
+
+        for (int ur_w = max_regs; ur_w >= min_regs; ur_w -= ur_step) {
+            /*
+             *  H*D of dst >= size_threshold, (H*D of dst) % ur_w == 0
+             *  or
+             *  H*D of dst < size_threshold, (H*W of dst) % ur_w == 0
+             */
+            if ((spatial >= size_threshold && spatial % ur_w == 0)
+                    || (spatial < size_threshold && jcp.os % ur_w == 0)) {
+                jcp.ur = ur_w;
+                break;
+            }
+        }
+
+        if (jcp.ur == 1) {
+            // If ur = 1, then min(max_regs, H*W of dst)
+            jcp.ur = nstl::min(max_regs, jcp.os);
+        }
+        jcp.bcast_block = jcp.ur; // block size of bcast (input data)
+        /* Number of steps for the dst address to output, used in bcast_loop() */
+        jcp.bcast_loop_output_step = jcp.ur * jcp.typesize_out * jcp.load_block;
+        jcp.bcast_loop_output_substep = -1; // unused
+
+        /* Number of steps for the src address to be broadcasted in bcast_loop() */
+        jcp.bcast_loop_bcast_step = jcp.ur * jcp.typesize_in * jcp.reduce_block;
+        jcp.bcast_loop_bcast_substep = -1; // unused
+
+        jcp.load_loop_iter_step = jcp.load_block;
+
+        if (jcp.prop_kind == backward_data)
+            jcp.loop_order = loop_lbr;
+        else
+            jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
+
+        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+        int nb_load = div_up(jcp.load_dim, jcp.load_block);
+
+        reduce_blocking = jcp.reduce_dim;
+        if (jcp.load_dim <= BIG_LOAD_DIM && spatial > SMALL_SPATIAL
+                && spatial < BIG_SPATIAL) {
+            reduce_blocking = nstl::min(jcp.reduce_dim, 80);
+        } else if (spatial > SMALL_SPATIAL)
+            reduce_blocking = nstl::min(jcp.reduce_dim, 512);
+        else
+            reduce_blocking = nstl::min(jcp.reduce_dim, 256);
+
+        // Check input data cache aliasing.
+        // For other ISA constants may be updated.
+        // 64 * 1024 is chosen due to 1MB L2 16-way cache.
+        // 7 is empirical value. It is about half of 16.
+        // So we leave about half of the set for other data - weights, dst
+        int way_size = (16 * 1024) / jcp.typesize_in;
+        int max_hits = 7;
+        if (jcp.bcast_dim * reduce_blocking > way_size * max_hits) {
+            int nrb = reduce_blocking / simd_w;
+            int sp = jcp.bcast_dim;
+            int wl = way_size / simd_w;
+            for (int start_off = 0; start_off < jcp.ur; start_off++) {
+                for (int off = start_off, hits = 0; off < sp * nrb; off += wl) {
+                    if (off % sp >= jcp.ur || ++hits < max_hits) continue;
+                    int max_r_blocking = simd_w * nstl::max(1, (off + wl) / sp);
+                    reduce_blocking
+                            = nstl::min(reduce_blocking, max_r_blocking);
+                    break;
+                }
+            }
+        }
+
+        if (reduce_blocking < jcp.reduce_dim) {
+            if (jcp.prop_kind == backward_data)
+                jcp.loop_order = reduce_src ? loop_lbr : loop_rlb;
+            else
+                jcp.loop_order = reduce_src ? loop_rbl : loop_rlb;
+        }
+        load_blocking = jcp.load_dim;
+
+        /* Number of weight elements to be loaded for dest */
+        int load_size = jcp.load_dim * jcp.reduce_dim;
+        /* Number of elements to be broadcasted from src */
+        auto bcast_size
+                = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
+
+        /* 12 cores per CMG */
+        if (jcp.nthr <= 12 && jcp.mb < jcp.nthr
+                && nb_load * nb_bcast > jcp.nthr) {
+            // Some heuristic here
+            float calc_koef = 0.01, best_cost = FLT_MAX;
+            int n_lgc = jcp.nthr;
+            float ratio = (float)load_size / (float)bcast_size;
+            int best_lgc = ratio > 1 ? n_lgc : 1;
+            auto calc_job_cost = [&](int lb, int tg, float mem_k) {
+                int bb_size = jcp.mb * div_up(nb_bcast, tg);
+                float calc_size = (float)(bb_size * jcp.ur)
+                        * (lb * jcp.load_block) * jcp.reduce_dim;
+                float mem_size = (float)(bb_size * jcp.ur + lb * jcp.load_block)
+                        * jcp.reduce_dim;
+                return calc_koef * calc_size + mem_k * mem_size;
+            };
+            for (int lgc, ilgc = 0; ilgc < n_lgc; ilgc++) {
+                lgc = ratio > 1 ? n_lgc - ilgc : ilgc + 1;
+                int min_lb = nb_load / lgc;
+                int max_lb = div_up(nb_load, lgc);
+                int min_tg = jcp.nthr / lgc;
+                int max_tg = div_up(jcp.nthr, lgc);
+                // Some heuristic here
+                float mem_koef = (max_tg == 1) ? 1.f : 1.3f;
+                float job_cost = 0.;
+                if (jcp.nthr % lgc < nb_load % lgc) {
+                    job_cost = calc_job_cost(max_lb, min_tg, mem_koef);
+                } else {
+                    auto job_cost1 = calc_job_cost(max_lb, max_tg, mem_koef);
+                    auto job_cost2 = calc_job_cost(min_lb, min_tg, mem_koef);
+                    job_cost = nstl::max(job_cost1, job_cost2);
+                }
+
+                if (job_cost < best_cost) {
+                    best_lgc = lgc;
+                    best_cost = job_cost;
+                }
+            }
+            jcp.load_grp_count = best_lgc;
+            load_blocking
+                    = div_up(nb_load, jcp.load_grp_count) * jcp.load_block;
+        } else {
+            jcp.load_grp_count
+                    = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
+            jcp.load_grp_count = best_divider(jcp.nthr, jcp.load_grp_count,
+                    2 * jcp.load_grp_count, false);
+        }
+        if (jcp.bcast_dim <= 49 && jcp.mb <= jcp.nthr && jcp.load_dim > 512
+                && jcp.load_dim / jcp.reduce_dim >= 4) {
+            jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2);
+            load_blocking = jcp.load_block;
+        }
+
+        bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                 div_up(jcp.nthr, jcp.load_grp_count))
+                * jcp.bcast_block;
+        bcast_blocking = nstl::min(jcp.bcast_dim, bcast_blocking);
+        bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
+
+        int space_for_bcast = (L2_capacity - /* kernel_size - */
+                2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
+                - 3 * 1024);
+        if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
+
+        int bcast_in_cache
+                = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
+        bcast_blocking = nstl::min(
+                bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+
+        load_blocking_max = load_blocking;
+        bcast_blocking_max = bcast_blocking * 3 / 2;
+        reduce_blocking_max = reduce_blocking;
+
+        jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur;
+
+    } else if (jcp.prop_kind == backward_weights) { /* BWD weight */
+
+        jcp.reduce_dim = jcp.is;
+
+        jcp.reduce_block = best_divider(jcp.reduce_dim, 7, 16, true);
+        if (jcp.reduce_dim % jcp.reduce_block != 0)
+            jcp.reduce_block = best_divider(jcp.iw, 4, jcp.iw, false);
+        if (jcp.reduce_block > 256) { jcp.reduce_block = 1; }
+
+        jcp.load_dim = jcp.oc;
+        jcp.load_block = jcp.oc_block;
+
+        jcp.bcast_dim = jcp.ic;
+        jcp.bcast_block = jcp.ic_block;
+
+        if (jcp.reduce_block <= 19) {
+            // if reduce_block is big then generated JIT code may be big
+            // for small values of ur because reduce_loop_unroll = reduce_block
+            jcp.ur = jcp.bcast_block / 2;
+        } else {
+            jcp.ur = jcp.bcast_block;
+        }
+
+        jcp.ur_tail = jcp.bcast_dim % jcp.bcast_block;
+        jcp.reduce_loop_unroll = jcp.reduce_block;
+        jcp.reduce_loop_bcast_step
+                = jcp.typesize_in * jcp.reduce_loop_unroll * jcp.ic_block;
+        jcp.reduce_loop_load_step
+                = jcp.typesize_in * jcp.reduce_loop_unroll * jcp.oc_block;
+
+        jcp.bcast_loop_output_step
+                = jcp.oc_block * jcp.ic_block * jcp.typesize_out;
+        jcp.bcast_loop_output_substep
+                = jcp.oc_block * jcp.ur * jcp.typesize_out;
+        jcp.bcast_loop_bcast_step = jcp.ic_block
+                * utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
+                * jcp.typesize_in;
+        jcp.bcast_loop_bcast_substep = jcp.ur * jcp.typesize_in;
+
+        jcp.load_loop_load_step = jcp.typesize_in * jcp.oc_block * jcp.os;
+        jcp.load_loop_iter_step = jcp.oc_block;
+
+        /* --- */
+        balance(jcp);
+
+        load_blocking = div_up(jcp.load_dim, jcp.load_block);
+        load_blocking = best_divider(load_blocking, 16, load_blocking, false);
+        load_blocking *= jcp.load_block;
+
+        load_blocking_max = load_blocking;
+        assert(jcp.load_dim % load_blocking == 0);
+
+        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        int min_bcast_blocking = 5;
+
+        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking = best_divider(
+                bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
+        bcast_blocking *= jcp.bcast_block;
+        bcast_blocking_max = bcast_blocking;
+        assert(jcp.bcast_dim % bcast_blocking == 0);
+
+        // for reduction balance
+        int max_reduce_blocking
+                = nstl::min(L1_capacity / jcp.ur, jcp.reduce_dim);
+        int min_reduce_blocking
+                = nstl::min(L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
+        reduce_blocking = best_divider(
+                jcp.reduce_dim, min_reduce_blocking, max_reduce_blocking, true);
+        reduce_blocking = nstl::max(
+                rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block);
+
+        reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
+    } else
+        return status::unimplemented;
+
+    assert(load_blocking);
+    assert(load_blocking_max);
+    assert(bcast_blocking);
+    assert(bcast_blocking_max);
+    assert(reduce_blocking);
+    assert(reduce_blocking_max);
+
+    assert(load_blocking % jcp.load_block == 0);
+    assert(reduce_blocking % jcp.reduce_block == 0);
+    assert(load_blocking_max % jcp.load_block == 0);
+    assert(reduce_blocking_max % jcp.reduce_block == 0);
+    assert(jcp.reduce_dim % jcp.reduce_block == 0);
+
+    assert(jcp.bcast_block % jcp.ur == 0);
+
+    jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
+    jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;
+    jcp.nb_load_blocking = utils::div_up(load_blocking, jcp.load_block);
+    jcp.nb_load_blocking_max = utils::div_up(load_blocking_max, jcp.load_block);
+    jcp.nb_reduce_blocking = utils::div_up(reduce_blocking, jcp.reduce_block);
+    jcp.nb_reduce_blocking_max
+            = utils::div_up(reduce_blocking_max, jcp.reduce_block);
+
+    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
+    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+
+    return status::success;
+}
+
+void jit_sve_512_1x1_conv_kernel::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad,
+        const jit_1x1_conv_conf_t &jcp) {
+
+    using namespace dnnl::impl::memory_tracking::names;
+
+    // Fox nxc layout bias is padded only for bwd_wb direction, as  bias
+    // reduction kernels can't handle tails yet.
+    if (jcp.with_bias && jcp.prop_kind != backward_data
+            && (jcp.oc != jcp.oc_without_padding // blocked layout
+                    || (jcp.prop_kind == backward_weights // nxc layout
+                            && jcp.oc % jcp.oc_block != 0))) {
+
+        const size_t nelems_padded_bias
+                = jcp.ngroups * utils::rnd_up(jcp.oc, jcp.oc_block);
+        scratchpad.book(
+                key_conv_padded_bias, nelems_padded_bias, jcp.typesize_out);
+    }
+
+    if (jcp.prop_kind == backward_weights) {
+        const size_t wei_size = (size_t)jcp.ngroups
+                * rnd_up(jcp.oc, jcp.oc_block) * rnd_up(jcp.ic, jcp.ic_block);
+        scratchpad.book(key_conv_wei_reduction, wei_size * (jcp.nthr_mb - 1),
+                jcp.typesize_out);
+    }
+}
+
+/* BWD W*/
+void jit_sve_512_1x1_conv_kernel::balance(jit_1x1_conv_conf_t &jcp) {
+    int nthreads = jcp.nthr;
+    // initialize jcp reduction threading properties
+    jcp.nthr = jcp.nthr_mb = jcp.nthr_g = jcp.nthr_oc_b = jcp.nthr_ic_b = 1;
+    if (nthreads < jcp.ngroups) {
+        /* simplification... fortunately it doesn't hurt much */
+        return;
+    }
+    // bcast_dim: src H*W, bcast_block: ur (fwd, bwd_d)
+    const int nb_bcast
+            = div_up(jcp.bcast_dim, jcp.bcast_block); // # of H*W loop
+    // load_dim: dst channel, load_block: simd_w
+    const int nb_load
+            = div_up(jcp.load_dim, jcp.load_block); // # of dst channel loop
+    // reduce_dim: src channel, reduce_block: simd_w
+    const int nb_reduce
+            = div_up(jcp.reduce_dim, jcp.reduce_block); // # of src channel loop
+
+    jcp.nthr_g = jcp.ngroups;
+    const int nthr = nthreads / jcp.nthr_g;
+
+    auto calc_mem_cost = [=](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
+        /* calculate per thread memory cost (read/write). high level
+        * optimizer tries to minimize memory consumption. few notes: (n1)
+        * unclear why, but that essentially helps first convolution...
+        *  (n2) assuming the reduction over minibatch is always there:
+        *    - instead of 8 it should be 5 here (write ~= 2 read):
+        *      kernel: temporal workspace 1 write
+        *      reduction: 1 read from workspace and 1 write to the diff_wei
+        *    - but experiments showed 8 works better than 5 or 6... */
+        int bcast_koeff = 1;
+        int load_koeff = 1;
+        int output_koeff = 12;
+        return 0
+                + (size_t)bcast_koeff * div_up(jcp.mb * nb_reduce, nthr_mb)
+                * div_up(jcp.ngroups, jcp.nthr_g) * div_up(nb_bcast, nthr_ic_b)
+                * jcp.ic_block * jcp.reduce_block / jcp.stride_h
+                / jcp.stride_w /* (n1) */
+                + (size_t)load_koeff * div_up(jcp.mb * nb_reduce, nthr_mb)
+                * div_up(jcp.ngroups, jcp.nthr_g) * div_up(nb_load, nthr_oc_b)
+                * jcp.oc_block * jcp.reduce_block
+                + (size_t)output_koeff /* (n2) */
+                * div_up(jcp.ngroups, jcp.nthr_g) * div_up(nb_load, nthr_oc_b)
+                * div_up(nb_bcast, nthr_ic_b) * jcp.ic_block * jcp.oc_block;
+    };
+
+    int nthr_mb = 1, nthr_oc_b = 1, nthr_ic_b = 1;
+    auto best_mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
+
+    /* step 1: find the best thread distribution with lowest memory cost */
+    const int nthr_mb_max = nstl::min(nthr, jcp.mb * nb_reduce);
+    for (nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
+        const int nthr_par = nthr / nthr_mb;
+        const int nthr_oc_b_max = nstl::min(nthr_par, nb_load);
+        for (nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
+            nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, nb_bcast);
+            auto mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
+            if (mem_cost <= best_mem_cost) {
+                best_mem_cost = mem_cost;
+                jcp.nthr_mb = nthr_mb;
+                jcp.nthr_oc_b = nthr_oc_b;
+                jcp.nthr_ic_b = nthr_ic_b;
+            }
+        }
+
+        const bool ready_for_async = utils::one_of(jcp.ver, ver_fma);
+        if (!ready_for_async && !dnnl_thr_syncable()) {
+            assert(nthr_mb == 1);
+            break;
+        }
+    }
+    if (jcp.nthr_mb > nthreads / 2 && jcp.nthr_mb < nthreads)
+        jcp.nthr_mb = nstl::min(jcp.mb, nthreads);
+
+    jcp.nthr = jcp.nthr_mb * jcp.nthr_g * jcp.nthr_oc_b * jcp.nthr_ic_b;
+    assert(jcp.nthr <= nthreads);
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
@@ -1,0 +1,184 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_SVE_1x1_CONV_KERNEL_HPP
+#define CPU_AARCH64_JIT_SVE_1x1_CONV_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_op_imm_check.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+#define DISABLE_ELTWISE
+#ifndef DISABLE_ELTWISE
+#include "cpu/aarch64/jit_uni_eltwise_injector.hpp"
+#endif
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+/* Get vector offsets, ofs / VL(VL: 512bits = 64Bytes) */
+#define VL64_OFS(ofs) ((ofs) >> 6)
+
+struct jit_sve_512_1x1_conv_kernel : public jit_generator {
+    jit_sve_512_1x1_conv_kernel(
+            const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr)
+        : jcp(ajcp)
+        , attr_(attr)
+#ifndef DISABLE_ELTWISE
+        , eltwise_injector_(nullptr)
+#endif
+    {
+        if (jcp.with_eltwise) {
+#ifndef DISABLE_ELTWISE
+            eltwise_injector_ = new jit_uni_eltwise_injector_f32<sve_512>(
+                    this, jcp.eltwise);
+#endif
+        }
+    }
+
+    ~jit_sve_512_1x1_conv_kernel() {
+#ifndef DISABLE_ELTWISE
+        delete eltwise_injector_;
+#endif
+    }
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_512_1x1_conv_kernel)
+
+    static bool post_ops_ok(
+            jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr);
+
+    static status_t init_conf(jit_1x1_conv_conf_t &jcp,
+            const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
+            const memory_desc_wrapper &weights_d,
+            const memory_desc_wrapper &dst_d, const primitive_attr_t &attr,
+            int nthreads, bool reduce_src);
+
+    static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+            const jit_1x1_conv_conf_t &jcp);
+
+    jit_1x1_conv_conf_t jcp;
+    const primitive_attr_t &attr_;
+
+private:
+    using reg64_t = const XReg;
+    const PReg reg_p_all_ones = p2;
+
+    /* Flags and loop variables */
+    reg64_t reg_reduce_pos_flag = x1;
+    reg64_t reduce_loop_iter = x2;
+    reg64_t reg_bcast_loop_iter = x3;
+    reg64_t reg_relu_ns = x20; // For forward
+    reg64_t reg_output_stride = x20; // For backward
+
+    /* Pointer */
+    reg64_t reg_bcast_data = x5; // Input
+    reg64_t reg_load_data = x6; // Weight
+    reg64_t reg_output_data = x7; // Output
+    reg64_t reg_bias_data = x8; // bias
+    reg64_t aux1_reg_bcast_data = x9;
+    reg64_t aux_reg_output_data = x10;
+    reg64_t aux_reg_bcast_data = x11;
+    reg64_t aux_reg_load_data = x12;
+    reg64_t reg_prev_bcast_addr
+            = x13; // Input: The reg keeps addr accessed by previous ldr inst
+    reg64_t reg_prev_out_addr
+            = x14; // Output: The reg keeps addr accessed by previous ldr or str inst
+
+    /* Workload */
+    reg64_t reg_load_loop_work = x15;
+    reg64_t reg_reduce_loop_work = x16;
+    reg64_t reg_bcast_loop_work = x17;
+
+    /* Temporay registers */
+    reg64_t reg_tmp_imm = x18; // tmp for add_imm
+    reg64_t reg_tmp_ofs = x19; // tmp reg to calc bwd wei offset in out_load
+
+    void prefetch(
+            const std::string prfop, int level, reg64_t in, long long int ofs) {
+        bool for_load = false;
+        if (prfop == "LD") {
+            for_load = true;
+        } else if (prfop == "ST") {
+            for_load = false;
+        } else {
+            assert(!"invalid prfop");
+        }
+
+        bool cacheline_aligned = ((ofs & 0xFF) == 0) ? true : false;
+        if (cacheline_aligned == true) {
+            Prfop op;
+            switch (level) {
+                case 1: op = (for_load == true) ? PLDL1KEEP : PSTL1KEEP; break;
+                case 2: op = (for_load == true) ? PLDL2KEEP : PSTL2KEEP; break;
+                case 3: op = (for_load == true) ? PLDL3KEEP : PSTL3KEEP; break;
+                default: assert(!"invalid prfop"); break;
+            }
+
+            if (prfm_imm_check(ofs)) {
+                prfm(op, ptr(in, static_cast<int32_t>(ofs)));
+            } else {
+                add_imm(reg_tmp_ofs, in, ofs, reg_tmp_imm);
+                prfm(op, ptr(reg_tmp_ofs));
+            }
+        } else {
+            PrfopSve op_sve;
+            switch (level) {
+                case 1:
+                    op_sve = (for_load == true) ? PLDL1KEEP_SVE : PSTL1KEEP_SVE;
+                    break;
+                case 2:
+                    op_sve = (for_load == true) ? PLDL2KEEP_SVE : PSTL2KEEP_SVE;
+                    break;
+                case 3:
+                    op_sve = (for_load == true) ? PLDL3KEEP_SVE : PSTL3KEEP_SVE;
+                    break;
+                default: assert(!"invalid prfop"); break;
+            }
+
+            if (prfw_imm_check(ofs)) {
+                prfw(op_sve, reg_p_all_ones,
+                        ptr(in, static_cast<int32_t>(VL64_OFS(ofs))));
+            } else {
+                add_imm(reg_tmp_ofs, in, ofs, reg_tmp_imm);
+                prfw(op_sve, reg_p_all_ones, ptr(reg_tmp_ofs));
+            }
+        }
+    }
+
+#ifndef DISABLE_ELTWISE
+    jit_uni_eltwise_injector_f32<sve_512> *eltwise_injector_;
+#endif
+    void bcast_loop(int load_loop_blk);
+    void reduce_loop(int load_loop_blk, int ur, int substep, bool wraparound);
+
+    void generate() override;
+    static void balance(jit_1x1_conv_conf_t &jcp);
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_sve_512_1x1_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_convolution.cpp
@@ -1,0 +1,896 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+
+#include "cpu/aarch64/jit_sve_512_1x1_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+#define data_blk_off(f, n, c, d, h, w) \
+    ((ndims == 3) ? (f).blk_off(n, c, w) \
+                  : ((ndims == 4) ? (f).blk_off(n, c, h, w) \
+                                  : (f).blk_off(n, c, d, h, w)))
+/* convolution forward */
+
+template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+void jit_sve_512_1x1_convolution_fwd_t<src_type, wei_type,
+        dst_type>::execute_forward(const exec_ctx_t &ctx) const {
+    auto src = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto bias = CTX_IN_MEM(const dst_data_t *, DNNL_ARG_BIAS);
+    auto dst = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+    auto weights_dw = CTX_IN_MEM(
+            const wei_data_t *, DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS);
+    auto bias_dw = CTX_IN_MEM(
+            const dst_data_t *, DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS);
+
+    auto scratchpad = ctx.get_scratchpad_grantor();
+
+    const auto &jcp = kernel_->jcp;
+    if (pd()->wants_padded_bias()) {
+        auto padded_bias
+                = scratchpad.template get<dst_data_t>(key_conv_padded_bias);
+        assert(padded_bias != nullptr);
+        utils::array_copy(padded_bias, bias, jcp.oc_without_padding);
+        utils::array_set(padded_bias + jcp.oc_without_padding, 0.f,
+                jcp.oc - jcp.oc_without_padding);
+        bias = padded_bias;
+    }
+
+    parallel(jcp.nthr, [&](const int ithr, const int nthr) {
+        execute_forward_thr(ithr, nthr, src, weights, bias, weights_dw, bias_dw,
+                dst, scratchpad);
+    });
+
+    if (pd()->wants_zero_pad_dst()) ctx.zero_pad_output(DNNL_ARG_DST);
+}
+
+template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+void jit_sve_512_1x1_convolution_fwd_t<src_type, wei_type,
+        dst_type>::execute_forward_thr(const int ithr, const int nthr,
+        const src_data_t *src, const wei_data_t *weights,
+        const dst_data_t *bias, const wei_data_t *weights_dw,
+        const dst_data_t *bias_dw, dst_data_t *dst,
+        const memory_tracking::grantor_t &scratchpad) const {
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = kernel_->jcp;
+    auto rtus_space = pd()->rtus_.reduce_src_
+            ? scratchpad.get<src_data_t>(key_conv_rtus_space)
+            : NULL;
+    const int ndims = src_d.ndims();
+    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const int stride_w = pd()->desc()->strides[ndims - 3];
+
+    auto step = [](int default_step, int remaining, int tail_step) {
+        assert(default_step <= tail_step);
+        return remaining < tail_step ? remaining : default_step;
+    };
+
+    auto p = jit_1x1_conv_call_s();
+
+    auto rp = rtus_driver_t<sve_512>::call_params_t();
+    const int nb_oc = jcp.nb_load;
+    const int nb_ic = jcp.nb_reduce;
+    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+
+    // override some constants for fused dw_conv
+    const int os_block = jcp.bcast_block;
+    const int nb_bcast = jcp.nb_bcast;
+    const int nb_bcast_blocking = jcp.nb_bcast_blocking;
+    const int nb_bcast_blocking_max = jcp.nb_bcast_blocking_max;
+    const int nb_load_blocking = jcp.nb_load_blocking;
+    const int nb_load_blocking_max = jcp.nb_load_blocking_max;
+
+    auto init_bcast = [&](int iwork, int bcast_end, int &n, int &g,
+                              int &bcast_step, int &od, int &oh, int &ow,
+                              int &id, int &ih, int &iw) {
+        int osb {0};
+        nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
+        bcast_step = step(
+                nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
+        bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+
+        const int os = osb * os_block;
+        od = os / (jcp.oh * jcp.ow);
+        int os_2d = os % (jcp.oh * jcp.ow);
+        oh = os_2d / jcp.ow;
+        ow = os_2d % jcp.ow;
+
+        id = od * stride_d;
+        ih = oh * stride_h;
+        iw = ow * stride_w;
+
+        p.bcast_dim = this_block_size(os, jcp.os, bcast_step * os_block);
+        rp.iw_start = iw;
+        rp.os = p.bcast_dim;
+    };
+
+    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+        load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
+        const auto max_oc = nstl::min(ocb_end * jcp.oc_block, jcp.oc);
+        p.load_dim = this_block_size(
+                ocb * jcp.oc_block, max_oc, load_step * jcp.oc_block);
+    };
+
+    auto init_reduce = [&](int icb) {
+        const int nb_ic_blocking_step
+                = nstl::min(icb + nb_ic_blocking, nb_ic) - icb;
+        p.first_last_flag = 0 | (icb == 0 ? FLAG_REDUCE_FIRST : 0)
+                | (icb + nb_ic_blocking_step >= nb_ic ? FLAG_REDUCE_LAST : 0);
+
+        p.reduce_dim = this_block_size(
+                icb * jcp.ic_block, jcp.ic, nb_ic_blocking_step * jcp.ic_block);
+        rp.icb = p.reduce_dim;
+    };
+
+    auto ker_1x1 = [&](int ocb, int ocb_start, int icb, int n, int g, int od,
+                           int oh, int ow, int id, int ih, int iw) {
+        const bool is_dst_layout_nxc = utils::one_of(jcp.dst_tag,
+                format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+        const int oc_off_idx = is_dst_layout_nxc
+                ? g * jcp.oc + ocb * jcp.oc_block
+                : g * nb_oc + ocb;
+        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+
+        p.output_data = &dst[dst_off];
+        p.bias_data
+                = &bias[oc_off_idx * (is_dst_layout_nxc ? 1 : jcp.oc_block)];
+
+        p.load_data
+                = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
+                                               : weights_d.blk_off(ocb, icb)];
+        const bool is_src_layout_nxc = utils::one_of(jcp.src_tag,
+                format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+        const int ic_off_idx = is_src_layout_nxc
+                ? g * jcp.ic + icb * jcp.ic_block
+                : g * nb_ic + icb;
+        if (pd()->rtus_.reduce_src_) {
+            rp.ws = rtus_space + ithr * pd()->rtus_.space_per_thread_
+                    + (is_src_layout_nxc ? ic_off_idx
+                                         : jcp.is * ic_off_idx * jcp.ic_block);
+            if (ocb == ocb_start) {
+                rp.src = src + data_blk_off(src_d, n, ic_off_idx, id, ih, iw);
+                (*rtus_driver_)(&rp);
+            }
+            p.bcast_data = rp.ws;
+        } else
+            p.bcast_data = src + data_blk_off(src_d, n, ic_off_idx, id, ih, iw);
+
+        (*kernel_)(&p);
+    };
+    auto conv_1x1 = [&](int bcast_start, int bcast_end, int ocb_start,
+                            int ocb_end) {
+        if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
+
+        if (jcp.loop_order == loop_rlb) {
+            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                init_reduce(icb);
+                int ocb = ocb_start;
+                while (ocb < ocb_end) {
+                    int load_step;
+                    init_load(ocb, ocb_end, load_step);
+                    int iwork = bcast_start;
+                    while (iwork < bcast_end) {
+                        int n {0}, g {0}, bcast_step {0}, od {0}, oh {0},
+                                ow {0}, id {0}, ih {0}, iw {0};
+                        init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh,
+                                ow, id, ih, iw);
+                        ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
+                                iw);
+                        iwork += bcast_step;
+                    }
+                    ocb += load_step;
+                }
+            }
+        } else if (jcp.loop_order == loop_lbr) {
+            int ocb = ocb_start;
+            while (ocb < ocb_end) {
+                int load_step;
+                init_load(ocb, ocb_end, load_step);
+                int iwork = bcast_start;
+                while (iwork < bcast_end) {
+                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                            id {0}, ih {0}, iw {0};
+                    init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
+                            id, ih, iw);
+                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                        init_reduce(icb);
+                        ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
+                                iw);
+                    }
+                    iwork += bcast_step;
+                }
+                ocb += load_step;
+            }
+        } else if (jcp.loop_order == loop_rbl) {
+            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                init_reduce(icb);
+                int iwork = bcast_start;
+                while (iwork < bcast_end) {
+                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                            id {0}, ih {0}, iw {0};
+                    init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
+                            id, ih, iw);
+                    int ocb = ocb_start;
+                    while (ocb < ocb_end) {
+                        int load_step;
+                        init_load(ocb, ocb_end, load_step);
+                        ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
+                                iw);
+                        ocb += load_step;
+                    }
+                    iwork += bcast_step;
+                }
+            }
+        } else if (jcp.loop_order == loop_blr) {
+            int iwork = bcast_start;
+            while (iwork < bcast_end) {
+                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                        id {0}, ih {0}, iw {0};
+                init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
+                        ih, iw);
+                int ocb = ocb_start;
+                while (ocb < ocb_end) {
+                    int load_step;
+                    init_load(ocb, ocb_end, load_step);
+                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                        init_reduce(icb);
+                        ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
+                                iw);
+                    }
+                    ocb += load_step;
+                }
+                iwork += bcast_step;
+            }
+        } else {
+            assert(!"unsupported loop order");
+        }
+    };
+
+    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+    balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
+            ocb_start, ocb_end, jcp.load_grp_count);
+
+    conv_1x1(bcast_start, bcast_end, ocb_start, ocb_end);
+}
+
+template struct jit_sve_512_1x1_convolution_fwd_t<data_type::f32>;
+
+/* convolution backward wtr data */
+template <data_type_t diff_dst_type, data_type_t wei_type,
+        data_type_t diff_src_type>
+void jit_sve_512_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
+        diff_src_type>::execute_backward_data(const exec_ctx_t &ctx) const {
+    auto diff_dst = CTX_IN_MEM(const diff_dst_data_t *, DNNL_ARG_DIFF_DST);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto diff_src = CTX_OUT_MEM(diff_src_data_t *, DNNL_ARG_DIFF_SRC);
+
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+    const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
+
+    const auto &jcp = kernel_->jcp;
+    auto rtus_space = pd()->rtus_.reduce_src_
+            ? ctx.get_scratchpad_grantor().template get<diff_src_data_t>(
+                    key_conv_rtus_space)
+            : NULL;
+    const int ndims = diff_src_d.ndims();
+
+    assert(jcp.stride_w == 1 && jcp.stride_h == 1 && jcp.stride_d == 1);
+
+    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const int stride_w = pd()->desc()->strides[ndims - 3];
+
+    const int nb_ic = jcp.nb_load;
+    const int nb_oc = jcp.nb_reduce;
+    const int os_block = jcp.bcast_block;
+    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+
+    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+
+    auto step = [](int default_step, int remaining, int tail_step) {
+        assert(default_step <= tail_step);
+        return remaining < tail_step ? remaining : default_step;
+    };
+
+    parallel(jcp.nthr, [&](const int ithr, const int nthr) {
+        auto p = jit_1x1_conv_call_s();
+        auto rp = rtus_driver_t<sve_512>::call_params_t();
+
+        int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+        balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
+                icb_start, icb_end, jcp.load_grp_count);
+
+        bool reduce_outer
+                = (jcp.loop_order == loop_rbl || jcp.loop_order == loop_rlb);
+        int nboc_outer = reduce_outer ? nb_oc : 1;
+        int ocb_outer_step = reduce_outer ? nb_oc_blocking : 1;
+
+        int nboc_inner = reduce_outer ? 1 : nb_oc;
+        int ocb_inner_step = reduce_outer ? 1 : nb_oc_blocking;
+        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
+
+        for (int ocb_outer = 0; ocb_outer < nboc_outer;
+                ocb_outer += ocb_outer_step) {
+            size_t cur_ocb_outer
+                    = nstl::min(ocb_outer + ocb_outer_step, nboc_outer)
+                    - ocb_outer;
+
+            int load_step = 0;
+            for (int icb = icb_start; icb < icb_end; icb += load_step) {
+                load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
+                        jcp.nb_load_blocking_max);
+
+                p.load_dim = this_block_size(
+                        icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
+                rp.icb = p.load_dim;
+                int bcast_step;
+                for (int iwork = bcast_start; iwork < bcast_end;
+                        iwork += bcast_step) {
+                    int n {0}, g {0}, osb {0};
+                    nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb,
+                            jcp.nb_bcast);
+
+                    bcast_step = step(jcp.nb_bcast_blocking, jcp.nb_bcast - osb,
+                            jcp.nb_bcast_blocking_max);
+                    bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+
+                    const int os = osb * os_block;
+                    p.bcast_dim = this_block_size(
+                            os, jcp.os, bcast_step * os_block);
+                    rp.os = p.bcast_dim;
+                    const int od = os / (jcp.oh * jcp.ow);
+                    const int os_2d = os % (jcp.oh * jcp.ow);
+                    const int oh = os_2d / jcp.ow;
+                    const int ow = os_2d % jcp.ow;
+                    const int id = od * stride_d;
+                    const int ih = oh * stride_h;
+                    const int iw = ow * stride_w;
+                    rp.iw_start = iw;
+                    const bool is_dsrc_layout_nxc
+                            = utils::one_of(jcp.src_tag, format_tag::nwc,
+                                    format_tag::nhwc, format_tag::ndhwc);
+                    const int ic_off_idx = is_dsrc_layout_nxc
+                            ? g * jcp.ic + icb * jcp.ic_block
+                            : g * nb_ic + icb;
+                    rp.src = diff_src
+                            + data_blk_off(
+                                    diff_src_d, n, ic_off_idx, id, ih, iw);
+                    if (pd()->rtus_.reduce_src_) {
+                        rp.ws = rtus_space
+                                + ithr * pd()->rtus_.space_per_thread_;
+                        p.output_data = rp.ws;
+                    } else
+                        p.output_data = diff_src
+                                + data_blk_off(
+                                        diff_src_d, n, ic_off_idx, id, ih, iw);
+
+                    for (int ocb_inner = 0; ocb_inner < nboc_inner;
+                            ocb_inner += ocb_inner_step) {
+                        int cur_ocb_inner
+                                = nstl::min(ocb_inner + ocb_inner_step,
+                                          nboc_inner)
+                                - ocb_inner;
+
+                        int ocb = reduce_outer ? ocb_outer : ocb_inner;
+                        int nb_oc_blocking_step
+                                = reduce_outer ? cur_ocb_outer : cur_ocb_inner;
+                        const bool is_ddst_layout_nxc
+                                = utils::one_of(jcp.dst_tag, format_tag::nwc,
+                                        format_tag::nhwc, format_tag::ndhwc);
+                        const int oc_off_idx = is_ddst_layout_nxc
+                                ? g * jcp.oc + ocb * jcp.oc_block
+                                : g * nb_oc + ocb;
+                        size_t diff_dst_off = data_blk_off(
+                                diff_dst_d, n, oc_off_idx, od, oh, ow);
+                        p.bcast_data = &diff_dst[diff_dst_off];
+
+                        p.load_data = &weights[pd()->with_groups()
+                                        ? weights_d.blk_off(g, ocb, icb)
+                                        : weights_d.blk_off(ocb, icb)];
+
+                        p.first_last_flag = ocb == 0 ? FLAG_REDUCE_FIRST : 0;
+
+                        p.reduce_dim = this_block_size(ocb * jcp.oc_block,
+                                jcp.oc, nb_oc_blocking_step * jcp.oc_block);
+
+                        (*kernel_)(&p);
+                    }
+                    if (pd()->rtus_.reduce_src_) { (*rtus_driver_)(&rp); }
+                }
+            }
+        }
+    });
+}
+
+template struct jit_sve_512_1x1_convolution_bwd_data_t<data_type::f32>;
+
+/* convolution backward wtr weights */
+
+#define wht_blk_off(d, g, ...) \
+    (pd()->with_groups() ? (d).blk_off((g), __VA_ARGS__) \
+                         : (d).blk_off(__VA_ARGS__))
+
+status_t jit_sve_512_1x1_convolution_bwd_weights_t ::init(engine_t *engine) {
+
+    CHECK(safe_ptr_assign(kernel_,
+            new jit_sve_512_1x1_conv_kernel(pd()->jcp_, *pd()->attr())));
+    CHECK(safe_ptr_assign(
+            acc_ker_, new cpu_accumulator_1d_t<data_type::f32>()));
+    CHECK(safe_ptr_assign(reducer_bias_,
+            new cpu_reducer_t<data_type::f32>(pd()->reducer_bia_conf_)));
+    CHECK(kernel_->create_kernel());
+    CHECK(acc_ker_->create_kernel());
+    CHECK(reducer_bias_->create_kernel());
+
+    CHECK(init_rtus_driver<sve_512>(this));
+    return status::success;
+}
+
+void jit_sve_512_1x1_convolution_bwd_weights_t::execute_backward_weights(
+        const exec_ctx_t &ctx) const {
+    auto diff_dst = CTX_IN_MEM(const data_t *, DNNL_ARG_DIFF_DST);
+    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+    auto diff_weights = CTX_OUT_MEM(data_t *, DNNL_ARG_DIFF_WEIGHTS);
+    auto diff_bias_in = CTX_OUT_MEM(data_t *, DNNL_ARG_DIFF_BIAS);
+
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
+
+    const auto &jcp = kernel_->jcp;
+
+    const auto scratchpad = ctx.get_scratchpad_grantor();
+    auto rtus_space = pd()->rtus_.reduce_src_
+            ? scratchpad.get<data_t>(key_conv_rtus_space)
+            : NULL;
+    const bool is_bias_padded
+            = pd()->with_bias() && jcp.oc_without_padding % jcp.oc_block != 0;
+
+    data_t *diff_bias = is_bias_padded
+            ? scratchpad.get<data_t>(key_conv_padded_bias)
+            : diff_bias_in;
+    auto wei_reduction = scratchpad.get<data_t>(key_conv_wei_reduction);
+
+    /* prepare src transposition barriers */
+    auto tr_src = scratchpad.get<data_t>(key_conv_tr_src);
+    auto tr_src_bctx
+            = scratchpad.get<simple_barrier::ctx_t>(key_conv_tr_src_bctx);
+    if (jcp.transpose_src) {
+        for (int i = 0; i < jcp.nthr; ++i)
+            simple_barrier::ctx_init(&tr_src_bctx[i]);
+    }
+
+    const int ndims = src_d.ndims();
+    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+            * rnd_up(jcp.ic, jcp.ic_block);
+
+    simple_barrier::ctx_t reduction_barrier;
+    simple_barrier::ctx_init(&reduction_barrier);
+
+    const auto reducer_bia_scratchpad
+            = memory_tracking::grantor_t(scratchpad, prefix_reducer_bia);
+    auto rb = this->reducer_bias_.get();
+    rb->init(reducer_bia_scratchpad);
+
+    // TODO (Roma): remove this restriction
+    assert(jcp.stride_w == 1 && jcp.stride_h == 1);
+
+    const int nb_ic = jcp.nb_bcast;
+    const int nb_ic_blocking = jcp.nb_bcast_blocking;
+
+    const int nb_oc = jcp.nb_load;
+    const int nb_oc_blocking = jcp.nb_load_blocking;
+
+    const int sp_nb = jcp.nb_reduce;
+    const int mb_sp_work = jcp.mb * sp_nb;
+
+    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
+    const int stride_w = pd()->desc()->strides[ndims - 3];
+
+    auto step = [](int default_step, int remaining, int tail_step) {
+        assert(default_step <= tail_step);
+        return remaining < tail_step ? remaining : default_step;
+    };
+
+    // TODO: use memory descriptor with the same fmt as src
+    // (or use a macro :))
+    auto tr_src_off = [&](int img, int icb, int is) {
+        const size_t tr_chn_size = jcp.tr_is * jcp.ic_block;
+        const size_t tr_img_size = tr_chn_size * nb_ic * jcp.ngroups;
+        return img * tr_img_size + icb * tr_chn_size + is * jcp.ic_block;
+    };
+
+    const bool is_src_layout_nxc = utils::one_of(
+            jcp.src_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+
+    const bool is_ddst_layout_nxc = utils::one_of(
+            jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+
+    auto ker = [&](const int ithr, const int nthr) {
+        assert(nthr == jcp.nthr);
+        const bool ready_for_async = utils::one_of(jcp.ver, ver_fma);
+        MAYBE_UNUSED(ready_for_async);
+        assert(IMPLICATION(
+                !ready_for_async && !dnnl_thr_syncable(), jcp.nthr_mb == 1));
+
+        const int ithr_ic_b = ithr % jcp.nthr_ic_b;
+        const int ithr_oc_b = ithr / jcp.nthr_ic_b % jcp.nthr_oc_b;
+        const int ithr_g = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b % jcp.nthr_g;
+        const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
+
+        /* reduction dimension */
+        int mb_sp_b_start {0}, mb_sp_b_end {0};
+        if (jcp.transpose_src && jcp.nthr_mb < jcp.mb / 2) {
+            // it's preferable to parallelize by mb if possible
+            int img_start {0}, img_end {0};
+            balance211(jcp.mb, jcp.nthr_mb, ithr_mb, img_start, img_end);
+            mb_sp_b_start = img_start * sp_nb;
+            mb_sp_b_end = img_end * sp_nb;
+        } else {
+            balance211(mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start,
+                    mb_sp_b_end);
+        }
+
+        /* independent dimensions */
+        int g_start {0}, oc_b_start {0}, ic_b_start {0};
+        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+
+        balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
+        balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(
+                jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
+
+        const int g_work = g_end - g_start;
+        const int oc_b_work = oc_b_end - oc_b_start;
+        const int ic_b_work = ic_b_end - ic_b_start;
+        const bool cache_aliasing
+                = (jcp.ic * jcp.ngroups * sizeof(float)) % 1024 == 0;
+        int reduce_step = jcp.nb_reduce_blocking;
+        int reduce_step_max = jcp.nb_reduce_blocking_max;
+        if (is_src_layout_nxc && cache_aliasing) {
+            // Experiments show 4 is a magic number with the tested shapes.
+            // TODO: maybe tune for shapes with sp_dim%4 != 0
+            reduce_step = nstl::min(4, reduce_step);
+            reduce_step_max = reduce_step;
+        }
+
+        data_t *diff_wei = ithr_mb == 0
+                ? diff_weights
+                : wei_reduction + (ithr_mb - 1) * wei_size;
+
+        int sp_b_step = 0;
+        for (int mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
+                mb_sp_b += sp_b_step) {
+            int img {0}, sp_b {0};
+            nd_iterator_init(mb_sp_b, img, jcp.mb, sp_b, sp_nb);
+            sp_b_step = step(reduce_step,
+                    nstl::min(sp_nb - sp_b, mb_sp_b_end - mb_sp_b),
+                    reduce_step_max);
+
+            for (int g = g_start; g < g_end; ++g) {
+                int load_step = 0;
+                int bcast_step = 0;
+                for (int ic_b = ic_b_start; ic_b < ic_b_end;
+                        ic_b += bcast_step) {
+                    if (is_src_layout_nxc && cache_aliasing) {
+                        bcast_step = ic_b_work;
+                    } else {
+                        bcast_step = step(nb_ic_blocking, ic_b_end - ic_b,
+                                jcp.nb_bcast_blocking_max);
+                    }
+                    if (jcp.transpose_src) {
+                        assert(!"Unsupported transpose_src");
+                    }
+
+                    for (int oc_b = oc_b_start; oc_b < oc_b_end;
+                            oc_b += load_step) {
+                        load_step = step(nb_oc_blocking, oc_b_end - oc_b,
+                                jcp.nb_load_blocking_max);
+                        const int _ic_b = g * nb_ic + ic_b;
+                        const int _ic_b_tr = g * nb_ic + ic_b_start;
+                        const int oc_off_idx = is_ddst_layout_nxc
+                                ? g * jcp.oc + oc_b * jcp.oc_block
+                                : g * nb_oc + oc_b;
+
+                        data_t *store_to;
+
+                        const size_t off
+                                = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
+                        store_to = diff_wei + off;
+
+                        const int ic_off_idx
+                                = (is_src_layout_nxc ? jcp.ic_block : 1)
+                                * _ic_b;
+                        const data_t *diff_src = jcp.transpose_src
+                                ? &tr_src[tr_src_off(ithr_mb, _ic_b_tr, 0)]
+                                : &src[src_d.blk_off(img, ic_off_idx)];
+
+                        int sp_b_end = sp_b + sp_b_step;
+                        const data_t *pdiff_dst = &diff_dst[diff_dst_d.blk_off(
+                                img, oc_off_idx)];
+                        const data_t *local_src = diff_src;
+
+                        auto p = jit_1x1_conv_call_s();
+                        auto rp = rtus_driver_t<sve_512>::call_params_t();
+                        p.output_stride = utils::rnd_up(jcp.ic, jcp.ic_block)
+                                * jcp.oc_block * jcp.typesize_out;
+
+                        p.load_dim = this_block_size(oc_b * jcp.oc_block,
+                                jcp.oc, load_step * jcp.oc_block);
+
+                        p.bcast_dim = this_block_size(ic_b * jcp.ic_block,
+                                jcp.ic, bcast_step * jcp.ic_block);
+                        rp.icb = p.bcast_dim;
+                        p.output_data = store_to;
+
+                        p.reduce_dim = sp_b_step * jcp.reduce_block;
+                        rp.os = p.reduce_dim;
+                        p.first_last_flag = 0
+                                | (mb_sp_b == mb_sp_b_start ? FLAG_REDUCE_FIRST
+                                                            : 0)
+                                | (sp_b_end == sp_nb ? FLAG_SP_LAST : 0);
+
+                        int sp = sp_b * jcp.reduce_block;
+                        int oc_mult
+                                = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
+                        p.load_data = pdiff_dst + sp * oc_mult;
+
+                        if (pd()->rtus_.reduce_src_) {
+                            const int oh = sp / jcp.ow;
+                            const int ow = sp % jcp.ow;
+
+                            const int ih = oh * stride_h;
+                            const int iw = ow * stride_w;
+                            rp.iw_start = iw;
+
+                            rp.ws = rtus_space
+                                    + ithr * pd()->rtus_.space_per_thread_
+                                    + sp * jcp.ic_block;
+
+                            if (ndims == 3)
+                                rp.src = local_src
+                                        + iw * src_d.blocking_desc().strides[2];
+                            else
+                                rp.src = local_src
+                                        + ih * src_d.blocking_desc().strides[2]
+                                        + iw * src_d.blocking_desc().strides[3];
+                            (*rtus_driver_)(&rp);
+
+                            p.bcast_data = rp.ws;
+                        } else {
+                            int ic_mult
+                                    = is_src_layout_nxc ? jcp.ic : jcp.ic_block;
+                            p.bcast_data = local_src + sp * ic_mult;
+                        }
+
+                        (*kernel_)(&p);
+                    }
+                }
+            }
+        }
+
+        /* diff_weights[:] += sum(wei_reduction[thr_mb][:]) */
+        if (dnnl_thr_syncable() && jcp.nthr_mb > 1) {
+            simple_barrier::barrier(&reduction_barrier, jcp.nthr);
+            const int work = g_work * oc_b_work * ic_b_work;
+            int start {0}, end {0};
+            balance211(work, jcp.nthr_mb, ithr_mb, start, end);
+            if (start == end) return;
+
+            for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
+                int w = start;
+                int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
+                        oc_b_work, sub_ic_b_start, ic_b_work);
+                while (w < end) {
+                    const int g = g_start + sub_g_start;
+                    const int oc_b = oc_b_start + sub_oc_b_start;
+                    const int ic_b = ic_b_start + sub_ic_b_start;
+                    const int ic_to_accumulate
+                            = nstl::min(end - w, ic_b_work - sub_ic_b_start)
+                            * jcp.ic_block;
+                    const int acc_size
+                            = this_block_size(ic_b * jcp.ic_block,
+                                      jcp.ic_without_padding, ic_to_accumulate)
+                            * jcp.oc_block;
+
+                    const size_t off
+                            = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
+                    data_t *d = diff_weights + off;
+                    data_t *s = wei_reduction + (thr_mb - 1) * wei_size + off;
+
+                    acc_ker_->accumulate(d, s, acc_size);
+
+                    nd_iterator_jump(w, end, sub_g_start, g_work,
+                            sub_oc_b_start, oc_b_work, sub_ic_b_start,
+                            ic_b_work);
+                }
+            }
+        }
+    };
+
+    auto ker_bias = [&](int ithr, int nthr) {
+        assert(nthr == rb->balancer().nthr_);
+
+        const int b_job_start = rb->balancer().ithr_job_off(ithr);
+        const int b_njobs = rb->balancer().ithr_njobs(ithr);
+
+        if (b_njobs == 0) return;
+
+        /* reduction dimension */
+        int img_start {0}, img_end {0};
+
+        balance211(jcp.mb, rb->balancer().nthr_per_group_,
+                rb->balancer().id_in_group(ithr), img_start, img_end);
+
+        /* jobs */
+        int g_start {0}, ocb_start {0};
+        nd_iterator_init(
+                b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_load);
+
+        for (int img = img_start; img < img_end; ++img) {
+            int g = g_start, ocb = ocb_start;
+            for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
+                const int oc_off_idx = is_ddst_layout_nxc
+                        ? g * jcp.oc + ocb * jcp.oc_block
+                        : g * jcp.nb_load + ocb;
+                const data_t *d_dst
+                        = &diff_dst[diff_dst_d.blk_off(img, oc_off_idx)];
+
+                data_t *d_bias = rb->get_local_ptr(ithr, diff_bias,
+                                         reducer_bia_scratchpad)
+                        + b_job_loc * rb->balancer().job_size_;
+                const int sp_shift = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
+                                                        : jcp.oc_block;
+                const auto max_oc = this_block_size(
+                        ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
+                if (img == img_start)
+                    for (int o = 0; o < 16; ++o)
+                        d_bias[o] = 0.;
+
+                for (int os = 0; os < jcp.os; ++os) {
+                    PRAGMA_OMP_SIMD()
+                    for (int o = 0; o < max_oc; ++o)
+                        d_bias[o] += d_dst[o];
+                    d_dst += sp_shift;
+                }
+
+                nd_iterator_step(g, jcp.ngroups, ocb, jcp.nb_load);
+            }
+        }
+
+        if (dnnl_thr_syncable())
+            rb->reduce(ithr, diff_bias, reducer_bia_scratchpad);
+    };
+
+    if (dnnl_thr_syncable()) {
+        parallel(jcp.nthr, [&](const int ithr, const int nthr) {
+            ker(ithr, jcp.nthr);
+            if (pd()->with_bias()) ker_bias(ithr, jcp.nthr);
+        });
+    } else {
+        parallel(jcp.nthr, [&](int ithr, int nthr) { ker(ithr, nthr); });
+        if (jcp.nthr_mb > 1)
+            parallel(jcp.nthr, [&](int ithr, int nthr) {
+                assert(nthr == jcp.nthr);
+
+                const int ithr_ic_b = ithr % jcp.nthr_ic_b;
+                const int ithr_oc_b = ithr / jcp.nthr_ic_b % jcp.nthr_oc_b;
+                const int ithr_g
+                        = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b % jcp.nthr_g;
+                const int ithr_mb
+                        = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
+
+                /* independent dimensions */
+                int g_start {0}, oc_b_start {0}, ic_b_start {0};
+                int g_end {0}, oc_b_end {0}, ic_b_end {0};
+
+                balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
+                balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start,
+                        oc_b_end);
+                balance211(jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
+                        ic_b_end);
+
+                const int g_work = g_end - g_start;
+                const int oc_b_work = oc_b_end - oc_b_start;
+                const int ic_b_work = ic_b_end - ic_b_start;
+
+                const int work = g_work * oc_b_work * ic_b_work;
+                int start {0}, end {0};
+                balance211(work, jcp.nthr_mb, ithr_mb, start, end);
+                if (start == end) return;
+
+                for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
+                    int w = start;
+                    int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                    nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
+                            oc_b_work, sub_ic_b_start, ic_b_work);
+                    while (w < end) {
+                        const int g = g_start + sub_g_start;
+                        const int oc_b = oc_b_start + sub_oc_b_start;
+                        const int ic_b = ic_b_start + sub_ic_b_start;
+                        const int ic_to_accumulate
+                                = nstl::min(end - w, ic_b_work - sub_ic_b_start)
+                                * jcp.ic_block;
+                        const int acc_size
+                                = this_block_size(ic_b * jcp.ic_block,
+                                          jcp.ic_without_padding,
+                                          ic_to_accumulate)
+                                * jcp.oc_block;
+
+                        const size_t off
+                                = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
+                        data_t *d = diff_weights + off;
+                        data_t *s
+                                = wei_reduction + (thr_mb - 1) * wei_size + off;
+
+                        acc_ker_->accumulate(d, s, acc_size);
+
+                        nd_iterator_jump(w, end, sub_g_start, g_work,
+                                sub_oc_b_start, oc_b_work, sub_ic_b_start,
+                                ic_b_work);
+                    }
+                }
+            });
+        if (pd()->with_bias()) {
+            parallel(jcp.nthr,
+                    [&](int ithr, int nthr) { ker_bias(ithr, nthr); });
+            parallel(jcp.nthr, [&](int ithr, int nthr) {
+                assert(nthr == rb->balancer().nthr_);
+                MAYBE_UNUSED(nthr);
+                if (rb->balancer().ithr_njobs(ithr) == 0) return;
+                rb->reduce_nolock(ithr, diff_bias, reducer_bia_scratchpad);
+            });
+        }
+    }
+
+    /* TODO: put this in ker_bias */
+    if (is_bias_padded) {
+        assert(IMPLICATION(!is_ddst_layout_nxc, jcp.ngroups == 1));
+        const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+        const int stride = jcp.oc_without_padding;
+        for (int g = 0; g < jcp.ngroups; ++g) {
+            utils::array_copy(diff_bias_in + g * stride,
+                    diff_bias + g * padded_stride, stride);
+        }
+    }
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_sve_512_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_convolution.hpp
@@ -1,0 +1,343 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_SVE_1X1_CONVOLUTION_HPP
+#define CPU_AARCH64_JIT_SVE_1X1_CONVOLUTION_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/primitive_hashing.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/cpu_reducer.hpp"
+#include "cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp"
+#include "cpu/cpu_convolution_pd.hpp"
+#include "cpu/platform.hpp"
+
+#include "cpu/aarch64/jit_uni_1x1_conv_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <impl::data_type_t src_type, impl::data_type_t wei_type = src_type,
+        impl::data_type_t dst_type = src_type>
+struct jit_sve_512_1x1_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
+            , jcp_()
+            , rtus_() {}
+        pd_t(const pd_t &other) : cpu_convolution_fwd_pd_t(other) {
+            if (copy(other) != status::success) is_initialized_ = false;
+        }
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", sve_512, ""),
+                jit_sve_512_1x1_convolution_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace utils;
+
+            bool ok = true && is_fwd()
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(src_type, wei_type, dst_type, dst_type,
+                            data_type::undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, dst_type)
+                    && !has_zero_dim_memory() && set_default_formats();
+            if (!ok) return status::unimplemented;
+
+            const convolution_desc_t *conv_d = desc();
+            const memory_desc_t *src_d = src_md();
+            rtus_prepare(this, conv_d, src_d, dst_md());
+
+            status_t status = jit_sve_512_1x1_conv_kernel::init_conf(jcp_,
+                    *conv_d, *src_d, *weights_md(), *dst_md(), *attr(),
+                    dnnl_get_max_threads(), rtus_.reduce_src_);
+            if (status != status::success) return status;
+            if (jcp_.with_dw_conv) { return status::unimplemented; }
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_sve_512_1x1_conv_kernel::init_scratchpad(scratchpad, jcp_);
+
+            rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
+
+            return status::success;
+        }
+
+        arg_usage_t arg_usage(int arg) const override {
+
+            if (utils::one_of(arg, DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS,
+                        DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return arg_usage_t::input;
+
+            return convolution_fwd_pd_t::arg_usage(arg);
+        }
+
+        jit_1x1_conv_conf_t jcp_;
+        reduce_to_unit_stride_t rtus_;
+
+    protected:
+        bool set_default_formats() {
+            using namespace format_tag;
+
+            auto dat_tag = utils::pick(ndims() - 3, nCw16c, nChw16c, nCdhw16c);
+            auto wei_tag = utils::pick(2 * ndims() - 6 + with_groups(),
+                    OIw16i16o, gOIw16i16o, OIhw16i16o, gOIhw16i16o, OIdhw16i16o,
+                    gOIdhw16i16o);
+
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+        status_t copy(const pd_t &other) {
+            jcp_ = other.jcp_;
+            rtus_ = other.rtus_;
+            return status::success;
+        }
+    };
+
+    template <cpu_isa_t isa, typename conv_t>
+    friend status_t init_rtus_driver(conv_t *self);
+
+    typedef typename prec_traits<src_type>::type src_data_t;
+    typedef typename prec_traits<wei_type>::type wei_data_t;
+    typedef typename prec_traits<dst_type>::type dst_data_t;
+
+    jit_sve_512_1x1_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t init(engine_t *engine) override {
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_sve_512_1x1_conv_kernel(pd()->jcp_, *pd()->attr())));
+        CHECK(kernel_->create_kernel());
+        CHECK(init_rtus_driver<sve_512>(this));
+        return status::success;
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_forward(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_forward(const exec_ctx_t &ctx) const;
+    void execute_forward_thr(const int ithr, const int nthr,
+            const src_data_t *src, const wei_data_t *weights,
+            const dst_data_t *bias, const wei_data_t *weights_dw,
+            const dst_data_t *bias_dw, dst_data_t *dst,
+            const memory_tracking::grantor_t &scratchpad) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_sve_512_1x1_conv_kernel> kernel_;
+    std::unique_ptr<rtus_driver_t<sve_512>> rtus_driver_;
+};
+
+using jit_sve_512_1x1_convolution_fwd_f32_t
+        = jit_sve_512_1x1_convolution_fwd_t<data_type::f32>;
+
+template <impl::data_type_t diff_dst_type,
+        impl::data_type_t wei_type = diff_dst_type,
+        impl::data_type_t diff_src_type = diff_dst_type>
+struct jit_sve_512_1x1_convolution_bwd_data_t : public primitive_t {
+    struct pd_t : public cpu_convolution_bwd_data_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const convolution_fwd_pd_t *hint_fwd_pd)
+            : cpu_convolution_bwd_data_pd_t(adesc, attr, hint_fwd_pd)
+            , jcp_()
+            , rtus_() {}
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", sve_512, ""),
+                jit_sve_512_1x1_convolution_bwd_data_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && desc()->prop_kind == prop_kind::backward_data
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(diff_src_type, wei_type,
+                            data_type::undef, diff_dst_type, data_type::undef)
+                    && attr()->has_default_values() && !has_zero_dim_memory()
+                    && set_default_formats();
+            if (!ok) return status::unimplemented;
+
+            const convolution_desc_t *conv_d = desc();
+            const memory_desc_t *diff_src_d = diff_src_md();
+            rtus_prepare(this, conv_d, diff_src_d, diff_dst_md());
+
+            status_t status = jit_sve_512_1x1_conv_kernel::init_conf(jcp_,
+                    *conv_d, *diff_src_d, *weights_md(), *diff_dst_md(),
+                    *attr(), dnnl_get_max_threads(), rtus_.reduce_src_);
+            if (status != status::success) return status;
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_sve_512_1x1_conv_kernel::init_scratchpad(scratchpad, jcp_);
+
+            rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
+
+            return status::success;
+        }
+
+        // TODO (Roma): structs conf header cleanup
+        jit_1x1_conv_conf_t jcp_;
+        reduce_to_unit_stride_t rtus_;
+
+    protected:
+        bool set_default_formats() {
+            using namespace format_tag;
+
+            auto dat_tag = utils::pick(ndims() - 3, nCw16c, nChw16c, nCdhw16c);
+            auto wei_tag = utils::pick(2 * ndims() - 6 + with_groups(),
+                    IOw16o16i, gIOw16o16i, IOhw16o16i, gIOhw16o16i, IOdhw16o16i,
+                    gIOdhw16o16i);
+
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+    };
+
+    template <cpu_isa_t isa, typename conv_t>
+    friend status_t init_rtus_driver(conv_t *self);
+
+    jit_sve_512_1x1_convolution_bwd_data_t(const pd_t *apd)
+        : primitive_t(apd) {}
+
+    status_t init(engine_t *engine) override {
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_sve_512_1x1_conv_kernel(pd()->jcp_, *pd()->attr())));
+        CHECK(kernel_->create_kernel());
+        CHECK(init_rtus_driver<sve_512>(this));
+        return status::success;
+    }
+
+    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits<wei_type>::type wei_data_t;
+    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_backward_data(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_backward_data(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::unique_ptr<jit_sve_512_1x1_conv_kernel> kernel_;
+    std::unique_ptr<rtus_driver_t<sve_512>> rtus_driver_;
+};
+
+using jit_sve_512_1x1_convolution_bwd_data_f32_t
+        = jit_sve_512_1x1_convolution_bwd_data_t<data_type::f32>;
+
+/* Backward weight */
+struct jit_sve_512_1x1_convolution_bwd_weights_t : public primitive_t {
+    struct pd_t : public cpu_convolution_bwd_weights_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const convolution_fwd_pd_t *hint_fwd_pd)
+            : cpu_convolution_bwd_weights_pd_t(adesc, attr, hint_fwd_pd)
+            , jcp_()
+            , rtus_() {}
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_1x1:", sve_512, ""),
+                jit_sve_512_1x1_convolution_bwd_weights_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && desc()->prop_kind == prop_kind::backward_weights
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(data_type::f32, data_type::f32,
+                            data_type::f32, data_type::f32, data_type::f32)
+                    && attr()->has_default_values() && !has_zero_dim_memory()
+                    && set_default_formats();
+            if (!ok) return status::unimplemented;
+
+            const convolution_desc_t *conv_d = desc();
+            const memory_desc_t *src_d = src_md();
+            rtus_prepare(this, conv_d, src_d, diff_dst_md());
+
+            status_t status = jit_sve_512_1x1_conv_kernel::init_conf(jcp_,
+                    *conv_d, *src_d, *diff_weights_md(), *diff_dst_md(),
+                    *attr(), dnnl_get_max_threads(), rtus_.reduce_src_);
+            if (status != status::success) return status;
+
+            init_balancers();
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_sve_512_1x1_conv_kernel::init_scratchpad(scratchpad, jcp_);
+
+            auto reducer_bia_scratchpad = memory_tracking::registrar_t(
+                    scratchpad, memory_tracking::names::prefix_reducer_bia);
+            reducer_bia_conf_.init_scratchpad(reducer_bia_scratchpad);
+            rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
+
+            return status::success;
+        }
+
+        // TODO (Roma): structs conf header cleanup
+        jit_1x1_conv_conf_t jcp_;
+        cpu_reducer_t<data_type::f32>::conf_t reducer_bia_conf_;
+        reduce_to_unit_stride_t rtus_;
+
+    protected:
+        bool set_default_formats() {
+            using namespace format_tag;
+
+            auto dat_tag = utils::pick(ndims() - 3, nCw16c, nChw16c, nCdhw16c);
+            auto wei_tag = utils::pick(2 * ndims() - 6 + with_groups(),
+                    OIw16i16o, gOIw16i16o, OIhw16i16o, gOIhw16i16o, OIdhw16i16o,
+                    gOIdhw16i16o);
+
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+
+    private:
+        void init_balancers() {
+            const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
+            if (with_bias()) {
+                reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
+                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_load, jcp_.mb,
+                        max_buffer_size, true));
+            }
+        }
+    };
+
+    template <cpu_isa_t isa, typename conv_t>
+    friend status_t init_rtus_driver(conv_t *self);
+
+    jit_sve_512_1x1_convolution_bwd_weights_t(const pd_t *apd)
+        : primitive_t(apd) {}
+
+    typedef typename prec_traits<data_type::f32>::type data_t;
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_backward_weights(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_backward_weights(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_sve_512_1x1_conv_kernel> kernel_;
+    std::unique_ptr<cpu_accumulator_1d_t<data_type::f32>> acc_ker_;
+    std::unique_ptr<cpu_reducer_t<data_type::f32>> reducer_bias_;
+    std::unique_ptr<rtus_driver_t<sve_512>> rtus_driver_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
@@ -1,0 +1,496 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_1X1_CONV_UTILS_HPP
+#define CPU_AARCH64_JIT_UNI_1X1_CONV_UTILS_HPP
+
+#include "common/convolution_pd.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/nstl.hpp"
+#include "common/primitive_iterator.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct reduce_to_unit_stride_t {
+    convolution_desc_t conv_d_;
+    bool reduce_src_;
+    size_t space_per_thread_;
+};
+
+/* 1x1-kernel does not support non-unit strides so far, so the idea is:
+ *  - for fwd or bwd_weights: to copy src to a scratch memory (with strides
+ *    equal to 1) and then call the kernel
+ *  - for bwd_data: reduce the problem to the one with unit stride by
+ *    performing computations in a scratch memory (with strides equal to 1)
+ *    and then copy the result to diff_src */
+template <typename conv_pd_t>
+inline void rtus_prepare(conv_pd_t *self, const convolution_desc_t *&conv_d,
+        const memory_desc_t *&src_d, const memory_desc_t *dst_d) {
+    const int ndims = src_d->ndims;
+
+    bool rtus_applicable = utils::one_of(ndims, 3, 4);
+    if (ndims == 3)
+        rtus_applicable = rtus_applicable && conv_d->strides[0] != 1
+                && conv_d->src_desc.data_type != data_type::s32;
+    else
+        rtus_applicable = rtus_applicable
+                && (conv_d->strides[0] != 1 || conv_d->strides[1] != 1);
+    for (int d = 2; d < ndims; ++d) {
+        /* TODO: relax these conditions (by improving reducer) */
+        rtus_applicable = rtus_applicable && conv_d->padding[0][d - 2] == 0
+                && dst_d->dims[d] * conv_d->strides[d - 2] == src_d->dims[d];
+    }
+    if (!rtus_applicable) return;
+
+    const auto dat_tag = ndims == 3
+            ? memory_desc_wrapper(src_d).matches_one_of_tag(
+                    format_tag::nCw8c, format_tag::nCw16c, format_tag::nwc)
+            : memory_desc_wrapper(src_d).matches_one_of_tag(
+                    format_tag::nChw8c, format_tag::nChw16c, format_tag::nhwc);
+    if (dat_tag == format_tag::undef) return;
+
+    const bool is_nspc
+            = utils::one_of(dat_tag, format_tag::nwc, format_tag::nhwc);
+    if (is_nspc && !mayiuse(sve_256)) return;
+
+    // rtus is applicable, configure it.
+    self->rtus_.reduce_src_ = true;
+    conv_d = &(self->rtus_.conv_d_ = *conv_d);
+    self->rtus_.conv_d_.strides[0] = 1;
+    if (ndims == 4) self->rtus_.conv_d_.strides[1] = 1;
+    utils::array_set(self->rtus_.conv_d_.padding[0], 0, 2);
+    if (ndims == 4) utils::array_set(self->rtus_.conv_d_.padding[1], 0, 2);
+    const int ic = src_d->dims[1];
+    if (self->desc()->prop_kind == prop_kind::backward_data) {
+        data_type_t data_type = self->rtus_.conv_d_.diff_src_desc.data_type;
+        src_d = &(self->rtus_.conv_d_.diff_src_desc = *dst_d);
+        self->rtus_.conv_d_.diff_src_desc.dims[1] = ic;
+        self->rtus_.conv_d_.diff_src_desc.data_type = data_type;
+        memory_desc_wrapper::compute_blocking(
+                self->rtus_.conv_d_.diff_src_desc, dat_tag);
+    } else {
+        data_type_t data_type = self->rtus_.conv_d_.src_desc.data_type;
+        src_d = &(self->rtus_.conv_d_.src_desc = *dst_d);
+        self->rtus_.conv_d_.src_desc.dims[1] = ic;
+        self->rtus_.conv_d_.src_desc.data_type = data_type;
+        memory_desc_wrapper::compute_blocking(
+                self->rtus_.conv_d_.src_desc, dat_tag);
+    }
+}
+
+template <typename conv_pd_t>
+inline void rtus_prepare_space_info(conv_pd_t *self,
+        memory_tracking::registrar_t &scratchpad, int max_threads) {
+    if (!self->rtus_.reduce_src_) return;
+    const auto &jcp = self->jcp_;
+    const bool is_nspc
+            = utils::one_of(jcp.src_tag, format_tag::nhwc, format_tag::nwc);
+
+    const size_t factor = utils::pick_by_prop_kind(self->desc()->prop_kind,
+            jcp.nb_reduce, jcp.nb_load_blocking_max, jcp.nb_bcast_blocking);
+    size_t typesize
+            = types::data_type_size(self->invariant_src_md()->data_type);
+
+    self->rtus_.space_per_thread_
+            = is_nspc ? jcp.is * jcp.ic : factor * jcp.is * jcp.ic_block;
+    scratchpad.book(memory_tracking::names::key_conv_rtus_space,
+            max_threads * self->rtus_.space_per_thread_, typesize);
+}
+
+template <cpu_isa_t isa>
+struct rtus_driver_t : public jit_generator {
+
+    struct call_params_t {
+        const void *ws; /* reduced image (w/ strides = 1) */
+        const void *src; /* source image (w/ non-unit strides) */
+        size_t icb;
+        size_t os;
+        size_t iw_start;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(rtus_driver_t)
+
+    Xbyak_aarch64::XReg reg_ws = x5;
+    Xbyak_aarch64::XReg reg_src = x6;
+    Xbyak_aarch64::XReg reg_icb = x7;
+    Xbyak_aarch64::XReg reg_os = x8;
+    Xbyak_aarch64::XReg reg_iw_start = x9;
+
+    Xbyak_aarch64::XReg reg_cur_os = x10;
+    Xbyak_aarch64::XReg reg_cur_iw = x11;
+    Xbyak_aarch64::XReg reg_cur_src = x12;
+    Xbyak_aarch64::XReg reg_cur_src_fin = reg_cur_iw; /* just reuse */
+
+    Xbyak_aarch64::PReg tail_mask = p1;
+
+    // nspc section
+    Xbyak_aarch64::XReg reg_cur_icb = x13;
+    Xbyak_aarch64::XReg reg_tail_mask = x14;
+    Xbyak_aarch64::XReg reg_icb_remainder = x15;
+    Xbyak_aarch64::XReg reg_ws_copy = x16;
+    Xbyak_aarch64::XReg reg_tmp_imm = x17;
+    Xbyak_aarch64::XReg reg_tmp = x18;
+
+    Xbyak_aarch64::ZReg reg_zero = Xbyak_aarch64::ZReg(0);
+    Xbyak_aarch64::ZReg reg_v = Xbyak_aarch64::ZReg(1);
+
+    int iw_, stride_w_;
+    int src_step_h_, src_step_icb_, ws_step_icb_, vlen_, vlen_shift_;
+    bool src_to_ws_;
+    size_t typesize_;
+    int ic_, ic_tail_;
+    bool is_nspc_;
+
+    rtus_driver_t(int iw, int stride_w, int src_step_h, int src_step_icb,
+            int ws_step_icb, bool src_to_ws, size_t typesize, int ic,
+            bool is_nspc = false)
+        : iw_(iw)
+        , stride_w_(stride_w)
+        , src_step_h_(src_step_h)
+        , src_step_icb_(src_step_icb)
+        , ws_step_icb_(ws_step_icb)
+        , src_to_ws_(src_to_ws)
+        , typesize_(typesize)
+        , ic_(ic)
+        , is_nspc_(is_nspc) {
+        using namespace Xbyak_aarch64;
+
+        assert(ic_ > 0);
+
+        auto Vmm = [=](int idx, size_t typesize) {
+            ZReg res = ZReg(idx);
+            if (is_nspc_) {
+                switch (isa) {
+                    case sve_512: res = ZReg(idx); break;
+                    default: assert(!"Not supported isa"); res = ZReg(idx);
+                }
+                return res;
+            }
+            switch (isa) {
+                case sve_512:
+                    switch (typesize) {
+                        case 4: res = ZReg(idx); break;
+                        default:
+                            assert(!"Not supported typesize");
+                            res = ZReg(idx);
+                    }
+            }
+            return res;
+        };
+
+        reg_zero = Vmm(0, typesize);
+        reg_v = Vmm(1, typesize);
+
+        vlen_ = reg_v.getBit() / 8;
+        vlen_shift_ = 0;
+
+        int tvlen = is_nspc_ ? typesize_ : vlen_;
+        while (tvlen > 1) {
+            tvlen /= 2;
+            vlen_shift_++;
+        }
+
+        const int simd_w = vlen_ / sizeof(float);
+        ic_tail_ = ic_ % simd_w;
+    }
+
+    void loop_is() {
+        using namespace Xbyak_aarch64;
+
+        mov(reg_cur_src, reg_src);
+        mov(reg_cur_iw, reg_iw_start);
+        mov(reg_cur_os, reg_os);
+
+        Label is_loop;
+        L(is_loop);
+
+        if (src_to_ws_) {
+            ldr(reg_v, ptr(reg_cur_src));
+            str(reg_v, ptr(reg_ws));
+        } else {
+            ldr(reg_v, ptr(reg_ws));
+            str(reg_v, ptr(reg_cur_src));
+            for (int w = 1; w < stride_w_; ++w) {
+                add_imm(reg_tmp, reg_cur_src, w * vlen_, reg_tmp_imm);
+                str(reg_zero, ptr(reg_tmp));
+            }
+        }
+
+        add_imm(reg_ws, reg_ws, vlen_, reg_tmp_imm);
+        add_imm(reg_cur_src, reg_cur_src, stride_w_ * vlen_, reg_tmp_imm);
+
+        // for 1d or stride_h=1 convolutions the loop over h should be skipped
+        if (!(src_step_icb_ == iw_ || src_step_h_ == iw_)) {
+            Label skip_h_step;
+            add_imm(reg_cur_iw, reg_cur_iw, stride_w_, reg_tmp_imm);
+            cmp(reg_cur_iw, iw_);
+            b(LT, skip_h_step);
+
+            if (src_to_ws_) {
+                add_imm(reg_cur_src, reg_cur_src, (src_step_h_ - iw_) * vlen_,
+                        reg_tmp_imm);
+            } else {
+                mov(reg_cur_src_fin, reg_cur_src);
+                add_imm(reg_cur_src_fin, reg_cur_src_fin,
+                        (src_step_h_ - iw_) * vlen_, reg_tmp_imm);
+                Label ih_loop;
+                L(ih_loop);
+
+                for (int w = 0; w < stride_w_; ++w) {
+                    add_imm(reg_tmp, reg_cur_src, w * vlen_, reg_tmp_imm);
+                    str(reg_zero, ptr(reg_tmp));
+                }
+
+                add_imm(reg_cur_src, reg_cur_src, stride_w_ * vlen_,
+                        reg_tmp_imm);
+                cmp(reg_cur_src, reg_cur_src_fin);
+                b(LT, ih_loop);
+            }
+            mov(reg_cur_iw, 0);
+            L(skip_h_step);
+        }
+
+        subs_imm(reg_cur_os, reg_cur_os, vlen_, reg_tmp_imm);
+        b(NE, is_loop);
+
+        /* restore dst */
+        sub(reg_ws, reg_ws, reg_os);
+    }
+
+    void loop_is_nspc() {}
+
+    void generate() override {
+        using namespace Xbyak_aarch64;
+        assert(isa == sve_512);
+
+        preamble();
+#define READ_PARAM(what) \
+    ldr(reg_##what, \
+            ptr(abi_param1, \
+                    static_cast<int32_t>(offsetof(call_params_t, what))))
+        READ_PARAM(src);
+        READ_PARAM(icb);
+        READ_PARAM(os);
+        READ_PARAM(iw_start);
+        READ_PARAM(ws);
+#undef READ_PARAM
+
+        if (!src_to_ws_) {
+            switch (reg_zero.getBit() / 8) {
+                case 64 /*ZReg*/: {
+                    Xbyak_aarch64::ZRegS zreg_s(reg_zero.getIdx());
+                    fmov(zreg_s); // zero clear
+                    break;
+                }
+                default: assert(!"rtus kernel failure");
+            }
+        }
+        if (is_nspc_) {
+            assert(!"loop_is_nspc error");
+        } else {
+            lsl(reg_os, reg_os, vlen_shift_);
+
+            Label icb_loop;
+            L(icb_loop);
+
+            loop_is();
+
+            add_imm(reg_ws, reg_ws, ws_step_icb_ * vlen_, reg_tmp_imm);
+            add_imm(reg_src, reg_src, src_step_icb_ * vlen_, reg_tmp_imm);
+
+            subs_imm(reg_icb, reg_icb, vlen_ / typesize_, reg_tmp_imm);
+            b(NE, icb_loop);
+        }
+
+        postamble();
+    }
+};
+
+template <cpu_isa_t isa, typename conv_t>
+inline status_t init_rtus_driver(conv_t *self) {
+    const auto &conf = *self->pd();
+    if (!conf.rtus_.reduce_src_) return status::success;
+
+    const auto &cd = *conf.desc();
+    const int ndims = conf.ndims();
+    const int stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
+    const int stride_w = cd.strides[ndims - 3];
+
+    const bool is_bwd_data = cd.prop_kind == prop_kind::backward_data;
+    const auto &src_d = is_bwd_data ? *conf.diff_src_md() : *conf.src_md();
+
+    const int ih = ndims == 3 ? 1 : src_d.dims[2];
+    const int iw = src_d.dims[ndims - 1];
+    const int ic = src_d.dims[1];
+
+    const auto src_tag = memory_desc_wrapper(src_d).matches_one_of_tag(
+            format_tag::nhwc, format_tag::nwc);
+    const bool is_nspc = src_tag != format_tag::undef;
+    const int src_step_h = stride_h * iw;
+    const int src_step_icb = !is_nspc ? ih * iw : 1;
+    const int ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
+    const bool src_to_ws = !is_bwd_data;
+    const size_t typesize
+            = types::data_type_size(self->pd()->invariant_src_md()->data_type);
+
+    CHECK(safe_ptr_assign(self->rtus_driver_,
+            new rtus_driver_t<isa>(iw, stride_w, src_step_h, src_step_icb,
+                    ws_step_icb, src_to_ws, typesize, ic, is_nspc)));
+    return self->rtus_driver_->create_kernel();
+}
+
+inline int best_divider(int value, int min_divider, int max_divider,
+        bool find_max, int step = 1) {
+    using namespace dnnl::impl::utils;
+    max_divider = nstl::max(1, nstl::min(max_divider, value));
+    min_divider = nstl::max(1, nstl::min(min_divider, max_divider));
+
+    auto loss_ratio = [](int total, int chunk) {
+        return float(rnd_up(total, chunk) - total) / rnd_up(total, chunk);
+    };
+
+    float min_loss = FLT_MAX;
+    int x_divider = max_divider;
+    for (int divider = max_divider; divider >= min_divider; divider -= step) {
+        const float loss = loss_ratio(value, divider);
+        if ((find_max && loss < min_loss) || (!find_max && loss <= min_loss)) {
+            min_loss = loss;
+            x_divider = divider;
+        }
+    }
+    return x_divider;
+}
+
+typedef jit_1x1_conv_conf_t jcp_t;
+
+inline bool is_bcast_layout_nxc(const jcp_t &jcp) {
+    switch (jcp.prop_kind) {
+        case prop_kind::forward_training:
+        case prop_kind::forward_inference:
+        case prop_kind::backward_weights:
+            return utils::one_of(jcp.src_tag, format_tag::ndhwc,
+                    format_tag::nhwc, format_tag::nwc);
+        case prop_kind::backward_data:
+            return utils::one_of(jcp.dst_tag, format_tag::ndhwc,
+                    format_tag::nhwc, format_tag::nwc);
+        default: assert(!"invalid prop_kind"); return false;
+    }
+}
+
+inline bool is_load_layout_nxc(const jcp_t &jcp) {
+    return jcp.prop_kind == prop_kind::backward_weights
+            && utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
+                    format_tag::nwc);
+}
+
+inline bool is_out_layout_nxc(const jcp_t &jcp) {
+    switch (jcp.prop_kind) {
+        case prop_kind::forward_training:
+        case prop_kind::forward_inference:
+            return utils::one_of(jcp.dst_tag, format_tag::ndhwc,
+                    format_tag::nhwc, format_tag::nwc);
+        case prop_kind::backward_data:
+            return utils::one_of(jcp.src_tag, format_tag::ndhwc,
+                    format_tag::nhwc, format_tag::nwc);
+        case prop_kind::backward_weights: return false;
+        default: assert(!"invalid prop_kind"); return false;
+    }
+}
+
+inline size_t get_bcast_u_offset(const jcp_t &jcp) {
+    return is_bcast_layout_nxc(jcp) ? jcp.ic : jcp.ic_block;
+}
+
+inline size_t get_bcast_j_offset(const jcp_t &jcp) {
+    return is_bcast_layout_nxc(jcp) ? jcp.reduce_dim : jcp.reduce_loop_unroll;
+}
+
+inline size_t get_bcast_offset(const jcp_t &jcp, int u, int j) {
+    size_t offset;
+    if (utils::one_of(jcp.prop_kind, prop_kind::forward_training,
+                prop_kind::forward_inference, prop_kind::backward_data)) {
+        assert(jcp.reduce_loop_unroll == jcp.reduce_block);
+        if (is_bcast_layout_nxc(jcp) || u != jcp.reduce_loop_unroll) {
+            offset = j * get_bcast_j_offset(jcp) + u;
+        } else {
+            offset = (jcp.bcast_dim + j) * get_bcast_j_offset(jcp);
+        }
+    } else {
+        offset = u * get_bcast_u_offset(jcp) + j;
+    }
+    return sizeof(float) * offset;
+}
+
+inline size_t get_load_u_offset(const jcp_t &jcp) {
+    return is_load_layout_nxc(jcp) ? jcp.oc : jcp.oc_block;
+}
+
+inline size_t get_load_i_offset(const jcp_t &jcp) {
+    return is_load_layout_nxc(jcp) ? jcp.oc_block : jcp.os;
+}
+
+inline size_t get_load_bwd_w_offset(const jcp_t &jcp, int i, int u0) {
+    if (is_load_layout_nxc(jcp)) {
+        return i * get_load_i_offset(jcp) + u0 * get_load_u_offset(jcp);
+    } else {
+        return (i * get_load_i_offset(jcp) + u0) * get_load_u_offset(jcp);
+    }
+}
+
+inline size_t get_output_i_offset(const jcp_t &jcp) {
+    if (is_out_layout_nxc(jcp)) {
+        return jcp.load_block;
+    } else {
+        return (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
+    }
+}
+
+inline size_t get_output_j_offset(const jcp_t &jcp) {
+    return is_out_layout_nxc(jcp) ? jcp.load_dim : jcp.load_block;
+}
+
+inline size_t get_load_loop_output_fwd_offset(
+        const jcp_t &jcp, int load_loop_blk) {
+    size_t offset = load_loop_blk * jcp.oc_block * sizeof(float);
+    if (!is_out_layout_nxc(jcp)) {
+        offset *= jcp.with_dw_conv ? jcp.ow : jcp.os;
+    }
+    return offset;
+}
+
+inline size_t get_load_loop_output_bwd_d_offset(
+        const jcp_t &jcp, int load_loop_blk) {
+    size_t offset = load_loop_blk * jcp.ic_block * sizeof(float);
+    if (!is_out_layout_nxc(jcp)) { offset *= jcp.os; }
+    return offset;
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -61,6 +61,7 @@ using namespace dnnl::impl::cpu::aarch64;
 #include "cpu/x64/jit_uni_x8s8s32x_convolution.hpp"
 using namespace dnnl::impl::cpu::x64;
 #elif DNNL_AARCH64
+#include "cpu/aarch64/jit_sve_512_1x1_convolution.hpp"
 #include "cpu/aarch64/jit_sve_512_convolution.hpp"
 using namespace dnnl::impl::cpu::aarch64;
 #endif
@@ -113,6 +114,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_sse41_1x1_convolution_fwd_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_fwd_t)
         CPU_INSTANCE_X64(jit_sse41_convolution_fwd_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
         CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
         CPU_INSTANCE(gemm_convolution_fwd_t)
@@ -156,6 +158,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_avx2_1x1_convolution_bwd_data_t)
         CPU_INSTANCE_X64(jit_sse41_dw_convolution_bwd_data_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_bwd_data_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_bwd_data_f32_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_convolution_bwd_data_t<f32>)
         CPU_INSTANCE(gemm_convolution_bwd_data_t)
         CPU_INSTANCE(ref_convolution_bwd_data_t<f32, f32, f32, f32>)
@@ -190,6 +193,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_avx2_1x1_convolution_bwd_weights_t)
         CPU_INSTANCE_X64(jit_sse41_dw_convolution_bwd_weights_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_bwd_weights_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_bwd_weights_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_convolution_bwd_weights_t<f32>)
         CPU_INSTANCE(gemm_convolution_bwd_weights_t)
         CPU_INSTANCE(ref_convolution_bwd_weights_t<f32, f32, f32, f32>)


### PR DESCRIPTION
# Description

This PR adds JIT support of convolution_fp32 with kernel size 1x1 for AArch64.
It includes JIT implementation for SVE 512.

Related RFC #841

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?

- [x] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

There is no need to make a new tests for this PR,
since we can use the existing gtests and benchdnn for this PR. 