### PR TITLE
Adds support for building documentation and API reference with Sphinx.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ CMakeSettings.json
 compile_flags.txt
 compile_commands.json
 .git-blame-ignore-revs
+doc/_build
+doc/api
+doc/xml

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1825,7 +1825,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,58 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'OneDNN'
+copyright = '2021, various'
+author = 'various'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ["breathe"]
+
+breathe_projects = {'dnn':'./xml'}
+breathe_default_project = 'dnn'
+breathe_implementation_filename_extensions = []
+
+primary_domain = 'cpp'
+
+
+# Add any paths that contain templates here, relative to this directory.
+#templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_book_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+#html_static_path = ['_static']

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,18 @@
+.. OneDNN documentation master file, created by
+   sphinx-quickstart on Wed May  5 13:37:14 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to OneDNN's documentation!
+==================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api/group__dnnl__api
+
+Indices and tables
+==================
+
+* :ref:`genindex`

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/doc/parse_doxygen_index.py
+++ b/doc/parse_doxygen_index.py
@@ -1,0 +1,167 @@
+import os
+from bs4 import BeautifulSoup, Tag, Doctype
+
+xml_path = 'xml/'
+api_path = 'api/'
+top_doc = 'group__dnnl__api.xml'
+
+def createTOCTree(soup, groupList):
+    filename = soup.attrs['id'] + ".rst"
+    filepath = api_path + filename
+    reST = ""
+    header = ""
+    description = ""
+    for child in soup.children:
+        if child.name is not None:
+            if child.name == "title":
+                header = child.text
+            if child.name == "briefdescription":
+                description = child.text
+    reST += header + "\n" + len(header)*'*' + "\n\n" + description + "\n\n"
+    reST += ".. toctree::\n"
+    reST += "   :maxdepth: 1\n\n"
+    for key, value in groupList.items():
+        reST += "   " + key + "\n"
+    with open(filepath, 'w') as f:
+        f.write(reST)
+
+def getGroupInfo(soup):
+    filename = soup.attrs['id'] + ".rst"
+    filepath = api_path + filename
+    reST = ""
+    header = ""
+    compoundName = ""
+    for child in soup.children:
+        if child.name is not None:
+            if child.name == "title":
+                header = child.text
+            if child.name == "compoundname":
+                compoundName = child.text
+    reST += header + "\n" + len(header)*'*' + "\n"
+    reST += """
+Contents
+   * `Defines <#breathe-section-title-defines>`__
+   * `TypeDefs <#breathe-section-title-typedefs>`__
+   * `Enums <#breathe-section-title-enums>`__
+   * `Functions <#breathe-section-title-functions>`__
+
+"""
+    reST += ".. doxygengroup:: " + compoundName + "\n"
+    reST += "   :inner:\n"
+    reST += "   :members:\n"
+    with open(filepath,'w') as f:
+        f.write(reST)
+
+def buildGroupInfo(soup):
+    filename = soup.attrs['id'] + ".rst"
+    filepath = api_path + filename
+    reST = ""
+    header = ""
+    compoundName = ""
+    for child in soup.children:
+        if child.name is not None:
+            if child.name == "title":
+                header = child.text
+    reST += header + "\n" + len(header)*'*' + "\n\n"
+    #Handle classes
+    innerClasses = soup.find_all('innerclass')
+    if len(innerClasses) > 0:
+        reST += 'Classes\n##########\n\n'
+        reST += '.. toctree::\n\n'
+        for iClass in innerClasses:
+            reST += buildClass(iClass)
+    reST += '\n'
+    members = soup.find_all('memberdef')
+    macros = []
+    typedefs = []
+    enums = []
+    functions = []
+    other = []
+    for member in members:
+        kind = member.attrs['kind']
+        if kind == "define":
+            macros.append(member)
+        elif kind == "typedef":
+            typedefs.append(member)
+        elif kind == "enum":
+            enums.append(member)
+        elif kind == "function":
+            functions.append(member)
+        else:
+            other.append(member)
+    #Handle macros
+    if len(macros) > 0:
+        reST += 'Macros\n#######\n\n'
+        for macro in macros:
+            macroName = macro.find('name')
+            reST += '.. doxygendefine:: ' + macroName.text + '\n\n'
+    #Handle typdefs
+    if len(typedefs) > 0:
+        reST += 'TypeDefs\n##########\n\n'
+        for typedef in typedefs:
+            typedefName = typedef.find('name')
+            reST += '.. doxygentypedef:: ' + typedefName.text + '\n\n'
+    #Handle enums
+    if len(enums) > 0:
+        reST += 'Enumerations\n#################\n\n'
+        for enum in enums:
+            enumName = enum.find('name')
+            reST += '.. doxygenenum:: ' + enumName.text + '\n\n'
+    #Handle functions
+    if len(functions) > 0:
+        reST += 'Functions\n##############\n\n'
+        for func in functions:
+            funcName = func.find('name')
+            funcArgs = func.find('argsstring')
+            reST += '.. doxygenfunction:: ' + funcName.text + funcArgs.text + '\n\n'
+    with open(filepath,'w') as f:
+        f.write(reST)
+
+def buildClass(theClass):
+    structName = theClass.attrs['refid']
+    structPath = api_path + structName + ".rst"
+    className = theClass.text
+    structReST = className + "\n" + len(className)*'*' + "\n\n"
+    structReST += ".. doxygenstruct:: " + className + "\n"
+    structReST += "   :members: \n\n"
+    tocEntry = '   ' + structName + '\n'
+    with open(structPath,'w') as f2:
+        f2.write(structReST)
+    return tocEntry
+
+def doxyWalker(soup, indent):
+    if soup.name is not None:
+        indent += " "
+        for child in soup.children:
+            if child.name is not None:
+                if child.name == "compounddef":
+                    if 'kind' in child.attrs and child.attrs['kind'] == 'group':
+                        kidGroups = {}
+                        for grand in child.children:
+                            if grand.name == "innergroup":
+                                if 'refid' in grand.attrs:
+                                    kidGroups[grand.attrs['refid']] = grand.text
+                                    newSoupPath = grand.attrs['refid'] + '.xml'
+                                    newSoup = getSoup(xml_path + newSoupPath)
+                                    doxyWalker(newSoup, indent)
+                    if len(kidGroups) > 0:
+                        createTOCTree(child, kidGroups)
+                    else:
+                        #getGroupInfo(child)
+                        buildGroupInfo(child)
+                else:
+                    #print(child.name)
+                    doxyWalker(child,indent)
+
+def getSoup(path):
+    with open(path) as f:
+        doxy = f.read()
+
+    soup = BeautifulSoup(doxy,features="html.parser")
+    return soup
+
+if not os.path.isdir(api_path):
+    os.mkdir(api_path)
+
+soup = getSoup(xml_path + top_doc)
+doxyWalker(soup, "")

