### PR TITLE
aarch64: build: update Compute Library min. version to v21.05

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -27,7 +27,7 @@ steps:
   image: ubuntu:16.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 21.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.05 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -80,7 +80,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 21.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.05 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -111,7 +111,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 21.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.05 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -18,7 +18,7 @@
 # *******************************************************************************
 
 # Compute Library build defaults
-ACL_VERSION="v21.02"
+ACL_VERSION="v21.05"
 ACL_DIR="${PWD}/ComputeLibrary"
 ACL_ARCH="arm64-v8a"
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ integration. Compute Library is an open-source library for machine learning appl
 and provides AArch64 optimized implementations of core functions. This functionality currently
 requires that Compute Library is downloaded and built separately, see
 [Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html). oneDNN is only
-compatible with Compute Library versions 21.02 or later.
+compatible with Compute Library versions 21.05 or later.
 
 > **WARNING**
 >

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -31,7 +31,7 @@ endif()
 
 find_package(ACL REQUIRED)
 
-set(ACL_MINIMUM_VERSION "21.02")
+set(ACL_MINIMUM_VERSION "21.05")
 
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -186,7 +186,7 @@ For a debug build of oneDNN it is advisable to specify a Compute Library build
 which has also been built with debug enabled.
 
 @warning
-oneDNN is only compatible with Compute Library builds v21.02 or later.
+oneDNN is only compatible with Compute Library builds v21.05 or later.
 
 #### Vendor BLAS libraries
 oneDNN can use a standard BLAS library for GEMM operations.

--- a/examples/CMakeLists.txt.in
+++ b/examples/CMakeLists.txt.in
@@ -94,10 +94,6 @@ else()
 endif()
 
 if(WIN32 AND DNNL_WITH_SYCL)
-    # Ignore warning LNK4078: multiple '__CLANG_OFFLOAD_BUNDLE__sycl-spi'
-    # sections found with different attributes
-    append(CMAKE_EXE_LINKER_FLAGS "-Xlinker /IGNORE:4078")
-
     # XXX: compiler always pulls in release C++ runtime by default, until
     # this is fixed we have to explicitly drop release C++ runtime for
     # debug build types.

--- a/examples/CMakeLists.txt.in
+++ b/examples/CMakeLists.txt.in
@@ -48,11 +48,17 @@ include_directories(${DNNLROOT}/examples)
 
 enable_testing()
 
+if(DNNL_CPU_RUNTIME MATCHES "(SYCL|DPCPP)" OR DNNL_GPU_RUNTIME MATCHES "(SYCL|DPCPP)")
+    set(DNNL_WITH_SYCL true)
+else()
+    set(DNNL_WITH_SYCL false)
+endif()
+
 if(UNIX OR MINGW)
     find_library(LIBM m)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
-    if (NOT DNNL_CPU_RUNTIME MATCHES "(SYCL|DPCPP)" AND NOT DNNL_GPU_RUNTIME MATCHES "(SYCL|DPCPP)")
+    if(NOT DNNL_WITH_SYCL)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     endif()
 

--- a/examples/CMakeLists.txt.in
+++ b/examples/CMakeLists.txt.in
@@ -97,6 +97,14 @@ if(WIN32 AND DNNL_WITH_SYCL)
     # Ignore warning LNK4078: multiple '__CLANG_OFFLOAD_BUNDLE__sycl-spi'
     # sections found with different attributes
     append(CMAKE_EXE_LINKER_FLAGS "-Xlinker /IGNORE:4078")
+
+    # XXX: compiler always pulls in release C++ runtime by default, until
+    # this is fixed we have to explicitly drop release C++ runtime for
+    # debug build types.
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" UPPERCASE_CMAKE_BUILD_TYPE)
+    if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker /NODEFAULTLIB:msvcrt")
+    endif()
 endif()
 
 # DNNL_CONFIGURATION is only used by oneAPI CMake config and ignored otherwise.

