### PR TITLE
version.cmake: tweak git log invocation

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -29,7 +29,7 @@ list(GET VERSION_LIST 2 DNNL_VERSION_PATCH)
 
 find_package(Git)
 if(GIT_FOUND)
-    execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%H
+    execute_process(COMMAND ${GIT_EXECUTABLE} -c log.showSignature=false log --no-abbrev-commit --oneline -1 --format=%H
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         RESULT_VARIABLE RESULT
         OUTPUT_VARIABLE DNNL_VERSION_HASH


### PR DESCRIPTION
If a user has set log.showSignature = true, then build will break
because DNNL_VERSION_HASH define will be overrun by muliple lines about
the signature of the commit.

If a user has customized core.abbrev-- e.g. Linux kernel developers are
encouraged to set it to 12-- then each build could display a commit hash
string of differing lengths. The git default is "auto", so length of the
hash string could change depending on, e.g., the number of commits in
this repository. That's probably undesirable. By explicitly overriding
abbrev on the command line, it ensures all builds going forward will
generate a hash of the same length (namely, the entire commit hash).

With --oneline one and only one line of output ought to appear, and it
will be the commit hash.

Signed-off-by: Joe Konno <joe.konno@intel.com>