### PR TITLE
cmake: support Fujitsu C++ compiler

### DIFF
--- a/cmake/SDL.cmake
+++ b/cmake/SDL.cmake
@@ -1,5 +1,6 @@
 #===============================================================================
-# Copyright 2017-2020 Intel Corporation
+# Copyright 2017-2021 Intel Corporation
+# Copyright 2021 FUJITSU LIMITED
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +44,11 @@ if(UNIX)
         append(CMAKE_SRC_CCXX_FLAGS "-Wmissing-field-initializers")
         append(CMAKE_EXAMPLE_CCXX_FLAGS "-Wmissing-field-initializers")
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        append(CMAKE_CCXX_FLAGS "-fstack-protector-all")
+        get_filename_component(CXX_CMD_NAME ${CMAKE_CXX_COMPILER} NAME)
+        # Fujitsu CXX compiler does not support "-fstack-protector-all".
+        if(NOT CXX_CMD_NAME STREQUAL "FCC")
+            append(CMAKE_CCXX_FLAGS "-fstack-protector-all")
+        endif()
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
         append(CMAKE_CXX_FLAGS "-fstack-protector")
     endif()


### PR DESCRIPTION
# Description

This pull request enables FCC (Fujitsu C/C++ compiler) to build oneDNN. 
FCC has the two operation modes below.
- simulating gcc version 6.1
- clang mode based on LLVM 7.1.0

This patch is for clang mode of FCC, which does not support `-fstack-protector-all`.