### PR TITLE
RFC: add f64 conv GPU support

### DIFF
--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -64,8 +64,9 @@ include/oneapi/dnnl/dnnl_types.h:
 Convolution primitive in particular has several configurations and parameters that deserve to be discussed in more detail with regards to f64 data type.
 - Table in https://oneapi-src.github.io/oneDNN/dev_guide_convolution.html describes the supported configurations in the convolution api. We propose adding one row, for which source, weights, destination and bias are all f64; for both forward and backward propagation.
 - Data Representation: f64 conv will be supported for all the representations which f32 is supported on.
-- Postops & attributes: all post-ops and attributes supported for f32 configuration will be supported for f64 on GPU.
+- Postops & attributes: all post-ops and attributes supported for f32 configuration will be supported for f64 on GPU; and the math will occur in f64.
 - Scales: scaling values will remain in f32 in order to minimize API changes. These values will be upconverted to f64 (accumulate data type) and the math will occur in f64 on the GPU.
+- Supported architectures: f64 configuration will not be supported on hardware that do not have double precision math capability, such as DG1 & DG2. 
 
 ## Known limitations
 

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -13,7 +13,8 @@ to recognize double-precision floating-point data type.
 
 Here's the list of of the changes in library header files:
 
-    include/oneapi/dnnl/dnnl.hpp:
+include/oneapi/dnnl/dnnl.hpp:
+
     /// Data type specification.
     enum class data_type {
         /// Undefined data type (used for empty memory descriptors).
@@ -35,7 +36,8 @@ Here's the list of of the changes in library header files:
         u8 = dnnl_u8,
     };
 
