### PR TITLE
Update required Compute Library version to 21.02

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2020 Arm Limited and affiliates.
+# Copyright 2020-2021 Arm Limited and affiliates.
 # Copyright 2020-2021 FUJITSU LIMITED
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -27,7 +27,7 @@ steps:
   image: ubuntu:16.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 20.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -80,7 +80,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 20.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -111,7 +111,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 20.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # *******************************************************************************
-# Copyright 2020 Arm Limited and affiliates.
+# Copyright 2020-2021 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,7 @@
 # *******************************************************************************
 
 # Compute Library build defaults
-ACL_VERSION="v20.11"
+ACL_VERSION="v21.02"
 ACL_DIR="${PWD}/ComputeLibrary"
 ACL_ARCH="arm64-v8a"
 

--- a/README.md
+++ b/README.md
@@ -120,10 +120,11 @@ require the use of run-time controls to enable them. See
 for more details.
 
 On a CPU based on Arm AArch64 architecture, oneDNN can be built with Arm Compute Library
-integration. Arm Compute Library is an open-source library for machine learning applications
+integration. Compute Library is an open-source library for machine learning applications
 and provides AArch64 optimized implementations of core functions. This functionality currently
-requires that Arm Compute Library is downloaded and built separately, see
-[Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html).
+requires that Compute Library is downloaded and built separately, see
+[Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html). oneDNN is only
+compatible with Compute Library versions 21.02 or later.
 
 > **WARNING**
 >

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -1,5 +1,5 @@
 # ******************************************************************************
-# Copyright 2020 Arm Limited and affiliates.
+# Copyright 2020-2021 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,19 +31,22 @@ endif()
 
 find_package(ACL REQUIRED)
 
+set(ACL_MINIMUM_VERSION "21.02")
+
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)
     if ("${ACL_VERSION_FILE}" STREQUAL "")
-        message(WARNING "Build may fail: Could not determine ACL version (minimum required is v20.11)")
+        message(WARNING "Build may fail: Could not determine ACL version (minimum required is ${ACL_MINIMUM_VERSION})")
     else()
         file(READ ${ACL_VERSION_FILE} ACL_VERSION_STRING)
-        string(REGEX MATCH "v[0-9]+\\.[0-9]+" ACL_VERSION ${ACL_VERSION_STRING})
+        string(REGEX MATCH "v([0-9]+\\.[0-9]+)" ACL_VERSION ${ACL_VERSION_STRING})
+        set(ACL_VERSION "${CMAKE_MATCH_1}")
         if (${ACL_VERSION} VERSION_EQUAL "0.0")
             # Unreleased ACL versions come with version string "v0.0-unreleased", and may not be compatible with oneDNN.
             # It is recommended to use the latest release of ACL.
-            message(WARNING "Build may fail: Using unreleased ACL version (minimum required is v20.11)")
-        elseif(${ACL_VERSION} VERSION_LESS "20.11")
-            message(FATAL_ERROR "Detected ACL version ${ACL_VERSION}, but minimum required is v20.11")
+            message(WARNING "Build may fail: Using unreleased ACL version (minimum required is ${ACL_MINIMUM_VERSION})")
+        elseif(${ACL_VERSION} VERSION_LESS ${ACL_MINIMUM_VERSION})
+            message(FATAL_ERROR "Detected ACL version ${ACL_VERSION}, but minimum required is ${ACL_MINIMUM_VERSION}")
         endif()
     endif()
 
@@ -55,4 +58,6 @@ if(ACL_FOUND)
     message(STATUS "Arm Compute Library headers: ${ACL_INCLUDE_DIRS}")
 
     add_definitions(-DDNNL_AARCH64_USE_ACL)
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_EXTENSIONS "OFF")
 endif()

--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -85,9 +85,8 @@ cmake .. \
          -DDNNL_AARCH64_USE_ACL=ON \
          <extra build options>
 ~~~
-Only ACL versions 20.11 or above are supported. Using ACL versions above	
-20.11 may require the `-DCMAKE_CXX_STANDARD=14` and `-DCMAKE_CXX_EXTENSIONS=OFF`
-flags to be passed.
+
+Only ACL versions 21.02 or above are supported.
 
 #### Build and Install the Library
 

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -158,7 +158,7 @@ For a debug build of oneDNN it is advisable to specify a Compute Library build
 which has also been built with debug enabled.
 
 @warning
-oneDNN is only compatible with Compute Library builds v20.11 or later.
+oneDNN is only compatible with Compute Library builds v21.02 or later.
 
 #### Vendor BLAS libraries
 oneDNN can use a standard BLAS library for GEMM operations.


### PR DESCRIPTION
# Description

This PR updates the minimum required version of Compute Library to the newly released [v21.02](https://arm-software.github.io/ComputeLibrary/v21.02/), which contains fixes for several bugs present in v20.11. v21.02 requires C++14, hence CMake flags are added to select it and ensure `c++14` (not `gnu14`) is used. [A previous PR](https://github.com/oneapi-src/oneDNN/pull/905) added this feature but was abandoned - now is a more appropriate time to add it as we now have a version of Compute Library that requires `--std=c++14`.

The affected DroneCI pipelines and relevant build documentation are also updated accordingly.

# Checklist

## Code-change submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [N/A] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [X] Have you provided motivation for adding a new feature?

### Bug fixes

- [N/A] Have you added relevant regression tests?
- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
