### PR TITLE
gpu: cuda: Add USM support for CUDNN

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -60,14 +60,6 @@ if(DNNL_CPU_SYCL)
     endforeach()
 endif()
 
-# Skip examples for CUDA since USM is a default model for the library which is
-# not yet supported for Nvidia backend.
-if(DNNL_SYCL_CUDA)
-    foreach(f ${sources})
-        list(REMOVE_ITEM sources "${f}")
-    endforeach()
-endif()
-
 foreach(src ${sources})
     file(RELATIVE_PATH src_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${src})
     string(REGEX REPLACE "[/_\\.]" "-" example_name ${src_rel_path})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,10 @@ endif()
 append(CMAKE_C_FLAGS "${CMAKE_EXAMPLE_CCXX_FLAGS}")
 append(CMAKE_CXX_FLAGS "${CMAKE_EXAMPLE_CCXX_FLAGS}")
 
+if(DNNL_SYCL_CUDA)
+    append(CMAKE_CXX_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda")
+endif()
+
 # propagate sanitizer flags
 append(CMAKE_C_FLAGS "${CMAKE_CCXX_SANITIZER_FLAGS}")
 append(CMAKE_CXX_FLAGS "${CMAKE_CCXX_SANITIZER_FLAGS}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,7 @@ append(CMAKE_CXX_FLAGS "${CMAKE_EXAMPLE_CCXX_FLAGS}")
 
 if(DNNL_SYCL_CUDA)
     append(CMAKE_CXX_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda")
+    append(CMAKE_CXX_FLAGS "-Wno-linker-warnings")
 endif()
 
 # propagate sanitizer flags
@@ -42,6 +43,22 @@ append_host_compiler_options(CMAKE_CXX_FLAGS "${DPCPP_CXX_NOWARN_FLAGS}")
 
 file(GLOB_RECURSE sources *.cpp *.c)
 file(GLOB_RECURSE headers *.hpp *.h)
+
+
+# Remove tests for CUDA which use unimplemented primitives
+if(DNNL_SYCL_CUDA)
+    list(REMOVE_ITEM sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/bnorm_u8_via_binary_postops.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/rnn_training_f32.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tutorials/matmul/inference_int8_matmul.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/binary.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/lstm.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/layer_normalization.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/prelu.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reduction.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reorder.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/shuffle.cpp)
+endif()
 
 # Skip SYCL, GPU and cross-engine examples
 foreach(f ${sources})

--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -27,7 +27,7 @@ cmake -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP \
 
 ## Memory
 
-Currently, only the buffer-based oneDNN API is supported for Nvidia backend.
+Both buffer-based  and USM-based oneDNN APIs are supported for Nvidia backend.
 
 ## Suported Data Types
 

--- a/src/gpu/nvidia/cudnn_batch_normalization_executor.hpp
+++ b/src/gpu/nvidia/cudnn_batch_normalization_executor.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-* Copyright 2020 Codeplay Software Limited
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "gpu/nvidia/sycl_cuda_utils.hpp"
+#include "sycl_cuda_memory_storage_helper.hpp"
+#include "sycl_cuda_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -40,155 +42,158 @@ struct bnorm_exec_base_t {
     virtual ~bnorm_exec_base_t() = default;
 
 protected:
-    template <typename T, ::sycl::access::mode md, typename sc_t>
-    void *mean_var_ptr(::sycl::accessor<T, 1, md> acc, sc_t &sc,
-            const compat::interop_handle &ih) const {
-        return sc.template memory<void *>(ih, acc);
-    }
-
-    template <typename sc_t>
-    std::nullptr_t mean_var_ptr(std::nullptr_t acc, sc_t &,
-            const compat::interop_handle &ih) const {
-        return acc;
-    }
-
-    template <typename read_acc_t, typename write_acc_t, typename wkspace_st_t,
-            typename float_acc_t, typename maybe_nullptr_t>
+    template <::sycl::access::mode flt_m,
+            ::sycl::access::mode mean_var_m = ::sycl::access::mode::write>
     void interop_task_fwd(
             std::shared_ptr<cudnn_batch_normalization_impl_base_t> bnorm_impl,
             engine_t *engine, ::sycl::handler &cgh,
-            nvidia::sycl_cuda_stream_t *cuda_stream, read_acc_t src_acc,
-            write_acc_t dst_acc, maybe_nullptr_t mean_acc,
-            maybe_nullptr_t var_acc, float_acc_t scale_acc,
-            float_acc_t bias_acc, wkspace_st_t wkspace_st, bool init_ss,
-            bool init_mean_var) const {
+            nvidia::sycl_cuda_stream_t *cuda_stream,
+            sycl_memory_arg_t<::sycl::access::mode::read> arg_src,
+            sycl_memory_arg_t<::sycl::access::mode::write> arg_dst,
+            sycl_memory_arg_t<flt_m> arg_scale_bias,
+            sycl_memory_arg_t<::sycl::access::mode::write> arg_wkspace,
+            bool init_ss, bool init_mv,
+            sycl_memory_arg_t<mean_var_m> arg_mean = {},
+            sycl_memory_arg_t<mean_var_m> arg_var = {}) const {
 
-        std::shared_ptr<
-                ::sycl::accessor<uint8_t, 1, ::sycl::access::mode::write>>
-                wkspace_acc;
-        if (!wkspace_st->is_null()) {
-            wkspace_acc.reset(new ::sycl::accessor<uint8_t, 1,
-                    ::sycl::access::mode::write>(
-                    utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
-                            wkspace_st)
-                            ->buffer()
-                            .template get_access<::sycl::access::mode::write>(
-                                    cgh)));
-        }
-
-        maybe_init_mean_var(cuda_stream, mean_acc, var_acc, init_mean_var);
-        maybe_init_ss(cuda_stream, scale_acc, bias_acc, init_ss);
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(engine);
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
 
-            auto x = sc.memory<void *>(ih, src_acc);
-            auto y = sc.memory<void *>(ih, dst_acc);
-            auto mean = mean_var_ptr(mean_acc, sc, ih);
-            auto var = mean_var_ptr(var_acc, sc, ih);
-            auto scale = sc.memory<float *>(ih, scale_acc);
-            auto bias = sc.memory<float *>(ih, bias_acc) + bnorm_impl->C();
+            if (init_ss)
+                init_scaleshift(
+                        sc, ih, cuda_stream, arg_scale_bias, bnorm_impl->C());
+            if (init_mv)
+                init_mean_var(sc, ih, cuda_stream, arg_mean, arg_var,
+                        bnorm_impl->C());
+
+            auto *x = arg_src.get_native_pointer(ih);
+            auto *y = arg_dst.get_native_pointer(ih);
+            auto *mean = arg_mean.get_native_pointer(ih);
+            auto *var = arg_var.get_native_pointer(ih);
+
+            auto *scale = static_cast<uint8_t *>(
+                    arg_scale_bias.get_native_pointer(ih));
+            auto *bias = scale + bnorm_impl->C() * sizeof(float);
             uint8_t *y_prime = nullptr, *save_mean = nullptr,
                     *save_var = nullptr;
-            if (!wkspace_st->is_null()) {
-                save_mean = sc.memory<uint8_t *>(ih, *wkspace_acc);
+
+            if (!arg_wkspace.empty()) {
+                save_mean = static_cast<uint8_t *>(
+                        arg_wkspace.get_native_pointer(ih));
                 save_var = save_mean + bnorm_impl->mean_var_size_bytes();
                 y_prime = save_var + bnorm_impl->mean_var_size_bytes();
             }
 
             std::shared_ptr<bnorm_args_t> args(new bnorm_fwd_args_t(x, y, mean,
                     var, scale, bias, y_prime, save_mean, save_var));
-
             bnorm_impl->execute(handle, args);
         });
     }
 
-    template <typename read_acc_t, typename write_acc_t, typename ss_acc_t,
-            typename d_ss_acc_t>
+    template <::sycl::access::mode ss_m, ::sycl::access::mode d_ss_m>
     void interop_task_bwd(
             std::shared_ptr<cudnn_batch_normalization_impl_base_t> bnorm_impl,
             engine_t *engine, ::sycl::handler &cgh,
-            nvidia::sycl_cuda_stream_t *cuda_stream, read_acc_t src_acc,
-            read_acc_t diff_dst_acc, write_acc_t diff_src_acc,
-            ss_acc_t scale_acc, ss_acc_t bias_acc,
-            d_ss_acc_t diff_scaleshift_acc, read_acc_t wkspace_acc,
-            std::shared_ptr<::sycl::accessor<uint8_t, 1,
-                    ::sycl::access::mode::read_write,
-                    sycl::compat::target_device>>
-                    temp_relu_output,
-            bool init_ss, bool init_mean_var) const {
+            nvidia::sycl_cuda_stream_t *cuda_stream,
+            sycl_memory_arg_t<::sycl::access::mode::read> arg_src,
+            sycl_memory_arg_t<::sycl::access::mode::read> arg_diff_dst,
+            sycl_memory_arg_t<::sycl::access::mode::write> arg_diff_src,
+            sycl_memory_arg_t<ss_m> arg_scale_bias,
+            sycl_memory_arg_t<d_ss_m> arg_diff_scale_bias,
+            sycl_memory_arg_t<::sycl::access::mode::read> arg_wkspace,
+            sycl_memory_arg_t<::sycl::access::mode::read_write> arg_temp_relu,
+            bool init_ss) const {
 
-        maybe_init_ss(cuda_stream, scale_acc, bias_acc, init_ss);
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(engine);
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
 
-            auto x = sc.memory<void *>(ih, src_acc);
-            auto dy = sc.memory<void *>(ih, diff_dst_acc);
-            auto dx = sc.memory<void *>(ih, diff_src_acc);
-            auto scale = sc.memory<uint8_t *>(ih, scale_acc);
-            auto bias = sc.memory<uint8_t *>(ih, bias_acc)
-                    + (bnorm_impl->C() * sizeof(float));
-            auto diff_scale = sc.memory<uint8_t *>(ih, diff_scaleshift_acc);
-            auto diff_bias = diff_scale + (bnorm_impl->C() * sizeof(float));
-            auto save_mean = sc.memory<uint8_t *>(ih, wkspace_acc);
-            auto save_var = save_mean + bnorm_impl->mean_var_size_bytes();
-            auto wkspace = save_var + bnorm_impl->mean_var_size_bytes();
-            auto relu_dy = bnorm_impl->fuse_norm_relu()
-                    ? sc.memory<void *>(ih, *temp_relu_output)
-                    : nullptr;
+            if (init_ss)
+                init_scaleshift(
+                        sc, ih, cuda_stream, arg_scale_bias, bnorm_impl->C());
+
+            auto *x = arg_src.get_native_pointer(ih);
+            auto *dy = arg_diff_dst.get_native_pointer(ih);
+            auto *dx = arg_diff_src.get_native_pointer(ih);
+
+            auto *scale = static_cast<uint8_t *>(
+                    arg_scale_bias.get_native_pointer(ih));
+            auto *bias = scale + bnorm_impl->C() * sizeof(float);
+
+            auto *diff_scale = static_cast<uint8_t *>(
+                    arg_diff_scale_bias.get_native_pointer(ih));
+            auto *diff_bias = diff_scale + (bnorm_impl->C() * sizeof(float));
+
+            auto *save_mean = static_cast<uint8_t *>(
+                    arg_wkspace.get_native_pointer(ih));
+            auto *save_var = save_mean + bnorm_impl->mean_var_size_bytes();
+            auto *wkspace = save_var + bnorm_impl->mean_var_size_bytes();
+            auto *relu_dy = arg_temp_relu.get_native_pointer(ih);
 
             std::shared_ptr<bnorm_args_t> args(
                     new bnorm_bwd_args_t(x, dx, dy, save_mean, save_var, scale,
                             bias, diff_scale, diff_bias, wkspace, relu_dy));
-
             bnorm_impl->execute(handle, args);
         });
     }
 
