### PR TITLE
cpu: aarch64: remove thread binding for Compute Library primitive

### DIFF
--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -106,13 +106,10 @@ void acl_thread_bind() {
     // The threads in Compute Library are bound for the cores 0..max_threads-1
     // dnnl_get_max_threads() returns OMP_NUM_THREADS
     const int max_threads = dnnl_get_max_threads();
-    arm_compute::IScheduler::BindFunc linear
-            = [](int i, int max_cores) { return i % max_cores; };
     // arm_compute::Scheduler does not support concurrent access thus a
     // workaround here restricts it to only one call
     std::call_once(flag_once, [&]() {
-        arm_compute::Scheduler::get().set_num_threads_with_affinity(
-                max_threads, linear);
+        arm_compute::Scheduler::get().set_num_threads(max_threads);
     });
 }
 


### PR DESCRIPTION
# Description                                                                                                                                                                                                                                                                   

Removes linear thread binding for Compute Library primitives originally introduced in #1063.

Profiling of TensorFlow workloads using both Compute Library and oneDNN C++ primitives demonstrates that the use of linear thread binding in Compute Library starves the non-Compute Library primitives of threads, leading to a net negative impact in performance.

# Checklist

## Code-change submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [X] Have you formatted the code using clang-format?

### New features

- [N/A] Have you added relevant tests?
- [N/A] Have you provided motivation for adding a new feature?

### Bug fixes

- [N/A] Have you added relevant regression tests?
- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
