### PR TITLE
cpu: aarch64: benchdnn: add aarch64 clause to conv driver for wino

### DIFF
--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -693,13 +693,15 @@ void check_known_skipped_case(const prb_t *prb, res_t *res) {
             // Compute Library supports only one eltwise post-op or
             // sum+eltwise post-ops
             if (eltwise_only || sum_with_eltwise) {
-                const auto act_type = po.entry[sum_with_eltwise].eltwise.alg;
-                eltwise_ok
-                        = one_of(act_type, dnnl_eltwise_relu, dnnl_eltwise_tanh,
-                                dnnl_eltwise_elu, dnnl_eltwise_square,
-                                dnnl_eltwise_abs, dnnl_eltwise_sqrt,
-                                dnnl_eltwise_linear, dnnl_eltwise_bounded_relu,
-                                dnnl_eltwise_soft_relu, dnnl_eltwise_logistic);
+                using alg_t = attr_t::post_ops_t::kind_t;
+                const std::vector<alg_t> supported_algs
+                        = {alg_t::RELU, alg_t::TANH, alg_t::ELU, alg_t::SQUARE,
+                                alg_t::ABS, alg_t::SQRT, alg_t::LINEAR,
+                                alg_t::BRELU, alg_t::SRELU, alg_t::LOGISTIC};
+                const auto act_type = po.entry[sum_with_eltwise].kind;
+                eltwise_ok = std::any_of(supported_algs.cbegin(),
+                        supported_algs.cend(),
+                        [&](const alg_t alg) { return act_type == alg; });
             }
 
             const bool post_ops_ok = eltwise_ok || (po.len() == 0);

--- a/tests/benchdnn/conv/conv_common.hpp
+++ b/tests/benchdnn/conv/conv_common.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018-2021 Intel Corporation
+* Copyright 2021 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -358,6 +359,15 @@ void compute_ref_bwd_bias(const prb_t *prb, const args_t &args);
 void compute_wino_ref_fwd(const prb_t *prb, const args_t &args);
 void compute_wino_ref_bwd_d(const prb_t *prb, const args_t &args);
 void compute_wino_ref_bwd_w(const prb_t *prb, const args_t &args);
+
+template <typename T, typename P>
+constexpr bool one_of(T val, P item) {
+    return val == item;
+}
+template <typename T, typename P, typename... Args>
+constexpr bool one_of(T val, P item, Args... item_others) {
+    return val == item || one_of(val, item_others...);
+}
 
 int compare_data(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
         dnn_mem_t &mem_fp, res_t *res);

--- a/tests/benchdnn/conv/conv_common.hpp
+++ b/tests/benchdnn/conv/conv_common.hpp
@@ -1,6 +1,5 @@
 /*******************************************************************************
 * Copyright 2018-2021 Intel Corporation
-* Copyright 2021 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -359,15 +358,6 @@ void compute_ref_bwd_bias(const prb_t *prb, const args_t &args);
 void compute_wino_ref_fwd(const prb_t *prb, const args_t &args);
 void compute_wino_ref_bwd_d(const prb_t *prb, const args_t &args);
 void compute_wino_ref_bwd_w(const prb_t *prb, const args_t &args);
-
-template <typename T, typename P>
-constexpr bool one_of(T val, P item) {
-    return val == item;
-}
-template <typename T, typename P, typename... Args>
-constexpr bool one_of(T val, P item, Args... item_others) {
-    return val == item || one_of(val, item_others...);
-}
 
 int compare_data(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
         dnn_mem_t &mem_fp, res_t *res);


### PR DESCRIPTION
# Description

The Winograd convolution implemented from Compute Library for the Arm Architecture (ACL),
is not currently being called in benchdnn tests due to differing requirements in conv.cpp.
This PR adds a clause for AArch64 to the wino section in the conv benchdnn driver,
so that the ACL winograd implementation can be picked up.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
