### PR TITLE
[rls-v2.4] cpu: aarch64: add fastmath support from Compute Library

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -27,7 +27,7 @@ steps:
   image: ubuntu:16.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 21.05 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -80,7 +80,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 21.05 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -111,7 +111,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 21.05 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -18,7 +18,7 @@
 # *******************************************************************************
 
 # Compute Library build defaults
-ACL_VERSION="v21.05"
+ACL_VERSION="v21.08"
 ACL_DIR="${PWD}/ComputeLibrary"
 ACL_ARCH="arm64-v8a"
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ integration. Compute Library is an open-source library for machine learning appl
 and provides AArch64 optimized implementations of core functions. This functionality currently
 requires that Compute Library is downloaded and built separately, see
 [Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html). oneDNN is only
-compatible with Compute Library versions 21.05 or later.
+compatible with Compute Library versions 21.08 or later.
 
 > **WARNING**
 >

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -31,7 +31,7 @@ endif()
 
 find_package(ACL REQUIRED)
 
-set(ACL_MINIMUM_VERSION "21.05")
+set(ACL_MINIMUM_VERSION "21.08")
 
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -189,10 +189,10 @@ By default, AArch64 builds will use the reference implementations throughout.
 The following options enable the use of AArch64 optimised implementations
 for a limited number of operations, provided by AArch64 libraries.
 
-| AArch64 build configuration           | CMake Option              | Environment variables                         | Dependencies
-| :---                                  | :---                      | :---                                          | :---
-| Arm Compute Library based primitives  | DNNL_AARCH64_USE_ACL=ON   | ACL_ROOT_DIR=*Arm Compute Library location*   | [Arm Compute Library](https://github.com/ARM-software/ComputeLibrary)
-| Vendor BLAS library support           | DNNL_BLAS_VENDOR=ARMPL    | None                                          | [Arm Performance Libraries](https://developer.arm.com/tools-and-software/server-and-hpc/downloads/arm-performance-libraries)
+| AArch64 build configuration           | CMake Option              | Environment variables                    | Dependencies
+| :---                                  | :---                      | :---                                     | :---
+| Arm Compute Library based primitives  | DNNL_AARCH64_USE_ACL=ON   | ACL_ROOT_DIR=*</path/to/ComputeLibrary>* | [Arm Compute Library](https://github.com/ARM-software/ComputeLibrary)
+| Vendor BLAS library support           | DNNL_BLAS_VENDOR=ARMPL    | None                                     | [Arm Performance Libraries](https://developer.arm.com/tools-and-software/server-and-hpc/downloads/arm-performance-libraries)
 
 #### Arm Compute Library
 Arm Compute Library is an open-source library for machine learning applications.

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -214,7 +214,7 @@ For a debug build of oneDNN it is advisable to specify a Compute Library build
 which has also been built with debug enabled.
 
 @warning
-oneDNN is only compatible with Compute Library builds v21.05 or later.
+oneDNN is only compatible with Compute Library builds v21.08 or later.
 
 #### Vendor BLAS libraries
 oneDNN can use a standard BLAS library for GEMM operations.

--- a/doc/programming_model/attributes_fpmath_mode.md
+++ b/doc/programming_model/attributes_fpmath_mode.md
@@ -36,3 +36,9 @@ down-conversion is allowed.  However, this default behavior can be
 changed with the `DNNL_DEFAULT_FPMATH_MODE` environment variable, the
 @ref dnnl_set_default_fpmath_mode (C API) or the @ref
 dnnl::set_default_fpmath_mode (C++ API) functions.
+
+@note
+For builds where Arm Compute Library is enabled, setting
+`DNNL_DEFAULT_FPMATH_MODE` to `BF16` or `ANY` will instruct Compute Library to
+dispatch bfloat16 kernels where available, provided the hardware supports
+bfloat16 instructions. _Note: this may introduce a drop in accuracy._

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -42,6 +42,7 @@ struct acl_conv_conf_t {
     bool with_bias;
     bool is_int8;
     bool sum_with_eltwise;
+    bool fast_math;
     arm_compute::TensorInfo src_info;
     arm_compute::TensorInfo wei_info;
     arm_compute::TensorInfo bia_info;

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -51,7 +51,8 @@ struct acl_resource_t : public resource_t {
             acp.padstride_info,
             acp.weights_info,
             acp.dilation_info,
-            acp.sum_with_eltwise ? arm_compute::ActivationLayerInfo() : acp.act_info);
+            acp.sum_with_eltwise ? arm_compute::ActivationLayerInfo() : acp.act_info,
+            acp.fast_math);
         // clang-format on
         if (acp.sum_with_eltwise) {
             acl_obj_->add.configure(&acl_obj_->dst_tensor,

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -54,7 +54,7 @@ struct acl_indirect_gemm_resource_t : public resource_t {
                                     acp.sum_with_eltwise
                                         ? arm_compute::ActivationLayerInfo()
                                         : acp.act_info,
-                                    false,
+                                    acp.fast_math,
                                     1));
         // clang-format on
         if (acp.sum_with_eltwise) {


### PR DESCRIPTION
# Description

(originally introduced as #1150)

This PR add fastmath support from Compute Library-enabled builds. 
The implementation makes use of existing environment variable `DNNL_DEFAULT_FPMATH_MODE`. If this variable is set to `BF16` or `ANY`, Compute Library will dispatch bfloat16 kernels where available, provided the hardware supports bfloat16 instructions.

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [x] Have you formatted the code using clang-format?

### New features

- [ ] Have you added relevant tests?
- [x] Have you provided motivation for adding a new feature?
