### PR TITLE
src: cpu: aarch64: eltwise: optimize jit-ed code for SVE512

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -504,163 +504,49 @@ void jit_uni_eltwise_injector_f32<isa>::elu_compute_vector_fwd(
 template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_f32<isa>::tanh_compute_vector_fwd(
         const TRegS &vmm_src) {
-    // we add a check as the avx2 code cannot be used for avx
-    using namespace Xbyak_aarch64::util;
-    const int tanh_n_polynomials = 32;
+    // tanh(x) = x(1 + (-1/3)x^2) for |x| < tanh_range
+    // tanh(x) = 1 - 2/(1 + exp(2 x)) for otherwise
 
-    // register mapping
-    // TODO: put sign on stack and alias zmm_table2 with vmm_sign to save a reg ?
-    TRegS vmm_dst = vmm_aux1, vmm_src_shift = vmm_aux1, vmm_coeff = vmm_aux1,
-          vmm_pol = vmm_aux2, vmm_indices = vmm_aux3,
-          vmm_src_original = vmm_aux4, vmm_sign = vmm_aux4;
+    const auto &t0 = ZRegS(IDX(vmm_src));
+    const auto &t1 = ZRegS(IDX(vmm_aux1));
+    const auto &t2 = ZRegS(IDX(vmm_aux2));
+    const auto &t3 = ZRegS(IDX(vmm_aux3));
+    const auto &oneS = ZRegS(IDX(vmm_aux4));
+    const auto &mask = PReg(6); // avoid pred regs used in *conv_kernel*
 
-    auto lut_zreg2_f32 = [&](const ZRegS &d, const ZRegS &s, const ZRegS &s2,
-                                 const ZRegS &t, const ZRegS &t2,
-                                 const ZRegS &t3, const PReg &p) {
-        h->ptrue(p.b);
-        h->mov(t, 0x1f);
-        h->and_(ZRegB(t.getIdx()), p, ZRegB(s.getIdx()));
-        for (int i = 0; i < 16; i++) {
-            h->cmpeq(h->P_TMP_0.s, p, t, 0);
-            h->sub(t, 0x1);
-            h->dup(t2, d[i]);
-            h->mov(t3, h->P_TMP_0 / T_m, t2);
-        }
-        for (int i = 0; i < 16; i++) {
-            h->cmpeq(h->P_TMP_0.s, p, t, i);
-            h->dup(t2, s2[i]);
-            h->mov(t3, h->P_TMP_0 / T_m, t2);
-        }
-        h->mov(ZRegD(d.getIdx()), ZRegD(t3.getIdx()));
-    };
+    h->fcpy(oneS, p_all, 1);
+    // make mask for small x
+    h->mov(t3, p_all, t0);
+    h->fabs(t1, p_all, t0);
+    h->cmplt(mask.s, p_all, t1, ZRegS(IDX(table_val(tanh_range, z_tmp))));
 
-    // We split the positive domain in 33 intervals:
-    // a) [0; linear_ubound]: in this interval tanh(x) = x
-    // b) [linear_ubound; 0x1.8p-12]: This interval spans part of a
-    //    half binade
-    // c) [0x1.8p-12; 0x1.0p-11], ..., [0x1.8p2; 0x1.0p3]:
-    //    one interval for each half binade, there are 29 of those
-    // d) [0x1.0p3; saturation_ubound]:
-    //    This interval spans part of a half binade
-    // e) [0x1.205966p3; saturation_ubound]: in this interval, tanh(x) = 1
-    // For b-d, we need 31 polynomials and will do a table lookup for those.
-    // To simplify the logic, we will also put a) in the table.
+    // 2x
+    h->fadd(t0, t0, t0);
+    // exp(2x)
+    exp_compute_vector_fwd(t0);
+    // 1+exp(2x)
+    h->fadd(t0, t0, oneS);
+    // 1/(1+exp(2x))
+    // 1st aprox ; a = 1/x + e
+    h->frecpe(t1, t0);
+    // 2nd aprox ; a' = (2 - ax)a = 1/x - e^2 x
+    h->frecps(t2, t0, t1);
+    h->fmul(t2, t2, t1);
+    // 3rd aprox ; a'' = (2 - a'x)a'
+    h->frecps(t0, t0, t2);
+    h->fmul(t0, t0, t2);
 
-    // The polynomials are of degree 6, so we need to gather 7 coefficients.
-    // - sse4.1: we do it the naive way using vextract/vinsert.
-    //           Here we will extract the indices in gpr only once and
-    //           reuse them as there are only 4 of them.
-    // - avx2: we use vpermps and blend for each coefficient.
-    //         This needs an extra vmm to store the mask
-    // - avx512: because the table fits in 2 registers, we can use vpermi2d.
-    auto coeffs_address = [&](int coeff_off, int off = 0) {
-        return table_val(tanh_pol_table, coeff_off * tanh_n_polynomials + off);
-    };
-    auto gather_coefficient_init = [&](TRegS vmm_pol_idx, int nelems) {
-        switch (isa) {
-            case sve_512: break;
-            default: assert(!"unimplemented");
-        }
-    };
-    auto gather_coefficient = [&](TRegS vmm_coeff, int coeff_idx,
-                                      TRegS vmm_pol_idx) {
-        switch (isa) {
-                // use gather instruction
-            case sve_512:
-                // we use vpermt2ps to not override the indices
-                // this also enables to save a register for table loading
-                {
-                    ZReg zmm_coeff(vmm_coeff.getIdx());
-                    ZReg zmm_pol_idx(vmm_pol_idx.getIdx());
-                    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-                    h->mov(ZRegD(IDX(zmm_coeff)),
-                            ZRegD(IDX(coeffs_address(coeff_idx, 0))));
-                    h->mov(ZRegS(IDX(zmm_coeff)), p_tmp0 / T_m, 0);
+    // 2/(1+exp(2x))
+    h->fadd(t0, t0, t0);
+    // 1-2/(1+exp(2x))
+    h->fsub(t0, oneS, t0);
 
-                    lut_zreg2_f32(ZRegS(IDX(zmm_coeff)),
-                            ZRegS(IDX(zmm_pol_idx)),
-                            ZRegS(IDX(coeffs_address(coeff_idx, 16))), vmm_aux5,
-                            vmm_aux6, vmm_aux7, p_tmp0);
-                    break;
-                }
-            default: assert(!"unimplemented");
-        }
-    };
-
-    // because tanh(x) = -tanh(-x), we extract sign to make x postive
-    // and reapply sign at the end
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_src_original)), ZRegD(IDX(vmm_src)));
-    h->mov(ZRegS(IDX(vmm_src_original)), p_tmp0 / T_m, 0);
-    h->and_(ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_src)),
-            ZRegD(IDX(table_val(positive_mask))));
-
-    // We compute the indices for the table lookup
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_indices)), ZRegD(IDX(vmm_src)));
-    h->mov(ZRegS(IDX(vmm_indices)), p_tmp0 / T_m, 0);
-    h->sub(ZRegS(IDX(vmm_indices)), ZRegS(IDX(vmm_indices)),
-            ZRegS(IDX(table_val(tanh_idx_bias))));
-    h->and_(ZRegD(IDX(vmm_indices)), ZRegD(IDX(vmm_indices)),
-            ZRegD(IDX(table_val(tanh_idx_mask))));
-    h->lsr(ZRegS(IDX(vmm_indices)), ZRegS(IDX(vmm_indices)), 22);
-
-    // we do the argument reduction
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_src_shift)), ZRegD(IDX(vmm_src)));
-    h->mov(ZRegS(IDX(vmm_src_shift)), p_tmp0 / T_m, 0);
-    h->and_(ZRegD(IDX(vmm_src_shift)), ZRegD(IDX(vmm_src_shift)),
-            ZRegD(IDX(table_val(tanh_idx_mask))));
-    h->fsub(vmm_src, vmm_src, ZRegS(IDX(vmm_src_shift)));
-
-    // we gather and evaluate the polynonials
-    gather_coefficient_init(vmm_indices, vlen / sizeof(float));
-    gather_coefficient(vmm_pol, 6, vmm_indices);
-
-    for (int deg = 5; deg >= 0; --deg) {
-        gather_coefficient(vmm_coeff, deg, vmm_indices);
-        h->fmad(ZRegS(IDX(vmm_pol)), p_all / T_m, vmm_src,
-                ZRegS(IDX(vmm_coeff)));
-    }
-
-    // we restore src with cleared sign, and keep sign
-    assert(vmm_sign.getIdx() == vmm_src_original.getIdx());
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_src_original)));
-    h->mov(vmm_src, p_tmp0 / T_m, 0);
-    h->and_(ZRegD(IDX(vmm_sign)), ZRegD(IDX(vmm_sign)),
-            ZRegD(IDX(table_val(sign_mask))));
-    h->and_(ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_src)),
-            ZRegD(IDX(table_val(positive_mask))));
-
-    // Now we blend the results
-    // [saturation_ubound; +inf[ : we return +/- 1
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_dst)), ZRegD(IDX(table_val(one))));
-    h->mov(vmm_dst, p_tmp0 / T_m, 0);
-
-    // [linear_ubound; saturation_lbound] : we return +/- P(x)
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_mask)), ZRegD(IDX(table_val(tanh_saturation_lbound))));
-    h->mov(vmm_mask, p_tmp0 / T_m, 0);
-
-    compute_cmp_mask(vmm_mask, vmm_src, _cmp_gt_os);
-    blend_with_mask(vmm_dst, vmm_pol);
-
-    // [0; linear_ubound]  : we return x
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_mask)), ZRegD(IDX(table_val(tanh_linear_ubound))));
-    h->mov(vmm_mask, p_tmp0 / T_m, 0);
-
-    compute_cmp_mask(vmm_mask, vmm_src, _cmp_gt_os);
-    blend_with_mask(vmm_dst, vmm_src);
-
-    // We reapply the sign and return
-    h->eor(ZRegD(IDX(vmm_dst)), ZRegD(IDX(vmm_dst)), ZRegD(IDX(vmm_sign)));
-
-    h->not_(p_tmp0.b, h->P_ALL_ONE / T_z, PRegB(IDX(p_all)));
-    h->mov(ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_dst)));
-    h->mov(vmm_src, p_tmp0 / T_m, 0);
+    // tanh(x) = x(1 - x^2/3) for |x| < tanh_range
+    h->fmul(t1, t3, t3);
+    h->fmad(t1, p_all, ZRegS(IDX(table_val(tanh_m1d3, z_tmp))), oneS);
+    h->fmul(t1, p_all, t3);
+    // select the correct value according to mask
+    h->mov(t0, mask, t1);
 }
 
 template <cpu_isa_t isa>
