### PR TITLE
Drop uneeded immintrin.h

### DIFF
--- a/src/gpu/jit/ngen/ngen_utils.hpp
+++ b/src/gpu/jit/ngen/ngen_utils.hpp
@@ -19,8 +19,6 @@
 
 #include <cstdint>
 
-#include <immintrin.h>
-
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif


### PR DESCRIPTION
# Description
This fixes compilation on non-x86 arches
Fixes #1137

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?


