### PR TITLE
cpu: aarch64: remove superflous header include

### DIFF
--- a/src/cpu/aarch64/acl_eltwise_utils.hpp
+++ b/src/cpu/aarch64/acl_eltwise_utils.hpp
@@ -17,8 +17,6 @@
 #ifndef CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
 #define CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
 
-#include "cpu/cpu_convolution_pd.hpp"
-
 #include "cpu/aarch64/acl_utils.hpp"
 
 namespace dnnl {


### PR DESCRIPTION
# Description

Remove superflous header file include of "cpu/cpu_convolution_pd.hpp".

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [n/a] Have you submitted performance data that demonstrates performance improvements?

### New features

- [n/a] Have you published an RFC for the new feature?
- [n/a] Was the RFC approved?
- [n/a] Have you added relevant tests?

### Bug fixes

- [n/a] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [n/a] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [n/a] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [n/a] Have you added a link to the rendered document?