### PR TITLE
broadcasting fix

### DIFF
--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -210,11 +210,14 @@ bool jit_uni_binary_t::pd_t::is_format_non_blocked(
             = IMPLICATION(strides[0] != 0,
                       strides[0] >= utils::array_product(dims + 1, ndims - 1))
             && IMPLICATION(ndims >= 3 && strides[2] != 0,
-                    strides[2] >= dims[1]*utils::array_product(dims + 3, ndims - 3))
+                    strides[2] >= dims[1]
+                                    * utils::array_product(dims + 3, ndims - 3))
             && IMPLICATION(ndims >= 4 && strides[3] != 0,
-                    strides[3] >= dims[1]*utils::array_product(dims + 4, ndims - 4))
+                    strides[3] >= dims[1]
+                                    * utils::array_product(dims + 4, ndims - 4))
             && IMPLICATION(ndims >= 5 && strides[4] != 0,
-                    strides[4] >= dims[1]*utils::array_product(dims + 5, ndims - 5))
+                    strides[4] >= dims[1]
+                                    * utils::array_product(dims + 5, ndims - 5))
             && IMPLICATION(strides[1] != 0, strides[1] == 1);
     return is_nxc || is_ncx;
 }

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -210,11 +210,11 @@ bool jit_uni_binary_t::pd_t::is_format_non_blocked(
             = IMPLICATION(strides[0] != 0,
                       strides[0] >= utils::array_product(dims + 1, ndims - 1))
             && IMPLICATION(ndims >= 3 && strides[2] != 0,
-                    strides[2] >= utils::array_product(dims + 2, ndims - 2))
+                    strides[2] >= dims[1]*utils::array_product(dims + 3, ndims - 3))
             && IMPLICATION(ndims >= 4 && strides[3] != 0,
-                    strides[3] >= utils::array_product(dims + 3, ndims - 3))
+                    strides[3] >= dims[1]*utils::array_product(dims + 4, ndims - 4))
             && IMPLICATION(ndims >= 5 && strides[4] != 0,
-                    strides[4] >= utils::array_product(dims + 4, ndims - 4))
+                    strides[4] >= dims[1]*utils::array_product(dims + 5, ndims - 5))
             && IMPLICATION(strides[1] != 0, strides[1] == 1);
     return is_nxc || is_ncx;
 }


### PR DESCRIPTION
# Description

We evaluated oneDNN 2.5 for purpose of integrating with PaddlePaddle project. There was one situation where there is 
performance degradation observed relatively to oneDNN 2.4. We investigated a problem and it seems that newly added
function in oneDNN 2.5 :` bool jit_uni_binary_t::pd_t::is_format_non_blocked` is having problem with detecting non-blocked NXC data which results in dispatching ref binary implementation that degradates performance.


**onednn 2.4:**
```
dnnl_verbose,exec,cpu,binary,jit:uni,undef,src_f32::blocked:acdb:f0 src_f32::blocked:abcd:f0 dst_f32::blocked:acdb:f0,,alg:binary_add,1x128x293x1:1x128x1x1,0.019043
dnnl_verbose,exec,cpu,binary,jit:uni,undef,src_f32::blocked:abc:f0 src_f32::blocked:acb:f0 dst_f32::blocked:abc:f0,,alg:binary_add,1x128x293:1x128x293,0.0458984
```

**onednn 2.5:**
```
onednn_verbose,exec,cpu,binary,ref:any,undef,src_f32::blocked:acdb:f0 src_f32::blocked:abcd:f0 dst_f32::blocked:acdb:f0,,alg:binary_add,1x128x293x1:1x128x1x1,4.96313
onednn_verbose,exec,cpu,binary,ref:any,undef,src_f32::blocked:abc:f0 src_f32::blocked:acb:f0 dst_f32::blocked:abc:f0,,alg:binary_add,1x128x293:1x128x293,4.33203
```

**To reproduce with benchDNN:**
`OMP_NUM_THREAD=1 ./benchdnn --mode=p --binary --sdt=f32:f32 --ddt=f32 --stag=nhwc:nchw --alg=ADD --inplace=false 1x128x293x1:1x128x1x1`