-    include/oneapi/dnnl/dnnl_types.h:
+include/oneapi/dnnl/dnnl_types.h:
+
     typedef enum {
         /// Undefined data type, used for empty memory descriptors.
         dnnl_data_type_undef = 0,
@@ -58,10 +60,12 @@ Here's the list of of the changes in library header files:
 ## Some details on Convolution primitive
 
 Convolution primitive in particular has several configurations and parameters that 
-deserves to be discussed in more detail with regard to f64 data type.
-...
-
+deserves to be discussed in more detail with regards to f64 data type.
+- Table in https://oneapi-src.github.io/oneDNN/dev_guide_convolution.html describes the supported configurations in the convolution api. We suggest adding one row, for which source, weights, destination and bias are all f64; for both forward and backward propagation.
+- Data Representation: f64 conv will be suppored for all the representations which f32 was supported on.
+- Postops & attributes: all post-ops and attributes supported for f32 configuration will be supported for f64 on GPU.
+- Scales: scaling values will remain in f32 in order to minimize API changes. These values will be upconverted to f64 (accumulate data type) and the math will occur in f64.
 
 ## Known limitations
 
-Reference computation in benchdnn is remained in f32. 
+- Reference computation in benchdnn is remained in f32. This decision is made in order to minimiaze changes in benchdnn infrastructure which uses f32 for reference computation, until some feedback is collected on this feature.

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -27,8 +27,8 @@ include/oneapi/dnnl/dnnl.hpp:
         bf16 = dnnl_bf16,
         /// [32-bit/single-precision floating point](https://en.wikipedia.org/wiki/Single-precision_floating-point_format).
         f32 = dnnl_f32,
-        **//// [64-bit/double-precision floating point](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
-        f64 = dnnl_f64,**
+        //// [64-bit/double-precision floating point](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
+        f64 = dnnl_f64,
         /// 32-bit signed integer.
         s32 = dnnl_s32,
         /// 8-bit signed integer.
@@ -56,8 +56,8 @@ include/oneapi/dnnl/dnnl_types.h:
         dnnl_s8 = 5,
         /// 8-bit unsigned integer.
         dnnl_u8 = 6,
-        **/// 64-bit/double-precision floating point.
-        dnnl_f64 = 7,**
+        /// 64-bit/double-precision floating point.
+        dnnl_f64 = 7,
     } dnnl_data_type_t;
 ```
 

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -5,9 +5,7 @@
 Some deep learning applications require higher numerical accuracy than traditionally 
 supported 32-bit floating points, especially for training phase. This RFC addresses
 this requirement by introducing 64-bit, double precision float convolution support in oneDNN.
-We propose adding f64 data type support for convolution on the GPU. Other primitives, 
-or engines are not impacted at this point; although library infrastrcture is modified
-to recognize double-precision floating-point data type.
+We propose adding f64 data type support for convolution on the GPU. Since `reorder` is used to support convolution with different tensor formats, fp64 support will be added to this primitive as well. Other primitives, or engines are not impacted at this point; although library infrastrcture is modified to recognize double-precision floating-point data type.
 
 ## API changes
 
@@ -63,13 +61,12 @@ include/oneapi/dnnl/dnnl_types.h:
 
 ## Some details on Convolution primitive
 
-Convolution primitive in particular has several configurations and parameters that 
-deserves to be discussed in more detail with regards to f64 data type.
+Convolution primitive in particular has several configurations and parameters that deserve to be discussed in more detail with regards to f64 data type.
 - Table in https://oneapi-src.github.io/oneDNN/dev_guide_convolution.html describes the supported configurations in the convolution api. We propose adding one row, for which source, weights, destination and bias are all f64; for both forward and backward propagation.
-- Data Representation: f64 conv will be suppored for all the representations which f32 is supported on.
+- Data Representation: f64 conv will be supported for all the representations which f32 is supported on.
 - Postops & attributes: all post-ops and attributes supported for f32 configuration will be supported for f64 on GPU.
 - Scales: scaling values will remain in f32 in order to minimize API changes. These values will be upconverted to f64 (accumulate data type) and the math will occur in f64 on the GPU.
 
 ## Known limitations
 
-- Reference computation in benchdnn is remained in f32. This decision is made in order to minimiaze changes in benchdnn infrastructure which uses f32 for reference computation for all configurations. As we collect more feedback on this feature, we will evaludate next steps for validating numerical resutls and the necessity to perform f64 reference compute.
+- Reference computation in benchdnn remains in f32. This decision is made in order to minimize changes in benchdnn infrastructure which uses f32 for reference computation for all configurations. As we collect more feedback on this feature, we will evaluate next steps for validating numerical resutls and the necessity to perform f64 reference compute.

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -1,0 +1,23 @@
+# RFC: f64 data_type support.
+
+## Introduction & Motivation
+
+Some deep learning applications require higher numerical accuracy than traditionally 
+supported 32-bit floating points, especially for training phase. This RFC addresses
+this requirement by introducing 64-bit, double precision float support in oneDNN.
+
+### API changes
+
+This is the list of the API changes required to add f64 data type support in oneDNN:
+// put the code here.
+
+## Some details on Convolution primitive
+
+Convolution primitive in particular has several configurations and parameters that 
+deserves to be discussed in more detail with regard to f64 data type.
+...
+
+
+### Additional changes
+
+Maybe f64 data type support needs to be expanded for other primitives in oneDNN?

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -63,8 +63,7 @@ include/oneapi/dnnl/dnnl_types.h:
 
 Convolution primitive in particular has several configurations and parameters that deserve to be discussed in more detail with regards to f64 data type.
 - Table in https://oneapi-src.github.io/oneDNN/dev_guide_convolution.html describes the supported configurations in the convolution api. We propose adding one row, for which source, weights, destination and bias are all f64; for both forward and backward propagation.
-- Data Representation: f64 conv will be supported for all the representations which f32 is supported on.
-- Postops & attributes: all post-ops and attributes supported for f32 configuration will be supported for f64 on GPU; and the math will occur in f64.
+- Postops: f64 configuration will not support any post-ops at this time.
 - Scales: scaling values will remain in f32 in order to minimize API changes. These values will be upconverted to f64 (accumulate data type) and the math will occur in f64 on the GPU.
 - Supported architectures: f64 configuration will not be supported on hardware that do not have double precision math capability, such as DG1 & DG2. 
 

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -5,11 +5,55 @@
 Some deep learning applications require higher numerical accuracy than traditionally 
 supported 32-bit floating points, especially for training phase. This RFC addresses
 this requirement by introducing 64-bit, double precision float support in oneDNN.
+We propose adding f64 data type support for convolution on the GPU. Other primitives, 
+or engines are not impacted at this point; although library infrastrcture is modified
+to recognize double-precision floating-point data type.
 
-### API changes
+## API changes
 
-This is the list of the API changes required to add f64 data type support in oneDNN:
-// put the code here.
+Here's the list of of the changes in library header files:
+
+    include/oneapi/dnnl/dnnl.hpp:
+    /// Data type specification.
+    enum class data_type {
+        /// Undefined data type (used for empty memory descriptors).
+        undef = dnnl_data_type_undef,
+        /// [16-bit/half-precision floating point](https://en.wikipedia.org/wiki/Half-precision_floating-point_format).
+        f16 = dnnl_f16,
+        /// non-standard
+        /// [16-bit floating point with 7-bit mantissa](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format).
+        bf16 = dnnl_bf16,
+        /// [32-bit/single-precision floating point](https://en.wikipedia.org/wiki/Single-precision_floating-point_format).
+        f32 = dnnl_f32,
+        **//// [64-bit/double-precision floating point](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
+        f64 = dnnl_f64,**
+        /// 32-bit signed integer.
+        s32 = dnnl_s32,
+        /// 8-bit signed integer.
+        s8 = dnnl_s8,
+        /// 8-bit unsigned integer.
+        u8 = dnnl_u8,
+    };
+
+    include/oneapi/dnnl/dnnl_types.h:
+    typedef enum {
+        /// Undefined data type, used for empty memory descriptors.
+        dnnl_data_type_undef = 0,
+        /// 16-bit/half-precision floating point.
+        dnnl_f16 = 1,
+        /// non-standard 16-bit (bfloat16 w/ 7 bit mantissa) floating point.
+        dnnl_bf16 = 2,
+        /// 32-bit/single-precision floating point.
+        dnnl_f32 = 3,
+        /// 32-bit signed integer.
+        dnnl_s32 = 4,
+        /// 8-bit signed integer.
+        dnnl_s8 = 5,
+        /// 8-bit unsigned integer.
+        dnnl_u8 = 6,
+        **/// 64-bit/double-precision floating point.
+        dnnl_f64 = 7,**
+    } dnnl_data_type_t;
 
 ## Some details on Convolution primitive
 
@@ -18,6 +62,6 @@ deserves to be discussed in more detail with regard to f64 data type.
 ...
 
 
-### Additional changes
+## Known limitations
 
-Maybe f64 data type support needs to be expanded for other primitives in oneDNN?
+Reference computation in benchdnn is remained in f32. 

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -15,6 +15,7 @@ Here's the list of of the changes in library header files:
 
 include/oneapi/dnnl/dnnl.hpp:
 
+```c
     /// Data type specification.
     enum class data_type {
         /// Undefined data type (used for empty memory descriptors).
@@ -35,9 +36,11 @@ include/oneapi/dnnl/dnnl.hpp:
         /// 8-bit unsigned integer.
         u8 = dnnl_u8,
     };
