### PR TITLE
Enable profilers to label JIT code with the appropriate kernel name

### DIFF
--- a/src/cpu/x64/amx_tile_configure.cpp
+++ b/src/cpu/x64/amx_tile_configure.cpp
@@ -27,7 +27,8 @@ struct jit_amx_tilecfg_t : public jit_generator {
 
     // TODO: Need to check status
     jit_amx_tilecfg_t()
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx) {
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx) {
         create_kernel();
     }
 
@@ -45,7 +46,8 @@ struct jit_amx_tilerelease_t : public jit_generator {
 
     // TODO: Need to check status
     jit_amx_tilerelease_t()
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx) {
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx) {
         create_kernel();
     }
 

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -37,7 +37,8 @@ using namespace dnnl::impl::utils;
 using namespace Xbyak;
 
 jit_brdgmm_kernel_base_t::jit_brdgmm_kernel_base_t(const brgemm_t &abrd)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core), brg(abrd) {
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core)
+    , brg(abrd) {
 
     if (brg.with_eltwise || brg.with_binary || brg.with_sum) {
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -38,7 +38,7 @@ using namespace Xbyak;
 
 struct jit_brgemm_amx_uker_base_t : public jit_generator {
     jit_brgemm_amx_uker_base_t(const brgemm_t &abrg)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core)
         , brg(abrg)
         , postops_injector_(nullptr) {
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -40,7 +40,7 @@ using namespace Xbyak;
 
 struct jit_brgemm_kernel_t : public jit_generator {
     jit_brgemm_kernel_t(const brgemm_t &abrg)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core)
         , brg(abrg)
         , postops_injector_(nullptr) {
 

--- a/src/cpu/x64/cpu_barrier.cpp
+++ b/src/cpu/x64/cpu_barrier.cpp
@@ -89,7 +89,7 @@ struct jit_t : public jit_generator {
     }
 
     // TODO: Need to check status
-    jit_t() { create_kernel(); }
+    jit_t() : jit_generator(jit_name()) { create_kernel(); }
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_t)
 };

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -32,6 +32,8 @@
 /* in order to make selinux happy memory that would be marked with X-bit should
  * be obtained with mmap */
 #define XBYAK_USE_MMAP_ALLOCATOR
+/* Use Xbyak's memfd-based allocation, if available */
+#define XBYAK_USE_MEMFD
 #define XBYAK_NO_EXCEPTION
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 /* turn off `size_t to other-type implicit casting` warning

--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -101,8 +101,9 @@ struct reducer_2d_driver_t : public jit_generator {
     using data_t = typename prec_traits<data_type>::type;
 
     reducer_2d_driver_t(int n_src, size_t src_ld, size_t src_step,
-            size_t dst_step, bool nullify_dst)
-        : n_src_(n_src)
+            size_t dst_step, bool nullify_dst, const char *name)
+        : jit_generator(name)
+        , n_src_(n_src)
         , src_ld_(src_ld)
         , src_step_(src_step)
         , dst_step_(dst_step)
@@ -159,7 +160,7 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
     reducer_2d_driver_f_s_32_t(int n_src, size_t src_ld, size_t src_step,
             size_t dst_step, bool nullify_dst)
         : reducer_2d_driver_t<data_type>(
-                n_src, src_ld, src_step, dst_step, nullify_dst) {}
+                n_src, src_ld, src_step, dst_step, nullify_dst, jit_name()) {}
 
     void nullify_dst(int nloads, int load_len) {
         UNUSED(load_len);

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_copy_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_copy_kern.cpp
@@ -496,7 +496,7 @@ void jit_avx512_core_amx_copy_kern::generate() {
 
 jit_avx512_core_amx_copy_kern::jit_avx512_core_amx_copy_kern(
         bool is_a, bool is_trans, int isize)
-    : jit_generator(nullptr, 800000), arg_b_(0) {
+    : jit_generator(jit_name(), nullptr, 800000), arg_b_(0) {
 
     is_a_ = is_a;
     is_trans_ = is_trans;

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
@@ -457,7 +457,7 @@ void jit_avx512_core_amx_gemm_kern::generate() {
 
 jit_avx512_core_amx_gemm_kern::jit_avx512_core_amx_gemm_kern(
         int typea, int typeb, int typec, int betaZero)
-    : jit_generator(nullptr, 2 * 1024)
+    : jit_generator(jit_name(), nullptr, 2 * 1024)
     , typea(typea)
     , typeb(typeb)
     , typec(typec)

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_gemm_bf16bf16f32_kern.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_gemm_bf16bf16f32_kern.cpp
@@ -425,7 +425,7 @@ void jit_avx512_core_gemm_bf16bf16f32_kern::generate() {
 
 jit_avx512_core_gemm_bf16bf16f32_kern::jit_avx512_core_gemm_bf16bf16f32_kern(
         bool beta_zero, bool alpha_one, bool use_zmm)
-    : jit_generator(nullptr, 170000)
+    : jit_generator(jit_name(), nullptr, 170000)
     , arg_a_(0)
     , arg_b_(0)
     , arg_c_(0)

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_gemv_bf16bf16f32_kern.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_gemv_bf16bf16f32_kern.cpp
@@ -515,7 +515,7 @@ void jit_avx512_core_gemv_bf16bf16f32_kern::generate() {
 // Function signature: gemv(*m, *n, *alpha, *a, *lda, *x, *incx, *y, *incy)
 jit_avx512_core_gemv_bf16bf16f32_kern::jit_avx512_core_gemv_bf16bf16f32_kern(
         bool trans)
-    : jit_generator(nullptr, 20000)
+    : jit_generator(jit_name(), nullptr, 20000)
     , arg_lda_(0)
     , arg_x_(0)
     , arg_incx_(0)

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_24x8_copy_an_kern::jit_avx512_core_s16_24x8_copy_an_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_24x8_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_24x8_copy_at_kern::jit_avx512_core_s16_24x8_copy_at_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_24x8_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_24x8_copy_bn_kern::jit_avx512_core_s16_24x8_copy_bn_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_24x8_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_24x8_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_24x8_copy_bt_kern::jit_avx512_core_s16_24x8_copy_bt_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_24x8_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_48x8_copy_an_kern::jit_avx512_core_s16_48x8_copy_an_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_48x8_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_48x8_copy_at_kern::jit_avx512_core_s16_48x8_copy_at_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_48x8_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_48x8_copy_bn_kern::jit_avx512_core_s16_48x8_copy_bn_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_48x8_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/bf16/jit_avx512_core_s16_48x8_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_s16_48x8_copy_bt_kern::jit_avx512_core_s16_48x8_copy_bt_kern()
-    : jit_generator(nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S16_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_s16_48x8_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_f32_copy_an_kern::jit_avx2_f32_copy_an_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_f32_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_f32_copy_at_kern::jit_avx2_f32_copy_at_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_f32_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_f32_copy_bn_kern::jit_avx2_f32_copy_bn_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_f32_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx2_f32_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_f32_copy_bt_kern::jit_avx2_f32_copy_bt_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_f32_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx2_kernel_sgemm_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx2_kernel_sgemm_kern.cpp
@@ -435,7 +435,7 @@ void jit_avx2_kernel_sgemm_kern::generate() {
 }
 
 jit_avx2_kernel_sgemm_kern::jit_avx2_kernel_sgemm_kern(bool beta_zero)
-    : jit_generator(nullptr, 65536) {
+    : jit_generator(jit_name(), nullptr, 65536) {
 
     beta_zero_ = beta_zero;
 }

--- a/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
@@ -64,7 +64,7 @@ struct xbyak_gemm_t : public jit_generator {
     xbyak_gemm_t(char isTransA, char isTransB, float beta, bool hasBias = false,
             void *code_ptr = nullptr,
             size_t code_size = 80 * Xbyak::DEFAULT_MAX_CODE_SIZE)
-        : jit_generator(code_ptr, code_size)
+        : jit_generator(jit_name(), code_ptr, code_size)
         , isTransA(isTransA)
         , isTransB(isTransB)
         , beta(beta)

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_f32_copy_an_kern::jit_avx512_core_f32_copy_an_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_f32_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_at_kern_part1_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_at_kern_part1_autogen.cpp
@@ -25,7 +25,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_f32_copy_at_kern::jit_avx512_core_f32_copy_at_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_f32_copy_at_kern::generate() {
     Xbyak::Label l1f80;

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_f32_copy_bn_kern::jit_avx512_core_f32_copy_bn_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_f32_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_f32_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_f32_copy_bt_kern::jit_avx512_core_f32_copy_bt_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_f32_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
@@ -46,7 +46,10 @@ struct xbyak_gemm_smalln_tn_t : public jit_generator {
     xbyak_gemm_smalln_tn_t(int N, float beta, float alpha,
             void *code_ptr = nullptr,
             size_t code_size = 80 * Xbyak::DEFAULT_MAX_CODE_SIZE)
-        : jit_generator(code_ptr, code_size), N(N), beta(beta), alpha(alpha) {}
+        : jit_generator(jit_name(), code_ptr, code_size)
+        , N(N)
+        , beta(beta)
+        , alpha(alpha) {}
 
     void generate() override ATTRIBUTE_OPTIMIZE {
         using namespace Xbyak;

--- a/src/cpu/x64/gemm/f32/jit_avx_f32_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_f32_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_f32_copy_an_kern::jit_avx_f32_copy_an_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_f32_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx_f32_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_f32_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_f32_copy_at_kern::jit_avx_f32_copy_at_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_f32_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx_f32_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_f32_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_f32_copy_bn_kern::jit_avx_f32_copy_bn_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_f32_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx_f32_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_f32_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_f32_copy_bt_kern::jit_avx_f32_copy_bt_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_f32_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -63,7 +63,7 @@ struct xbyak_gemm_t : public jit_generator {
     xbyak_gemm_t(char isTransA, char isTransB, float beta, bool hasBias = false,
             void *code_ptr = nullptr,
             size_t code_size = 80 * Xbyak::DEFAULT_MAX_CODE_SIZE)
-        : jit_generator(code_ptr, code_size)
+        : jit_generator(jit_name(), code_ptr, code_size)
         , isTransA(isTransA)
         , isTransB(isTransB)
         , hasBias(hasBias)

--- a/src/cpu/x64/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
@@ -302,7 +302,7 @@ void jit_avx_gemv_t_f32_kern::generate() {
 
 // Function signature: gemv(*m, *n, *alpha, *a, *lda, *x, *incx, *y, *incy)
 jit_avx_gemv_t_f32_kern::jit_avx_gemv_t_f32_kern()
-    : jit_generator(nullptr, 100000)
+    : jit_generator(jit_name(), nullptr, 100000)
     , arg_lda_(0)
     , arg_x_(0)
     , arg_incx_(0)

--- a/src/cpu/x64/gemm/f32/jit_avx_kernel_b0_sgemm_kern_part1_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_kernel_b0_sgemm_kern_part1_autogen.cpp
@@ -25,7 +25,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_b0_sgemm_kern::jit_avx_kernel_b0_sgemm_kern()
-    : jit_generator(nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_b0_sgemm_kern::generate() {
     Xbyak::Label l259c;

--- a/src/cpu/x64/gemm/f32/jit_avx_kernel_sgemm_kern_part1_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_kernel_sgemm_kern_part1_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_sgemm_kern::jit_avx_kernel_sgemm_kern()
-    : jit_generator(nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_sgemm_kern::generate() {
     Xbyak::Label l1efc;

--- a/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_f32_copy_an_kern::jit_sse41_f32_copy_an_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_f32_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_f32_copy_at_kern::jit_sse41_f32_copy_at_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_f32_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_f32_copy_bn_kern::jit_sse41_f32_copy_bn_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_f32_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_f32_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_f32_copy_bt_kern::jit_sse41_f32_copy_bt_kern()
-    : jit_generator(nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_f32_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_sse41_gemv_n_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_gemv_n_f32_kern.cpp
@@ -312,7 +312,7 @@ void jit_sse41_gemv_n_f32_kern::generate() {
 
 // Function signature: gemv(*m, *n, *alpha, *a, *lda, *x, *incx, *y, *incy)
 jit_sse41_gemv_n_f32_kern::jit_sse41_gemv_n_f32_kern(void)
-    : jit_generator(nullptr, 100000)
+    : jit_generator(jit_name(), nullptr, 100000)
     , arg_lda_(0)
     , arg_x_(0)
     , arg_incx_(0)

--- a/src/cpu/x64/gemm/f32/jit_sse41_gemv_t_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_gemv_t_f32_kern.cpp
@@ -273,7 +273,7 @@ void jit_sse41_gemv_t_f32_kern::generate() {
 
 // Function signature: gemv(*m, *n, *alpha, *a, *lda, *x, *incx, *y, *incy)
 jit_sse41_gemv_t_f32_kern::jit_sse41_gemv_t_f32_kern()
-    : jit_generator(nullptr, 100000)
+    : jit_generator(jit_name(), nullptr, 100000)
     , arg_lda_(0)
     , arg_x_(0)
     , arg_incx_(0)

--- a/src/cpu/x64/gemm/f32/jit_sse41_kernel_b0_sgemm_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_kernel_b0_sgemm_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_kernel_b0_sgemm_kern::jit_sse41_kernel_b0_sgemm_kern()
-    : jit_generator(nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_b0_sgemm_kern::generate() {
 

--- a/src/cpu/x64/gemm/f32/jit_sse41_kernel_sgemm_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/f32/jit_sse41_kernel_sgemm_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_kernel_sgemm_kern::jit_sse41_kernel_sgemm_kern()
-    : jit_generator(nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, F32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_sgemm_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_gemm_s8u8s32_kern.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_gemm_s8u8s32_kern.cpp
@@ -454,7 +454,7 @@ void jit_avx2_gemm_s8u8s32_kern::generate() {
 
 jit_avx2_gemm_s8u8s32_kern::jit_avx2_gemm_s8u8s32_kern(bool beta_zero,
         bool enable_offset_c, bool enable_offset_r, int unroll_m)
-    : jit_generator(nullptr, 100000)
+    : jit_generator(jit_name(), nullptr, 100000)
     , arg_a_(0)
     , arg_b_(0)
     , arg_c_(0)

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_an_kern::jit_avx2_u8_copy_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_at_kern::jit_avx2_u8_copy_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_bn_kern::jit_avx2_u8_copy_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_bt_kern::jit_avx2_u8_copy_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_sum_an_kern::jit_avx2_u8_copy_sum_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_sum_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_sum_at_kern::jit_avx2_u8_copy_sum_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_sum_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_sum_bn_kern::jit_avx2_u8_copy_sum_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_sum_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_u8_copy_sum_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_u8_copy_sum_bt_kern::jit_avx2_u8_copy_sum_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_u8_copy_sum_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_an_kern::jit_avx2_vnni_u8_copy_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_at_kern::jit_avx2_vnni_u8_copy_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_bn_kern::jit_avx2_vnni_u8_copy_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_bt_kern::jit_avx2_vnni_u8_copy_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_sum_an_kern::jit_avx2_vnni_u8_copy_sum_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_sum_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_sum_at_kern::jit_avx2_vnni_u8_copy_sum_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_sum_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_sum_bn_kern::jit_avx2_vnni_u8_copy_sum_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_sum_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx2_vnni_u8_copy_sum_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx2_vnni_u8_copy_sum_bt_kern::jit_avx2_vnni_u8_copy_sum_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx2_vnni_u8_copy_sum_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_gemm_s8u8s32_kern.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_gemm_s8u8s32_kern.cpp
@@ -486,7 +486,7 @@ void jit_avx512_core_gemm_s8u8s32_kern::generate() {
 
 jit_avx512_core_gemm_s8u8s32_kern::jit_avx512_core_gemm_s8u8s32_kern(
         bool beta_zero, bool enable_offset_c, bool enable_offset_r)
-    : jit_generator(nullptr, 100000)
+    : jit_generator(jit_name(), nullptr, 100000)
     , arg_a_(0)
     , arg_b_(0)
     , arg_c_(0)

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_kernel_gemv_s8x8s32_kern.hpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_kernel_gemv_s8x8s32_kern.hpp
@@ -79,7 +79,7 @@ class jit_avx512_core_gemv_s8x8s32_kern : public jit_generator {
 
 public:
     jit_avx512_core_gemv_s8x8s32_kern(ver_t ver)
-        : jit_generator(nullptr, 32 * 1024), ver(ver) {}
+        : jit_generator(jit_name(), nullptr, 32 * 1024), ver(ver) {}
 };
 
 } // namespace x64

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_u8_copy_an_kern::jit_avx512_core_u8_copy_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_u8_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_u8_copy_at_kern::jit_avx512_core_u8_copy_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_u8_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_bn_kern_autogen.cpp
@@ -24,7 +24,8 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_u8_copy_bn_kern::jit_avx512_core_u8_copy_bn_kern(bool s8_case)
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE), s8_case(s8_case) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE)
+    , s8_case(s8_case) {}
 
 void jit_avx512_core_u8_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_bt_kern_autogen.cpp
@@ -24,7 +24,8 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_u8_copy_bt_kern::jit_avx512_core_u8_copy_bt_kern(bool s8_case)
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE), s8_case(s8_case) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE)
+    , s8_case(s8_case) {}
 
 void jit_avx512_core_u8_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_u8_copy_sum_an_kern::jit_avx512_core_u8_copy_sum_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_u8_copy_sum_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx512_core_u8_copy_sum_at_kern::jit_avx512_core_u8_copy_sum_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx512_core_u8_copy_sum_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_bn_kern_autogen.cpp
@@ -25,7 +25,8 @@ namespace x64 {
 
 jit_avx512_core_u8_copy_sum_bn_kern::jit_avx512_core_u8_copy_sum_bn_kern(
         bool s8_case)
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE), s8_case(s8_case) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE)
+    , s8_case(s8_case) {}
 
 void jit_avx512_core_u8_copy_sum_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_u8_copy_sum_bt_kern_autogen.cpp
@@ -25,7 +25,8 @@ namespace x64 {
 
 jit_avx512_core_u8_copy_sum_bt_kern::jit_avx512_core_u8_copy_sum_bt_kern(
         bool s8_case)
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE), s8_case(s8_case) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE)
+    , s8_case(s8_case) {}
 
 void jit_avx512_core_u8_copy_sum_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_b_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_b_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_b0_b_gemm_s8u8s32_kern::jit_avx_kernel_b0_b_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_b0_b_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_c_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_c_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_b0_c_gemm_s8u8s32_kern::jit_avx_kernel_b0_c_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_b0_c_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_b0_gemm_s8u8s32_kern::jit_avx_kernel_b0_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_b0_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_r_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b0_r_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_b0_r_gemm_s8u8s32_kern::jit_avx_kernel_b0_r_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_b0_r_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_b_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_b_gemm_s8u8s32_kern::jit_avx_kernel_b_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_b_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_c_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_c_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_c_gemm_s8u8s32_kern::jit_avx_kernel_c_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_c_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_gemm_s8u8s32_kern::jit_avx_kernel_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_r_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_kernel_r_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_kernel_r_gemm_s8u8s32_kern::jit_avx_kernel_r_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_avx_kernel_r_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_an_kern::jit_avx_u8_copy_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_at_kern::jit_avx_u8_copy_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_bn_kern::jit_avx_u8_copy_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_bt_kern::jit_avx_u8_copy_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_sum_an_kern::jit_avx_u8_copy_sum_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_sum_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_sum_at_kern::jit_avx_u8_copy_sum_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_sum_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_sum_bn_kern::jit_avx_u8_copy_sum_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_sum_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx_u8_copy_sum_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_avx_u8_copy_sum_bt_kern::jit_avx_u8_copy_sum_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_avx_u8_copy_sum_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_b_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_b_gemm_s8u8s32_kern_autogen.cpp
@@ -25,7 +25,7 @@ namespace x64 {
 
 jit_sse41_kernel_b0_b_gemm_s8u8s32_kern::
         jit_sse41_kernel_b0_b_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_b0_b_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_c_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_c_gemm_s8u8s32_kern_autogen.cpp
@@ -25,7 +25,7 @@ namespace x64 {
 
 jit_sse41_kernel_b0_c_gemm_s8u8s32_kern::
         jit_sse41_kernel_b0_c_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_b0_c_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_kernel_b0_gemm_s8u8s32_kern::jit_sse41_kernel_b0_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_b0_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_r_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b0_r_gemm_s8u8s32_kern_autogen.cpp
@@ -25,7 +25,7 @@ namespace x64 {
 
 jit_sse41_kernel_b0_r_gemm_s8u8s32_kern::
         jit_sse41_kernel_b0_r_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_b0_r_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_b_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_kernel_b_gemm_s8u8s32_kern::jit_sse41_kernel_b_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_b_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_c_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_c_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_kernel_c_gemm_s8u8s32_kern::jit_sse41_kernel_c_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_c_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_kernel_gemm_s8u8s32_kern::jit_sse41_kernel_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_r_gemm_s8u8s32_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_kernel_r_gemm_s8u8s32_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_kernel_r_gemm_s8u8s32_kern::jit_sse41_kernel_r_gemm_s8u8s32_kern()
-    : jit_generator(nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, S8U8S32_COMPUTE_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_kernel_r_gemm_s8u8s32_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_an_kern::jit_sse41_u8_copy_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_at_kern::jit_sse41_u8_copy_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_bn_kern::jit_sse41_u8_copy_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_bt_kern::jit_sse41_u8_copy_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_an_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_an_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_sum_an_kern::jit_sse41_u8_copy_sum_an_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_sum_an_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_at_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_at_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_sum_at_kern::jit_sse41_u8_copy_sum_at_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_sum_at_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_bn_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_bn_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_sum_bn_kern::jit_sse41_u8_copy_sum_bn_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_sum_bn_kern::generate() {
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_bt_kern_autogen.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_sse41_u8_copy_sum_bt_kern_autogen.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 jit_sse41_u8_copy_sum_bt_kern::jit_sse41_u8_copy_sum_bt_kern()
-    : jit_generator(nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
+    : jit_generator(jit_name(), nullptr, U8_COPY_KERNEL_CODE_SIZE) {}
 
 void jit_sse41_u8_copy_sum_bt_kern::generate() {
 

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -71,7 +71,8 @@ void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, size_t g_start, size_t g_end,
 
 template <data_type_t dst_data_type>
 gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
-    : jcp_(pd->jcp_)
+    : jit_generator(jit_name())
+    , jcp_(pd->jcp_)
     , do_sum_(dst_data_type != data_type::f32 && jcp_.with_sum)
     , max_data_reg_idx_(31)
     , max_unroll_(12)

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -47,7 +47,7 @@ using namespace Xbyak;
 jit_avx2_1x1_conv_kernel_f32::jit_avx2_1x1_conv_kernel_f32(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, avx2)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, avx2)
     , jcp(ajcp)
     , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -44,7 +44,7 @@ using namespace Xbyak;
 jit_avx2_conv_fwd_kernel_f32::jit_avx2_conv_fwd_kernel_f32(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, avx2)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, avx2)
     , jcp(ajcp)
     , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
@@ -144,7 +144,7 @@ struct jit_avx2_conv_bwd_data_kernel_f32 : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_bwd_data_kernel_f32)
 
     jit_avx2_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &diff_src_d,
@@ -250,7 +250,7 @@ struct jit_avx2_conv_bwd_weights_kernel_f32 : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_bwd_weights_kernel_f32)
 
     jit_avx2_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -50,7 +50,7 @@ using namespace Xbyak;
 jit_avx512_common_1x1_conv_kernel::jit_avx512_common_1x1_conv_kernel(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jcp(ajcp), attr_(attr) {
+    : jit_generator(jit_name()), jcp(ajcp), attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -94,7 +94,7 @@ template <typename Vmm>
 _jit_avx512_common_conv_fwd_kernel<Vmm>::_jit_avx512_common_conv_fwd_kernel(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jcp(ajcp), attr_(attr) {
+    : jit_generator(jit_name()), jcp(ajcp), attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -221,7 +221,7 @@ template <typename Vmm>
 struct _jit_avx512_common_conv_bwd_data_kernel_f32 : public jit_generator {
 
     _jit_avx512_common_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_avx512_common_conv_bwd_data_kernel_f32)
     jit_conv_conf_t jcp;
@@ -381,7 +381,7 @@ private:
 struct jit_avx512_common_conv_bwd_weights_kernel_f32 : public jit_generator {
 
     jit_avx512_common_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
 
     void generate() override {
         if (jcp.harness != harness_nxc)

--- a/src/cpu/x64/jit_avx512_common_resampling.cpp
+++ b/src/cpu/x64/jit_avx512_common_resampling.cpp
@@ -50,7 +50,7 @@ struct jit_avx512_common_resampling_kernel_t
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_common_resampling)
 
     jit_avx512_common_resampling_kernel_t(const resampling_pd_t *pd)
-        : jit_avx512_common_resampling_kernel_base_t(pd)
+        : jit_avx512_common_resampling_kernel_base_t(pd, jit_name())
         , is_saturation_needed_(utils::one_of(dst_data_type(), data_type::u8,
                   data_type::s8, data_type::s32)) {
 
@@ -787,8 +787,9 @@ private:
 } // namespace
 
 jit_avx512_common_resampling_kernel_base_t::
-        jit_avx512_common_resampling_kernel_base_t(const resampling_pd_t *pd)
-    : pd_(pd) {}
+        jit_avx512_common_resampling_kernel_base_t(
+                const resampling_pd_t *pd, const char *name)
+    : jit_generator(name), pd_(pd) {}
 
 data_type_t jit_avx512_common_resampling_kernel_base_t::src_data_type() const {
     if (pd_->is_fwd())

--- a/src/cpu/x64/jit_avx512_common_resampling.hpp
+++ b/src/cpu/x64/jit_avx512_common_resampling.hpp
@@ -33,7 +33,8 @@ namespace x64 {
 struct jit_resampling_args_t;
 
 struct jit_avx512_common_resampling_kernel_base_t : public jit_generator {
-    jit_avx512_common_resampling_kernel_base_t(const resampling_pd_t *pd);
+    jit_avx512_common_resampling_kernel_base_t(
+            const resampling_pd_t *pd, const char *name);
     virtual ~jit_avx512_common_resampling_kernel_base_t() = default;
 
 protected:

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -39,7 +39,7 @@ using namespace Xbyak;
 jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
     , jcp(ajcp)
     , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1050,7 +1050,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
 jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
     , jcp(ajcp)
     , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -41,7 +41,8 @@ struct jit_avx512_core_amx_compute_zp_pbuff_t : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_amx_compute_zp_pbuff_t)
 
     jit_avx512_core_amx_compute_zp_pbuff_t(const jit_conv_conf_t &ajcp)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
         , jcp(ajcp) {}
 
     static const int max_regs_ur = 30;
@@ -109,7 +110,8 @@ struct jit_avx512_core_amx_copy_to_wbuffer_t : public jit_generator {
     using reg64_t = Xbyak::Reg64;
 
     jit_avx512_core_amx_copy_to_wbuffer_t(const jit_conv_conf_t &ajcp)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
         , jcp(ajcp) {}
 
 private:
@@ -135,7 +137,8 @@ struct jit_avx512_core_amx_copy_to_pbuffer_t : public jit_generator {
     using reg64_t = Xbyak::Reg64;
 
     jit_avx512_core_amx_copy_to_pbuffer_t(const jit_conv_conf_t &ajcp)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
         , jcp(ajcp) {}
 
 private:
@@ -423,7 +426,8 @@ struct jit_avx512_core_amx_bwd_data_copy_kernel_t : public jit_generator {
     using reg64_t = Xbyak::Reg64;
 
     jit_avx512_core_amx_bwd_data_copy_kernel_t(jit_conv_conf_t ajcp)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
         , jcp(ajcp) {}
 
 private:
@@ -469,7 +473,8 @@ struct jit_avx512_core_amx_bwd_data_kernel_t : public jit_generator {
 
     jit_avx512_core_amx_bwd_data_kernel_t(
             const jit_conv_conf_t ajcp, const primitive_attr_t &attr)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
         , jcp(ajcp)
         , attr_(attr)
         , eltwise_injector_(nullptr) {
@@ -607,7 +612,8 @@ private:
 struct jit_avx512_core_amx_bwd_weights_kernel_t : public jit_generator {
 
     jit_avx512_core_amx_bwd_weights_kernel_t(const jit_conv_conf_t &ajcp)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
         , jcp(ajcp) {}
 
     ~jit_avx512_core_amx_bwd_weights_kernel_t() {}

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -44,7 +44,7 @@ using namespace Xbyak;
 jit_avx512_core_bf16_1x1_conv_kernel::jit_avx512_core_bf16_1x1_conv_kernel(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, ker_code_size, true, avx512_core_bf16)
+    : jit_generator(jit_name(), nullptr, ker_code_size, true, avx512_core_bf16)
     , jcp(ajcp)
     , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -98,7 +98,7 @@ template <typename Vmm>
 _jit_avx512_core_bf16_fwd_kernel<Vmm>::_jit_avx512_core_bf16_fwd_kernel(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, ker_code_size, true, avx512_core_bf16)
+    : jit_generator(jit_name(), nullptr, ker_code_size, true, avx512_core_bf16)
     , jcp(ajcp)
     , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -253,7 +253,8 @@ template <typename Vmm>
 struct _jit_avx512_core_bf16_bwd_data_kernel : public jit_generator {
 
     _jit_avx512_core_bf16_bwd_data_kernel(const jit_conv_conf_t &ajcp)
-        : jit_generator(nullptr, ker_code_size, true, avx512_core_bf16)
+        : jit_generator(
+                jit_name(), nullptr, ker_code_size, true, avx512_core_bf16)
         , jcp(ajcp)
         , bf16_emu_(nullptr) {
         if (!isa_has_bf16(jcp.isa))
@@ -461,7 +462,8 @@ struct jit_avx512_core_bf16_conv_bwd_weights_kernel_f32 : public jit_generator {
 
     jit_avx512_core_bf16_conv_bwd_weights_kernel_f32(
             const jit_conv_conf_t &ajcp)
-        : jit_generator(nullptr, ker_code_size, true, avx512_core_bf16)
+        : jit_generator(
+                jit_name(), nullptr, ker_code_size, true, avx512_core_bf16)
         , jcp(ajcp)
         , bf16_emu_(nullptr) {
         if (!isa_has_bf16(jcp.isa)) {

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -35,7 +35,7 @@ using namespace dnnl::impl::utils;
 
 jit_avx512_dw_conv_fwd_kernel_bf16::jit_avx512_dw_conv_fwd_kernel_bf16(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
-    : jcp(ajcp) {
+    : jit_generator(jit_name()), jcp(ajcp) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -130,7 +130,7 @@ struct jit_avx512_dw_conv_bwd_data_kernel_bf16 : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_bwd_data_kernel_bf16)
 
     jit_avx512_dw_conv_bwd_data_kernel_bf16(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp), bf16_emu_(nullptr) {
+        : jit_generator(jit_name()), jcp(ajcp), bf16_emu_(nullptr) {
 
         if (!isa_has_bf16(jcp.isa))
             bf16_emu_ = new bf16_emulation_t(this, bf16_emu_reserv_1,
@@ -207,7 +207,7 @@ struct jit_avx512_dw_conv_bwd_weights_kernel_bf16 : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_bwd_weights_kernel_bf16)
 
     jit_avx512_dw_conv_bwd_weights_kernel_bf16(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp), bf16_emu_(nullptr) {
+        : jit_generator(jit_name()), jcp(ajcp), bf16_emu_(nullptr) {
 
         if (!isa_has_bf16(jcp.isa))
             bf16_emu_ = new bf16_emulation_t(this, bf16_emu_reserv_1,

--- a/src/cpu/x64/jit_avx512_core_bf16_sum.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_sum.hpp
@@ -49,7 +49,7 @@ struct jit_sum_call_s {
 
 struct jit_avx512_core_bf16_sum_kernel : public jit_generator {
     jit_avx512_core_bf16_sum_kernel(jit_sum_conf_t ajsp)
-        : jsp(ajsp), bf16_emu_(nullptr) {
+        : jit_generator(jit_name()), jsp(ajsp), bf16_emu_(nullptr) {
         if (!mayiuse(avx512_core_bf16))
             bf16_emu_ = new bf16_emulation_t(this, bf16_emu_reserved_1,
                     bf16_emu_reserved_2, bf16_emu_reserved_3, bf16_emu_scratch,

--- a/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
@@ -176,7 +176,8 @@ struct jit_avx512_core_cvt_ps_to_bf16_t : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_cvt_ps_to_bf16)
 
     jit_avx512_core_cvt_ps_to_bf16_t(size_t nelems = 0)
-        : nelems_(nelems)
+        : jit_generator(jit_name())
+        , nelems_(nelems)
         , simd_w_(16)
         , tail_mask_((1 << (nelems % simd_w_)) - 1)
         , is_dynamic_size_(nelems_ == 0) {
@@ -319,7 +320,9 @@ struct jit_avx512_core_cvt_bf16_to_ps_t : public jit_generator {
 
     jit_avx512_core_cvt_bf16_to_ps_t(
             bool with_add = false, size_t row_stride = 0)
-        : with_add_(with_add), row_stride_(row_stride) {
+        : jit_generator(jit_name())
+        , with_add_(with_add)
+        , row_stride_(row_stride) {
         create_kernel();
     }
 
@@ -341,7 +344,8 @@ private:
 struct jit_avx512_core_add_cvt_ps_to_bf16_t : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_add_cvt_ps_to_bf16)
 
-    jit_avx512_core_add_cvt_ps_to_bf16_t() : simd_w_(16) {
+    jit_avx512_core_add_cvt_ps_to_bf16_t()
+        : jit_generator(jit_name()), simd_w_(16) {
         bf16_emu_ = new bf16_emulation_t(
                 this, one, even, selector, scratch, fp32_tmp, fp32_tmp);
 
@@ -453,10 +457,10 @@ struct jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_bf16_reorder_s16c_to_S16c2s)
 
     jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t()
-        : simd_w_(16), in_stride_(16) {}
+        : jit_generator(jit_name()), simd_w_(16), in_stride_(16) {}
 
     jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t(int in_stride)
-        : simd_w_(16), in_stride_(in_stride) {}
+        : jit_generator(jit_name()), simd_w_(16), in_stride_(in_stride) {}
 
     ~jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t() {}
 

--- a/src/cpu/x64/jit_avx512_core_f32_wino_conv_2x3.cpp
+++ b/src/cpu/x64/jit_avx512_core_f32_wino_conv_2x3.cpp
@@ -52,7 +52,7 @@ struct jit_avx512_core_f32_wino_conv_2x3_src_trans_t : public jit_generator {
 
     jit_avx512_core_f32_wino_conv_2x3_src_trans_t(
             const jit_conv_conf_2x3_wino_t &ajcp, const primitive_attr_t &attr)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
 
     void generate() override;
 
@@ -177,7 +177,7 @@ struct jit_avx512_core_f32_wino_conv_2x3_dst_trans_t : public jit_generator {
 
     jit_avx512_core_f32_wino_conv_2x3_dst_trans_t(
             const jit_conv_conf_2x3_wino_t &ajcp, const primitive_attr_t &attr)
-        : jcp(ajcp), attr_(attr) {}
+        : jit_generator(jit_name()), jcp(ajcp), attr_(attr) {}
 
     void generate() override;
     bool maybe_relu(int position);
@@ -380,7 +380,7 @@ struct jit_avx512_core_f32_wino_conv_2x3_fwd_ker_t : public jit_generator {
 
     jit_avx512_core_f32_wino_conv_2x3_fwd_ker_t(
             const jit_conv_conf_2x3_wino_t &ajcp, const primitive_attr_t &attr)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
 
     static status_t init_conf(jit_conv_conf_2x3_wino_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_md,

--- a/src/cpu/x64/jit_avx512_core_f32_wino_conv_4x3_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_f32_wino_conv_4x3_kernel.hpp
@@ -36,7 +36,7 @@ constexpr int simd_w = 16;
 struct _jit_avx512_core_f32_wino_conv_4x3_data_kernel : public jit_generator {
     _jit_avx512_core_f32_wino_conv_4x3_data_kernel(
             const jit_conv_winograd_conf_t &ajcp)
-        : jit_generator(nullptr, MAX_CODE_SIZE, false, avx512_core)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, false, avx512_core)
         , jcp(ajcp) {}
 
     void generate() override {
@@ -194,7 +194,7 @@ struct jit_avx512_core_f32_wino_conv_4x3_bwd_weights_kernel
 
     jit_avx512_core_f32_wino_conv_4x3_bwd_weights_kernel(
             const jit_conv_winograd_conf_t &ajcp)
-        : jit_generator(nullptr, MAX_CODE_SIZE, false, avx512_core)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, false, avx512_core)
         , jcp(ajcp) {}
 
     void generate() override {

--- a/src/cpu/x64/jit_avx512_core_u8s8s32x_wino_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_u8s8s32x_wino_convolution.cpp
@@ -67,7 +67,10 @@ struct jit_avx512_core_u8s8s32x_wino_conv_src_trans_t : public jit_generator {
 
     jit_avx512_core_u8s8s32x_wino_conv_src_trans_t(
             jit_conv_conf_2x3_wino_t ajcp, const primitive_attr_t &attr)
-        : jcp(ajcp), attr_(attr), unsign_val_in_wino_domain(5) {}
+        : jit_generator(jit_name())
+        , jcp(ajcp)
+        , attr_(attr)
+        , unsign_val_in_wino_domain(5) {}
     void generate() override;
 
     int reg_inp_ind(int i) const {
@@ -263,7 +266,7 @@ struct jit_avx512_core_u8s8s32x_wino_conv_dst_trans_t : public jit_generator {
 
     jit_avx512_core_u8s8s32x_wino_conv_dst_trans_t(
             jit_conv_conf_2x3_wino_t ajcp, const primitive_attr_t &attr)
-        : jcp(ajcp), attr_(attr) {}
+        : jit_generator(jit_name()), jcp(ajcp), attr_(attr) {}
 
     void generate() override;
     bool maybe_relu(int position);
@@ -532,7 +535,7 @@ struct jit_avx512_core_u8s8s32x_wino_conv_fwd_ker_t : public jit_generator {
 
     jit_avx512_core_u8s8s32x_wino_conv_fwd_ker_t(
             jit_conv_conf_2x3_wino_t ajcp, const primitive_attr_t &attr)
-        : jcp(ajcp), attr_(attr) {}
+        : jit_generator(jit_name()), jcp(ajcp), attr_(attr) {}
 
     static status_t init_conf(jit_conv_conf_2x3_wino_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_md,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -48,7 +48,10 @@ _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Vmm>::
         _jit_avx512_core_x8s8s32x_1x1_conv_kernel(
                 const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
                 const memory_desc_t &dst_md)
-    : jcp(ajcp), attr_(attr), postops_injector_(nullptr) {
+    : jit_generator(jit_name())
+    , jcp(ajcp)
+    , attr_(attr)
+    , postops_injector_(nullptr) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -56,7 +56,10 @@ template <typename Vmm>
 _jit_avx512_core_x8s8s32x_fwd_kernel<Vmm>::_jit_avx512_core_x8s8s32x_fwd_kernel(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jcp(ajcp), attr_(attr), postops_injector_(nullptr) {
+    : jit_generator(jit_name())
+    , jcp(ajcp)
+    , attr_(attr)
+    , postops_injector_(nullptr) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -43,7 +43,10 @@ template <typename Vmm>
 jit_avx512_core_x8s8s32x_deconv_fwd_kernel<Vmm>::
         jit_avx512_core_x8s8s32x_deconv_fwd_kernel(const jit_conv_conf_t &ajcp,
                 const primitive_attr_t &attr, const memory_desc_t &dst_md)
-    : jcp(ajcp), attr_(attr), postops_injector_(nullptr) {
+    : jit_generator(jit_name())
+    , jcp(ajcp)
+    , attr_(attr)
+    , postops_injector_(nullptr) {
 
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         const std::size_t tail_size = jcp.is_depthwise

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -33,7 +33,8 @@ namespace jit_avx512_core_brgemm_conv_comp_pad_kernel {
 jit_avx512_core_brgemm_conv_comp_pad_kernel_t::
         jit_avx512_core_brgemm_conv_comp_pad_kernel_t(
                 const jit_brgemm_conv_conf_t &ajcp)
-    : jcp_(ajcp)
+    : jit_generator(jit_name())
+    , jcp_(ajcp)
     , inp_dsz_(jcp_.wei_dsz)
     , out_dsz_(jcp_.acc_dsz)
     , nb_ic_(utils::div_up(jcp_.ic, 4))

--- a/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
@@ -32,8 +32,8 @@ namespace jit_avx512_core_brgemm_conv_trans_kernel {
 
 jit_avx512_core_brgemm_conv_trans_kernel_t::
         jit_avx512_core_brgemm_conv_trans_kernel_t(
-                const jit_brgemm_conv_conf_t &ajcp)
-    : jcp(ajcp) {
+                const jit_brgemm_conv_conf_t &ajcp, const char *name)
+    : jit_generator(name), jcp(ajcp) {
     inp_dsz = jcp.src_dsz;
     ic_block_sz = inp_dsz * jcp.ic_block;
     dst_w_block = dst_w(jcp.ow_block);
@@ -394,7 +394,7 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block_body(
 jit_avx512_core_brgemm_conv_rtus_kernel_t::
         jit_avx512_core_brgemm_conv_rtus_kernel_t(
                 const jit_brgemm_conv_conf_t &ajcp)
-    : jit_avx512_core_brgemm_conv_trans_kernel_t(ajcp) {
+    : jit_avx512_core_brgemm_conv_trans_kernel_t(ajcp, jit_name()) {
     ic_block_sz = inp_dsz * jcp.LDA; // output may or may not be zero padded
     dst_h_offset = jcp.iwp * ic_block_sz;
 }

--- a/src/cpu/x64/jit_brgemm_conv_trans_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_trans_kernel.hpp
@@ -42,7 +42,7 @@ struct jit_avx512_core_brgemm_conv_trans_kernel_t : public jit_generator {
     using reg64_t = const Xbyak::Reg64;
 
     jit_avx512_core_brgemm_conv_trans_kernel_t(
-            const jit_brgemm_conv_conf_t &ajcp);
+            const jit_brgemm_conv_conf_t &ajcp, const char *name = jit_name());
 
     int dst_w(int out_w) const;
 

--- a/src/cpu/x64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.hpp
@@ -46,7 +46,8 @@ struct brgemm_kernel_diff_bias_t {
 struct jit_brgemm_kernel_diff_bias_t : public jit_generator {
     jit_brgemm_kernel_diff_bias_t(
             const jit_brgemm_primitive_conf_t &ajbgp, const brgemm_t &abrg)
-        : brg_(abrg)
+        : jit_generator(jit_name())
+        , brg_(abrg)
         , ddst_dt_(ajbgp.dst_dt)
         , bia_dt_(ajbgp.bia_dt)
         , acc_dt_(ajbgp.acc_dt)
@@ -274,7 +275,8 @@ struct jit_brgemm_kernel_post_ops : public jit_generator {
 
     jit_brgemm_kernel_post_ops(const jit_brgemm_conv_conf_t &ajcp,
             const brgemm_t &abrg, const primitive_attr_t &aattr)
-        : brg(abrg)
+        : jit_generator(jit_name())
+        , brg(abrg)
         , jcp(ajcp)
         , attr(aattr)
         , postops_injector_(nullptr)

--- a/src/cpu/x64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.cpp
@@ -38,7 +38,7 @@ struct jit_brgemm_trans_m_k_f32_t : public jit_brgemm_trans_src_t,
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_m_k_f32_t)
 
     jit_brgemm_trans_m_k_f32_t(const jit_brgemm_primitive_conf_t *conf)
-        : jit_brgemm_trans_src_t(conf) {}
+        : jit_brgemm_trans_src_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -317,7 +317,7 @@ struct jit_brgemm_trans_m_k_bf16_t : public jit_brgemm_trans_src_t,
                                      public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_m_k_bf16_t)
     jit_brgemm_trans_m_k_bf16_t(const jit_brgemm_primitive_conf_t *conf)
-        : jit_brgemm_trans_src_t(conf) {}
+        : jit_brgemm_trans_src_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -883,7 +883,8 @@ struct jit_trans_to_vnni_t : public jit_brgemm_trans_to_vnni_t,
     jit_trans_to_vnni_t(const jit_brgemm_primitive_conf_t *conf,
             jit_brgemm_trans_to_vnni_t::matrix_to_transform_t
                     matrix_to_transform)
-        : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform) {}
+        : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform)
+        , jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -1185,7 +1186,8 @@ struct jit_copy_f32_t : public jit_brgemm_trans_to_vnni_t,
     jit_copy_f32_t(const jit_brgemm_primitive_conf_t *conf,
             jit_brgemm_trans_to_vnni_t::matrix_to_transform_t
                     matrix_to_transform)
-        : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform) {}
+        : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform)
+        , jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -1326,7 +1328,7 @@ struct jit_brgemm_trans_wei_f32_t : public jit_brgemm_trans_wei_t,
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_wei_f32_t)
 
     jit_brgemm_trans_wei_f32_t(const jit_brgemm_primitive_conf_t *conf)
-        : jit_brgemm_trans_wei_t(conf) {}
+        : jit_brgemm_trans_wei_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -1621,7 +1623,7 @@ struct jit_brgemm_trans_wei_bf16_t : public jit_brgemm_trans_wei_t,
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_wei_bf16_t)
 
     jit_brgemm_trans_wei_bf16_t(const jit_brgemm_primitive_conf_t *conf)
-        : jit_brgemm_trans_wei_t(conf) {}
+        : jit_brgemm_trans_wei_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -1861,7 +1863,8 @@ struct jit_amx_ip_trans_diff_wei_to_vnni_t : public jit_amx_ip_trans_diff_wei,
 
     jit_amx_ip_trans_diff_wei_to_vnni_t(const jit_brgemm_primitive_conf_t *jbgp,
             const int ext_ic_block, const int ext_oc_block)
-        : jit_amx_ip_trans_diff_wei(jbgp, ext_ic_block, ext_oc_block) {}
+        : jit_amx_ip_trans_diff_wei(jbgp, ext_ic_block, ext_oc_block)
+        , jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }

--- a/src/cpu/x64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.hpp
@@ -59,7 +59,8 @@ struct jit_brgemm_copy_to_coarse_t : public jit_generator {
     status_t create_kernel() override { return jit_generator::create_kernel(); }
 
     jit_brgemm_copy_to_coarse_t(const jit_brgemm_primitive_conf_t *conf)
-        : conf_(conf)
+        : jit_generator(jit_name())
+        , conf_(conf)
         , typesize_(conf_->isa == avx512_core_bf16_amx_int8
                           ? sizeof(int8_t)
                           : sizeof(bfloat16_t))

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -268,7 +268,8 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
         const primitive_attr_t *attr, data_type_t bias_dt, data_type_t acc_dt,
         const memory_desc_t *dst_md, bool skip_sum)
     : pp_kernel_t(
-            OC, MB, dst_mb_stride, attr, bias_dt, acc_dt, dst_md, skip_sum) {
+            OC, MB, dst_mb_stride, attr, bias_dt, acc_dt, dst_md, skip_sum)
+    , jit_generator(jit_name()) {
     assert(IMPLICATION(this->dst_data_type_ == bf16, mayiuse(avx512_core)));
 
     if (this->do_scale_) vreg_scale = Vmm(idx_compute_vreg_start_++);

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -142,6 +142,7 @@ private:
 jit_pp_ker_t::jit_pp_ker_t(
         const convolution_pd_t *pd, const conv_gemm_conf_t &jcp)
     : pp_ker_t(pd, jcp)
+    , jit_generator(jit_name())
     , number_of_reserved_zmm_regs_(0)
     , bias_data_type_size_(jcp.bias_data_type != data_type::undef
                       ? types::data_type_size(jcp.bias_data_type)

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -142,7 +142,9 @@ constexpr Xbyak::Operand::Code abi_not_param_reg =
 
 #endif
 
-class jit_generator : public Xbyak::CodeGenerator, public c_compatible {
+class jit_generator : public Xbyak::MmapAllocator,
+                      public Xbyak::CodeGenerator,
+                      public c_compatible {
 public:
     using c_compatible::operator new;
     using c_compatible::operator new[];
@@ -2175,11 +2177,14 @@ public:
 public:
     /* All uni_ instructions -- apart from uni_vzeroupper() -- will comply with
      * the max_cpu_isa argument */
-    jit_generator(void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE,
-            bool use_autogrow = true, cpu_isa_t max_cpu_isa = isa_all)
-        : Xbyak::CodeGenerator(code_size,
-                (code_ptr == nullptr && use_autogrow) ? Xbyak::AutoGrow
-                                                      : code_ptr)
+    jit_generator(const char *name, void *code_ptr = nullptr,
+            size_t code_size = MAX_CODE_SIZE, bool use_autogrow = true,
+            cpu_isa_t max_cpu_isa = isa_all)
+        : Xbyak::MmapAllocator(name)
+        , Xbyak::CodeGenerator(code_size,
+                  (code_ptr == nullptr && use_autogrow) ? Xbyak::AutoGrow
+                                                        : code_ptr,
+                  /*allocator=*/this)
         , max_cpu_isa_(max_cpu_isa) {}
 
     virtual ~jit_generator() {}

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -44,9 +44,13 @@
 #define ATTRIBUTE_OPTIMIZE
 #endif
 
-#define DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_name) \
-    const char *name() const override { return STRINGIFY(jit_name); } \
-    const char *source_file() const override { return __FILE__; }
+#define DECLARE_CPU_JIT_AUX_FUNCTIONS(gen_name) \
+    const char *name() const override { return STRINGIFY(gen_name); } \
+    const char *source_file() const override { return __FILE__; } \
+    static const char *jit_name() { \
+        static constexpr char ret[] = "/oneDNN:" STRINGIFY(gen_name); \
+        return ret; \
+    }
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -41,7 +41,7 @@ using namespace Xbyak;
 jit_sse41_1x1_conv_kernel_f32::jit_sse41_1x1_conv_kernel_f32(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, sse41)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, sse41)
     , jcp(ajcp)
     , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -40,7 +40,9 @@ using namespace Xbyak;
 jit_sse41_conv_fwd_kernel_f32::jit_sse41_conv_fwd_kernel_f32(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, sse41), jcp(ajcp), attr_(attr) {
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, sse41)
+    , jcp(ajcp)
+    , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary) {
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -36,7 +36,7 @@ using namespace Xbyak;
 struct jit_trans_iw_ic_int16_t : public jit_trans_src_t, public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_trans_iw_ic_int16_t)
     jit_trans_iw_ic_int16_t(const jit_conv_conf_t *conf)
