### PR TITLE
src: cpu: aarch64: add sum+relu post-ops support on AArch64

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -217,7 +217,10 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
                 arm_compute::QuantizationInfo(1.0f / scales[0], 0));
     }
 
-    // Post-op activations
+    // Post-convolutional operations (post-ops)
+    const auto &post_ops = attr.post_ops_;
+    acp.sum_with_eltwise = (post_ops.len() == 2) && post_ops.entry_[0].is_sum()
+            && post_ops.entry_[1].is_eltwise();
     acp.act_info = acl_convolution_utils::get_acl_act(attr);
 
     return status::success;

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -34,15 +34,19 @@ namespace aarch64 {
 template <typename NEConv>
 struct acl_obj_t {
     NEConv conv;
+    arm_compute::NEArithmeticAddition add;
+    arm_compute::NEActivationLayer act;
     arm_compute::Tensor src_tensor;
     arm_compute::Tensor wei_tensor;
     arm_compute::Tensor bia_tensor;
     arm_compute::Tensor dst_tensor;
+    arm_compute::Tensor dst_acc_tensor;
 };
 
 struct acl_conv_conf_t {
     bool with_bias;
     bool is_int8;
+    bool sum_with_eltwise;
     arm_compute::TensorInfo src_info;
     arm_compute::TensorInfo wei_info;
     arm_compute::TensorInfo bia_info;

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Arm Ltd. and affiliates
+* Copyright 2020-2021 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ status_t acl_gemm_convolution_fwd_t<src_type, wei_type, dst_type,
     auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
 
     bool with_bias = pd()->acp_.with_bias;
+    bool sum_with_eltwise = pd()->acp_.sum_with_eltwise;
 
     // Retrieve primitive resource and configured Compute Library objects
     auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
@@ -67,6 +68,11 @@ status_t acl_gemm_convolution_fwd_t<src_type, wei_type, dst_type,
     }
 
     acl_obj.conv.run();
+
+    if (sum_with_eltwise) {
+        acl_obj.add.run();
+        acl_obj.act.run();
+    }
 
     acl_obj.src_tensor.allocator()->free();
     acl_obj.wei_tensor.allocator()->free();


### PR DESCRIPTION
# Description

This PR introduces support for `sum` post-op in the case of GEMM-based convolution on AArch64 (`acl_gemm_convolution_fwd_t`). It supports the use case where a convolution is followed by two operations: `sum` and `eltwise` activation. Examples include a ResNet50 inference in TensorFlow framework, where it enables the use of NHWC memory layout for all the primitives thus completely eliminating `reorder` calls which results in ~70% performance gain for FP32. Implementation follows the same approach as was detailed in RFC [#795](https://github.com/oneapi-src/oneDNN/pull/795).

## Outline

The key changes are listed below:

- Two post-ops in the form of sum together with eltwise activation are now supported
for a convolution on AArch64 (`--attr-post-ops="'sum;relu;'"` in benchdnn terms);
- The changes affect files in `src/cpu/aarch64` directory only;
- Memory allocation for one new ACL tensor is performed in `configure()` method of `acl_resource_t`.

# Checklist

## Code-change submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [X] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [X] Have you provided motivation for adding a new feature?

### Bug fixes

- [N/A] Have you added relevant regression tests?
- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?