-    template <typename T>
-    void maybe_init_ss(
-            nvidia::sycl_cuda_stream_t *cuda_stream, T, T, bool) const {}
+    template <typename T = float>
+    void init_scaleshift(cuda_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            nvidia::sycl_cuda_stream_t *cuda_stream, T, size_t) const {}
 
-    template <typename T>
-    void maybe_init_ss(nvidia::sycl_cuda_stream_t *cuda_stream,
-            ::sycl::accessor<T, 1, ::sycl::access::mode::write> scale_acc,
-            ::sycl::accessor<T, 1, ::sycl::access::mode::write> bias_acc,
-            bool init_ss) const {
-        if (init_ss) {
-            constexpr T scale_val = 1, bias_val = 0;
-            cuda_stream->interop_task([&](::sycl::handler &cgh) {
-                cgh.fill(scale_acc, scale_val);
-            });
-
-            cuda_stream->interop_task([&](::sycl::handler &cgh) {
-                cgh.fill(bias_acc, bias_val);
-            });
-        }
+    template <typename T = float>
+    void init_scaleshift(cuda_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            nvidia::sycl_cuda_stream_t *cuda_stream,
+            sycl_memory_arg_t<::sycl::access::mode::write> arg_scale_bias,
+            const size_t n) const {
+        T scale_val = 1, bias_val = 0;
+        cuda_stream->interop_task([&](::sycl::handler &cgh) {
+            T *scale_ptr
+                    = static_cast<T *>(arg_scale_bias.get_native_pointer(ih));
+            T *bias_ptr = scale_ptr + n;
+            CUDA_EXECUTE_FUNC(cuMemsetD32Async,
+                    reinterpret_cast<CUdeviceptr>(scale_ptr),
+                    reinterpret_cast<int &>(scale_val), n,
+                    cuda_stream->get_underlying_stream());
+            CUDA_EXECUTE_FUNC(cuMemsetD32Async,
+                    reinterpret_cast<CUdeviceptr>(bias_ptr),
+                    reinterpret_cast<int &>(bias_val), n,
+                    cuda_stream->get_underlying_stream());
+            cudaDeviceSynchronize();
+        });
     }
 
     // Handle the cases when mean and var are read-only accessors or nullptr
-    template <typename T>
-    void maybe_init_mean_var(
-            nvidia::sycl_cuda_stream_t *cuda_stream, T, T, bool) const {}
+    template <typename T, typename U>
+    void init_mean_var(cuda_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            nvidia::sycl_cuda_stream_t *cuda_stream, T, U, const size_t) const {
+    }
 
-    template <typename T>
-    void maybe_init_mean_var(nvidia::sycl_cuda_stream_t *cuda_stream,
-            ::sycl::accessor<T, 1, ::sycl::access::mode::write> mean_acc,
-            ::sycl::accessor<T, 1, ::sycl::access::mode::write> var_acc,
-            bool init_mean_var) const {
-        if (init_mean_var) {
-            constexpr T mean_var_val = 0;
-            cuda_stream->interop_task([&](::sycl::handler &cgh) {
-                cgh.fill(mean_acc, mean_var_val);
-            });
-
-            cuda_stream->interop_task([&](::sycl::handler &cgh) {
-                cgh.fill(var_acc, mean_var_val);
-            });
-        }
+    template <typename T = float>
+    void init_mean_var(cuda_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            nvidia::sycl_cuda_stream_t *cuda_stream,
+            sycl_memory_arg_t<::sycl::access_mode::write> arg_mean,
+            sycl_memory_arg_t<::sycl::access_mode::write> arg_var,
+            const size_t n) const {
+        constexpr T mean_var_val = 0;
+        cuda_stream->interop_task([&](::sycl::handler &cgh) {
+            T *mean_ptr = static_cast<T *>(arg_mean.get_native_pointer(ih));
+            T *var_ptr = static_cast<T *>(arg_var.get_native_pointer(ih));
+            CUDA_EXECUTE_FUNC(cuMemsetD32Async,
+                    reinterpret_cast<CUdeviceptr>(mean_ptr), mean_var_val, n,
+                    cuda_stream->get_underlying_stream());
+            CUDA_EXECUTE_FUNC(cuMemsetD32Async,
+                    reinterpret_cast<CUdeviceptr>(var_ptr), mean_var_val, n,
+                    cuda_stream->get_underlying_stream());
+            cudaDeviceSynchronize();
+        });
     }
 };
 
@@ -198,27 +203,24 @@ struct bnorm_exec_fwd_inf_t : public bnorm_exec_base_t {
             const override {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
-
-        auto wkspace_storage = bnorm_impl->is_training()
-                ? ctx.output(DNNL_ARG_WORKSPACE)->memory_storage()
-                : &memory_storage_t::empty_storage();
-
         auto n_channels = bnorm_impl->C();
-        ::sycl::buffer<float> scaleshift_buff(n_channels * 2);
+        ::sycl::buffer<uint8_t> scale_bias_buff(n_channels * 2 * sizeof(float));
+
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, n_channels);
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_scale_bias
+                    = sycl_memory_arg_t<::sycl::access::mode::write>(
+                            scale_bias_buff, cgh);
+            auto arg_wkspace = bnorm_impl->is_training()
+                    ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
+                    : sycl_memory_arg_t<::sycl::access::mode::write>();
+
             bool init_ss = true, init_mean_var = false;
 
-            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    dst_acc, nullptr, nullptr, scale_acc, bias_acc,
-                    wkspace_storage, init_ss, init_mean_var);
+            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_dst, arg_scale_bias, arg_wkspace, init_ss,
+                    init_mean_var);
         });
     }
 };
