### PR TITLE
fix a logical bug to show onednn version info in verbose

### DIFF
--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -80,7 +80,7 @@ int get_verbose() {
         if (!verbose.initialized()) verbose.set(0);
     }
     static std::atomic_flag version_printed = ATOMIC_FLAG_INIT;
-    if (!version_printed.test_and_set() && verbose.get() > 0) {
+    if (verbose.get() > 0 && !version_printed.test_and_set()) {
         printf("dnnl_verbose,info,oneDNN v%d.%d.%d (commit %s)\n",
                 dnnl_version()->major, dnnl_version()->minor,
                 dnnl_version()->patch, dnnl_version()->hash);


### PR DESCRIPTION
# Description

The current condition check is as the following, which will check and set version_printed variable then check verbose.
if (!version_printed.test_and_set() && verbose.get() > 0)
This will cause a problem if verbose is set to 1 in middle of execution, even the verbose is 0, version_printed has already been set. So when verbose is set to 1, the version_printed had already been set, and thus, the version info will not be printed.

Swap order of these 2 conditions solves this problem.
if (verbose.get() > 0 && !version_printed.test_and_set())

Fixes # (github issue)

# Checklist

## General

- [Y] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [Y] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [Y] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N] Have you added relevant regression tests?
No regression

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
