### PR TITLE
src: cpu: aarch64: add support for ACL-based inner product

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -17,14 +17,9 @@
 #ifndef CPU_AARCH64_ACL_CONVOLUTION_UTILS_HPP
 #define CPU_AARCH64_ACL_CONVOLUTION_UTILS_HPP
 
-#include "common/c_types_map.hpp"
-#include "common/dnnl_thread.hpp"
-#include "common/memory_tracking.hpp"
-
 #include "cpu/cpu_convolution_pd.hpp"
-#include "cpu/cpu_engine.hpp"
 
-#include "arm_compute/runtime/NEON/NEFunctions.h"
+#include "cpu/aarch64/acl_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -73,10 +68,6 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
         const primitive_attr_t &attr);
-
-arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
-arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
-bool acl_act_ok(alg_kind_t eltwise_activation);
 
 } // namespace acl_convolution_utils
 

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -14,15 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "oneapi/dnnl/dnnl_types.h"
-
-#include "common/c_types_map.hpp"
-#include "common/dnnl_thread.hpp"
-#include "common/type_helpers.hpp"
-#include "common/utils.hpp"
 #include "cpu/aarch64/acl_gemm_convolution.hpp"
-
-#include <cstring>
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -71,7 +71,7 @@ struct acl_inner_product_fwd_t : public primitive_t {
     struct pd_t : public cpu_inner_product_fwd_pd_t {
         using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("inner_product:acl", acl_inner_product_fwd_t);
+        DECLARE_COMMON_PD_T("acl", acl_inner_product_fwd_t);
 
         status_t init(engine_t *engine) {
             using namespace utils;

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -71,7 +71,7 @@ struct acl_inner_product_fwd_t : public primitive_t {
     struct pd_t : public cpu_inner_product_fwd_pd_t {
         using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T("acl", acl_inner_product_fwd_t);
+        DECLARE_COMMON_PD_T("inner_product:acl", acl_inner_product_fwd_t);
 
         status_t init(engine_t *engine) {
             using namespace utils;

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -1,0 +1,153 @@
+/*******************************************************************************
+* Copyright 2021 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_INNER_PRODUCT_HPP
+#define CPU_AARCH64_ACL_INNER_PRODUCT_HPP
+
+#include "cpu/cpu_inner_product_pd.hpp"
+
+#include "cpu/aarch64/acl_inner_product_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct acl_ip_resource_t : public resource_t {
+    acl_ip_resource_t() : acl_ip_obj_(utils::make_unique<acl_ip_obj_t>()) {}
+
+    status_t configure(const acl_ip_conf_t &aip) {
+        if (!acl_ip_obj_) return status::out_of_memory;
+
+        // Init Compute Library tensors based on info from descriptor
+        acl_ip_obj_->src_tensor.allocator()->init(aip.src_info);
+        acl_ip_obj_->wei_tensor.allocator()->init(aip.wei_info);
+        acl_ip_obj_->dst_tensor.allocator()->init(aip.dst_info);
+        acl_ip_obj_->bia_tensor.allocator()->init(aip.bia_info);
+        if (aip.with_sum) {
+            acl_ip_obj_->dst_acc_tensor.allocator()->init(aip.dst_info);
+        }
+
+        // clang-format off
+        acl_ip_obj_->fc.configure(
+            &acl_ip_obj_->src_tensor,
+            &acl_ip_obj_->wei_tensor,
+            aip.with_bias ? &acl_ip_obj_->bia_tensor : nullptr,
+            aip.with_sum ? &acl_ip_obj_->dst_acc_tensor : &acl_ip_obj_->dst_tensor,
+            aip.fc_info);
+        // clang-format on
+        if (aip.with_sum) {
+            acl_ip_obj_->add.configure(&acl_ip_obj_->dst_tensor,
+                    &acl_ip_obj_->dst_acc_tensor, &acl_ip_obj_->dst_tensor,
+                    arm_compute::ConvertPolicy::SATURATE);
+            acl_ip_obj_->dst_acc_tensor.allocator()->allocate();
+        }
+
+        return status::success;
+    }
+
+    acl_ip_obj_t &get_acl_obj() const { return *acl_ip_obj_; }
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_ip_resource_t);
+
+private:
+    std::unique_ptr<acl_ip_obj_t> acl_ip_obj_;
+}; // acl_ip_resource_t
+
+struct acl_inner_product_fwd_t : public primitive_t {
+    struct pd_t : public cpu_inner_product_fwd_pd_t {
+        using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("inner_product:acl", acl_inner_product_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace utils;
+
+            const bool ok = is_fwd() && !has_zero_dim_memory()
+                    && expect_data_types(data_type::f32, data_type::f32,
+                            data_type::f32, data_type::f32, data_type::f32)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops,
+                            data_type::f32)
+                    && (set_default_params() == status::success)
+                    && post_ops_ok();
+
+            if (!ok) return status::unimplemented;
+
+            auto conf_status = acl_inner_product_utils::init_conf_ip(aip_,
+                    src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
+
+            if (conf_status != status::success) return status::unimplemented;
+
+            acl_common_utils::acl_thread_bind();
+
+            return status::success;
+        }
+
+        acl_ip_conf_t aip_;
+
+    protected:
+        bool post_ops_ok() const {
+            auto const &po = attr()->post_ops_;
+            auto is_eltwise
+                    = [&](int idx) { return po.entry_[idx].is_eltwise(); };
+            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
+
+            bool eltwise_ok = false;
+            // Compute Library supports here only one eltwise post-op or sum
+            if (po.len() == 1 && is_eltwise(0)) {
+                const auto act_type = po.entry_[0].eltwise.alg;
+                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
+            }
+
+            return eltwise_ok || (po.len() == 1 && is_sum(0))
+                    || (po.len() == 0);
+        }
+    }; // pd_t
+
+    acl_inner_product_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const override {
+        if (mapper.has_resource(this)) return status::success;
+
+        auto r = utils::make_unique<acl_ip_resource_t>();
+        if (!r) return status::out_of_memory;
+
+        // Configure the resource based on information from primitive descriptor
+        auto st = r->configure(pd()->aip_);
+        if (st == status::success) { mapper.add(this, std::move(r)); }
+
+        return st;
+    }
+
+    using data_t = typename prec_traits<data_type::f32>::type;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+}; // acl_inner_product_fwd_t
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_INNER_PRODUCT_HPP

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -89,8 +89,8 @@ struct acl_inner_product_fwd_t : public primitive_t {
 
             auto conf_status = acl_inner_product_utils::init_conf_ip(aip_,
                     src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
-
-            if (conf_status != status::success) return status::unimplemented;
+            // conf_status here can be either status::success or status::unimplemented
+            if (conf_status != status::success) return conf_status;
 
             acl_common_utils::acl_thread_bind();
 

--- a/src/cpu/aarch64/acl_inner_product_utils.cpp
+++ b/src/cpu/aarch64/acl_inner_product_utils.cpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+* Copyright 2021 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_inner_product_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace acl_inner_product_utils {
+
+using namespace format_tag;
+using namespace utils;
+using namespace status;
+
+status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
+        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
+        const inner_product_desc_t &ipd, const primitive_attr_t &attr) {
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper wei_d(&wei_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bia_d(&bias_md);
+
+    // Compute Library currently supports forward propagation only
+    const prop_kind_t prop_kind = ipd.prop_kind;
+    const bool is_fwd = (prop_kind == dnnl_forward_training)
+            || (prop_kind == dnnl_forward_inference);
+    if (!is_fwd) return status::unimplemented;
+
+    const int with_groups = wei_d.ndims() == src_d.ndims() + 1;
+    const int ndims = src_d.ndims();
+
+    // There are two sub-cases: src & wei tensors are either 2- or 4-dimensional
+    const bool is_2d = (ndims == 2) && (wei_d.ndims() == 2);
+    const bool is_4d = (ndims == 4) && (wei_d.ndims() == 4);
+
+    // Compute Library unsupported shape scenarios
+    // FP32 only is supported at the moment
+    if (one_of(true, !(is_4d || is_2d), with_groups)) { return unimplemented; }
+
+    // batch size
+    const int mb = src_d.dims()[0];
+
+    // src/input channels, height, width
+    const int ic = src_d.dims()[1];
+    const int ih = is_4d ? src_d.dims()[ndims - 2] : 0;
+    const int iw = is_4d ? src_d.dims()[ndims - 1] : 0;
+
+    // dst/output channels
+    const int oc = dst_d.dims()[1];
+
+    // weights height, width
+    const int kh = is_4d ? wei_d.dims()[with_groups + ndims - 2] : 0;
+    const int kw = is_4d ? wei_d.dims()[with_groups + ndims - 1] : 0;
+
+    aip.with_bias = ipd.bias_desc.format_kind != format_kind::undef;
+
+    // Data layout is already defined thus should only be checked
+    auto src_tag = memory_desc_matches_one_of_tag(src_md, nhwc, nchw, nc, cn);
+    auto wei_tag = memory_desc_matches_one_of_tag(wei_md, ohwi, oihw, oi, io);
+    auto dst_tag = memory_desc_matches_one_of_tag(dst_md, nc, cn);
+    if (one_of(format_tag::undef, src_tag, wei_tag, dst_tag)) {
+        return status::unimplemented;
+    }
+
+    arm_compute::TensorShape src_shape {(src_tag == nc)
+                    ? arm_compute::TensorShape(ic, mb)
+                    : arm_compute::TensorShape(mb, ic)};
+    if (is_4d) {
+        src_shape = (src_tag == nhwc)
+                ? arm_compute::TensorShape(ic, iw, ih, mb)
+                : arm_compute::TensorShape(iw, ih, ic, mb);
+    }
+
+    // Compute Library requires the weights to be 2-dimensional for FC layer
+    arm_compute::TensorShape wei_shape {
+            arm_compute::TensorShape(is_4d ? ic * kh * kw : ic, oc)};
+    if (is_2d && wei_tag == io) {
+        wei_shape = arm_compute::TensorShape(oc, ic);
+    }
+
+    arm_compute::DataLayout wei_layout {(wei_tag == ohwi || wei_tag == oi)
+                    ? arm_compute::DataLayout::NHWC
+                    : arm_compute::DataLayout::NCHW};
+
+    // clang-format off
+    aip.src_info = arm_compute::TensorInfo(
+            src_shape,
+            1,
+            arm_compute::DataType::F32,
+            (src_tag == nhwc || src_tag == nc) ?
+            arm_compute::DataLayout::NHWC : arm_compute::DataLayout::NCHW);
+
+    aip.wei_info = arm_compute::TensorInfo(
+            wei_shape,
+            1,
+            arm_compute::DataType::F32,
+            wei_layout);
+
+    aip.dst_info = arm_compute::TensorInfo(
+            (dst_tag == nhwc || dst_tag == nc) ?
+            arm_compute::TensorShape(oc, mb) : arm_compute::TensorShape(mb, oc),
+            1,
+            arm_compute::DataType::F32,
+            (dst_tag == nhwc || dst_tag == nc) ?
+            arm_compute::DataLayout::NHWC : arm_compute::DataLayout::NCHW);
+
+    aip.bia_info = arm_compute::TensorInfo(
+            aip.with_bias ?
+            arm_compute::TensorShape(oc) : arm_compute::TensorShape(),
+            1,
+            arm_compute::DataType::F32);
+    // clang-format on
+
+    aip.fc_info.weights_trained_layout = wei_layout;
+    if (is_2d && wei_tag != src_tag) { aip.fc_info.transpose_weights = false; }
+
+    // Either activation or sum is supported as post-op at the moment
+    aip.fc_info.activation_info = acl_common_utils::get_acl_act(attr);
+    const auto &post_ops = attr.post_ops_;
+    aip.with_sum = (post_ops.len() == 1) && post_ops.entry_[0].is_sum();
+
+    // clang-format off
+    // Validate convolution manually to check for return status
+    auto acl_st = arm_compute::NEFullyConnectedLayer::validate(
+        &aip.src_info,
+        &aip.wei_info,
+        aip.with_bias ? &aip.bia_info : nullptr,
+        &aip.dst_info,
+	aip.fc_info);
+    // clang-format on
+    if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
+        return status::unimplemented;
+    }
+
+    return status::success;
+}
+
+} // namespace acl_inner_product_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_inner_product_utils.hpp
+++ b/src/cpu/aarch64/acl_inner_product_utils.hpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+* Copyright 2021 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
+#define CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
+
+#include "cpu/cpu_inner_product_pd.hpp"
+
+#include "cpu/aarch64/acl_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct acl_ip_obj_t {
+    arm_compute::NEFullyConnectedLayer fc;
+    arm_compute::NEArithmeticAddition add;
+    arm_compute::Tensor src_tensor;
+    arm_compute::Tensor wei_tensor;
+    arm_compute::Tensor bia_tensor;
+    arm_compute::Tensor dst_tensor;
+    arm_compute::Tensor dst_acc_tensor;
+};
+
+struct acl_ip_conf_t {
+    bool with_bias;
+    bool with_sum;
+    arm_compute::TensorInfo src_info;
+    arm_compute::TensorInfo wei_info;
+    arm_compute::TensorInfo bia_info;
+    arm_compute::TensorInfo dst_info;
+    arm_compute::FullyConnectedLayerInfo fc_info;
+};
+
+namespace acl_inner_product_utils {
+
+status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
+        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
+        const inner_product_desc_t &ipd, const primitive_attr_t &attr);
+
+} // namespace acl_inner_product_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP

--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -1,0 +1,107 @@
+/*******************************************************************************
+* Copyright 2021 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace acl_common_utils {
+
+using namespace dnnl::impl::alg_kind;
+using namespace data_type;
+
+arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt) {
+    switch (dt) {
+        case bf16: return arm_compute::DataType::BFLOAT16; break;
+        case f32: return arm_compute::DataType::F32; break;
+        case s32: return arm_compute::DataType::S32; break;
+        case f16: return arm_compute::DataType::F16; break;
+        case s8: return arm_compute::DataType::QASYMM8_SIGNED; break;
+        case u8: return arm_compute::DataType::QASYMM8; break;
+        default: return arm_compute::DataType::UNKNOWN;
+    }
+}
+
+arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr) {
+    const auto &post_ops = attr.post_ops_;
+    const int entry_idx = post_ops.find(primitive_kind::eltwise);
+    if (entry_idx == -1) { return arm_compute::ActivationLayerInfo(); }
+
+    const auto eltwise_alg = post_ops.entry_[entry_idx].eltwise.alg;
+    float alpha = post_ops.entry_[entry_idx].eltwise.alpha;
+    float beta = post_ops.entry_[entry_idx].eltwise.beta;
+
+    using acl_act_t = arm_compute::ActivationLayerInfo::ActivationFunction;
+    acl_act_t acl_act_alg;
+    switch (eltwise_alg) {
+        case eltwise_relu:
+            // oneDNN defines RELU: f(x) = (x > 0) ? x : a*x
+            // Compute Library defines LEAKY_RELU: f(x) = (x > 0) ? x : a*x
+            // whilst Compute Library RELU is defined as: f(x) = max(0,x)
+            if (alpha == 0) {
+                acl_act_alg = acl_act_t::RELU;
+            } else {
+                acl_act_alg = acl_act_t::LEAKY_RELU;
+            }
+            break;
+        case eltwise_tanh:
+            // oneDNN defines TANH activation as:          f(x) = tanh(x)
+            // Compute Library defines TANH activation as: f(x) = a*tanh(b*x)
+            // Setting a=b=1 makes the two equivalent
+            alpha = 1.f;
+            beta = 1.f;
+            acl_act_alg = acl_act_t::TANH;
+            break;
+        case eltwise_elu: acl_act_alg = acl_act_t::ELU; break;
+        case eltwise_square: acl_act_alg = acl_act_t::SQUARE; break;
+        case eltwise_abs: acl_act_alg = acl_act_t::ABS; break;
+        case eltwise_sqrt: acl_act_alg = acl_act_t::SQRT; break;
+        case eltwise_linear: acl_act_alg = acl_act_t::LINEAR; break;
+        case eltwise_bounded_relu: acl_act_alg = acl_act_t::BOUNDED_RELU; break;
+        case eltwise_soft_relu: acl_act_alg = acl_act_t::SOFT_RELU; break;
+        case eltwise_logistic: acl_act_alg = acl_act_t::LOGISTIC; break;
+        default: return arm_compute::ActivationLayerInfo();
+    }
+
+    return arm_compute::ActivationLayerInfo(acl_act_alg, alpha, beta);
+}
+
+bool acl_act_ok(alg_kind_t eltwise_activation) {
+    return utils::one_of(eltwise_activation, eltwise_relu, eltwise_tanh,
+            eltwise_elu, eltwise_square, eltwise_abs, eltwise_sqrt,
+            eltwise_linear, eltwise_bounded_relu, eltwise_soft_relu,
+            eltwise_logistic);
+}
+
+void acl_thread_bind() {
+    // The threads in Compute Library are bound for the cores 0..max_threads-1
+    // dnnl_get_max_threads() returns OMP_NUM_THREADS
+    const int max_threads = dnnl_get_max_threads();
+    arm_compute::IScheduler::BindFunc linear
+            = [](int i, int max_cores) { return i % max_cores; };
+    arm_compute::Scheduler::get().set_num_threads_with_affinity(
+            max_threads, linear);
+}
+
+} // namespace acl_common_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_utils.hpp
+++ b/src/cpu/aarch64/acl_utils.hpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright 2021 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_UTILS_HPP
+#define CPU_AARCH64_ACL_UTILS_HPP
+
+#include "oneapi/dnnl/dnnl_types.h"
+
+#include "common/bfloat16.hpp"
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/cpu_engine.hpp"
+
+#include "arm_compute/runtime/NEON/NEFunctions.h"
+#include "arm_compute/runtime/NEON/NEScheduler.h"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace acl_common_utils {
+
+arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
+arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
+bool acl_act_ok(alg_kind_t eltwise_activation);
+void acl_thread_bind();
+
+} // namespace acl_common_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_UTILS_HPP

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -26,6 +26,11 @@
 using namespace dnnl::impl::cpu::x64;
 #endif
 
+#if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
+#include "cpu/aarch64/acl_inner_product.hpp"
+using namespace dnnl::impl::cpu::aarch64;
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -39,6 +44,7 @@ const impl_list_item_t impl_list[] = {
         CPU_INSTANCE_X64(brgemm_inner_product_fwd_t<avx512_core>)
         CPU_INSTANCE_X64(brgemm_inner_product_bwd_data_t<avx512_core>)
         CPU_INSTANCE_X64(brgemm_inner_product_bwd_weights_t<avx512_core>)
+        CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
         CPU_INSTANCE(gemm_inner_product_fwd_t<f32>)
         CPU_INSTANCE(gemm_inner_product_bwd_data_t<f32>)
         CPU_INSTANCE(gemm_inner_product_bwd_weights_t<f32>)


### PR DESCRIPTION
# Description

This PR introduces support for [inner product](https://oneapi-src.github.io/oneDNN/dev_guide_inner_product.html) operation for AArch64 with the help of Arm Compute Library routines. It provides improved performance on NLP workloads on AArch64 CPUs compared to the reference variant. This implementation falls in line with the same approach as was detailed in the original RFC [#795](https://github.com/oneapi-src/oneDNN/pull/795).

## Outline

The key changes are listed below:
- New `acl_inner_product.cpp/.hpp` files added in `src/cpu/aarch64` directory;
- New implementation `acl_inner_product_fwd_t` added in `src/cpu/cpu_inner_product_list.cpp`;
- Some refactoring was performed for ACL-related functions in `src/cpu/aarch64` directory: common functions were grouped in the `acl_utils.cpp/.hpp` files.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [X] Have you published an RFC for the new feature?
- [X] Was the RFC approved?
- [N/A] Have you added relevant tests?