### PR TITLE
cpu: aarch64: implemented thread binding for ACL calls

### DIFF
--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -117,8 +117,11 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
 
             // Number of threads in Compute Library is set by OMP_NUM_THREADS
             // dnnl_get_max_threads() == OMP_NUM_THREADS
-            arm_compute::Scheduler::get().set_num_threads(
-                    dnnl_get_max_threads());
+
+            arm_compute::IScheduler::BindFunc linear
+                    = [](int i, int max_cores) { return i % max_cores; };
+            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+                    dnnl_get_max_threads(), linear);
 
             // TODO: remove dependence on scratchpad memory
             // Using user provided memory for the biases currently segfaults

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -106,8 +106,11 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
 
             // Number of threads in Compute Library is set by OMP_NUM_THREADS
             // dnnl_get_max_threads() == OMP_NUM_THREADS
-            arm_compute::Scheduler::get().set_num_threads(
-                    dnnl_get_max_threads());
+
+            arm_compute::IScheduler::BindFunc linear
+                    = [](int i, int max_cores) { return i % max_cores; };
+            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+                    dnnl_get_max_threads(), linear);
 
             // TODO: remove dependence on scratchpad memory
             // Using user provided memory for the biases currently segfaults

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -104,8 +104,11 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
 
             // Number of threads in Compute Library is set by OMP_NUM_THREADS
             // dnnl_get_max_threads() == OMP_NUM_THREADS
-            arm_compute::Scheduler::get().set_num_threads(
-                    dnnl_get_max_threads());
+
+            arm_compute::IScheduler::BindFunc linear
+                    = [](int i, int max_cores) { return i % max_cores; };
+            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+                    dnnl_get_max_threads(), linear);
 
             // TODO: remove dependence on scratchpad memory
             // Using user provided memory for the biases currently segfaults


### PR DESCRIPTION
# Description

Adding linear thread binding implementation for Compute Library primitives in oneDNN.
It gives improved performance at high thread counts in BenchDNN ResNet50 benchmark.

# Checklist

## Code-change submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [X] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

### Bug fixes

- [N/A] Have you added relevant regression tests?
- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
