### PR TITLE
gpu: cuda: fix test_deconvolution_buffer test failures

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_utils.hpp
+++ b/src/gpu/nvidia/sycl_cuda_utils.hpp
@@ -55,6 +55,11 @@ namespace nvidia {
             ->buffer() \
             .get_access<::sycl::access::mode::read_write>(cgh)
 
+#define CTX_SCRATCH_OFFSET(arg) \
+    utils::downcast<sycl::sycl_buffer_memory_storage_t *>( \
+            ctx.get_scratchpad_grantor().get_memory_storage(arg).get()) \
+            ->base_offset()
+
 bool compare_cuda_devices(const ::sycl::device &lhs, const ::sycl::device &rhs);
 
 // Check if the device type matches the passed engine kind


### PR DESCRIPTION
# Description
`test_deconvolution_buffer` fails anytime the convolution algorithm selector selected `CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM` or `CUDNN_CONVOLUTION_BWD_DATA_ALGO_1` for certain data formats. This is failure is due to the scratchpad memory being reserved for more than one use. The first use is for transposing the filter and the second as workspace memory for the above-specified algorithms. However, we found that they were both receiving the same pointer for both the filter transpose result and the workspace memory instead of the workspace memory being an offset of the base pointer of the filter transpose pointer, which caused the convolution algorithm to overwrite the filter data and yield an incorrect result. The filter transpose and the convolution workspace memory got the same pointer because the scratchpad memory is now booked in bulk, with each instance being an offset of a base pointer.

Fixes # (#1233 )
This is just a fix for the convolution algorithms, we may want a more general fix in the future
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
