### PR TITLE
cpu: aarch64: update ACL to v21.11 and enable further support for bf1…

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -27,7 +27,7 @@ steps:
   image: ubuntu:16.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 21.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -80,7 +80,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 21.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -111,7 +111,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 21.08 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 21.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -18,7 +18,7 @@
 # *******************************************************************************
 
 # Compute Library build defaults
-ACL_VERSION="v21.08"
+ACL_VERSION="v21.11"
 ACL_DIR="${PWD}/ComputeLibrary"
 ACL_ARCH="arm64-v8a"
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ integration. Compute Library is an open-source library for machine learning appl
 and provides AArch64 optimized implementations of core functions. This functionality currently
 requires that Compute Library is downloaded and built separately, see
 [Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html). oneDNN is only
-compatible with Compute Library versions 21.08 or later.
+compatible with Compute Library versions 21.11 or later.
 
 > **WARNING**
 >

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -31,7 +31,7 @@ endif()
 
 find_package(ACL REQUIRED)
 
-set(ACL_MINIMUM_VERSION "21.08")
+set(ACL_MINIMUM_VERSION "21.11")
 
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -229,7 +229,7 @@ For a debug build of oneDNN it is advisable to specify a Compute Library build
 which has also been built with debug enabled.
 
 @warning
-oneDNN is only compatible with Compute Library builds v21.08 or later.
+oneDNN is only compatible with Compute Library builds v21.11 or later.
 
 #### Vendor BLAS libraries
 oneDNN can use a standard BLAS library for GEMM operations.

--- a/src/cpu/aarch64/acl_inner_product_utils.cpp
+++ b/src/cpu/aarch64/acl_inner_product_utils.cpp
@@ -134,6 +134,12 @@ status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
     const auto &post_ops = attr.post_ops_;
     aip.with_sum = (post_ops.len() == 1) && post_ops.entry_[0].is_sum();
 
+    // Fast math mode
+    auto math_mode = get_fpmath_mode();
+    bool is_fastmath_enabled
+            = one_of(math_mode, fpmath_mode::bf16, fpmath_mode::any);
+    aip.fc_info.enable_fast_math = is_fastmath_enabled;
+
     // clang-format off
     // Validate fully connected layer manually to check for return status
     auto acl_st = arm_compute::NEFullyConnectedLayer::validate(

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -82,10 +82,18 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
             = arm_compute::TensorInfo(arm_compute::TensorShape(N, M, 1, batch),
                     1, arm_compute::DataType::F32);
 
+    // Fast-math mode
+    auto math_mode = get_fpmath_mode();
+    bool is_fastmath_enabled
+            = one_of(math_mode, fpmath_mode::bf16, fpmath_mode::any);
+    amp.gemm_info.set_fast_math(is_fastmath_enabled);
+
     // Fused ReLU activation
     amp.gemm_info.set_activation_info(get_acl_act(attr));
+
     // Set alpha (output scaling)
     amp.alpha = attr.output_scales_.scales_[0];
+
     // Validate ACL transpose
     if (amp.is_transA) {
         auto acl_transA_st = arm_compute::NETranspose::validate(


### PR DESCRIPTION
# Description

The latest Arm Compute Library release (https://arm-software.github.io/ComputeLibrary/v21.11/)
comes with further support for bf16 fast-math for the inner product and matmul operators.

Changes to the oneDNN source code follow the same approach as in the previous PR https://github.com/oneapi-src/oneDNN/pull/1150,
where this support was added for the convolution operator only.

Additional changes were made to the documentation and the CI to reflect the version bump.

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [x] Have you formatted the code using clang-format?

### New features

- [ ] Have you added relevant tests?
- [x] Have you provided motivation for adding a new feature?
