### PR TITLE
cpu: aarch64: add missing validate calls for ACL primitives

### DIFF
--- a/doc/performance_considerations/verbose.md
+++ b/doc/performance_considerations/verbose.md
@@ -128,6 +128,12 @@ synchronization on entry and on exit in the dnnl::primitive::execute() call.
 The execution time is calculated based on wall time measured before and after
 primitive execution.
 
+@note
+When oneDNN verbose mode is enabled for builds with
+[Compute Library for the Arm architecture](https://oneapi-src.github.io/oneDNN/dev_guide_build.html#gcc-with-arm-compute-library-acl-on-aarch64-host),
+any failures in the validation of Compute Library primitives will be detailed
+in the verbose output.
+
 @warning
 Verbose mode has non-negligible performance impact especially on GPU or if the
 output rate is high.

--- a/src/cpu/aarch64/acl_utils.hpp
+++ b/src/cpu/aarch64/acl_utils.hpp
@@ -46,6 +46,11 @@ arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
 bool acl_act_ok(alg_kind_t eltwise_activation);
 void acl_thread_bind();
 
+#define MAYBE_REPORT_ACL_ERROR(msg) \
+    do { \
+        if (get_verbose()) printf("dnnl_verbose,cpu,error,acl,%s\n", (msg)); \
+    } while (0)
+
 } // namespace acl_common_utils
 
 } // namespace aarch64

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -91,7 +91,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
         auto acl_transA_st = arm_compute::NETranspose::validate(
                 &amp.src_acc_info, &amp.src_info);
         if (acl_transA_st.error_code() != arm_compute::ErrorCode::OK) {
-            printf("%s\n", acl_transA_st.error_description().c_str());
+            MAYBE_REPORT_ACL_ERROR(acl_transA_st.error_description().c_str());
             return status::unimplemented;
         }
     }
@@ -99,7 +99,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
         auto acl_transB_st = arm_compute::NETranspose::validate(
                 &amp.wei_acc_info, &amp.wei_info);
         if (acl_transB_st.error_code() != arm_compute::ErrorCode::OK) {
-            printf("%s\n", acl_transB_st.error_description().c_str());
+            MAYBE_REPORT_ACL_ERROR(acl_transB_st.error_description().c_str());
             return status::unimplemented;
         }
     }
@@ -107,7 +107,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
     auto acl_st = arm_compute::NEGEMM::validate(&amp.src_info, &amp.wei_info,
             nullptr, &amp.dst_info, amp.alpha, 0.0f, amp.gemm_info);
     if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
-        printf("%s\n", acl_st.error_description().c_str());
+        MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
         return status::unimplemented;
     }
 


### PR DESCRIPTION
# Description

ACL uses a validate step as part of the initialisation.
This should be carried out for every ACL layer used.
As a result, primitives need a validate step for each
layer used, such as in [acl_matmul_utils.cpp](https://github.com/oneapi-src/oneDNN/blob/master/src/cpu/aarch64/matmul/acl_matmul_utils.cpp).

Validate calls added:
ACL Convolution
    - ActivationLayer
    - ArithmeticAddition
ACL Inner Product
    - ArithmeticAddition

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
