### PR TITLE
Enable further compiling capabilities: compiling for Unix-based systems and cross-compiling from Windows

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/examples)
 
 if(UNIX)
-    find_library(LIBM m)
+    find_library(LIBM m REQUIRED)
 endif()
 
 file(GLOB_RECURSE sources *.cpp *.c)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,11 +205,17 @@ else()
         else()
             set(compat_link "${CMAKE_CURRENT_BINARY_DIR}/libmkldnn${ext_and_ver}")
         endif()
-        add_custom_command(OUTPUT ${compat_link}
-            # to make the next command work fine
-            COMMAND ${CMAKE_COMMAND} -E remove -f ${compat_link}
-            COMMAND ${CMAKE_COMMAND} -E create_symlink libdnnl${ext_and_ver} ${compat_link}
-            DEPENDS ${LIB_NAME})
+        if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)               
+            add_custom_command(OUTPUT ${compat_link}
+                COMMAND ${CMAKE_COMMAND} -E copy libdnnl${ext_and_ver} ${compat_link}
+                DEPENDS ${LIB_NAME})
+        else()
+            add_custom_command(OUTPUT ${compat_link}
+                # to make the next command work fine
+                COMMAND ${CMAKE_COMMAND} -E remove -f ${compat_link}
+                COMMAND ${CMAKE_COMMAND} -E create_symlink libdnnl${ext_and_ver} ${compat_link}
+                DEPENDS ${LIB_NAME})
+        endif()
         add_custom_target(compat_libs${ver} ALL DEPENDS ${compat_link})
         install(FILES ${compat_link} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
     endforeach()

--- a/src/common/memory_debug.cpp
+++ b/src/common/memory_debug.cpp
@@ -21,7 +21,7 @@
 #include <windows.h>
 #endif
 
-#if defined __linux__ || defined __APPLE__ || defined __FreeBSD__
+#if defined __unix__ || defined __APPLE__ || defined __FreeBSD__
 #include <unistd.h>
 #include <sys/mman.h>
 #endif

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -19,11 +19,11 @@
 #include <windows.h>
 #endif
 
-#if defined __linux__ || defined __APPLE__ || defined __FreeBSD__
+#if defined __unix__ || defined __APPLE__ || defined __FreeBSD__
 #include <unistd.h>
 #endif
 
-#ifdef __linux__
+#ifdef __unix__
 #include <sys/stat.h>
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
# Description
Enable further compiling capabilities: compiling for Unix-based systems and cross-compiling from Windows. No functional change in previously existing build configurations.

Fixes #1029 #1031 #1032.