### PR TITLE
common: fix annoying warning that std::is_pod is deprecated

### DIFF
--- a/src/common/bit_cast.hpp
+++ b/src/common/bit_cast.hpp
@@ -37,8 +37,8 @@ inline T bit_cast(const U &u) {
     static_assert(sizeof(T) == sizeof(U), "Bit-casting must preserve size.");
     // Use std::is_pod as older GNU versions do not support
     // std::is_trivially_copyable.
-    static_assert(std::is_pod<T>::value, "T must be trivially copyable.");
-    static_assert(std::is_pod<U>::value, "U must be trivially copyable.");
+    static_assert(std::is_trivial<T>::value, "T must be trivially copyable.");
+    static_assert(std::is_trivial<U>::value, "U must be trivially copyable.");
 
     T t;
     std::memcpy(&t, &u, sizeof(U));

--- a/src/common/bit_cast.hpp
+++ b/src/common/bit_cast.hpp
@@ -35,8 +35,6 @@ namespace utils {
 template <typename T, typename U>
 inline T bit_cast(const U &u) {
     static_assert(sizeof(T) == sizeof(U), "Bit-casting must preserve size.");
-    // Use std::is_pod as older GNU versions do not support
-    // std::is_trivially_copyable.
     static_assert(std::is_trivial<T>::value, "T must be trivially copyable.");
     static_assert(std::is_trivial<U>::value, "U must be trivially copyable.");
 


### PR DESCRIPTION
The static_assert message is talking about the types being trivially
copyable. We should use std::is_trivially_copyable, but that didn't
exist in GCC 4.8 (first in 5.0), so we use a superset of that: trivial
types are both trivially copyable and trivially destructible.
