### PR TITLE
cpu: fix warning about binary op on two different enums

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -162,7 +162,7 @@ private:
     };
 
     static constexpr bool has_avx512() {
-        return (isa & cpu_isa_bit_t::avx512_common_bit)
+        return (unsigned(isa) & unsigned(cpu_isa_bit_t::avx512_common_bit))
                 == cpu_isa_bit_t::avx512_common_bit;
     }
 


### PR DESCRIPTION
```
src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp:165:21: warning: bitwise operation between different enumeration types ‘dnnl::impl::cpu::x64::cpu_isa_t’ and ‘dnnl::impl::cpu::x64::cpu_isa_bit_t’ is deprecated [-Wdeprecated-enum-enum-conversion]
  165 |         return (isa & cpu_isa_bit_t::avx512_common_bit)
      |                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```