### PR TITLE
cpu: aarch64: missing include for arm_compute::Scheduler

### DIFF
--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -26,6 +26,7 @@
 
 #include "arm_compute/runtime/FunctionDescriptors.h"
 #include "arm_compute/runtime/NEON/NEFunctions.h"
+#include "arm_compute/runtime/Scheduler.h"
 
 namespace dnnl {
 namespace impl {


### PR DESCRIPTION
# Description

error: 'arm_compute::Scheduler' has not been declared
There is a missing include which leads to a compilation error

The issue shows up in testing with the Compute Library master, so it is
currently working with the 21.02 release, as used in the CI,
see: https://github.com/oneapi-src/oneDNN/blob/ca6ca816faa92025a231f3ff1d110b73c5a460c1/.github/automation/build_acl.sh#L21

However, this change is required to support builds from the tip of the Compute Library master, and future releases.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?

- [N/A] Have you provided motivation for adding a new feature?

###Bug fixes

- [N/A] Have you added relevant regression tests?

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?