### PR TITLE
Updated Nvidia build instruction to avoid cuda opencl header conflict.

### DIFF
--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -16,28 +16,35 @@ in-order queue when creating a stream if needed.
 
 ## Build command
 
-These build instructions have been validated with the latest CUDA 11.4 toolkit.
+These build instructions have been validated with the latest CUDA 11.4 toolkit and DPC++ compiler release 2021.4.0.
+In order that the correct OpenCL headers are used it is necessary to manually specify their path using the OpenCL_INCLUDE_DIR cmake variable.
+The up to date header can be found [here](https://github.com/KhronosGroup/OpenCL-Headers).
 
 ```bash
-mkdir build
-cd build
-cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
--DOpenCL_INCLUDE_DIR=/path/to/DPCPP/build/_deps/ocl-headers-src \
+$ mkdir build
+$ cd build
+$ cmake -DCMAKE_C_COMPILER=/path/to/DPC++_bin/clang -DCMAKE_CXX_COMPILER=/path/to/DPC++_bin/clang++ \
+-DOpenCL_INCLUDE_DIR=/path/to/OpenCL-Headers/ \
 -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP -DDNNL_GPU_VENDOR=NVIDIA \
 -DCUBLAS_LIBRARY=/path/to/cuda/lib64/libcublas.so \
--DCUBLAS_INCLUDE_DIR=/path/to/cuda/include \
--DCUDNN_INCLUDE_DIR=/path/to/cuda/include \
--G Ninja -DOPENCLROOT=/path/to/DPCPP/build/lib ..
+-DCUBLAS_INCLUDE_DIR=/path/to/cuda/include/ \
+-DCUDNN_INCLUDE_DIR=/path/to/cuda/include/ \
+-G Ninja ..
+$ ninja
 ```
 
-The default /path/to/cuda is /usr/local/cuda
+The /path/to/cuda/ for a default cuda installation is /usr/local/cuda/
+The /path/to/OpenCLlib/ using the 2021.4.0 DPC++ compiler release is /opt/intel/oneapi/compiler/2021.4.0/linux/lib/
+The /path/to/DPC++_bin/ using the 2021.4.0 DPC++ compiler release is /opt/intel/oneapi/compiler/2021.4.0/linux/bin/
+
+If you have a manual, non-packaged build of DPC++ in your home directory then it is also necessary to add -DOPENCLROOT=/path/to/OpenCLlib/ to the cmake invocation.
 
 ## Running Tests
 
-Add the path to the dynamic libraries from DPC++ to LD_LIBRARY_PATH:
+If you have a manual, non-packaged build of DPC++ in your home directory then it is also necessary to add the path to the dynamic libraries from DPC++ to LD_LIBRARY_PATH:
 
 ```bash
-export LD_LIBRARY_PATH=/path/to/DPCPP/build/lib/:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/path/to/OpenCLlib/:$LD_LIBRARY_PATH
 ```
 
 Run tests:

--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -14,17 +14,26 @@ Nvidia GPUs. The stream in Nvidia backend for oneDNN defines an out-of-order
 SYCL queue by default. Similar to the existing oneDNN API, user can specify an
 in-order queue when creating a stream if needed.
 
+## Additional prerequisites
+
+Installing oneDNN with the Nvidia backend requires a compatible CUDA toolkit (> 10.2) and the DPC++ SYCL compiler.
+Build instructions for the DPC++ compiler using the Nvidia CUDA backend can be found here:
+
+https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md
+
+###Clarification
+
+Please note that the oneDNN Nvidia backend cannot be compiled using the DPC++ compiler from the oneAPI HPC toolkit.
+
 ## Build command
 
-These build instructions have been validated with the latest CUDA 11.4 toolkit and DPC++ compiler release 2021.4.0.
-In order that the correct OpenCL headers are used it is necessary to manually specify their path using the OpenCL_INCLUDE_DIR cmake variable.
-The up to date headers can be found [here](https://github.com/KhronosGroup/OpenCL-Headers).
+These build instructions have been validated with the CUDA 11.4 toolkit.
+
 
 ```bash
 $ mkdir build
 $ cd build
-$ cmake -DCMAKE_C_COMPILER=/path/to/DPC++_bin/clang -DCMAKE_CXX_COMPILER=/path/to/DPC++_bin/clang++ \
--DOpenCL_INCLUDE_DIR=/path/to/OpenCL-Headers/ \
+$ cmake -DCMAKE_C_COMPILER=/path/to/DPC++_install/bin/clang -DCMAKE_CXX_COMPILER=/path/to/DPC++_install/bin/clang++ \
 -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP -DDNNL_GPU_VENDOR=NVIDIA \
 -DCUBLAS_LIBRARY=/path/to/cuda/lib64/libcublas.so \
 -DCUBLAS_INCLUDE_DIR=/path/to/cuda/include/ \
@@ -33,23 +42,9 @@ $ cmake -DCMAKE_C_COMPILER=/path/to/DPC++_bin/clang -DCMAKE_CXX_COMPILER=/path/t
 $ ninja
 ```
 
-The /path/to/cuda/ for a default cuda installation is /usr/local/cuda/
-
-The /path/to/OpenCLlib/ using the 2021.4.0 DPC++ compiler release is /opt/intel/oneapi/compiler/2021.4.0/linux/lib/
-
-The /path/to/DPC++_bin/ using the 2021.4.0 DPC++ compiler release is /opt/intel/oneapi/compiler/2021.4.0/linux/bin/
-
-If you have a manual, non-packaged build of DPC++ in your home directory, then it is also necessary to add `-DOPENCLROOT=/path/to/OpenCLlib/` to the cmake invocation.
-
 ## Running Tests
 
-If you have a manual, non-packaged build of DPC++ in your home directory, then it is also necessary to add the path to the dynamic libraries from DPC++ to `LD_LIBRARY_PATH`:
-
-```bash
-export LD_LIBRARY_PATH=/path/to/OpenCLlib/:$LD_LIBRARY_PATH
-```
-
-Run tests:
+Following the above build instructions you can run tests:
 
 ```bash
 ctest

--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -16,15 +16,37 @@ in-order queue when creating a stream if needed.
 
 ## Build command
 
+These build instructions have been validated with the latest CUDA 11.4 toolkit.
+
 ```bash
-export CC=/path/to/dpcpp/install/bin/clang
-export CXX=/path/to/dpcpp/install/bin/clang++
 mkdir build
 cd build
-cmake -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP \
-      -DDNNL_GPU_VENDOR=NVIDIA -G Ninja \
-      -DOPENCLROOT=/path/to/the/root/folder/of/libOpenCL.so ..
+cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+-DOpenCL_INCLUDE_DIR=/path/to/DPCPP/build/_deps/ocl-headers-src \
+-DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP -DDNNL_GPU_VENDOR=NVIDIA \
+-DCUBLAS_LIBRARY=/path/to/cuda/lib64/libcublas.so \
+-DCUBLAS_INCLUDE_DIR=/path/to/cuda/include \
+-DCUDNN_INCLUDE_DIR=/path/to/cuda/include \
+-G Ninja -DOPENCLROOT=/path/to/DPCPP/build/lib ..
 ```
+
+The default /path/to/cuda is /usr/local/cuda
+
+## Running Tests
+
+Add the path to the dynamic libraries from DPC++ to LD_LIBRARY_PATH:
+
+```bash
+export LD_LIBRARY_PATH=/path/to/DPCPP/build/lib/:$LD_LIBRARY_PATH
+```
+
+Run tests:
+
+```bash
+ctest
+```
+
+All tests are expected to pass.
 
 ## Memory
 

--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -21,7 +21,7 @@ Build instructions for the DPC++ compiler using the Nvidia CUDA backend can be f
 
 https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md
 
-###Clarification
+### Clarification
 
 Please note that the oneDNN Nvidia backend cannot be compiled using the DPC++ compiler from the oneAPI HPC toolkit.
 
@@ -44,7 +44,7 @@ $ ninja
 
 ## Running Tests
 
-Following the above build instructions you can run tests:
+Following the above build instructions you can run the tests:
 
 ```bash
 ctest
@@ -56,7 +56,7 @@ All tests are expected to pass.
 
 Currently, only the buffer-based oneDNN API is supported for Nvidia backend.
 
-## Suported Data Types
+## Supported Data Types
 
 The following table documents the supported data types.
 

--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -18,7 +18,7 @@ in-order queue when creating a stream if needed.
 
 These build instructions have been validated with the latest CUDA 11.4 toolkit and DPC++ compiler release 2021.4.0.
 In order that the correct OpenCL headers are used it is necessary to manually specify their path using the OpenCL_INCLUDE_DIR cmake variable.
-The up to date header can be found [here](https://github.com/KhronosGroup/OpenCL-Headers).
+The up to date headers can be found [here](https://github.com/KhronosGroup/OpenCL-Headers).
 
 ```bash
 $ mkdir build
@@ -34,14 +34,16 @@ $ ninja
 ```
 
 The /path/to/cuda/ for a default cuda installation is /usr/local/cuda/
+
 The /path/to/OpenCLlib/ using the 2021.4.0 DPC++ compiler release is /opt/intel/oneapi/compiler/2021.4.0/linux/lib/
+
 The /path/to/DPC++_bin/ using the 2021.4.0 DPC++ compiler release is /opt/intel/oneapi/compiler/2021.4.0/linux/bin/
 
-If you have a manual, non-packaged build of DPC++ in your home directory then it is also necessary to add -DOPENCLROOT=/path/to/OpenCLlib/ to the cmake invocation.
+If you have a manual, non-packaged build of DPC++ in your home directory, then it is also necessary to add `-DOPENCLROOT=/path/to/OpenCLlib/` to the cmake invocation.
 
 ## Running Tests
 
-If you have a manual, non-packaged build of DPC++ in your home directory then it is also necessary to add the path to the dynamic libraries from DPC++ to LD_LIBRARY_PATH:
+If you have a manual, non-packaged build of DPC++ in your home directory, then it is also necessary to add the path to the dynamic libraries from DPC++ to `LD_LIBRARY_PATH`:
 
 ```bash
 export LD_LIBRARY_PATH=/path/to/OpenCLlib/:$LD_LIBRARY_PATH


### PR DESCRIPTION
# Description

OpenCL_INCLUDE_DIR must be manually set during cmake invocation to set the correct openCL headers first in the list of include directories.  See this DPC++ issue for more context: https://github.com/intel/llvm/issues/3084; also see https://github.com/oneapi-src/oneDNN/issues/919#issuecomment-755135790
The new cmake invocation should generally lead to a successful build providing the user has all necessary prerequisites installed.

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>

Fixes # 

https://github.com/intel/llvm/issues/3084
https://github.com/oneapi-src/oneDNN/issues/919#issuecomment-755135790