@@ -1589,7 +1475,7 @@ void jit_uni_eltwise_injector_f32<isa>::compute_body(
         }
         if (scale_ != 1.f) {
             h->fmul(ZRegS(IDX(TRegS(idx))), ZRegS(IDX(TRegS(idx))),
-                    ZRegS(IDX(table_val(scale))));
+                    ZRegS(IDX(table_val(scale, z_tmp))));
         }
     });
 }
@@ -1700,245 +1586,9 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
     };
 
     // tanh(x) constants for four interval approximation
-    static const table_t tanh_consts {{tanh_idx_bias, {0x39800000, true}},
-            {tanh_idx_mask, {0xffc00000, true}},
-            {tanh_linear_ubound, {0x39ddb3d7, true}},
-            {tanh_saturation_lbound, {0x41102cb3, true}}};
-
-    // tanh(x) polynomial approximation
-    // For each coefficient, there is 32 entries
-    static const table_t tanh_polynomial_table {
-            // coefficients of degree 0
-            {tanh_pol_table, {0x00000000, false}},
-            {tanh_pol_table, {0x39bfffff, false}},
-            {tanh_pol_table, {0x39ffffff, false}},
-            {tanh_pol_table, {0x3a3ffffe, false}},
-            {tanh_pol_table, {0x3a7ffffb, false}},
-            {tanh_pol_table, {0x3abffff7, false}},
-            {tanh_pol_table, {0x3affffeb, false}},
-            {tanh_pol_table, {0x3b3fffdc, false}},
-            {tanh_pol_table, {0x3b7fffab, false}},
-            {tanh_pol_table, {0x3bbfff70, false}},
-            {tanh_pol_table, {0x3bfffeab, false}},
-            {tanh_pol_table, {0x3c3ffdc0, false}},
-            {tanh_pol_table, {0x3c7ffaab, false}},
-            {tanh_pol_table, {0x3cbff701, false}},
-            {tanh_pol_table, {0x3cffeaad, false}},
-            {tanh_pol_table, {0x3d3fdc08, false}},
-            {tanh_pol_table, {0x3d7faacd, false}},
-            {tanh_pol_table, {0x3dbf7081, false}},
-            {tanh_pol_table, {0x3dfeacc9, false}},
-            {tanh_pol_table, {0x3e3dc7fd, false}},
-            {tanh_pol_table, {0x3e7acbf5, false}},
-            {tanh_pol_table, {0x3eb77a9f, false}},
-            {tanh_pol_table, {0x3eec9a9f, false}},
-            {tanh_pol_table, {0x3f22991f, false}},
-            {tanh_pol_table, {0x3f42f7d6, false}},
-            {tanh_pol_table, {0x3f67b7cc, false}},
-            {tanh_pol_table, {0x3f76ca83, false}},
-            {tanh_pol_table, {0x3f7ebbe9, false}},
-            {tanh_pol_table, {0x3f7fd40c, false}},
-            {tanh_pol_table, {0x3f7fff32, false}},
-            {tanh_pol_table, {0x3f7ffffc, false}},
-            {tanh_pol_table, {0x3f800000, false}},
-            // coefficients of degree 1
-            {tanh_pol_table, {0x3f800000, false}},
-            {tanh_pol_table, {0x3f800018, false}},
-            {tanh_pol_table, {0x3f7fffe8, false}},
-            {tanh_pol_table, {0x3f7fffda, false}},
-            {tanh_pol_table, {0x3f7fffdc, false}},
-            {tanh_pol_table, {0x3f7fffdc, false}},
-            {tanh_pol_table, {0x3f7fffac, false}},
-            {tanh_pol_table, {0x3f7fff70, false}},
-            {tanh_pol_table, {0x3f7ffeec, false}},
-            {tanh_pol_table, {0x3f7ffdc0, false}},
-            {tanh_pol_table, {0x3f7ffbed, false}},
-            {tanh_pol_table, {0x3f7ff704, false}},
-            {tanh_pol_table, {0x3f7feff5, false}},
-            {tanh_pol_table, {0x3f7fdbca, false}},
-            {tanh_pol_table, {0x3f7fbfff, false}},
-            {tanh_pol_table, {0x3f7f7041, false}},
-            {tanh_pol_table, {0x3f7f009b, false}},
-            {tanh_pol_table, {0x3f7dc36c, false}},
-            {tanh_pol_table, {0x3f7c0aa8, false}},
-            {tanh_pol_table, {0x3f7734b8, false}},
-            {tanh_pol_table, {0x3f70a4de, false}},
-            {tanh_pol_table, {0x3f5f1fd8, false}},
-            {tanh_pol_table, {0x3f495493, false}},
-            {tanh_pol_table, {0x3f18b9ec, false}},
-            {tanh_pol_table, {0x3ed706cb, false}},
-            {tanh_pol_table, {0x3e390b06, false}},
-            {tanh_pol_table, {0x3d90b11f, false}},
-            {tanh_pol_table, {0x3c21a053, false}},
-            {tanh_pol_table, {0x3aaf7fdb, false}},
-            {tanh_pol_table, {0x37ccc1a3, false}},
-            {tanh_pol_table, {0x355c6733, false}},
-            {tanh_pol_table, {0x00000000, false}},
-            // coefficients of degree 2
-            {tanh_pol_table, {0x00000000, false}},
-            {tanh_pol_table, {0xbe4e0ff1, false}},
-            {tanh_pol_table, {0x3d25b1b1, false}},
-            {tanh_pol_table, {0x3d6b6dab, false}},
-            {tanh_pol_table, {0x3c9fb1d5, false}},
-            {tanh_pol_table, {0xbabff06f, false}},
-            {tanh_pol_table, {0x3c07b3f6, false}},
-            {tanh_pol_table, {0xbb3fc1bc, false}},
-            {tanh_pol_table, {0x3a9f5921, false}},
-            {tanh_pol_table, {0xbbbf06f2, false}},
-            {tanh_pol_table, {0xbbb0f402, false}},
-            {tanh_pol_table, {0xbc47db9e, false}},
-            {tanh_pol_table, {0xbc73d5e7, false}},
-            {tanh_pol_table, {0xbca25bda, false}},
-            {tanh_pol_table, {0xbcfca780, false}},
-            {tanh_pol_table, {0xbd40e07c, false}},
-            {tanh_pol_table, {0xbd7dab03, false}},
-            {tanh_pol_table, {0xbdbe4a0f, false}},
-            {tanh_pol_table, {0xbdfb14a5, false}},
-            {tanh_pol_table, {0xbe36cc8d, false}},
-            {tanh_pol_table, {0xbe6bd102, false}},
-            {tanh_pol_table, {0xbe9fe7c5, false}},
-            {tanh_pol_table, {0xbeba0f10, false}},
-            {tanh_pol_table, {0xbec206a8, false}},
-            {tanh_pol_table, {0xbea3c388, false}},
-            {tanh_pol_table, {0xbe277d62, false}},
-            {tanh_pol_table, {0xbd8b7960, false}},
-            {tanh_pol_table, {0xbc209f49, false}},
-            {tanh_pol_table, {0xbaad44ca, false}},
-            {tanh_pol_table, {0xb7c6eeac, false}},
-            {tanh_pol_table, {0xb663aa41, false}},
-            {tanh_pol_table, {0x00000000, false}},
-            // coefficients of degree 3
-            {tanh_pol_table, {0x00000000, false}},
-            {tanh_pol_table, {0x45b3ae96, false}},
-            {tanh_pol_table, {0xc414eb20, false}},
-            {tanh_pol_table, {0xc450e02e, false}},
-            {tanh_pol_table, {0xc3152b4e, false}},
-            {tanh_pol_table, {0xbead2f56, false}},
-            {tanh_pol_table, {0xc2162e02, false}},
-            {tanh_pol_table, {0xbeb4bd5a, false}},
-            {tanh_pol_table, {0xc11a59a4, false}},
-            {tanh_pol_table, {0xbed2f507, false}},
-            {tanh_pol_table, {0xc020d32c, false}},
-            {tanh_pol_table, {0x3dd0f506, false}},
-            {tanh_pol_table, {0xbf2a75e2, false}},
-            {tanh_pol_table, {0xbff950e3, false}},
-            {tanh_pol_table, {0xbed47334, false}},
-            {tanh_pol_table, {0xbe809b8c, false}},
-            {tanh_pol_table, {0xbeb64532, false}},
-            {tanh_pol_table, {0xbe961a5b, false}},
-            {tanh_pol_table, {0xbe9b63ac, false}},
-            {tanh_pol_table, {0xbea0d4b2, false}},
-            {tanh_pol_table, {0xbe828a77, false}},
-            {tanh_pol_table, {0xbe378612, false}},
-            {tanh_pol_table, {0xbdc20908, false}},
-            {tanh_pol_table, {0x3d2d3957, false}},
-            {tanh_pol_table, {0x3dd46e89, false}},
-            {tanh_pol_table, {0x3db3f629, false}},
-            {tanh_pol_table, {0x3d2c5e7b, false}},
-            {tanh_pol_table, {0x3bd20403, false}},
-            {tanh_pol_table, {0x3a59dfae, false}},
-            {tanh_pol_table, {0x3770af45, false}},
-            {tanh_pol_table, {0x372cc014, false}},
-            {tanh_pol_table, {0x00000000, false}},
-            // coefficients of degree 4
-            {tanh_pol_table, {0x00000000, false}},
-            {tanh_pol_table, {0xcc981a1b, false}},
-            {tanh_pol_table, {0x4a7edd3d, false}},
-            {tanh_pol_table, {0x4ab1007c, false}},
-            {tanh_pol_table, {0x48fedd9c, false}},
-            {tanh_pol_table, {0x41a557b5, false}},
-            {tanh_pol_table, {0x477ee32a, false}},
-            {tanh_pol_table, {0x422557f5, false}},
-            {tanh_pol_table, {0x45ff3ce4, false}},
-            {tanh_pol_table, {0x42a55641, false}},
-            {tanh_pol_table, {0x446e0867, false}},
-            {tanh_pol_table, {0xc33dc19a, false}},
-            {tanh_pol_table, {0x42915214, false}},
-            {tanh_pol_table, {0x43af4fad, false}},
-            {tanh_pol_table, {0x4110fe88, false}},
-            {tanh_pol_table, {0xc1099b75, false}},
-            {tanh_pol_table, {0x3fc8a8dc, false}},
-            {tanh_pol_table, {0xbfbeaef5, false}},
-            {tanh_pol_table, {0xbe365aad, false}},
-            {tanh_pol_table, {0x3f4d9652, false}},
-            {tanh_pol_table, {0x3ddfa08f, false}},
-            {tanh_pol_table, {0x3e34e9b8, false}},
-            {tanh_pol_table, {0x3e2d07a6, false}},
-            {tanh_pol_table, {0x3dc63567, false}},
-            {tanh_pol_table, {0x3cdaeb78, false}},
-            {tanh_pol_table, {0xbcd17537, false}},
-            {tanh_pol_table, {0xbc92829c, false}},
-            {tanh_pol_table, {0xbb43ab99, false}},
-            {tanh_pol_table, {0xb9b471dd, false}},
-            {tanh_pol_table, {0xb6baad5a, false}},
-            {tanh_pol_table, {0xb78bafc7, false}},
-            {tanh_pol_table, {0x00000000, false}},
-            // coefficients of degree 5
-            {tanh_pol_table, {0x00000000, false}},
-            {tanh_pol_table, {0x52f688d5, false}},
-            {tanh_pol_table, {0xd0505c72, false}},
-            {tanh_pol_table, {0xd08f98e3, false}},
-            {tanh_pol_table, {0xce505cc9, false}},
-            {tanh_pol_table, {0xc7162b8a, false}},
-            {tanh_pol_table, {0xcc5061d6, false}},
-            {tanh_pol_table, {0xc7162bdf, false}},
-            {tanh_pol_table, {0xca50b37f, false}},
-            {tanh_pol_table, {0xc7162a3a, false}},
-            {tanh_pol_table, {0xc8422086, false}},
-            {tanh_pol_table, {0x471a714e, false}},
-            {tanh_pol_table, {0xc5ece1f1, false}},
-            {tanh_pol_table, {0xc70e3d90, false}},
-            {tanh_pol_table, {0xc3eba94a, false}},
-            {tanh_pol_table, {0x43e0c424, false}},
-            {tanh_pol_table, {0xc21f4552, false}},
-            {tanh_pol_table, {0x42217cc8, false}},
-            {tanh_pol_table, {0x405e7dc4, false}},
-            {tanh_pol_table, {0xc10dd401, false}},
-            {tanh_pol_table, {0x3e96b602, false}},
-            {tanh_pol_table, {0xbd1a6d2f, false}},
-            {tanh_pol_table, {0xbd393883, false}},
-            {tanh_pol_table, {0xbd674682, false}},
-            {tanh_pol_table, {0xbd310016, false}},
-            {tanh_pol_table, {0xb961e269, false}},
-            {tanh_pol_table, {0x3ba32495, false}},
-            {tanh_pol_table, {0x3a7680d5, false}},
-            {tanh_pol_table, {0x38b3173c, false}},
-            {tanh_pol_table, {0x35a9deea, false}},
-            {tanh_pol_table, {0x375c3f2a, false}},
-            {tanh_pol_table, {0x00000000, false}},
-            // coefficients of degree 6
-            {tanh_pol_table, {0x00000000, false}},
-            {tanh_pol_table, {0xd8995ed1, false}},
-            {tanh_pol_table, {0x558285ea, false}},
-            {tanh_pol_table, {0x55b2cd69, false}},
-            {tanh_pol_table, {0x53028625, false}},
-            {tanh_pol_table, {0x4bc9991f, false}},
-            {tanh_pol_table, {0x5082898a, false}},
-            {tanh_pol_table, {0x4b4999b3, false}},
-            {tanh_pol_table, {0x4e02c07c, false}},
-            {tanh_pol_table, {0x4ac99764, false}},
-            {tanh_pol_table, {0x4b72c822, false}},
-            {tanh_pol_table, {0xca40c0e1, false}},
-            {tanh_pol_table, {0x489413e4, false}},
-            {tanh_pol_table, {0x49b12224, false}},
-            {tanh_pol_table, {0x46134c4e, false}},
-            {tanh_pol_table, {0xc60c2d57, false}},
-            {tanh_pol_table, {0x43c83910, false}},
-            {tanh_pol_table, {0xc3c872d1, false}},
-            {tanh_pol_table, {0xc186bc9e, false}},
-            {tanh_pol_table, {0x42325bc3, false}},
-            {tanh_pol_table, {0xbf2ffa4a, false}},
-            {tanh_pol_table, {0x3d9a203c, false}},
-            {tanh_pol_table, {0xbc545a43, false}},
-            {tanh_pol_table, {0xbae08fee, false}},
-            {tanh_pol_table, {0x3c80225d, false}},
-            {tanh_pol_table, {0x3b1fd1df, false}},
-            {tanh_pol_table, {0xba36b9d1, false}},
-            {tanh_pol_table, {0xb91de544, false}},
-            {tanh_pol_table, {0xb71f100f, false}},
-            {tanh_pol_table, {0xb408e2ed, false}},
-            {tanh_pol_table, {0xb685fec8, false}},
-            {tanh_pol_table, {0x00000000, false}},
+    static const table_t tanh_consts {
+            {tanh_range, {0x3d4ccccd, true}},
+            {tanh_m1d3, {0xbeaaaaab, true}},
     };
 
     // soft_relu(x) constants
@@ -2120,7 +1770,10 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
                 case eltwise_log: log_ = true; break;
                 case eltwise_soft_relu: soft_relu_ = true; break;
                 case eltwise_tanh_use_dst_for_bwd:
-                case eltwise_tanh: tanh_ = true; break;
+                case eltwise_tanh:
+                    exp_ = true;
+                    tanh_ = true;
+                    break;
                 default: break;
             }
         }
