### PR TITLE
rfc: update: bnorm: single-pass formula for calculating mean and variance (#1065)

### DIFF
--- a/rfcs/20210519-single-pass-bnorm/README.md
+++ b/rfcs/20210519-single-pass-bnorm/README.md
@@ -1,22 +1,22 @@
-# Proposal to calculate mean & variance in batchnorm in single pass
+# Proposal to calculate mean & variance in batch normalization(BN) in single pass
 
 ## Requester
 GPU Enabling team
 
 ## Motivation
 Using new formula for calculating variance will result in up to 33% performance
-improvement in batchnorm fwd training operation. 
+improvement in BN forward training operation.
 
-Currently bnorm performance is far below projections. Projections are based on
-assumption that bnorm reads input tensor once and writes result once. Current
-implementation requires bnorm to read input tensor 3 times. Proposed change
+Currently BN performance is far below projections. Projections are based on
+assumption that BN reads input tensor once and writes result once. Current
+implementation requires BN to read input tensor 3 times. Proposed change
 will decrease it to 2 reads. There is no known generic algorithm to decrease it
 to 1 read, although such efficiency is possible for special cases where input
 tensor is small enough.
 
 ## Proposal
 Use the following formula to calculate variance:
-```
+```python
 Var(X) = E(X^2) - (E(X))^2
 ```
 where X = input tensor, E = average
@@ -24,21 +24,21 @@ where X = input tensor, E = average
 This formula allows hardware to calculate both mean and variance in single pass
 over input tensor.
 For reference, the canonical formula is:
-```
+```python
 Var(X) = E((X - Mean(X))^2)
 ```
-The benefit of new formula is 25-33% performance improvement. Batchnorm kernel
-is memory-bound, with new formula it will need to read input tensor 2 times 
+The benefit of new formula is 25-33% performance improvement. BN kernel
+is memory-bound, with new formula it will need to read input tensor 2 times
 (1: mean&var, 2: normalize) instead of 3 times (1: mean, 2: var, 3: normalize)
 
-This formula will be used whenever batchnorm kernel calculates mean and 
-variance, which means forward propagation in training. However, with 
-non-standard combination of flags, oneDNN's batchnorm implementaton may be
+This formula will be used whenever BN kernel calculates mean and
+variance, which means forward propagation in training. However, with
+non-standard combination of flags, oneDNN's BN implementation may be
 configured to calculate those two values in inference as well.
 
 ## Design
 Algorithm for calculating variance will be implemented as:
-```
+```python
 Sum = 0
 SumOfSquares = 0
 for each x in X:
@@ -55,10 +55,10 @@ large in relation to result of the formula. In order to minimize rounding
 errors:
 - Sum and SumOfSquares will be stored in fp32 precision, regardless of input
 	data type
-- Kahan summation algorithm will be used
+- Kahan summation algorithm [[#1]][1] will be used
 
 The last line, max( ) is there to make sure rounding errors won't cause
-variance to go negative. Further in batchnorm calculations square root is taken
+variance to go negative. Further in BN calculations square root is taken
 from variance. Negative value would result in NaN.
 
 New formula is considered experimental for now. By default the old one will be
@@ -66,8 +66,8 @@ used. There needs to be a way for user to choose formula.
 
 ### Enable through build flag and environment variable
 A new build flag `DNNL_EXPERIMENTAL` is introduced, disabled by default.
-When built with this flag enabled, oneDNN will read env var 
-`DNNL_EXPERIMENTAL_BNORM_STATS_ONE_PASS` and will select bnorm formula 
+When built with this flag enabled, oneDNN will read environment variable
+`DNNL_EXPERIMENTAL_BNORM_STATS_ONE_PASS` and will select BN formula
 according to that flag. Default is the slower but numerically stable formula.
 
 Pros:
@@ -76,16 +76,16 @@ Pros:
 - Clearly defined default state
 
 Cons:
-- No fine-tuning per instance of bnorm primitive
-- Harder to reproduce bugs related to bnorm: value of this flag will need to be
+- No fine-tuning per instance of BN primitive
+- Harder to reproduce bugs related to BN: value of this flag will need to be
  reported in bug reports to allow reproduction.
  - Inconvenient long-term. State of oneDNN will have a dependency which is not
  obvious to users.
 
-## Layernorm
-Batchnorm and layernorm primitives work according to the same principles and
+## Layer normalization (LN)
+BN and LN primitives work according to the same principles and
 formulas. Only difference is in dimension across which the normalization is
-performed. Therefore layernorm's performance may benefit from using the new
+performed. Therefore LN's performance may benefit from using the new
 formula for calculating mean & variance.
 
 ## Validation
@@ -94,3 +94,9 @@ broader set of topologies are needed. Until such tests are performed, new
 formula should be optionally available but disabled by default. The point
 of this request is to make new formula available for further validation, while
 external customers can keep using the old and proven formula.
+
+## References
+
+1. [Kahan summation algorithm][1]
+
+[1]: https://en.wikipedia.org/wiki/Kahan_summation_algorithm


### PR DESCRIPTION
These changes extend the original RFC with information that was placed "here and there" in the discussions for the feature;

The changes don't change the initial proposal with adding an experimental build, but they clarify behavior for integration and validation of the feature:
- Extend verbose to emphasize an experimental build
- Modify benchdnn to avoid false-positive issues
- Enable all experimental features by default in an experimental build
- Extend regular testing to cover experimental builds
- Move experimental features to default build based on feedback from users

The motivation for a separate build:
- least impact to end users (we limit experimental build for frameworks use to experiment)
- zero-effort integration (once experimental build is obtained all experiment features are enabled by default)

[Rendered document](https://github.com/igorsafo/oneDNN/tree/rfcs/rfcs/20210519-single-pass-bnorm)
