### PR TITLE
cpu: aarch64: clean up p registers

### DIFF
--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -115,13 +115,13 @@ public:
     const Xbyak_aarch64::XReg X_DEFAULT_ADDR = x28;
     const Xbyak_aarch64::XReg X_SP = x21;
     const Xbyak_aarch64::XReg X_TRANSLATOR_STACK = x22;
-    const Xbyak_aarch64::PReg P_TMP = p0;
+    const Xbyak_aarch64::PReg P_TMP = p7;
     const Xbyak_aarch64::PReg P_TMP_0 = p11;
     const Xbyak_aarch64::PReg P_TMP_1 = p12;
     const Xbyak_aarch64::PReg P_ALL_ZERO = p10;
     const Xbyak_aarch64::PReg P_NOT_256 = p13;
     const Xbyak_aarch64::PReg P_NOT_128 = p14;
-    const Xbyak_aarch64::PReg P_ALL_ONE = p7;
+    const Xbyak_aarch64::PReg P_ALL_ONE = p0;
 
     const std::vector<Xbyak_aarch64::XReg> x_tmp_vec
             = {X_TMP_0, X_TMP_1, X_TMP_2, X_TMP_3, X_TMP_4};

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -165,11 +165,11 @@ void jit_sve_512_1x1_conv_kernel::reduce_loop(
         ofs = jcp.typesize_in * ofs;
         int tmp_ofs = ofs;
         if (ld1rw_imm_check(ofs)) {
-            ld1rw(ZRegS(bcast_idx), reg_p_all_ones,
+            ld1rw(ZRegS(bcast_idx), P_ALL_ONE,
                     ptr(aux_reg_bcast_data, static_cast<int32_t>(ofs)));
         } else {
             if ((prev_ofs != -1) && ld1rw_imm_check(ofs - prev_ofs)) {
-                ld1rw(ZRegS(bcast_idx), reg_p_all_ones,
+                ld1rw(ZRegS(bcast_idx), P_ALL_ONE,
                         ptr(reg_prev_bcast_addr,
                                 static_cast<int32_t>((ofs - prev_ofs))));
             } else {
@@ -183,8 +183,7 @@ void jit_sve_512_1x1_conv_kernel::reduce_loop(
                 }
                 prev_ofs = tmp_ofs;
 
-                ld1rw(ZRegS(bcast_idx), reg_p_all_ones,
-                        ptr(reg_prev_bcast_addr));
+                ld1rw(ZRegS(bcast_idx), P_ALL_ONE, ptr(reg_prev_bcast_addr));
             }
         }
         return prev_ofs;
@@ -436,7 +435,7 @@ void jit_sve_512_1x1_conv_kernel::reduce_loop(
             for (int i_ur = 0; i_ur < ur; ++i_ur) {
 
                 for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
-                    fmla(vreg_accum_s(i_load, i_ur), reg_p_all_ones,
+                    fmla(vreg_accum_s(i_load, i_ur), P_ALL_ONE,
                             vreg_load_s(i_load, 0),
                             ZRegS(bcast_reg_ofs
                                     + ((bcast_reg_startidx + i_ur)
@@ -485,9 +484,6 @@ void jit_sve_512_1x1_conv_kernel::reduce_loop(
 
 void jit_sve_512_1x1_conv_kernel::generate() {
     preamble();
-
-    /* All 1 predicate register */
-    ptrue(reg_p_all_ones.b);
 
     /* Pointers indicate weight, input, and output data */
     ldr(reg_bcast_data, ptr(abi_param1, GET_OFF(bcast_data))); // Input

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,7 +82,6 @@ struct jit_sve_512_1x1_conv_kernel : public jit_generator {
 
 private:
     using reg64_t = const XReg;
-    const PReg reg_p_all_ones = p2;
 
     /* Flags and loop variables */
     reg64_t reg_reduce_pos_flag = x1;
@@ -157,11 +156,11 @@ private:
             }
 
             if (prfw_imm_check(ofs)) {
-                prfw(op_sve, reg_p_all_ones,
+                prfw(op_sve, P_ALL_ONE,
                         ptr(in, static_cast<int32_t>(VL64_OFS(ofs))));
             } else {
                 add_imm(reg_tmp_ofs, in, ofs, reg_tmp_imm);
-                prfw(op_sve, reg_p_all_ones, ptr(reg_tmp_ofs));
+                prfw(op_sve, P_ALL_ONE, ptr(reg_tmp_ofs));
             }
         }
     }

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-* Copyright 2020-2021 FUJITSU LIMITED
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -72,8 +72,6 @@ private:
         typesize = sizeof(float),
         ker_reg_base_idx = 28,
     };
-
-    const PReg reg_p_all_ones = p3;
 
     reg64_t param = abi_param1;
     reg64_t reg_inp = x1; // src base addr (2d)
@@ -154,11 +152,11 @@ private:
 
             if ((VL_OFS(ofs) <= PRFWMAX)
                     && (VL_OFS(ofs) >= (-1 * PRFWMAX - 1))) {
-                prfw(op_sve, reg_p_all_ones,
+                prfw(op_sve, P_ALL_ONE,
                         ptr(in, static_cast<int32_t>(VL_OFS(ofs))));
             } else {
                 add_imm(reg_tmp_addr, in, ofs, reg_tmp_imm);
-                prfw(op_sve, reg_p_all_ones, ptr(reg_tmp_addr));
+                prfw(op_sve, P_ALL_ONE, ptr(reg_tmp_addr));
             }
         }
     }
@@ -292,8 +290,6 @@ private:
     reg64_t reg_input_org = x22;
     reg64_t reg_kernel_org = x26;
 
-    const PReg reg_p_all_ones = p3;
-
     long long int prefetch(const std::string prfop, int level, reg64_t in,
             long long int ofs, long long int prev_ofs) {
         bool for_load = false;
@@ -343,16 +339,16 @@ private:
             long long int tmp_ofs = ofs - prev_ofs;
             if ((VL_OFS(ofs) <= PRFWMAX)
                     && (VL_OFS(ofs) >= (-1 * PRFWMAX - 1))) {
-                prfw(op_sve, reg_p_all_ones,
+                prfw(op_sve, P_ALL_ONE,
                         ptr(in, static_cast<int32_t>(VL_OFS(ofs))));
             } else if ((VL_OFS(tmp_ofs) <= PRFWMAX)
                     && (VL_OFS(tmp_ofs) >= (-1 * PRFWMAX - 1))) {
-                prfw(op_sve, reg_p_all_ones,
+                prfw(op_sve, P_ALL_ONE,
                         ptr(reg_tmp_addr,
                                 static_cast<int32_t>(VL_OFS(tmp_ofs))));
             } else {
                 add_imm(reg_tmp_addr, in, ofs, reg_tmp_imm);
-                prfw(op_sve, reg_p_all_ones, ptr(reg_tmp_addr));
+                prfw(op_sve, P_ALL_ONE, ptr(reg_tmp_addr));
                 prev_ofs = ofs;
             }
         }
@@ -492,8 +488,6 @@ private:
     reg64_t reg_ker_start_addr = x27;
     reg64_t reg_addr_diff_input = x28;
 
-    const PReg reg_p_all_ones = p3;
-
     void prefetch(
             const std::string prfop, int level, reg64_t in, long long int ofs) {
         bool for_load = false;
@@ -538,11 +532,11 @@ private:
 
             if ((VL_OFS(ofs) <= PRFWMAX)
                     && (VL_OFS(ofs) >= (-1 * PRFWMAX - 1))) {
-                prfw(op_sve, reg_p_all_ones,
+                prfw(op_sve, P_ALL_ONE,
                         ptr(in, static_cast<int32_t>(VL_OFS(ofs))));
             } else {
                 add_imm(reg_add_tmp, in, ofs, reg_tmp_imm);
-                prfw(op_sve, reg_p_all_ones, ptr(reg_add_tmp));
+                prfw(op_sve, P_ALL_ONE, ptr(reg_add_tmp));
             }
         }
     }

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +50,6 @@ struct jit_uni_dw_conv_fwd_kernel_f32 : public jit_generator {
 
 private:
     using reg64_t = const XReg;
-    const PReg reg_p_all_ones = p2;
     const int vlen = cpu_isa_traits<isa>::vlen;
 
     // dw convolution
@@ -147,7 +146,6 @@ struct jit_uni_dw_conv_bwd_data_kernel_f32 : public jit_generator {
 
 private:
     using reg64_t = const XReg;
-    const PReg reg_p_all_ones = p2;
 
     inline ZReg get_ker_reg(int idx) { return ZReg(idx + 0); }
     inline ZReg get_src_reg(int idx) { return ZReg(idx + 1); }
@@ -195,7 +193,6 @@ struct jit_uni_dw_conv_bwd_weights_kernel_f32 : public jit_generator {
 
 private:
     using reg64_t = const XReg;
-    const PReg reg_p_all_ones = p2;
     int simd_w = cpu_isa_traits<isa>::vlen / sizeof(float);
 
     inline ZReg get_bias_reg(int idx = 0) { return ZReg(idx); }

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2017-2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2017-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,7 +89,6 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
         add_imm(X_TMP_0, param, GET_OFF(work_amount), X_TMP_1);
         ldr(reg_work_amount, ptr(X_TMP_0));
         eltwise_injector_->load_table_addr();
-        ptrue(p_512.b);
 
         Label reminder_loop_start, reminder_loop_end;
         Label vectorized_loop_start, vectorized_loop_end;
@@ -181,7 +180,6 @@ private:
     TRegS vmm_diff_dst {2};
     std::unique_ptr<jit_uni_eltwise_injector_f32<isa>> eltwise_injector_;
 
-    PReg p_512 {7}; /* Index is temporal. */
     PReg p_tmp0 {4}; /* Index is temporal. */
 };
 

--- a/src/cpu/aarch64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2020-2022 Intel Corporation
 * Copyright 2018 YANDEX LLC
-* Copyright 2020-2021 FUJITSU LIMITED
+* Copyright 2020-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -95,10 +95,9 @@ private:
     PReg k_store_mask = p6;
 
     /* Caution: Chose predicate registers not used by x64's implementation. */
-    PReg p_all_zero = p0;
-    PReg p_512 = p2;
+    PReg p_all_zero = p1;
     PReg p_tmp0 = p3;
-    PReg p_lsb = p2;
+    PReg p_lsb = P_ALL_ONE;
 
     using xreg_t = const XReg;
     xreg_t reg_param = x0;

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -167,7 +167,7 @@ struct jit_softmax_base_t : public jit_generator {
         const uint32_t idxSrc = src.getIdx();
         const uint32_t idxSrc2 = src2.getIdx();
         uint32_t pattern = 0;
-        PReg mask_reg = p0; // 0 is dummy index.
+        PReg mask_reg(DUMMY_IDX);
 
         pattern += (idxDst == idxSrc) ? (1 << 2) : 0;
         pattern += (idxDst == idxSrc2) ? (1 << 1) : 0;


### PR DESCRIPTION
# Description

This PR cleans up the usage of P registers. Most SVE instructions require a P register as an operand. In many cases, a P register with all valid bits is used as the operand, so it is convenient to prepare a P register whose all bits enabled. "p0" is assigned for this purpose.

Please merge this PR before https://github.com/oneapi-src/oneDNN/pull/1279.
Thank you.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?