### PR TITLE
CMake: don't downgrade the build to C++11 or C99

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,10 +131,27 @@ include("cmake/host_compiler.cmake")
 include("cmake/configuring_primitive_list.cmake")
 
 if(UNIX OR MINGW)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-    # Let SYCL to choose the C++ standard it needs.
-    if(NOT DNNL_WITH_SYCL)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    if(CMAKE_VERSION VERSION_LESS "3.1.0")
+        # No CMAKE_<lang>_STANDARD, so add directly to CMAKE_<lang>_FLAGS
+        # (prepended so the user can override)
+        set(CMAKE_C_FLAGS "-std=c99 ${CMAKE_C_FLAGS}")
+        # Let SYCL to choose the C++ standard it needs.
+        if(NOT DNNL_WITH_SYCL)
+            set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+        endif()
+    else()
+        # CMAKE_<lang>_STANDARD support, so set it to our defaults, unless
+        # overridden by the user
+        if(NOT DEFINED CMAKE_C_STANDARD)
+            set(CMAKE_C_STANDARD 99)
+        endif()
+        if(NOT DEFINED CMAKE_CXX_STANDARD)
+            set(CMAKE_CXX_STANDARD 11)
+        endif()
+
+        # Disable -std=gnuXX and -std=gnu++XX
+        set(CMAKE_C_EXTENSIONS OFF)
+        set(CMAKE_CXX_EXTENSIONS OFF)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ if(UNIX OR MINGW)
         if(NOT DEFINED CMAKE_C_STANDARD)
             set(CMAKE_C_STANDARD 99)
         endif()
-        if(NOT DEFINED CMAKE_CXX_STANDARD)
+        if(NOT DEFINED CMAKE_CXX_STANDARD AND NOT DNNL_WITH_SYCL)
             set(CMAKE_CXX_STANDARD 11)
         endif()
 


### PR DESCRIPTION
If the CMAKE_{C,CXX}_STANDARD is set to any value, it's likely set to a
more recent standard than C99 or C++11 (otherwise, the build will break
and someone will notice). But the important part is not to
force-downgrade to C++11, since Xbyak has some content that is
C++14-only (notably XBYAK_CONSTEXPR macro).