-        : jit_trans_src_t(conf) {}
+        : jit_trans_src_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
 
@@ -473,7 +473,8 @@ void jit_trans_iw_ic_int16_t::generate() {
 
 struct jit_trans_ow_oc_t : public jit_trans_dst_t, public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_trans_ow_oc_t)
-    jit_trans_ow_oc_t(const jit_conv_conf_t *conf) : jit_trans_dst_t(conf) {}
+    jit_trans_ow_oc_t(const jit_conv_conf_t *conf)
+        : jit_trans_dst_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
 

--- a/src/cpu/x64/jit_transpose_utils.hpp
+++ b/src/cpu/x64/jit_transpose_utils.hpp
@@ -80,7 +80,7 @@ struct jit_transpose4x16_src : public jit_generator {
 
     jit_transpose4x16_src(const jit_1x1_conv_conf_t *aparams,
             jit_transpose4x16_src_t *tparams_)
-        : params(aparams), tparams(tparams_) {}
+        : jit_generator(jit_name()), params(aparams), tparams(tparams_) {}
 
     const jit_1x1_conv_conf_t *params;
     const jit_transpose4x16_src_t *tparams;
@@ -122,7 +122,8 @@ struct jit_diff_wei_trans_to_vnni_t : public jit_generator {
 
     jit_diff_wei_trans_to_vnni_t(const int &kd, const int &kh, const int &kw,
             const int &ic_block, const int &oc_block)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, avx512_core_bf16)
+        : jit_generator(
+                jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_bf16)
         , kd_(kd)
         , kh_(kh)
         , kw_(kw)

--- a/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
@@ -169,7 +169,7 @@ struct rtus_driver_t : public jit_generator {
     rtus_driver_t(int iw, int stride_w, int src_step_h, int src_step_icb,
             int ws_step_icb, bool src_to_ws, size_t typesize, int ic,
             bool is_nspc = false)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, isa)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
         , iw_(iw)
         , stride_w_(stride_w)
         , src_step_h_(src_step_h)

--- a/src/cpu/x64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.cpp
@@ -1730,7 +1730,8 @@ struct jit_bnorm_t : public jit_generator {
         }
     }
 
