### PR TITLE
cpu: aarch64: shuffle: add jit impl. for sve_512

### DIFF
--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-* Copyright 2020-2021 FUJITSU LIMITED
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -455,6 +455,39 @@ struct jit_pool_call_s {
     float ker_area_h;
     size_t ur_bc; // contains number of channel blocks to processing
     size_t b_c; // contains number of channel blocks already processed
+};
+
+struct jit_shuffle_conf_t {
+    unsigned ndims = 0;
+
+    unsigned mb = 0, c = 0, d = 0, h = 0, w = 0, sp = 0;
+
+    unsigned stride_mb = 0;
+    unsigned blk_size = 0;
+    unsigned group_size = 0;
+    unsigned axis = 0;
+    unsigned axis_size = 0;
+    unsigned simd_tail = 0;
+    unsigned simd_w = 0;
+
+    jit_memory_tag_kind_t tag_kind = jit_memory_tag_kind_t::undef;
+    data_type_t data_type = data_type::undef;
+    size_t dt_size = 0;
+    unsigned el_size_of_indices = 0;
+    dim_t c_split_size = 0;
+    dim_t sp_split_size = 0;
+
+    cpu_isa_t isa = isa_any;
+};
+
+struct jit_shuffle_call_s {
+    const void *src = nullptr;
+    void *dst = nullptr;
+    const void *input_off_ptr = nullptr;
+
+    dim_t cb_loop_size
+            = 0; // number of loop iterations over corresponding C batches
+    bool is_padded_block = false;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
@@ -1,0 +1,211 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cassert>
+
+#include "common/bfloat16.hpp"
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/shuffle/jit_uni_shuffle.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa>
+status_t jit_uni_shuffle_t<isa>::pd_t::init(engine_t *engine) {
+    using namespace format_tag;
+    using namespace data_type;
+
+    conf_.data_type = data_md()->data_type;
+
+    const bool ok = mayiuse(isa)
+            && utils::one_of(conf_.data_type, f32, s32, bf16)
+            && platform::has_data_type_support(conf_.data_type)
+            && attr()->has_default_values() && axis() == 1
+            && IMPLICATION(!is_fwd(), set_default_formats_common());
+
+    if (!ok) return status::unimplemented;
+
+    conf_.isa = isa;
+
+    const format_tag_t blocked_format
+            = memory_desc_matches_one_of_tag(*data_md(), nCw16c, nChw16c,
+                    nCdhw16c, nCw8c, nChw8c, nCdhw8c, nCw4c, nChw4c, nCdhw4c);
+
+    if (blocked_format == format_tag::undef) return status::unimplemented;
+
+    const memory_desc_wrapper data_d(data_md());
+    conf_.blk_size = data_d.blocking_desc().strides[ndims() - 1];
+    conf_.simd_w = cpu_isa_traits<isa>::vlen / sizeof(float);
+
+    const bool has_spatial = utils::one_of(ndims(), 3, 4, 5);
+    const dim_t HW = H() * W();
+    conf_.sp = has_spatial ? D() * HW : HW;
+
+    if (conf_.simd_w <= conf_.blk_size) {
+        conf_.tag_kind = jit_memory_tag_kind_t::blocked;
+        conf_.simd_tail = C() % conf_.simd_w;
+        conf_.c_split_size = conf_.blk_size;
+        if (C() < std::sqrt(conf_.sp))
+            conf_.sp_split_size
+                    = conf_.sp / math::gcd(conf_.sp, dnnl_get_max_threads());
+        else
+            conf_.sp_split_size = conf_.sp;
+    } else
+        return status::unimplemented;
+
+    conf_.ndims = ndims();
+    conf_.mb = MB();
+    conf_.c = C();
+    conf_.d = D();
+    conf_.h = H();
+    conf_.w = W();
+
+    conf_.dt_size = types::data_type_size(conf_.data_type);
+    conf_.stride_mb = data_d.blocking_desc().strides[0];
+    conf_.group_size = group_size();
+    conf_.axis = axis();
+    conf_.axis_size = axis_size();
+    conf_.el_size_of_indices = sizeof(unsigned);
+
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_shuffle_t<isa>::precompute_offsets() {
+    const auto conf = pd()->get_conf();
+    const int axis_size = conf.axis_size;
+    const int group_size = conf.group_size;
+    const int transpose_row
+            = pd()->is_fwd() ? group_size : axis_size / group_size;
+    const int transpose_col
+            = pd()->is_fwd() ? axis_size / group_size : group_size;
+    std::vector<int> rev_transposed_(axis_size);
+
+    // Precompute transposed axis helper array
+    parallel_nd(transpose_col, transpose_row, [&](dim_t i, dim_t j) {
+        rev_transposed_[j * transpose_col + i] = i * transpose_row + j;
+    });
+
+    const dim_t C = conf.c;
+    input_off_ = (unsigned *)malloc(
+            C * sizeof(unsigned), platform::get_cache_line_size());
+    if (input_off_ == nullptr) return dnnl_out_of_memory;
+
+    if (pd()->get_conf().tag_kind == jit_memory_tag_kind_t::blocked) {
+        const dim_t blk_size = conf.blk_size;
+        const dim_t CB = utils::div_up(C, blk_size);
+        const dim_t SP = conf.sp;
+
+        // Precompute input offsets using transposed axis
+        parallel_nd(CB, [&](dim_t cb) {
+            const int blk_end = nstl::min(blk_size, C - cb * blk_size);
+            PRAGMA_OMP_SIMD()
+            for (int cc = 0; cc < blk_end; ++cc) {
+                const int off = cb * blk_size + cc;
+                const int &input_c = rev_transposed_[off];
+                input_off_[off] = (input_c / blk_size * SP * blk_size
+                                          + input_c % blk_size)
+                        * conf.dt_size;
+            }
+        });
+    } else {
+        assert(!"Invalid memory format kind.");
+        return status::invalid_arguments;
+    }
+
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_shuffle_t<isa>::init(engine_t *engine) {
+    CHECK(precompute_offsets());
+    CHECK(safe_ptr_assign(
+            kernel_, new jit_uni_shuffle_kernel_t<isa>(pd()->get_conf())));
+    CHECK(kernel_->create_kernel());
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+inline jit_uni_shuffle_t<isa>::jit_uni_shuffle_t(const pd_t *apd)
+    : primitive_t(apd) {}
+
+template <cpu_isa_t isa>
+jit_uni_shuffle_t<isa>::~jit_uni_shuffle_t() {
+    free(this->input_off_);
+}
+
+template <cpu_isa_t isa>
+status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
+    using namespace prop_kind;
+    using namespace utils;
+
+    const auto i_arg = pd()->is_fwd() ? DNNL_ARG_SRC : DNNL_ARG_DIFF_DST;
+    const auto o_arg = pd()->is_fwd() ? DNNL_ARG_DST : DNNL_ARG_DIFF_SRC;
+    auto input = CTX_IN_MEM(const uint8_t *, i_arg);
+    auto output = CTX_OUT_MEM(uint8_t *, o_arg);
+
+    const auto conf = pd()->get_conf();
+
+    const dim_t MB = conf.mb;
+    const dim_t SP = conf.sp;
+    const dim_t C = conf.c;
+    const dim_t stride_mb = conf.stride_mb;
+    const int data_type_size = conf.dt_size;
+
+    if (pd()->get_conf().tag_kind == jit_memory_tag_kind_t::blocked) {
+        const dim_t CB = utils::div_up(C, conf.c_split_size);
+        const dim_t SPB = SP / conf.sp_split_size;
+        parallel_nd(MB, SPB, CB, [&](dim_t mb, dim_t spb, dim_t cb) {
+            const dim_t c_work
+                    = nstl::min(conf.c_split_size, C - cb * conf.c_split_size);
+            const dim_t c_curr = cb * conf.c_split_size;
+            const dim_t sp_work = conf.sp_split_size;
+            const dim_t sp_curr = spb * sp_work;
+            const dim_t off = mb * stride_mb + sp_curr * conf.blk_size;
+
+            jit_shuffle_call_s args;
+            args.src = input + off * data_type_size;
+            args.dst = output + (off + SP * c_curr) * data_type_size;
+
+            args.cb_loop_size = c_work;
+            args.is_padded_block = cb + 1 == CB;
+
+            args.input_off_ptr = this->input_off_ + c_curr;
+            (*kernel_)(&args);
+        });
+    } else {
+        assert(!"Invalid memory format kind.");
+        return status::invalid_arguments;
+    }
+
+    return status::success;
+}
+
+template struct jit_uni_shuffle_t<sve_512>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_SHUFFLE_HPP
+#define CPU_AARCH64_JIT_UNI_SHUFFLE_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+
+#include "cpu/cpu_shuffle_pd.hpp"
+
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#include "cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa>
+struct jit_uni_shuffle_kernel_t;
+
+template <cpu_isa_t isa>
+struct jit_uni_shuffle_t : public primitive_t {
+    struct pd_t : public cpu_shuffle_pd_t {
+        using cpu_shuffle_pd_t::cpu_shuffle_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                JIT_IMPL_NAME_HELPER("jit:", conf_.isa, ""), jit_uni_shuffle_t);
+
+        status_t init(engine_t *engine);
+
+        jit_shuffle_conf_t get_conf() const { return conf_; };
+
+    private:
+        jit_shuffle_conf_t conf_;
+    };
+
+    jit_uni_shuffle_t(const pd_t *apd);
+
+    ~jit_uni_shuffle_t();
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t precompute_offsets();
+    std::unique_ptr<jit_uni_shuffle_kernel_t<isa>> kernel_;
+    unsigned *input_off_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -1,0 +1,304 @@
+/*******************************************************************************
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cassert>
+
+#include "common/bfloat16.hpp"
+#include "common/c_types_map.hpp"
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace Xbyak_aarch64;
+
+#define GET_OFF(field) offsetof(jit_shuffle_call_s, field)
+
+static size_t get_padding_size(const jit_shuffle_conf_t &conf) {
+    const auto padding_tail_size = conf.c % conf.blk_size;
+    return (padding_tail_size) ? conf.blk_size - padding_tail_size : 0;
+}
+
+template <cpu_isa_t isa>
+jit_uni_shuffle_kernel_t<isa>::jit_uni_shuffle_kernel_t(
+        const jit_shuffle_conf_t conf)
+    : jit_generator(nullptr, MAX_CODE_SIZE, true)
+    , conf_(conf)
+    , padding_size_(get_padding_size(conf)) {}
+
+template <cpu_isa_t isa>
+void jit_uni_shuffle_kernel_t<isa>::prepare_mask() {}
+
+template <>
+void jit_uni_shuffle_kernel_t<sve_512>::prepare_mask() {
+    using namespace data_type;
+    if (conf_.simd_tail > 0) {
+        assert(utils::one_of(conf_.data_type, f32, s32));
+        assert(conf_.simd_tail < cpu_isa_traits<sve_512>::vlen / sizeof(float));
+        index(vmm_tmp_.s, 0, 1);
+        cmplt(k_tail_mask_.s, P_ALL_ONE / T_z, vmm_tmp_.s, conf_.simd_tail);
+    }
+
+    /* Implemented only for 32-bit data */
+    ptrue(k_full_mask_.s, VL16);
+}
+
+template <>
+void jit_uni_shuffle_kernel_t<sve_512>::gather_data(const XReg &reg_src_addr,
+        const int indices_idx, const int data_idx, const bool is_tail) {
+    if (conf_.dt_size == sizeof(float)) {
+        const PReg &mask = is_tail ? k_tail_mask_ : k_full_mask_;
+        lsr(TRegS(indices_idx), TRegS(indices_idx), 2);
+        ld1w(TRegS(data_idx), mask / T_z,
+                ptr(reg_src_addr, TRegS(indices_idx), UXTW, 2));
+    } else {
+        assert(!"unsupported emu_gather_data");
+    }
+}
+
+template <>
+void jit_uni_shuffle_kernel_t<sve_512>::store_data(const int data_idx,
+        const XReg &reg_dst_addr, const int offset, const bool is_tail) {
+    const auto extend_for_padding
+            = is_tail && padding_size_ + conf_.simd_tail >= conf_.simd_w;
+    if (extend_for_padding) {
+        sel(vmm_tmp_.s, k_tail_mask_, TRegS(data_idx), vmm_zero_.s);
+        add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset, X_TMP_0);
+        str(vmm_tmp_, ptr(X_DEFAULT_ADDR));
+    } else {
+        if (is_tail) {
+            add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset, X_TMP_0);
+            st1w(TRegS(data_idx), k_tail_mask_, ptr(X_DEFAULT_ADDR));
+        } else {
+            add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset, X_TMP_0);
+            str(ZReg(data_idx), ptr(X_DEFAULT_ADDR));
+        }
+    }
+    append_zero_padding(reg_dst_, extend_for_padding);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
+    const XReg &reg_sp = reg_tmp2_;
+    const XReg &reg_cb = reg_tmp3_;
+    const XReg &reg_cb_loop_size = reg_tmp4_;
+    const XReg &reg_blk_tail = reg_tmp5_;
+    const XReg &reg_src_save = reg_tmp6_;
+    const int simd_in_blk = conf_.blk_size / conf_.simd_w;
+    const int simd_in_tail_blk
+            = utils::div_up(conf_.c % conf_.blk_size, conf_.simd_w);
+    const TReg vmm_tmp[4] = {TReg(5), TReg(6), TReg(7), TReg(8)};
+
+    auto load_indices = ([&](bool is_blk_tail) {
+        const int simd_to_process
+                = is_blk_tail ? simd_in_tail_blk : simd_in_blk;
+        for (int i = 0; i < simd_to_process; ++i) {
+            ldr(vmm_tmp[i], ptr(reg_indices_, i, Xbyak_aarch64::MUL_VL));
+        }
+    });
+
+    auto shuffle = ([&](bool is_blk_tail) {
+        const int simd_to_process
+                = is_blk_tail ? simd_in_tail_blk : simd_in_blk;
+        for (int i = 0; i < simd_to_process; ++i) {
+            const bool simd_tail_condition = is_blk_tail && conf_.simd_tail > 0
+                    && i == simd_to_process - 1;
+            orr(ZRegD(vmm_indices_.getIdx()), ZRegD(vmm_tmp[i].getIdx()),
+                    ZRegD(vmm_tmp[i].getIdx()));
+            gather_data(reg_src_, vmm_indices_.getIdx(), vmm_src_.getIdx(),
+                    simd_tail_condition);
+
+            store_data(vmm_src_.getIdx(), reg_dst_,
+                    i * conf_.simd_w * conf_.dt_size, simd_tail_condition);
+        }
+    });
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(cb_loop_size), X_TMP_0);
+    ldr(reg_cb_loop_size, ptr(X_DEFAULT_ADDR));
+
+    Label sp_loop_begin, sp_loop_end;
+    Label sp_tail_loop_begin, sp_tail_loop_end;
+    Label cb_loop_begin, cb_loop_end;
+    Label simd_loop_begin, simd_loop_end;
+    Label blk_tail_loop_begin, blk_tail_loop_end;
+    Label blk_tail_check_end;
+    Label no_tail;
+
+    eor(reg_blk_tail, reg_blk_tail, reg_blk_tail);
+
+    mov_imm(X_TMP_0, conf_.blk_size);
+    cmp(reg_cb_loop_size, X_TMP_0);
+    b(EQ, no_tail);
+
+    mov(reg_blk_tail, reg_cb_loop_size);
+    eor(reg_cb_loop_size, reg_cb_loop_size, reg_cb_loop_size);
+
+    L(no_tail);
+
+    eor(reg_cb, reg_cb, reg_cb);
+    L(cb_loop_begin);
+    {
+        cmp(reg_cb, reg_cb_loop_size);
+        b(EQ, cb_loop_end);
+
+        load_indices(false);
+
+        mov(reg_src_save, reg_src_);
+
+        eor(reg_sp, reg_sp, reg_sp);
+        L(sp_loop_begin);
+        {
+            mov_imm(X_TMP_0, conf_.sp_split_size);
+            cmp(reg_sp, X_TMP_0);
+            b(EQ, sp_loop_end);
+
+            shuffle(false);
+
+            add_imm(reg_sp, reg_sp, 1, X_TMP_0);
+            add_imm(reg_src_, reg_src_, conf_.blk_size * conf_.dt_size,
+                    X_TMP_0);
+            add_imm(reg_dst_, reg_dst_, conf_.blk_size * conf_.dt_size,
+                    X_TMP_0);
+
+            b(sp_loop_begin);
+        }
+        L(sp_loop_end);
+
+        mov(reg_src_, reg_src_save);
+
+        add_imm(reg_cb, reg_cb, conf_.blk_size, X_TMP_0);
+        add_imm(reg_dst_, reg_dst_,
+                conf_.blk_size * (conf_.sp - conf_.sp_split_size)
+                        * conf_.dt_size,
+                X_TMP_0);
+        add_imm(reg_indices_, reg_indices_,
+                conf_.blk_size * conf_.el_size_of_indices, X_TMP_0);
+
+        b(cb_loop_begin);
+    }
+    L(cb_loop_end);
+
+    cmp(reg_blk_tail, 0);
+    b(EQ, blk_tail_check_end);
+
+    load_indices(true);
+
+    eor(reg_sp, reg_sp, reg_sp);
+    L(sp_tail_loop_begin);
+    {
+        mov_imm(X_TMP_0, conf_.sp_split_size);
+        cmp(reg_sp, X_TMP_0);
+        b(EQ, sp_tail_loop_end);
+
+        shuffle(true);
+
+        add_imm(reg_sp, reg_sp, 1, X_TMP_0);
+        add_imm(reg_src_, reg_src_, conf_.blk_size * conf_.dt_size, X_TMP_0);
+        add_imm(reg_dst_, reg_dst_, conf_.blk_size * conf_.dt_size, X_TMP_0);
+
+        b(sp_tail_loop_begin);
+    }
+    L(sp_tail_loop_end);
+
+    L(blk_tail_check_end);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_shuffle_kernel_t<isa>::append_zero_padding(
+        const XReg &reg_dst_addr, const bool extend_for_padding) {
+
+    static constexpr size_t reg64_size = 8;
+    const size_t simd_w_byte = conf_.simd_w * sizeof(float);
+
+    if (!padding_size_) return;
+
+    const auto padding_start
+            = (extend_for_padding) ? conf_.simd_w : conf_.c % conf_.blk_size;
+    const auto padding_end = (extend_for_padding)
+            ? padding_size_ - (conf_.simd_w - conf_.simd_tail)
+            : padding_size_;
+    const auto off_start = padding_start * conf_.dt_size;
+    const auto padding_to_add = padding_end * conf_.dt_size;
+
+    if (!padding_to_add) return;
+
+    Label end;
+    unsigned int off = 0;
+
+    cmp(WReg(reg_padded_block.getIdx()), 0);
+    b(EQ, end);
+
+    if (simd_w_byte <= padding_to_add) {
+        eor(ZRegD(vmm_zero_.getIdx()), ZRegD(vmm_zero_.getIdx()),
+                ZRegD(vmm_zero_.getIdx()));
+        for (; off + simd_w_byte < padding_to_add; off += simd_w_byte) {
+            add_imm(X_DEFAULT_ADDR, reg_dst_addr, off_start + off, X_TMP_0);
+            str(vmm_zero_, ptr(X_DEFAULT_ADDR));
+        }
+    }
+
+    if (off != padding_to_add) {
+        eor(reg_tmp_, reg_tmp_, reg_tmp_);
+        for (; off + reg64_size < padding_to_add; off += reg64_size) {
+            add_imm(X_DEFAULT_ADDR, reg_dst_addr, off_start + off, X_TMP_0);
+            str(reg_tmp_, ptr(X_DEFAULT_ADDR));
+        }
+        for (; off < padding_to_add; off++) {
+            add_imm(X_DEFAULT_ADDR, reg_dst_addr, off_start + off, X_TMP_0);
+            strb(WReg(reg_tmp_.getIdx()), ptr(X_DEFAULT_ADDR));
+        }
+    }
+
+    L(end);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_shuffle_kernel_t<isa>::generate() {
+    preamble();
+
+    mov(vmm_zero_.s, 0);
+    prepare_mask();
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(input_off_ptr), X_TMP_0);
+    ldr(reg_indices_, ptr(X_DEFAULT_ADDR));
+
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(src), X_TMP_0);
+    ldr(reg_src_, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(dst), X_TMP_0);
+    ldr(reg_dst_, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(is_padded_block), X_TMP_0);
+    ldrb(WReg(reg_padded_block.getIdx()), ptr(X_DEFAULT_ADDR));
+
+    shuffle_blocked_format();
+
+    postamble();
+}
+
+template struct jit_uni_shuffle_kernel_t<sve_512>;
+
+#undef GET_OFF
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_SHUFFLE_KERNEL_HPP
+#define CPU_AARCH64_JIT_UNI_SHUFFLE_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/cpu_shuffle_pd.hpp"
+
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+#include "cpu/aarch64/shuffle/jit_uni_shuffle.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace Xbyak_aarch64;
+
+template <cpu_isa_t isa>
+struct jit_uni_shuffle_kernel_t : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_shuffle_kernel_t)
+
+    jit_uni_shuffle_kernel_t(const jit_shuffle_conf_t conf);
+
+    using TReg = typename utils::conditional<isa == asimd, VReg, ZReg>::type;
+    using TRegS = typename cpu_isa_traits<isa>::TRegS;
+
+    constexpr int vmm_idx(int idx) const {
+        return (cpu_isa_traits<isa>::n_vregs - 1) - idx;
+    }
+
+    /*
+     * Prepare the mask to be used during tail processing.
+     * if it is sve_512 at least then k_tail_mask_ is filled.
+     */
+    void prepare_mask();
+
+    /*
+     * Emulates the behavior of vgatherdps for architectures
+     * that do not support this instruction.
+     */
+    void emu_gather_data(const XReg &reg_src_addr, const int indices_idx,
+            const int data_idx, const bool is_tail = false);
+
+    void gather_data(const XReg &reg_src_addr, const int indices_idx,
+            const int data_idx, const bool is_tail = false);
+
+    void store_data(const int data_idx, const XReg &reg_dst_addr,
+            const int offset = 0, const bool is_tail = false);
+
+    void shuffle_blocked_format();
+
+    void append_zero_padding(
+            const XReg &reg_dst_addr, const bool zero_extend_write);
+
+    void generate() override;
+
+    const TReg vmm_full_mask_ = TReg(1);
+    const TReg vmm_src_ = TReg(2);
+    const TReg vmm_tmp_ = TReg(3);
+    const TReg vmm_indices_ = TReg(4);
+    const TReg vmm_zero_ = TReg(11);
+
+    const PReg k_tail_mask_ = p1;
+    const PReg k_full_mask_ = p2;
+
+    const XReg &reg_tmp_ = x7;
+    const XReg &reg_dst_ = x3;
+    const XReg &reg_indices_ = x1;
+    const XReg &reg_work_ = x2;
+    // Always mimic the Unix ABI
+    const XReg &reg_param = x0;
+    const XReg &reg_src_ = x6;
+    const XReg &reg_tmp1_ = x8;
+    const XReg &reg_tmp2_ = x9;
+    const XReg &reg_tmp3_ = x10;
+    const XReg &reg_tmp4_ = x11;
+    const XReg &reg_tmp5_ = x12;
+    const XReg &reg_tmp6_ = x13;
+    const XReg &reg_padded_block = x14; //WReg(x14.getIdx());
+
+    const jit_shuffle_conf_t conf_;
+    const size_t padding_size_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/cpu_shuffle_list.cpp
+++ b/src/cpu/cpu_shuffle_list.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,6 +23,9 @@
 #if DNNL_X64
 #include "cpu/x64/shuffle/jit_uni_shuffle.hpp"
 using namespace dnnl::impl::cpu::x64;
+#elif DNNL_AARCH64
+#include "cpu/aarch64/shuffle/jit_uni_shuffle.hpp"
+using namespace dnnl::impl::cpu::aarch64;
 #endif
 
 namespace dnnl {
@@ -36,6 +40,7 @@ constexpr impl_list_item_t impl_list[] = REG_SHUFFLE_P({
         CPU_INSTANCE_X64(jit_uni_shuffle_t<avx512_core>)
         CPU_INSTANCE_X64(jit_uni_shuffle_t<avx>)
         CPU_INSTANCE_X64(jit_uni_shuffle_t<sse41>)
+        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve_512>)
         CPU_INSTANCE(ref_shuffle_t)
         /* eol */
         nullptr,


### PR DESCRIPTION
# Description

This PR adds jit implementation of shuffle for SVE 512.
Please merge this PR after https://github.com/oneapi-src/oneDNN/pull/1280

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