--- a/src/common/bfloat16.hpp
+++ b/src/common/bfloat16.hpp
@@ -38,7 +38,7 @@ bool DNNL_API try_cvt_float_to_bfloat16(bfloat16_t *out, const float *inp);
 #endif
 
 struct bfloat16_t {
-    uint16_t raw_bits_ = 0;
+    uint16_t raw_bits_;
     bfloat16_t() = default;
     constexpr bfloat16_t(uint16_t r, bool) : raw_bits_(r) {}
     bfloat16_t(float f) { (*this) = f; }

--- a/src/common/bfloat16.hpp
+++ b/src/common/bfloat16.hpp
@@ -38,7 +38,7 @@ bool DNNL_API try_cvt_float_to_bfloat16(bfloat16_t *out, const float *inp);
 #endif
 
 struct bfloat16_t {
-    uint16_t raw_bits_;
+    uint16_t raw_bits_ = 0;
     bfloat16_t() = default;
     constexpr bfloat16_t(uint16_t r, bool) : raw_bits_(r) {}
     bfloat16_t(float f) { (*this) = f; }

--- a/src/cpu/platform.hpp
+++ b/src/cpu/platform.hpp
@@ -97,7 +97,7 @@ dnnl_cpu_isa_hints_t get_cpu_isa_hints();
 
 bool DNNL_API prefer_ymm_requested();
 bool DNNL_API has_data_type_support(data_type_t data_type);
-float s8s8_weights_scale_factor();
+float DNNL_API s8s8_weights_scale_factor();
 
 unsigned get_per_core_cache_size(int level);
 unsigned get_num_cores();

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -495,6 +495,7 @@ struct rnn_conf_t {
     dim_t Nproj, Nproj_blocks, nproj_tail;
     dim_t LDAproj, LDBproj, LDCproj[4];
     int dhc_block_peephole, dhc_tail_peephole, dhc_blocks_peephole;
+    bool brgemm_fwd_iter_layer_fuse_possible = false;
 
     dim_t nthr;
 #if DNNL_X64

--- a/src/cpu/x64/amx_tile_configure.cpp
+++ b/src/cpu/x64/amx_tile_configure.cpp
@@ -64,14 +64,16 @@ private:
     }
 };
 
-void amx_tile_configure(const char palette[64]) {
+status_t amx_tile_configure(const char palette[64]) {
     static const jit_amx_tilecfg_t tilecfg;
     tilecfg.tile_configure(palette);
+    return status::success;
 };
 
-void amx_tile_release() {
+status_t amx_tile_release() {
     static const jit_amx_tilerelease_t tilerls;
     tilerls.tile_release();
+    return status::success;
 };
 
 } // namespace x64

--- a/src/cpu/x64/amx_tile_configure.hpp
+++ b/src/cpu/x64/amx_tile_configure.hpp
@@ -17,13 +17,15 @@
 #ifndef CPU_X64_AMX_TILE_CONFIGURE_HPP
 #define CPU_X64_AMX_TILE_CONFIGURE_HPP
 
+#include "common/type_helpers.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace x64 {
 
-void amx_tile_configure(const char palette[64]);
-void amx_tile_release();
+status_t DNNL_API amx_tile_configure(const char palette[64]);
+status_t DNNL_API amx_tile_release();
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -947,12 +947,12 @@ void jit_brgemm_kernel_base_t::store_accumulators(
                                             reg_aux_zp_c_values);
                                 }
                             }
-                            mov(reg_buf, ptr[rsp + reg_buf_offs_]);
                             add(reg_aux_D, ldb_D_offset(1));
                         } else {
                             store_accumulators_without_post_ops(
                                     adj_bd_block, 1, is_ld_tail);
                         }
