### PR TITLE
gpu: jit: fix compile error for DPCPP compiler 2021.3+

### DIFF
--- a/src/gpu/jit/conv/tensor.cpp
+++ b/src/gpu/jit/conv/tensor.cpp
@@ -129,7 +129,7 @@ memory_desc_t layout_t::to_dnnl(const dim_t *dims_hint) const {
             blk.inner_nblks++;
             if (prev_stride > 0) {
                 // Inner block must be dense.
-                ir_assert(prev_stride == b.block * b.stride);
+                ir_assert(prev_stride == b.block * dim_t(b.stride));
             }
             prev_stride = b.stride;
             in_inner_block = true;


### PR DESCRIPTION
Compiling with Intel oneAPI DPC++ Compiler 2021.3 or later with GPU support results in a compile error:

> [build] oneDNN/src/gpu/jit/conv/tensor.cpp:132:39: error: use of overloaded operator '==' is ambiguous (with operand types 'dnnl::impl::dim_t' (aka 'long') and 'dnnl::impl::gpu::jit::stride_t')
> [build]                 ir_assert(prev_stride == b.block * b.stride);
> [build]                           ~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~

I could reproduce this with:
- Intel oneAPI DPC++ Compiler 2021.3
- DPC++ daily (https://github.com/intel/llvm.git be9d7fdd563c336677c4ef6c8e093c128646a4fb)