@@ -230,30 +232,19 @@ struct bnorm_exec_fwd_inf_ss_t : public bnorm_exec_base_t {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
-        auto wkspace_storage = bnorm_impl->is_training()
-                ? ctx.output(DNNL_ARG_WORKSPACE)->memory_storage()
-                : &memory_storage_t::empty_storage();
-
-        auto scaleshift_buff
-                = utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
-                        &CTX_IN_STORAGE(DNNL_ARG_SCALE_SHIFT))
-                          ->buffer();
-        auto n_channels = bnorm_impl->C();
-
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, n_channels);
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_scale_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_SCALE_SHIFT);
+            auto arg_wkspace = bnorm_impl->is_training()
+                    ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
+                    : sycl_memory_arg_t<::sycl::access::mode::write>();
+
             bool init_ss = false, init_mean_var = false;
 
-            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    dst_acc, nullptr, nullptr, scale_acc, bias_acc,
-                    wkspace_storage, init_ss, init_mean_var);
+            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_dst, arg_scale_bias, arg_wkspace, init_ss,
+                    init_mean_var);
         });
     }
 };
@@ -264,29 +255,26 @@ struct bnorm_exec_fwd_inf_stats_t : public bnorm_exec_base_t {
             const override {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
-
-        auto wkspace_storage = bnorm_impl->is_training()
-                ? ctx.output(DNNL_ARG_WORKSPACE)->memory_storage()
-                : &memory_storage_t::empty_storage();
-
         auto n_channels = bnorm_impl->C();
-        ::sycl::buffer<float> scaleshift_buff(n_channels * 2);
+        ::sycl::buffer<uint8_t> scale_bias_buff(n_channels * 2 * sizeof(float));
+
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-            auto mean_acc = CTX_IN_ACCESSOR(DNNL_ARG_MEAN);
-            auto var_acc = CTX_IN_ACCESSOR(DNNL_ARG_VARIANCE);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, n_channels);
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_mean = CTX_IN_SYCL_MEMORY(DNNL_ARG_MEAN);
+            auto arg_var = CTX_IN_SYCL_MEMORY(DNNL_ARG_VARIANCE);
+            auto arg_scale_bias
+                    = sycl_memory_arg_t<::sycl::access::mode::write>(
+                            scale_bias_buff, cgh);
+            auto arg_wkspace = bnorm_impl->is_training()
+                    ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
+                    : sycl_memory_arg_t<::sycl::access::mode::write>();
+
             bool init_ss = true, init_mean_var = false;
 
-            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    dst_acc, mean_acc, var_acc, scale_acc, bias_acc,
-                    wkspace_storage, init_ss, init_mean_var);
+            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_dst, arg_scale_bias, arg_wkspace, init_ss,
+                    init_mean_var, arg_mean, arg_var);
         });
     }
 };
@@ -298,32 +286,21 @@ struct bnorm_exec_fwd_inf_ss_stats_t : public bnorm_exec_base_t {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
-        auto wkspace_storage = bnorm_impl->is_training()
-                ? ctx.output(DNNL_ARG_WORKSPACE)->memory_storage()
-                : &memory_storage_t::empty_storage();
-
-        auto scaleshift_buff
-                = utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
-                        &CTX_IN_STORAGE(DNNL_ARG_SCALE_SHIFT))
-                          ->buffer();
-        auto n_channels = bnorm_impl->C();
-
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-            auto mean_acc = CTX_IN_ACCESSOR(DNNL_ARG_MEAN);
-            auto var_acc = CTX_IN_ACCESSOR(DNNL_ARG_VARIANCE);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, n_channels);
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_mean = CTX_IN_SYCL_MEMORY(DNNL_ARG_MEAN);
+            auto arg_var = CTX_IN_SYCL_MEMORY(DNNL_ARG_VARIANCE);
+            auto arg_scale_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_SCALE_SHIFT);
+            auto arg_wkspace = bnorm_impl->is_training()
+                    ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
+                    : sycl_memory_arg_t<::sycl::access::mode::write>();
+
             bool init_ss = false, init_mean_var = false;
 
-            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    dst_acc, mean_acc, var_acc, scale_acc, bias_acc,
-                    wkspace_storage, init_ss, init_mean_var);
+            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_dst, arg_scale_bias, arg_wkspace, init_ss,
+                    init_mean_var, arg_mean, arg_var);
         });
     }
 };
@@ -334,30 +311,26 @@ struct bnorm_exec_fwd_t : public bnorm_exec_base_t {
             const override {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
-
-        auto wkspace_storage = bnorm_impl->is_training()
-                ? ctx.output(DNNL_ARG_WORKSPACE)->memory_storage()
-                : &memory_storage_t::empty_storage();
-
         auto n_channels = bnorm_impl->C();
+        ::sycl::buffer<uint8_t> scale_bias_buff(n_channels * 2 * sizeof(float));
 
-        ::sycl::buffer<float> scaleshift_buff(n_channels * 2);
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-            auto mean_acc = CTX_OUT_ACCESSOR(DNNL_ARG_MEAN);
-            auto var_acc = CTX_OUT_ACCESSOR(DNNL_ARG_VARIANCE);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, n_channels);
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_mean = CTX_OUT_SYCL_MEMORY(DNNL_ARG_MEAN);
+            auto arg_var = CTX_OUT_SYCL_MEMORY(DNNL_ARG_VARIANCE);
+            auto arg_scale_bias
+                    = sycl_memory_arg_t<::sycl::access::mode::write>(
+                            scale_bias_buff, cgh);
+            auto arg_wkspace = bnorm_impl->is_training()
+                    ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
+                    : sycl_memory_arg_t<::sycl::access::mode::write>();
+
             bool init_ss = true, init_mean_var = true;
 
-            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    dst_acc, mean_acc, var_acc, scale_acc, bias_acc,
-                    wkspace_storage, init_ss, init_mean_var);
+            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_dst, arg_scale_bias, arg_wkspace, init_ss,
+                    init_mean_var, arg_mean, arg_var);
         });
     }
 };
@@ -369,32 +342,21 @@ struct bnorm_exec_fwd_ss_t : public bnorm_exec_base_t {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
-        auto wkspace_storage = bnorm_impl->is_training()
-                ? ctx.output(DNNL_ARG_WORKSPACE)->memory_storage()
-                : &memory_storage_t::empty_storage();
-
-        auto scaleshift_buff
-                = utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
-                        &CTX_IN_STORAGE(DNNL_ARG_SCALE_SHIFT))
-                          ->buffer();
-        auto n_channels = bnorm_impl->C();
-
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-            auto mean_acc = CTX_OUT_ACCESSOR(DNNL_ARG_MEAN);
-            auto var_acc = CTX_OUT_ACCESSOR(DNNL_ARG_VARIANCE);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, n_channels);
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_mean = CTX_OUT_SYCL_MEMORY(DNNL_ARG_MEAN);
+            auto arg_var = CTX_OUT_SYCL_MEMORY(DNNL_ARG_VARIANCE);
+            auto arg_scale_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_SCALE_SHIFT);
+            auto arg_wkspace = bnorm_impl->is_training()
+                    ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
+                    : sycl_memory_arg_t<::sycl::access::mode::write>();
+
             bool init_ss = false, init_mean_var = true;
 
