### PR TITLE
Implement USM support for cudnn_binary

### DIFF
--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -34,6 +34,8 @@ status_t cudnn_binary_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
+        cgh.depends_on(cuda_stream->get_deps());
+        
         auto arg_src_0 = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC_0);
         auto arg_src_1 = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC_1);
         auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);

--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -34,8 +34,6 @@ status_t cudnn_binary_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        cgh.depends_on(cuda_stream->get_deps());
-        
         auto arg_src_0 = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC_0);
         auto arg_src_1 = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC_1);
         auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);

--- a/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright 2022 Intel Corporation
+* Copyright 2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_NVIDIA_SYCL_CUDA_MEMORY_STORAGE_HELPER_HPP
+#define GPU_NVIDIA_SYCL_CUDA_MEMORY_STORAGE_HELPER_HPP
+
+#include <optional>
+#include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
+#include "sycl/sycl_memory_storage.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace nvidia {
+
+#define CTX_IN_SYCL_MEMORY(arg) \
+    sycl_memory_arg_t<::sycl::access::mode::read>(&CTX_IN_STORAGE(arg), cgh)
+
+#define CTX_OUT_SYCL_MEMORY(arg) \
+    sycl_memory_arg_t<::sycl::access::mode::write>(&CTX_OUT_STORAGE(arg), cgh)
+
+template <::sycl::access_mode mode>
+class sycl_memory_arg_t {
+public:
+    sycl_memory_arg_t() = default;
+    sycl_memory_arg_t(memory_storage_t *raw_mem, ::sycl::handler &cgh) {
+        if (raw_mem->is_null()) { return; }
+        auto *mem = static_cast<sycl::sycl_memory_storage_base_t *>(raw_mem);
+        switch (mem->memory_kind()) {
+            case sycl::memory_kind::buffer: {
+                auto *buffer_storage
+                        = utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
+                                mem);
+                acc_.emplace(buffer_storage->buffer(), cgh);
+                offset_ = buffer_storage->base_offset();
+                break;
+            }
+            case sycl::memory_kind::usm: {
+                raw_ptr_ = utils::downcast<
+                        const sycl::sycl_usm_memory_storage_t *>(mem)
+                                   ->usm_ptr();
+                break;
+            }
+            default: assert(!"unexpected memory kind");
+        }
+    }
+
+    template <::sycl::backend be = ::sycl::backend::ext_oneapi_cuda,
+            typename T = void>
+    T *get_native_pointer(const compat::interop_handle &ih) const {
+        void *raw_ptr;
+        if (acc_.has_value()) {
+            raw_ptr = reinterpret_cast<T *>(
+                    reinterpret_cast<uint8_t *>(
+                            ih.get_native_mem<be>(acc_.value()))
+                    + offset_);
+        } else {
+            raw_ptr = raw_ptr_;
+        }
+        return reinterpret_cast<T *>(raw_ptr);
+    }
+
+    bool empty() const { return !raw_ptr_ && !acc_.has_value(); }
+
+private:
+    void *raw_ptr_ = nullptr;
+    std::optional<::sycl::accessor<uint8_t, 1, mode>> acc_;
+    size_t offset_;
+};
+
+} // namespace nvidia
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/nvidia/sycl_cuda_stream.cpp
+++ b/src/gpu/nvidia/sycl_cuda_stream.cpp
@@ -97,9 +97,10 @@ status_t sycl_cuda_stream_t::init() {
 status_t sycl_cuda_stream_t::interop_task(
         std::function<void(::sycl::handler &)> sycl_cuda_interop_) {
     try {
-        cgh.depends_on(get_deps());
-        this->set_deps({queue().submit(
-                [&](::sycl::handler &cgh) { sycl_cuda_interop_(cgh); })});
+        this->set_deps({queue().submit([&](::sycl::handler &cgh) {
+            cgh.depends_on(get_deps());
+            sycl_cuda_interop_(cgh);
+        })});
         return status::success;
     } catch (std::runtime_error &e) {
         error::wrap_c_api(status::runtime_error, e.what());

--- a/src/gpu/nvidia/sycl_cuda_stream.cpp
+++ b/src/gpu/nvidia/sycl_cuda_stream.cpp
@@ -97,6 +97,7 @@ status_t sycl_cuda_stream_t::init() {
 status_t sycl_cuda_stream_t::interop_task(
         std::function<void(::sycl::handler &)> sycl_cuda_interop_) {
     try {
+        cgh.depends_on(get_deps());
         this->set_deps({queue().submit(
                 [&](::sycl::handler &cgh) { sycl_cuda_interop_(cgh); })});
         return status::success;


### PR DESCRIPTION
# Description

Adds support for USM for memory storage for cudnn_binary operation.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