@@ -2164,7 +1817,6 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
     if (need.exp()) push_entries_of(exp_polynomial);
     if (need.exp()) push_entries_of(exp_consts2);
     if (need.tanh()) push_entries_of(tanh_consts);
-    if (need.tanh()) push_entries_of(tanh_polynomial_table);
     if (need.soft_relu()) push_entries_of(soft_relu_consts);
     if (need.soft_relu()) push_entries_of(soft_relu_polynomial);
     if (need.gelu_tanh()) push_entries_of(gelu_tanh_consts);

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -432,71 +432,27 @@ template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_f32<isa>::exp_compute_vector_fwd(
         const TRegS &vmm_src) {
 
-    // exp(x) =
-    // = exp(n * ln(2) + r) // divide x by ln(2) and get quot and rem
-    // = 2^n * exp(r) // simplify the exp(n*ln(2)) expression
-
-    // get mask of values lower than log(FLT_MIN) to zero them in the output
-    compute_cmp_mask(vmm_src, table_val(exp_ln_flt_min_f), _cmp_lt_os);
-
-    h->mov(PRegB(IDX(p_tmp0)), h->P_ALL_ONE.b);
-    h->mov(ZRegD(IDX(z_tmp)), ZRegD(IDX(table_val(exp_ln_flt_max_f))));
-    h->fminnm(z_tmp, p_tmp0, vmm_src);
-    h->fmin(z_tmp, p_tmp0, vmm_src);
-    h->mov(ZRegD(IDX(vmm_src)), ZRegD(IDX(z_tmp)));
-
-    h->mov(ZRegD(IDX(z_tmp)), ZRegD(IDX(table_val(exp_ln_flt_min_f))));
-    h->fmaxnm(z_tmp, p_tmp0, vmm_src);
-    h->fmax(z_tmp, p_tmp0, vmm_src);
-    h->mov(ZRegD(IDX(vmm_src)), ZRegD(IDX(z_tmp)));
-
-    h->mov(ZRegD(IDX(vmm_aux1)), ZRegD(IDX(vmm_src)));
-
-    // calculate exp(x)
-    // fx = x * log2ef + 0.5
-    h->fmul(vmm_src, vmm_src, ZRegS(IDX(table_val(exp_log2ef))));
-    h->fadd(vmm_src, vmm_src, ZRegS(IDX(table_val(half))));
-
-    // tmp = floorf(fx)
-
-    h->frintm(vmm_aux2, p_tmp0 / T_m, vmm_src);
-
-    // keep vmm_src = fx for further computations
-    h->mov(ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_aux2)));
-
-    // x = x - fx * ln2
-    h->fmls(vmm_aux1, p_tmp0 / T_m, vmm_aux2, ZRegS(IDX(table_val(ln2f))));
-
-    // We do not count 2^n here, because n can reach 128 and 2^128 is not
-    // representable by fp32, so to get around this problem, instead of computing
-    // 2^n * exp(r) will be counted 2*2^(n-1)*exp(r), because 2^127
-    // and 2 are numbers representable in fp32.
-
-    // compute 2^(n-1)
-    h->fsub(vmm_src, vmm_src, ZRegS(IDX(table_val(one))));
-    h->frinti(vmm_aux2, p_tmp0 / T_m, vmm_src);
-    h->fcvtzs(vmm_aux2, p_tmp0 / T_m, vmm_aux2);
-    h->add(vmm_aux2, vmm_aux2, ZRegS(IDX(table_val(exponent_bias))));
-    h->lsl(vmm_aux2, vmm_aux2,
-
-            n_mantissa_bits); //TRegS(6) = 2^-fx
-
-    // use vmm_src as tmp vmm_zero when applying mask
-    h->eor(ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_src)));
-    // set zeroes at those points which were < log(FLT_MIN)
-    blend_with_mask(vmm_aux2, vmm_src);
-
-    // compute polynomial
-    h->mov(ZRegD(IDX(vmm_src)), ZRegD(IDX(table_val(exp_pol, 4))));
-    h->fmad(vmm_src, p_all / T_m, vmm_aux1, ZRegS(IDX(table_val(exp_pol, 3))));
-    h->fmad(vmm_src, p_all / T_m, vmm_aux1, ZRegS(IDX(table_val(exp_pol, 2))));
-    h->fmad(vmm_src, p_all / T_m, vmm_aux1, ZRegS(IDX(table_val(exp_pol, 1))));
-    h->fmad(vmm_src, p_all / T_m, vmm_aux1, ZRegS(IDX(table_val(exp_pol, 0))));
-    h->fmad(vmm_src, p_all / T_m, vmm_aux1, ZRegS(IDX(table_val(one))));
-
-    // y = y * 2^n
-    h->fmul(vmm_src, vmm_src, vmm_aux2);
-    h->fmul(vmm_src, vmm_src, ZRegS(IDX(table_val(two))));
+    const auto &t0 = ZRegS(IDX(vmm_src));
+    const auto &t1 = ZRegS(IDX(vmm_aux1));
+    const auto &t2 = ZRegS(IDX(vmm_aux2));
+    h->fmin(t0, p_all, ZRegS(IDX(table_val(exp_ln_flt_max_f, z_tmp))));
+    h->fmax(t0, p_all, ZRegS(IDX(table_val(exp_ln_flt_min_f, z_tmp))));
+    h->fmul(t0, t0, ZRegS(IDX(table_val(exp_log2ef, z_tmp))));
+    h->movprfx(t1, p_all, t0);
+    h->frintm(t1, p_all, t0);
+    h->fcvtzs(t2, p_all, t1);
+    h->fsub(t1, t0, t1);
+    h->fadd(t0, t1, ZRegS(IDX(table_val(one, z_tmp))));
+    h->lsr(t1, t0, 17);
+    h->fexpa(t1, t1);
+    h->fscale(t1, p_all, t2);
+    h->and_(ZRegD(t2.getIdx()), ZRegD(t0.getIdx()),
+            ZRegD(IDX(table_val(exp_not_mask17, z_tmp))));
+    h->fsub(t2, t0, t2);
+    h->movprfx(t0, p_all, ZRegS(IDX(table_val(exp_coeff2, z_tmp))));
+    h->fmad(t0, p_all, t2, ZRegS(IDX(table_val(exp_coeff1, z_tmp))));
+    h->fmad(t0, p_all, t2, ZRegS(IDX(table_val(one, z_tmp))));
+    h->fmul(t0, t1, t0);
 }
 
 template <cpu_isa_t isa>
