### PR TITLE
src: cpu: aarch64: add support for 'sum+act' post-ops

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -205,8 +205,9 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
 
     // Post-convolutional operations (post-ops)
     const auto &post_ops = attr.post_ops_;
+    // is_eltwise(true) here stands for eltwise.scale == 1.f check
     acp.sum_with_eltwise = (post_ops.len() == 2) && post_ops.entry_[0].is_sum()
-            && post_ops.entry_[1].is_eltwise();
+            && post_ops.entry_[1].is_eltwise(true);
     acp.act_info = acl_common_utils::get_acl_act(attr);
 
     return status::success;

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -21,51 +21,20 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-using namespace dnnl::impl::status;
-using namespace dnnl::impl::memory_tracking::names;
-using namespace dnnl::impl::utils;
-
+// src_type is enum and is mapped to src_data_t via
+// prec_traits<src_type>::type src_data_t
 template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type,
         data_type_t bia_type>
 status_t acl_gemm_convolution_fwd_t<src_type, wei_type, dst_type,
         bia_type>::execute_forward(const exec_ctx_t &ctx) const {
-    status_t status = status::success;
-    auto src_base = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
-    auto wei_base = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
-    auto bia_base = CTX_IN_MEM(const bia_data_t *, DNNL_ARG_BIAS);
-    auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
-
-    bool with_bias = pd()->acp_.with_bias;
-    bool sum_with_eltwise = pd()->acp_.sum_with_eltwise;
-
     // Retrieve primitive resource and configured Compute Library objects
     auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
     acl_obj_t<arm_compute::NEGEMMConvolutionLayer> &acl_obj
             = acl_resource->get_acl_obj();
 
-    acl_obj.src_tensor.allocator()->import_memory(
-            const_cast<src_data_t *>(src_base));
-    acl_obj.wei_tensor.allocator()->import_memory(
-            const_cast<wei_data_t *>(wei_base));
-    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
-    if (with_bias) {
-        acl_obj.bia_tensor.allocator()->import_memory(
-                const_cast<bia_data_t *>(bia_base));
-    }
-
-    acl_obj.conv.run();
-
-    if (sum_with_eltwise) {
-        acl_obj.add.run();
-        acl_obj.act.run();
-    }
-
-    acl_obj.src_tensor.allocator()->free();
-    acl_obj.wei_tensor.allocator()->free();
-    acl_obj.dst_tensor.allocator()->free();
-    if (with_bias) { acl_obj.bia_tensor.allocator()->free(); }
-
-    return status;
+    return execute_forward_conv_acl<
+            acl_obj_t<arm_compute::NEGEMMConvolutionLayer>, pd_t, src_data_t,
+            wei_data_t, dst_data_t, bia_data_t>(ctx, acl_obj, pd());
 }
 
 using namespace data_type;

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -132,8 +132,9 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
 
         bool post_ops_ok() const {
             auto const &po = attr()->post_ops_;
+            // "true" here stands for eltwise.scale == 1.f check
             auto is_eltwise
-                    = [&](int idx) { return po.entry_[idx].is_eltwise(); };
+                    = [&](int idx) { return po.entry_[idx].is_eltwise(true); };
             auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
 
             bool sum_with_eltwise

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -102,8 +102,9 @@ struct acl_inner_product_fwd_t : public primitive_t {
     protected:
         bool post_ops_ok() const {
             auto const &po = attr()->post_ops_;
+            // "true" here stands for eltwise.scale == 1.f check
             auto is_eltwise
-                    = [&](int idx) { return po.entry_[idx].is_eltwise(); };
+                    = [&](int idx) { return po.entry_[idx].is_eltwise(true); };
             auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
 
             bool eltwise_ok = false;

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -40,16 +40,30 @@ struct acl_wino_resource_t : public resource_t {
         acl_wino_obj_->dst_tensor.allocator()->init(acp.dst_info);
         acl_wino_obj_->bia_tensor.allocator()->init(acp.bia_info);
 
+        if (acp.sum_with_eltwise) {
+            acl_wino_obj_->dst_acc_tensor.allocator()->init(acp.dst_info);
+        }
         // clang-format off
         acl_wino_obj_->conv.configure(
             &acl_wino_obj_->src_tensor,
             &acl_wino_obj_->wei_tensor,
             acp.with_bias ? &acl_wino_obj_->bia_tensor : nullptr,
-            &acl_wino_obj_->dst_tensor,
+            acp.sum_with_eltwise ? &acl_wino_obj_->dst_acc_tensor
+                                 : &acl_wino_obj_->dst_tensor,
             acp.padstride_info,
-            acp.act_info,
+            acp.sum_with_eltwise ? arm_compute::ActivationLayerInfo()
+                                 : acp.act_info,
             true); // to support 5x5, 7x7 filter shapes in addition to 3x3
         // clang-format on
+        if (acp.sum_with_eltwise) {
+            acl_wino_obj_->add.configure(&acl_wino_obj_->dst_tensor,
+                    &acl_wino_obj_->dst_acc_tensor,
+                    &acl_wino_obj_->dst_acc_tensor,
+                    arm_compute::ConvertPolicy::SATURATE);
+            acl_wino_obj_->act.configure(&acl_wino_obj_->dst_acc_tensor,
+                    &acl_wino_obj_->dst_tensor, acp.act_info);
+            acl_wino_obj_->dst_acc_tensor.allocator()->allocate();
+        }
 
         return status::success;
     }
@@ -103,13 +117,19 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
     protected:
         bool post_ops_ok() const {
             auto const &po = attr()->post_ops_;
+            // "true" here stands for eltwise.scale == 1.f check
             auto is_eltwise
-                    = [&](int idx) { return po.entry_[idx].is_eltwise(); };
+                    = [&](int idx) { return po.entry_[idx].is_eltwise(true); };
+            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
 
+            bool sum_with_eltwise
+                    = (po.len() == 2) && is_sum(0) && is_eltwise(1);
+            bool eltwise_only = (po.len() == 1) ? is_eltwise(0) : false;
             bool eltwise_ok = false;
-            // Compute Library supports only one eltwise post-op
-            if (po.len() == 1 && is_eltwise(0)) {
-                const auto act_type = po.entry_[0].eltwise.alg;
+            // Compute Library supports only one eltwise post-op or
+            // sum+eltwise post-ops
+            if (eltwise_only || sum_with_eltwise) {
+                const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
                 eltwise_ok = acl_common_utils::acl_act_ok(act_type);
             }
 


### PR DESCRIPTION
# Description

This PR introduces support for the `sum` post-op followed by an activation for indirect and Winograd convolution implementations on AArch64, which increases the coverage of use cases compared to an activation only. Part of the code base is also templated to reduce its size. Implementation follows the same approach as was detailed in RFC [#795](https://github.com/oneapi-src/oneDNN/pull/795).

## Outline

The key changes are listed below:

- Two post-ops in the form of sum together with eltwise activation are now supported for indirect (`acl_indirect_gemm_convolution_fwd_t`) and Winograd (`acl_wino_convolution_fwd_t`) convolutions on AArch64;
- The function `execute_forward_conv_acl` is templated to reduce the code base size.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?