### PR TITLE
cpu: hacky solution to remove the global variables per .cpp

### DIFF
--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -170,19 +170,19 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
 }
 
 Ymm jit_avx512_core_amx_1x1_fwd_kernel_t::ymm_mask(
-        const Ymm &ymm_in, bool mask_flag, bool store) {
+        const Ymm ymm_in, bool mask_flag, bool store) {
     return mask_flag ? (store ? ymm_in | ktail_mask : ymm_in | ktail_mask | T_z)
                      : ymm_in;
 }
 
 Zmm jit_avx512_core_amx_1x1_fwd_kernel_t::zmm_mask(
-        const Zmm &zmm_in, bool mask_flag, bool store) {
+        const Zmm zmm_in, bool mask_flag, bool store) {
     return mask_flag ? (store ? zmm_in | ktail_mask : zmm_in | ktail_mask | T_z)
                      : zmm_in;
 }
 
 void jit_avx512_core_amx_1x1_fwd_kernel_t::cvt2ps(data_type_t type_in,
-        const Zmm &zmm_in, const Operand &op, bool mask_flag = false) {
+        const Zmm zmm_in, const Operand &op, bool mask_flag = false) {
     using namespace dnnl::impl::data_type;
     const Zmm zmm = zmm_mask(zmm_in, mask_flag);
     switch (type_in) {
@@ -199,7 +199,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::cvt2ps(data_type_t type_in,
     if (utils::one_of(type_in, s32, s8, u8)) vcvtdq2ps(zmm_in, zmm_in);
 }
 
-void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_sum(const Zmm &zmm_out,
+void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_sum(const Zmm zmm_out,
         const float *p_sum_scale, const int32_t *p_sum_zp,
         const Xbyak::Address &addr, const bool mask_flag) {
     if (p_sum_scale) {
@@ -222,7 +222,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_sum(const Zmm &zmm_out,
     }
 }
 
-void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_postops(const Zmm &zmm_out,
+void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_postops(const Zmm zmm_out,
         const float *p_sum_scale, const int32_t *p_sum_zp,
         const Xbyak::Address &addr, const size_t off, const bool mask_flag) {
     if (jcp.with_eltwise || jcp.with_binary
@@ -392,7 +392,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
 }
 
 void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
-        const Zmm &zmm_out, int ocb, int h, int w) {
+        const Zmm zmm_out, int ocb, int h, int w) {
 
     const auto off = out_row_offset(h, w, ocb);
     const auto addr = EVEX_compress_addr(out_ptr, off);
@@ -515,7 +515,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_bf16(
 }
 
 void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_bf16(
-        const Zmm &zmm_out, int ocb, int h, int w) {
+        const Zmm zmm_out, int ocb, int h, int w) {
     const auto off = out_row_offset(h, w, ocb);
     const auto addr = EVEX_compress_addr(out_ptr, off);
 
@@ -571,7 +571,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors(
 
 // Store single row
 void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector(
-        const Zmm &zmm_out, int ocb, int h, int w) {
+        const Zmm zmm_out, int ocb, int h, int w) {
     if (is_bf16()) {
         store_output_vector_bf16(zmm_out, ocb, h, w);
     } else {

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
@@ -69,46 +69,46 @@ private:
     bool last_oc_block_flag_ = false;
 
     /* data regs */
-    const Xbyak::Reg64 &inp_ptr = r15;
-    const Xbyak::Reg64 &wei_ptr = r14;
-    const Xbyak::Reg64 &out_ptr = r13;
-    const Xbyak::Reg64 &wsp_ptr = r12;
+    const Xbyak::Reg64 inp_ptr = r15;
+    const Xbyak::Reg64 wei_ptr = r14;
+    const Xbyak::Reg64 out_ptr = r13;
+    const Xbyak::Reg64 wsp_ptr = r12;
 
-    const Xbyak::Reg64 &reg_bias = r11;
-    const Xbyak::Reg64 &reg_ptr_scales = r10;
-    const Xbyak::Reg64 &reg_ptr_sum_scale = r9;
-    const Xbyak::Reg64 &reg_ptr_sum_zp = rax;
-    const Xbyak::Reg64 &aux_reg_saturation = reg_ptr_sum_scale;
-    const Xbyak::Reg64 &reg_last_h = r8;
+    const Xbyak::Reg64 reg_bias = r11;
+    const Xbyak::Reg64 reg_ptr_scales = r10;
+    const Xbyak::Reg64 reg_ptr_sum_scale = r9;
+    const Xbyak::Reg64 reg_ptr_sum_zp = rax;
+    const Xbyak::Reg64 aux_reg_saturation = reg_ptr_sum_scale;
+    const Xbyak::Reg64 reg_last_h = r8;
 
-    const Xbyak::Reg64 &stride_seq = rbx;
-    const Xbyak::Reg64 &stride_nhwc = rsi;
-    const Xbyak::Reg64 &reg_tmp = abi_not_param1;
+    const Xbyak::Reg64 stride_seq = rbx;
+    const Xbyak::Reg64 stride_nhwc = rsi;
+    const Xbyak::Reg64 reg_tmp = abi_not_param1;
 
-    const Xbyak::Reg64 &reg_oc_blocks = rdx;
-    const Xbyak::Reg64 &reg_is_osb = rsi;
-    const Xbyak::Reg64 &reg_postop = abi_not_param1;
-    const Xbyak::Reg64 &reg_scratch = reg_bias;
-    const Xbyak::Reg64 &reg_tilebuff = reg_ptr_scales;
+    const Xbyak::Reg64 reg_oc_blocks = rdx;
+    const Xbyak::Reg64 reg_is_osb = rsi;
+    const Xbyak::Reg64 reg_postop = abi_not_param1;
+    const Xbyak::Reg64 reg_scratch = reg_bias;
+    const Xbyak::Reg64 reg_tilebuff = reg_ptr_scales;
     /* zero-point */
-    const Xbyak::Reg64 &reg_zp_compensation = reg_last_h;
-    const Xbyak::Reg64 &reg_src_zero_point = reg_oc_blocks;
-    const Xbyak::Reg64 &reg_dst_zero_point = rax;
+    const Xbyak::Reg64 reg_zp_compensation = reg_last_h;
+    const Xbyak::Reg64 reg_src_zero_point = reg_oc_blocks;
+    const Xbyak::Reg64 reg_dst_zero_point = rax;
 
-    const Xbyak::Zmm &zmm_bias = zmm31;
-    const Xbyak::Zmm &zmm_saturation = zmm_bias;
-    const Xbyak::Zmm &zmm_zero = zmm30;
-    const Xbyak::Zmm &zmm_prev_dst = zmm29;
-    const Xbyak::Zmm &zmm_sum_zp = zmm26;
+    const Xbyak::Zmm zmm_bias = zmm31;
+    const Xbyak::Zmm zmm_saturation = zmm_bias;
+    const Xbyak::Zmm zmm_zero = zmm30;
+    const Xbyak::Zmm zmm_prev_dst = zmm29;
+    const Xbyak::Zmm zmm_sum_zp = zmm26;
     /* zero-point */
-    const Xbyak::Zmm &zmm_zp = zmm29;
-    const Xbyak::Zmm &zmm_src_zp = zmm28;
-    const Xbyak::Zmm &zmm_dst_zp = zmm27;
+    const Xbyak::Zmm zmm_zp = zmm29;
+    const Xbyak::Zmm zmm_src_zp = zmm28;
+    const Xbyak::Zmm zmm_dst_zp = zmm27;
 
-    const Xbyak::Reg64 &bin_injector_helper_reg_1 = r14;
-    const Xbyak::Reg64 &bin_injector_helper_reg_2 = r15;
+    const Xbyak::Reg64 bin_injector_helper_reg_1 = r14;
+    const Xbyak::Reg64 bin_injector_helper_reg_2 = r15;
 
-    const Xbyak::Opmask &ktail_mask = k2;
+    const Xbyak::Opmask ktail_mask = k2;
 
     bool is_bf16() const;
 
@@ -126,7 +126,7 @@ private:
 
     void prepare_output();
 
-    void cvt2ps(data_type_t type_in, const Xbyak::Zmm &ymm_in,
+    void cvt2ps(data_type_t type_in, const Xbyak::Zmm ymm_in,
             const Xbyak::Operand &op, bool mask_flag);
     Xbyak::Zmm zmm_out(const int idx) {
         const int upper_limit
@@ -136,29 +136,29 @@ private:
         return Xbyak::Zmm(idx);
     }
     Xbyak::Zmm zmm_mask(
-            const Xbyak::Zmm &zmm_in, bool mask_flag, bool store = false);
+            const Xbyak::Zmm zmm_in, bool mask_flag, bool store = false);
     Xbyak::Ymm ymm_mask(
-            const Xbyak::Ymm &ymm_in, bool mask_flag, bool store = false);
+            const Xbyak::Ymm ymm_in, bool mask_flag, bool store = false);
 
     void update_buffer_pointers();
     void interleave_store();
-    void apply_sum(const Xbyak::Zmm &zmm_out, const float *p_sum_scale,
+    void apply_sum(const Xbyak::Zmm zmm_out, const float *p_sum_scale,
             const int32_t *p_sum_zp, const Xbyak::Address &addr,
             const bool mask_flag);
-    void apply_postops(const Xbyak::Zmm &zmm_out, const float *p_sum_scale,
+    void apply_postops(const Xbyak::Zmm zmm_out, const float *p_sum_scale,
             const int32_t *p_sum_zp, const Xbyak::Address &addr,
             const size_t off, const bool mask_flag);
     static bool is_fast_postops(const jit_conv_conf_t &jcp);
     void store_output_vectors_int8(int ocb, int osb);
     void store_output_vector_int8(
-            const Xbyak::Zmm &zmm_out, int ocb, int h, int w);
+            const Xbyak::Zmm zmm_out, int ocb, int h, int w);
     inline void store_output_ymm_bf16(
             const int idx, const Xbyak::Address &addr, const bool mask_flag);
     void store_output_vectors_bf16(int ocb, int osb);
     void store_output_vector_bf16(
-            const Xbyak::Zmm &zmm_out, int ocb, int h, int w);
+            const Xbyak::Zmm zmm_out, int ocb, int h, int w);
     void store_output_vectors(int ocb, int osb);
-    void store_output_vector(const Xbyak::Zmm &zmm_out, int ocb, int h, int w);
+    void store_output_vector(const Xbyak::Zmm zmm_out, int ocb, int h, int w);
     void store_output(bool do_store, bool is_tail);
     void icb_loop(bool do_store);
     void osb_loop(int nb_os = 1);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -115,16 +115,16 @@ struct jit_avx512_core_amx_copy_to_wbuffer_t : public jit_generator {
 private:
     jit_conv_conf_t jcp;
 
-    const reg64_t &reg_src = rax;
-    const reg64_t &reg_dst = rbx;
-    const reg64_t &reg_tmp = rdx;
+    const reg64_t reg_src = rax;
+    const reg64_t reg_dst = rbx;
+    const reg64_t reg_tmp = rdx;
 
-    const Xbyak::Opmask &kmask_load = k2;
+    const Xbyak::Opmask kmask_load = k2;
 
-    const Xbyak::Zmm &zmm_src = zmm0;
-    const Xbyak::Zmm &zmm_dst = zmm1;
-    const Xbyak::Zmm &zmm_idx = zmm2;
-    const Xbyak::Zmm &zmm_zero = zmm3;
+    const Xbyak::Zmm zmm_src = zmm0;
+    const Xbyak::Zmm zmm_dst = zmm1;
+    const Xbyak::Zmm zmm_idx = zmm2;
+    const Xbyak::Zmm zmm_zero = zmm3;
 
     void generate() override;
 };
@@ -141,38 +141,38 @@ struct jit_avx512_core_amx_copy_to_pbuffer_t : public jit_generator {
 private:
     jit_conv_conf_t jcp;
 
-    const reg64_t &reg_inp_ptr = r15;
-    const reg64_t &reg_out_ptr = r14;
+    const reg64_t reg_inp_ptr = r15;
+    const reg64_t reg_out_ptr = r14;
 
-    const reg64_t &reg_aux_inp_ptr = r13;
-    const reg64_t &reg_aux_out_ptr = r12;
+    const reg64_t reg_aux_inp_ptr = r13;
+    const reg64_t reg_aux_out_ptr = r12;
 
-    const reg64_t &reg_khp = r10;
+    const reg64_t reg_khp = r10;
 
     /* relow stuff */
-    const reg64_t &reg_kht = r11;
-    const reg64_t &reg_tov = r9;
-    const reg64_t &reg_bov = r8;
-    const reg64_t &reg_kwp = rax;
-    const reg64_t &reg_lov = reg_aux_inp_ptr;
-    const reg64_t &reg_rov = rbx;
-    const reg64_t &reg_save_out_ptr = rdx;
-    const reg64_t &reg_cnt = rbp;
+    const reg64_t reg_kht = r11;
+    const reg64_t reg_tov = r9;
+    const reg64_t reg_bov = r8;
+    const reg64_t reg_kwp = rax;
+    const reg64_t reg_lov = reg_aux_inp_ptr;
+    const reg64_t reg_rov = rbx;
+    const reg64_t reg_save_out_ptr = rdx;
+    const reg64_t reg_cnt = rbp;
     /* relow stuff */
 
     /* non-relow stuff */
-    const reg64_t &reg_kdp = abi_not_param1;
-    const reg64_t &reg_kdc = rbp;
-    const reg64_t &reg_khc = r11;
+    const reg64_t reg_kdp = abi_not_param1;
+    const reg64_t reg_kdc = rbp;
+    const reg64_t reg_khc = r11;
 
-    const reg64_t &reg_kh_over = r8;
-    const reg64_t &reg_tover = rax;
-    const reg64_t &reg_bover = rbx;
+    const reg64_t reg_kh_over = r8;
+    const reg64_t reg_tover = rax;
+    const reg64_t reg_bover = rbx;
 
-    const reg64_t &reg_owb = rdx;
+    const reg64_t reg_owb = rdx;
     /* non-relow stuff */
 
-    const reg64_t &reg_tmp = rsi;
+    const reg64_t reg_tmp = rsi;
 
     const Xbyak::Opmask &ktail_mask = k2;
 
@@ -295,34 +295,34 @@ private:
     std::queue<w_pad_output> w_padding;
 
     /* data regs */
-    const Xbyak::Reg64 &reg_inp_ptr = r15;
-    const Xbyak::Reg64 &reg_wei_ptr = r14;
-    const Xbyak::Reg64 &reg_out_ptr = r13;
-    const Xbyak::Reg64 &reg_wsp_ptr = r12;
+    const Xbyak::Reg64 reg_inp_ptr = r15;
+    const Xbyak::Reg64 reg_wei_ptr = r14;
+    const Xbyak::Reg64 reg_out_ptr = r13;
+    const Xbyak::Reg64 reg_wsp_ptr = r12;
 
-    const Xbyak::Reg64 &reg_kd = r9;
+    const Xbyak::Reg64 reg_kd = r9;
 
-    const Xbyak::Reg64 &reg_bias = r11;
-    const Xbyak::Reg64 &reg_ptr_scales = r10;
-    const Xbyak::Reg64 &reg_ptr_sum_scale = r9;
-    const Xbyak::Reg64 &reg_ptr_sum_zp = abi_not_param1;
-    const Xbyak::Reg64 &reg_aux_saturation = reg_ptr_sum_scale;
+    const Xbyak::Reg64 reg_bias = r11;
+    const Xbyak::Reg64 reg_ptr_scales = r10;
+    const Xbyak::Reg64 reg_ptr_sum_scale = r9;
+    const Xbyak::Reg64 reg_ptr_sum_zp = abi_not_param1;
+    const Xbyak::Reg64 reg_aux_saturation = reg_ptr_sum_scale;
 
-    const Xbyak::Reg64 &reg_inp_stride = rbx;
-    const Xbyak::Reg64 &reg_wei_stride = rdx;
+    const Xbyak::Reg64 reg_inp_stride = rbx;
+    const Xbyak::Reg64 reg_wei_stride = rdx;
     // zero-point computation
-    const Xbyak::Reg64 &reg_zp_compensation = rax;
-    const Xbyak::Reg64 &reg_src_zero_point = r8;
-    const Xbyak::Reg64 &reg_zero_point_pbuff = rsi;
-    const Xbyak::Reg64 &reg_dst_zero_point = abi_not_param1;
+    const Xbyak::Reg64 reg_zp_compensation = rax;
+    const Xbyak::Reg64 reg_src_zero_point = r8;
+    const Xbyak::Reg64 reg_zero_point_pbuff = rsi;
+    const Xbyak::Reg64 reg_dst_zero_point = abi_not_param1;
 
     // rbp - reserved for EVEX compression
-    const Xbyak::Reg64 &reg_last_h = abi_not_param1;
-    const Xbyak::Reg64 &reg_jmp_blk = reg_last_h;
+    const Xbyak::Reg64 reg_last_h = abi_not_param1;
+    const Xbyak::Reg64 reg_jmp_blk = reg_last_h;
 
     // temporary, used in generate() function only
-    const Xbyak::Reg64 &reg_oc_blocks = rax;
-    const Xbyak::Reg64 &reg_tmp = r8;
+    const Xbyak::Reg64 reg_oc_blocks = rax;
+    const Xbyak::Reg64 reg_tmp = r8;
 
     const Xbyak::Opmask &ktail_mask = k2;
 
@@ -336,8 +336,8 @@ private:
     const Xbyak::Zmm &zmm_src_zp = zmm28;
     const Xbyak::Zmm &zmm_dst_zp = zmm27;
 
-    const Xbyak::Reg64 &bin_injector_helper_reg_1 = r14;
-    const Xbyak::Reg64 &bin_injector_helper_reg_2 = r15;
+    const Xbyak::Reg64 bin_injector_helper_reg_1 = r14;
+    const Xbyak::Reg64 bin_injector_helper_reg_2 = r15;
 
     // AUX: Steps, shifts and offsets
     size_t get_inp_icb_step() const;
@@ -430,34 +430,34 @@ private:
     jit_conv_conf_t jcp;
 
     // pointers
-    const reg64_t &reg_ptr_inp = r15;
-    const reg64_t &reg_ptr_out = r14;
+    const reg64_t reg_ptr_inp = r15;
+    const reg64_t reg_ptr_out = r14;
 
     // auxiliary pointers
-    const reg64_t &reg_ptr_aux_inp_h = r13;
-    const reg64_t &reg_ptr_aux_inp_w = r12;
-    const reg64_t &reg_ptr_aux_out = r11;
+    const reg64_t reg_ptr_aux_inp_h = r13;
+    const reg64_t reg_ptr_aux_inp_w = r12;
+    const reg64_t reg_ptr_aux_out = r11;
 
     // variables
-    const reg64_t &reg_khp = r10; // kh padding
-    const reg64_t &reg_tov = r9; // top overflow
-    const reg64_t &reg_bov = reg_tov; // bottom overflow
-    const reg64_t &reg_kwp = rax; // kw padding
-    const reg64_t &reg_lov = rbx; // left overflow
-    const reg64_t &reg_rov = abi_not_param1; // right overflow
-    const reg64_t &reg_kd = r8; // 3d filter
+    const reg64_t reg_khp = r10; // kh padding
+    const reg64_t reg_tov = r9; // top overflow
+    const reg64_t reg_bov = reg_tov; // bottom overflow
+    const reg64_t reg_kwp = rax; // kw padding
+    const reg64_t reg_lov = rbx; // left overflow
+    const reg64_t reg_rov = abi_not_param1; // right overflow
+    const reg64_t reg_kd = r8; // 3d filter
 
     // counters
-    const reg64_t &reg_cnt_khp = rdx;
-    const reg64_t &reg_cnt_tmp = rbp;
-    const reg64_t &reg_cnt_ocb = rsi;
+    const reg64_t reg_cnt_khp = rdx;
+    const reg64_t reg_cnt_tmp = rbp;
+    const reg64_t reg_cnt_ocb = rsi;
 
-    const reg64_t &reg_tmp = reg_cnt_tmp;
+    const reg64_t reg_tmp = reg_cnt_tmp;
 
-    const Xbyak::Opmask &ktail_mask = k2;
+    const Xbyak::Opmask ktail_mask = k2;
 
-    const Xbyak::Zmm &zmm_tmp = zmm1;
-    const Xbyak::Zmm &zmm_zero = zmm0;
+    const Xbyak::Zmm zmm_tmp = zmm1;
+    const Xbyak::Zmm zmm_zero = zmm0;
 
     void generate() override;
     void copy_row(bool is_masked);
@@ -521,36 +521,36 @@ private:
     int prv_width_save_ = 0;
 
     /* data regs */
-    const Xbyak::Reg64 &reg_inp_ptr = r15;
-    const Xbyak::Reg64 &reg_wei_ptr = r14;
-    const Xbyak::Reg64 &reg_out_ptr = r13;
-    const Xbyak::Reg64 &reg_wsp_ptr = r12;
+    const Xbyak::Reg64 reg_inp_ptr = r15;
+    const Xbyak::Reg64 reg_wei_ptr = r14;
+    const Xbyak::Reg64 reg_out_ptr = r13;
+    const Xbyak::Reg64 reg_wsp_ptr = r12;
 
-    const Xbyak::Reg64 &reg_bias = r11;
-    const Xbyak::Reg64 &reg_ptr_scales = r10;
-    const Xbyak::Reg64 &reg_ptr_sum_scale = r9;
-    const Xbyak::Reg64 &reg_ptr_sum_zp = abi_not_param1;
-    const Xbyak::Reg64 &reg_aux_saturation = reg_ptr_sum_scale;
+    const Xbyak::Reg64 reg_bias = r11;
+    const Xbyak::Reg64 reg_ptr_scales = r10;
+    const Xbyak::Reg64 reg_ptr_sum_scale = r9;
+    const Xbyak::Reg64 reg_ptr_sum_zp = abi_not_param1;
+    const Xbyak::Reg64 reg_aux_saturation = reg_ptr_sum_scale;
 
-    const Xbyak::Reg64 &reg_aux_inp_ptr = r8;
-    const Xbyak::Reg64 &reg_inp_stride = rbx;
-    const Xbyak::Reg64 &reg_wei_stride = rdx;
+    const Xbyak::Reg64 reg_aux_inp_ptr = r8;
+    const Xbyak::Reg64 reg_inp_stride = rbx;
+    const Xbyak::Reg64 reg_wei_stride = rdx;
 
     // rbp - reserved for EVEX compression
-    const Xbyak::Reg64 &reg_last_h = abi_not_param1;
-    const Xbyak::Reg64 &reg_kd = rsi;
+    const Xbyak::Reg64 reg_last_h = abi_not_param1;
+    const Xbyak::Reg64 reg_kd = rsi;
 
     // temporary, used in generate() function only
-    const Xbyak::Reg64 &reg_ic_blocks = rax;
-    const Xbyak::Reg64 &reg_tmp = reg_aux_inp_ptr;
+    const Xbyak::Reg64 reg_ic_blocks = rax;
+    const Xbyak::Reg64 reg_tmp = reg_aux_inp_ptr;
 
-    const Xbyak::Opmask &ktail_mask = k2;
+    const Xbyak::Opmask ktail_mask = k2;
 
-    const Xbyak::Zmm &zmm_bias = zmm31;
-    const Xbyak::Zmm &zmm_saturation = zmm_bias;
-    const Xbyak::Zmm &zmm_zero = zmm30;
-    const Xbyak::Zmm &zmm_prev_dst = zmm29;
-    const Xbyak::Zmm &zmm_sum_zp = zmm28;
+    const Xbyak::Zmm zmm_bias = zmm31;
+    const Xbyak::Zmm zmm_saturation = zmm_bias;
+    const Xbyak::Zmm zmm_zero = zmm30;
+    const Xbyak::Zmm zmm_prev_dst = zmm29;
+    const Xbyak::Zmm zmm_sum_zp = zmm28;
 
     // AUX: Steps, shifts and offsets
     size_t get_inp_ocb_step() const;

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -65,23 +65,23 @@ private:
     void apply_postops(const bool apply_mask, const int vmm_idx,
             const size_t offset, bool runtime_tail_mask);
     void prepare_mask(const size_t tail);
-    void load_no_tail(const Vmm &v, Xbyak::Address op, const data_type_t dt);
-    void load_tail(const Vmm &v, const arg_t arg_num, const size_t off,
+    void load_no_tail(const Vmm v, Xbyak::Address op, const data_type_t dt);
+    void load_tail(const Vmm v, const arg_t arg_num, const size_t off,
             const data_type_t dt, const size_t tail);
-    void load_and_cvt(const Vmm &v, const arg_t arg_num, const size_t off,
+    void load_and_cvt(const Vmm v, const arg_t arg_num, const size_t off,
             const size_t tail, bool do_cvt = true);
     // convert and store instances for each case of Vmm
-    void cvt_and_store(const Xbyak::Zmm &v, const arg_t arg_num,
+    void cvt_and_store(const Xbyak::Zmm v, const arg_t arg_num,
             const size_t off, const size_t tail);
-    void cvt_and_store(const Xbyak::Ymm &v, const arg_t arg_num,
+    void cvt_and_store(const Xbyak::Ymm v, const arg_t arg_num,
             const size_t off, const size_t tail);
-    void cvt_and_store(const Xbyak::Xmm &v, const arg_t arg_num,
+    void cvt_and_store(const Xbyak::Xmm v, const arg_t arg_num,
             const size_t off, const size_t tail);
-    void runtime_tail_load_cvt(const Vmm &v, const arg_t arg_num,
+    void runtime_tail_load_cvt(const Vmm v, const arg_t arg_num,
             const size_t off, bool cvt = true);
     void runtime_tail_cvt_store(
-            const Vmm &v, const arg_t arg_num, const size_t off);
-    void data_copy(const Vmm &v, const arg_t arg_num, const size_t off,
+            const Vmm v, const arg_t arg_num, const size_t off);
+    void data_copy(const Vmm v, const arg_t arg_num, const size_t off,
             data_op_t data_op, const size_t tail,
             const bool is_needed_runtime_tail_process,
             const bool do_cvt = true);
@@ -128,40 +128,40 @@ private:
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
 
 #ifdef _WIN32
-    const Xbyak::Reg64 &reg_binary_inj_param_ = abi_not_param1;
+    const Xbyak::Reg64 reg_binary_inj_param_ = abi_not_param1;
 #else
-    const Xbyak::Reg64 &reg_binary_inj_param_ = abi_param1;
+    const Xbyak::Reg64 reg_binary_inj_param_ = abi_param1;
 #endif
 
-    const Xbyak::Reg64 &reg_param = abi_param1;
-    const Xbyak::Reg64 &reg_stack_frame_ = rbp;
-    const Xbyak::Reg64 &reg_dst = rdx;
-    const Xbyak::Reg64 &reg_acc = rax;
-    const Xbyak::Reg64 &reg_bias = rbx;
-    const Xbyak::Reg64 &reg_scales = rsi;
+    const Xbyak::Reg64 reg_param = abi_param1;
+    const Xbyak::Reg64 reg_stack_frame_ = rbp;
+    const Xbyak::Reg64 reg_dst = rdx;
+    const Xbyak::Reg64 reg_acc = rax;
+    const Xbyak::Reg64 reg_bias = rbx;
+    const Xbyak::Reg64 reg_scales = rsi;
 
-    const Xbyak::Reg64 &reg_oc = r13;
-    const Xbyak::Reg64 &reg_len = r8;
-    const Xbyak::Reg64 &reg_tmp = rcx; // intentional for shifting purposes
-    const Xbyak::Reg64 &reg_tail = reg_tmp;
-    const Xbyak::Reg64 &reg_oc_offset = r9;
-    const Xbyak::Reg64 &reg_rem_mask = r10;
-    const Xbyak::Opmask &kreg_rem_mask = k1;
-    const Xbyak::Opmask &opmask_binary = k3;
+    const Xbyak::Reg64 reg_oc = r13;
+    const Xbyak::Reg64 reg_len = r8;
+    const Xbyak::Reg64 reg_tmp = rcx; // intentional for shifting purposes
+    const Xbyak::Reg64 reg_tail = reg_tmp;
+    const Xbyak::Reg64 reg_oc_offset = r9;
+    const Xbyak::Reg64 reg_rem_mask = r10;
+    const Xbyak::Opmask kreg_rem_mask = k1;
+    const Xbyak::Opmask opmask_binary = k3;
     const Vmm vmm_rem_mask = Vmm(0);
     // register used for temp computation, needs not to be preserved
-    const Xbyak::Reg64 &reg_tmp_comp = r15;
+    const Xbyak::Reg64 reg_tmp_comp = r15;
 
     // *mb_stride used only in matmul_pp_kernel && compute_oc_channel_blk()
-    const Xbyak::Reg64 &reg_dst_mb_stride = r12;
-    const Xbyak::Reg64 &reg_acc_mb_stride = r14;
+    const Xbyak::Reg64 reg_dst_mb_stride = r12;
+    const Xbyak::Reg64 reg_acc_mb_stride = r14;
 
     // Will be assigned in constructor
     Vmm vreg_zero, vreg_saturation_ubound, vreg_scale, vreg_sum_scale,
             vreg_sum_zp, vreg_dst_zero_points;
 
-    const Xbyak::Reg64 &eltwise_reserved_gpr_ = r11;
-    const Xbyak::Opmask &eltwise_reserved_opmask_ = k2;
+    const Xbyak::Reg64 eltwise_reserved_gpr_ = r11;
+    const Xbyak::Opmask eltwise_reserved_opmask_ = k2;
 
     Xbyak::Zmm bf16_emu_reserv_1 = Xbyak::Zmm(28);
     Xbyak::Zmm bf16_emu_reserv_2 = Xbyak::Zmm(29);
@@ -478,7 +478,7 @@ void jit_pp_kernel_t<isa>::prepare_mask(const size_t tail) {
 
 template <cpu_isa_t isa>
 void jit_pp_kernel_t<isa>::load_no_tail(
-        const Vmm &v, Xbyak::Address op, const data_type_t dt) {
+        const Vmm v, Xbyak::Address op, const data_type_t dt) {
     using namespace data_type;
     switch (dt) {
         case s8: uni_vpmovsxbd(v, op); break;
@@ -494,7 +494,7 @@ void jit_pp_kernel_t<isa>::load_no_tail(
 }
 
 template <cpu_isa_t isa>
-void jit_pp_kernel_t<isa>::load_tail(const Vmm &v, const arg_t arg_num,
+void jit_pp_kernel_t<isa>::load_tail(const Vmm v, const arg_t arg_num,
         const size_t off, const data_type_t dt, const size_t tail) {
     using namespace data_type;
     if (is_avx512_) {
@@ -524,7 +524,7 @@ void jit_pp_kernel_t<isa>::load_tail(const Vmm &v, const arg_t arg_num,
 }
 
 template <cpu_isa_t isa>
-void jit_pp_kernel_t<isa>::load_and_cvt(const Vmm &v, const arg_t arg_num,
+void jit_pp_kernel_t<isa>::load_and_cvt(const Vmm v, const arg_t arg_num,
         const size_t off, const size_t tail, bool do_cvt) {
     using namespace data_type;
     const data_type_t dt = get_data_type(arg_num);
@@ -537,7 +537,7 @@ void jit_pp_kernel_t<isa>::load_and_cvt(const Vmm &v, const arg_t arg_num,
 }
 
 template <cpu_isa_t isa>
-void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Zmm &v,
+void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Zmm v,
         const arg_t arg_num, const size_t off, const size_t tail) {
     using namespace data_type;
     const data_type_t dt = get_data_type(arg_num);
@@ -568,7 +568,7 @@ void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Zmm &v,
 }
 
 template <cpu_isa_t isa>
-void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Ymm &v,
+void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Ymm v,
         const arg_t arg_num, const size_t off, const size_t tail) {
     using namespace data_type;
     const data_type_t dt = get_data_type(arg_num);
@@ -618,7 +618,7 @@ void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Ymm &v,
 }
 
 template <cpu_isa_t isa>
-void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Xmm &v,
+void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Xmm v,
         const arg_t arg_num, const size_t off, const size_t tail) {
     using namespace data_type;
     const data_type_t dt = get_data_type(arg_num);
@@ -666,13 +666,13 @@ void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Xmm &v,
 
 template <cpu_isa_t isa>
 void jit_pp_kernel_t<isa>::runtime_tail_load_cvt(
-        const Vmm &v, const arg_t arg_num, const size_t off, bool cvt) {
+        const Vmm v, const arg_t arg_num, const size_t off, bool cvt) {
     assert(!is_avx512_);
     const data_type_t dt = get_data_type(arg_num);
     const bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
     const Xbyak::Xmm x = Xbyak::Xmm(v.getIdx());
     const Xbyak::Ymm y = Xbyak::Ymm(v.getIdx());
-    const Xbyak::Reg64 &reg_addr = get_reg_address(arg_num);
+    const Xbyak::Reg64 reg_addr = get_reg_address(arg_num);
 
     auto runtime_tail_load = [&](int load_size) {
         if (is_ymm)
@@ -688,13 +688,13 @@ void jit_pp_kernel_t<isa>::runtime_tail_load_cvt(
 
 template <cpu_isa_t isa>
 void jit_pp_kernel_t<isa>::runtime_tail_cvt_store(
-        const Vmm &v, const arg_t arg_num, const size_t off) {
+        const Vmm v, const arg_t arg_num, const size_t off) {
     assert(!is_avx512_);
     const data_type_t dt = get_data_type(arg_num);
     const bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
     const Xbyak::Xmm x = Xbyak::Xmm(v.getIdx());
     const Xbyak::Ymm y = Xbyak::Ymm(v.getIdx());
-    const Xbyak::Reg64 &reg_addr = get_reg_address(arg_num);
+    const Xbyak::Reg64 reg_addr = get_reg_address(arg_num);
 
     if (utils::one_of(dt, u8, s8, s32)) {
         saturate_f32(v, vreg_zero, vreg_saturation_ubound, dt);
@@ -712,7 +712,7 @@ void jit_pp_kernel_t<isa>::runtime_tail_cvt_store(
 }
 
 template <cpu_isa_t isa>
-void jit_pp_kernel_t<isa>::data_copy(const Vmm &v, const arg_t arg_num,
+void jit_pp_kernel_t<isa>::data_copy(const Vmm v, const arg_t arg_num,
         const size_t off, data_op_t data_op, const size_t tail,
         const bool is_needed_runtime_tail_process, const bool do_cvt) {
     if (data_op == data_op_t::load) {
@@ -795,7 +795,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
     };
 
     // Advance all pointers by a value stored in a register
-    auto advance_ptrs_reg = [&](const Reg64 &offset) {
+    auto advance_ptrs_reg = [&](const Reg64 offset) {
         lea(reg_dst, ptr[reg_dst + offset * this->dst_data_type_size_]);
         lea(reg_acc, ptr[reg_acc + offset * this->acc_data_type_size_]);
         if (this->do_scale_ && this->scale_idx_mult_ == 1)

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -95,6 +95,8 @@ static inline void tc_configure_tile(
 //
 // (Roma)
 
+} // namespace
+
 #ifdef XBYAK64
 constexpr Xbyak::Operand::Code abi_save_gpr_regs[] = {
         Xbyak::Operand::RBX,
@@ -109,19 +111,32 @@ constexpr Xbyak::Operand::Code abi_save_gpr_regs[] = {
 #endif
 };
 
+constexpr Xbyak::Operand::Code abi_param_regs[] = {
 #ifdef _WIN32
-static const Xbyak::Reg64 abi_param1(Xbyak::Operand::RCX),
-        abi_param2(Xbyak::Operand::RDX), abi_param3(Xbyak::Operand::R8),
-        abi_param4(Xbyak::Operand::R9), abi_not_param1(Xbyak::Operand::RDI);
+        Xbyak::Operand::RCX, Xbyak::Operand::RDX, Xbyak::Operand::R8,
+        Xbyak::Operand::R9
 #else
-static const Xbyak::Reg64 abi_param1(Xbyak::Operand::RDI),
-        abi_param2(Xbyak::Operand::RSI), abi_param3(Xbyak::Operand::RDX),
-        abi_param4(Xbyak::Operand::RCX), abi_param5(Xbyak::Operand::R8),
-        abi_param6(Xbyak::Operand::R9), abi_not_param1(Xbyak::Operand::RCX);
+        Xbyak::Operand::RDI, Xbyak::Operand::RSI, Xbyak::Operand::RDX,
+        Xbyak::Operand::RCX, Xbyak::Operand::R8, Xbyak::Operand::R9
 #endif
+};
+
+constexpr Xbyak::Operand::Code abi_not_param_reg =
+#ifdef _WIN32
+        Xbyak::Operand::RDI;
+#else
+        Xbyak::Operand::RCX;
 #endif
 
-} // namespace
+#define abi_param1 Xbyak::Reg64(abi_param_regs[0])
+#define abi_param2 Xbyak::Reg64(abi_param_regs[1])
+#define abi_param3 Xbyak::Reg64(abi_param_regs[2])
+#define abi_param4 Xbyak::Reg64(abi_param_regs[3])
+#define abi_param5 Xbyak::Reg64(abi_param_regs[4])
+#define abi_param6 Xbyak::Reg64(abi_param_regs[5])
+#define abi_not_param1 Xbyak::Reg64(abi_not_param_reg)
+
+#endif
 
 class jit_generator : public Xbyak::CodeGenerator, public c_compatible {
 public:

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -81,26 +81,26 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     const bool is_avx512_not_mic
             = is_avx512_core || (is_avx512_common && !conf_.is_i8);
 
-    const Reg64 &reg_param_ = abi_param1;
-    const Reg64 &reg_src0_ = r8;
-    const Reg64 &reg_src1_ = r9;
-    const Reg64 &reg_dst_ = r10;
-    const Reg64 &reg_offt_src0_ = r11;
-    const Reg64 &reg_outer_dims_range_ = r12;
-    const Reg64 &reg_offt_src1_ = rax;
-    const Reg64 &reg_src1_stride_range_ = r15;
-    const Reg64 &reg_reverse_src1_stride_range_ = rax;
-    const Reg64 &reg_reverse_spat_offt_ = r13;
-    const Reg64 &reg_tmp_ = r14;
-    const Reg64 &reg_tmp1_ = abi_not_param1;
-    const Reg64 &reg_elt_inj_table_ = r15;
-    const Reg64 &reg_off_rhs_postops_ = rdx;
-    const Reg64 &reg_scales_src0_ = rbx;
-    const Reg64 &reg_scales_src1_ = rbp;
-    const Reg64 &reg_offt_dst_ = rdx;
-    const Opmask &tail_opmask_ = k2;
-    const Opmask &cmp_mask = k3;
-    const Opmask &full_mask_ = k4;
+    const Reg64 reg_param_ = abi_param1;
+    const Reg64 reg_src0_ = r8;
+    const Reg64 reg_src1_ = r9;
+    const Reg64 reg_dst_ = r10;
+    const Reg64 reg_offt_src0_ = r11;
+    const Reg64 reg_outer_dims_range_ = r12;
+    const Reg64 reg_offt_src1_ = rax;
+    const Reg64 reg_src1_stride_range_ = r15;
+    const Reg64 reg_reverse_src1_stride_range_ = rax;
+    const Reg64 reg_reverse_spat_offt_ = r13;
+    const Reg64 reg_tmp_ = r14;
+    const Reg64 reg_tmp1_ = abi_not_param1;
+    const Reg64 reg_elt_inj_table_ = r15;
+    const Reg64 reg_off_rhs_postops_ = rdx;
+    const Reg64 reg_scales_src0_ = rbx;
+    const Reg64 reg_scales_src1_ = rbp;
+    const Reg64 reg_offt_dst_ = rdx;
+    const Opmask tail_opmask_ = k2;
+    const Opmask cmp_mask = k3;
+    const Opmask full_mask_ = k4;
     const Vmm vmm_tail_vmask_ = Vmm(0);
     const Vmm vreg_sum_scale_ = Vmm(is_avx512 ? 17 : 9);
     const Xmm xreg_sum_scale_ = Xmm(9);
@@ -135,7 +135,7 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     io::jit_io_multi_dt_helper_t<Vmm> io_;
     std::unique_ptr<injector::jit_uni_postops_injector_t<inject_isa>>
             postops_injector_;
-    const Opmask &elt_inj_opmask_ = k1;
+    const Opmask elt_inj_opmask_ = k1;
 
     void init();
     void init_post_ops_injector();

--- a/src/cpu/x64/jit_uni_layer_normalization_kernels.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization_kernels.cpp
@@ -207,16 +207,16 @@ private:
 
     void reduce();
 
-    const Xbyak::Reg64 &reg_param = abi_param1;
-    const Xbyak::Reg64 &reg_src = rdx;
-    const Xbyak::Reg64 &reg_dst = rax;
-    const Xbyak::Reg64 &reg_mean = rbx;
-    const Xbyak::Reg64 &reg_var = rbp;
-    const Xbyak::Reg64 &reg_scale = r8;
-    const Xbyak::Reg64 &reg_block_end = r9;
-    const Xbyak::Reg64 &reg_eps = r10;
-    const Xbyak::Reg64 &reg_tmp = r11;
-    const Xbyak::Reg64 &reg_shift = r12;
+    const Xbyak::Reg64 reg_param = abi_param1;
+    const Xbyak::Reg64 reg_src = rdx;
+    const Xbyak::Reg64 reg_dst = rax;
+    const Xbyak::Reg64 reg_mean = rbx;
+    const Xbyak::Reg64 reg_var = rbp;
+    const Xbyak::Reg64 reg_scale = r8;
+    const Xbyak::Reg64 reg_block_end = r9;
+    const Xbyak::Reg64 reg_eps = r10;
+    const Xbyak::Reg64 reg_tmp = r11;
+    const Xbyak::Reg64 reg_shift = r12;
 
     Vmm vmm_ones = Vmm(8);
     Vmm vmm_eps = Vmm(9);
@@ -467,14 +467,14 @@ private:
 
     void generate() override;
 
-    const Xbyak::Reg64 &reg_param = abi_param1;
-    const Xbyak::Reg64 &reg_src = rdx;
-    const Xbyak::Reg64 &reg_diff_dst = rax;
-    const Xbyak::Reg64 &reg_block_end = rbx;
-    const Xbyak::Reg64 &reg_mean = r11;
-    const Xbyak::Reg64 &reg_inv_sqrtvar = r10;
-    const Xbyak::Reg64 &reg_diff_gamma = r9;
-    const Xbyak::Reg64 &reg_diff_beta = r8;
+    const Xbyak::Reg64 reg_param = abi_param1;
+    const Xbyak::Reg64 reg_src = rdx;
+    const Xbyak::Reg64 reg_diff_dst = rax;
+    const Xbyak::Reg64 reg_block_end = rbx;
+    const Xbyak::Reg64 reg_mean = r11;
+    const Xbyak::Reg64 reg_inv_sqrtvar = r10;
+    const Xbyak::Reg64 reg_diff_gamma = r9;
+    const Xbyak::Reg64 reg_diff_beta = r8;
 
     Xbyak::Xmm xmm_tmp = Xbyak::Xmm(9);
 
@@ -627,17 +627,17 @@ private:
 
     void reduce(Vmm vmm_vec);
 
-    const Xbyak::Reg64 &reg_param = abi_param1;
-    const Xbyak::Reg64 &reg_src = rdx;
-    const Xbyak::Reg64 &reg_diff_src = rax;
-    const Xbyak::Reg64 &reg_diff_dst = rbx;
-    const Xbyak::Reg64 &reg_block_end = rbp;
-    const Xbyak::Reg64 &reg_mean = r13;
-    const Xbyak::Reg64 &reg_inv_sqrtvar = r12;
-    const Xbyak::Reg64 &reg_gamma = r11;
-    const Xbyak::Reg64 &reg_tmp = r10;
-    const Xbyak::Reg64 &reg_dd_gamma = r9;
-    const Xbyak::Reg64 &reg_dd_gamma_x = r8;
+    const Xbyak::Reg64 reg_param = abi_param1;
+    const Xbyak::Reg64 reg_src = rdx;
+    const Xbyak::Reg64 reg_diff_src = rax;
+    const Xbyak::Reg64 reg_diff_dst = rbx;
+    const Xbyak::Reg64 reg_block_end = rbp;
+    const Xbyak::Reg64 reg_mean = r13;
+    const Xbyak::Reg64 reg_inv_sqrtvar = r12;
+    const Xbyak::Reg64 reg_gamma = r11;
+    const Xbyak::Reg64 reg_tmp = r10;
+    const Xbyak::Reg64 reg_dd_gamma = r9;
+    const Xbyak::Reg64 reg_dd_gamma_x = r8;
 
     Xbyak::Xmm xmm_tmp = Xbyak::Xmm(7);
 

--- a/src/cpu/x64/jit_uni_reduction_kernel.hpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.hpp
@@ -96,14 +96,14 @@ private:
     const Xbyak::Zmm vmm_bf16_emu_3_ = Xbyak::Zmm(30);
     const Xbyak::Zmm vmm_bf16_emu_4_ = Xbyak::Zmm(31);
 
-    const Xbyak::Opmask &k_tail_load_mask_ = k3;
-    const Xbyak::Opmask &k_tail_store_mask_ = k4;
+    const Xbyak::Opmask k_tail_load_mask_ = k3;
+    const Xbyak::Opmask k_tail_store_mask_ = k4;
 
-    const Xbyak::Reg64 &reg_work_ = rax;
-    const Xbyak::Reg64 &reg_src_ = rbx;
-    const Xbyak::Reg64 &reg_dst_ = rdx;
-    const Xbyak::Reg64 &reg_param_ = abi_param1;
-    const Xbyak::Reg64 &reg_tmp_ = abi_not_param1;
+    const Xbyak::Reg64 reg_work_ = rax;
+    const Xbyak::Reg64 reg_src_ = rbx;
+    const Xbyak::Reg64 reg_dst_ = rdx;
+    const Xbyak::Reg64 reg_param_ = abi_param1;
+    const Xbyak::Reg64 reg_tmp_ = abi_not_param1;
 
     static constexpr bool is_zmm_ = std::is_same<Vmm, Xbyak::Zmm>::value;
     static constexpr bool is_ymm_ = std::is_same<Vmm, Xbyak::Ymm>::value;

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -251,7 +251,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         using namespace data_type;
 
         const auto cvt2ps
-                = [=](const Ymm &dst, const Operand &src, data_type_t idt) {
+                = [=](const Ymm dst, const Operand &src, data_type_t idt) {
                       switch (idt) {
                           case f32:
                               if (src.isMEM() || src.getIdx() != dst.getIdx())
@@ -274,7 +274,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
                       }
                   };
 
-        const auto cvt2odt = [=](const Ymm &ymm, data_type_t odt,
+        const auto cvt2odt = [=](const Ymm ymm, data_type_t odt,
                                      data_type_t idt) {
             const Xmm xmm = Xmm(ymm.getIdx());
             switch (odt) {
@@ -330,7 +330,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             }
         };
 
-        auto load = [=](const Ymm &ymm, const Address &addr, int size) {
+        auto load = [=](const Ymm ymm, const Address &addr, int size) {
             const Xmm xmm = Xmm(ymm.getIdx());
             switch (size) {
                 case 32: vmovups(ymm, addr); break;
@@ -340,7 +340,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             }
         };
 
-        auto store = [=](const Address &addr, const Ymm &ymm, int size) {
+        auto store = [=](const Address &addr, const Ymm ymm, int size) {
             const Xmm xmm = Xmm(ymm.getIdx());
             switch (size) {
                 case 32: vmovups(addr, ymm); break;
@@ -534,7 +534,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         using namespace data_type;
 
         const auto cvt2ps
-                = [=](const Xmm &dst, const Operand &src, data_type_t idt) {
+                = [=](const Xmm dst, const Operand &src, data_type_t idt) {
                       Xmm dst_pure = Xmm(dst.getIdx());
                       switch (idt) {
                           case f32:
@@ -561,7 +561,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
                       }
                   };
 
-        const auto cvt2odt = [=](const Xmm &xmm, data_type_t odt,
+        const auto cvt2odt = [=](const Xmm xmm, data_type_t odt,
                                      data_type_t idt) {
             switch (odt) {
                 case bf16:
@@ -615,7 +615,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             }
         };
 
-        auto load = [=](const Xmm &xmm, const Address &addr, int size) {
+        auto load = [=](const Xmm xmm, const Address &addr, int size) {
             switch (size) {
                 case 16: uni_vmovups(xmm, addr); break;
                 case 8: uni_vmovsd(xmm, addr); break;
@@ -627,7 +627,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         };
 
         auto load_bytes
-                = [=](const Xmm &xmm, const Address &addr, int size, int imm) {
+                = [=](const Xmm xmm, const Address &addr, int size, int imm) {
                       switch (size) {
                           case 4: uni_vpinsrd(xmm, xmm, addr, imm); break;
                           case 2: uni_vpinsrw(xmm, xmm, addr, imm); break;
@@ -636,7 +636,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
                       }
                   };
 
-        auto store = [=](const Address &addr, const Xmm &xmm, int size) {
+        auto store = [=](const Address &addr, const Xmm xmm, int size) {
             switch (size) {
                 case 16: uni_vmovups(addr, xmm); break;
                 case 8: uni_vmovsd(addr, xmm); break;
@@ -924,7 +924,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             };
             const bool mayiuse_avx2 = mayiuse(avx2);
             const auto uni_vpaddd_wrapper
-                    = [&](const Xmm &xmm, const Address &addr) {
+                    = [&](const Xmm xmm, const Address &addr) {
                           if (mayiuse_avx2)
                               vpaddd(xmm, xmm, addr);
                           else {
@@ -1115,7 +1115,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         L(l);
     }
 
-    void check_if_this_is_last_chunk(const Reg64 &reg_curr_chunk, int node_id) {
+    void check_if_this_is_last_chunk(const Reg64 reg_curr_chunk, int node_id) {
         // Chunks are backwards numered i.e:
         // [0] -> [node_size]
         // [1] -> [node_size - 1]
@@ -1194,7 +1194,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             add(reg_off_comp_, padded_area * c_step * sizeof(int32_t));
     }
 
-    void loop_end(Label &l, const Reg64 &reg_cnt, int len, int i_step,
+    void loop_end(Label &l, const Reg64 reg_cnt, int len, int i_step,
             int o_step, int s_step, int c_step, const int curr_node_id) {
         add(reg_off_in_, i_step * itype_sz_);
         add(reg_off_out_, o_step * otype_sz_);
@@ -1265,7 +1265,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             const int parent_node_id = prb_.nodes[curr_node_id].parent_node_id;
             const int tail_size = prb_.tail(curr_node_id) / unroll_factor;
             const int node_size = prb_.n(curr_node_id) / unroll_factor;
-            const Reg64 &reg_loop_cnt = reg_cnt[jit_loop - 1];
+            const Reg64 reg_loop_cnt = reg_cnt[jit_loop - 1];
             const bool curr_node_has_tail = prb_.tail(curr_node_id) != 0;
             Label loop, if_no_tail, if_end;
 
@@ -1447,35 +1447,35 @@ private:
     int otype_sz_;
     int stype_sz_;
 
-    const Reg64 &reg_ptr_in_ = rsi;
-    const Reg64 &reg_ptr_out_ = rdx;
-    const Reg64 &reg_ptr_scale_ = abi_not_param1;
-    const Reg64 &reg_ptr_comp_ = rbx;
+    const Reg64 reg_ptr_in_ = rsi;
+    const Reg64 reg_ptr_out_ = rdx;
+    const Reg64 reg_ptr_scale_ = abi_not_param1;
+    const Reg64 reg_ptr_comp_ = rbx;
     const Reg32 &reg_scale_adjust_ = ebp;
 
-    const Reg64 &reg_off_in_ = r8;
-    const Reg64 &reg_off_out_ = r9;
-    const Reg64 &reg_off_scale_ = r10;
-    const Reg64 &reg_off_comp_ = r11;
+    const Reg64 reg_off_in_ = r8;
+    const Reg64 reg_off_out_ = r9;
+    const Reg64 reg_off_scale_ = r10;
+    const Reg64 reg_off_comp_ = r11;
 
-    const Reg64 &reg_tmp_ = rax;
+    const Reg64 reg_tmp_ = rax;
 
-    const Xmm &xmm_scale_ = xmm15;
-    const Xmm &xmm_zero_ = xmm14;
-    const Xmm &xmm_4x127b_ = xmm13; // TODO: unite with ymm_zero_
-    const Ymm &ymm_zero_ = ymm14;
-    const Ymm &ymm_8x127b_ = ymm13;
-    const Xmm &xmm_tmp_ = xmm12;
-    const Xmm &xmm_src_zp_ = xmm9;
-    const Xmm &xmm_dst_zp_ = xmm11;
-    const Xmm &xmm_saturation_ubound_ = xmm12;
-    const Ymm &ymm_saturation_ubound_ = ymm12;
+    const Xmm xmm_scale_ = xmm15;
+    const Xmm xmm_zero_ = xmm14;
+    const Xmm xmm_4x127b_ = xmm13; // TODO: unite with ymm_zero_
+    const Ymm ymm_zero_ = ymm14;
+    const Ymm ymm_8x127b_ = ymm13;
+    const Xmm xmm_tmp_ = xmm12;
+    const Xmm xmm_src_zp_ = xmm9;
+    const Xmm xmm_dst_zp_ = xmm11;
+    const Xmm xmm_saturation_ubound_ = xmm12;
+    const Ymm ymm_saturation_ubound_ = ymm12;
 
     /* bf16 support on SKX */
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
     const Zmm bf16_emu_reserv_1_ = Zmm(16);
     const Zmm bf16_emu_reserv_2_ = Zmm(17);
-    const Reg64 &bf16_emu_scratch_ = reg_tmp_;
+    const Reg64 bf16_emu_scratch_ = reg_tmp_;
     const Zmm bf16_emu_reserv_3_ = Zmm(18);
     const Zmm bf16_emu_reserv_4_ = Zmm(19);
 };
@@ -1594,7 +1594,7 @@ struct jit_single_blk_kernel_t : public jit_generator {
         postamble();
     }
 
-    void gen_loadu(const Ymm &ymm, const Address &addr, int size) {
+    void gen_loadu(const Ymm ymm, const Address &addr, int size) {
         Xmm xmm(ymm.getIdx());
         switch (size) {
             case 32: vmovups(ymm, addr); break;
@@ -1603,7 +1603,7 @@ struct jit_single_blk_kernel_t : public jit_generator {
         }
     }
 
-    void gen_storeu(const Address &addr, const Ymm &ymm, int size) {
+    void gen_storeu(const Address &addr, const Ymm ymm, int size) {
         Xmm xmm(ymm.getIdx());
         switch (size) {
             case 32: vmovups(addr, ymm); break;
@@ -1613,7 +1613,7 @@ struct jit_single_blk_kernel_t : public jit_generator {
     }
 
     void gen_maskloadu(
-            const Ymm &ymm, const Address &addr, const Ymm mask, int size) {
+            const Ymm ymm, const Address &addr, const Ymm mask, int size) {
         Xmm xmm(ymm.getIdx());
         Xmm mask128(mask.getIdx());
         switch (size) {
@@ -1624,7 +1624,7 @@ struct jit_single_blk_kernel_t : public jit_generator {
     }
 
     void gen_maskstoreu(
-            const Address &addr, const Ymm &ymm, const Ymm mask, int size) {
+            const Address &addr, const Ymm ymm, const Ymm mask, int size) {
         Xmm xmm(ymm.getIdx());
         Xmm mask128(mask.getIdx());
         switch (size) {

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -122,21 +122,21 @@ private:
     const Zmm vmm_bf16_emu_3_ = Zmm(22);
     const Zmm vmm_bf16_emu_4_ = Zmm(23);
 
-    const Opmask &k_tail_mask_ = k3;
-    const Opmask &k_full_mask_ = k4;
+    const Opmask k_tail_mask_ = k3;
+    const Opmask k_full_mask_ = k4;
 
-    const Reg64 &reg_tmp_ = rax;
-    const Reg64 &reg_dst_ = rbx;
-    const Reg64 &reg_work_ = rdx;
-    const Reg64 &reg_indices_ = rsi;
-    const Reg64 &reg_c_offset = rbp;
-    const Reg64 &reg_param = abi_param1;
-    const Reg64 &reg_weights = abi_not_param1;
-    const Reg64 &reg_src_ = r8;
-    const Reg64 &reg_aux_src_0_ = r9;
-    const Reg64 &reg_aux_src_1_ = r10;
-    const Reg64 &reg_aux_src_2_ = r11;
-    const Reg64 &reg_tmp1_ = r15;
+    const Reg64 reg_tmp_ = rax;
+    const Reg64 reg_dst_ = rbx;
+    const Reg64 reg_work_ = rdx;
+    const Reg64 reg_indices_ = rsi;
+    const Reg64 reg_c_offset = rbp;
+    const Reg64 reg_param = abi_param1;
+    const Reg64 reg_weights = abi_not_param1;
+    const Reg64 reg_src_ = r8;
+    const Reg64 reg_aux_src_0_ = r9;
+    const Reg64 reg_aux_src_1_ = r10;
+    const Reg64 reg_aux_src_2_ = r11;
+    const Reg64 reg_tmp1_ = r15;
 
     // Registers which are used only for linear algorithm
     // and for channel oriented formats.
@@ -163,14 +163,14 @@ private:
     const Vmm src_bbl_ = Vmm(vmm_idx(6));
     const Vmm src_bbr_ = Vmm(vmm_idx(7));
 
-    const Reg64 &reg_src_ftl_ = reg_src_;
-    const Reg64 &reg_src_ftr_ = reg_aux_src_0_;
-    const Reg64 &reg_src_fbl_ = reg_aux_src_1_;
-    const Reg64 &reg_src_fbr_ = reg_aux_src_2_;
-    const Reg64 &reg_src_btl_ = r12;
-    const Reg64 &reg_src_btr_ = r13;
-    const Reg64 &reg_src_bbl_ = r14;
-    const Reg64 &reg_src_bbr_ = r15;
+    const Reg64 reg_src_ftl_ = reg_src_;
+    const Reg64 reg_src_ftr_ = reg_aux_src_0_;
+    const Reg64 reg_src_fbl_ = reg_aux_src_1_;
+    const Reg64 reg_src_fbr_ = reg_aux_src_2_;
+    const Reg64 reg_src_btl_ = r12;
+    const Reg64 reg_src_btr_ = r13;
+    const Reg64 reg_src_bbl_ = r14;
+    const Reg64 reg_src_bbr_ = r15;
 
     static constexpr bool is_zmm_ = std::is_same<Vmm, Xbyak::Zmm>::value;
     static constexpr bool is_ymm_ = std::is_same<Vmm, Xbyak::Ymm>::value;

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -433,21 +433,21 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator {
         size_t do_normalise;
     };
 
-    const Reg64 &reg_param_ = abi_param1;
-    const Reg64 &reg_tmp_ = abi_not_param1;
-    const Reg64 &reg_N_ = rsi;
-    const Reg64 &reg_S_ = rax;
-    const Reg64 &reg_C_ = rdx;
-    const Reg64 &reg_off_c_ = rbx;
-    const Reg64 &reg_blk_has_tail_ = rbp;
+    const Reg64 reg_param_ = abi_param1;
+    const Reg64 reg_tmp_ = abi_not_param1;
+    const Reg64 reg_N_ = rsi;
+    const Reg64 reg_S_ = rax;
+    const Reg64 reg_C_ = rdx;
+    const Reg64 reg_off_c_ = rbx;
+    const Reg64 reg_blk_has_tail_ = rbp;
 
-    const Reg64 &reg_off_dat_ = r8;
-    const Reg64 &reg_off_dat_save_ = r9;
-    const Reg64 &reg_ptr_mean_ = r10;
-    const Reg64 &reg_ptr_var_ = r11;
-    const Reg64 &reg_ptr_src_ = r12;
-    const Reg64 &reg_do_normalise_ = r13;
-    const Reg64 &reg_ptr_stat_ = r14;
+    const Reg64 reg_off_dat_ = r8;
+    const Reg64 reg_off_dat_save_ = r9;
+    const Reg64 reg_ptr_mean_ = r10;
+    const Reg64 reg_ptr_var_ = r11;
+    const Reg64 reg_ptr_src_ = r12;
+    const Reg64 reg_do_normalise_ = r13;
+    const Reg64 reg_ptr_stat_ = r14;
 
     const Vmm v_ = Vmm(0);
     const Vmm vtmp_ = Vmm(1);
@@ -466,7 +466,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator {
                     && number_of_vmms_to_unrolling_variables_ != 0,
             "Number of register to unrolling must to be divisible by 2.");
 
-    const Opmask &ktail_mask_ = k2;
+    const Opmask ktail_mask_ = k2;
 
     const batch_normalization_pd_t *bdesc_;
     const jit_memory_tag_kind_t tag_kind_;
@@ -788,24 +788,24 @@ struct jit_bnorm_fwd_t : public jit_generator {
         size_t blk_has_tail;
     };
 
-    const Reg64 &reg_param_ = abi_param1;
-    const Reg64 &reg_tmp_ = abi_not_param1;
-    const Reg64 &reg_N_ = rsi;
-    const Reg64 &reg_S_ = rax;
-    const Reg64 &reg_C_ = rdx;
-    const Reg64 &reg_off_c_ = rbx;
-    const Reg64 &reg_blk_has_tail_ = rbp;
+    const Reg64 reg_param_ = abi_param1;
+    const Reg64 reg_tmp_ = abi_not_param1;
+    const Reg64 reg_N_ = rsi;
+    const Reg64 reg_S_ = rax;
+    const Reg64 reg_C_ = rdx;
+    const Reg64 reg_off_c_ = rbx;
+    const Reg64 reg_blk_has_tail_ = rbp;
 
-    const Reg64 &reg_off_dat_ = r8;
-    const Reg64 &reg_off_dat_save_ = r9;
-    const Reg64 &reg_ptr_ws_ = r10;
-    const Reg64 &reg_ptr_scale_ = r11;
-    const Reg64 &reg_ptr_shift_ = reg_N_;
-    const Reg64 &reg_ptr_var_ = r12;
-    const Reg64 &reg_ptr_mean_ = r13;
-    const Reg64 &reg_ptr_dst_ = r14;
-    const Reg64 &reg_ptr_src_ = r15;
-    const Reg64 &reg_alpha_ = reg_ptr_ws_;
+    const Reg64 reg_off_dat_ = r8;
+    const Reg64 reg_off_dat_save_ = r9;
+    const Reg64 reg_ptr_ws_ = r10;
+    const Reg64 reg_ptr_scale_ = r11;
+    const Reg64 reg_ptr_shift_ = reg_N_;
+    const Reg64 reg_ptr_var_ = r12;
+    const Reg64 reg_ptr_mean_ = r13;
+    const Reg64 reg_ptr_dst_ = r14;
+    const Reg64 reg_ptr_src_ = r15;
+    const Reg64 reg_alpha_ = reg_ptr_ws_;
 
     const Vmm vmask = Vmm(0); // required for avx2 and sse41 ReLU computation
     const Vmm vone_ = Vmm(1);
@@ -822,8 +822,8 @@ struct jit_bnorm_fwd_t : public jit_generator {
     const Vmm valpha = Vmm(12);
     const Vmm vstore_mask_ = vtmp_;
 
-    const Opmask &kstore_mask_ = k1;
-    const Opmask &ktail_mask_ = k2;
+    const Opmask kstore_mask_ = k1;
+    const Opmask ktail_mask_ = k2;
 
     const batch_normalization_pd_t *bdesc_;
     const jit_memory_tag_kind_t tag_kind_;
@@ -1079,21 +1079,21 @@ struct jit_bnorm_bwd_t : public jit_generator {
         size_t blk_has_tail;
     };
 
-    const Reg64 &reg_param_ = abi_param1;
-    const Reg64 &reg_tmp_ = abi_not_param1;
-    const Reg64 &reg_N_ = rsi;
-    const Reg64 &reg_S_ = rax;
-    const Reg64 &reg_C_ = rdx;
-    const Reg64 &reg_off_c_ = rbx;
-    const Reg64 &reg_blk_has_tail_ = rbp;
+    const Reg64 reg_param_ = abi_param1;
+    const Reg64 reg_tmp_ = abi_not_param1;
+    const Reg64 reg_N_ = rsi;
+    const Reg64 reg_S_ = rax;
+    const Reg64 reg_C_ = rdx;
+    const Reg64 reg_off_c_ = rbx;
+    const Reg64 reg_blk_has_tail_ = rbp;
 
-    const Reg64 &reg_off_dat_ = r8;
-    const Reg64 &reg_off_dat_save_ = r9;
-    const Reg64 &reg_ptr_c_ = r10;
-    const Reg64 &reg_ptr_ws_ = r11;
-    const Reg64 &reg_ptr_diff_dst_ = r12;
-    const Reg64 &reg_ptr_diff_src_ = r13;
-    const Reg64 &reg_ptr_src_ = r14;
+    const Reg64 reg_off_dat_ = r8;
+    const Reg64 reg_off_dat_save_ = r9;
+    const Reg64 reg_ptr_c_ = r10;
+    const Reg64 reg_ptr_ws_ = r11;
+    const Reg64 reg_ptr_diff_dst_ = r12;
+    const Reg64 reg_ptr_diff_src_ = r13;
+    const Reg64 reg_ptr_src_ = r14;
 
     const Vmm vzero_ = Vmm(0);
     const Vmm vone_ = Vmm(1);
@@ -1109,8 +1109,8 @@ struct jit_bnorm_bwd_t : public jit_generator {
     const Vmm vtail_mask_ = Vmm(11);
     const Vmm vstore_mask_ = vtmp_;
 
-    const Opmask &kstore_mask_ = k1;
-    const Opmask &ktail_mask_ = k2;
+    const Opmask kstore_mask_ = k1;
+    const Opmask ktail_mask_ = k2;
 
     const batch_normalization_pd_t *bdesc_;
     const jit_memory_tag_kind_t tag_kind_;
@@ -1365,22 +1365,22 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator {
         size_t blk_has_tail;
     };
 
-    const Reg64 &reg_param_ = abi_param1;
-    const Reg64 &reg_tmp_ = abi_not_param1;
-    const Reg64 &reg_N_ = rsi;
-    const Reg64 &reg_S_ = rax;
-    const Reg64 &reg_C_ = rdx;
-    const Reg64 &reg_off_c_ = rbx;
-    const Reg64 &reg_blk_has_tail_ = rbp;
+    const Reg64 reg_param_ = abi_param1;
+    const Reg64 reg_tmp_ = abi_not_param1;
+    const Reg64 reg_N_ = rsi;
+    const Reg64 reg_S_ = rax;
+    const Reg64 reg_C_ = rdx;
+    const Reg64 reg_off_c_ = rbx;
+    const Reg64 reg_blk_has_tail_ = rbp;
 
-    const Reg64 &reg_off_dat_ = r8;
-    const Reg64 &reg_off_dat_save_ = r9;
-    const Reg64 &reg_ptr_c_ = r10;
-    const Reg64 &reg_ptr_diff_gamma_ = r11;
-    const Reg64 &reg_ptr_diff_beta_ = r12;
-    const Reg64 &reg_ptr_ws_ = r13;
-    const Reg64 &reg_ptr_diff_dst_ = r14;
-    const Reg64 &reg_ptr_src_ = r15;
+    const Reg64 reg_off_dat_ = r8;
+    const Reg64 reg_off_dat_save_ = r9;
+    const Reg64 reg_ptr_c_ = r10;
+    const Reg64 reg_ptr_diff_gamma_ = r11;
+    const Reg64 reg_ptr_diff_beta_ = r12;
+    const Reg64 reg_ptr_ws_ = r13;
+    const Reg64 reg_ptr_diff_dst_ = r14;
+    const Reg64 reg_ptr_src_ = r15;
 
     const Vmm vtail_mask_ = Vmm(0);
     const Vmm v_ = Vmm(1);
@@ -1404,8 +1404,8 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator {
                     && number_of_vmms_to_unrolling_variables_ != 0,
             "Number of register to unrolling must to be divisible by 3.");
 
-    const Opmask &kstore_mask_ = k1;
-    const Opmask &ktail_mask_ = k2;
+    const Opmask kstore_mask_ = k1;
+    const Opmask ktail_mask_ = k2;
 
     const batch_normalization_pd_t *bdesc_;
     const jit_memory_tag_kind_t tag_kind_;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -488,7 +488,7 @@ int _jit_uni_x8s8s32x_deconv_fwd_kernel<isa, Vmm>::get_tail_size() const
 
 template <cpu_isa_t isa, typename Vmm>
 void _jit_uni_x8s8s32x_deconv_fwd_kernel<isa, Vmm>::compute(
-        const Vmm &vreg_acc, const Vmm &vreg_wei, const Vmm &vreg_src) {
+        const Vmm vreg_acc, const Vmm vreg_wei, const Vmm vreg_src) {
 
     if (jcp_.has_vnni) {
         vpdpbusd(vreg_acc, vreg_src, vreg_wei, Xbyak::VexEncoding);
@@ -573,7 +573,7 @@ void _jit_uni_x8s8s32x_deconv_fwd_kernel<isa, Vmm>::append_zp_src_pad_str_comp(
         }
     };
 
-    const auto load_zp_src_pad_comp = [&](const Vmm &zp_pad_comp_vmm,
+    const auto load_zp_src_pad_comp = [&](const Vmm zp_pad_comp_vmm,
                                               const Xbyak::Address &comp_addr,
                                               const int ocb) {
         const bool is_tail = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
@@ -980,7 +980,7 @@ void _jit_uni_x8s8s32x_deconv_fwd_kernel<isa, Vmm>::prepare_output(int ur_w) {
 
 template <cpu_isa_t isa, typename Vmm>
 void _jit_uni_x8s8s32x_deconv_fwd_kernel<isa, Vmm>::cvt2ps(data_type_t type_in,
-        const Vmm &vmm_in, const Reg64 &reg, int offset, int load_size) {
+        const Vmm vmm_in, const Reg64 reg, int offset, int load_size) {
 
     load_data(type_in, vmm_in, reg, offset, load_size);
     if (type_in != data_type::f32) uni_vcvtdq2ps(vmm_in, vmm_in);

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -69,37 +69,37 @@ private:
     };
 
     /* data regs */
-    const reg64_t &reg_src_ = r8;
-    const reg64_t &reg_filt_ = r9;
-    const reg64_t &reg_dst_ = r10;
-    const reg64_t &param1_ = abi_param1;
-    const reg64_t &reg_kh_ = abi_not_param1;
-    const reg64_t &reg_ki_ = r14;
+    const reg64_t reg_src_ = r8;
+    const reg64_t reg_filt_ = r9;
+    const reg64_t reg_dst_ = r10;
+    const reg64_t param1_ = abi_param1;
+    const reg64_t reg_kh_ = abi_not_param1;
+    const reg64_t reg_ki_ = r14;
 
-    const reg64_t &reg_nur_w_ = rbx;
-    const reg64_t &reg_bias_ = rdx;
-    const reg64_t &reg_icb_ = reg_bias_;
-    const reg64_t &reg_ptr_scales_ = rax;
-    const reg64_t &reg_ptr_saturation_ubound_ = rax;
-    const reg64_t &reg_oc_blocks_ = rsi;
+    const reg64_t reg_nur_w_ = rbx;
+    const reg64_t reg_bias_ = rdx;
+    const reg64_t reg_icb_ = reg_bias_;
+    const reg64_t reg_ptr_scales_ = rax;
+    const reg64_t reg_ptr_saturation_ubound_ = rax;
+    const reg64_t reg_oc_blocks_ = rsi;
 
-    const reg64_t &aux_reg_src_ = r11;
-    const reg64_t &aux_reg_filt_ = r12;
+    const reg64_t aux_reg_src_ = r11;
+    const reg64_t aux_reg_filt_ = r12;
 
-    const reg64_t &aux_reg_src_d_ = r13;
-    const reg64_t &aux_reg_filt_d_ = r15;
+    const reg64_t aux_reg_src_d_ = r13;
+    const reg64_t aux_reg_filt_d_ = r15;
 
-    const reg64_t &reg_compensation_ = r14;
-    const reg64_t &reg_scratch_ = r14;
-    const reg64_t &reg_ptr_sum_scale_ = r11;
-    const reg64_t &reg_ptr_sum_zp_ = r15;
-    const reg64_t &reg_bias_alpha_ = abi_not_param1;
-    const reg64_t &reg_overflow_ = rax;
-    const reg64_t &reg_comp_strides_ = reg_overflow_;
-    const reg64_t &reg_ker_long_offt_ = r15;
-    const reg64_t &reg_zp_dst_ = r15;
-    const reg64_t &reg_zp_src_ = r15;
-    const reg64_t &reg_zp_compensation_ = r11;
+    const reg64_t reg_compensation_ = r14;
+    const reg64_t reg_scratch_ = r14;
+    const reg64_t reg_ptr_sum_scale_ = r11;
+    const reg64_t reg_ptr_sum_zp_ = r15;
+    const reg64_t reg_bias_alpha_ = abi_not_param1;
+    const reg64_t reg_overflow_ = rax;
+    const reg64_t reg_comp_strides_ = reg_overflow_;
+    const reg64_t reg_ker_long_offt_ = r15;
+    const reg64_t reg_zp_dst_ = r15;
+    const reg64_t reg_zp_src_ = r15;
+    const reg64_t reg_zp_compensation_ = r11;
     const Xbyak::Address zp_src_pad_comp_addr_ = ptr[rsp];
     const Xbyak::Address reg_scratch_preserved_ = ptr[rsp + 8];
     static constexpr int reserved_stack_size_ = 16;
@@ -108,15 +108,15 @@ private:
     const Vmm vmm_one_ = Vmm(2);
     /* used during write-out section of store_output */
     const Vmm vmm_zero_ = Vmm(0);
-    const Vmm &vmm_saturation_ = vmm_zero_;
-    const Vmm &vmm_wei_ = vmm_zero_;
-    const Vmm &vmm_scale_ = vmm_zero_;
+    const Vmm vmm_saturation_ = vmm_zero_;
+    const Vmm vmm_wei_ = vmm_zero_;
+    const Vmm vmm_scale_ = vmm_zero_;
     /* signed input */
     const Vmm vmm_shift_ = Vmm(1);
     const Vmm vmm_comp_ = Vmm(1);
-    const Vmm &vmm_bias_ = vmm_zero_;
-    const Vmm &vmm_prev_dst_ = vmm_zero_;
-    const Vmm &vmm_sum_zp_ = vmm_tmp_;
+    const Vmm vmm_bias_ = vmm_zero_;
+    const Vmm vmm_prev_dst_ = vmm_zero_;
+    const Vmm vmm_sum_zp_ = vmm_tmp_;
 
     Vmm vmm_out(int i_ur, int i_oc) const;
     Vmm vmm_inp(int i_ic, int nb_x_blocking) const;
@@ -134,7 +134,7 @@ private:
     void store_output(int ur_w, bool last_oc_block);
     void compute_ker(int ur_w, int l_overflow, int r_overflow,
             ker_block_t last_ic_block_flag, bool h_padded = false);
-    void compute(const Vmm &vreg_acc, const Vmm &vreg_wei, const Vmm &vreg_src);
+    void compute(const Vmm vreg_acc, const Vmm vreg_wei, const Vmm vreg_src);
     std::function<Vmm()> prepare_round_robin_vmm_inp_generator(int ur_w) const
             noexcept;
     void apply_zp_src_pad_str_comp(
@@ -144,7 +144,7 @@ private:
     void kh_loop(int ur_w, int pad_l, int pad_r, ker_block_t last_ker_block);
     void icb_loop(int ur_w, int pad_l, int pad_r, bool last_block);
     void generate() override;
-    void cvt2ps(data_type_t type_in, const Vmm &vmm_in, const Reg64 &reg,
+    void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Reg64 reg,
             int offset, int load_size);
 };
 


### PR DESCRIPTION
Removing the macros left as an exercise for the reader.

This wouldn't be necessary if we could depend on C++14, because then `Xbyak::util::rax` and family are also `constexpr`.
