### PR TITLE
cpu, common: replace dynamically-initialized variables with functions

### DIFF
--- a/src/common/broadcast_strategy.hpp
+++ b/src/common/broadcast_strategy.hpp
@@ -42,8 +42,12 @@ enum class broadcasting_strategy_t {
 
 using bcast_set_t = std::set<broadcasting_strategy_t>;
 
-static const bcast_set_t default_strategies {broadcasting_strategy_t::scalar,
-        broadcasting_strategy_t::per_oc, broadcasting_strategy_t::no_broadcast};
+inline const bcast_set_t &default_strategies() {
+    static const bcast_set_t s
+            = {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+                    broadcasting_strategy_t::no_broadcast};
+    return s;
+}
 
 output_dims_t make_output_dims(const memory_desc_wrapper &dst_d);
 

--- a/src/cpu/gemm_inner_product_utils.hpp
+++ b/src/cpu/gemm_inner_product_utils.hpp
@@ -91,15 +91,18 @@ protected:
     bool runtime_mb() const { return MB_ == (size_t)DNNL_RUNTIME_DIM_VAL; }
 };
 
-static const bcast_set_t gemm_default_strategies {
-        broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
-        broadcasting_strategy_t::per_oc_spatial,
-        broadcasting_strategy_t::no_broadcast};
+inline const bcast_set_t &gemm_default_strategies() {
+    static const bcast_set_t s
+            = {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+                    broadcasting_strategy_t::per_oc_spatial,
+                    broadcasting_strategy_t::no_broadcast};
+    return s;
+}
 
 bool post_ops_ok(const post_ops_t &post_ops, const memory_desc_wrapper *dst_d,
-        const bcast_set_t &enabled_bcast_strategy = gemm_default_strategies);
+        const bcast_set_t &enabled_bcast_strategy = gemm_default_strategies());
 bool post_ops_ok(const post_ops_t &post_ops, const memory_desc_t *dst_d,
-        const bcast_set_t &enabled_bcast_strategy = gemm_default_strategies);
+        const bcast_set_t &enabled_bcast_strategy = gemm_default_strategies());
 
 } // namespace inner_product_utils
 } // namespace cpu

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -143,7 +143,7 @@ struct post_ops_ok_args_t {
             const bool sum_at_pos_0_only = false,
             const bool sum_requires_scale_one = false,
             const bool sum_requires_zp_zero = true,
-            const bcast_set_t &enabled_bcast_strategy = default_strategies);
+            const bcast_set_t &enabled_bcast_strategy = default_strategies());
 
     const cpu_isa_t isa;
     const std::vector<post_op_type> &accepted_post_op_types;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -303,7 +303,7 @@ struct matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
     void update_configuration(brgemm_matmul_conf_t &bgmmc) const;
     float get_blocking_scores() const { return efficiency_score_; }
 
-    static size_t L2_threshold;
+    static size_t L2_threshold();
 
 private:
     // num threads for parallelism wrt k dimension
@@ -479,8 +479,9 @@ struct matmul_avx512_blocking_params_t {
     }
 };
 
-size_t matmul_amx_blocking_params_t::L2_threshold
-        = 3 * platform::get_per_core_cache_size(2) / 4;
+size_t matmul_amx_blocking_params_t::L2_threshold() {
+    return 3 * platform::get_per_core_cache_size(2) / 4;
+}
 
 void compute_blocking_heuristic_amx(const brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
@@ -1060,7 +1061,7 @@ void matmul_amx_blocking_params_t::set_blocking_parameters(
 
         update_k_blocking_dependent_params();
         auto chunk_sz = calculate_chunk_memory_size();
-        float k_div = (float)chunk_sz / L2_threshold;
+        float k_div = (float)chunk_sz / L2_threshold();
         if (k_div > 1.0f)
             k_chunk_size_ = static_cast<int>(
                     static_cast<float>(k_chunk_size_) / k_div + 0.6f);
@@ -1124,8 +1125,8 @@ float matmul_amx_blocking_params_t::get_copied_data_reusage_scores() {
 // for L2 utilization
 float matmul_amx_blocking_params_t::get_L2_utilization_scores() const {
     const float relative_difference_with_L2
-            = fabsf((float)L2_threshold - blocking_chunk_mem_size_)
-            / nstl::max(L2_threshold, blocking_chunk_mem_size_);
+            = fabsf((float)L2_threshold() - blocking_chunk_mem_size_)
+            / nstl::max(L2_threshold(), blocking_chunk_mem_size_);
     return 1.0f - relative_difference_with_L2;
 }
 


### PR DESCRIPTION
If all we need is a set of default values in a non-trivial type, just make it a function.