+                        mov(reg_buf, ptr[rsp + reg_buf_offs_]);
                     } else {
                         tilestored(ptr[reg_aux_C + reg_stride_ld_block],
                                 Tmm(brg.get_C_tensor(bdb, idx)));

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -345,6 +345,7 @@ void jit_avx2_1x1_conv_kernel_f32::generate_reduce_loop(
                 jmp(load_init_done);
 
                 L(load_init_tail);
+                vxorps(vreg_load(i), vreg_load(i), vreg_load(i));
                 load_bytes(vreg_load(i), aux_reg_load_data,
                         get_load_offset_bwd_w(0, i),
                         load_dim_tail * sizeof(float));
@@ -420,9 +421,8 @@ void jit_avx2_1x1_conv_kernel_f32::generate_reduce_loop(
                         lea(reg_tmp,
                                 ptr[aux_reg_output_data
                                         + reg_tmp_output_stride]);
-                        store_bytes(vreg_accum(load_loop_blk, i, j), reg_tmp,
-                                get_output_offset(i, j),
-                                load_dim_tail * sizeof(float));
+                        vmovups(output_ptr(i, j),
+                                vreg_accum(load_loop_blk, i, j));
                     } else {
                         store_bytes(vreg_accum(load_loop_blk, i, j),
                                 aux_reg_output_data, get_output_offset(i, j),
@@ -466,6 +466,7 @@ void jit_avx2_1x1_conv_kernel_f32::generate_reduce_loop(
                             jmp(fma_load_done);
 
                             L(fma_load_tail);
+                            vxorps(vreg_load(i), vreg_load(i), vreg_load(i));
                             load_bytes(vreg_load(i), aux_reg_load_data,
                                     get_load_offset_bwd_w(u + 1, i),
                                     load_dim_tail * sizeof(float));

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -434,7 +434,7 @@ void jit_avx2_conv_fwd_kernel_f32::width_blk_step(
         for (int ii = 0; ii < oc_blocks; ii++)
             for (int jj = 0; jj < ur_w; jj++) {
                 Ymm reg_out = get_ymm(ur_w, ii, jj);
-                if (is_tail && ii == oc_blocks - 1)
+                if (is_tail && ii == oc_blocks - 1 && is_src_layout_nxc())
                     store_bytes(reg_out, reg_output, get_output_offset(ii, jj),
                             tail * sizeof(float));
                 else

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -750,6 +750,29 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
     const bool is_ddst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
+
+    auto maybe_zero_icpad = [&](const int g_start, const int g_end,
+                                    const int ocb_start, const int ocb_end) {
+        // write zeros to IC padded region.
+        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        if (is_ddst_layout_nxc && ic_tail != 0) {
+            for_(int g = g_start; g < g_end; ++g)
+            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
+                const int z_icb = nb_ic - 1;
+                const size_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
+                        + ic_tail * jcp.oc_block;
+                data_t *z_wei = diff_weights + off;
+                const int zero_work
+                        = (nb_ic * jcp.ic_block - jcp.ic_without_padding)
+                        * jcp.oc_block;
+                PRAGMA_OMP_SIMD()
+                for (int o = 0; o < zero_work; ++o) {
+                    z_wei[o] = 0;
+                }
+            }
+        }
+    };
+
     auto ker = [&](const int ithr, const int nthr) {
         assert(nthr == jcp.nthr);
         const bool ready_for_async
@@ -928,6 +951,10 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                     }
                 }
             }
+        }
+
+        if (ic_b_end >= jcp.nb_bcast) {
+            maybe_zero_icpad(g_start, g_end, oc_b_start, oc_b_end);
         }
 
         /* diff_weights[:] += sum(wei_reduction[thr_mb][:]) */

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -284,12 +284,12 @@ void _jit_avx512_common_conv_fwd_kernel<Vmm>::store_output(int ur_w) {
     }
 
     L(store_label);
-
+    const bool dst_layout_nxc = is_dst_layout_nxc();
     for (int k = 0; k < jcp.nb_oc_blocking; k++)
         for (int j = 0; j < ur_w; j++) {
             Vmm vmm = vmm_out(j, k);
             // mask only needed for last oc_block
-            if (oc_tail && k + 1 == jcp.nb_oc_blocking)
+            if (oc_tail && k + 1 == jcp.nb_oc_blocking && dst_layout_nxc)
                 vmm = vmm | k_oc_tail_mask;
             size_t aux_output_offset = get_output_offset(j, k);
 

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -1958,8 +1958,8 @@ void _jit_avx512_common_conv_bwd_data_kernel_f32<Vmm>::prepare_output(
 template <typename Vmm>
 void _jit_avx512_common_conv_bwd_data_kernel_f32<Vmm>::store_output(int ur_w) {
     Label no_update_label;
-    const int ic_tail = jcp.ic_tail;
-
+    const int ic_tail = jcp.ic_without_padding % jcp.simd_w;
+    const bool dsrc_layout_nxc = is_dsrc_layout_nxc();
     mov(reg_channel, ptr[param + GET_OFF(channel)]);
     cmp(reg_channel, 0);
     je(no_update_label, T_NEAR);
@@ -1978,7 +1978,7 @@ void _jit_avx512_common_conv_bwd_data_kernel_f32<Vmm>::store_output(int ur_w) {
         for (int j = 0; j < ur_w; j++) {
             Vmm vmm = vmm_out(j, k);
             // mask only needed for last oc_block
-            if (ic_tail && k + 1 == jcp.nb_ic_blocking)
+            if (ic_tail && k + 1 == jcp.nb_ic_blocking && dsrc_layout_nxc)
                 vmm = vmm | k_ic_tail_mask;
             size_t aux_src_offset = get_diff_src_offset(j, k);
             vmovups(EVEX_compress_addr_safe(

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -162,7 +162,7 @@ int ip_fwd_get_adjusted_oc_block(const jit_brgemm_primitive_conf_t &jbgp) {
 
     int oc_block = get_oc_block(jbgp, true);
     if (ip_fwd_adjust_thread_balance(jbgp)) {
-        return (jbgp.oc > 16) ? oc_block / 2 : oc_block;
+        return (oc_block > 16) ? oc_block / 2 : oc_block;
     } else {
         return oc_block;
     }

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -556,7 +556,8 @@ struct jit_softmax_t<avx2> : public jit_softmax_base_t<avx2> {
 
                     if (axis_is_blocked_) {
                         uni_vxorps(vzeropad, vzeropad, vzeropad);
-                        vpblendvb(vzeropad, vzeropad, vreg_tmp_src, tail_vmask);
+                        uni_vblendvps(
+                                vzeropad, vzeropad, vreg_tmp_src, tail_vmask);
                         uni_vmovups(dst_ptr(axis_stride_ * i), vzeropad);
                     } else {
                         uni_vmovups_tail(dst_ptr(axis_stride_ * i), tail_vmask,

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
@@ -45,6 +45,7 @@ public:
 
 private:
     void kernel(const int ithr, const int nthr) const;
+    void kernel_fused_iter_layer(const int ithr, const int nthr) const;
 
     const ref_rnn_brgemm_t &rnn_brgemm_;
     const rnn_utils::rnn_conf_t &rnn_;
@@ -96,6 +97,7 @@ private:
     gemm_acc_t *const amx_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
     const postgemm_fused_t fused_postgemm_;
+    const bool is_fused_layer_iter_brgemm_;
 };
 
 template <typename src_t, typename weights_t, typename gemm_acc_t>

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -73,7 +73,7 @@ std::tuple<dim_t, dim_t, x64::cpu_isa_t> brgemm_calc_k_block_with_isa(dim_t K1,
         const auto k2_block_tail = K2 % k2_block_amx;
         const bool amx_block_invalid = k1_block_tail % padding
                 || k2_block_tail % padding || k1_block_amx % padding
-                || k2_block_amx % padding || k1_block != k2_block;
+                || k2_block_amx % padding;
 
         if (!amx_block_invalid) {
             k1_block = k1_block_amx;

--- a/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -281,7 +281,7 @@ void jit_uni_shuffle_kernel_t<avx>::store_data(const int data_idx,
 
         if (extend_for_padding) {
             uni_vxorps(xmm_tmp, xmm_tmp, xmm_tmp);
-            vpblendvb(xmm_tmp, xmm_tmp, to_store_data, vmm_tail_mask_);
+            uni_vblendvps(xmm_tmp, xmm_tmp, to_store_data, vmm_tail_mask_);
             vmovups(ptr[reg_dst_addr + offset], xmm_tmp);
         } else {
             if (is_tail)
@@ -294,7 +294,7 @@ void jit_uni_shuffle_kernel_t<avx>::store_data(const int data_idx,
     } else {
         if (extend_for_padding) {
             uni_vxorps(vmm_tmp_, vmm_tmp_, vmm_tmp_);
-            vpblendvb(vmm_tmp_, vmm_tmp_, Vmm(data_idx), vmm_tail_mask_);
+            uni_vblendvps(vmm_tmp_, vmm_tmp_, Vmm(data_idx), vmm_tail_mask_);
             vmovups(ptr[reg_dst_addr + offset], vmm_tmp_);
         } else {
             if (is_tail)

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -779,3 +779,11 @@ stream_t::stream_t(dnnl_engine_t engine) {
 stream_t::~stream_t() {
     DNN_SAFE_V(dnnl_stream_destroy(stream_));
 }
+
+float reorder_rescale_factor() {
+    float factor = 1.f;
+#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
+    factor = dnnl::impl::cpu::platform::s8s8_weights_scale_factor();
+#endif
+    return factor;
+}

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -458,4 +458,6 @@ int check_mem_size(const_dnnl_primitive_desc_t const_pd);
 
 sycl_memory_kind_ext_t str2sycl_memory_kind(const char *str);
 
+float reorder_rescale_factor();
+
 #endif

--- a/tests/benchdnn/inputs/conv/set_perf_gpu_large_mb
+++ b/tests/benchdnn/inputs/conv/set_perf_gpu_large_mb
@@ -13,6 +13,6 @@
 --batch=shapes_unet
 --batch=shapes_vgg_19
 --batch=shapes_yolov2
---batch=shapes_3d_resnext101
+#--batch=shapes_3d_resnext101
 --batch=shapes_pointnet
 --batch=shapes_ffn

--- a/tests/benchdnn/inputs/ip/shapes_regression
+++ b/tests/benchdnn/inputs/ip/shapes_regression
@@ -1,0 +1,1 @@
+mb1_ic16oc26_n"small_oc_block"

--- a/tests/benchdnn/inputs/ip/test_ip_bfloat16
+++ b/tests/benchdnn/inputs/ip/test_ip_bfloat16
@@ -2,11 +2,11 @@
 
 --dir=FWD_B
 --cfg=bf16bf16bf16,bf16bf16f32
---batch=set_all --batch=shapes_0d
+--batch=set_all --batch=shapes_0d --batch=shapes_regression
 
 --dir=BWD_D
 --cfg=bf16bf16bf16,f32bf16bf16
---batch=set_all --batch=shapes_0d
+--batch=set_all --batch=shapes_0d --batch=shapes_regression
 
 --dir=BWD_WB
 --cfg=bf16bf16bf16,bf16f32bf16

--- a/tests/benchdnn/inputs/reorder/harness_reorder_compensation
+++ b/tests/benchdnn/inputs/reorder/harness_reorder_compensation
@@ -4,6 +4,7 @@
 --ddt=s8
 
 # Non-grouped cases
+--attr-oscale=,common:2
 --oflag=,s8s8_comp:1,zp_comp:1,s8s8_comp:1+zp_comp:1
 --stag=abx,xba
 --dtag=xba,ABx2b8a4b,ABx4a4b,ABx4b16a4b,ABx4b32a4b,ABx4b64a4b
@@ -15,6 +16,7 @@
 80x24
 
 # Following tags have no s8s8 compensation support.
+--attr-oscale=
 --oflag=,zp_comp:1
 ## Special case: no general 3D-spatial support
 --dtag=AxB16a4b,ABx16b16a4b
@@ -25,6 +27,7 @@
 --dtag=Adcb16a 32x32x3x3
 
 # Grouped cases
+--attr-oscale=,common:2
 --oflag=,s8s8_comp:3,zp_comp:3,s8s8_comp:3+zp_comp:3
 --stag=abx,xcab
 --dtag=xcab        2x32x32x3 2x32x32x3x3 16x32x32x3x3x3
@@ -35,6 +38,7 @@
 --dtag=Abcx16a,Abcx8a,Abcx4a 64x1x1x3 512x1x1x3x3
 
 # Following tags have no s8s8 compensation support.
+--attr-oscale=
 --oflag=,zp_comp:3
 ## Special case: no general 3D support for AMX and depthwise
 --dtag=aBxC16b4c,aBCx16c16b4c 2x32x32x3 2x32x32x3x3

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -112,6 +112,13 @@ int fill_memory_extra(const prb_t *prb, dnnl_memory_extra_desc_t &extra) {
             if (i_oflag.first & FLAG_S8S8_COMP) {
                 extra.flags |= dnnl_memory_extra_flag_compensation_conv_s8s8;
                 extra.compensation_mask = i_oflag.second;
+
+                const float s8_scale_factor = reorder_rescale_factor();
+                const bool need_rescale = s8_scale_factor != 1.f;
+                if (need_rescale) {
+                    extra.flags |= dnnl_memory_extra_flag_scale_adjust;
+                    extra.scale_adjust = s8_scale_factor;
+                }
             }
             if (i_oflag.first & FLAG_ZP_COMP) {
                 extra.flags
@@ -186,7 +193,7 @@ static int init_pd(dnnl_engine_t engine, const prb_t *prb,
                  rc.tag_out),
             CRIT);
 
-    // assign extra for dst_md
+    // Prepare and assign extra for dst_md.
     dnnl_memory_extra_desc_t dst_md_extra {};
     fill_memory_extra(prb, dst_md_extra);
     dst_d.extra = dst_md_extra;
@@ -247,9 +254,15 @@ void check_known_skipped_case(const prb_t *prb, res_t *res) {
 
     if (prb->is_reorder_with_compensation()) {
         // compensation is supported for dst_dt = s8 so far
-        // compensation does not support any attributes or runtime dims
-        if (ddt != dnnl_s8 || !prb->attr.is_def()
-                || prb->runtime_dim_mask != 0) {
+        const bool dt_ok = ddt == dnnl_s8;
+        // compensation does not support any attributes but oscale
+        const bool attr_ok = prb->attr.scales.is_def()
+                && prb->attr.zero_points.is_def() && prb->attr.post_ops.is_def()
+                && prb->attr.oscale.runtime == false;
+        // compensation does not support runtime dims
+        const bool rt_ok = prb->runtime_dim_mask == 0;
+
+        if (!dt_ok || !attr_ok || !rt_ok) {
             res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
             return;
         }
@@ -414,7 +427,11 @@ int doit(const prb_t *prb, res_t *res) {
             dnn_mem_t ref_dst_dt_out_fmt_out(dst_md, dst_engine);
             ref_dst_dt_out_fmt_out.md_.extra = dst_extra;
 
-            SAFE(ref_dst_dt_out_fmt_out.reorder(src_dt_in_fmt_ref), WARN);
+            const_dnnl_primitive_attr_t const_attr;
+            DNN_SAFE(dnnl_primitive_desc_get_attr(const_pd, &const_attr), WARN);
+
+            SAFE(ref_dst_dt_out_fmt_out.reorder(src_dt_in_fmt_ref, const_attr),
+                    WARN);
 
             /* Step 5b: compare results (expect bit-wise exactness) */
             SAFE(compare_bootstrap(

--- a/tests/gtests/api/test_engine.cpp
+++ b/tests/gtests/api/test_engine.cpp
@@ -29,14 +29,6 @@ protected:
     engine::kind eng_kind;
 };
 
-// FIXME: When Clang uses `thread` header from GNU 11.1.0 it causes
-// crash due to a compatibility problem (presumably because of a bug) between
-// Clang and GNU 11.1.0. This makes public CI red. Disable this test case for
-// Clang compiler until GNU 11 becomes stable.
-//
-// See https://github.com/actions/virtual-environments/issues/3454 for more
-// details. The request is to not install unstable GNU version by default.
-#ifndef __clang__
 HANDLE_EXCEPTIONS_FOR_TEST_P(engine_test_t, TestMultithreading) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_NONE
     if (eng_kind == engine::kind::cpu) {
@@ -80,7 +72,6 @@ HANDLE_EXCEPTIONS_FOR_TEST_P(engine_test_t, TestMultithreading) {
 
     exe.join();
 }
-#endif
 
 INSTANTIATE_TEST_SUITE_P(AllEngineKinds, engine_test_t,
         ::testing::Values(engine::kind::cpu, engine::kind::gpu));

--- a/tests/gtests/test_brgemm.cpp
+++ b/tests/gtests/test_brgemm.cpp
@@ -14,11 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "gtest-param-test.h"
-#include "gtest.h"
 #include "test_gemm_data_preparation.hpp"
 #include "test_gemm_params.hpp"
 #include "test_gemm_validation.hpp"
+#include "gtest/gtest.h"
 
 #include "dnnl_test_common.hpp"
 
@@ -117,7 +116,7 @@ private:
     std::vector<brgemm_params_t> params;
 };
 
-class brgemm_test_t : public testing::TestWithParam<brgemm_params_t> {
+class brgemm_test_t : public ::testing::TestWithParam<brgemm_params_t> {
 protected:
     void SetUp() override {
         const auto &p = GetParam();

--- a/tests/gtests/test_brgemm.cpp
+++ b/tests/gtests/test_brgemm.cpp
@@ -183,6 +183,7 @@ private:
 
         //initialize brgemm kernel
         char palette[64];
+        char tile_buffer[1024];
         x64::brgemm_t desc;
         auto res = brgemm_desc_init(&desc, x64::cpu_isa_t::isa_any,
                 p.batch_kind, p.dt_a, p.dt_b, p.tr_a(), p.tr_b(), p.layout,
@@ -203,7 +204,8 @@ private:
         batch_element.vvpad.top = 0;
         batch_element.vvpad.bottom = 0;
         if (desc.is_amx) amx_tile_configure(palette);
-        brgemm_kernel_execute(_t_ptr, p.bs, &batch_element, C, nullptr);
+        brgemm_kernel_execute(_t_ptr, p.bs, &batch_element, C,
+                desc.is_amx ? tile_buffer : nullptr);
 
         brgemm_kernel_destroy(_t_ptr);
         if (desc.is_amx) amx_tile_release();

--- a/tests/gtests/test_brgemm.cpp
+++ b/tests/gtests/test_brgemm.cpp
@@ -23,6 +23,7 @@
 
 #include "dnnl.hpp"
 
+#include "cpu/x64/amx_tile_configure.hpp"
 #include "cpu/x64/brgemm/brgemm.hpp"
 
 namespace dnnl {
@@ -174,6 +175,7 @@ private:
     template <typename a_dt, typename b_dt, typename c_dt>
     dnnl_status_t run_brgemm(const brgemm_params_t &p) {
         using namespace dnnl::impl::cpu;
+        using namespace impl::cpu::x64;
 
         mapped_ptr_t<a_dt> A = map_memory<a_dt>(*gemm_data_.a_mem);
         mapped_ptr_t<b_dt> B = get_B_mem<b_dt>(p);
@@ -200,9 +202,11 @@ private:
         batch_element.ptr.B = B;
         batch_element.vvpad.top = 0;
         batch_element.vvpad.bottom = 0;
+        if (desc.is_amx) amx_tile_configure(palette);
         brgemm_kernel_execute(_t_ptr, p.bs, &batch_element, C, nullptr);
 
         brgemm_kernel_destroy(_t_ptr);
+        if (desc.is_amx) amx_tile_release();
 
         return res;
     }

--- a/tests/gtests/test_gemm_params.hpp
+++ b/tests/gtests/test_gemm_params.hpp
@@ -18,6 +18,7 @@
 #define TEST_GEMM_DATA_H
 
 #include <cstdint>
+#include <utility>
 #include <type_traits>
 
 #include "oneapi/dnnl/dnnl_types.h"


### PR DESCRIPTION
Description

Updates minimum Compute Library version for builds on AArch64 with the
Compute Library backend. Updates from 21.02 to 21.05

DroneCI build updated
Docs updated
CMake updated
Checklist

Note: master PR = #1081

Code-change submissions

 Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally?
[N/A] Have you formatted the code using clang-format?
New features

[N/A] Have you added relevant tests?
[N/A] Have you provided motivation for adding a new feature?
Bug fixes

[N/A] Have you added relevant regression tests?
[N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?