-    jit_bnorm_t(const batch_normalization_pd_t *bdesc) : bdesc_(bdesc) {
+    jit_bnorm_t(const batch_normalization_pd_t *bdesc)
+        : jit_generator(jit_name()), bdesc_(bdesc) {
         static_assert(isa == sse41 || isa == avx2 || isa == avx512_core,
                 "unsupported isa");
 

--- a/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
@@ -207,7 +207,8 @@ struct jit_bnorm_base_t : public jit_generator {
         postamble();
     }
 
-    jit_bnorm_base_t(const batch_normalization_pd_t *pd) : pd_(pd) {}
+    jit_bnorm_base_t(const batch_normalization_pd_t *pd)
+        : jit_generator(jit_name()), pd_(pd) {}
 };
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -33,8 +33,9 @@ static bcast_set_t get_supported_postops_bcast_strategies() {
 }
 
 binary_kernel_t::binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
-        const jit_binary_conf_t conf, bool tail_kernel)
-    : vlen_(vlen)
+        const jit_binary_conf_t conf, const char *name, bool tail_kernel)
+    : jit_generator(name)
+    , vlen_(vlen)
     , simd_w_(vlen / sizeof(float))
     , pd_(pd)
     , conf_(conf)
@@ -82,7 +83,8 @@ size_t binary_kernel_t::get_tail_size() const {
 template <cpu_isa_t isa>
 jit_uni_binary_kernel_t<isa>::jit_uni_binary_kernel_t(
         const binary_pd_t *pd, const jit_binary_conf_t conf, bool tail_kernel)
-    : binary_kernel_t(cpu_isa_traits<isa>::vlen, pd, conf, tail_kernel)
+    : binary_kernel_t(
+            cpu_isa_traits<isa>::vlen, pd, conf, jit_name(), tail_kernel)
     , offt_src0_(vlen_ / (conf_.is_bf16 ? 2 : 1))
     , offt_src1_(conf_.use_stride_src1 ? offt_src0_ : 0)
     , io_(this, isa, {conf_.src0_type, conf_.src1_type, conf_.dst_type},

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -43,7 +43,8 @@ struct binary_kernel_t : public jit_generator {
     using bcast_t = binary_bcast_t;
 
     binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
-            const jit_binary_conf_t conf, bool tail_kernel = false);
+            const jit_binary_conf_t conf, const char *name,
+            bool tail_kernel = false);
     ~binary_kernel_t() override = default;
 
     void operator()(jit_binary_call_s *p) { jit_generator::operator()(p); }

--- a/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -29,7 +29,8 @@ namespace zp {
 
 jit_uni_deconv_zp_pad_str_kernel_base_t::
         jit_uni_deconv_zp_pad_str_kernel_base_t(const jit_conv_conf_t &jcp)
-    : jcp_(jcp)
+    : jit_generator(jit_name())
+    , jcp_(jcp)
     , tail_size_(jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
                                   : jcp.oc_without_padding % jcp.oc_block) {}
 

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -38,7 +38,7 @@ using namespace Xbyak;
 template <cpu_isa_t isa>
 jit_uni_dw_conv_fwd_kernel_f32<isa>::jit_uni_dw_conv_fwd_kernel_f32(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, isa), jcp(ajcp) {
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa), jcp(ajcp) {
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
@@ -129,7 +129,7 @@ struct jit_uni_dw_conv_bwd_data_kernel_f32 : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32)
 
     jit_uni_dw_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
     jit_conv_conf_t jcp;
 
 private:
@@ -194,7 +194,7 @@ struct jit_uni_dw_conv_bwd_weights_kernel_f32 : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_weights_kernel_f32)
 
     jit_uni_dw_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
-        : jcp(ajcp) {}
+        : jit_generator(jit_name()), jcp(ajcp) {}
 
     jit_conv_conf_t jcp;
 

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -43,7 +43,8 @@ struct jit_args_t {
 };
 
 struct jit_uni_eltwise_kernel : public jit_generator {
-    jit_uni_eltwise_kernel(const eltwise_pd_t *pd) : pd_(pd) {}
+    jit_uni_eltwise_kernel(const eltwise_pd_t *pd, const char *name)
+        : jit_generator(name), pd_(pd) {}
 
     void operator()(jit_args_t *p) { jit_generator::operator()(p); }
 
@@ -123,7 +124,8 @@ template <cpu_isa_t isa>
 struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_kernel)
 
-    jit_uni_kernel_t(const eltwise_pd_t *pd) : jit_uni_eltwise_kernel(pd) {
+    jit_uni_kernel_t(const eltwise_pd_t *pd)
+        : jit_uni_eltwise_kernel(pd, jit_name()) {
         if (is_bf16()) {
             if (!mayiuse(avx512_core_bf16))
                 bf16_emu_.reset(new bf16_emulation_t(this, bf16_emu_reserv_1,

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -38,7 +38,8 @@ struct jit_args_t {
 };
 
 struct jit_uni_eltwise_int_kernel : public jit_generator {
-    jit_uni_eltwise_int_kernel(const eltwise_desc_t &desc) : desc_(desc) {}
+    jit_uni_eltwise_int_kernel(const eltwise_desc_t &desc, const char *name)
+        : jit_generator(name), desc_(desc) {}
 
     void operator()(jit_args_t *p) { jit_generator::operator()(p); }
 
@@ -61,7 +62,7 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_subkernel_int)
 
     jit_uni_subkernel_int_t(const eltwise_desc_t &desc)
-        : jit_uni_eltwise_int_kernel(desc) {
+        : jit_uni_eltwise_int_kernel(desc, jit_name()) {
         using namespace data_type;
 
         // Relu and linear for int types: s32, s8, u8; Only forward direction

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -231,7 +231,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator {
 
     jit_uni_i8i8_pooling_fwd_ker_t(
             const jit_pool_conf_t &jpp_, const memory_desc_t *dst_md)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, isa)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
         , jpp(jpp_)
         , postops_injector_(nullptr) {
 

--- a/src/cpu/x64/jit_uni_layer_normalization_kernels.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization_kernels.cpp
@@ -237,7 +237,9 @@ private:
 template <data_type_t data_type>
 jit_stat_and_data_kernel_t<data_type>::jit_stat_and_data_kernel_t(
         const layer_normalization_pd_t *pd)
-    : stat_and_data_kernel_t<data_type>(pd), jit_transfer_ {*this} {
+    : stat_and_data_kernel_t<data_type>(pd)
+    , jit_generator(jit_name())
+    , jit_transfer_ {*this} {
     assert(data_type == bf16 ? mayiuse(avx512_core) : mayiuse(avx2));
 }
 
@@ -492,7 +494,9 @@ private:
 template <data_type_t data_type>
 jit_diff_ss_kernel_t<data_type>::jit_diff_ss_kernel_t(
         const layer_normalization_pd_t *pd)
-    : diff_ss_kernel_t<data_type>(pd), jit_transfer_ {*this} {
+    : diff_ss_kernel_t<data_type>(pd)
+    , jit_generator(jit_name())
+    , jit_transfer_ {*this} {
     assert(data_type == bf16 ? mayiuse(avx512_core) : mayiuse(avx2));
 }
 
@@ -658,7 +662,9 @@ private:
 template <data_type_t data_type>
 jit_diff_data_kernel_t<data_type>::jit_diff_data_kernel_t(
         const layer_normalization_pd_t *pd)
-    : diff_data_kernel_t<data_type>(pd), jit_transfer_ {*this} {
+    : diff_data_kernel_t<data_type>(pd)
+    , jit_generator(jit_name())
+    , jit_transfer_ {*this} {
     assert(data_type == bf16 ? mayiuse(avx512_core) : mayiuse(avx2));
 }
 

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -42,7 +42,7 @@ jit_uni_pool_kernel<isa>::~jit_uni_pool_kernel() = default;
 template <cpu_isa_t isa>
 jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
         const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, isa)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
     , jpp(ajpp)
     , bf16_emu_(nullptr) {
     if (jpp.is_bf16 && !isa_has_bf16(jpp.isa))

--- a/src/cpu/x64/jit_uni_reduction_kernel.hpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.hpp
@@ -37,7 +37,7 @@ struct jit_uni_reduction_kernel_base_t : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_reduction)
 
     jit_uni_reduction_kernel_base_t(const jit_reduction_conf_t &conf)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, conf.isa)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, conf.isa)
         , conf_(conf)
         , sum_scales_(conf_.sum_scales) {}
     virtual ~jit_uni_reduction_kernel_base_t() = default;

--- a/src/cpu/x64/jit_uni_reduction_kernel.hpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.hpp
@@ -34,7 +34,7 @@ namespace cpu {
 namespace x64 {
 
 struct jit_uni_reduction_kernel_base_t : public jit_generator {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_resampling)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_reduction)
 
     jit_uni_reduction_kernel_base_t(const jit_reduction_conf_t &conf)
         : jit_generator(nullptr, MAX_CODE_SIZE, true, conf.isa)

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -1353,7 +1353,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
     }
 
     jit_uni_reorder_kernel_f32_t(const desc_t &desc)
-        : kernel_t(desc), bf16_emu_(nullptr) {
+        : kernel_t(desc), jit_generator(jit_name()), bf16_emu_(nullptr) {
         itype_sz_ = data_type_size(prb_.itype);
         otype_sz_ = data_type_size(prb_.otype);
         stype_sz_ = sizeof(float);
@@ -1527,7 +1527,8 @@ struct jit_single_blk_kernel_t : public jit_generator {
     }
 
     jit_single_blk_kernel_t(const tr::prb_t &prb)
-        : prb_(prb)
+        : jit_generator(jit_name())
+        , prb_(prb)
         , itype_sz_(data_type_size(prb_.itype))
         , otype_sz_(data_type_size(prb_.otype))
         , block_sz(prb.nodes[0].n) {}

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -38,7 +38,7 @@ struct jit_uni_resampling_kernel_base_t : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_resampling)
 
     jit_uni_resampling_kernel_base_t(const jit_resampling_conf_t &conf)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, conf.isa)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, conf.isa)
         , conf_(conf)
         , sum_scales_(conf_.sum_scales) {}
 

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -300,7 +300,7 @@ struct jit_softmax_base_t : public jit_generator {
     }
 
     jit_softmax_base_t(const softmax_pd_t *pd)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, isa)
+        : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
         , pd_(pd)
         , src_d_(pd_->is_fwd() ? pd_->src_md() : pd_->diff_src_md())
         , dst_d_(pd_->dst_md())

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -713,7 +713,8 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator {
 
     jit_bnorm_fwd_statistics_t(const batch_normalization_pd_t *bdesc,
             const jit_memory_tag_kind_t tag_kind)
-        : bdesc_(bdesc)
+        : jit_generator(jit_name())
+        , bdesc_(bdesc)
         , tag_kind_(tag_kind)
         , vlen(get_vlen<isa>(tag_kind))
         , simd_w(get_simd_w<isa>(tag_kind))
@@ -988,7 +989,8 @@ struct jit_bnorm_fwd_t : public jit_generator {
 
     jit_bnorm_fwd_t(const batch_normalization_pd_t *bdesc,
             const jit_memory_tag_kind_t tag_kind)
-        : bdesc_(bdesc)
+        : jit_generator(jit_name())
+        , bdesc_(bdesc)
         , tag_kind_(tag_kind)
         , vlen(get_vlen<isa>(tag_kind))
         , simd_w(get_simd_w<isa>(tag_kind))
@@ -1278,7 +1280,8 @@ struct jit_bnorm_bwd_t : public jit_generator {
 
     jit_bnorm_bwd_t(const batch_normalization_pd_t *bdesc,
             const jit_memory_tag_kind_t tag_kind)
-        : bdesc_(bdesc)
+        : jit_generator(jit_name())
+        , bdesc_(bdesc)
         , tag_kind_(tag_kind)
         , vlen(get_vlen<isa>(tag_kind))
         , simd_w(get_simd_w<isa>(tag_kind))
@@ -1675,7 +1678,8 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator {
 
     jit_bnorm_bwd_diff_ss_t(const batch_normalization_pd_t *bdesc,
             const jit_memory_tag_kind_t tag_kind)
-        : bdesc_(bdesc)
+        : jit_generator(jit_name())
+        , bdesc_(bdesc)
         , tag_kind_(tag_kind)
         , vlen(get_vlen<isa>(tag_kind))
         , simd_w(get_simd_w<isa>(tag_kind))

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -47,7 +47,9 @@ template <cpu_isa_t isa, typename Vmm>
 _jit_uni_x8s8s32x_1x1_conv_kernel<isa, Vmm>::_jit_uni_x8s8s32x_1x1_conv_kernel(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, isa), jcp(ajcp), attr_(attr) {
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
+    , jcp(ajcp)
+    , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -56,7 +56,9 @@ template <cpu_isa_t isa, typename Vmm>
 _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::_jit_uni_x8s8s32x_fwd_kernel(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, isa), jcp(ajcp), attr_(attr) {
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
+    , jcp(ajcp)
+    , attr_(attr) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -395,7 +395,7 @@ template <cpu_isa_t isa, typename Vmm>
 _jit_uni_x8s8s32x_deconv_fwd_kernel<isa,
         Vmm>::_jit_uni_x8s8s32x_deconv_fwd_kernel(const jit_conv_conf_t &ajcp,
         const primitive_attr_t &attr, const memory_desc_wrapper &dst_d)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, isa)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
     , jcp_(ajcp)
     , postops_injector_(nullptr) {
 

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.cpp
@@ -171,8 +171,8 @@ void jit_avx512_common_lrn_kernel_bwd_t<bf16>::store_tail(int tail_value,
 template <data_type_t d_type>
 jit_avx512_common_lrn_kernel_bwd_t<d_type>::jit_avx512_common_lrn_kernel_bwd_t(
         float alpha, float beta, int local_size, void *code_ptr,
-        size_t code_size)
-    : jit_generator(code_ptr, code_size, true, avx512_core_bf16)
+        size_t code_size, const char *name)
+    : jit_generator(name, code_ptr, code_size, true, avx512_core_bf16)
     , local_size_ {local_size - !(local_size % 2)}
     , z_prev_ {[this]() {
         std::vector<int> v(this->local_size_ / 2);

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.hpp
@@ -42,7 +42,7 @@ template <data_type_t d_type>
 class jit_avx512_common_lrn_kernel_bwd_t : public jit_generator {
 public:
     jit_avx512_common_lrn_kernel_bwd_t(float alpha, float beta, int local_size,
-            void *code_ptr, size_t code_size);
+            void *code_ptr, size_t code_size, const char *name = jit_name());
 
     using data_t = typename prec_traits<d_type>::type;
 

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_blocked.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_blocked.cpp
@@ -30,7 +30,7 @@ jit_avx512_common_lrn_kernel_bwd_blocked_t<d_type>::
                 int local_size, int use_h_parallel, void *code_ptr,
                 size_t code_size)
     : jit_avx512_common_lrn_kernel_bwd_t<d_type>(
-            alpha, beta, local_size, code_ptr, code_size)
+            alpha, beta, local_size, code_ptr, code_size, jit_name())
     , xmm_size_ {4 * sizeof(acc_data_t)}
     , zmm_size_ {64}
     , buffer_block_ {xmm_size_ + zmm_size_ + xmm_size_}

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
@@ -31,7 +31,7 @@ jit_avx512_common_lrn_kernel_bwd_nhwc_t<
         float alpha, float beta, int local_size, void *code_ptr,
         size_t code_size)
     : jit_avx512_common_lrn_kernel_bwd_t<d_type>(
-            alpha, beta, local_size, code_ptr, code_size)
+            alpha, beta, local_size, code_ptr, code_size, jit_name())
     , tmp_mask_prev_ {[this]() {
         std::vector<int> v(this->local_size_ / 2);
         std::iota(v.begin(), v.end(), this->zdiffsrc_ + 2);

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
@@ -166,8 +166,8 @@ void jit_avx512_common_lrn_kernel_fwd_t<bf16>::store_tail(int tail_value,
 template <data_type_t d_type>
 jit_avx512_common_lrn_kernel_fwd_t<d_type>::jit_avx512_common_lrn_kernel_fwd_t(
         prop_kind_t prop_kind, float alpha, float beta, float k, int local_size,
-        void *code_ptr, size_t code_size)
-    : jit_generator(code_ptr, code_size, true, avx512_core_bf16)
+        void *code_ptr, size_t code_size, const char *name)
+    : jit_generator(name, code_ptr, code_size, true, avx512_core_bf16)
     , pk_(prop_kind)
     , alpha_(alpha)
     , beta_(beta)

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.hpp
@@ -43,7 +43,7 @@ class jit_avx512_common_lrn_kernel_fwd_t : public jit_generator {
 public:
     jit_avx512_common_lrn_kernel_fwd_t(prop_kind_t prop_kind, float alpha,
             float beta, float k, int local_size, void *code_ptr,
-            size_t code_size);
+            size_t code_size, const char *name = jit_name());
 
     using data_t = typename prec_traits<d_type>::type;
 

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_blocked.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_blocked.cpp
@@ -27,8 +27,8 @@ jit_avx512_common_lrn_kernel_fwd_blocked_t<d_type>::
                 const struct nChw16c_across_t &J, prop_kind_t prop_kind,
                 int use_h_parallel, float alpha, float beta, float k,
                 int local_size, void *code_ptr, size_t code_size)
-    : jit_avx512_common_lrn_kernel_fwd_t<d_type>(
-            prop_kind, alpha, beta, k, local_size, code_ptr, code_size)
+    : jit_avx512_common_lrn_kernel_fwd_t<d_type>(prop_kind, alpha, beta, k,
+            local_size, code_ptr, code_size, jit_name())
     , use_h_parallelism_(use_h_parallel) {
     // some registers needed for conversion from bf16 to f32
     src_prev_offset_ = this->vlen_ - 4 * sizeof(data_t);

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
@@ -28,8 +28,8 @@ jit_avx512_common_lrn_kernel_fwd_nhwc_t<
         d_type>::jit_avx512_common_lrn_kernel_fwd_nhwc_t(unsigned C,
         prop_kind_t prop_kind, float alpha, float beta, float k, int local_size,
         void *code_ptr, size_t code_size)
-    : jit_avx512_common_lrn_kernel_fwd_t<d_type>(
-            prop_kind, alpha, beta, k, local_size, code_ptr, code_size)
+    : jit_avx512_common_lrn_kernel_fwd_t<d_type>(prop_kind, alpha, beta, k,
+            local_size, code_ptr, code_size, jit_name())
     , tmp_mask_prev_ {[this]() {
         std::vector<int> v(this->local_size_ / 2);
         std::iota(v.begin(), v.end(), this->zc_ + 2);

--- a/src/cpu/x64/lrn/jit_uni_lrn_kernel.hpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn_kernel.hpp
@@ -85,10 +85,10 @@ template <template <cpu_isa_t isa, data_type_t d_type> class Derived,
         cpu_isa_t isa, data_type_t d_type>
 class jit_uni_lrn_kernel_t<Derived<isa, d_type>> : public jit_generator {
 public:
-    jit_uni_lrn_kernel_t(
-            void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE);
+    jit_uni_lrn_kernel_t(void *code_ptr = nullptr,
+            size_t code_size = MAX_CODE_SIZE, const char *name = jit_name());
     jit_uni_lrn_kernel_t(const within_config_t &J, void *code_ptr = nullptr,
-            size_t code_size = MAX_CODE_SIZE);
+            size_t code_size = MAX_CODE_SIZE, const char *name = jit_name());
 
     ~jit_uni_lrn_kernel_t();
 

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -40,6 +40,7 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
 
     jit_brgemm_matmul_copy_a_impl_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_a_t(conf)
+        , jit_generator(jit_name())
         , typesize(conf_->a_dt_sz)
         , vnni_granularity(granularity_max / typesize)
         , k_step(bytes_in_zmm / typesize) {}
@@ -377,6 +378,7 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
 
     jit_brgemm_matmul_copy_a_transposed_impl_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_a_t(conf)
+        , jit_generator(jit_name())
         , typesize(conf_->a_dt_sz)
         , src_stride(conf_->src_tag == format_tag::adbc
                           ? conf_->copy_A_src_stride
@@ -887,7 +889,7 @@ struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_b_int8_t)
 
     jit_brgemm_matmul_copy_b_int8_t(const brgemm_matmul_conf_t *conf)
-        : jit_brgemm_matmul_copy_b_t(conf) {}
+        : jit_brgemm_matmul_copy_b_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -1367,7 +1369,7 @@ struct jit_brgemm_matmul_copy_b_bf16_t : public jit_brgemm_matmul_copy_b_t,
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_b_bf16_t)
 
     jit_brgemm_matmul_copy_b_bf16_t(const brgemm_matmul_conf_t *conf)
-        : jit_brgemm_matmul_copy_b_t(conf) {}
+        : jit_brgemm_matmul_copy_b_t(conf), jit_generator(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -1553,6 +1555,7 @@ struct jit_brgemm_matmul_copy_b_f32_t : public jit_brgemm_matmul_copy_b_t,
 
     jit_brgemm_matmul_copy_b_f32_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
+        , jit_generator(jit_name())
         , src_stride_(conf_->wei_tag == acbd ? conf_->copy_B_wei_stride
                                              : conf_->N * typesize)
         , tr_src_stride_(conf_->LDB * typesize) {}
@@ -1692,6 +1695,7 @@ struct jit_brgemm_matmul_copy_b_transposed_t
 
     jit_brgemm_matmul_copy_b_transposed_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
+        , jit_generator(jit_name())
         , typesize(conf_->b_dt_sz)
         , vnni_granularity(granularity_max / typesize)
         , k_blk_step(bytes_in_zmm / typesize)

--- a/src/cpu/x64/prelu/jit_prelu_base_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_base_kernel.cpp
@@ -23,8 +23,8 @@ namespace x64 {
 
 jit_prelu_base_kernel_t::jit_prelu_base_kernel_t(const cpu_isa_t &isa, int vlen,
         const prelu::bcast &bcast, const memory_desc_wrapper &tensor_md,
-        size_t number_vmm_single_compute)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, isa)
+        size_t number_vmm_single_compute, const char *name)
+    : jit_generator(name, nullptr, MAX_CODE_SIZE, true, isa)
     , isa_(isa)
     , simd_w_(vlen / sizeof(float))
     , bcast_(bcast)

--- a/src/cpu/x64/prelu/jit_prelu_base_kernel.hpp
+++ b/src/cpu/x64/prelu/jit_prelu_base_kernel.hpp
@@ -29,7 +29,7 @@ class jit_prelu_base_kernel_t : public jit_generator {
 public:
     jit_prelu_base_kernel_t(const cpu_isa_t &isa, const int vlen,
             const prelu::bcast &bcast, const memory_desc_wrapper &tensor_md,
-            const size_t number_vmm_single_compute);
+            const size_t number_vmm_single_compute, const char *name);
 
     size_t simd_w() const noexcept;
     prelu::bcast get_bcast() const noexcept;

--- a/src/cpu/x64/prelu/jit_prelu_reduction_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_reduction_kernel.cpp
@@ -32,8 +32,9 @@ static dim_t get_C(const cpu_prelu_bwd_pd_t *pd) {
 
 jit_prelu_reduction_kernel_t::jit_prelu_reduction_kernel_t(
         const cpu_prelu_bwd_pd_t *pd, int simd_w)
-    : scratchpad_c_block_offset_(
-            utils::rnd_up(get_C(pd), alignment) * sizeof(float))
+    : jit_generator(jit_name())
+    , scratchpad_c_block_offset_(
+              utils::rnd_up(get_C(pd), alignment) * sizeof(float))
     , simd_w_(simd_w)
     , data_type_(pd->diff_weights_md(0)->data_type)
     , tail_size_(get_C(pd) % simd_w)

--- a/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
@@ -28,7 +28,8 @@ jit_prelu_backward_kernel_t::jit_prelu_backward_kernel_t(
     : jit_prelu_base_kernel_t(isa, vlen,
             prelu::get_bcast_type(memory_desc_wrapper(pd->diff_src_md(0)),
                     memory_desc_wrapper(pd->diff_weights_md(0))),
-            memory_desc_wrapper(pd->diff_src_md(0)), number_vmm_single_compute)
+            memory_desc_wrapper(pd->diff_src_md(0)), number_vmm_single_compute,
+            jit_name())
     , pd_(pd)
     , src_dt_(pd->src_md(0)->data_type)
     , wei_dt_(pd->weights_md(0)->data_type)

--- a/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
@@ -28,7 +28,8 @@ jit_prelu_forward_kernel_t::jit_prelu_forward_kernel_t(
     : jit_prelu_base_kernel_t(isa, vlen,
             prelu::get_bcast_type(memory_desc_wrapper(pd->src_md(0)),
                     memory_desc_wrapper(pd->weights_md(0))),
-            memory_desc_wrapper(pd->src_md(0)), number_vmm_single_compute)
+            memory_desc_wrapper(pd->src_md(0)), number_vmm_single_compute,
+            jit_name())
     , src_dt_(pd->src_md(0)->data_type)
     , wei_dt_(pd->weights_md(0)->data_type)
     , dst_dt_(pd->dst_md(0)->data_type)

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.cpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.cpp
@@ -26,7 +26,8 @@ namespace x64 {
 
 jit_brgemm_transpose_single_row_t::jit_brgemm_transpose_single_row_t(
         const int m_block)
-    : m_block_(m_block)
+    : jit_generator(jit_name())
+    , m_block_(m_block)
     , full_loop_iters_(m_block_ / (vmms_available_ * simd_w_))
     , tail_(m_block_ % simd_w_)
     , k_blocks_nb_(m_block_ / simd_w_) {}

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
@@ -25,7 +25,8 @@ namespace x64 {
 
 jit_diff_weights_peephole_t::jit_diff_weights_peephole_t(
         const rnn_utils::rnn_conf_t &rnn, const dim_t dhc_block_size)
-    : c_states_dt_(rnn.src_iter_c_dt)
+    : jit_generator(jit_name())
+    , c_states_dt_(rnn.src_iter_c_dt)
     , scratch_dt_(rnn.is_bf16() ? data_type::bf16 : data_type::f32)
     , dst_dt_(data_type::f32)
     , compute_block_size_(dhc_block_size)

--- a/src/cpu/x64/rnn/jit_gates_reduction.cpp
+++ b/src/cpu/x64/rnn/jit_gates_reduction.cpp
@@ -26,7 +26,8 @@ namespace x64 {
 
 jit_gates_reduction_t::jit_gates_reduction_t(
         const rnn_utils::rnn_conf_t &rnn, bool is_n_tail)
-    : rnn_(rnn)
+    : jit_generator(jit_name())
+    , rnn_(rnn)
     , is_n_tail_(is_n_tail)
     , n_block_(is_n_tail_ ? rnn_.diff_wei_brgemm.n_tail
                           : rnn_.diff_wei_brgemm.n_block)

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
@@ -31,7 +31,7 @@ struct jit_uni_gru_cell_postgemm_part1_bwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_cell_postgemm_part1_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     ~jit_uni_gru_cell_postgemm_part1_bwd() {}
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
@@ -36,7 +36,7 @@ struct jit_uni_gru_cell_postgemm_part1_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_cell_postgemm_part1_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
         jit_uni_rnn_postgemm::init(src_data_t);

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
@@ -31,7 +31,7 @@ struct jit_uni_gru_cell_postgemm_part2_bwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_cell_postgemm_part2_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     ~jit_uni_gru_cell_postgemm_part2_bwd() {}
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
@@ -35,7 +35,7 @@ struct jit_uni_gru_cell_postgemm_part2_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_cell_postgemm_part2_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
         jit_uni_rnn_postgemm::init(src_data_t);

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
@@ -31,7 +31,7 @@ struct jit_uni_gru_lbr_cell_postgemm_bwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_lbr_cell_postgemm_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     ~jit_uni_gru_lbr_cell_postgemm_bwd() {}
 

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
@@ -36,7 +36,7 @@ struct jit_uni_gru_lbr_cell_postgemm_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_lbr_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
         jit_uni_rnn_postgemm::init(src_data_t);

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
@@ -36,7 +36,7 @@ struct jit_uni_lstm_cell_postgemm_bwd
 
     jit_uni_lstm_cell_postgemm_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd)
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name())
         , jit_uni_lstm_cell_postgemm_t<isa>(
                   this, 11 /*tmp_id_begin*/, static_cast<bool>(bf16_emu_)) {}
     ~jit_uni_lstm_cell_postgemm_bwd() = default;

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
@@ -35,7 +35,7 @@ struct jit_uni_lstm_cell_postgemm_fwd
 
     jit_uni_lstm_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd)
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name())
         , jit_uni_lstm_cell_postgemm_t<isa>(
                   this, 6 /*tmp_id_begin*/, static_cast<bool>(bf16_emu_)) {}
 

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_projection_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_projection_postgemm_fwd.hpp
@@ -31,7 +31,7 @@ struct jit_uni_lstm_cell_projection_postgemm_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_lstm_cell_projection_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     ~jit_uni_lstm_cell_projection_postgemm_fwd() {}
 

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
@@ -31,7 +31,7 @@ struct jit_uni_rnn_cell_postgemm_bwd : public jit_uni_rnn_postgemm {
 
     jit_uni_rnn_cell_postgemm_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     ~jit_uni_rnn_cell_postgemm_bwd() {}
 

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
@@ -36,7 +36,7 @@ struct jit_uni_rnn_cell_postgemm_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_rnn_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd) {}
+        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
         jit_uni_rnn_postgemm::init(src_data_t);

--- a/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
@@ -36,8 +36,10 @@ namespace x64 {
 
 struct jit_uni_rnn_postgemm : public jit_generator {
 
-    jit_uni_rnn_postgemm(const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : rnn_(rnn)
+    jit_uni_rnn_postgemm(const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd,
+            const char *name)
+        : jit_generator(name)
+        , rnn_(rnn)
         , pd_(pd)
         , projection_(false)
         , bias_dt_size_(types::data_type_size(rnn.bias_dt))

--- a/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -39,7 +39,7 @@ static size_t get_padding_size(const jit_shuffle_conf_t &conf) {
 template <cpu_isa_t isa>
 jit_uni_shuffle_kernel_t<isa>::jit_uni_shuffle_kernel_t(
         const jit_shuffle_conf_t conf)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, isa)
+    : jit_generator(jit_name(), nullptr, MAX_CODE_SIZE, true, isa)
     , conf_(conf)
     , padding_size_(get_padding_size(conf)) {}
 


### PR DESCRIPTION
This is achieved by (1) using Xbyak's memfd-based allocation, (2) adding support in Xbyak to pass an optional memory region name [I've also sent a PR to upstream Xbyak about this, it is linked in the patch], (3) defining the `jit_name()` member function from the `DECLARE_CPU_JIT_AUX_FUNCTIONS` macro, and (4) constructing `jit_generator` with `name=jit_name()`.

See the last patch's commit message for a before/after comparison using perf(1).

Note: the first commit in this PR is just an unrelated fix.