@@ -1820,6 +1776,12 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
             {exp_pol, {0x3d2b9d0d, true}}, // p4 = 0.0418978221f
             {exp_pol, {0x3c07cfce, true}} // p5 = 0.00828929059f
     };
+    // exp(x) constants2
+    static const table_t exp_consts2 {
+            {exp_coeff1, {0x3f31721c, true}},
+            {exp_coeff2, {0x3e772df2, true}},
+            {exp_not_mask17, {~((1u << 17) - 1), true}},
+    };
 
     // tanh(x) constants for four interval approximation
     static const table_t tanh_consts {{tanh_idx_bias, {0x39800000, true}},
@@ -2281,6 +2243,7 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
     push_entries_of(common_values);
     if (need.exp()) push_entries_of(exp_consts);
     if (need.exp()) push_entries_of(exp_polynomial);
+    if (need.exp()) push_entries_of(exp_consts2);
     if (need.tanh()) push_entries_of(tanh_consts);
     if (need.tanh()) push_entries_of(tanh_polynomial_table);
     if (need.soft_relu()) push_entries_of(soft_relu_consts);

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -252,6 +252,9 @@ private:
         exp_ln_flt_max_f, // logf(FLT_MAX) - max normal value
         exp_ln_flt_min_f, // logf(FLT_MIN) - min normal value
         exp_pol, // see correspondent table for float values
+        exp_coeff1, // 0.6931473921 (0x3f31721c)
+        exp_coeff2, // 0.2413862043 (0x3e772df2)
+        exp_not_mask17, // ~((1u << 17) - 1)
         tanh_idx_bias, // bias applied during index computation
         tanh_idx_mask, // mask applied to extract index
         tanh_linear_ubound, // arg below which tanh(x) = x

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -255,11 +255,8 @@ private:
         exp_coeff1, // 0.6931473921 (0x3f31721c)
         exp_coeff2, // 0.2413862043 (0x3e772df2)
         exp_not_mask17, // ~((1u << 17) - 1)
-        tanh_idx_bias, // bias applied during index computation
-        tanh_idx_mask, // mask applied to extract index
-        tanh_linear_ubound, // arg below which tanh(x) = x
-        tanh_saturation_lbound, // arg after which tanh(x) = 1.f
-        tanh_pol_table, // table of polynomial coefficients
+        tanh_range, // tanh(x) = x - x^3/3 for |x| < tanh_range
+        tanh_m1d3, // -1/3
         soft_relu_one_twenty_six, // 126.f
         soft_relu_mantissa_sign_mask, // mask for mantissa bits and sign
         soft_relu_pol, // see correspondent table for float values

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -192,6 +192,7 @@ private:
             const injector_utils::vmm_index_set_iterator_t start_idx_it);
     void injector_postamble();
     void assign_regs();