+```
 
 include/oneapi/dnnl/dnnl_types.h:
 
+```c
     typedef enum {
         /// Undefined data type, used for empty memory descriptors.
         dnnl_data_type_undef = 0,
@@ -56,6 +59,7 @@ include/oneapi/dnnl/dnnl_types.h:
         **/// 64-bit/double-precision floating point.
         dnnl_f64 = 7,**
     } dnnl_data_type_t;
+```
 
 ## Some details on Convolution primitive
 

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -1,10 +1,10 @@
-# RFC: f64 data type support
+# RFC: f64 convolution support
 
 ## Introduction & Motivation
 
 Some deep learning applications require higher numerical accuracy than traditionally 
 supported 32-bit floating points, especially for training phase. This RFC addresses
-this requirement by introducing 64-bit, double precision float support in oneDNN.
+this requirement by introducing 64-bit, double precision float convolution support in oneDNN.
 We propose adding f64 data type support for convolution on the GPU. Other primitives, 
 or engines are not impacted at this point; although library infrastrcture is modified
 to recognize double-precision floating-point data type.
@@ -65,11 +65,11 @@ include/oneapi/dnnl/dnnl_types.h:
 
 Convolution primitive in particular has several configurations and parameters that 
 deserves to be discussed in more detail with regards to f64 data type.
-- Table in https://oneapi-src.github.io/oneDNN/dev_guide_convolution.html describes the supported configurations in the convolution api. We suggest adding one row, for which source, weights, destination and bias are all f64; for both forward and backward propagation.
-- Data Representation: f64 conv will be suppored for all the representations which f32 was supported on.
+- Table in https://oneapi-src.github.io/oneDNN/dev_guide_convolution.html describes the supported configurations in the convolution api. We propose adding one row, for which source, weights, destination and bias are all f64; for both forward and backward propagation.
+- Data Representation: f64 conv will be suppored for all the representations which f32 is supported on.
 - Postops & attributes: all post-ops and attributes supported for f32 configuration will be supported for f64 on GPU.
-- Scales: scaling values will remain in f32 in order to minimize API changes. These values will be upconverted to f64 (accumulate data type) and the math will occur in f64.
+- Scales: scaling values will remain in f32 in order to minimize API changes. These values will be upconverted to f64 (accumulate data type) and the math will occur in f64 on the GPU.
 
 ## Known limitations
 
-- Reference computation in benchdnn is remained in f32. This decision is made in order to minimiaze changes in benchdnn infrastructure which uses f32 for reference computation, until some feedback is collected on this feature.
+- Reference computation in benchdnn is remained in f32. This decision is made in order to minimiaze changes in benchdnn infrastructure which uses f32 for reference computation for all configurations. As we collect more feedback on this feature, we will evaludate next steps for validating numerical resutls and the necessity to perform f64 reference compute.

--- a/rfcs/20220128-f64-data_type/Readme.md
+++ b/rfcs/20220128-f64-data_type/Readme.md
@@ -1,4 +1,4 @@
-# RFC: f64 data_type support.
+# RFC: f64 data type support
 
 ## Introduction & Motivation
 


### PR DESCRIPTION
This RFC PR proposes to add f64 data type support to oneDNN. 
As the first step, GPU reference implementation for convolutions will be extended to support f64. 
Other primitives or engines will not be affected for now.