### PR TITLE
src: sycl: removing the use of single_task

### DIFF
--- a/src/sycl/sycl_stream_cpu_thunk.cpp
+++ b/src/sycl/sycl_stream_cpu_thunk.cpp
@@ -27,9 +27,9 @@
 using namespace dnnl::impl;
 using namespace dnnl::impl::sycl;
 
-extern "C" void dnnl_impl_sycl_cpu_thunk(const thunk_params_t *params) {
+void dnnl_impl_sycl_cpu_thunk(const thunk_params_t *params) {
 
-    auto *submit_ctx = reinterpret_cast<submit_ctx_t *>(params->submit_ctx_ptr);
+    auto *submit_ctx = params->submit_ctx_ptr;
     auto *prim_iface = submit_ctx->prim_iface;
 
     assert(params->size == submit_ctx->sycl_mem_storages.size());

--- a/src/sycl/sycl_stream_cpu_thunk.hpp
+++ b/src/sycl/sycl_stream_cpu_thunk.hpp
@@ -42,16 +42,14 @@ struct thunk_params_t {
 
     size_t size;
     uintptr_t native_pointers[max_size];
-    uintptr_t submit_ctx_ptr;
+    submit_ctx_t *submit_ctx_ptr;
 };
 
 } // namespace sycl
 } // namespace impl
 } // namespace dnnl
 
