### PR TITLE
update verbose flag to ONEDNN_VERBOSE

### DIFF
--- a/examples/performance_profiling.cpp
+++ b/examples/performance_profiling.cpp
@@ -24,7 +24,7 @@
 ///
 /// > Example code: @ref performance_profiling.cpp
 ///
-/// This example uses [DNNL_VERBOSE](@ref dev_guide_verbose) trace output
+/// This example uses [ONEDNN_VERBOSE](@ref dev_guide_verbose) trace output
 /// to tune oneDNN code to align
 /// with the [best practices](@ref dev_guide_inference).
 ///
@@ -69,7 +69,7 @@
 /// Before you run the program, set your `DNNL_VERBOSE` environment
 /// variable to 1:
 /// ~~~sh
-/// export DNNL_VERBOSE=1
+/// export ONEDNN_VERBOSE=1
 /// ~~~
 ///
 /// The program starts by creating oneDNN memory objects in **NCHW**


### PR DESCRIPTION
# Description
The verbose flag have been updated to ONEDNN_VERBOSE in ONEDNN, the DNNL_VERBOSE flag is invalid. Just update the comments in source code file.


Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
