### PR TITLE
src: cpu: aarch64: fix gcc-11 compile error

### DIFF
--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
@@ -28,6 +28,7 @@
 #include <deque>
 #include <initializer_list>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <type_traits>
 #include <unordered_map>


### PR DESCRIPTION
# Description

This PR fixes gcc-11 compile error for AArch64 (#1085).

