### PR TITLE
fix a compile error with gcc 11

### DIFF
--- a/src/common/primitive_cache.cpp
+++ b/src/common/primitive_cache.cpp
@@ -209,7 +209,7 @@ void lru_primitive_cache_t::update_entry(
     //    by another thread
     // 2. After the requested entry had been evicted it was inserted again
     //    by another thread
-    if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
+    if (it == cache_mapper_.end() || !(it->first.thread_id() == key.thread_id()))
         return;
 
     const auto *op_desc = pd->op_desc();

--- a/src/common/primitive_cache.cpp
+++ b/src/common/primitive_cache.cpp
@@ -16,14 +16,34 @@
 
 #include "primitive_cache.hpp"
 #include "c_types_map.hpp"
+#include "primitive.hpp"
 #include "primitive_desc.hpp"
 #include "rw_mutex.hpp"
+#include "z_magic.hpp"
 
-#include <list>
+#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
+#include "cpu/platform.hpp"
+#else
+#include <chrono>
+#endif
+
+#include <algorithm>
 #include <unordered_map>
 
 namespace dnnl {
 namespace impl {
+
+namespace {
+
+size_t get_timestamp() {
+#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
+  return cpu::platform::get_timestamp();
+#else
+  return std::chrono::steady_clock::now().time_since_epoch().count();
+#endif
+}
+
+} // namespace
 
 primitive_cache_t &primitive_cache() {
 #ifndef DNNL_DISABLE_PRIMITIVE_CACHE
@@ -46,13 +66,24 @@ status_t get_primitive_cache_size(int *size) {
   return dnnl::impl::status::success;
 }
 
+bool is_pd_in_cache(const primitive_desc_iface_t *pd_iface) {
+  const auto *pd = pd_iface->impl().get();
+  const auto *engine = pd_iface->engine();
+  primitive_hashing::key_t key(pd, engine);
+  return bool(primitive_cache().get_pd(key));
+}
+
+bool is_primitive_in_cache(const primitive_iface_t *p_iface) {
+  return is_pd_in_cache(p_iface->pd());
+}
+
 status_t lru_primitive_cache_t::set_capacity(int capacity) {
   utils::lock_write_t lock_w(rw_mutex());
   capacity_ = (size_t)capacity;
   // Check if number of entries exceeds the new capacity
-  if (cache_list_.size() > capacity_) {
+  if (cache_mapper_.size() > capacity_) {
     // Evict excess entries
-    size_t n_excess_entries = cache_list_.size() - capacity_;
+    size_t n_excess_entries = cache_mapper_.size() - capacity_;
     evict(n_excess_entries);
   }
   return status::success;
@@ -66,31 +97,44 @@ int lru_primitive_cache_t::get_capacity() const {
 // For undocumented API
 int lru_primitive_cache_t::get_size() const {
   utils::lock_read_t lock_r(rw_mutex());
-  return (int)cache_list_.size();
+  return (int)cache_mapper_.size();
 }
 
 lru_primitive_cache_t::value_t
 lru_primitive_cache_t::get_or_add(const key_t &key, const value_t &value) {
-  // Cache is disabled
+  // 1. Section with shared access (read lock)
   lock_read();
+  // Check if the cache is enabled.
   if (capacity_ == 0) {
     unlock_read();
     return value_t();
   }
+  // Check if the requested entry is present in the cache (likely cache_hit)
+  auto e = get(key);
+  if (e.valid()) {
+    unlock_read();
+    return e;
+  }
 
   unlock_read();
-  lock_write();
 
+  // 2. Section with exclusive access (write lock).
+  // In a multithreaded scenario, in the context of one thread the cache
+  // may have changed by another thread between releasing the read lock and
+  // acquiring the write lock (a.k.a. ABA problem), therefore additional
+  // checks have to be performed for correctness.
   // Double check the capacity due to possible race condition
+  lock_write();
   if (capacity_ == 0) {
     unlock_write();
     return value_t();
   }
 
-  // Check if the requested entry is present in the cache
-  auto e = get(key);
+  // Double check if the requested entry is present in the cache (unlikely
+  // cache_hit).
+  e = get(key);
   if (!e.valid()) {
-    // If the entry is missing in the cache then add it
+    // If the entry is missing in the cache then add it (cache_miss)
     add(key, value);
   }
   unlock_write();
@@ -104,21 +148,36 @@ void lru_primitive_cache_t::add(const key_t &key, const value_t &value) {
     // Evict the least recently used entry
     evict(1);
   }
-  // Place a new entry to cache_list_ and update cache_mapper_
-  cache_list_.emplace_front(key, value);
-  cache_mapper_.insert(std::make_pair(key, cache_list_.begin()));
-  assert(cache_list_.size() == cache_mapper_.size());
+
+  size_t timestamp = get_timestamp();
+
+  auto res = cache_mapper_.emplace(std::piecewise_construct,
+                                   std::forward_as_tuple(key),
+                                   std::forward_as_tuple(value, timestamp));
+  MAYBE_UNUSED(res);
+  assert(res.second);
 }
 
 lru_primitive_cache_t::value_t lru_primitive_cache_t::get(const key_t &key) {
   auto it = cache_mapper_.find(key);
-  if (it == cache_mapper_.end()) {
+  if (it == cache_mapper_.end())
     return value_t();
-  }
 
-  // Move 1 cache_list_ node to the front of the cache_list_
-  cache_list_.splice(cache_list_.begin(), cache_list_, it->second);
-  return cache_list_.front().second;
+  size_t timestamp = get_timestamp();
+  it->second.timestamp_.store(timestamp);
+  // Return the entry
+  return it->second.value_;
+}
+
+std::shared_ptr<primitive_desc_t>
+lru_primitive_cache_t::get_pd(const key_t &key) {
+  lock_read();
+  auto e = get(key);
+  unlock_read();
+
+  if (e.valid())
+    return e.get().primitive->pd();
+  return nullptr;
 }
 
 void lru_primitive_cache_t::remove_if_invalidated(const key_t &key) {
@@ -130,7 +189,7 @@ void lru_primitive_cache_t::remove_if_invalidated(const key_t &key) {
     return;
   }
 
-  const auto &value = it->second->second;
+  const auto &value = it->second.value_;
   if (value.get().primitive) {
     // If the entry is not invalidated
     unlock_write();
@@ -138,9 +197,7 @@ void lru_primitive_cache_t::remove_if_invalidated(const key_t &key) {
   }
 
   // Remove the invalidated entry
-  cache_list_.erase(it->second);
   cache_mapper_.erase(it);
-  assert(cache_list_.size() == cache_mapper_.size());
   unlock_write();
 }
 
@@ -163,17 +220,38 @@ void lru_primitive_cache_t::update_entry(const key_t &key,
   // Update key in cache_mapper_
   it->first.op_desc_ = op_desc;
   it->first.attr_ = attr;
-
-  // Update key in cache_list_
-  it->second->first.op_desc_ = op_desc;
-  it->second->first.attr_ = attr;
 }
 
 // Evicts n the least recently used entries
 void lru_primitive_cache_t::evict(size_t n) {
+  if (n == capacity_) {
+    cache_mapper_.clear();
+    return;
+  }
+
   for (size_t e = 0; e < n; e++) {
-    cache_mapper_.erase(cache_list_.back().first);
-    cache_list_.pop_back();
+    // Find the smallest timestamp
+    // TODO: revisit the eviction algorithm due to O(n) complexity, E.g.
+    // maybe evict multiple entries at once.
+    auto it = std::min_element(
+        cache_mapper_.begin(), cache_mapper_.end(),
+        [&](const decltype(cache_mapper_)::value_type &left,
+            const decltype(cache_mapper_)::value_type &right) {
+          // By default, load() and operator T use sequentially
+          // consistent memory ordering, which enforces writing the
+          // timestamps into registers in the same exact order they
+          // are read from the CPU cache line. Since eviction is
+          // performed under a write lock, this order is not
+          // important, therefore we can safely use the weakest memory
+          // ordering (relaxed). This brings about a few microseconds
+          // performance improvement for default primitive cache
+          // capacity.
+          return left.second.timestamp_.load(std::memory_order_relaxed) <
+                 right.second.timestamp_.load(std::memory_order_relaxed);
+        });
+    auto res = cache_mapper_.erase(it->first);
+    MAYBE_UNUSED(res);
+    assert(res);
   }
 }
 

--- a/src/common/primitive_cache.cpp
+++ b/src/common/primitive_cache.cpp
@@ -1,257 +1,180 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+ * Copyright 2020-2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 
 #include "primitive_cache.hpp"
 #include "c_types_map.hpp"
-#include "primitive.hpp"
 #include "primitive_desc.hpp"
 #include "rw_mutex.hpp"
-#include "z_magic.hpp"
 
-#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
-#include "cpu/platform.hpp"
-#else
-#include <chrono>
-#endif
-
-#include <algorithm>
+#include <list>
 #include <unordered_map>
 
 namespace dnnl {
 namespace impl {
 
-namespace {
-
-size_t get_timestamp() {
-#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
-    return cpu::platform::get_timestamp();
-#else
-    return std::chrono::steady_clock::now().time_since_epoch().count();
-#endif
-}
-
-} // namespace
-
 primitive_cache_t &primitive_cache() {
 #ifndef DNNL_DISABLE_PRIMITIVE_CACHE
-    static const int capacity
-            = getenv_int("DNNL_PRIMITIVE_CACHE_CAPACITY", 1024);
+  static const int capacity = getenv_int("DNNL_PRIMITIVE_CACHE_CAPACITY", 1024);
 #else
-    static const int capacity = 0;
+  static const int capacity = 0;
 #endif
-    static lru_primitive_cache_t cache(capacity);
-    return cache;
+  static lru_primitive_cache_t cache(capacity);
+  return cache;
 }
 
 // Undocumented API, for testing only
 status_t get_primitive_cache_size(int *size) {
-    if (size == nullptr) return dnnl::impl::status::invalid_arguments;
-    *size = 0;
+  if (size == nullptr)
+    return dnnl::impl::status::invalid_arguments;
+  *size = 0;
 #ifndef DNNL_DISABLE_PRIMITIVE_CACHE
-    *size = primitive_cache().get_size();
+  *size = primitive_cache().get_size();
 #endif
-    return dnnl::impl::status::success;
-}
-
-bool is_pd_in_cache(const primitive_desc_iface_t *pd_iface) {
-    const auto *pd = pd_iface->impl().get();
-    const auto *engine = pd_iface->engine();
-    primitive_hashing::key_t key(pd, engine);
-    return bool(primitive_cache().get_pd(key));
-}
-
-bool is_primitive_in_cache(const primitive_iface_t *p_iface) {
-    return is_pd_in_cache(p_iface->pd());
+  return dnnl::impl::status::success;
 }
 
 status_t lru_primitive_cache_t::set_capacity(int capacity) {
-    utils::lock_write_t lock_w(rw_mutex());
-    capacity_ = (size_t)capacity;
-    // Check if number of entries exceeds the new capacity
-    if (cache_mapper_.size() > capacity_) {
-        // Evict excess entries
-        size_t n_excess_entries = cache_mapper_.size() - capacity_;
-        evict(n_excess_entries);
-    }
-    return status::success;
+  utils::lock_write_t lock_w(rw_mutex());
+  capacity_ = (size_t)capacity;
+  // Check if number of entries exceeds the new capacity
+  if (cache_list_.size() > capacity_) {
+    // Evict excess entries
+    size_t n_excess_entries = cache_list_.size() - capacity_;
+    evict(n_excess_entries);
+  }
+  return status::success;
 }
 
 int lru_primitive_cache_t::get_capacity() const {
-    utils::lock_read_t lock_r(rw_mutex());
-    return (int)capacity_;
+  utils::lock_read_t lock_r(rw_mutex());
+  return (int)capacity_;
 }
 
 // For undocumented API
 int lru_primitive_cache_t::get_size() const {
-    utils::lock_read_t lock_r(rw_mutex());
-    return (int)cache_mapper_.size();
+  utils::lock_read_t lock_r(rw_mutex());
+  return (int)cache_list_.size();
 }
 
-lru_primitive_cache_t::value_t lru_primitive_cache_t::get_or_add(
-        const key_t &key, const value_t &value) {
-    // 1. Section with shared access (read lock)
-    lock_read();
-    // Check if the cache is enabled.
-    if (capacity_ == 0) {
-        unlock_read();
-        return value_t();
-    }
-    // Check if the requested entry is present in the cache (likely cache_hit)
-    auto e = get(key);
-    if (e.valid()) {
-        unlock_read();
-        return e;
-    }
-
+lru_primitive_cache_t::value_t
+lru_primitive_cache_t::get_or_add(const key_t &key, const value_t &value) {
+  // Cache is disabled
+  lock_read();
+  if (capacity_ == 0) {
     unlock_read();
+    return value_t();
+  }
 
-    // 2. Section with exclusive access (write lock).
-    // In a multithreaded scenario, in the context of one thread the cache
-    // may have changed by another thread between releasing the read lock and
-    // acquiring the write lock (a.k.a. ABA problem), therefore additional
-    // checks have to be performed for correctness.
-    // Double check the capacity due to possible race condition
-    lock_write();
-    if (capacity_ == 0) {
-        unlock_write();
-        return value_t();
-    }
+  unlock_read();
+  lock_write();
 
-    // Double check if the requested entry is present in the cache (unlikely
-    // cache_hit).
-    e = get(key);
-    if (!e.valid()) {
-        // If the entry is missing in the cache then add it (cache_miss)
-        add(key, value);
-    }
+  // Double check the capacity due to possible race condition
+  if (capacity_ == 0) {
     unlock_write();
-    return e;
+    return value_t();
+  }
+
+  // Check if the requested entry is present in the cache
+  auto e = get(key);
+  if (!e.valid()) {
+    // If the entry is missing in the cache then add it
+    add(key, value);
+  }
+  unlock_write();
+  return e;
 }
 
 void lru_primitive_cache_t::add(const key_t &key, const value_t &value) {
-    // std::list::size() method has linear complexity. Check the primitive cache
-    // size using std::unordered_map::size();
-    if (cache_mapper_.size() == capacity_) {
-        // Evict the least recently used entry
-        evict(1);
-    }
-
-    size_t timestamp = get_timestamp();
-
-    auto res = cache_mapper_.emplace(std::piecewise_construct,
-            std::forward_as_tuple(key),
-            std::forward_as_tuple(value, timestamp));
-    MAYBE_UNUSED(res);
-    assert(res.second);
+  // std::list::size() method has linear complexity. Check the primitive cache
+  // size using std::unordered_map::size();
+  if (cache_mapper_.size() == capacity_) {
+    // Evict the least recently used entry
+    evict(1);
+  }
+  // Place a new entry to cache_list_ and update cache_mapper_
+  cache_list_.emplace_front(key, value);
+  cache_mapper_.insert(std::make_pair(key, cache_list_.begin()));
+  assert(cache_list_.size() == cache_mapper_.size());
 }
 
 lru_primitive_cache_t::value_t lru_primitive_cache_t::get(const key_t &key) {
-    auto it = cache_mapper_.find(key);
-    if (it == cache_mapper_.end()) return value_t();
+  auto it = cache_mapper_.find(key);
+  if (it == cache_mapper_.end()) {
+    return value_t();
+  }
 
-    size_t timestamp = get_timestamp();
-    it->second.timestamp_.store(timestamp);
-    // Return the entry
-    return it->second.value_;
-}
-
-std::shared_ptr<primitive_desc_t> lru_primitive_cache_t::get_pd(
-        const key_t &key) {
-    lock_read();
-    auto e = get(key);
-    unlock_read();
-
-    if (e.valid()) return e.get().primitive->pd();
-    return nullptr;
+  // Move 1 cache_list_ node to the front of the cache_list_
+  cache_list_.splice(cache_list_.begin(), cache_list_, it->second);
+  return cache_list_.front().second;
 }
 
 void lru_primitive_cache_t::remove_if_invalidated(const key_t &key) {
-    lock_write();
-    auto it = cache_mapper_.find(key);
-    if (it == cache_mapper_.end()) {
-        // The entry has been already evicted at this point
-        unlock_write();
-        return;
-    }
-
-    const auto &value = it->second.value_;
-    if (value.get().primitive) {
-        // If the entry is not invalidated
-        unlock_write();
-        return;
-    }
-
-    // Remove the invalidated entry
-    cache_mapper_.erase(it);
+  lock_write();
+  auto it = cache_mapper_.find(key);
+  if (it == cache_mapper_.end()) {
+    // The entry has been already evicted at this point
     unlock_write();
+    return;
+  }
+
+  const auto &value = it->second->second;
+  if (value.get().primitive) {
+    // If the entry is not invalidated
+    unlock_write();
+    return;
+  }
+
+  // Remove the invalidated entry
+  cache_list_.erase(it->second);
+  cache_mapper_.erase(it);
+  assert(cache_list_.size() == cache_mapper_.size());
+  unlock_write();
 }
 
-void lru_primitive_cache_t::update_entry(
-        const key_t &key, const primitive_desc_t *pd) {
-    utils::lock_write_t lock_w(rw_mutex());
-    auto it = cache_mapper_.find(key);
+void lru_primitive_cache_t::update_entry(const key_t &key,
+                                         const primitive_desc_t *pd) {
+  utils::lock_write_t lock_w(rw_mutex());
+  auto it = cache_mapper_.find(key);
 
-    // There is nothing to do in two cases:
-    // 1. The requested entry is not in the cache because it has been evicted
-    //    by another thread
-    // 2. After the requested entry had been evicted it was inserted again
-    //    by another thread
-    if (it == cache_mapper_.end() || !(it->first.thread_id() == key.thread_id()))
-        return;
+  // There is nothing to do in two cases:
+  // 1. The requested entry is not in the cache because it has been evicted
+  //    by another thread
+  // 2. After the requested entry had been evicted it was inserted again
+  //    by another thread
+  if (it == cache_mapper_.end() || !(it->first.thread_id() == key.thread_id()))
+    return;
 
-    const auto *op_desc = pd->op_desc();
-    const auto *attr = pd->attr();
+  const auto *op_desc = pd->op_desc();
+  const auto *attr = pd->attr();
 
-    // Update key in cache_mapper_
-    it->first.op_desc_ = op_desc;
-    it->first.attr_ = attr;
+  // Update key in cache_mapper_
+  it->first.op_desc_ = op_desc;
+  it->first.attr_ = attr;
+
+  // Update key in cache_list_
+  it->second->first.op_desc_ = op_desc;
+  it->second->first.attr_ = attr;
 }
 
 // Evicts n the least recently used entries
 void lru_primitive_cache_t::evict(size_t n) {
-    if (n == capacity_) {
-        cache_mapper_.clear();
-        return;
-    }
-
-    for (size_t e = 0; e < n; e++) {
-        // Find the smallest timestamp
-        // TODO: revisit the eviction algorithm due to O(n) complexity, E.g.
-        // maybe evict multiple entries at once.
-        auto it = std::min_element(cache_mapper_.begin(), cache_mapper_.end(),
-                [&](const decltype(cache_mapper_)::value_type &left,
-                        const decltype(cache_mapper_)::value_type &right) {
-                    // By default, load() and operator T use sequentially
-                    // consistent memory ordering, which enforces writing the
-                    // timestamps into registers in the same exact order they
-                    // are read from the CPU cache line. Since eviction is
-                    // performed under a write lock, this order is not
-                    // important, therefore we can safely use the weakest memory
-                    // ordering (relaxed). This brings about a few microseconds
-                    // performance improvement for default primitive cache
-                    // capacity.
-                    return left.second.timestamp_.load(
-                                   std::memory_order_relaxed)
-                            < right.second.timestamp_.load(
-                                    std::memory_order_relaxed);
-                });
-        auto res = cache_mapper_.erase(it->first);
-        MAYBE_UNUSED(res);
-        assert(res);
-    }
+  for (size_t e = 0; e < n; e++) {
+    cache_mapper_.erase(cache_list_.back().first);
+    cache_list_.pop_back();
+  }
 }
 
 } // namespace impl
@@ -259,18 +182,20 @@ void lru_primitive_cache_t::evict(size_t n) {
 
 // API
 dnnl::impl::status_t dnnl_get_primitive_cache_capacity(int *capacity) {
-    if (capacity == nullptr) return dnnl::impl::status::invalid_arguments;
-    *capacity = 0;
+  if (capacity == nullptr)
+    return dnnl::impl::status::invalid_arguments;
+  *capacity = 0;
 #ifndef DNNL_DISABLE_PRIMITIVE_CACHE
-    *capacity = dnnl::impl::primitive_cache().get_capacity();
+  *capacity = dnnl::impl::primitive_cache().get_capacity();
 #endif
-    return dnnl::impl::status::success;
+  return dnnl::impl::status::success;
 }
 
 dnnl::impl::status_t dnnl_set_primitive_cache_capacity(int capacity) {
-    if (capacity < 0) return dnnl::impl::status::invalid_arguments;
+  if (capacity < 0)
+    return dnnl::impl::status::invalid_arguments;
 #ifndef DNNL_DISABLE_PRIMITIVE_CACHE
-    return dnnl::impl::primitive_cache().set_capacity(capacity);
+  return dnnl::impl::primitive_cache().set_capacity(capacity);
 #endif
-    return dnnl::impl::status::success;
+  return dnnl::impl::status::success;
 }


### PR DESCRIPTION
It seems that, gcc11 do not support a `!=` operator for `std::thread::id`
I tried to fix it by switch the `!=` operator to `==` and put the `!` operator outside the compare op.

I don't know whether the compare op behaves correct, but that's the only way I could bypass that error.

Error:
```
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp: In member function 'virtual void dnnl::impl::lru_primitive_cache_t::update_entry(const key_t&, const dnnl::impl::primitive_desc_t*)':
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:60: error: no match for 'operator!=' (operand types are 'const std::thread::id' and 'const std::thread::id')
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                      ~~~~~~~~~~~~~~~~~~~~~ ^~ ~~~~~~~~~~~~~~~
      |                                                         |                  |
      |                                                         |                  const std::thread::id
      |                                                         const std::thread::id
In file included from /usr/include/c++/11.1.0/utility:70,
                 from /usr/include/c++/11.1.0/tuple:38,
                 from /usr/include/c++/11.1.0/mutex:38,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_pair.h:496:5: note: candidate: 'template<class _T1, class _T2> constexpr bool std::operator!=(const std::pair<_T1, _T2>&, const std::pair<_T1, _T2>&)'
  496 |     operator!=(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_pair.h:496:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::pair<_T1, _T2>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/11.1.0/array:40,
                 from /usr/include/c++/11.1.0/tuple:39,
                 from /usr/include/c++/11.1.0/mutex:38,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_iterator.h:428:5: note: candidate: 'template<class _Iterator> bool std::operator!=(const std::reverse_iterator<_Iterator>&, const std::reverse_iterator<_Iterator>&)'
  428 |     operator!=(const reverse_iterator<_Iterator>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_iterator.h:428:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::reverse_iterator<_Iterator>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/11.1.0/array:40,
                 from /usr/include/c++/11.1.0/tuple:39,
                 from /usr/include/c++/11.1.0/mutex:38,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_iterator.h:467:5: note: candidate: 'template<class _IteratorL, class _IteratorR> bool std::operator!=(const std::reverse_iterator<_Iterator>&, const std::reverse_iterator<_IteratorR>&)'
  467 |     operator!=(const reverse_iterator<_IteratorL>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_iterator.h:467:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::reverse_iterator<_Iterator>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/11.1.0/array:40,
                 from /usr/include/c++/11.1.0/tuple:39,
                 from /usr/include/c++/11.1.0/mutex:38,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_iterator.h:1550:5: note: candidate: 'template<class _IteratorL, class _IteratorR> bool std::operator!=(const std::move_iterator<_IteratorL>&, const std::move_iterator<_IteratorR>&)'
 1550 |     operator!=(const move_iterator<_IteratorL>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_iterator.h:1550:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::move_iterator<_IteratorL>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/11.1.0/array:40,
                 from /usr/include/c++/11.1.0/tuple:39,
                 from /usr/include/c++/11.1.0/mutex:38,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_iterator.h:1607:5: note: candidate: 'template<class _Iterator> bool std::operator!=(const std::move_iterator<_IteratorL>&, const std::move_iterator<_IteratorL>&)'
 1607 |     operator!=(const move_iterator<_Iterator>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_iterator.h:1607:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::move_iterator<_IteratorL>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/tuple:39,
                 from /usr/include/c++/11.1.0/mutex:38,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/array:305:5: note: candidate: 'template<class _Tp, long unsigned int _Nm> bool std::operator!=(const std::array<_Tp, _Nm>&, const std::array<_Tp, _Nm>&)'
  305 |     operator!=(const array<_Tp, _Nm>& __one, const array<_Tp, _Nm>& __two)
      |     ^~~~~~~~
/usr/include/c++/11.1.0/array:305:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::array<_Tp, _Nm>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/mutex:38,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/tuple:1531:5: note: candidate: 'template<class ... _TElements, class ... _UElements> constexpr bool std::operator!=(const std::tuple<_Tps ...>&, const std::tuple<_Elements ...>&)'
 1531 |     operator!=(const tuple<_TElements...>& __t,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/tuple:1531:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::tuple<_Tps ...>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/iosfwd:40,
                 from /usr/include/c++/11.1.0/system_error:40,
                 from /usr/include/c++/11.1.0/mutex:42,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/postypes.h:227:5: note: candidate: 'template<class _StateT> bool std::operator!=(const std::fpos<_StateT>&, const std::fpos<_StateT>&)'
  227 |     operator!=(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/postypes.h:227:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::fpos<_StateT>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/string:41,
                 from /usr/include/c++/11.1.0/stdexcept:39,
                 from /usr/include/c++/11.1.0/system_error:41,
                 from /usr/include/c++/11.1.0/mutex:42,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/allocator.h:213:5: note: candidate: 'template<class _T1, class _T2> bool std::operator!=(const std::allocator<_CharT>&, const std::allocator<_T2>&)'
  213 |     operator!=(const allocator<_T1>&, const allocator<_T2>&)
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/allocator.h:213:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::allocator<_CharT>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/string:55,
                 from /usr/include/c++/11.1.0/stdexcept:39,
                 from /usr/include/c++/11.1.0/system_error:41,
                 from /usr/include/c++/11.1.0/mutex:42,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/basic_string.h:6288:5: note: candidate: 'template<class _CharT, class _Traits, class _Alloc> bool std::operator!=(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)'
 6288 |     operator!=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/basic_string.h:6288:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/string:55,
                 from /usr/include/c++/11.1.0/stdexcept:39,
                 from /usr/include/c++/11.1.0/system_error:41,
                 from /usr/include/c++/11.1.0/mutex:42,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/basic_string.h:6301:5: note: candidate: 'template<class _CharT, class _Traits, class _Alloc> bool std::operator!=(const _CharT*, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)'
 6301 |     operator!=(const _CharT* __lhs,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/basic_string.h:6301:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   mismatched types 'const _CharT*' and 'std::thread::id'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/string:55,
                 from /usr/include/c++/11.1.0/stdexcept:39,
                 from /usr/include/c++/11.1.0/system_error:41,
                 from /usr/include/c++/11.1.0/mutex:42,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/basic_string.h:6313:5: note: candidate: 'template<class _CharT, class _Traits, class _Alloc> bool std::operator!=(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, const _CharT*)'
 6313 |     operator!=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/basic_string.h:6313:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/shared_ptr_base.h:59,
                 from /usr/include/c++/11.1.0/bits/shared_ptr.h:53,
                 from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/unique_ptr.h:774:5: note: candidate: 'template<class _Tp, class _Dp, class _Up, class _Ep> bool std::operator!=(const std::unique_ptr<_Tp, _Dp>&, const std::unique_ptr<_Up, _Ep>&)'
  774 |     operator!=(const unique_ptr<_Tp, _Dp>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/unique_ptr.h:774:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::unique_ptr<_Tp, _Dp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/shared_ptr_base.h:59,
                 from /usr/include/c++/11.1.0/bits/shared_ptr.h:53,
                 from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/unique_ptr.h:781:5: note: candidate: 'template<class _Tp, class _Dp> bool std::operator!=(const std::unique_ptr<_Tp, _Dp>&, std::nullptr_t)'
  781 |     operator!=(const unique_ptr<_Tp, _Dp>& __x, nullptr_t) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/unique_ptr.h:781:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::unique_ptr<_Tp, _Dp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/shared_ptr_base.h:59,
                 from /usr/include/c++/11.1.0/bits/shared_ptr.h:53,
                 from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/unique_ptr.h:787:5: note: candidate: 'template<class _Tp, class _Dp> bool std::operator!=(std::nullptr_t, const std::unique_ptr<_Tp, _Dp>&)'
  787 |     operator!=(nullptr_t, const unique_ptr<_Tp, _Dp>& __x) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/unique_ptr.h:787:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::unique_ptr<_Tp, _Dp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/shared_ptr.h:53,
                 from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/shared_ptr_base.h:1436:5: note: candidate: 'template<class _Tp1, class _Tp2, __gnu_cxx::_Lock_policy _Lp> bool std::operator!=(const std::__shared_ptr<_Tp1, _Lp>&, const std::__shared_ptr<_Tp2, _Lp>&)'
 1436 |     operator!=(const __shared_ptr<_Tp1, _Lp>& __a,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/shared_ptr_base.h:1436:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::__shared_ptr<_Tp1, _Lp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/shared_ptr.h:53,
                 from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/shared_ptr_base.h:1442:5: note: candidate: 'template<class _Tp, __gnu_cxx::_Lock_policy _Lp> bool std::operator!=(const std::__shared_ptr<_Tp, _Lp>&, std::nullptr_t)'
 1442 |     operator!=(const __shared_ptr<_Tp, _Lp>& __a, nullptr_t) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/shared_ptr_base.h:1442:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::__shared_ptr<_Tp, _Lp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/bits/shared_ptr.h:53,
                 from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/shared_ptr_base.h:1447:5: note: candidate: 'template<class _Tp, __gnu_cxx::_Lock_policy _Lp> bool std::operator!=(std::nullptr_t, const std::__shared_ptr<_Tp, _Lp>&)'
 1447 |     operator!=(nullptr_t, const __shared_ptr<_Tp, _Lp>& __a) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/shared_ptr_base.h:1447:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::__shared_ptr<_Tp, _Lp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/shared_ptr.h:470:5: note: candidate: 'template<class _Tp, class _Up> bool std::operator!=(const std::shared_ptr<_Tp>&, const std::shared_ptr<_Tp>&)'
  470 |     operator!=(const shared_ptr<_Tp>& __a, const shared_ptr<_Up>& __b) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/shared_ptr.h:470:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::shared_ptr<_Tp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/shared_ptr.h:476:5: note: candidate: 'template<class _Tp> bool std::operator!=(const std::shared_ptr<_Tp>&, std::nullptr_t)'
  476 |     operator!=(const shared_ptr<_Tp>& __a, nullptr_t) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/shared_ptr.h:476:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::shared_ptr<_Tp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/condition_variable:43,
                 from /usr/include/c++/11.1.0/future:39,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/shared_ptr.h:482:5: note: candidate: 'template<class _Tp> bool std::operator!=(std::nullptr_t, const std::shared_ptr<_Tp>&)'
  482 |     operator!=(nullptr_t, const shared_ptr<_Tp>& __a) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/shared_ptr.h:482:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::shared_ptr<_Tp>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/future:47,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/std_function.h:707:5: note: candidate: 'template<class _Res, class ... _Args> bool std::operator!=(const std::function<_Res(_ArgTypes ...)>&, std::nullptr_t)'
  707 |     operator!=(const function<_Res(_Args...)>& __f, nullptr_t) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/std_function.h:707:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::function<_Res(_ArgTypes ...)>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/future:47,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/std_function.h:713:5: note: candidate: 'template<class _Res, class ... _Args> bool std::operator!=(std::nullptr_t, const std::function<_Res(_ArgTypes ...)>&)'
  713 |     operator!=(nullptr_t, const function<_Res(_Args...)>& __f) noexcept
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/std_function.h:713:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::function<_Res(_ArgTypes ...)>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/list:63,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:21,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_list.h:2057:5: note: candidate: 'template<class _Tp, class _Alloc> bool std::operator!=(const std::__cxx11::list<_Tp, _Alloc>&, const std::__cxx11::list<_Tp, _Alloc>&)'
 2057 |     operator!=(const list<_Tp, _Alloc>& __x, const list<_Tp, _Alloc>& __y)
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_list.h:2057:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::__cxx11::list<_Tp, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/unordered_map:47,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:23,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/unordered_map.h:2141:5: note: candidate: 'template<class _Key, class _Tp, class _Hash, class _Pred, class _Alloc> bool std::operator!=(const std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>&, const std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>&)'
 2141 |     operator!=(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/unordered_map.h:2141:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/unordered_map:47,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:23,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/unordered_map.h:2155:5: note: candidate: 'template<class _Key, class _Tp, class _Hash, class _Pred, class _Alloc> bool std::operator!=(const std::unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>&, const std::unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>&)'
 2155 |     operator!=(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/unordered_map.h:2155:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/vector:67,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/internal_desc_types.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/c_types_map.hpp:23,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:25,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_vector.h:1937:5: note: candidate: 'template<class _Tp, class _Alloc> bool std::operator!=(const std::vector<_Tp, _Alloc>&, const std::vector<_Tp, _Alloc>&)'
 1937 |     operator!=(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_vector.h:1937:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::vector<_Tp, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/map:61,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_attr.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_hashing.hpp:25,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:27,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_map.h:1508:5: note: candidate: 'template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator!=(const std::map<_Key, _Tp, _Compare, _Alloc>&, const std::map<_Key, _Tp, _Compare, _Alloc>&)'
 1508 |     operator!=(const map<_Key, _Tp, _Compare, _Alloc>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_map.h:1508:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::map<_Key, _Tp, _Compare, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /usr/include/c++/11.1.0/map:62,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_attr.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_hashing.hpp:25,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:27,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/bits/stl_multimap.h:1173:5: note: candidate: 'template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator!=(const std::multimap<_Key, _Tp, _Compare, _Alloc>&, const std::multimap<_Key, _Tp, _Compare, _Alloc>&)'
 1173 |     operator!=(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
      |     ^~~~~~~~
/usr/include/c++/11.1.0/bits/stl_multimap.h:1173:5: note:   template argument deduction/substitution failed:
/me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:155:77: note:   'const std::thread::id' is not derived from 'const std::multimap<_Key, _Tp, _Compare, _Alloc>'
  155 |     if (it == cache_mapper_.end() || it->first.thread_id() != key.thread_id())
      |                                                                             ^
In file included from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_attr.hpp:27,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_hashing.hpp:25,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:27,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/me/incubator-mxnet/3rdparty/onednn/src/common/type_helpers.hpp:314:13: note: candidate: 'bool dnnl::impl::operator!=(const memory_desc_t&, const memory_desc_t&)'
  314 | inline bool operator!=(const memory_desc_t &lhs, const memory_desc_t &rhs) {
      |             ^~~~~~~~
/me/incubator-mxnet/3rdparty/onednn/src/common/type_helpers.hpp:314:45: note:   no known conversion for argument 1 from 'const std::thread::id' to 'const memory_desc_t&' {aka 'const dnnl_memory_desc_t&'}
  314 | inline bool operator!=(const memory_desc_t &lhs, const memory_desc_t &rhs) {
      |                        ~~~~~~~~~~~~~~~~~~~~~^~~
In file included from /usr/include/c++/11.1.0/mutex:42,
                 from /usr/include/c++/11.1.0/future:38,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.hpp:20,
                 from /me/incubator-mxnet/3rdparty/onednn/src/common/primitive_cache.cpp:17:
/usr/include/c++/11.1.0/system_error:400:3: note: candidate: 'bool std::operator!=(const std::error_code&, const std::error_code&)'
  400 |   operator!=(const error_code& __lhs, const error_code& __rhs) noexcept
      |   ^~~~~~~~
/usr/include/c++/11.1.0/system_error:400:32: note:   no known conversion for argument 1 from 'const std::thread::id' to 'const std::error_code&'
  400 |   operator!=(const error_code& __lhs, const error_code& __rhs) noexcept
      |              ~~~~~~~~~~~~~~~~~~^~~~~
/usr/include/c++/11.1.0/system_error:406:3: note: candidate: 'bool std::operator!=(const std::error_code&, const std::error_condition&)'
  406 |   operator!=(const error_code& __lhs, const error_condition& __rhs) noexcept
      |   ^~~~~~~~
/usr/include/c++/11.1.0/system_error:406:32: note:   no known conversion for argument 1 from 'const std::thread::id' to 'const std::error_code&'
  406 |   operator!=(const error_code& __lhs, const error_condition& __rhs) noexcept
      |              ~~~~~~~~~~~~~~~~~~^~~~~
/usr/include/c++/11.1.0/system_error:412:3: note: candidate: 'bool std::operator!=(const std::error_condition&, const std::error_code&)'
  412 |   operator!=(const error_condition& __lhs, const error_code& __rhs) noexcept
      |   ^~~~~~~~
/usr/include/c++/11.1.0/system_error:412:37: note:   no known conversion for argument 1 from 'const std::thread::id' to 'const std::error_condition&'
  412 |   operator!=(const error_condition& __lhs, const error_code& __rhs) noexcept
      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/usr/include/c++/11.1.0/system_error:417:3: note: candidate: 'bool std::operator!=(const std::error_condition&, const std::error_condition&)'
  417 |   operator!=(const error_condition& __lhs,
      |   ^~~~~~~~
/usr/include/c++/11.1.0/system_error:417:37: note:   no known conversion for argument 1 from 'const std::thread::id' to 'const std::error_condition&'
  417 |   operator!=(const error_condition& __lhs,
      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
