### PR TITLE
cpu: aarch64: add a JIT implementation for FP32 dw convolution

### DIFF
--- a/src/cpu/aarch64/cpu_barrier.cpp
+++ b/src/cpu/aarch64/cpu_barrier.cpp
@@ -109,7 +109,7 @@ struct jit_t : public jit_generator {
 };
 
 void barrier(ctx_t *ctx, int nthr) {
-    static jit_t j; /* XXX: constructed on load ... */
+    static jit_t j;
     j(ctx, nthr);
 }
 

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
@@ -1,0 +1,1129 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/memory.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp"
+
+#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_call_s, field))
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::prop_kind;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+using namespace Xbyak_aarch64;
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_fwd_kernel_f32<isa>::load_src(int ur_ch_blocks, int ur_w) {
+
+    const auto dst_layout_nxc = is_dst_layout_nxc();
+    const auto ch_blk = jcp.ch_block;
+    const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
+    const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
+
+    for (int ch = 0; ch < ur_ch_blocks; ch++) {
+        for (int ow = 0; ow < ur_w; ow++) {
+            ZReg zreg_acc = get_acc_reg(ch * ur_w + ow);
+            ZRegS zregs_acc = get_acc_reg_s(ch * ur_w + ow);
+
+            int b_off = ch * ch_blk;
+            if (this->jcp.with_bias) {
+                add_imm(reg_tmp_addr, reg_bias, b_off * sizeof(float),
+                        reg_tmp_imm);
+                ldr(zreg_acc, ptr(reg_tmp_addr));
+            } else
+                fmov(zregs_acc); // zero clear
+
+            int o_off = ch * ocb_stride + ow * ow_stride;
+            if (this->jcp.with_sum) {
+                add_imm(reg_tmp_addr, reg_output, o_off * sizeof(float),
+                        reg_tmp_imm);
+                ldr(ZReg(0), ptr(reg_tmp_addr));
+                fadd(zregs_acc, zregs_acc, ZRegS(0));
+            }
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
+        int ur_ch_blocks, int ur_w, int pad_l, int pad_r) {
+    int ch_blk = jcp.ch_block;
+    int dilate_h = jcp.dilate_h + 1;
+    int dilate_w = jcp.dilate_w + 1;
+    int stride_w = jcp.stride_w;
+
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
+    const auto ih_stride = jcp.iw * iw_stride;
+    const auto icb_stride = src_layout_nxc
+            ? ch_blk
+            : (jcp.is_fused_conv ? 1 : jcp.ih) * jcp.iw * ch_blk;
+
+    Label iter_exit_label;
+
+    cmp(reg_kh, 0);
+    b(EQ, iter_exit_label);
+
+    mov(iter_kh, reg_kh);
+    Label kh_label;
+    L(kh_label);
+    {
+        if (jcp.is_fused_conv) {
+            ldr(aux_reg_input, ptr(aux_reg_input_buffer_ptr));
+            add(aux_reg_input, aux_reg_input, reg_iw_offset);
+        }
+        for (int ch = 0; ch < ur_ch_blocks; ch++) {
+            for (int kw = 0; kw < jcp.kw; kw++) {
+                int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+
+                ZReg zreg_ker = get_ker_reg(0);
+                ZRegS zregs_ker = get_ker_reg_s(0);
+                add_imm(reg_tmp_addr, aux_reg_kernel, ker_off * sizeof(float),
+                        reg_tmp_imm);
+                ldr(zreg_ker, ptr(reg_tmp_addr));
+
+                int ow_start = get_ow_start(kw, pad_l);
+                int ow_end = get_ow_end(ur_w, kw, pad_r);
+                for (int ow = ow_start; ow < ow_end; ow++) {
+                    int inp_off = ch * icb_stride
+                            + (ow * stride_w - pad_l) * iw_stride
+                            + kw * dilate_w * iw_stride;
+
+                    ZReg zreg_src = get_src_reg(0);
+                    ZRegS zregs_src = get_src_reg_s(0);
+                    add_imm(reg_tmp_addr, aux_reg_input,
+                            inp_off * jcp.typesize_in, reg_tmp_imm);
+                    ldr(zreg_src, ptr(reg_tmp_addr));
+
+                    ZRegS zregs_acc = get_acc_reg_s(ch * ur_w + ow);
+                    fmla(zregs_acc, reg_p_all_ones, zregs_src, zregs_ker);
+                }
+            }
+        }
+
+        add_imm(aux_reg_kernel, aux_reg_kernel, jcp.kw * ch_blk * sizeof(float),
+                reg_tmp_imm);
+        if (jcp.is_fused_conv) {
+            // Move to next row pointer in the buffer
+            add_imm(aux_reg_input_buffer_ptr, aux_reg_input_buffer_ptr,
+                    sizeof(void *), reg_tmp_imm);
+        } else {
+            add_imm(aux_reg_input, aux_reg_input,
+                    ih_stride * dilate_h * sizeof(float), reg_tmp_imm);
+        }
+
+        sub(iter_kh, iter_kh, 1);
+        cmp(iter_kh, 0);
+        b(GT, kh_label);
+    }
+
+    L(iter_exit_label);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_activation(
+        int ur_ch_blocks, int ur_w) {
+    if (this->jcp.with_eltwise) {
+        eltwise_injector_->compute_vector_range(4, ur_w * ur_ch_blocks + 4);
+    }
+}
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_fwd_kernel_f32<isa>::store_dst(
+        int ur_ch_blocks, int ur_w) {
+
+    const auto dst_layout_nxc = is_dst_layout_nxc();
+    const auto ch_blk = jcp.ch_block;
+    const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
+    const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
+
+    for (int ch = 0; ch < ur_ch_blocks; ch++) {
+        for (int ow = 0; ow < ur_w; ow++) {
+            const int o_off = ch * ocb_stride + ow * ow_stride;
+
+            ZReg zreg_dst = get_acc_reg(ch * ur_w + ow);
+
+            add_imm(reg_tmp_addr, reg_output, o_off * sizeof(float),
+                    reg_tmp_imm);
+            str(zreg_dst, ptr(reg_tmp_addr));
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_fwd_kernel_f32<isa>::compute_loop(
+        int ur_w, int ur_ch_blocks, int pad_l, int pad_r) {
+
+    const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
+    // ch_loop currently happen only when data layout is nxc. The strides are
+    // calculated for this layout only.
+    const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw
+            * jcp.ch_block * jcp.typesize_in;
+    const size_t inp_ch_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
+    const size_t out_ch_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
+    const size_t bias_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+
+    auto compute = [&](int ur_ch_blocks) {
+        if (jcp.is_fused_conv) {
+            mov(aux_reg_input_buffer_ptr, reg_input_buffer_ptr);
+        } else {
+            mov(aux_reg_input, reg_input);
+        }
+
+        mov(aux_reg_kernel, reg_kernel);
+        load_src(ur_ch_blocks, ur_w);
+        apply_filter_unrolled(ur_ch_blocks, ur_w, pad_l, pad_r);
+        apply_activation(ur_ch_blocks, ur_w);
+        store_dst(ur_ch_blocks, ur_w);
+    };
+
+    if (ch_loop) {
+        Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
+        const int ch_tail = jcp.nb_ch % jcp.nb_ch_blocking;
+
+        mov(aux_reg_ch_blocks, reg_ch_blocks);
+        mov(reg_kernel_stack, reg_kernel);
+        mov(reg_input_stack, reg_input);
+        mov(reg_output_stack, reg_output);
+        if (jcp.with_bias) mov(reg_bias_stack, reg_bias);
+
+        if (ch_tail) {
+            cmp(aux_reg_ch_blocks, jcp.nb_ch_blocking);
+            b(LT, ch_tail_label);
+        }
+
+        L(ch_loop_label);
+        {
+            compute(jcp.nb_ch_blocking);
+            add_imm(reg_kernel, reg_kernel, wei_ch_stride, reg_tmp_imm);
+            add_imm(reg_input, reg_input, inp_ch_stride, reg_tmp_imm);
+            add_imm(reg_output, reg_output, out_ch_stride, reg_tmp_imm);
+            if (jcp.with_bias)
+                add_imm(reg_bias, reg_bias, bias_stride, reg_tmp_imm);
+            sub_imm(aux_reg_ch_blocks, aux_reg_ch_blocks, jcp.nb_ch_blocking,
+                    reg_tmp_imm);
+            cmp(aux_reg_ch_blocks, jcp.nb_ch_blocking);
+            b(GE, ch_loop_label);
+        }
+
+        if (ch_tail) {
+            L(ch_tail_label);
+            cmp(aux_reg_ch_blocks, 0);
+            b(LE, skip_ch_tail_label);
+            compute(ch_tail);
+            L(skip_ch_tail_label);
+        }
+
+        if (jcp.with_bias) mov(reg_bias, reg_bias_stack);
+        mov(reg_output, reg_output_stack);
+        mov(reg_input, reg_input_stack);
+        mov(reg_kernel, reg_kernel_stack);
+
+    } else {
+        compute(ur_ch_blocks);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_fwd_kernel_f32<isa>::ow_loop(int ur_ch_blocks) {
+
+    int iw = jcp.iw;
+    int ow = jcp.ow;
+    int kw = jcp.kw;
+    int l_pad = jcp.l_pad;
+    int ur_w = jcp.ur_w;
+    int ur_w_tail = jcp.ur_w_tail;
+    int stride_w = jcp.stride_w;
+
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
+    size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
+    size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
+
+    int inp_shift_pad
+            = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
+
+    int r_pad = nstl::max(0, jcp.r_pad);
+    int n_oi = ow / ur_w;
+    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+            calculate_extended_filter_size(kw, jcp.dilate_w));
+
+    assert(jcp.nb_ow <= 1);
+
+    if (r_pad1 > 0) n_oi--;
+    mov(reg_oi, 0);
+    if (ow == ur_w) {
+        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
+    } else {
+        if (n_oi == 0) {
+            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
+            add_imm(reg_input, reg_input, inp_shift_pad, reg_tmp_imm);
+            add_imm(reg_output, reg_output, out_shift, reg_tmp_imm);
+            if (ur_w_tail != 0) {
+                compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
+            }
+        } else {
+            if (l_pad > 0) {
+                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
+                add_imm(reg_input, reg_input, inp_shift_pad, reg_tmp_imm);
+                add_imm(reg_output, reg_output, out_shift, reg_tmp_imm);
+                add(reg_oi, reg_oi, 1);
+            }
+            if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
+                Label ow_loop_label;
+                L(ow_loop_label);
+                {
+                    compute_loop(ur_w, ur_ch_blocks, 0, 0);
+                    add_imm(reg_input, reg_input, inp_shift, reg_tmp_imm);
+                    add_imm(reg_output, reg_output, out_shift, reg_tmp_imm);
+
+                    add(reg_oi, reg_oi, 1);
+                    cmp(reg_oi, n_oi);
+                    b(LT, ow_loop_label);
+                }
+            }
+            if (r_pad1 > 0) {
+                compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
+                add_imm(reg_input, reg_input, inp_shift, reg_tmp_imm);
+                add_imm(reg_output, reg_output, out_shift, reg_tmp_imm);
+            }
+            if (ur_w_tail != 0) {
+                compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
+            }
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_fwd_kernel_f32<isa>::generate() {
+    this->preamble();
+    ptrue(reg_p_all_ones.b);
+    if (jcp.is_fused_conv) {
+        ldr(reg_input_buffer_ptr, ptr(abi_param1, GET_OFF(src)));
+        mov(reg_iw_offset, 0);
+    } else {
+        ldr(reg_input, ptr(abi_param1, GET_OFF(src)));
+    }
+    ldr(reg_output, ptr(abi_param1, GET_OFF(dst)));
+    ldr(reg_kernel, ptr(abi_param1, GET_OFF(filt)));
+    if (jcp.with_bias) { ldr(reg_bias, ptr(abi_param1, GET_OFF(bias))); }
+    ldr(reg_kh, ptr(abi_param1, GET_OFF(kh_padding)));
+    ldr(reg_ch_blocks, ptr(abi_param1, GET_OFF(ch_blocks)));
+
+    Label ch_blocks_tail_label;
+    Label exit_label;
+
+    int ch_blocks_tail = jcp.nb_ch % jcp.nb_ch_blocking;
+
+    if (is_src_layout_nxc()) {
+        ow_loop(jcp.nb_ch);
+    } else {
+        cmp(reg_ch_blocks, jcp.nb_ch_blocking);
+        b(NE, ch_blocks_tail ? ch_blocks_tail_label : exit_label);
+
+        ow_loop(jcp.nb_ch_blocking); // channel main loop
+
+        if (ch_blocks_tail) {
+            L(ch_blocks_tail_label);
+
+            cmp(reg_ch_blocks, ch_blocks_tail);
+            b(NE, exit_label);
+
+            ow_loop(ch_blocks_tail); // channel tail loop
+        }
+
+        L(exit_label);
+    }
+
+    this->postamble();
+    if (jcp.with_eltwise) { eltwise_injector_->prepare_table(); }
+}
+
+template struct jit_uni_dw_conv_fwd_kernel_f32<sve_512>;
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::load_ddst(
+        int ur_ch_blocks, int ur_str_w) {
+    for (int ch = 0; ch < ur_ch_blocks; ch++) {
+        for (int w = 0; w < ur_str_w; w++) {
+            ZRegS zregs_acc = get_acc_reg_s(ch * ur_str_w + w);
+            fmov(zregs_acc); // zero clear
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::apply_filter(
+        int ur_ch_blocks, int ur_str_w) {
+    int kw = jcp.kw;
+    int kh = jcp.kh;
+    int ow = jcp.ow;
+    int oh = jcp.oh;
+
+    int ch_blk = jcp.ch_block;
+    int stride_h = jcp.stride_h;
+    int stride_w = jcp.stride_w;
+
+    Label iter_exit_label;
+
+    cmp(reg_kh, 0);
+    b(EQ, iter_exit_label);
+
+    cmp(reg_kw, 0);
+    b(EQ, iter_exit_label);
+
+    mov(iter_kh, reg_kh);
+    Label kh_label;
+    L(kh_label);
+    { // KH loop
+        mov(aux1_reg_ddst, aux_reg_ddst);
+        mov(aux1_reg_kernel, aux_reg_kernel);
+
+        mov(iter_kw, reg_kw);
+        Label kw_label;
+        L(kw_label);
+        { // KW loop
+            for (int ch = 0; ch < ur_ch_blocks;
+                    ch++) { // unrolloing channel blocks
+                int ker_off = ch * kh * kw * ch_blk;
+                ZReg zreg_ker = get_ker_reg(0);
+                ZRegS zregs_ker = get_ker_reg_s(0);
+
+                add_imm(reg_tmp_addr, aux1_reg_kernel, ker_off * sizeof(float),
+                        reg_tmp_imm);
+                ldr(zreg_ker, ptr(reg_tmp_addr));
+
+                for (int w = 0; w < ur_str_w; w++) {
+                    int ddst_off = (ch * oh * ow + w) * ch_blk;
+
+                    ZReg zreg_src = get_src_reg(0);
+                    ZRegS zregs_src = get_src_reg_s(0);
+                    add_imm(reg_tmp_addr, aux1_reg_ddst,
+                            ddst_off * sizeof(float), reg_tmp_imm);
+                    ldr(zreg_src, ptr(reg_tmp_addr));
+
+                    ZRegS zregs_acc = get_acc_reg_s(ch * ur_str_w + w);
+                    fmla(zregs_acc, reg_p_all_ones, zregs_src, zregs_ker);
+                }
+            }
+
+            add_imm(aux1_reg_kernel, aux1_reg_kernel,
+                    ch_blk * stride_w * sizeof(float), reg_tmp_imm);
+            sub_imm(aux1_reg_ddst, aux1_reg_ddst,
+                    ch_blk * (jcp.dilate_w + 1) * sizeof(float), reg_tmp_imm);
+            sub_imm(iter_kw, iter_kw, stride_w, reg_tmp_imm);
+            cmp(iter_kw, 0);
+            b(GT, kw_label);
+        }
+
+        add_imm(aux_reg_kernel, aux_reg_kernel,
+                kw * ch_blk * stride_h * sizeof(float), reg_tmp_imm);
+        sub_imm(aux_reg_ddst, aux_reg_ddst,
+                ow * ch_blk * (jcp.dilate_h + 1) * sizeof(float), reg_tmp_imm);
+        sub_imm(iter_kh, iter_kh, stride_h, reg_tmp_imm);
+        cmp(iter_kh, 0);
+        b(GT, kh_label);
+    }
+
+    L(iter_exit_label);
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::store_dsrc(
+        int ur_ch_blocks, int ur_str_w) {
+    int ch_blk = jcp.ch_block;
+    int iw = jcp.iw;
+    int ih = jcp.ih;
+    int stride_w = jcp.stride_w;
+
+    for (int ch = 0; ch < ur_ch_blocks; ch++) {
+        for (int w = 0; w < ur_str_w; w++) {
+            int dsrc_off = (ch * ih * iw + w * stride_w) * ch_blk;
+            ZReg zreg_acc = get_acc_reg(ch * ur_str_w + w);
+
+            add_imm(reg_tmp_addr, reg_dsrc, dsrc_off * sizeof(float),
+                    reg_tmp_imm);
+            str(zreg_acc, ptr(reg_tmp_addr));
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::loop_body(
+        int ur_ch_blocks) {
+    Label unrolled_w_label;
+    Label tail_w_label;
+    Label exit_label;
+
+    L(unrolled_w_label);
+    {
+        int ur_w = jcp.ur_w;
+
+        cmp(reg_ur_str_w, ur_w);
+        b(LT, tail_w_label);
+
+        mov(aux_reg_ddst, reg_ddst);
+        mov(aux_reg_kernel, reg_kernel);
+
+        load_ddst(ur_ch_blocks, ur_w); // zero clear
+        apply_filter(ur_ch_blocks, ur_w);
+        store_dsrc(ur_ch_blocks, ur_w);
+
+        add_imm(reg_dsrc, reg_dsrc,
+                sizeof(float) * ur_w * jcp.ch_block * jcp.stride_w,
+                reg_tmp_imm);
+        add_imm(reg_ddst, reg_ddst, sizeof(float) * ur_w * jcp.ch_block,
+                reg_tmp_imm);
+
+        sub_imm(reg_ur_str_w, reg_ur_str_w, ur_w, reg_tmp_imm);
+        b(unrolled_w_label);
+    }
+
+    L(tail_w_label);
+    {
+        int ur_w = 1;
+
+        cmp(reg_ur_str_w, ur_w);
+        b(LT, exit_label);
+
+        mov(aux_reg_ddst, reg_ddst);
+        mov(aux_reg_kernel, reg_kernel);
+
+        load_ddst(ur_ch_blocks, ur_w);
+        apply_filter(ur_ch_blocks, ur_w);
+        store_dsrc(ur_ch_blocks, ur_w);
+
+        add_imm(reg_dsrc, reg_dsrc,
+                sizeof(float) * ur_w * jcp.ch_block * jcp.stride_w,
+                reg_tmp_imm);
+        add_imm(reg_ddst, reg_ddst, sizeof(float) * ur_w * jcp.ch_block,
+                reg_tmp_imm);
+
+        sub_imm(reg_ur_str_w, reg_ur_str_w, ur_w, reg_tmp_imm);
+        b(tail_w_label);
+    }
+
+    L(exit_label);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::generate() {
+    preamble();
+    ptrue(reg_p_all_ones.b);
+    ldr(reg_dsrc, ptr(abi_param1, GET_OFF(src)));
+    ldr(reg_ddst, ptr(abi_param1, GET_OFF(dst)));
+    ldr(reg_kernel, ptr(abi_param1, GET_OFF(filt)));
+    ldr(reg_kh, ptr(abi_param1, GET_OFF(kh_padding)));
+    ldr(reg_kw, ptr(abi_param1, GET_OFF(kw_padding)));
+    ldr(reg_ch_blocks, ptr(abi_param1, GET_OFF(ch_blocks)));
+    ldr(reg_ur_str_w, ptr(abi_param1, GET_OFF(ur_str_w)));
+
+    Label ch_blocks_tail_label;
+    Label exit_label;
+
+    int ch_blocks_tail = jcp.nb_ch % jcp.nb_ch_blocking;
+
+    cmp(reg_ch_blocks, jcp.nb_ch_blocking);
+    b(NE, ch_blocks_tail ? ch_blocks_tail_label : exit_label);
+
+    loop_body(jcp.nb_ch_blocking); // channel main loop
+
+    if (ch_blocks_tail) {
+        L(ch_blocks_tail_label);
+
+        cmp(reg_ch_blocks, ch_blocks_tail);
+        b(NE, exit_label);
+
+        loop_body(ch_blocks_tail); // channel tail loop
+    }
+
+    L(exit_label);
+
+    this->postamble();
+}
+
+template struct jit_uni_dw_conv_bwd_data_kernel_f32<sve_512>;
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter() {
+    for (int i = 0; i < jcp.kw; ++i) {
+        ZRegS zregs_acc = get_acc_reg_s(i);
+        fmov(zregs_acc); // zero clear
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_filter() {
+    for (int i = 0; i < jcp.kw; ++i) {
+        int off_filter = i * simd_w;
+        add_imm(reg_tmp_addr, reg_tmp_filter, off_filter * sizeof(float),
+                reg_tmp_imm);
+        if (simd_w == 16) {
+            ZReg zreg_acc = get_acc_reg(i);
+            ldr(zreg_acc, ptr(reg_tmp_addr));
+        } else if (simd_w == 8) {
+            ZRegS zregs_acc = get_acc_reg_s(i);
+            ld1w(zregs_acc, reg_p_all_ones, ptr(reg_tmp_addr));
+        } else {
+            assert(!"Unsupport: simd_w != 16, 8");
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_bias() {
+    ZRegS zregs_bias = get_bias_reg_s(0);
+    fmov(zregs_bias); // zero clear
+}
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_bias() {
+    if (simd_w == 16) {
+        ZReg zreg_bias = get_bias_reg(0);
+        ldr(zreg_bias, ptr(reg_bias_baddr));
+    } else if (simd_w == 8) {
+        ZRegS zregs_bias = get_bias_reg_s(0);
+        ld1w(zregs_bias, reg_p_all_ones, ptr(reg_bias_baddr));
+    } else {
+        assert(!"Unsupport: simd_w != 16, 8");
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_step_unroll(
+        int unroll_w, int l_pad, int pad_offset, int ow_block) {
+
+    const int iw_block = ow_block * jcp.stride_w;
+    const int right_border = jcp.iw - iw_block;
+    const int r_pad = jcp.r_pad;
+
+    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+
+    /* preamble count for number of cascaded LOAD + FMA operation */
+    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const bool is_last_block = (unroll_w + ow_block == jcp.ow);
+
+    /* LOAD initial input registers, then cascade LOADs and FMAs*/
+    for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
+        int off_output = i_ur * simd_w;
+        ZReg zreg_output = get_output_reg(0);
+        ZRegS zregs_output = get_output_reg_s(0);
+
+        add_imm(reg_tmp_addr, reg_tmp_output, off_output * sizeof(float),
+                reg_tmp_imm);
+        if (simd_w == 16) {
+            ldr(zreg_output, ptr(reg_tmp_addr));
+        } else if (simd_w == 8) {
+            ld1w(zregs_output, reg_p_all_ones, ptr(reg_tmp_addr));
+        } else {
+            assert(!"Unsupport: simd_w != 16, 8");
+        }
+
+        if (i_ur == 0) {
+            for (int c = 0; c < input_overlap; ++c) {
+                int off_input = (c - pad_offset) * simd_w;
+                if (off_input < 0 && unroll_w == jcp.ow) continue;
+
+                const bool over_steps_bdry = true && is_last_block
+                        && (c - pad_offset + r_pad > right_border);
+                if (over_steps_bdry) continue;
+
+                add_imm(reg_tmp_addr, reg_tmp_input, off_input * sizeof(float),
+                        reg_tmp_imm);
+                if (simd_w == 16) {
+                    ZReg zreg_input = get_input_reg(c % jcp.kw);
+                    ldr(zreg_input, ptr(reg_tmp_addr));
+                } else if (simd_w == 8) {
+                    ZRegS zregs_input = get_input_reg_s(c % jcp.kw);
+                    ld1w(zregs_input, reg_p_all_ones, ptr(reg_tmp_addr));
+                } else {
+                    assert(!"Unsupport: simd_w != 16, 8");
+                }
+            }
+        } else {
+            for (int c = 0; c < cascade_input; ++c) {
+                int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
+                int off_input = (overlap + c - pad_offset) * simd_w;
+                if (off_input < 0 || overlap + c + l_pad > right_border)
+                    continue;
+
+                const bool over_steps_bdry = true && is_last_block
+                        && (overlap + c - pad_offset + r_pad > right_border);
+                if (over_steps_bdry) continue;
+
+                add_imm(reg_tmp_addr, reg_tmp_input, off_input * sizeof(float),
+                        reg_tmp_imm);
+                if (simd_w == 16) {
+                    ZReg zreg_input = get_input_reg((overlap + c) % jcp.kw);
+                    ldr(zreg_input, ptr(reg_tmp_addr));
+                } else if (simd_w == 8) {
+                    ZRegS zregs_input = get_input_reg_s((overlap + c) % jcp.kw);
+                    ld1w(zregs_input, reg_p_all_ones, ptr(reg_tmp_addr));
+                } else {
+                    assert(!"Unsupport: simd_w != 16, 8");
+                }
+            }
+        }
+
+        for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
+            int io_overlap = i_kw + (i_ur * jcp.stride_w);
+
+            /* Don't apply FMAs that fall into the padded region */
+            if (io_overlap - l_pad < 0
+                    || io_overlap - jcp.l_pad >= right_border)
+                continue;
+
+            const bool over_steps_bdry = true && is_last_block
+                    && (io_overlap - jcp.l_pad + jcp.r_pad > right_border);
+            if (over_steps_bdry) continue;
+
+            ZRegS zregs_input = get_input_reg_s((io_overlap - l_pad) % jcp.kw);
+            ZRegS zregs_acc = get_acc_reg_s(i_kw);
+            ZRegS zregs_aux = zregs_input;
+
+            fmla(zregs_acc, reg_p_all_ones, zregs_aux, zregs_output);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void
+jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_step_unroll(
+        const int unroll_w) {
+    for (int i = 0; i < unroll_w; ++i) {
+        ZRegS zregs_bias = get_bias_reg_s(0);
+        int off_output = i * simd_w;
+        add_imm(reg_tmp_addr, reg_tmp_output, off_output * sizeof(float),
+                reg_tmp_imm);
+        if (simd_w == 16) {
+            ldr(ZReg(31), ptr(reg_tmp_addr));
+        } else if (simd_w == 8) {
+            ld1w(ZRegS(31), reg_p_all_ones, ptr(reg_tmp_addr));
+        } else {
+            assert(!"Unsupport: simd_w != 16, 8");
+        }
+        fadd(zregs_bias, zregs_bias, ZRegS(31));
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_filter() {
+    for (int i = 0; i < jcp.kw; ++i) {
+        int off_filter = i * simd_w;
+        add_imm(reg_tmp_addr, reg_tmp_filter, off_filter * sizeof(float),
+                reg_tmp_imm);
+        if (simd_w == 16) {
+            ZReg zreg_acc = get_acc_reg(i);
+            str(zreg_acc, ptr(reg_tmp_addr));
+        } else if (simd_w == 8) {
+            ZRegS zregs_acc = get_acc_reg_s(i);
+            st1w(zregs_acc, reg_p_all_ones, ptr(reg_tmp_addr));
+        } else {
+            assert(!"Unsupported: simd_w != 16, 8");
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_bias() {
+    if (simd_w == 16) {
+        ZReg zreg_bias = get_bias_reg(0);
+        str(zreg_bias, ptr(reg_bias_baddr));
+    } else if (simd_w == 8) {
+        ZRegS zregs_bias = get_bias_reg_s(0);
+        st1w(zregs_bias, reg_p_all_ones, ptr(reg_bias_baddr));
+    } else {
+        assert(!"Unsupported: simd_w != 16, 8");
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_loop(
+        const int block_size) {
+    Label oh_label;
+    Label ow_blk_label;
+
+    const int unroll_w = nstl::min(block_size, jcp.ow);
+    const int unroll_w_trips = jcp.ow / unroll_w;
+    const int tail_w = jcp.ow > block_size ? jcp.ow % block_size : 0;
+
+    const int ch_offset = jcp.ch_block;
+
+    ldr(reg_oh,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, oh_index))));
+    ldr(reg_oh_worksize,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, oh_count))));
+
+    mov(reg_tmp_output, reg_output_baddr);
+    L(oh_label);
+    {
+
+        mov_imm(reg_iter_ow_blk, unroll_w_trips);
+        L(ow_blk_label);
+        {
+
+            compute_bias_step_unroll(unroll_w);
+            add_imm(reg_tmp_output, reg_tmp_output,
+                    unroll_w * ch_offset * sizeof(float), reg_tmp_imm);
+
+            sub(reg_iter_ow_blk, reg_iter_ow_blk, 1);
+            cmp(reg_iter_ow_blk, 0);
+            b(GT, ow_blk_label);
+        }
+
+        if (tail_w > 0) {
+            compute_bias_step_unroll(tail_w);
+            add_imm(reg_tmp_output, reg_tmp_output,
+                    tail_w * ch_offset * sizeof(float), reg_tmp_imm);
+        }
+
+        add(reg_oh, reg_oh, 1);
+        cmp(reg_oh, reg_oh_worksize);
+        b(LT, oh_label);
+    }
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_zero_filter() {
+
+    const int ch_offset = jcp.ch_block;
+
+    Label kh_loop_label, skip_zeroing_label;
+
+    ldr(reg_exec_flags,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, exec_flags))));
+    and_(reg_exec_flags, reg_exec_flags, FLAG_ZERO_FILTER);
+    tst(reg_exec_flags, reg_exec_flags);
+    b(EQ, skip_zeroing_label);
+
+    zero_filter();
+
+    mov(reg_tmp_filter, reg_filter_baddr);
+    mov_imm(reg_kh, jcp.kh);
+    L(kh_loop_label);
+    {
+        store_filter();
+
+        add_imm(reg_tmp_filter, reg_tmp_filter,
+                jcp.kw * ch_offset * sizeof(float), reg_tmp_imm);
+        sub(reg_kh, reg_kh, 1);
+        cmp(reg_kh, 0);
+        b(GT, kh_loop_label);
+    }
+
+    /* Comeback pointers */
+    sub_imm(reg_tmp_filter, reg_tmp_filter,
+            jcp.kh * jcp.kw * ch_offset * sizeof(float), reg_tmp_imm);
+
+    L(skip_zeroing_label);
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_step(
+        int unroll_w, int l_pad, int pad_offset, int ow_block) {
+
+    const int ch_offset = jcp.ch_block;
+
+    Label kh_loop_label, skip_loop_label;
+
+    cmp(reg_kh_count, 0);
+    b(EQ, skip_loop_label);
+
+    mov(reg_kh, reg_kh_count);
+    L(kh_loop_label);
+    {
+        load_filter();
+        compute_ow_step_unroll(unroll_w, l_pad, pad_offset, ow_block);
+        store_filter();
+
+        add_imm(reg_tmp_filter, reg_tmp_filter,
+                jcp.kw * ch_offset * sizeof(float), reg_tmp_imm);
+        add_imm(reg_tmp_input, reg_tmp_input,
+                jcp.iw * ch_offset * sizeof(float), reg_tmp_imm);
+        sub(reg_kh, reg_kh, 1);
+        cmp(reg_kh, 0);
+        b(GT, kh_loop_label);
+    }
+
+    /* Comeback pointers */
+    Label kh_comeback_label;
+    mov(reg_kh, reg_kh_count);
+    L(kh_comeback_label);
+    {
+        sub_imm(reg_tmp_input, reg_tmp_input,
+                jcp.iw * ch_offset * sizeof(float), reg_tmp_imm);
+        sub_imm(reg_tmp_filter, reg_tmp_filter,
+                jcp.kw * ch_offset * sizeof(float), reg_tmp_imm);
+        sub(reg_kh, reg_kh, 1);
+        cmp(reg_kh, 0);
+        b(GT, kh_comeback_label);
+    }
+
+    L(skip_loop_label);
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_loop(
+        int unroll_w, int l_pad, int pad_offset, int ow_block) {
+
+    // last index of output that is not influenced by right padding
+    const size_t io_overlap
+            = jcp.oh - 1 - utils::div_up(jcp.b_pad, jcp.stride_h);
+
+    const int ch_offset = jcp.ch_block;
+    const int t_overlap_off = jcp.t_pad % jcp.stride_h == 0 ? jcp.stride_h : 1;
+    const int b_overlap_off = jcp.b_pad % jcp.stride_h == 0 ? jcp.stride_h : 1;
+
+    Label tpad_loop_label, h_loop_label, skip_tpad_label, skip_bpad_label;
+
+    ldr(reg_oh,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, oh_index))));
+    ldr(reg_oh_worksize,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, oh_count))));
+    ldr(reg_kh_count,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, kh_count))));
+
+    mov(reg_tmp_output, reg_output_baddr);
+    mov(reg_tmp_input, reg_input_baddr);
+    mov(reg_tmp_filter, reg_filter_baddr);
+
+    L(h_loop_label);
+    {
+
+        compute_h_step(unroll_w, l_pad, pad_offset, ow_block);
+
+        add_imm(reg_tmp_output, reg_tmp_output,
+                jcp.ow * ch_offset * sizeof(float), reg_tmp_imm);
+
+        /* If within the top_pad region */
+        if (jcp.t_pad > 0) {
+            /* Skip t_pad area if no longer in initial h_block */
+            cmp(reg_oh, jcp.t_pad);
+            b(GT, skip_tpad_label);
+
+            cmp(reg_kh_count, jcp.kh);
+            b(GE, skip_tpad_label);
+
+            add_imm(reg_kh_count, reg_kh_count, t_overlap_off, reg_tmp_imm);
+            sub_imm(reg_tmp_filter, reg_tmp_filter,
+                    t_overlap_off * jcp.kw * ch_offset * sizeof(float),
+                    reg_tmp_imm);
+
+            /* kernel has moved beyond padding (adjust for stride effects) */
+            if (jcp.t_pad % jcp.stride_h != 0) {
+                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add_imm(reg_tmp_input, reg_tmp_input,
+                        inp_corr * jcp.iw * ch_offset * sizeof(float),
+                        reg_tmp_imm);
+            }
+            b(tpad_loop_label);
+        }
+
+        L(skip_tpad_label);
+
+        cmp(reg_oh, io_overlap);
+        b(LT, skip_bpad_label);
+        sub_imm(reg_kh_count, reg_kh_count, b_overlap_off, reg_tmp_imm);
+
+        L(skip_bpad_label);
+        add_imm(reg_tmp_input, reg_tmp_input,
+                jcp.stride_h * jcp.iw * ch_offset * sizeof(float), reg_tmp_imm);
+
+        L(tpad_loop_label);
+
+        add(reg_oh, reg_oh, 1);
+
+        cmp(reg_oh, reg_oh_worksize);
+        b(LT, h_loop_label);
+    }
+}
+
+template <cpu_isa_t isa>
+inline void
+jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_block_unroll() {
+
+    const int ch_offset = jcp.ch_block;
+    int ow = jcp.ow;
+    int pad_offset = 0;
+    int l_pad = jcp.l_pad;
+    int r_pad = jcp.r_pad;
+
+    /* Is this strictly defined by:
+     * -code-size (?)
+     * -address size (?) */
+    const int max_unroll_w = 30;
+    const int block_size = 15;
+
+    int unroll_w_tail = 0;
+    int unroll_w = 0;
+    int unroll_w_trips = 0;
+    const bool do_unroll_w = jcp.ow > max_unroll_w;
+
+    if (do_unroll_w) {
+        unroll_w = nstl::min(block_size, jcp.ow);
+        unroll_w_trips = ow / unroll_w;
+        /* calculate tail */
+        unroll_w_tail = ow % unroll_w;
+        /* Perform some rebalancing if tail too small*/
+        if ((unroll_w_tail == 0 && r_pad != 0)
+                || (r_pad > 0 && r_pad >= unroll_w_tail)) {
+            if (unroll_w_trips > 1) {
+                unroll_w_tail += unroll_w;
+                unroll_w_trips--;
+            } else {
+                /* Idealy, this case shouldn't happen */
+                unroll_w_tail += (unroll_w - unroll_w / 2);
+                unroll_w = unroll_w / 2;
+            }
+        }
+    } else {
+        unroll_w_tail = jcp.ow;
+    }
+    if (jcp.with_bias) {
+        Label skip_load_bias;
+        ldr(reg_bias_baddr,
+                ptr(abi_param1,
+                        static_cast<int32_t>(
+                                offsetof(jit_dw_conv_call_s, bias))));
+
+        zero_bias();
+
+        ldr(reg_exec_flags,
+                ptr(abi_param1,
+                        static_cast<int32_t>(
+                                offsetof(jit_dw_conv_call_s, exec_flags))));
+
+        and_(reg_exec_flags, reg_exec_flags, FLAG_ZERO_BIAS);
+        tst(reg_exec_flags, reg_exec_flags);
+        b(NE, skip_load_bias);
+
+        load_bias();
+
+        L(skip_load_bias);
+        compute_bias_loop(block_size);
+
+        store_bias();
+    }
+
+    /* Pass filter address, then offset for h_padding. */
+    compute_zero_filter();
+    ldr(reg_kh_offset,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, filter_pad_off))));
+    add(reg_filter_baddr, reg_filter_baddr, reg_kh_offset);
+
+    /* compute left padded block */
+    if (l_pad && do_unroll_w) {
+        compute_h_loop(unroll_w, l_pad, 0, 0);
+        add_imm(reg_output_baddr, reg_output_baddr,
+                unroll_w * ch_offset * sizeof(float), reg_tmp_imm);
+        add_imm(reg_input_baddr, reg_input_baddr,
+                unroll_w * jcp.stride_w * ch_offset * sizeof(float),
+                reg_tmp_imm);
+        unroll_w_trips--;
+        pad_offset = l_pad;
+        l_pad = 0;
+    }
+
+    /* compute middle block */
+    Label ow_blk_label;
+
+    /* Insert loop for 'ow' block when middle block needs to execute more
+     * than once */
+    bool do_ow_blk_loop = unroll_w_trips > 1;
+    if (do_ow_blk_loop) {
+        mov_imm(reg_iter_ow_blk, unroll_w_trips);
+        L(ow_blk_label);
+    }
+    if (unroll_w_trips > 0) {
+        compute_h_loop(unroll_w, l_pad, pad_offset, 0);
+        add_imm(reg_output_baddr, reg_output_baddr,
+                unroll_w * ch_offset * sizeof(float), reg_tmp_imm);
+        add_imm(reg_input_baddr, reg_input_baddr,
+                unroll_w * jcp.stride_w * ch_offset * sizeof(float),
+                reg_tmp_imm);
+    }
+    if (do_ow_blk_loop) {
+        sub(reg_iter_ow_blk, reg_iter_ow_blk, 1);
+        cmp(reg_iter_ow_blk, 0);
+        b(GT, ow_blk_label);
+    }
+
+    /* compute right padded block */
+    if (unroll_w_tail) {
+        compute_h_loop(
+                unroll_w_tail, l_pad, pad_offset, jcp.ow - unroll_w_tail);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::generate() {
+    preamble();
+    if (simd_w == 16) {
+        ptrue(reg_p_all_ones.b);
+    } else if (simd_w == 8) {
+        ptrue(reg_p_all_ones.b, VL32);
+    } else {
+        assert(!"Unsupport: simd_w != 16, 8");
+    }
+    ldr(reg_input_baddr,
+            ptr(abi_param1,
+                    static_cast<int32_t>(offsetof(jit_dw_conv_call_s, input))));
+    ldr(reg_output_baddr,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, output))));
+    ldr(reg_filter_baddr,
+            ptr(abi_param1,
+                    static_cast<int32_t>(
+                            offsetof(jit_dw_conv_call_s, filter))));
+
+    compute_ow_block_unroll();
+
+    this->postamble();
+}
+
+template struct jit_uni_dw_conv_bwd_weights_kernel_f32<sve_512>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -1,0 +1,271 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_F32_HPP
+#define CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_F32_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa>
+struct jit_uni_dw_conv_fwd_kernel_f32 : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_fwd_kernel_f32)
+
+    jit_uni_dw_conv_fwd_kernel_f32(jit_conv_conf_t ajcp)
+        : jcp(ajcp), eltwise_injector_(nullptr) {
+        if (jcp.with_eltwise)
+            eltwise_injector_ = new jit_uni_eltwise_injector_f32<sve_512>(
+                    this, jcp.eltwise);
+    }
+
+    ~jit_uni_dw_conv_fwd_kernel_f32() { delete eltwise_injector_; }
+
+    jit_conv_conf_t jcp;
+
+private:
+    using reg64_t = const XReg;
+    const PReg reg_p_all_ones = p2;
+    const int vlen = cpu_isa_traits<isa>::vlen;
+
+    // dw convolution
+    reg64_t reg_input = x1;
+    reg64_t aux_reg_input = x2;
+    reg64_t reg_kernel = x3;
+    reg64_t aux_reg_kernel = x5;
+    reg64_t reg_ch_blocks = x6;
+    reg64_t reg_output = x7;
+    reg64_t reg_bias = x8;
+    reg64_t reg_kh = x9;
+    reg64_t iter_kh = x10;
+    reg64_t reg_oi = x11;
+    reg64_t aux_reg_ch_blocks = x12;
+    // fused convolution
+    reg64_t reg_input_buffer_ptr = x13;
+    reg64_t aux_reg_input_buffer_ptr = x14;
+    reg64_t reg_iw_offset = reg_input;
+
+    /* Temprary regs */
+    reg64_t reg_tmp_imm = x15;
+    reg64_t reg_kernel_stack = x16;
+    reg64_t reg_input_stack = x17;
+    reg64_t reg_output_stack = x18;
+    reg64_t reg_bias_stack = x19;
+    reg64_t reg_tmp_addr = x20;
+
+    inline void load_src(int ur_ch_blocks, int ur_w);
+    inline void compute_loop(int ur_w, int ur_ch_blocks, int pad_l, int pad_r);
+    inline void ow_loop(int ur_ch_blocks);
+    inline void apply_filter_unrolled(
+            int ur_ch_blocks, int ur_w, int pad_l, int pad_r);
+    inline void apply_activation(int ur_ch_blocks, int ur_w);
+    inline void store_dst(int ur_ch_blocks, int ur_w);
+
+    inline ZReg get_ker_reg(int idx) {
+        assert(idx <= 31);
+        return ZReg(idx + 0);
+    }
+    inline ZRegS get_ker_reg_s(int idx) {
+        assert(idx <= 31);
+        return ZRegS(idx + 0);
+    }
+    inline ZReg get_src_reg(int idx) {
+        assert((idx + 1) <= 31);
+        return ZReg(idx + 1);
+    }
+    inline ZRegS get_src_reg_s(int idx) {
+        assert((idx + 1) <= 31);
+        return ZRegS(idx + 1);
+    }
+
+    inline ZReg get_acc_reg(int idx) {
+        assert((idx + 4) <= 31);
+        return ZReg(idx + 4);
+    }
+    inline ZRegS get_acc_reg_s(int idx) {
+        assert((idx + 4) <= 31);
+        return ZRegS(idx + 4);
+    }
+
+    int get_ow_start(int ki, int pad_l) {
+        return nstl::max(0,
+                utils::div_up(pad_l - ki * (jcp.dilate_w + 1), jcp.stride_w));
+    }
+
+    int get_ow_end(int ur_w, int ki, int pad_r) {
+        return ur_w
+                - nstl::max(0,
+                        utils::div_up(
+                                pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1),
+                                jcp.stride_w));
+    }
+
+    inline bool is_src_layout_nxc() {
+        return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+    inline bool is_dst_layout_nxc() {
+        return utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
+                format_tag::nwc);
+    }
+
+    jit_uni_eltwise_injector_f32<sve_512> *eltwise_injector_;
+    void generate() override;
+};
+
+template <cpu_isa_t isa>
+struct jit_uni_dw_conv_bwd_data_kernel_f32 : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32)
+
+    jit_uni_dw_conv_bwd_data_kernel_f32(jit_conv_conf_t ajcp) : jcp(ajcp) {}
+    jit_conv_conf_t jcp;
+
+private:
+    using reg64_t = const XReg;
+    const PReg reg_p_all_ones = p2;
+
+    inline ZReg get_ker_reg(int idx) { return ZReg(idx + 0); }
+    inline ZReg get_src_reg(int idx) { return ZReg(idx + 1); }
+    inline ZReg get_acc_reg(int idx) { return ZReg(idx + 4); }
+    inline ZRegS get_ker_reg_s(int idx) { return ZRegS(idx + 0); }
+    inline ZRegS get_src_reg_s(int idx) { return ZRegS(idx + 1); }
+    inline ZRegS get_acc_reg_s(int idx) { return ZRegS(idx + 4); }
+
+    reg64_t reg_ddst = x1;
+    reg64_t aux_reg_ddst = x2;
+    reg64_t aux1_reg_ddst = x3;
+    reg64_t reg_kernel = x5;
+    reg64_t aux_reg_kernel = x6;
+    reg64_t aux1_reg_kernel = x7;
+    reg64_t reg_dsrc = x8;
+
+    reg64_t reg_ur_str_w = x9;
+    reg64_t reg_ch_blocks = x10;
+
+    reg64_t iter_kh = x11;
+    reg64_t iter_kw = x12;
+    reg64_t reg_kh = x13;
+    reg64_t reg_kw = x14;
+
+    /* Temprary regs */
+    reg64_t reg_tmp_imm = x15;
+    reg64_t reg_tmp_addr = x16;
+
+    inline void loop_body(int ur_ch_blocks);
+    inline void load_ddst(int ur_ch_blocks, int ur_str_w);
+    inline void apply_filter(int ur_ch_blocks, int ur_str_w);
+    inline void store_dsrc(int ur_ch_blocks, int ur_str_w);
+
+    void generate() override;
+};
+
+template <cpu_isa_t isa>
+struct jit_uni_dw_conv_bwd_weights_kernel_f32 : public jit_generator {
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_weights_kernel_f32)
+
+    jit_uni_dw_conv_bwd_weights_kernel_f32(jit_conv_conf_t ajcp) : jcp(ajcp) {}
+
+    jit_conv_conf_t jcp;
+
+private:
+    using reg64_t = const XReg;
+    const PReg reg_p_all_ones = p2;
+    int simd_w = cpu_isa_traits<isa>::vlen / sizeof(float);
+
+    inline ZReg get_bias_reg(int idx = 0) { return ZReg(idx); }
+    inline ZReg get_output_reg(int idx) { return ZReg(idx + 1); }
+    inline ZReg get_input_reg(int idx) { return ZReg(idx + 5); }
+    inline ZReg get_acc_reg(int idx) { return ZReg(idx + 2); }
+    inline ZReg get_aux_reg() { return ZReg(0); }
+    inline ZRegS get_bias_reg_s(int idx = 0) { return ZRegS(idx); }
+    inline ZRegS get_output_reg_s(int idx) { return ZRegS(idx + 1); }
+    inline ZRegS get_input_reg_s(int idx) { return ZRegS(idx + 5); }
+    inline ZRegS get_acc_reg_s(int idx) { return ZRegS(idx + 2); }
+    inline ZRegS get_aux_reg_s() { return ZRegS(0); }
+
+    reg64_t reg_tmp_input = x1;
+    reg64_t reg_tmp_output = x2;
+    reg64_t reg_tmp_filter = x3;
+    reg64_t reg_kh_offset = x5;
+
+    /* parameter passed by driver into kernel */
+    reg64_t reg_exec_flags = x14;
+
+    reg64_t reg_oh_worksize = x6;
+    reg64_t reg_oh = x5;
+
+    reg64_t reg_iter_ow_blk = x7;
+
+    reg64_t reg_kh = x8;
+    reg64_t reg_kh_count = x9;
+
+    /* Base addresses for convolution parameters. */
+    reg64_t reg_input_baddr = x10;
+    reg64_t reg_output_baddr = x11;
+    reg64_t reg_filter_baddr = x12;
+    reg64_t reg_bias_baddr = x13;
+
+    /* Temporary regs */
+    reg64_t reg_tmp_imm = x15;
+    reg64_t reg_tmp_addr = x16;
+
+    /* Micro-kernel JIT'ing, fusing 'kw' and 'ow_block' loops into unrolled FMAs
+     */
+    inline void compute_ow_step_unroll(
+            int unroll_w, int l_pad, int pad_offset, int ow_block);
+
+    /* JIT'ing the outer loops for the micro-kernel -> {kh, oh_block} */
+    inline void compute_h_step(
+            int unroll_w, int l_pad, int pad_offset, int ow_block);
+    inline void compute_h_loop(
+            int unroll_w, int l_pad, int pad_offset, int ow_block);
+
+    /* Write 'width' micro-kernel JITs; depending on the padding and convolution
+     * size, write a micro-kernel for the left ow-block, middle ow-block(s), and
+     * right ow-block.*/
+    inline void compute_ow_block_unroll();
+
+    inline void compute_zero_filter();
+    inline void load_filter();
+    inline void zero_filter();
+    inline void load_bias();
+    inline void zero_bias();
+    inline void compute_bias_step_unroll(const int unroll_w);
+    inline void compute_bias_loop(const int block_size);
+    inline void store_filter();
+    inline void store_bias();
+
+    void generate() override;
+};
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -1,0 +1,566 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_UTILS_HPP
+#define CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_UTILS_HPP
+
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+#include "cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp"
+
+#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+struct jit_uni_dw_conv_fwd_kernel {
+
+    jit_uni_dw_conv_fwd_kernel(jit_conv_conf_t ajcp) : ker_(nullptr) {
+        ker_ = new jit_uni_dw_conv_fwd_kernel_f32<isa>(ajcp);
+    }
+    status_t create_kernel() { return ker_->create_kernel(); }
+    ~jit_uni_dw_conv_fwd_kernel() { delete ker_; }
+
+    static bool post_ops_ok(jit_conv_conf_t &jcp, const primitive_attr_t &attr);
+
+    static status_t init_conf(jit_conv_conf_t &jcp,
+            const convolution_desc_t &cd, memory_desc_t &src_md,
+            memory_desc_t &weights_md, memory_desc_t &bias_md,
+            memory_desc_t &dst_md, const primitive_attr_t &attr);
+
+    static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+            const jit_conv_conf_t &jcp);
+
+    jit_generator *ker() const { return ker_; }
+    void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
+
+private:
+    jit_uni_dw_conv_fwd_kernel_f32<isa> *ker_;
+};
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+bool jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::post_ops_ok(
+        jit_conv_conf_t &jcp, const primitive_attr_t &attr) {
+    const auto &p = attr.post_ops_;
+
+    auto is_eltwise = [&](int idx) { return p.entry_[idx].is_eltwise(); };
+    auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(); };
+
+    switch (p.len()) {
+        case 0: return true; // no post_ops
+        case 1: return is_eltwise(0) || is_sum(0); // sum OR eltwise
+        case 2: return is_sum(0) && is_eltwise(1); // sum -> eltwise
+        default: return false;
+    }
+
+    return false;
+}
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+status_t jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
+        jit_conv_conf_t &jcp, const convolution_desc_t &cd,
+        memory_desc_t &src_md, memory_desc_t &weights_md,
+        memory_desc_t &bias_md, memory_desc_t &dst_md,
+        const primitive_attr_t &attr) {
+
+    using namespace dnnl::impl::format_tag;
+    using namespace dnnl::impl::utils;
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bias_d(&bias_md);
+
+    const int ndims = src_d.ndims();
+    // Currently this kernel only supports 2D convolutions.
+    if (ndims != 4) return status::unimplemented;
+
+    const auto blocked_tag = isa == sve_512 ? nChw16c : nChw8c;
+    const auto wei_tag = isa == sve_512 ? Goihw16g : Goihw8g;
+    const auto nxc_tag = nhwc;
+    jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
+    if ((blocked_tag != nChw16c) || (wei_tag != Goihw16g))
+        return status::unimplemented;
+
+    if (src_d.format_kind() == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(src_md, blocked_tag));
+        jcp.src_tag = blocked_tag;
+    } else {
+        jcp.src_tag = src_d.matches_one_of_tag(blocked_tag, nxc_tag);
+    }
+
+    if (weights_d.format_kind() == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(weights_md, wei_tag));
+        jcp.wei_tag = wei_tag;
+    } else {
+        jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
+    }
+
+    if (dst_d.format_kind() == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(dst_md, blocked_tag));
+        jcp.dst_tag = blocked_tag;
+    } else {
+        jcp.dst_tag = dst_d.matches_one_of_tag(blocked_tag, nxc_tag);
+    }
+
+    if (jcp.with_bias) {
+        if (bias_d.format_kind() == format_kind::any)
+            CHECK(memory_desc_init_by_tag(bias_md, format_tag::x));
+    }
+
+    if (jcp.dst_tag != jcp.src_tag) return status::unimplemented;
+    const auto data_tag = jcp.src_tag;
+    const bool is_data_layout_nxc = data_tag == nxc_tag;
+
+    jcp.dst_dt = cd.dst_desc.data_type;
+    jcp.isa = isa;
+
+    if (!mayiuse(isa)) return status::unimplemented;
+
+    const int simd_w = isa == sve_512 ? 16 : 8;
+    if (simd_w != 16) return status::unimplemented;
+
+    jcp.prop_kind = cd.prop_kind;
+
+    const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
+    if (!with_groups) return status::unimplemented;
+
+    jcp.ngroups = weights_d.dims()[0];
+    jcp.mb = src_d.dims()[0];
+
+    jcp.oc = dst_d.dims()[1];
+    jcp.oc_without_padding = jcp.oc;
+    jcp.ic = src_d.dims()[1];
+
+    jcp.ih = src_d.dims()[2];
+    jcp.iw = src_d.dims()[3];
+    jcp.oh = dst_d.dims()[2];
+    jcp.ow = dst_d.dims()[3];
+
+    jcp.kh = weights_d.dims()[3];
+    jcp.kw = weights_d.dims()[4];
+
+    jcp.t_pad = cd.padding[0][0];
+    jcp.l_pad = cd.padding[0][1];
+    jcp.b_pad = cd.padding[1][0];
+    jcp.r_pad = cd.padding[1][1];
+
+    jcp.stride_h = cd.strides[0];
+    jcp.stride_w = cd.strides[1];
+
+    jcp.dilate_h = cd.dilates[0];
+    jcp.dilate_w = cd.dilates[1];
+
+    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in = types::data_type_size(src_d.data_type());
+
+    jcp.loop_order = loop_ngcw;
+
+    jcp.ur_w = isa == sve_512 ? 6 : isa == sve_256 ? 4 : 3;
+    jcp.ur_w = nstl::min(jcp.ur_w, jcp.ow);
+
+    if (is_data_layout_nxc) {
+        jcp.loop_order = loop_nhwcg;
+        bool cache_aliasing
+                = (jcp.ngroups * jcp.iw * jcp.typesize_in) % 1024 == 0;
+        if (cache_aliasing) {
+            // currently only tuned for mobilenet-v1 shapes
+            const int limit = jcp.ow > 7 ? 7 : 4;
+            jcp.ur_w = nstl::min(jcp.ur_w, limit);
+        }
+    }
+
+    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+
+    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    jcp.r_pad = calculate_end_padding(
+            jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
+    jcp.b_pad = calculate_end_padding(
+            jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh);
+    bool kernel_outside_src = false || ext_kw <= jcp.l_pad
+            || ext_kw <= jcp.r_pad || ext_kh <= jcp.t_pad
+            || ext_kh <= jcp.b_pad;
+    if (kernel_outside_src) return status::unimplemented;
+    int r_pad_no_tail = nstl::max(0,
+            calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
+                    jcp.stride_w, ext_kw));
+    if (jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w)
+        return status::unimplemented;
+
+    if (!post_ops_ok(jcp, attr)) return status::unimplemented;
+
+    const auto &p = attr.post_ops_;
+    jcp.with_sum = p.find(primitive_kind::sum) != -1;
+    const int eltwise_ind = p.find(primitive_kind::eltwise);
+    jcp.with_eltwise = eltwise_ind != -1;
+
+    if (jcp.with_eltwise) {
+        jcp.eltwise = p.entry_[eltwise_ind].eltwise;
+        if (jcp.eltwise.alg == alg_kind::eltwise_pow)
+            return status::unimplemented;
+        if (dst_d.data_type() == data_type::s32) return status::unimplemented;
+    }
+    bool ok_to_pad_channels = true && jcp.oc == jcp.ngroups
+            && jcp.ic == jcp.ngroups && isa == sve_512;
+    if (ok_to_pad_channels) {
+        jcp.oc = rnd_up(jcp.oc, simd_w);
+        jcp.ic = rnd_up(jcp.oc, simd_w);
+        jcp.ngroups = rnd_up(jcp.ngroups, simd_w);
+    }
+
+    bool args_ok = true && jcp.oc == jcp.ngroups && jcp.ic == jcp.ngroups
+            && jcp.ngroups % simd_w == 0 && jcp.wei_tag == wei_tag
+            && data_tag != format_tag::undef && jcp.ic <= src_d.padded_dims()[1]
+            && jcp.oc <= dst_d.padded_dims()[1]
+            && jcp.ngroups <= weights_d.padded_dims()[0];
+    if (!args_ok) return status::unimplemented;
+
+    jcp.ch_block = simd_w;
+    jcp.nb_ch = jcp.oc / jcp.ch_block;
+    jcp.nb_ch_blocking = isa == sve_512 ? 4 : isa == sve_256 ? 3 : 2;
+    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+
+    jcp.bia_dt = jcp.with_bias ? cd.bias_desc.data_type : data_type::undef;
+
+    return status::success;
+}
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+void jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
+    using namespace dnnl::impl::memory_tracking::names;
+    if (jcp.with_bias && jcp.oc_without_padding != jcp.oc)
+        scratchpad.book<float>(key_conv_padded_bias, jcp.oc);
+}
+
+template struct jit_uni_dw_conv_fwd_kernel<sve_512, data_type::f32>;
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+struct jit_uni_dw_conv_bwd_data_kernel {
+
+    jit_uni_dw_conv_bwd_data_kernel(jit_conv_conf_t ajcp) : ker_(nullptr) {
+        ker_ = new jit_uni_dw_conv_bwd_data_kernel_f32<isa>(ajcp);
+    }
+
+    status_t create_kernel() { return ker_->create_kernel(); }
+    ~jit_uni_dw_conv_bwd_data_kernel() { delete ker_; }
+
+    static status_t init_conf(jit_conv_conf_t &jcp,
+            const convolution_desc_t &cd, const memory_desc_wrapper &diff_src_d,
+            const memory_desc_wrapper &weights_d,
+            const memory_desc_wrapper &diff_dst_d);
+
+    static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+            const jit_conv_conf_t &jcp);
+
+    void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
+
+private:
+    jit_uni_dw_conv_bwd_data_kernel_f32<isa> *ker_;
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel);
+};
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+status_t jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_conf(
+        jit_conv_conf_t &jcp, const convolution_desc_t &cd,
+        const memory_desc_wrapper &diff_src_d,
+        const memory_desc_wrapper &weights_d,
+        const memory_desc_wrapper &diff_dst_d) {
+    using namespace dnnl::impl::format_tag;
+    using namespace dnnl::impl::utils;
+
+    jcp.dsrc_dt = cd.diff_src_desc.data_type;
+    jcp.isa = isa;
+
+    if (!mayiuse(isa)) return status::unimplemented;
+
+    const int simd_w = isa == sve_512 ? 16 : 8;
+
+    const bool with_groups = weights_d.ndims() == diff_src_d.ndims() + 1;
+    if (!with_groups) return status::unimplemented;
+
+    jcp.ngroups = weights_d.dims()[0];
+    jcp.mb = diff_src_d.dims()[0];
+
+    jcp.oc = diff_dst_d.dims()[1];
+    jcp.oc_without_padding = jcp.oc;
+    jcp.ic = diff_src_d.dims()[1];
+
+    jcp.ih = diff_src_d.dims()[2];
+    jcp.iw = diff_src_d.dims()[3];
+    jcp.oh = diff_dst_d.dims()[2];
+    jcp.ow = diff_dst_d.dims()[3];
+
+    jcp.kh = weights_d.dims()[3];
+    jcp.kw = weights_d.dims()[4];
+
+    jcp.t_pad = cd.padding[0][0];
+    jcp.l_pad = cd.padding[0][1];
+    jcp.b_pad = cd.padding[1][0];
+    jcp.r_pad = cd.padding[1][1];
+
+    jcp.stride_h = cd.strides[0];
+    jcp.stride_w = cd.strides[1];
+
+    jcp.dilate_h = cd.dilates[0];
+    jcp.dilate_w = cd.dilates[1];
+    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    jcp.r_pad = calculate_end_padding(
+            jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
+    jcp.b_pad = calculate_end_padding(
+            jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh);
+    bool kernel_outside_src = false || ext_kw <= jcp.l_pad
+            || ext_kw <= jcp.r_pad || ext_kh <= jcp.t_pad
+            || ext_kh <= jcp.b_pad;
+    if (kernel_outside_src) { return status::unimplemented; }
+
+    jcp.ihp = jcp.ih + jcp.t_pad + jcp.b_pad;
+    jcp.iwp = jcp.iw + jcp.l_pad + jcp.r_pad;
+
+    bool ok_to_pad_channels = true && jcp.oc == jcp.ngroups
+            && jcp.ic == jcp.ngroups && isa == sve_512;
+    if (ok_to_pad_channels) {
+        jcp.oc = rnd_up(jcp.oc, simd_w);
+        jcp.ic = rnd_up(jcp.oc, simd_w);
+        jcp.ngroups = rnd_up(jcp.ngroups, simd_w);
+    }
+
+    auto dat_tag = isa == sve_512 ? nChw16c : nChw8c;
+    auto wei_tag = isa == sve_512 ? Goihw16g : Goihw8g;
+
+    jcp.src_tag = diff_src_d.matches_one_of_tag(dat_tag);
+    jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
+    jcp.dst_tag = diff_dst_d.matches_one_of_tag(dat_tag);
+
+    bool args_ok = true && jcp.oc == jcp.ngroups && jcp.ic == jcp.ngroups
+            && jcp.ngroups % simd_w == 0 && jcp.src_tag == dat_tag
+            && jcp.wei_tag == wei_tag && jcp.dst_tag == dat_tag
+            && jcp.ic <= diff_src_d.padded_dims()[1]
+            && jcp.oc <= diff_dst_d.padded_dims()[1]
+            && jcp.ngroups <= weights_d.padded_dims()[0];
+    if (!args_ok) return status::unimplemented;
+
+    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
+    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
+
+    jcp.ur_w = isa == sve_512 ? 6 : isa == sve_256 ? 4 : 3;
+
+    jcp.ch_block = simd_w;
+    jcp.nb_ch = jcp.ic / jcp.ch_block;
+    jcp.nb_ch_blocking = isa == sve_512 ? 4 : isa == sve_256 ? 3 : 2;
+    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+
+    return status::success;
+}
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+void jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
+    UNUSED(scratchpad);
+    UNUSED(jcp);
+}
+
+template struct jit_uni_dw_conv_bwd_data_kernel<sve_512, data_type::f32>;
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+struct jit_uni_dw_conv_bwd_weights_kernel {
+
+    jit_uni_dw_conv_bwd_weights_kernel(jit_conv_conf_t ajcp) : ker_(nullptr) {
+        ker_ = new jit_uni_dw_conv_bwd_weights_kernel_f32<isa>(ajcp);
+    }
+
+    status_t create_kernel() { return ker_->create_kernel(); }
+    ~jit_uni_dw_conv_bwd_weights_kernel() { delete ker_; }
+
+    static status_t init_conf(jit_conv_conf_t &jcp,
+            const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
+            const memory_desc_wrapper &diff_weights_d,
+            const memory_desc_wrapper &diff_dst_d, int nthreads);
+
+    static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+            const jit_conv_conf_t &jcp);
+
+    static void balance(jit_conv_conf_t &jcp, int nthreads);
+
+    void operator()(const jit_dw_conv_call_s *p) const { (*ker_)(p); }
+
+private:
+    jit_uni_dw_conv_bwd_weights_kernel_f32<isa> *ker_;
+};
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+status_t jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_conf(
+        jit_conv_conf_t &jcp, const convolution_desc_t &cd,
+        const memory_desc_wrapper &src_d,
+        const memory_desc_wrapper &diff_weights_d,
+        const memory_desc_wrapper &diff_dst_d, int nthreads) {
+    using namespace dnnl::impl::format_tag;
+    using namespace dnnl::impl::utils;
+
+    jcp.dwei_dt = cd.diff_weights_desc.data_type;
+    jcp.isa = isa;
+
+    if (!mayiuse(isa)) return status::unimplemented;
+
+    jcp.ngroups = diff_weights_d.dims()[0];
+    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+
+    const bool with_groups = diff_weights_d.ndims() == src_d.ndims() + 1;
+
+    jcp.is_depthwise = true && with_groups && everyone_is(1, jcp.oc, jcp.ic);
+
+    if (!jcp.is_depthwise) return status::unimplemented;
+
+    jcp.ch_block = isa == sve_512 ? 16 : 8;
+    jcp.simd_w = jcp.ch_block;
+
+    jcp.mb = src_d.dims()[0];
+
+    jcp.ih = src_d.dims()[2];
+    jcp.iw = src_d.dims()[3];
+    jcp.oh = diff_dst_d.dims()[2];
+    jcp.ow = diff_dst_d.dims()[3];
+
+    jcp.kh = diff_weights_d.dims()[3];
+    jcp.kw = diff_weights_d.dims()[4];
+
+    jcp.stride_h = cd.strides[0];
+    jcp.stride_w = cd.strides[1];
+
+    jcp.t_pad = cd.padding[0][0];
+    jcp.b_pad = cd.padding[1][0];
+
+    jcp.l_pad = cd.padding[0][1];
+    jcp.r_pad = cd.padding[1][1];
+
+    jcp.dilate_h = cd.dilates[0];
+    jcp.dilate_w = cd.dilates[1];
+
+    jcp.ihp = jcp.ih + jcp.t_pad + jcp.b_pad;
+    jcp.iwp = jcp.iw + jcp.l_pad + jcp.r_pad;
+
+    jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
+
+    auto dat_tag = isa == sve_512 ? nChw16c : nChw8c;
+    auto wei_tag = isa == sve_512 ? Goihw16g : Goihw8g;
+
+    jcp.src_tag = src_d.matches_one_of_tag(dat_tag);
+    jcp.wei_tag = diff_weights_d.matches_one_of_tag(wei_tag);
+    jcp.dst_tag = diff_dst_d.matches_one_of_tag(dat_tag);
+
+    bool args_ok = true && jcp.src_tag == dat_tag && jcp.wei_tag == wei_tag
+            && jcp.dst_tag == dat_tag && jcp.ngroups % jcp.ch_block == 0
+            && jcp.dilate_h == 0 && jcp.dilate_w == 0 && jcp.kw <= 3
+            && jcp.stride_w <= jcp.kw // no gaps in kernel
+            && jcp.oh == (jcp.ihp - jcp.kh) / jcp.stride_h + 1
+            && jcp.ow == (jcp.iwp - jcp.kw) / jcp.stride_w + 1;
+    if (!args_ok) return status::unimplemented;
+
+    jcp.nb_ch = jcp.ngroups / jcp.ch_block;
+
+    /* kernel applicability check wrt boundaries
+     * the conditions are quite general across the kernels we have,
+     * but ideally the check should belong to a specific kernel... */
+    const int max_hpad = (jcp.kh - 1 + 1) / 2;
+    const int max_wpad = (jcp.kw - 1 + 1) / 2;
+    const int min_ih = jcp.kh + nstl::modulo(-jcp.t_pad, jcp.stride_h);
+    const bool boundaries_ok = true && jcp.t_pad <= max_hpad
+            && jcp.b_pad <= max_hpad && jcp.l_pad <= max_wpad
+            && jcp.r_pad <= max_wpad
+            // input must fully accommodate the filter
+            && jcp.ih >= min_ih
+            // non-unit padding must be a multiple of the stride
+            && IMPLICATION(jcp.t_pad > 1, jcp.t_pad % jcp.stride_h == 0)
+            && IMPLICATION(jcp.b_pad > 1, jcp.b_pad % jcp.stride_h == 0);
+    if (!boundaries_ok) return status::unimplemented;
+
+    /* BF16: accumulation of output happens in f32, down-conversion to bf16
+     * happens during the reduction phase. */
+    jcp.typesize_out = sizeof(float);
+    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.bia_dt = jcp.with_bias ? cd.diff_bias_desc.data_type : data_type::undef;
+
+    balance(jcp, nthreads);
+
+    return status::success;
+}
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_scratchpad(
+        memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
+    using namespace dnnl::impl::memory_tracking::names;
+    /* Notes: if splitting thread work on 'mb', then a reduction has to take
+     * place. Hence, book a per-thread, local weights-buffer for the
+     * reduction */
+    if (jcp.nthr_mb > 1) {
+        const size_t mb = jcp.dwei_dt == data_type::bf16 ? jcp.nthr_mb
+                                                         : jcp.nthr_mb - 1;
+        const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
+        scratchpad.book<float>(key_conv_wei_reduction, wei_size * mb);
+
+        if (jcp.with_bias)
+            scratchpad.book<float>(
+                    key_conv_bia_reduction, jcp.ngroups * (jcp.nthr_mb - 1));
+    } else if (jcp.nthr_mb == 1 && jcp.dwei_dt == data_type::bf16) {
+        const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
+        scratchpad.book<float>(key_conv_wei_reduction, wei_size);
+    }
+    if (jcp.bia_dt == data_type::bf16)
+        scratchpad.book<float>(key_conv_bias_bf16_convert_wsp, jcp.ngroups);
+}
+
+template <cpu_isa_t isa, data_type_t kernel_dt>
+void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::balance(
+        jit_conv_conf_t &jcp, int nthreads) {
+    jcp.nthr = nthreads;
+    jcp.nthr_g = jcp.nthr_mb = 1;
+
+    /* Basic-Heuristics for parallel strategy:
+     * 1) Tries to parallel on the number of Groups (g) where tasks are
+     * independent. Otherwise,
+     * 2) Tries to split the work across g and MiniBatch (mb).
+     * Parallelizing on mb requires computing a reduction for weights.
+     *
+     * NOTE: because of 'task partitioning' scheme, there will be unbalanced
+     * per-thread load when the number of threads is high (e.g. > 16).
+     */
+    jcp.nthr_g = nstl::min(jcp.nb_ch, jcp.nthr);
+    jcp.nthr_mb = nstl::min(nstl::max(1, jcp.nthr / jcp.nthr_g), jcp.mb);
+
+    jcp.nthr = jcp.nthr_g * jcp.nthr_mb;
+}
+
+template struct jit_uni_dw_conv_bwd_weights_kernel<sve_512, data_type::f32>;
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+#endif /* CPU_X64_JIT_UNI_DW_CONV_KERNEL_UTILS_HPP */