-            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    dst_acc, mean_acc, var_acc, scale_acc, bias_acc,
-                    wkspace_storage, init_ss, init_mean_var);
+            interop_task_fwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_dst, arg_scale_bias, arg_wkspace, init_ss,
+                    init_mean_var, arg_mean, arg_var);
         });
     }
 };
@@ -405,42 +367,31 @@ struct bnorm_exec_bwd_t : public bnorm_exec_base_t {
             const override {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
-
         auto n_channels = bnorm_impl->C();
-        ::sycl::buffer<float> scaleshift_buff(n_channels * 2);
-        ::sycl::buffer<float> diff_scaleshift_buff(n_channels * 2);
+        ::sycl::buffer<uint8_t> scale_bias_buff(n_channels * 2 * sizeof(float));
+        ::sycl::buffer<uint8_t> diff_scale_bias_buff(
+                n_channels * 2 * sizeof(float));
 
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
-            auto diff_src_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SRC);
-            auto wkspace_acc = CTX_IN_ACCESSOR(DNNL_ARG_WORKSPACE);
-            auto diff_scaleshift_acc
-                    = diff_scaleshift_buff
-                              .get_access<::sycl::access::mode::read>(cgh);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::write>(
-                            cgh, n_channels, n_channels);
-            bool init_ss = true, init_mean_var = false;
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+            auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+            auto arg_wkspace = CTX_IN_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+            auto arg_scale_bias
+                    = sycl_memory_arg_t<::sycl::access::mode::write>(
+                            scale_bias_buff, cgh);
+            auto arg_diff_scale_bias
+                    = sycl_memory_arg_t<::sycl::access::mode::write>(
+                            diff_scale_bias_buff, cgh);
 
-            std::shared_ptr<::sycl::accessor<uint8_t, 1,
-                    ::sycl::access::mode::read_write,
-                    sycl::compat::target_device>>
-                    temp_relu_output = nullptr;
-            if (bnorm_impl->fuse_norm_relu()) {
-                temp_relu_output = std::make_shared<::sycl::accessor<uint8_t, 1,
-                        ::sycl::access::mode::read_write,
-                        sycl::compat::target_device>>(
-                        CTX_SCRATCH_ACCESSOR(memory_tracking::names::key_none));
-            }
+            auto arg_temp_relu
+                    = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
 
-            interop_task_bwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    diff_dst_acc, diff_src_acc, scale_acc, bias_acc,
-                    diff_scaleshift_acc, wkspace_acc, temp_relu_output, init_ss,
-                    init_mean_var);
+            bool init_ss = true;
+
+            interop_task_bwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_diff_dst, arg_diff_src, arg_scale_bias,
+                    arg_diff_scale_bias, arg_wkspace, arg_temp_relu, init_ss);
         });
     }
 };
@@ -452,43 +403,22 @@ struct bnorm_exec_bwd_dw_ss_t : public bnorm_exec_base_t {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
-        auto scaleshift_buff
-                = utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
-                        &CTX_IN_STORAGE(DNNL_ARG_SCALE_SHIFT))
-                          ->buffer();
-
-        auto n_channels = bnorm_impl->C();
-
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
-            auto diff_src_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SRC);
-            auto diff_scaleshift_acc
-                    = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SCALE_SHIFT);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, n_channels);
-            auto wkspace_acc = CTX_IN_ACCESSOR(DNNL_ARG_WORKSPACE);
-            bool init_ss = false, init_mean_var = false;
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+            auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+            auto arg_scale_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_SCALE_SHIFT);
+            auto arg_diff_scale_bias
+                    = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SCALE_SHIFT);
+            auto arg_wkspace = CTX_IN_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+            bool init_ss = false;
 
-            std::shared_ptr<::sycl::accessor<uint8_t, 1,
-                    ::sycl::access::mode::read_write,
-                    sycl::compat::target_device>>
-                    temp_relu_output = nullptr;
-            if (bnorm_impl->fuse_norm_relu()) {
-                temp_relu_output = std::make_shared<::sycl::accessor<uint8_t, 1,
-                        ::sycl::access::mode::read_write,
-                        sycl::compat::target_device>>(
-                        CTX_SCRATCH_ACCESSOR(memory_tracking::names::key_none));
-            }
+            auto arg_temp_relu
+                    = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
 
-            interop_task_bwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    diff_dst_acc, diff_src_acc, scale_acc, bias_acc,
-                    diff_scaleshift_acc, wkspace_acc, temp_relu_output, init_ss,
-                    init_mean_var);
+            interop_task_bwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_diff_dst, arg_diff_src, arg_scale_bias,
+                    arg_diff_scale_bias, arg_wkspace, arg_temp_relu, init_ss);
         });
     }
 };
@@ -499,45 +429,27 @@ struct bnorm_exec_bwd_d_ss_t : public bnorm_exec_base_t {
             const override {
         nvidia::sycl_cuda_stream_t *cuda_stream
                 = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
-
-        auto scaleshift_buff
-                = utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
-                        &CTX_IN_STORAGE(DNNL_ARG_SCALE_SHIFT))
-                          ->buffer();
         auto n_channels = bnorm_impl->C();
+        ::sycl::buffer<uint8_t> diff_scale_bias_buff(
+                n_channels * 2 * sizeof(float));
 
-        ::sycl::buffer<float> diff_scaleshift_buff(n_channels * 2);
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-            auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
-            auto diff_src_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SRC);
-            auto scale_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, 0);
-            auto bias_acc
-                    = scaleshift_buff.get_access<::sycl::access::mode::read>(
-                            cgh, n_channels, n_channels);
-            auto diff_scaleshift_acc
-                    = diff_scaleshift_buff
-                              .get_access<::sycl::access::mode::read>(cgh);
-            auto wkspace_acc = CTX_IN_ACCESSOR(DNNL_ARG_WORKSPACE);
-            bool init_ss = false, init_mean_var = false;
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+            auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+            auto arg_scale_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_SCALE_SHIFT);
+            auto arg_diff_scale_bias
+                    = sycl_memory_arg_t<::sycl::access::mode::write>(
+                            diff_scale_bias_buff, cgh);
+            auto arg_wkspace = CTX_IN_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+            auto arg_temp_relu
+                    = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
 
-            std::shared_ptr<::sycl::accessor<uint8_t, 1,
-                    ::sycl::access::mode::read_write,
-                    sycl::compat::target_device>>
-                    temp_relu_output = nullptr;
-            if (bnorm_impl->fuse_norm_relu()) {
-                temp_relu_output = std::make_shared<::sycl::accessor<uint8_t, 1,
-                        ::sycl::access::mode::read_write,
-                        sycl::compat::target_device>>(
-                        CTX_SCRATCH_ACCESSOR(memory_tracking::names::key_none));
-            }
+            bool init_ss = false;
 
-            interop_task_bwd(bnorm_impl, engine, cgh, cuda_stream, src_acc,
-                    diff_dst_acc, diff_src_acc, scale_acc, bias_acc,
-                    diff_scaleshift_acc, wkspace_acc, temp_relu_output, init_ss,
-                    init_mean_var);
+            interop_task_bwd(bnorm_impl, engine, cgh, cuda_stream, arg_src,
+                    arg_diff_dst, arg_diff_src, arg_scale_bias,
+                    arg_diff_scale_bias, arg_wkspace, arg_temp_relu, init_ss);
         });
     }
 };

