### PR TITLE
cpu: aarch64: acl: update softmax to be compatible to softmax_v2

### DIFF
--- a/src/cpu/aarch64/acl_softmax.cpp
+++ b/src/cpu/aarch64/acl_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021 Arm Ltd. and affiliates
+* Copyright 2021-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,23 +21,21 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-template <impl::data_type_t data_type>
-status_t acl_softmax_fwd_t<data_type>::execute_forward(
-        const exec_ctx_t &ctx) const {
+status_t acl_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
     // Lock here is needed because resource_mapper does not support
     // concurrent multithreaded access.
     std::lock_guard<std::mutex> _lock {this->mtx};
 
-    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
-    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+    auto src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
 
     // Retrieve primitive resource and configured Compute Library objects
     auto *acl_resource
             = ctx.get_resource_mapper()->get<acl_softmax_resource_t>(this);
     acl_softmax_obj_t &acl_obj = acl_resource->get_acl_obj();
 
-    acl_obj.src_tensor.allocator()->import_memory(const_cast<data_t *>(src));
+    acl_obj.src_tensor.allocator()->import_memory(const_cast<void *>(src));
     acl_obj.dst_tensor.allocator()->import_memory(dst);
 
     acl_obj.softmax->run();
@@ -47,8 +45,6 @@ status_t acl_softmax_fwd_t<data_type>::execute_forward(
 
     return status::success;
 }
-
-template struct acl_softmax_fwd_t<data_type::f32>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/acl_softmax.hpp
+++ b/src/cpu/aarch64/acl_softmax.hpp
@@ -93,7 +93,7 @@ struct acl_softmax_fwd_t : public primitive_t {
 
         status_t init(engine_t *engine) {
 
-            bool ok = desc()->prop_kind == dnnl_forward_inference
+            bool ok = is_fwd()
                     // ACL only supports matching src/dst data types
                     && src_md()->data_type == dst_md()->data_type
                     && utils::one_of(src_md()->data_type, data_type::f32)

--- a/src/cpu/cpu_softmax_list.cpp
+++ b/src/cpu/cpu_softmax_list.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
-* Copyright 2021 Arm Ltd. and affiliates
+* Copyright 2021-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_softmax_fwd_t<sse41>)
             CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve_512>)
             CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve_512>)
-            CPU_INSTANCE_AARCH64_ACL(acl_softmax_fwd_t<f32>)
+            CPU_INSTANCE_AARCH64_ACL(acl_softmax_fwd_t)
             CPU_INSTANCE(ref_softmax_fwd_t)
             nullptr,
         }},

--- a/tests/benchdnn/inputs/softmax/test_softmax_acl
+++ b/tests/benchdnn/inputs/softmax/test_softmax_acl
@@ -1,0 +1,31 @@
+--reset
+
+# only FWD_I is supported with ACL
+--dir=FWD_I
+
+# do not run ref
+--skip-impl=ref
+
+--alg=SOFTMAX,LOGSOFTMAX
+
+--sdt=f32
+--ddt=f32
+--dtag=any
+
+--axis=0,1
+--batch=shapes_ci
+--batch=shapes_nlp
+
+--stag=abx
+--axis=0,1
+--batch=set_0d
+--axis=1,3
+--batch=shapes_2d
+--axis=3,4
+--batch=shapes_3d
+
+--stag=axb
+--axis=0,1
+--batch=shapes_2d
+--batch=shapes_3d
+


### PR DESCRIPTION
# Description

Updates the Compute Library (ACL) based softmax primitive to be compatible with the new softmax_v2 API.

Addresses an issue where the ACL implementation wasn't being called anymore
since softmax_v2 was introduced.

Also adds ACL-specific benchdnn testing harness.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [N/A]

### New features

- [x] Have you added relevant tests?
