### PR TITLE
gpu: cuda: Enabling support for usm in sum primitve

### DIFF
--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -19,7 +19,7 @@
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "sycl/sycl_buffer_memory_storage.hpp"
-#include "sycl_cuda_memory_storage_helper.hpp"
+#include "gpu/nvidia/sycl_cuda_memory_storage_helper.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -16,10 +16,10 @@
 *******************************************************************************/
 
 #include "gpu/nvidia/cudnn_binary.hpp"
+#include "gpu/nvidia/sycl_cuda_memory_storage_helper.hpp"
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "sycl/sycl_buffer_memory_storage.hpp"
-#include "gpu/nvidia/sycl_cuda_memory_storage_helper.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
-* Copyright 2022 Codeplay Software Limited
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/nvidia/sycl_cuda_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_helper.hpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_NVIDIA_SYCL_CUDA_HELPER_HPP
+#define GPU_NVIDIA_SYCL_CUDA_HELPER_HPP
+
+#include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
+#include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl/sycl_usm_memory_storage.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace nvidia {
+
+template <typename T_acc>
+inline std::optional<T_acc> get_cudnn_accessor(
+        sycl::sycl_memory_storage_base_t *mem, ::sycl::handler &cgh) {
+    std::optional<T_acc> acc;
+    if (mem->memory_kind() == sycl::memory_kind::buffer) {
+        acc.emplace(utils::downcast<sycl::sycl_buffer_memory_storage_t *>(mem)
+                            ->buffer(),
+                cgh);
+    }
+    return acc;
+}
+
+template <typename T_acc>
+inline void *get_cudnn_ptr(cuda_sycl_scoped_context_handler_t &sc,
+        const compat::interop_handle &ih, const std::optional<T_acc> &acc,
+        sycl::sycl_memory_storage_base_t *mem) {
+    void *ptr;
+    switch (mem->memory_kind()) {
+        case sycl::memory_kind::buffer:
+            ptr = sc.memory<void *>(ih, acc.value());
+            break;
+        case sycl::memory_kind::usm:
+            ptr = utils::downcast<const sycl::sycl_usm_memory_storage_t *>(mem)
+                          ->usm_ptr();
+            break;
+        default: assert(!"unexpected memory kind");
+    }
+    return ptr;
+}
+
+} // namespace nvidia
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
@@ -28,10 +28,16 @@ namespace gpu {
 namespace nvidia {
 
 #define CTX_IN_SYCL_MEMORY(arg) \
-    sycl_memory_arg<::sycl::access::mode::read>(static_cast<sycl::sycl_memory_storage_base_t *>(&CTX_IN_STORAGE(arg)), cgh)
+    sycl_memory_arg<::sycl::access::mode::read>( \
+            static_cast<sycl::sycl_memory_storage_base_t *>( \
+                    &CTX_IN_STORAGE(arg)), \
+            cgh)
 
 #define CTX_OUT_SYCL_MEMORY(arg) \
-    sycl_memory_arg<::sycl::access::mode::write>(static_cast<sycl::sycl_memory_storage_base_t *>(&CTX_OUT_STORAGE(arg)), cgh)
+    sycl_memory_arg<::sycl::access::mode::write>( \
+            static_cast<sycl::sycl_memory_storage_base_t *>( \
+                    &CTX_OUT_STORAGE(arg)), \
+            cgh)
 
 template <::sycl::access_mode mode>
 class sycl_memory_arg {
@@ -56,8 +62,8 @@ public:
     }
 
     template <typename T = void>
-    T *get_native_pointer(const compat::interop_handle &ih, 
-            const cuda_sycl_scoped_context_handler_t& sc) const {
+    T *get_native_pointer(const compat::interop_handle &ih,
+            const cuda_sycl_scoped_context_handler_t &sc) const {
         void *raw_ptr;
         if (usm_mem_) {
             raw_ptr = usm_mem_->usm_ptr();
@@ -68,8 +74,8 @@ public:
     }
 
     template <typename T = void>
-    T *get_native_pointer(const compat::interop_handle &ih, 
-            const cuda_sycl_scoped_context_handler_t& sc, size_t offset) const {
+    T *get_native_pointer(const compat::interop_handle &ih,
+            const cuda_sycl_scoped_context_handler_t &sc, size_t offset) const {
         return reinterpret_cast<T *>(
                 reinterpret_cast<uint8_t *>(get_native_pointer<T>(ih, sc))
                 + offset);

--- a/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
@@ -26,7 +26,7 @@ namespace dnnl {
 namespace impl {
 namespace gpu {
 namespace nvidia {
-    
+
 #define CTX_IN_MEMORY(arg) \
     static_cast<sycl::sycl_memory_storage_base_t *>(&CTX_IN_STORAGE(arg))
 
@@ -37,7 +37,7 @@ namespace nvidia {
     get_cudnn_accessor<decltype(CTX_IN_ACCESSOR(arg))>(memory, cgh)
 
 #define CTX_OUT_OPTIONAL_ACCESSOR(arg, memory) \
-    get_cudnn_accessor<decltype(CTX_IN_ACCESSOR(arg))>(memory, cgh)
+    get_cudnn_accessor<decltype(CTX_OUT_ACCESSOR(arg))>(memory, cgh)
 
 template <typename T_acc>
 inline std::optional<T_acc> get_cudnn_accessor(

--- a/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-* Copyright 2020 Codeplay Software Limited
+* Copyright 2022 Intel Corporation
+* Copyright 2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,26 +15,46 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef GPU_NVIDIA_SYCL_CUDA_HELPER_HPP
-#define GPU_NVIDIA_SYCL_CUDA_HELPER_HPP
+#ifndef GPU_NVIDIA_SYCL_CUDA_MEMORY_STORAGE_HELPER_HPP
+#define GPU_NVIDIA_SYCL_CUDA_MEMORY_STORAGE_HELPER_HPP
 
+#include <optional>
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
-#include "sycl/sycl_buffer_memory_storage.hpp"
-#include "sycl/sycl_usm_memory_storage.hpp"
+#include "sycl/sycl_memory_storage.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace gpu {
 namespace nvidia {
+    
+#define CTX_IN_MEMORY(arg) \
+    static_cast<sycl::sycl_memory_storage_base_t *>(&CTX_IN_STORAGE(arg))
+
+#define CTX_OUT_MEMORY(arg) \
+    static_cast<sycl::sycl_memory_storage_base_t *>(&CTX_OUT_STORAGE(arg))
+
+#define CTX_IN_OPTIONAL_ACCESSOR(arg, memory) \
+    get_cudnn_accessor<decltype(CTX_IN_ACCESSOR(arg))>(memory, cgh)
+
+#define CTX_OUT_OPTIONAL_ACCESSOR(arg, memory) \
+    get_cudnn_accessor<decltype(CTX_IN_ACCESSOR(arg))>(memory, cgh)
 
 template <typename T_acc>
 inline std::optional<T_acc> get_cudnn_accessor(
         sycl::sycl_memory_storage_base_t *mem, ::sycl::handler &cgh) {
     std::optional<T_acc> acc;
-    if (mem->memory_kind() == sycl::memory_kind::buffer) {
-        acc.emplace(utils::downcast<sycl::sycl_buffer_memory_storage_t *>(mem)
+    switch (mem->memory_kind()) {
+        case sycl::memory_kind::buffer:
+            acc.emplace(
+                    utils::downcast<sycl::sycl_buffer_memory_storage_t *>(mem)
                             ->buffer(),
-                cgh);
+                    cgh);
+            break;
+        case sycl::memory_kind::usm:
+            // USM storage does not use accessors, so in this case empty
+            // std:optional is returned
+            break;
+        default: assert(!"unexpected memory kind");
     }
     return acc;
 }

--- a/src/gpu/nvidia/sycl_cuda_scoped_context.hpp
+++ b/src/gpu/nvidia/sycl_cuda_scoped_context.hpp
@@ -47,7 +47,7 @@ public:
     // This is a work-around function for reinterpret_casting the memory. This
     // will be fixed when SYCL-2020 has been implemented for Pi backend.
     template <typename T, typename U>
-    inline T memory(const compat::interop_handle &ih, U acc) {
+    inline T memory(const compat::interop_handle &ih, U acc) const {
         return compat::get_native_mem<T>(ih, acc);
     }
 };

--- a/src/gpu/ocl/ref_sum.hpp
+++ b/src/gpu/ocl/ref_sum.hpp
@@ -137,6 +137,9 @@ struct ref_sum_t : public gpu_primitive_t {
             r_ctx.set_scratchpad_grantor(ns.grantor());
             CHECK(reorders_[n]->execute(r_ctx));
         }
+#ifdef DNNL_SYCL_CUDA
+        ctx.stream()->wait();
+#endif
 
         return status::success;
     }


### PR DESCRIPTION
# Description

Adds fix to enable usm support for sum primitive. Previously, the src memory_object was being destroyed before the host_task was completed. This patch fixes that. Based on commits from #1259
Will update with syntax/macros if need be.