--- a/src/gpu/nvidia/cudnn_deconvolution.cpp
+++ b/src/gpu/nvidia/cudnn_deconvolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2022 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "gpu/nvidia/sycl_cuda_utils.hpp"
+#include "sycl_cuda_memory_storage_helper.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -34,8 +35,8 @@ status_t cudnn_deconvolution_bwd_weights_t::execute_bias(
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        auto bias_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_BIAS);
-        auto y_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
+        auto arg_diff_bias = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_BIAS);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
 
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
@@ -43,8 +44,8 @@ status_t cudnn_deconvolution_bwd_weights_t::execute_bias(
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
 
-            auto bias = sc.memory<void *>(ih, bias_acc);
-            auto y = sc.memory<void *>(ih, y_acc);
+            void *bias = arg_diff_bias.get_native_pointer(ih);
+            void *y = arg_diff_dst.get_native_pointer(ih);
 
             impl_->execute_bias(handle, y, bias);
         });

--- a/src/gpu/nvidia/cudnn_inner_product.cpp
+++ b/src/gpu/nvidia/cudnn_inner_product.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-* Copyright 2020 Codeplay Software Limited
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl_cuda_memory_storage_helper.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -34,35 +35,16 @@ status_t cudnn_inner_product_fwd_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        using scratch_acc_t = ::sycl::accessor<uint8_t, 1,
-                ::sycl::access::mode::read_write, sycl::compat::target_device>;
-        using read_acc_t = ::sycl::accessor<uint8_t, 1,
-                ::sycl::access::mode::read, sycl::compat::target_device>;
-        auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-        auto wei_acc = CTX_IN_ACCESSOR(DNNL_ARG_WEIGHTS);
-        std::shared_ptr<read_acc_t> bias_acc;
-        if (pd()->with_bias()) {
-            bias_acc = std::make_shared<read_acc_t>(
-                    CTX_IN_ACCESSOR(DNNL_ARG_BIAS));
-        }
-        auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-        std::shared_ptr<scratch_acc_t> ip_scratch_acc;
-        std::shared_ptr<scratch_acc_t> spacial_scratch_acc;
-        std::shared_ptr<scratch_acc_t> scaled_bias_scratch_acc;
-        if (pd()->inner_product_impl_->ip_using_scratchpad()) {
-            ip_scratch_acc = std::make_shared<
-                    scratch_acc_t>(CTX_SCRATCH_ACCESSOR(
-                    memory_tracking::names::key_iprod_int_dat_in_acc_dt));
-        }
-        if (pd()->inner_product_impl_->need_to_transform_filter()) {
-            spacial_scratch_acc = std::make_shared<scratch_acc_t>(
-                    CTX_SCRATCH_ACCESSOR(memory_tracking::names::key_none));
-        }
-        if (pd()->inner_product_impl_->conv_using_scale_scratchpad()) {
-            scaled_bias_scratch_acc
-                    = std::make_shared<scratch_acc_t>(CTX_SCRATCH_ACCESSOR(
-                            memory_tracking::names::key_conv_adjusted_scales));
-        }
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_wei = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+        auto arg_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_BIAS);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_ip_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_iprod_int_dat_in_acc_dt);
+        auto arg_spacial_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+        auto arg_scaled_bias_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_conv_adjusted_scales);
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
                     cuda_stream->engine());
@@ -72,23 +54,14 @@ status_t cudnn_inner_product_fwd_t::execute(const exec_ctx_t &ctx) const {
 
             std::vector<void *> args;
 
-            args.push_back(sc.memory<void *>(ih, src_acc));
-            args.push_back(sc.memory<void *>(ih, wei_acc));
-            args.push_back(
-                    ((pd()->with_bias()) ? sc.memory<void *>(ih, *bias_acc)
-                                         : nullptr));
-            args.push_back(sc.memory<void *>(ih, dst_acc));
-            args.push_back((pd()->inner_product_impl_->ip_using_scratchpad()
-                            ? sc.memory<void *>(ih, *ip_scratch_acc)
-                            : nullptr));
-            args.push_back((
-                    pd()->inner_product_impl_->need_to_transform_filter()
-                            ? sc.memory<void *>(ih, *spacial_scratch_acc)
-                            : nullptr));
-            args.push_back((
-                    pd()->inner_product_impl_->conv_using_scale_scratchpad()
-                            ? sc.memory<void *>(ih, *scaled_bias_scratch_acc)
-                            : nullptr));
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_wei.get_native_pointer(ih));
+            args.push_back(arg_bias.get_native_pointer(ih));
+            args.push_back(arg_dst.get_native_pointer(ih));
+            args.push_back(arg_ip_scratch.get_native_pointer(ih));
+            args.push_back(arg_spacial_scratch.get_native_pointer(ih));
+            args.push_back(arg_scaled_bias_scratch.get_native_pointer(ih));
+
             pd()->inner_product_impl_->execute(
                     cudnn_handle, cublas_handle, args);
         });
@@ -101,22 +74,14 @@ status_t cudnn_inner_product_bwd_data_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        using scratch_acc_t = ::sycl::accessor<uint8_t, 1,
-                ::sycl::access::mode::read_write, sycl::compat::target_device>;
-        auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
-        auto wei_acc = CTX_IN_ACCESSOR(DNNL_ARG_WEIGHTS);
-        auto diff_src_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SRC);
-        std::shared_ptr<scratch_acc_t> ip_scratch_acc;
-        std::shared_ptr<scratch_acc_t> spacial_scratch_acc;
-        if (pd()->inner_product_impl_->ip_using_scratchpad()) {
-            ip_scratch_acc = std::make_shared<
-                    scratch_acc_t>(CTX_SCRATCH_ACCESSOR(
-                    memory_tracking::names::key_iprod_int_dat_in_acc_dt));
-        }
-        if (pd()->inner_product_impl_->need_to_transform_filter()) {
-            spacial_scratch_acc = std::make_shared<scratch_acc_t>(
-                    CTX_SCRATCH_ACCESSOR(memory_tracking::names::key_none));
-        }
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_wei = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto arg_ip_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_iprod_int_dat_in_acc_dt);
+        auto arg_spacial_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
                     cuda_stream->engine());
@@ -126,16 +91,12 @@ status_t cudnn_inner_product_bwd_data_t::execute(const exec_ctx_t &ctx) const {
 
             std::vector<void *> args;
 
-            args.push_back(sc.memory<void *>(ih, diff_src_acc));
-            args.push_back(sc.memory<void *>(ih, wei_acc));
-            args.push_back(sc.memory<void *>(ih, diff_dst_acc));
-            args.push_back((pd()->inner_product_impl_->ip_using_scratchpad()
-                            ? sc.memory<void *>(ih, *ip_scratch_acc)
-                            : nullptr));
-            args.push_back((
-                    pd()->inner_product_impl_->need_to_transform_filter()
-                            ? sc.memory<void *>(ih, *spacial_scratch_acc)
-                            : nullptr));
+            args.push_back(arg_diff_src.get_native_pointer(ih));
+            args.push_back(arg_wei.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+            args.push_back(arg_ip_scratch.get_native_pointer(ih));
+            args.push_back(arg_spacial_scratch.get_native_pointer(ih));
+
             pd()->inner_product_impl_->execute(
                     cudnn_handle, cublas_handle, args);
         });
@@ -155,46 +116,28 @@ status_t cudnn_inner_product_bwd_weights_t::execute(
                         : 0);
 
         if (wei_sz != 0) {
-            auto status = cuda_stream->interop_task([&](::sycl::handler &cgh) {
-                auto diff_wei_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_WEIGHTS);
-                cgh.fill(diff_wei_acc, static_cast<uint8_t>(0));
-            });
+            auto status = cuda_stream->fill(
+                    CTX_OUT_STORAGE(DNNL_ARG_DIFF_WEIGHTS), 0, wei_sz);
             if (status != status::success) return status;
         }
         if (bias_sz != 0) {
-            auto status = cuda_stream->interop_task([&](::sycl::handler &cgh) {
-                auto diff_bia_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_BIAS);
-                cgh.fill(diff_bia_acc, static_cast<uint8_t>(0));
-            });
+            auto status = cuda_stream->fill(
+                    CTX_OUT_STORAGE(DNNL_ARG_DIFF_BIAS), 0, bias_sz);
             if (status != status::success) return status;
         }
         return status::success;
     }
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        using scratch_acc_t = ::sycl::accessor<uint8_t, 1,
-                ::sycl::access::mode::read_write, sycl::compat::target_device>;
-        auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-        auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
-        auto diff_wei_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_WEIGHTS);
-        using write_acc_t = ::sycl::accessor<uint8_t, 1,
-                ::sycl::access::mode::write, sycl::compat::target_device>;
-        std::shared_ptr<write_acc_t> diff_bias_acc;
-        if (pd()->with_bias()) {
-            diff_bias_acc = std::make_shared<write_acc_t>(
-                    CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_BIAS));
-        }
-        std::shared_ptr<scratch_acc_t> ip_scratch_acc;
-        std::shared_ptr<scratch_acc_t> spacial_scratch_acc;
-        if (pd()->inner_product_impl_->ip_using_scratchpad()) {
-            ip_scratch_acc = std::make_shared<
-                    scratch_acc_t>(CTX_SCRATCH_ACCESSOR(
-                    memory_tracking::names::key_iprod_int_dat_in_acc_dt));
-        }
-        if (pd()->inner_product_impl_->need_to_transform_filter()) {
-            spacial_scratch_acc = std::make_shared<scratch_acc_t>(
-                    CTX_SCRATCH_ACCESSOR(memory_tracking::names::key_none));
-        }
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_diff_wei = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_WEIGHTS);
+        auto arg_bias = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_BIAS);
+        auto arg_ip_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_iprod_int_dat_in_acc_dt);
+        auto arg_spacial_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
                     cuda_stream->engine());