-// OpenCL for CPU cannot find mangled functions so use
-// C linkage for the thunk
-extern "C" void DNNL_API dnnl_impl_sycl_cpu_thunk(
+void DNNL_API dnnl_impl_sycl_cpu_thunk(
         const dnnl::impl::sycl::thunk_params_t *params);
 
 #endif // SYCL_STREAM_CPU_THUNK_HPP

--- a/src/sycl/sycl_stream_submit_cpu_primitive.cpp
+++ b/src/sycl/sycl_stream_submit_cpu_primitive.cpp
@@ -34,10 +34,6 @@
 #include <vector>
 #include <CL/sycl.hpp>
 
-// A global scope tag type to use for enqueueing a single task
-template <typename... types>
-class dnnl_submit_primitive_tag_t;
-
 namespace dnnl {
 namespace impl {
 namespace sycl {
@@ -56,10 +52,6 @@ void init_thunk_params(
             = reinterpret_cast<uintptr_t>(&acc[0]);
     init_thunk_params<N>(p, accessors...);
 }
-
-template <typename... accessor_types>
-using make_kernel_tag
-        = dnnl_submit_primitive_tag_t<typename accessor_types::value_type...>;
 
 template <typename... param_types>
 status_t submit_cpu_primitive_with_params_impl(submit_ctx_t *submit_ctx,

--- a/src/sycl/sycl_stream_submit_cpu_primitive.cpp
+++ b/src/sycl/sycl_stream_submit_cpu_primitive.cpp
@@ -67,9 +67,8 @@ status_t submit_cpu_primitive_with_params_impl(submit_ctx_t *submit_ctx,
     // Trick the compiler by capturing scalar values in the kernel
     // instead of pointers what is not allowed.
     uintptr_t submit_ctx_ptr = reinterpret_cast<uintptr_t>(submit_ctx);
-    using tag_type = make_kernel_tag<param_types...>;
 
-    host_task<tag_type>(cgh, [=]() {
+    host_task(cgh, [=]() {
         thunk_params_t thunk_params;
         thunk_params.submit_ctx_ptr = submit_ctx_ptr;
 

--- a/src/sycl/sycl_stream_submit_cpu_primitive.cpp
+++ b/src/sycl/sycl_stream_submit_cpu_primitive.cpp
@@ -64,20 +64,16 @@ using make_kernel_tag
 template <typename... param_types>
 status_t submit_cpu_primitive_with_params_impl(submit_ctx_t *submit_ctx,
         cl::sycl::handler &cgh, param_types... params) {
-    // Trick the compiler by capturing scalar values in the kernel
-    // instead of pointers what is not allowed.
-    uintptr_t submit_ctx_ptr = reinterpret_cast<uintptr_t>(submit_ctx);
 
     host_task(cgh, [=]() {
         thunk_params_t thunk_params;
-        thunk_params.submit_ctx_ptr = submit_ctx_ptr;
+        thunk_params.submit_ctx_ptr = submit_ctx;
 
         constexpr size_t nparams = sizeof...(param_types);
 
         // Extract pointers from params
         init_thunk_params<nparams>(&thunk_params, params...);
 
-        // Call C-linkage thunk which executes CPU primitive natively
         dnnl_impl_sycl_cpu_thunk(&thunk_params);
     });
     return status::success;

--- a/src/sycl/sycl_utils.hpp
+++ b/src/sycl/sycl_utils.hpp
@@ -53,11 +53,9 @@ inline cl::sycl::nd_range<3> to_sycl_nd_range(
 // Automatically use host_task if it is supported by compiler,
 // otherwise fall back to single_task.
 template <typename K, typename H, typename F>
-inline auto host_task_impl(H &cgh, F f, int)
-        -> decltype(cgh.host_task(f)) {
+inline auto host_task_impl(H &cgh, F f, int) -> decltype(cgh.host_task(f)) {
     cgh.host_task(f);
 }
-
 template <typename K, typename H, typename F>
 inline void host_task_impl(H &cgh, F f, long) {
     cgh.template single_task<K>(f);

--- a/src/sycl/sycl_utils.hpp
+++ b/src/sycl/sycl_utils.hpp
@@ -50,12 +50,12 @@ inline cl::sycl::nd_range<3> to_sycl_nd_range(
     return cl::sycl::nd_range<3>(sycl_global_range, sycl_local_range);
 }
 
-// Automatically use codeplay_host_task if it is supported by compiler,
+// Automatically use host_task if it is supported by compiler,
 // otherwise fall back to single_task.
 template <typename K, typename H, typename F>
 inline auto host_task_impl(H &cgh, F f, int)
-        -> decltype(cgh.codeplay_host_task(f)) {
-    cgh.codeplay_host_task(f);
+        -> decltype(cgh.host_task(f)) {
+    cgh.host_task(f);
 }
 
 template <typename K, typename H, typename F>
@@ -66,7 +66,7 @@ inline void host_task_impl(H &cgh, F f, long) {
 template <typename K, typename H, typename F>
 inline void host_task(H &cgh, F f) {
     // Third argument is 0 (int) which prefers the
-    // run_on_host_intel option if both are available.
+    // host_task option if both are available.
     host_task_impl<K>(cgh, f, 0);
 }
 

--- a/src/sycl/sycl_utils.hpp
+++ b/src/sycl/sycl_utils.hpp
@@ -51,21 +51,23 @@ inline cl::sycl::nd_range<3> to_sycl_nd_range(
 }
 
 // Automatically use host_task if it is supported by compiler,
-// otherwise fall back to single_task.
-template <typename K, typename H, typename F>
+// otherwise fall back to codeplay_host_task.
+template <typename H, typename F>
 inline auto host_task_impl(H &cgh, F f, int) -> decltype(cgh.host_task(f)) {
     cgh.host_task(f);
 }
-template <typename K, typename H, typename F>
-inline void host_task_impl(H &cgh, F f, long) {
-    cgh.template single_task<K>(f);
+
+template <typename H, typename F>
+inline auto host_task_impl(H &cgh, F f, long)
+        -> decltype(cgh.codeplay_host_task(f)) {
+    cgh.codeplay_host_task(f);
 }
 
-template <typename K, typename H, typename F>
+template <typename H, typename F>
 inline void host_task(H &cgh, F f) {
     // Third argument is 0 (int) which prefers the
     // host_task option if both are available.
-    host_task_impl<K>(cgh, f, 0);
+    host_task_impl(cgh, f, 0);
 }
 
 enum class backend_t { unknown, host, level0, opencl, nvidia };

--- a/src/sycl/sycl_utils.hpp
+++ b/src/sycl/sycl_utils.hpp
@@ -53,18 +53,18 @@ inline cl::sycl::nd_range<3> to_sycl_nd_range(
 // Automatically use host_task if it is supported by compiler,
 // otherwise fall back to codeplay_host_task.
 template <typename H, typename F>
-inline auto host_task_impl(H &cgh, F f, int) -> decltype(cgh.host_task(f)) {
+inline auto host_task_impl(H &cgh, F &&f, int) -> decltype(cgh.host_task(f)) {
     cgh.host_task(f);
 }
 
 template <typename H, typename F>
-inline auto host_task_impl(H &cgh, F f, long)
+inline auto host_task_impl(H &cgh, F &&f, long)
         -> decltype(cgh.codeplay_host_task(f)) {
     cgh.codeplay_host_task(f);
 }
 
 template <typename H, typename F>
-inline void host_task(H &cgh, F f) {
+inline void host_task(H &cgh, F &&f) {
     // Third argument is 0 (int) which prefers the
     // host_task option if both are available.
     host_task_impl(cgh, f, 0);


### PR DESCRIPTION
# Description

Codeplay host task was removed from DPC++. So the code would fallback on using single_task and thus made compilation impossible. This commit removes single_task and uses codeplay_host_task as a fallback for older versions of DPC++.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?