### PR TITLE
ci: replace Ubuntu16+GCC7 stage in AArch64 CI with Ubuntu20+GCC10

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2020-2021 Arm Limited and affiliates.
+# Copyright 2020-2022 Arm Limited and affiliates.
 # Copyright 2020-2021 FUJITSU LIMITED
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -17,33 +17,36 @@
 # *******************************************************************************
 
 kind: pipeline
-name: Ubuntu16+ACL
+name: Ubuntu20+ACL
 
 platform:
   arch: arm64
 
 steps:
-- name: gcc-test+ACL
-  image: ubuntu:16.04
+- name: gcc10-test+ACL
+  image: ubuntu:20.04
   commands:
-  - apt-get update && apt-get install -y git build-essential cmake scons
+  - export DEBIAN_FRONTEND=noninteractive
+  - apt-get update && apt-get install -y git build-essential cmake scons gcc-10 g++-10
+  - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 1 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 1
   - .github/automation/build_acl.sh  --version 21.11 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
 ---
-
 kind: pipeline
-name: Ubuntu16
+name: Ubuntu20
 
 platform:
   arch: arm64
 
 steps:
-- name: gcc-test
-  image: ubuntu:16.04
+- name: gcc10-test
+  image: ubuntu:20.04
   commands:
-  - apt-get update && apt-get install -y git build-essential cmake
+  - export DEBIAN_FRONTEND=noninteractive
+  - apt-get update && apt-get install -y git build-essential cmake gcc-10 g++-10
+  - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 1 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 1
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 


### PR DESCRIPTION
# Description

This PR removes the Ubuntu 16 stages from the DroneCI setup used to perform CI for AArch64 targets.

As discussed in #1256, the Compute Library build is currently failing for Ubuntu16 due to the GCC version.
While these failures can be overcome with changes to the Compute Library source, there are currently no plans to do so for the upcoming release.
Given this, the limited value of the Ubuntu16 stage, and constrained CI resources, it is proposed that the Ubuntu16 stage be removed and replaced with an Ubuntu20 build, using GCC 10.

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
Tests are currently failing due to #1256, however these changes ensure the Compute Library build failure is no longer present.
- [N/A] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
See discussion in #1256 for details.
- [N/A] Have you added relevant regression tests?
Not relevant for the scope of these changes.
