### PR TITLE
common, cpu: remove unnecessary #include <iostream>

### DIFF
--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -15,7 +15,6 @@
 *******************************************************************************/
 
 #include <atomic>
-#include <iostream>
 #include <sstream>
 #include <type_traits>
 

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
@@ -17,7 +17,6 @@
 #ifndef CPU_X64_RNN_JIT_UNI_LSTM_CELL_POSTGEMM_BWD_HPP
 #define CPU_X64_RNN_JIT_UNI_LSTM_CELL_POSTGEMM_BWD_HPP
 
-#include <iostream>
 #include <memory>
 #include "common/utils.hpp"
 #include "cpu/x64/rnn/jit_uni_lstm_cell_postgemm.hpp"


### PR DESCRIPTION
With GCC, that causes the emission of a global-static to initialize `std::cin`, `cout`, `cerr`.
