### PR TITLE
cpu: aarch64: add logsoftmax to ACL softmax primitive

### DIFF
--- a/src/cpu/aarch64/acl_softmax.cpp
+++ b/src/cpu/aarch64/acl_softmax.cpp
@@ -40,7 +40,7 @@ status_t acl_softmax_fwd_t<data_type>::execute_forward(
     acl_obj.src_tensor.allocator()->import_memory(const_cast<data_t *>(src));
     acl_obj.dst_tensor.allocator()->import_memory(dst);
 
-    acl_obj.softmax.run();
+    acl_obj.softmax->run();
 
     acl_obj.src_tensor.allocator()->free();
     acl_obj.dst_tensor.allocator()->free();


### PR DESCRIPTION
# Description

Extends #1175, adding logsoftmax to the existing `acl_softmax_fwd_t`. The heuristic has been tweaked based on data for more cores and on different machines, but is broadly similar. The performance difference between the Compute Library for Arm (ACL) and the reference implementation is similar for logsoftmax and softmax, so the same heuristic is used.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? (Except test_convolution_format_any as reported in #1210)
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?