--- a/src/cpu/aarch64/jit_uni_dw_convolution.cpp
+++ b/src/cpu/aarch64/jit_uni_dw_convolution.cpp
@@ -1,0 +1,534 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+
+#include "common/bfloat16.hpp"
+
+#include "cpu/aarch64/jit_uni_dw_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+template <cpu_isa_t isa, data_type_t src_type, data_type_t dst_type>
+void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
+        const exec_ctx_t &ctx) const {
+    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+    auto weights = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+    auto dst = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+    const memory_desc_wrapper bias_d(pd()->weights_md(1));
+
+    const auto &jcp = pd()->jcp_;
+
+    f32_data_t *bias = nullptr;
+    if (pd()->desc()->bias_desc.data_type == data_type::bf16) {
+        auto bias_in = CTX_IN_MEM(const bf16_data_t *, DNNL_ARG_BIAS);
+        bias = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                key_conv_bias_bf16_convert_wsp);
+        cvt_bfloat16_to_float(bias, bias_in, jcp.oc_without_padding);
+        utils::array_set(bias + jcp.oc_without_padding, 0.f,
+                jcp.oc - jcp.oc_without_padding);
+    } else {
+        auto bias_in = CTX_IN_MEM(const f32_data_t *, DNNL_ARG_BIAS);
+        if (pd()->wants_padded_bias()) {
+            auto padded_bias
+                    = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                            key_conv_padded_bias);
+            utils::array_copy(padded_bias, bias_in, jcp.oc_without_padding);
+            utils::array_set(padded_bias + jcp.oc_without_padding, 0.f,
+                    jcp.oc - jcp.oc_without_padding);
+            bias = padded_bias;
+        } else
+            bias = const_cast<float *>(bias_in);
+    }
+
+    const int dil_h = jcp.dilate_h + 1;
+    const int str_h = jcp.stride_h;
+    const int ch_step = jcp.nb_ch_blocking;
+    const int ow = 0;
+    const int iw = 0;
+    const int kw = 0;
+    const int chb_work = utils::div_up(jcp.nb_ch, ch_step);
+    const auto is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
+    const auto is_dst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
+
+    const int work_amount = jcp.mb * chb_work * jcp.oh;
+    const auto nthr = jcp.nthr;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        int start {0}, end {0};
+        balance211(work_amount, nthr, ithr, start, end);
+
+        int n {0}, chb {0}, oh {0};
+        if (jcp.loop_order == loop_ngcw)
+            utils::nd_iterator_init(
+                    start, n, jcp.mb, chb, chb_work, oh, jcp.oh);
+        else if (jcp.loop_order == loop_nhwcg)
+            utils::nd_iterator_init(
+                    start, n, jcp.mb, oh, jcp.oh, chb, chb_work);
+        else
+            assert(!"unsupported loop order");
+
+        auto iwork = start;
+        while (iwork < end) {
+
+            int ch = chb * ch_step;
+
+            const int i_t_overflow
+                    = nstl::max(0, (int)(jcp.t_pad - oh * str_h));
+            const int i_b_overflow
+                    = nstl::max(jcp.ih,
+                              (int)(oh * str_h + (jcp.kh - 1) * dil_h
+                                      - jcp.t_pad + 1))
+                    - jcp.ih;
+
+            const int ih
+                    = nstl::max((int)(oh * str_h - jcp.t_pad
+                                        + div_up(i_t_overflow, dil_h) * dil_h),
+                            0);
+            const int kh = div_up(i_t_overflow, dil_h);
+            const int kh_padding = jcp.kh - div_up(i_t_overflow, dil_h)
+                    - div_up(i_b_overflow, dil_h);
+
+            const auto ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
+            const auto oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
+
+            auto par_conv = jit_conv_call_s();
+            par_conv.src = jcp.is_fused_conv
+                    ? src
+                    : &src[src_d.blk_off(n, ic_off_idx, ih, iw)];
+            par_conv.dst = &dst[dst_d.blk_off(n, oc_off_idx, oh, ow)];
+
+            par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0, kh, kw)];
+            if (bias) par_conv.bias = &bias[bias_d.blk_off(ch * jcp.ch_block)];
+
+            par_conv.kh_padding = (size_t)nstl::max(0, kh_padding);
+
+            if (is_src_layout_nxc) {
+                // maximize jit work along contiguous dimension
+                int work_rem = end - iwork;
+                par_conv.ch_blocks = ch + work_rem * ch_step >= jcp.nb_ch
+                        ? jcp.nb_ch - ch
+                        : work_rem * ch_step;
+                assert(jcp.loop_order == loop_nhwcg);
+            } else {
+                par_conv.ch_blocks
+                        = utils::this_block_size(ch, jcp.nb_ch, ch_step);
+                assert(jcp.loop_order != loop_nhwcg);
+            }
+
+            (*kernel_)(&par_conv);
+
+            if (jcp.loop_order == loop_ngcw) {
+                ++iwork;
+                utils::nd_iterator_step(n, jcp.mb, chb, chb_work, oh, jcp.oh);
+            } else if (jcp.loop_order == loop_nhwcg) {
+                utils::nd_iterator_jump(
+                        iwork, end, n, jcp.mb, oh, jcp.oh, chb, chb_work);
+            } else
+                assert(!"unsupported loop order");
+        }
+    });
+
+    if (pd()->wants_zero_pad_dst()) ctx.zero_pad_output(DNNL_ARG_DST);
+}
+
+template struct jit_uni_dw_convolution_fwd_t<sve_512, data_type::f32>;
+
+template <cpu_isa_t isa, data_type_t diff_dst_type, data_type_t diff_src_type>
+void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
+        diff_src_type>::execute_backward_data(const exec_ctx_t &ctx) const {
+    auto diff_dst = CTX_IN_MEM(const diff_dst_data_t *, DNNL_ARG_DIFF_DST);
+    auto weights = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+    auto diff_src = CTX_OUT_MEM(diff_src_data_t *, DNNL_ARG_DIFF_SRC);
+
+    const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
+    const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto &jcp = pd()->jcp_;
+
+    auto kernel_params = [&](int ur_str_w, int iw, int oh, int ih,
+                                 int i_t_overflow, int i_b_overflow,
+                                 int stride_off_h, int ch, int ch_num, int n) {
+        auto par_conv = jit_conv_call_s();
+
+        const int i_l_overflow = div_up(
+                nstl::max(0,
+                        ((jcp.kw - 1) * (jcp.dilate_w + 1) - iw - jcp.l_pad)),
+                (jcp.dilate_w + 1));
+        const int i_r_overflow
+                = div_up(nstl::max(0,
+                                 ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                                         - (jcp.iw - 1 - iw) - jcp.r_pad)),
+                        (jcp.dilate_w + 1));
+
+        int ow = iw + jcp.l_pad - i_r_overflow * (jcp.dilate_w + 1);
+        int stride_off_w = ow % jcp.stride_w;
+        ow /= jcp.stride_w;
+
+        par_conv.src = &diff_src[diff_src_d.blk_off(n, ch, ih, iw)];
+        par_conv.dst = &diff_dst[diff_dst_d.blk_off(n, ch, oh, ow)];
+        par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0,
+                i_b_overflow + stride_off_h, i_r_overflow + stride_off_w)];
+
+        par_conv.kh_padding = nstl::max(
+                0, jcp.kh - i_t_overflow - i_b_overflow - stride_off_h);
+        par_conv.kw_padding = nstl::max(
+                0, jcp.kw - i_l_overflow - i_r_overflow - stride_off_w);
+
+        par_conv.ur_str_w = ur_str_w;
+
+        par_conv.ch_blocks = nstl::min(ch + ch_num, jcp.nb_ch) - ch;
+        return par_conv;
+    };
+
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int aux_w
+            = nstl::min(jcp.iw, jcp.iw - ext_kw + jcp.r_pad + jcp.stride_w);
+    const int chb_work = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
+    parallel_nd(jcp.mb, chb_work, jcp.ih, [&](int n, int chb, int ih) {
+        int ch = chb * jcp.nb_ch_blocking;
+        int ch_num = jcp.nb_ch_blocking;
+
+        const int i_t_overflow
+                = div_up(nstl::max(0,
+                                 (int)((jcp.kh - 1) * (jcp.dilate_h + 1) - ih
+                                         - jcp.t_pad)),
+                        (jcp.dilate_h + 1));
+        const int i_b_overflow
+                = div_up(nstl::max(0,
+                                 (int)((jcp.kh - 1) * (jcp.dilate_h + 1)
+                                         - (jcp.ih - 1 - ih) - jcp.b_pad)),
+                        (jcp.dilate_h + 1));
+
+        int oh = ih + jcp.t_pad - i_b_overflow * (jcp.dilate_h + 1);
+        int stride_off_h = oh % jcp.stride_h;
+        oh /= jcp.stride_h;
+
+        for (int i_str_w = 0; i_str_w < jcp.stride_w; i_str_w++) {
+            // left border
+            int iw = i_str_w;
+            int l_border = nstl::min(
+                    (jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad, jcp.iw);
+            int ur_str_w = 1;
+            for (; iw < l_border; iw += jcp.stride_w) {
+                jit_conv_call_s par_conv
+                        = kernel_params(ur_str_w, iw, oh, ih, i_t_overflow,
+                                i_b_overflow, stride_off_h, ch, ch_num, n);
+                (*kernel_)(&par_conv);
+            }
+
+            // main loop
+            ur_str_w = (aux_w - iw) / jcp.stride_w;
+            if (ur_str_w > 0) {
+                jit_conv_call_s par_conv
+                        = kernel_params(ur_str_w, iw, oh, ih, i_t_overflow,
+                                i_b_overflow, stride_off_h, ch, ch_num, n);
+                (*kernel_)(&par_conv);
+                iw += ur_str_w * jcp.stride_w;
+            }
+
+            // right border
+            ur_str_w = 1;
+            for (; iw < jcp.iw; iw += jcp.stride_w) {
+                jit_conv_call_s par_conv
+                        = kernel_params(ur_str_w, iw, oh, ih, i_t_overflow,
+                                i_b_overflow, stride_off_h, ch, ch_num, n);
+
+                (*kernel_)(&par_conv);
+            }
+        }
+    });
+}
+
+template struct jit_uni_dw_convolution_bwd_data_t<sve_512, data_type::f32>;
+
+template <cpu_isa_t isa, data_type_t src_type, data_type_t diff_weights_type>
+jit_uni_dw_convolution_bwd_weights_t<isa, src_type, diff_weights_type>::
+        jit_uni_dw_convolution_bwd_weights_t(const pd_t *apd)
+    : primitive_t(apd), acc_ker_(nullptr), kernel_(nullptr) {}
+
+template <cpu_isa_t isa, data_type_t src_type, data_type_t diff_weights_type>
+void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
+        diff_weights_type>::execute_backward_weights(const exec_ctx_t &ctx)
+        const {
+    auto diff_dst = CTX_IN_MEM(const diff_dst_data_t *, DNNL_ARG_DIFF_DST);
+    auto src = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+    auto diff_weights
+            = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_WEIGHTS);
+
+    auto diff_wei_reduction_buf
+            = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                    key_conv_wei_reduction);
+    auto diff_bia_reduction_buf
+            = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                    key_conv_bia_reduction);
+
+    const auto &jcp = pd()->jcp_;
+
+    float *diff_bias = nullptr;
+    if (jcp.bia_dt == data_type::bf16) {
+        diff_bias = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                key_conv_bias_bf16_convert_wsp);
+    } else {
+        diff_bias = CTX_OUT_MEM(f32_data_t *, DNNL_ARG_DIFF_BIAS);
+    }
+
+    const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
+    const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
+
+    const int ch_block = jcp.ch_block;
+
+    auto set_kernel_params
+            = [&](jit_dw_conv_call_s *conv_params, const int batch,
+                      const int group, const int oh_start, const int work_size,
+                      const unsigned char exec_flag, const size_t kh_padding,
+                      const size_t filter_off) {
+                  const int tpad_underflow_off = jcp.t_pad - filter_off;
+
+                  conv_params->exec_flags = exec_flag;
+                  conv_params->kh_count = jcp.kh - kh_padding;
+
+                  const int oh_s = oh_start;
+                  const int oh_e = oh_start + work_size;
+                  const int ih_s = oh_s * jcp.stride_h;
+
+                  conv_params->filter_pad_off
+                          = filter_off * jcp.kw * ch_block * jcp.typesize_out;
+                  conv_params->oh_index = oh_s;
+                  conv_params->oh_count = oh_e;
+
+                  size_t diff_dst_off
+                          = ((batch * (jcp.ngroups / ch_block) + group) * jcp.oh
+                                    + oh_start)
+                          * jcp.ow;
+
+                  size_t src_off
+                          = ((batch * (jcp.ngroups / ch_block) + group) * jcp.ih
+                                    + ih_s - tpad_underflow_off)
+                          * jcp.iw;
+
+                  conv_params->output = &diff_dst[diff_dst_off * ch_block];
+                  conv_params->input = &src[src_off * ch_block];
+              };
+
+    parallel(jcp.nthr, [&](const int ithr, const int nthr) {
+        assert(nthr == jcp.nthr);
+
+        auto conv_params = jit_dw_conv_call_s();
+        const int h_block_size = 15;
+
+        /* assign iteration space to thread */
+        const int ithr_g = ithr % jcp.nthr_g;
+        const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
+
+        /* split dimensions */
+        int g_start {0}, g_end {0};
+        balance211(jcp.nb_ch, jcp.nthr_g, ithr_g, g_start, g_end);
+
+        int mb_start {0}, mb_end {0};
+        balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
+
+        auto i_mb
+                = diff_weights_type == data_type::bf16 ? ithr_mb : ithr_mb - 1;
+        f32_data_t *diff_wei
+                = (ithr_mb == 0 && diff_weights_type == data_type::f32)
+                ? (f32_data_t *)diff_weights
+                : diff_wei_reduction_buf + i_mb * wei_size;
+
+        auto diff_bia = ithr_mb == 0
+                ? diff_bias
+                : diff_bia_reduction_buf + (ithr_mb - 1) * bias_size;
+
+        for (int g = g_start; g < g_end; ++g) {
+            unsigned char zero_filter_flag = FLAG_ZERO_FILTER;
+            unsigned char zero_bias_flag = jcp.with_bias ? FLAG_ZERO_BIAS : 0;
+
+            size_t diff_wei_off = g * jcp.kh * jcp.kw;
+            conv_params.filter = &diff_wei[diff_wei_off * ch_block];
+
+            if (jcp.with_bias) conv_params.bias = &diff_bia[g * ch_block];
+
+            for (int mb = mb_start; mb < mb_end; ++mb) {
+                int oh = 0;
+                while (oh < jcp.oh) {
+                    const int h_work = nstl::min(h_block_size, jcp.oh - oh);
+                    auto kh_t_padding = nstl::max(0, jcp.t_pad - oh);
+                    auto kh_b_padding
+                            = (oh * jcp.stride_h + jcp.kh > jcp.ih + jcp.t_pad)
+                            ? nstl::max(jcp.b_pad - (h_work - 1), 0)
+                            : 0;
+
+                    set_kernel_params(&conv_params, mb, g, oh, h_work,
+                            zero_filter_flag | zero_bias_flag,
+                            kh_t_padding + kh_b_padding, kh_t_padding);
+                    (*kernel_)(&conv_params);
+
+                    zero_bias_flag &= ~FLAG_ZERO_BIAS;
+                    zero_filter_flag &= ~FLAG_ZERO_FILTER;
+                    oh += h_work;
+                }
+            }
+        }
+    });
+}
+
+/* TODO: Performing a Parallel Reduction could potentially improve performance;
+ * this should be explored in the future if further optimizations are required.
+ */
+template <>
+void jit_uni_dw_convolution_bwd_weights_t<sve_512,
+        data_type::bf16>::execute_reduction(const exec_ctx_t &ctx) const {
+
+    auto diff_wei_reduction_buf
+            = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                    key_conv_wei_reduction);
+    auto diff_bia_reduction_buf
+            = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                    key_conv_bia_reduction);
+    auto diff_weights
+            = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_WEIGHTS);
+
+    const auto &jcp = pd()->jcp_;
+    assert(jcp.dwei_dt == data_type::bf16);
+
+    const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
+    const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
+
+    const int ch_block = jcp.ch_block;
+
+    float *diff_bias = nullptr;
+    if (jcp.bia_dt == data_type::bf16) {
+        diff_bias = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                key_conv_bias_bf16_convert_wsp);
+    } else {
+        diff_bias = CTX_OUT_MEM(f32_data_t *, DNNL_ARG_DIFF_BIAS);
+    }
+
+    /* Apply single-threaded 'mb' reduction */
+    if (jcp.with_bias && jcp.nthr_mb > 1) {
+        for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
+            size_t b_accum_offset = (thr_mb - 1) * bias_size;
+
+            for (int g = 0; g < jcp.nb_ch; ++g) {
+                /* Reduction on Bias */
+                PRAGMA_OMP_SIMD()
+                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                    size_t bias_offset = g * ch_block + g_block;
+                    diff_bias[bias_offset]
+                            += diff_bia_reduction_buf[b_accum_offset
+                                    + bias_offset];
+                }
+            }
+        }
+    }
+    if (jcp.bia_dt == data_type::bf16) {
+        auto diff_bias_in = CTX_OUT_MEM(bf16_data_t *, DNNL_ARG_DIFF_BIAS);
+        cvt_float_to_bfloat16(diff_bias_in, diff_bias, jcp.ngroups);
+    }
+    /* Apply single-threaded 'mb' reduction */
+    if (jcp.nthr_mb > 1) {
+        for (int thr_mb = 2; thr_mb < jcp.nthr_mb; ++thr_mb) {
+            size_t mb_accum_offset = thr_mb * wei_size;
+            acc_ker_->accumulate(&diff_wei_reduction_buf[0],
+                    &diff_wei_reduction_buf[mb_accum_offset], wei_size);
+        }
+        add_floats_and_cvt_to_bfloat16((bfloat16_t *)&(diff_weights[0]),
+                (float *)&diff_wei_reduction_buf[0],
+                (float *)&diff_wei_reduction_buf[wei_size], wei_size);
+    } else {
+        cvt_float_to_bfloat16((bfloat16_t *)&(diff_weights[0]),
+                (const float *)&(diff_wei_reduction_buf[0]), wei_size);
+    }
+}
+
+template <cpu_isa_t isa, data_type_t src_type, data_type_t diff_weights_type>
+void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
+        diff_weights_type>::execute_reduction(const exec_ctx_t &ctx) const {
+
+    auto diff_wei_reduction_buf
+            = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                    key_conv_wei_reduction);
+    auto diff_bia_reduction_buf
+            = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                    key_conv_bia_reduction);
+    auto diff_weights = CTX_OUT_MEM(f32_data_t *, DNNL_ARG_DIFF_WEIGHTS);
+
+    const auto &jcp = pd()->jcp_;
+
+    const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
+    const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
+
+    const int ch_block = jcp.ch_block;
+
+    assert(diff_weights_type == data_type::f32
+            && jcp.dwei_dt == data_type::f32);
+
+    float *diff_bias = nullptr;
+    if (jcp.bia_dt == data_type::bf16) {
+        diff_bias = ctx.get_scratchpad_grantor().template get<f32_data_t>(
+                key_conv_bias_bf16_convert_wsp);
+    } else {
+        diff_bias = CTX_OUT_MEM(f32_data_t *, DNNL_ARG_DIFF_BIAS);
+    }
+
+    /* Apply single-threaded 'mb' reduction */
+    for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
+        size_t mb_accum_offset = (thr_mb - 1) * wei_size;
+        size_t b_accum_offset = (thr_mb - 1) * bias_size;
+
+        for (int g = 0; g < jcp.nb_ch; ++g) {
+            /* Reduction on Bias */
+            if (jcp.with_bias) {
+                PRAGMA_OMP_SIMD()
+                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                    size_t bias_offset = g * ch_block + g_block;
+                    diff_bias[bias_offset]
+                            += diff_bia_reduction_buf[b_accum_offset
+                                    + bias_offset];
+                }
+            }
+        }
+        acc_ker_->accumulate(&diff_weights[0],
+                &diff_wei_reduction_buf[mb_accum_offset], wei_size);
+    }
+
+    if (jcp.bia_dt == data_type::bf16) {
+        auto diff_bias_in = CTX_OUT_MEM(bf16_data_t *, DNNL_ARG_DIFF_BIAS);
+        cvt_float_to_bfloat16(diff_bias_in, diff_bias, jcp.ngroups);
+    }
+}
+
+template struct jit_uni_dw_convolution_bwd_weights_t<sve_512, data_type::f32>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_convolution.hpp
@@ -1,0 +1,277 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2021 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_DW_CONVOLUTION_HPP
+#define CPU_AARCH64_JIT_UNI_DW_CONVOLUTION_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+
+#include "cpu/aarch64/cpu_barrier.hpp"
+#include "cpu/aarch64/cpu_reducer.hpp"
+#include "cpu/cpu_convolution_pd.hpp"
+
+#include "cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa, data_type_t src_type, data_type_t dst_type = src_type>
+struct jit_uni_dw_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), jcp_() {}
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
+                jit_uni_dw_convolution_fwd_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && is_fwd()
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(src_type, src_type, data_type::undef,
+                            dst_type, data_type::f32)
+                    && IMPLICATION(this->with_bias(),
+                            utils::one_of(this->desc()->bias_desc.data_type,
+                                    data_type::f32, data_type::bf16))
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, dst_type)
+                    && !has_zero_dim_memory();
+            if (!ok) return status::unimplemented;
+
+            status_t status
+                    = jit_uni_dw_conv_fwd_kernel<isa, src_type>::init_conf(jcp_,
+                            *desc(), src_md_, weights_md_, bias_md_, dst_md_,
+                            *attr());
+            if (status != status::success) return status;
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_uni_dw_conv_fwd_kernel<isa, src_type>::init_scratchpad(
+                    scratchpad, jcp_);
+
+            return status::success;
+        }
+
+        jit_conv_conf_t jcp_;
+    };
+
+    jit_uni_dw_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    typedef typename prec_traits<data_type::f32>::type f32_data_t;
+    typedef typename prec_traits<data_type::bf16>::type bf16_data_t;
+    typedef typename prec_traits<src_type>::type data_t;
+    typedef typename prec_traits<dst_type>::type dst_data_t;
+
+    status_t init(engine_t *engine) override {
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_uni_dw_conv_fwd_kernel<isa, src_type>(pd()->jcp_)));
+        return kernel_->create_kernel();
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_forward(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_uni_dw_conv_fwd_kernel<isa, src_type>> kernel_;
+};
+
+using jit_sve_512_dw_convolution_fwd_t
+        = jit_uni_dw_convolution_fwd_t<sve_512, data_type::f32>;
+
+template <cpu_isa_t isa, data_type_t diff_dst_type,
+        data_type_t diff_src_type = diff_dst_type>
+struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
+    struct pd_t : public cpu_convolution_bwd_data_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const convolution_fwd_pd_t *hint_fwd_pd)
+            : cpu_convolution_bwd_data_pd_t(adesc, attr, hint_fwd_pd), jcp_() {}
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
+                jit_uni_dw_convolution_bwd_data_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && desc()->prop_kind == prop_kind::backward_data
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(diff_src_type, diff_dst_type,
+                            data_type::undef, diff_dst_type, data_type::f32)
+                    && attr()->has_default_values() && !has_zero_dim_memory()
+                    && set_default_formats();
+
+            if (!ok) return status::unimplemented;
+
+            status_t status = jit_uni_dw_conv_bwd_data_kernel<isa,
+                    diff_dst_type>::init_conf(jcp_, *desc(), *diff_src_md(),
+                    *weights_md(), *diff_dst_md());
+            if (status != status::success) return status;
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_uni_dw_conv_bwd_data_kernel<isa,
+                    diff_dst_type>::init_scratchpad(scratchpad, jcp_);
+
+            return status::success;
+        }
+
+        jit_conv_conf_t jcp_;
+
+    protected:
+        bool set_default_formats() {
+            using namespace format_tag;
+
+            auto dat_tag = nChw16c;
+            auto wei_tag = Goihw16g;
+
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+    };
+
+    jit_uni_dw_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
+
+    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits<diff_dst_type>::type wei_data_t;
+
+    status_t init(engine_t *engine) override {
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_uni_dw_conv_bwd_data_kernel<isa, diff_dst_type>(
+                        pd()->jcp_)));
+        return kernel_->create_kernel();
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_backward_data(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_backward_data(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<jit_uni_dw_conv_bwd_data_kernel<isa, diff_dst_type>>
+            kernel_;
+};
+
+using jit_sve_512_dw_convolution_bwd_data_t
+        = jit_uni_dw_convolution_bwd_data_t<sve_512, data_type::f32>;
+
+template <cpu_isa_t isa, data_type_t src_type,
+        data_type_t diff_weights_type = src_type>
+struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
+    struct pd_t : public cpu_convolution_bwd_weights_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const convolution_fwd_pd_t *hint_fwd_pd)
+            : cpu_convolution_bwd_weights_pd_t(adesc, attr, hint_fwd_pd)
+            , jcp_() {}
+        using jit_uni_dw_convolution_bwd_weights
+                = jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
+                        diff_weights_type>;
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("jit_dw:", jcp_.isa, ""),
+                jit_uni_dw_convolution_bwd_weights);
+
+        status_t init(engine_t *engine) {
+            bool ok = true && desc()->prop_kind == prop_kind::backward_weights
+                    && set_default_alg_kind(alg_kind::convolution_direct)
+                    && expect_data_types(src_type, diff_weights_type,
+                            data_type::undef, src_type, data_type::f32)
+                    && IMPLICATION(this->with_bias(),
+                            utils::one_of(
+                                    this->desc()->diff_bias_desc.data_type,
+                                    data_type::f32, data_type::bf16))
+                    && attr()->has_default_values() && !has_zero_dim_memory()
+                    && set_default_formats();
+            if (!ok) return status::unimplemented;
+
+            const int max_threads
+                    = dnnl_in_parallel() ? 1 : dnnl_get_max_threads();
+
+            status_t status = jit_uni_dw_conv_bwd_weights_kernel<isa,
+                    src_type>::init_conf(jcp_, *desc(), *src_md(),
+                    *diff_weights_md(), *diff_dst_md(), max_threads);
+            if (status != status::success) return status;
+
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_uni_dw_conv_bwd_weights_kernel<isa, src_type>::init_scratchpad(
+                    scratchpad, jcp_);
+
+            return status::success;
+        }
+
+        jit_conv_conf_t jcp_;
+
+    protected:
+        bool set_default_formats() {
+            using namespace format_tag;
+
+            auto dat_tag = isa == sve_512 ? nChw16c : nChw8c;
+            auto wei_tag = isa == sve_512 ? Goihw16g : Goihw8g;
+
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+    };
+
+    jit_uni_dw_convolution_bwd_weights_t(const pd_t *apd);
+
+    typedef typename prec_traits<data_type::bf16>::type bf16_data_t;
+    typedef typename prec_traits<data_type::f32>::type f32_data_t;
+    typedef typename prec_traits<src_type>::type src_data_t;
+    typedef typename prec_traits<src_type>::type diff_dst_data_t;
+    typedef typename prec_traits<diff_weights_type>::type diff_weights_data_t;
+
+    status_t init(engine_t *engine) override {
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_uni_dw_conv_bwd_weights_kernel<isa, src_type>(
+                        pd()->jcp_)));
+        CHECK(kernel_->create_kernel());
+
+        if (pd()->jcp_.nthr_mb > 1) {
+            CHECK(safe_ptr_assign(
+                    acc_ker_, new cpu_accumulator_1d_t<data_type::f32>()));
+            CHECK(acc_ker_->create_kernel());
+        }
+        return status::success;
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_backward_weights(ctx);
+        execute_reduction(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_backward_weights(const exec_ctx_t &ctx) const;
+    void execute_reduction(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<cpu_accumulator_1d_t<data_type::f32>> acc_ker_;
+    std::unique_ptr<jit_uni_dw_conv_bwd_weights_kernel<isa, src_type>> kernel_;
+};
+
+using jit_sve_512_dw_convolution_bwd_weights_t
+        = jit_uni_dw_convolution_bwd_weights_t<sve_512, data_type::f32>;
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -64,6 +64,7 @@ using namespace dnnl::impl::cpu::x64;
 #elif DNNL_AARCH64
 #include "cpu/aarch64/jit_sve_512_1x1_convolution.hpp"
 #include "cpu/aarch64/jit_sve_512_convolution.hpp"
+#include "cpu/aarch64/jit_uni_dw_convolution.hpp"
 using namespace dnnl::impl::cpu::aarch64;
 #endif
 
@@ -115,6 +116,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_sse41_1x1_convolution_fwd_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_fwd_t)
         CPU_INSTANCE_X64(jit_sse41_convolution_fwd_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
         CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
@@ -160,6 +162,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_avx2_1x1_convolution_bwd_data_t)
         CPU_INSTANCE_X64(jit_sse41_dw_convolution_bwd_data_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_bwd_data_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_bwd_data_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_bwd_data_f32_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_convolution_bwd_data_t<f32>)
         CPU_INSTANCE(gemm_convolution_bwd_data_t)
@@ -195,6 +198,7 @@ const std::map<conv_impl_key_t, std::vector<pd_create_f>> impl_list_map {
         CPU_INSTANCE_X64(jit_avx2_1x1_convolution_bwd_weights_t)
         CPU_INSTANCE_X64(jit_sse41_dw_convolution_bwd_weights_t)
         CPU_INSTANCE_X64(jit_avx2_convolution_bwd_weights_t)
+        CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_bwd_weights_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_bwd_weights_t)
         CPU_INSTANCE_AARCH64(jit_sve_512_convolution_bwd_weights_t<f32>)
         CPU_INSTANCE(gemm_convolution_bwd_weights_t)


### PR DESCRIPTION
# Description

This PR adds JIT support of FP32 dw convolution for AArch64.
It includes JIT implementation for SVE 512.

Related RFC #841

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [x] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

There is no need to make a new tests for this PR,
since we can use the existing gtests and benchdnn for this PR.