@@ -203,20 +146,13 @@ status_t cudnn_inner_product_bwd_weights_t::execute(
             auto cublas_handle = cuda_stream->get_cublas_handle();
             std::vector<void *> args;
 
-            args.push_back(sc.memory<void *>(ih, src_acc));
-            args.push_back(sc.memory<void *>(ih, diff_dst_acc));
-            args.push_back(sc.memory<void *>(ih, diff_wei_acc));
-            args.push_back(
-                    ((pd()->with_bias()) ? sc.memory<void *>(ih, *diff_bias_acc)
-                                         : nullptr));
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+            args.push_back(arg_diff_wei.get_native_pointer(ih));
+            args.push_back(arg_bias.get_native_pointer(ih));
+            args.push_back(arg_ip_scratch.get_native_pointer(ih));
+            args.push_back(arg_spacial_scratch.get_native_pointer(ih));
 
-            args.push_back((pd()->inner_product_impl_->ip_using_scratchpad()
-                            ? sc.memory<void *>(ih, *ip_scratch_acc)
-                            : nullptr));
-            args.push_back((
-                    pd()->inner_product_impl_->need_to_transform_filter()
-                            ? sc.memory<void *>(ih, *spacial_scratch_acc)
-                            : nullptr));
             pd()->inner_product_impl_->execute(
                     cudnn_handle, cublas_handle, args);
         });

--- a/src/gpu/nvidia/cudnn_pooling.cpp
+++ b/src/gpu/nvidia/cudnn_pooling.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-* Copyright 2020 Codeplay Software Limited
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 
 #include "common/nstl.hpp"
 
+#include "sycl_cuda_memory_storage_helper.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace gpu {
@@ -37,11 +39,6 @@ status_t cudnn_pooling_fwd_t::execute(const exec_ctx_t &ctx) const {
     nvidia::sycl_cuda_stream_t *cuda_stream
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
-    bool is_training = pd()->desc()->prop_kind == prop_kind::forward_training;
-    auto wkspace_st = is_training
-            ? ctx.output(DNNL_ARG_WORKSPACE)->memory_storage()
-            : &memory_storage_t::empty_storage();
-
     memory_desc_wrapper src_wrap(pd()->src_md());
     auto dst_offset_bytes = src_wrap.nelems() * src_wrap.data_type_size();
 
@@ -49,14 +46,14 @@ status_t cudnn_pooling_fwd_t::execute(const exec_ctx_t &ctx) const {
     // numeric_limits<dt>::lowest() to match the other backends' behaviour
     if (src_wrap.size() == 0 && dst_wrap.size() != 0) {
         return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-            auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
 
             compat::host_task(cgh, [=](const compat::interop_handle &ih) {
                 auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
                         cuda_stream->engine());
                 auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
 
-                auto dst = sc.memory<void *>(ih, dst_acc);
+                void *dst = arg_dst.get_native_pointer(ih);
 
                 if (dst_wrap.data_type() == data_type_t::dnnl_f32) {
                     auto val = nstl::numeric_limits<float>::lowest();
@@ -81,21 +78,9 @@ status_t cudnn_pooling_fwd_t::execute(const exec_ctx_t &ctx) const {
     }
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-        auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
-
-        std::shared_ptr<
-                ::sycl::accessor<uint8_t, 1, ::sycl::access::mode::write>>
-                wkspace_acc;
-        if (!wkspace_st->is_null()) {
-            wkspace_acc = std::make_shared<
-                    ::sycl::accessor<uint8_t, 1, ::sycl::access::mode::write>>(
-                    utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
-                            wkspace_st)
-                            ->buffer()
-                            .template get_access<::sycl::access::mode::write>(
-                                    cgh));
-        }
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_wkspace = CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
 
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
@@ -103,11 +88,13 @@ status_t cudnn_pooling_fwd_t::execute(const exec_ctx_t &ctx) const {
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
 
-            auto x = sc.memory<void *>(ih, src_acc);
-            auto y = sc.memory<void *>(ih, dst_acc);
+            void *x = arg_src.get_native_pointer(ih);
+            void *y = arg_dst.get_native_pointer(ih);
+
             uint8_t *ws_x = nullptr, *ws_y = nullptr;
-            if (!wkspace_st->is_null()) {
-                ws_x = sc.memory<uint8_t *>(ih, *wkspace_acc);
+            if (!arg_wkspace.empty()) {
+                ws_x = static_cast<uint8_t *>(
+                        arg_wkspace.get_native_pointer(ih));
                 ws_y = ws_x + dst_offset_bytes;
             }
 
@@ -131,9 +118,9 @@ status_t cudnn_pooling_bwd_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        auto diff_src_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SRC);
-        auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
-        auto wkspace_acc = CTX_IN_ACCESSOR(DNNL_ARG_WORKSPACE);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_wkspace = CTX_IN_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
 
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
@@ -141,10 +128,11 @@ status_t cudnn_pooling_bwd_t::execute(const exec_ctx_t &ctx) const {
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
 
-            auto dx = sc.memory<void *>(ih, diff_src_acc);
-            auto dy = sc.memory<void *>(ih, diff_dst_acc);
-            auto ws_x = sc.memory<uint8_t *>(ih, wkspace_acc);
-            auto ws_y = ws_x + dst_offset_bytes;
+            void *dx = arg_diff_src.get_native_pointer(ih);
+            void *dy = arg_diff_dst.get_native_pointer(ih);
+            void *ws_x = arg_wkspace.get_native_pointer(ih);
+
+            auto ws_y = (uint8_t *)ws_x + dst_offset_bytes;
 
             pd()->pooling_impl_->execute(handle, dx, dy, ws_x, ws_y);
         });

--- a/src/gpu/nvidia/cudnn_resampling.cpp
+++ b/src/gpu/nvidia/cudnn_resampling.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
-* Copyright 2020 Codeplay Software Limited
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include "gpu/nvidia/cudnn_resampling.hpp"
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
+#include "sycl_cuda_memory_storage_helper.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -34,8 +35,9 @@ status_t cudnn_resampling_fwd_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-        auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+
         auto grid_acc = buffer(grid_storage_.get())
                                 .get_access<::sycl::access::mode::read>(cgh);
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
@@ -45,9 +47,9 @@ status_t cudnn_resampling_fwd_t::execute(const exec_ctx_t &ctx) const {
             auto handle = cuda_stream->get_cudnn_handle();
             std::vector<void *> args;
 
-            args.push_back(sc.memory<void *>(ih, src_acc));
+            args.push_back(arg_src.get_native_pointer(ih));
             args.push_back(sc.memory<void *>(ih, grid_acc));
-            args.push_back(sc.memory<void *>(ih, dst_acc));
+            args.push_back(arg_dst.get_native_pointer(ih));
 
             pd()->resampling_impl_->execute(handle, args);
         });
@@ -64,22 +66,22 @@ status_t cudnn_resampling_bwd_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        auto diff_src_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SRC);
-        auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
         auto grid_acc = buffer(grid_storage_.get())
                                 .get_access<::sycl::access::mode::read>(cgh);
-        auto diff_grid_acc
-                = CTX_SCRATCH_ACCESSOR(memory_tracking::names::key_none);
+        auto arg_diff_grid
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
                     cuda_stream->engine());
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
             std::vector<void *> args;
-            args.push_back(sc.memory<void *>(ih, diff_src_acc));
-            args.push_back(sc.memory<void *>(ih, diff_dst_acc));
+            args.push_back(arg_diff_src.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
             args.push_back(sc.memory<void *>(ih, grid_acc));
-            args.push_back(sc.memory<void *>(ih, diff_grid_acc));
+            args.push_back(arg_diff_grid.get_native_pointer(ih));
 
             pd()->resampling_impl_->execute(handle, args);
         });

