### PR TITLE
tests: benchdnn: rnn: fix check for unsupported cases

### DIFF
--- a/tests/benchdnn/rnn/rnn.cpp
+++ b/tests/benchdnn/rnn/rnn.cpp
@@ -785,7 +785,7 @@ void check_known_skipped_case(const prb_t &prb, res_t *res) {
         return;
     }
 
-#if !defined(DNNL_X64)
+#if !defined(DNNL_X64) || DNNL_X64 == 0
     // int8 is not supported altogether since RNN relies on packed IGEMM
     // FIXME: this will disable int8 RNN testing if the library is built with
     //        Intel MKL that does have packed IGEMM


### PR DESCRIPTION
The changes introduced in 79be1a9 always define DNNL_X64, which breaks a check for unsupported test cases in benchdnn rnn tests.

Fixes #1108 