+    void set_coef_to_regs();
     void compute_cmp_mask(
             const TRegS &vmm_src, const TRegS &vmm_cmpare, int cmp_predicate);
     void blend_with_mask(const TRegS &vmm_dst, const TRegS &src);
@@ -300,6 +301,20 @@ private:
 
         h->ldr(TReg(z_tmp.getIdx()), ptr(x_addr));
         return z_tmp;
+    }
+
+    TRegS table_val(key_t key, TRegS zreg, size_t key_off_val_shift = 0) {
+        Xbyak_aarch64::XReg x_addr(h->X_DEFAULT_ADDR);
+        auto off = table_off(key, key_off_val_shift);
+
+        if (off) {
+            h->add_imm(x_addr, x_table, off, h->X_TMP_0);
+        } else {
+            x_addr = x_table;
+        }
+
+        h->ldr(TReg(zreg.getIdx()), ptr(x_addr));
+        return zreg;
     }
 
     // we accept only 32bit hexadecimal table values to avoid any rounding

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -275,6 +275,12 @@ private:
         log_five_bit_offset, // 5 bits off (31 = 2^5 - 1)
         log_pol, // see correspondent table for float values
         log_predefined_vals, // see correspondent table for float values
+        log_i127shl23,
+        log_x7fffff,
+        log_log2,
+        log_log1p5,
+        log_f2div3,
+        log_coeffTbl,
         undef_key,
     };
 
@@ -287,20 +293,6 @@ private:
         const auto &te = (*it).second;
         const auto scale = te.bcast ? vlen : sizeof(table_entry_val_t);
         return te.off + key_off_val_shift * scale;
-    }
-
-    TRegS table_val(key_t key, size_t key_off_val_shift = 0) {
-        Xbyak_aarch64::XReg x_addr(h->X_DEFAULT_ADDR);
-        auto off = table_off(key, key_off_val_shift);
-
-        if (off) {
-            h->add_imm(x_addr, x_table, off, h->X_TMP_0);
-        } else {
-            x_addr = x_table;
-        }
-
-        h->ldr(TReg(z_tmp.getIdx()), ptr(x_addr));
-        return z_tmp;
     }
 
     TRegS table_val(key_t key, TRegS zreg, size_t key_off_val_shift = 0) {


### PR DESCRIPTION
# Description

This PR improves the JIT-ed code of eltwise for AArch64 SVE 512 as same as https://github.com/oneapi-src/oneDNN/pull/1089

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