--- a/src/gpu/nvidia/cudnn_softmax.cpp
+++ b/src/gpu/nvidia/cudnn_softmax.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2022 Intel Corporation
-* Copyright 2020 Codeplay Software Limited
+* Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl_cuda_memory_storage_helper.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -32,8 +33,8 @@ status_t cudnn_softmax_fwd_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        auto src_acc = CTX_IN_ACCESSOR(DNNL_ARG_SRC);
-        auto dst_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DST);
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
 
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             std::vector<void *> args;
@@ -42,8 +43,8 @@ status_t cudnn_softmax_fwd_t::execute(const exec_ctx_t &ctx) const {
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
 
-            args.push_back(sc.memory<void *>(ih, src_acc));
-            args.push_back(sc.memory<void *>(ih, dst_acc));
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_dst.get_native_pointer(ih));
 
             pd()->softmax_impl_->execute(handle, args.data(), args.size());
         });
@@ -57,9 +58,9 @@ status_t cudnn_softmax_bwd_t::execute(const exec_ctx_t &ctx) const {
             = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
 
     return cuda_stream->interop_task([&](::sycl::handler &cgh) {
-        auto dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DST);
-        auto diff_dst_acc = CTX_IN_ACCESSOR(DNNL_ARG_DIFF_DST);
-        auto diff_src_acc = CTX_OUT_ACCESSOR(DNNL_ARG_DIFF_SRC);
+        auto arg_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
 
         compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             std::vector<void *> args;
@@ -68,9 +69,9 @@ status_t cudnn_softmax_bwd_t::execute(const exec_ctx_t &ctx) const {
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
 
-            args.push_back(sc.memory<void *>(ih, dst_acc));
-            args.push_back(sc.memory<void *>(ih, diff_dst_acc));
-            args.push_back(sc.memory<void *>(ih, diff_src_acc));
+            args.push_back(arg_dst.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+            args.push_back(arg_diff_src.get_native_pointer(ih));
 
             pd()->softmax_impl_->execute(handle, args.data(), args.size());
         });

--- a/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
@@ -33,12 +33,16 @@ namespace nvidia {
 #define CTX_OUT_SYCL_MEMORY(arg) \
     sycl_memory_arg_t<::sycl::access::mode::write>(&CTX_OUT_STORAGE(arg), cgh)
 
+#define CTX_SCRATCH_SYCL_MEMORY(arg) \
+    sycl_memory_arg_t<::sycl::access::mode::read_write>( \
+            ctx.get_scratchpad_grantor().get_memory_storage(arg).get(), cgh)
+
 template <::sycl::access_mode mode>
 class sycl_memory_arg_t {
 public:
     sycl_memory_arg_t() = default;
     sycl_memory_arg_t(memory_storage_t *raw_mem, ::sycl::handler &cgh) {
-        if (raw_mem->is_null()) { return; }
+        if (!raw_mem || raw_mem->is_null()) { return; }
         auto *mem = static_cast<sycl::sycl_memory_storage_base_t *>(raw_mem);
         switch (mem->memory_kind()) {
             case sycl::memory_kind::buffer: {

--- a/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
@@ -63,10 +63,16 @@ public:
         }
     }
 
+    sycl_memory_arg_t(::sycl::buffer<uint8_t> buf, ::sycl::handler &cgh,
+            size_t offset = 0)
+        : offset_ {offset} {
+        acc_.emplace(buf, cgh);
+    }
+
     template <::sycl::backend be = ::sycl::backend::ext_oneapi_cuda,
             typename T = void>
     T *get_native_pointer(const compat::interop_handle &ih) const {
-        void *raw_ptr;
+        void *raw_ptr = nullptr;
         if (acc_.has_value()) {
             raw_ptr = reinterpret_cast<T *>(
                     reinterpret_cast<uint8_t *>(

--- a/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
+++ b/src/gpu/nvidia/sycl_cuda_memory_storage_helper.hpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright 2022 Intel Corporation
+* Copyright 2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_NVIDIA_SYCL_CUDA_MEMORY_STORAGE_HELPER_HPP
+#define GPU_NVIDIA_SYCL_CUDA_MEMORY_STORAGE_HELPER_HPP
+
+#include <optional>
+#include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
+#include "sycl/sycl_memory_storage.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace nvidia {
+
+#define CTX_IN_SYCL_MEMORY(arg) \
+    sycl_memory_arg_t<::sycl::access::mode::read>(&CTX_IN_STORAGE(arg), cgh)
+
+#define CTX_OUT_SYCL_MEMORY(arg) \
+    sycl_memory_arg_t<::sycl::access::mode::write>(&CTX_OUT_STORAGE(arg), cgh)
+
+template <::sycl::access_mode mode>
+class sycl_memory_arg_t {
+public:
+    sycl_memory_arg_t() = default;
+    sycl_memory_arg_t(memory_storage_t *raw_mem, ::sycl::handler &cgh) {
+        if (raw_mem->is_null()) { return; }
+        auto *mem = static_cast<sycl::sycl_memory_storage_base_t *>(raw_mem);
+        switch (mem->memory_kind()) {
+            case sycl::memory_kind::buffer: {
+                auto *buffer_storage
+                        = utils::downcast<sycl::sycl_buffer_memory_storage_t *>(
+                                mem);
+                acc_.emplace(buffer_storage->buffer(), cgh);
+                offset_ = buffer_storage->base_offset();
+                break;
+            }
+            case sycl::memory_kind::usm: {
+                raw_ptr_ = utils::downcast<
+                        const sycl::sycl_usm_memory_storage_t *>(mem)
+                                   ->usm_ptr();
+                break;
+            }
+            default: assert(!"unexpected memory kind");
+        }
+    }
+
+    template <::sycl::backend be = ::sycl::backend::ext_oneapi_cuda,
+            typename T = void>
+    T *get_native_pointer(const compat::interop_handle &ih) const {
+        void *raw_ptr;
+        if (acc_.has_value()) {
+            raw_ptr = reinterpret_cast<T *>(
+                    reinterpret_cast<uint8_t *>(
+                            ih.get_native_mem<be>(acc_.value()))
+                    + offset_);
+        } else {
+            raw_ptr = raw_ptr_;
+        }
+        return reinterpret_cast<T *>(raw_ptr);
+    }
+
+    bool empty() const { return !raw_ptr_ && !acc_.has_value(); }
+
+private:
+    void *raw_ptr_ = nullptr;
+    std::optional<::sycl::accessor<uint8_t, 1, mode>> acc_;
+    size_t offset_;
+};
+
+} // namespace nvidia
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/nvidia/sycl_cuda_stream.cpp
+++ b/src/gpu/nvidia/sycl_cuda_stream.cpp
@@ -97,8 +97,10 @@ status_t sycl_cuda_stream_t::init() {
 status_t sycl_cuda_stream_t::interop_task(
         std::function<void(::sycl::handler &)> sycl_cuda_interop_) {
     try {
-        this->set_deps({queue().submit(
-                [&](::sycl::handler &cgh) { sycl_cuda_interop_(cgh); })});
+        this->set_deps({queue().submit([&](::sycl::handler &cgh) {
+            cgh.depends_on(get_deps());
+            sycl_cuda_interop_(cgh);
+        })});
         return status::success;
     } catch (std::runtime_error &e) {
         error::wrap_c_api(status::runtime_error, e.what());

--- a/tests/benchdnn/conv/deconv.cpp
+++ b/tests/benchdnn/conv/deconv.cpp
@@ -238,8 +238,10 @@ void check_known_skipped_case(const prb_t *prb, res_t *res) {
         const bool bwd_tag_ok
                 = !((prb->dir == BWD_W || prb->dir == BWD_WB) && stag_is_axb);
         const bool tag_ok = fwd_tag_ok && bwd_tag_ok;
+        const bool data_type_ok
+                = prb->cfg[SRC].dt != dnnl_s8 && prb->cfg[SRC].dt != dnnl_u8;
         // TODO: specified wtag (even for supported formats) is not working?
-        if (!pad_ok || !out_ok || !post_ops_ok || !tag_ok) {
+        if (!pad_ok || !out_ok || !post_ops_ok || !tag_ok || !data_type_ok) {
             res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
             return;
         }

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -113,15 +113,6 @@ int dnn_mem_t::reorder(const dnn_mem_t &rhs, const_dnnl_primitive_attr_t attr) {
 
 int dnn_mem_t::initialize_memory_create_sycl(const handle_info_t &handle_info) {
 #ifdef DNNL_WITH_SYCL
-    if (is_nvidia_gpu(engine_)) {
-        // USM is not supported with Nvidia so ignore memory_kind and
-        // force SYCL buffers.
-        DNN_SAFE(dnnl_sycl_interop_memory_create(&m_, &md_, engine_,
-                         dnnl_sycl_interop_buffer, handle_info.ptr),
-                CRIT);
-        return OK;
-    }
-
     if (handle_info.is_host_ptr) {
         // Ignore memory_kind with host pointers and force USM.
         DNN_SAFE(dnnl_sycl_interop_memory_create(&m_, &md_, engine_,

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -293,14 +293,18 @@ void check_known_skipped_case(const prb_t *prb, res_t *res) {
                 assert(!"unknown post-op type");
         }
 
-        const bool oscale_ok = prb->attr.oscale.policy == policy_t::COMMON;
+        const bool oscale_ok = (prb->attr.oscale.policy == policy_t::COMMON)
+                && !prb->attr.oscale.runtime;
         const bool zp_ok = prb->attr.zero_points.is_def();
         const bool dims_ok = prb->ndims <= 3;
         const bool batch_bcast_ok = IMPLICATION(
                 prb->ndims == 3, prb->src_dims()[0] == prb->weights_dims()[0]);
+        const bool dtag_ok = (prb->dtag != "ba") ? true : false;
+        const bool dst_bias_mismatch_ok = !((prb->cfg[DST].dt == dnnl_s8)
+                && (prb->bia_dt == dnnl_data_type_undef));
 
-        if (!post_ops_ok || !oscale_ok || !zp_ok || !dims_ok
-                || !batch_bcast_ok) {
+        if (!post_ops_ok || !oscale_ok || !zp_ok || !dims_ok || !batch_bcast_ok
+                || !dtag_ok || !dst_bias_mismatch_ok) {
             res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
             return;
         }

--- a/tests/gtests/CMakeLists.txt
+++ b/tests/gtests/CMakeLists.txt
@@ -96,6 +96,7 @@ file(GLOB PRIM_TEST_CASES_SRC
                               test_matmul.cpp
                               test_resampling.cpp
                               test_reduction.cpp
+			      test_softmax_v2.cpp
                               )
 
 if(DNNL_CPU_RUNTIME STREQUAL "NONE")

--- a/tests/gtests/CMakeLists.txt
+++ b/tests/gtests/CMakeLists.txt
@@ -96,7 +96,6 @@ file(GLOB PRIM_TEST_CASES_SRC
                               test_matmul.cpp
                               test_resampling.cpp
                               test_reduction.cpp
-                              test_softmax_v2.cpp
                               )
 
 if(DNNL_CPU_RUNTIME STREQUAL "NONE")
@@ -237,7 +236,7 @@ endif()
 
 foreach(TEST_FILE ${PRIM_TEST_CASES_SRC})
     get_filename_component(exe ${TEST_FILE} NAME_WE)
-    if(NOT ${exe} MATCHES "${skip_usm_pattern}" AND NOT DNNL_SYCL_CUDA)
+    if(NOT ${exe} MATCHES "${skip_usm_pattern}")
         register_gtest(${exe} ${TEST_FILE})
     endif()
 

--- a/tests/gtests/api/CMakeLists.txt
+++ b/tests/gtests/api/CMakeLists.txt
@@ -25,11 +25,6 @@ if(DNNL_USE_CLANG_SANITIZER)
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_memory.cpp)
 endif()
 
-# Switch off C API tests for CUDA since USM model is not supported
-if(NOT DNNL_SYCL_CUDA)
-    register_exe(${TEST_EXE} "${TEST_SOURCES}" "test" "dnnl_gtest")
-endif()
-
 # Create DPC++ buffer target.
 if(DNNL_WITH_SYCL)
     register_exe(${TEST_EXE}_buffer "${TEST_SOURCES}" "test" "dnnl_gtest")

--- a/tests/gtests/sycl/api/test_memory_usm.cpp
+++ b/tests/gtests/sycl/api/test_memory_usm.cpp
@@ -53,10 +53,6 @@ protected:
 TEST_P(sycl_memory_usm_test, Constructor) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
-#ifdef DNNL_SYCL_CUDA
-    SKIP_IF(eng_kind == engine::kind::gpu,
-            "USM is not supported on CUDA backend");
-#endif
 
     engine eng(eng_kind, 0);
     memory::dim n = 100;
@@ -98,10 +94,6 @@ TEST_P(sycl_memory_usm_test, Constructor) {
 TEST_P(sycl_memory_usm_test, ConstructorNone) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
-#ifdef DNNL_SYCL_CUDA
-    SKIP_IF(eng_kind == engine::kind::gpu,
-            "USM is not supported on CUDA backend");
-#endif
 
     engine eng(eng_kind, 0);
     memory::desc mem_d({0}, memory::data_type::f32, memory::format_tag::x);
@@ -123,10 +115,6 @@ TEST_P(sycl_memory_usm_test, ConstructorNone) {
 TEST_P(sycl_memory_usm_test, ConstructorAllocate) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
-#ifdef DNNL_SYCL_CUDA
-    SKIP_IF(eng_kind == engine::kind::gpu,
-            "USM is not supported on CUDA backend");
-#endif
 
     engine eng(eng_kind, 0);
     memory::dim n = 100;
@@ -158,10 +146,6 @@ TEST_P(sycl_memory_usm_test, ConstructorAllocate) {
 TEST_P(sycl_memory_usm_test, DefaultConstructor) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
-#ifdef DNNL_SYCL_CUDA
-    SKIP_IF(eng_kind == engine::kind::gpu,
-            "USM is not supported on CUDA backend");
-#endif
 
     engine eng(eng_kind, 0);
     memory::dim n = 100;

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -472,7 +472,7 @@ static auto cases_ef = []() {
     cases.push_back({{{{16, 16}, data_type::f32, tag::AB8a4b},
                              {{16, 16}, data_type::f32, tag::AB8a4b},
                              {{16, 16}, data_type::f32, tag::AB8a4b}},
-            {}, true, dnnl_unimplemented});
+            {}});
 
     return ::testing::ValuesIn(cases);
 };

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -472,7 +472,7 @@ static auto cases_ef = []() {
     cases.push_back({{{{16, 16}, data_type::f32, tag::AB8a4b},
                              {{16, 16}, data_type::f32, tag::AB8a4b},
                              {{16, 16}, data_type::f32, tag::AB8a4b}},
-            {}});
+            {}, true, dnnl_unimplemented});
 
     return ::testing::ValuesIn(cases);
 };


### PR DESCRIPTION
# Description

This PR collects multiple patches that add support for USM for the cudnn backend. In addition it adds USM support to cudnn_matmul. Currently all tests pass with the exception of 10 of the example cases, which fail due to the primitive not being implemented by cudnn, or the primitive is being used in a way that is unsupported.

Already reviewed changes that are included in this PR:
#1258, #1259, #1262, #1263, #1264, #1265, #1266, #1267

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

