### PR TITLE
Fix mistake in benchdnn matmul driver documentation

### DIFF
--- a/tests/benchdnn/doc/driver_matmul.md
+++ b/tests/benchdnn/doc/driver_matmul.md
@@ -98,7 +98,7 @@ runtime, but sizes specified at creation time:
                --cfg=u8s8u8 \
                --wtag=any \
                --attr-zero-points=src:1*_dst:-2* \
-               10x30:30x20 # or m10n20k3 with deprecated matmul desc
+               10x30:30x20 # or m10n20k30 with deprecated matmul desc
 ```
 
 Run single precision batched matrix multiplication with bias, of which only the
@@ -106,7 +106,7 @@ full dimension is along the `n`-axis:
 ``` sh
     ./benchdnn --matmul \
                --bia_dt=f32 --bia_mask=4 \
-               2x10x30:2x30x20 # or mb2m10n20k3 with deprecated matmul desc
+               2x10x30:2x30x20 # or mb2m10n20k30 with deprecated matmul desc
 ```
 
 More examples with different driver options can be found at


### PR DESCRIPTION
I think the example (line 101 and line 109) should be mb2m10n20k30 and not the mb2m10n20k3, is that right?

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