--- a/doc/replace_string.py
+++ b/doc/replace_string.py
@@ -1,0 +1,24 @@
+import os
+# This is needed to remove the DNNL_API string from the xml as it causes Breathe to crash.
+
+findString = "DNNL_API"
+replaceString = ""
+targetDir = "xml"
+
+fileExtension = ".xml"
+files = []
+
+def getFiles():
+    for dirpath, dirnames, filenames in os.walk(targetDir):
+        for filename in [f for f in filenames if f.endswith(fileExtension)]:
+            filePath = os.path.join(dirpath,filename)
+            print("replacing strings in " + filePath)
+            outdata = None
+            with open(filePath) as f:
+                read_data = f.read()
+                outdata = read_data.replace(findString,replaceString)
+            with open(filePath,"w") as f:
+                f.write(outdata)
+
+getFiles()
+

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+breathe
+sphinx_book_theme
+bs4


### PR DESCRIPTION
Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>

# Description

Adds support for building documentation and API reference with Sphinx. It requires Python 3.5 or better. Use these steps to generate the Sphinx HTML output locally.

1. pip3 install -r requirements.txt
2. cmake .
3. make doc
4. mv reference/xml doc
5. cd doc
6. python3 replace_string.py
7. python3 parse_doxygen_index.py
8. make html (or sphinx-build -b html . _build/html)

**HTML output will be in doc/_build/html**

It requires the following Sphinx libraries to be installed (included in requirements.txt):

* sphinx
* breathe
* sphinx_book_theme
* bs4

This is a custom solution for publishing the oneDNN API reference, which depends on 2 python scripts:

1. replace_string.py - the DNNL_API string that appears in the declarations for a lot of objects in the Doxygen XML output causes Breathe to crash. This script strips them out. It expects the Doxygen output to be in doc/xml. 
2. parse_doxygen_index.py - This script creates .rst documents with Breathe directives in doc/api that mimics the output of the current Doxygen HTML output of the API reference. It expects the Doxygen XML output to be in doc/xml.

Fixes #1046

@jedippold will follow up with content changes.
