### PR TITLE
src: cpu: x64: remove templated param from constructor resulting in GCC 11.2.1 build error

### DIFF
--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -233,7 +233,7 @@ struct jit_uni_x8s8s32x_fwd_kernel {
     void (*jit_ker)(jit_conv_call_s *);
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel<isa>);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel);
     jit_generator *kernel_;
 };
 


### PR DESCRIPTION
This is not valid C++:
```c++
  Klass<T>(const Klass<T> &);
```
I don't know what old compiler used to allow this, but GCC 11.2.1 doesn't.

Error was:
```
/home/tjmaciei/src/oneDNN/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp: At global scope:
/home/tjmaciei/src/oneDNN/src/common/utils.hpp:64:7: error: expected unqualified-id before ‘const’
   64 |     T(const T &) = delete; \
      |       ^~~~~
/home/tjmaciei/src/oneDNN/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp:236:5: note: in expansion of macro ‘DNNL_DISALLOW_COPY_AND_ASSIGN’
  236 |     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel<isa>);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/tjmaciei/src/oneDNN/src/common/utils.hpp:64:7: error: expected ‘)’ before ‘const’
   64 |     T(const T &) = delete; \
      |      ~^~~~~
/home/tjmaciei/src/oneDNN/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp:236:5: note: in expansion of macro ‘DNNL_DISALLOW_COPY_AND_ASSIGN’
  236 |     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel<isa>);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
