### PR TITLE
gpu: cuda: enable USM tests and update README to say USM is supported

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -60,14 +60,6 @@ if(DNNL_CPU_SYCL)
     endforeach()
 endif()
 
-# Skip examples for CUDA since USM is a default model for the library which is
-# not yet supported for Nvidia backend.
-if(DNNL_SYCL_CUDA)
-    foreach(f ${sources})
-        list(REMOVE_ITEM sources "${f}")
-    endforeach()
-endif()
-
 foreach(src ${sources})
     file(RELATIVE_PATH src_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${src})
     string(REGEX REPLACE "[/_\\.]" "-" example_name ${src_rel_path})

--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -27,7 +27,7 @@ cmake -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP \
 
 ## Memory
 
-Currently, only the buffer-based oneDNN API is supported for Nvidia backend.
+Both buffer-based  and USM-based oneDNN APIs are supported for Nvidia backend.
 
 ## Suported Data Types
 

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -113,15 +113,6 @@ int dnn_mem_t::reorder(const dnn_mem_t &rhs, const_dnnl_primitive_attr_t attr) {
 
 int dnn_mem_t::initialize_memory_create_sycl(const handle_info_t &handle_info) {
 #ifdef DNNL_WITH_SYCL
-    if (is_nvidia_gpu(engine_)) {
-        // USM is not supported with Nvidia so ignore memory_kind and
-        // force SYCL buffers.
-        DNN_SAFE(dnnl_sycl_interop_memory_create(&m_, &md_, engine_,
-                         dnnl_sycl_interop_buffer, handle_info.ptr),
-                CRIT);
-        return OK;
-    }
-
     if (handle_info.is_host_ptr) {
         // Ignore memory_kind with host pointers and force USM.
         DNN_SAFE(dnnl_sycl_interop_memory_create(&m_, &md_, engine_,

--- a/tests/gtests/CMakeLists.txt
+++ b/tests/gtests/CMakeLists.txt
@@ -96,7 +96,6 @@ file(GLOB PRIM_TEST_CASES_SRC
                               test_matmul.cpp
                               test_resampling.cpp
                               test_reduction.cpp
-                              test_softmax_v2.cpp
                               )
 
 if(DNNL_CPU_RUNTIME STREQUAL "NONE")
@@ -237,7 +236,7 @@ endif()
 
 foreach(TEST_FILE ${PRIM_TEST_CASES_SRC})
     get_filename_component(exe ${TEST_FILE} NAME_WE)
-    if(NOT ${exe} MATCHES "${skip_usm_pattern}" AND NOT DNNL_SYCL_CUDA)
+    if(NOT ${exe} MATCHES "${skip_usm_pattern}")
         register_gtest(${exe} ${TEST_FILE})
     endif()
 


### PR DESCRIPTION
# Description

Update docs to say USM is supported for cudnn operations and enable tests for USM in cudnn operations.

This is blocked by all PRs enabling USM in cudnn operations, including, but not limited to: https://github.com/oneapi-src/oneDNN/pull/1258, https://github.com/oneapi-src/oneDNN/pull/1263, https://github.com/oneapi-src/oneDNN/pull/1262, https://github.com/oneapi-src/oneDNN/pull/1259


# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
