### PR TITLE
gpu: convolution: add fpmath mode for controlling TC usage

### DIFF
--- a/src/gpu/nvidia/cudnn_convolution_impl.hpp
+++ b/src/gpu/nvidia/cudnn_convolution_impl.hpp
@@ -218,8 +218,7 @@ public:
 
         if (computation_data_type == CUDNN_DATA_FLOAT) {
 
-            dnnl_fpmath_mode_t dnnl_fpmath_mode;
-            dnnl_get_default_fpmath_mode(&dnnl_fpmath_mode);
+            dnnl_fpmath_mode_t dnnl_fpmath_mode = pd->attr()->fpmath_mode_;
 
             switch (dnnl_fpmath_mode) {
                 case dnnl_fpmath_mode_strict:
@@ -603,8 +602,7 @@ public:
                 descs[x], weights_desc, conv_desc, descs[y],
                 requested_algo_count, &returned_algo_count, perf.data()));
 
-        dnnl_fpmath_mode_t dnnl_fpmath_mode;
-        dnnl_get_default_fpmath_mode(&dnnl_fpmath_mode);
+        dnnl_fpmath_mode_t dnnl_fpmath_mode = pd->attr()->fpmath_mode_;
 
         auto submit_status = CUDNN_STATUS_NOT_SUPPORTED;
         for (size_t i = 0; i < returned_algo_count; i++) {
@@ -739,8 +737,7 @@ protected:
                 handle, weights_desc, descs[y], conv_desc, descs[x],
                 requested_algo_count, &returned_algo_count, perf.data()));
 
-        dnnl_fpmath_mode_t dnnl_fpmath_mode;
-        dnnl_get_default_fpmath_mode(&dnnl_fpmath_mode);
+        dnnl_fpmath_mode_t dnnl_fpmath_mode = pd->attr()->fpmath_mode_;
 
         for (size_t i = 0; i < returned_algo_count; i++) {
             if (perf[i].status == CUDNN_STATUS_SUCCESS) {
@@ -889,8 +886,7 @@ public:
                 handle, descs[x], descs[y], conv_desc, weights_desc,
                 requested_algo_count, &returned_algo_count, perf.data()));
 
-        dnnl_fpmath_mode_t dnnl_fpmath_mode;
-        dnnl_get_default_fpmath_mode(&dnnl_fpmath_mode);
+        dnnl_fpmath_mode_t dnnl_fpmath_mode = pd->attr()->fpmath_mode_;
 
         for (size_t i = 0; i < returned_algo_count; i++) {
             if (perf[i].status == CUDNN_STATUS_SUCCESS) {


### PR DESCRIPTION
# Description

This patch introduces the Floating-point Math Mode for the CUDNN convolutions.

The [oneDNN math modes](https://oneapi-src.github.io/oneDNN/enum_dnnl_fpmath_mode_t.html) are mapped to different [cuDNN math types](https://docs.nvidia.com/deeplearning/cudnn/api/index.html#cudnnMathType_t) which allow or not datatype conversions in order to use the tensor cores. For further details refer to https://github.com/oneapi-src/oneDNN/issues/1268.

Fixes # (https://github.com/oneapi-src/oneDNN/issues/1268)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
