### PR TITLE
src: cpu: aarch64: remove dependence on scratchpad memory to store bias

### DIFF
--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -56,15 +56,9 @@ status_t acl_gemm_convolution_fwd_t<src_type, wei_type, dst_type,
     acl_obj.wei_tensor.allocator()->import_memory(
             const_cast<wei_data_t *>(wei_base));
     acl_obj.dst_tensor.allocator()->import_memory(dst_base);
-
-    // Retrieve extra bias memory from the scratchpad and copy from user memory
     if (with_bias) {
-        const auto scratchpad = ctx.get_scratchpad_grantor();
-        auto *bia_memory = scratchpad.template get<bia_data_t>(
-                memory_tracking::names::key_none);
-        size_t oc = acl_obj.bia_tensor.info()->tensor_shape()[0];
-        std::memcpy(bia_memory, bia_base, oc * sizeof(bia_data_t));
-        acl_obj.bia_tensor.allocator()->import_memory(bia_memory);
+        acl_obj.bia_tensor.allocator()->import_memory(
+                const_cast<bia_data_t *>(bia_base));
     }
 
     acl_obj.conv.run();

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -123,15 +123,6 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
             arm_compute::Scheduler::get().set_num_threads_with_affinity(
                     dnnl_get_max_threads(), linear);
 
-            // TODO: remove dependence on scratchpad memory
-            // Using user provided memory for the biases currently segfaults
-            if (acp_.with_bias) {
-                auto scratchpad = scratchpad_registry().registrar();
-                const size_t bia_mem_sz_ = acp_.bia_info.tensor_shape()[0];
-                scratchpad.template book<bia_data_t>(
-                        memory_tracking::names::key_none, bia_mem_sz_);
-            }
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -43,15 +43,9 @@ status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
     acl_indirect_gemm_obj.wei_tensor.allocator()->import_memory(
             const_cast<data_t *>(wei_base));
     acl_indirect_gemm_obj.dst_tensor.allocator()->import_memory(dst_base);
-
-    // Retrieve extra bias memory from the scratchpad and copy from user memory
     if (with_bias) {
-        const auto scratchpad = ctx.get_scratchpad_grantor();
-        data_t *bia_memory = scratchpad.template get<data_t>(
-                memory_tracking::names::key_none);
-        size_t oc = acl_indirect_gemm_obj.bia_tensor.info()->tensor_shape()[0];
-        std::memcpy(bia_memory, bia_base, oc * sizeof(data_t));
-        acl_indirect_gemm_obj.bia_tensor.allocator()->import_memory(bia_memory);
+        acl_indirect_gemm_obj.bia_tensor.allocator()->import_memory(
+                const_cast<data_t *>(bia_base));
     }
 
     acl_indirect_gemm_obj.conv.run();

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -112,15 +112,6 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
             arm_compute::Scheduler::get().set_num_threads_with_affinity(
                     dnnl_get_max_threads(), linear);
 
-            // TODO: remove dependence on scratchpad memory
-            // Using user provided memory for the biases currently segfaults
-            if (acp_.with_bias) {
-                auto scratchpad = scratchpad_registry().registrar();
-                const size_t bia_mem_sz_ = acp_.bia_info.tensor_shape()[0];
-                scratchpad.template book<data_t>(
-                        memory_tracking::names::key_none, bia_mem_sz_);
-            }
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Arm Ltd. and affiliates
+* Copyright 2020-2021 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,15 +55,9 @@ status_t acl_wino_convolution_fwd_t::execute_forward(
     acl_wino_obj.wei_tensor.allocator()->import_memory(
             const_cast<data_t *>(wei_base));
     acl_wino_obj.dst_tensor.allocator()->import_memory(dst_base);
-
-    // Retrieve extra bias memory from the scratchpad and copy from user memory
     if (with_bias) {
-        const auto scratchpad = ctx.get_scratchpad_grantor();
-        data_t *bia_memory = scratchpad.template get<data_t>(
-                memory_tracking::names::key_none);
-        size_t oc = acl_wino_obj.bia_tensor.info()->tensor_shape()[0];
-        std::memcpy(bia_memory, bia_base, oc * sizeof(data_t));
-        acl_wino_obj.bia_tensor.allocator()->import_memory(bia_memory);
+        acl_wino_obj.bia_tensor.allocator()->import_memory(
+                const_cast<data_t *>(bia_base));
     }
 
     acl_wino_obj.conv.run();

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Arm Ltd. and affiliates
+* Copyright 2020-2021 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,15 +109,6 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
                     = [](int i, int max_cores) { return i % max_cores; };
             arm_compute::Scheduler::get().set_num_threads_with_affinity(
                     dnnl_get_max_threads(), linear);
-
-            // TODO: remove dependence on scratchpad memory
-            // Using user provided memory for the biases currently segfaults
-            if (acp_.with_bias) {
-                auto scratchpad = scratchpad_registry().registrar();
-                const size_t bia_mem_sz_ = acp_.bia_info.tensor_shape()[0];
-                scratchpad.template book<data_t>(
-                        memory_tracking::names::key_none, bia_mem_sz_);
-            }
 
             return status::success;
         }


### PR DESCRIPTION
# Description

This PR removes workaround introduced previously in [PR#820](https://github.com/oneapi-src/oneDNN/pull/820) (GEMM-based convolution), [PR#886](https://github.com/oneapi-src/oneDNN/pull/886) (Winograd-based convolution), and [PR#973](https://github.com/oneapi-src/oneDNN/pull/973) (indirect convolution). With the v21.05 release of Compute Library this workaround is not needed anymore. Minimum Compute Library version in oneDNN has recently been updated in [PR#1081](https://github.com/oneapi-src/oneDNN/pull/1081).

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [N/A ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?
