### PR TITLE
src: cpu: aarch64 Add threadpool runtime support for AArch64

### DIFF
--- a/src/cpu/aarch64/CMakeLists.txt
+++ b/src/cpu/aarch64/CMakeLists.txt
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright 2020 Arm Ltd. and affiliates
+# Copyright 2020-2022 Arm Ltd. and affiliates
 # Copyright 2020-2021 FUJITSU LIMITED
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +32,15 @@ if(NOT DNNL_AARCH64_USE_ACL)
         ${CMAKE_CURRENT_SOURCE_DIR}/acl_*.[ch]pp
         )
     list(REMOVE_ITEM SOURCES ${ACL_FILES})
+endif()
+
+# If the runtime is not THREADPOOL remove threadpool_scheduler sources.
+if(NOT DNNL_CPU_RUNTIME STREQUAL "THREADPOOL")
+    list(APPEND ACL_THREADPOOL_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/acl_threadpool_scheduler.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/acl_threadpool_scheduler.hpp
+    )
+    list(REMOVE_ITEM SOURCES ${ACL_THREADPOOL_FILES})
 endif()
 
 set(OBJ_LIB ${DNNL_LIBRARY_NAME}_cpu_aarch64)

--- a/src/cpu/aarch64/acl_binary.hpp
+++ b/src/cpu/aarch64/acl_binary.hpp
@@ -181,9 +181,6 @@ struct acl_binary_t : public primitive_t {
             // Call operator specific validate function to check support
             ACL_CHECK_VALID(validate(asp_));
 
-            // Initialize the ACL threads
-            acl_thread_bind();
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -78,8 +78,6 @@ struct acl_eltwise_fwd_t : public primitive_t {
                     aep_, data_md_, *desc(), *attr());
             if (conf_status != status::success) return status::unimplemented;
 
-            acl_utils::acl_thread_bind();
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -108,8 +108,6 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
                     src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
             if (conf_status != status::success) return status::unimplemented;
 
-            acl_utils::acl_thread_bind();
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -109,8 +109,6 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
                     *attr());
             if (conf_status != status::success) return status::unimplemented;
 
-            acl_utils::acl_thread_bind();
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -265,12 +265,6 @@ struct acl_inner_product_fwd_t : public primitive_t {
 
     acl_inner_product_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    status_t init(engine_t *engine) override {
-        acl_utils::acl_thread_bind();
-
-        return status::success;
-    }
-
     status_t create_resource(
             engine_t *engine, resource_mapper_t &mapper) const override {
         if (mapper.has_resource(this)) return status::success;

--- a/src/cpu/aarch64/acl_softmax.hpp
+++ b/src/cpu/aarch64/acl_softmax.hpp
@@ -197,8 +197,6 @@ struct acl_softmax_fwd_t : public primitive_t {
                         &asp_.src_info, &asp_.dst_info, asp_.beta, asp_.axis));
             }
 
-            acl_utils::acl_thread_bind();
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/acl_thread.cpp
+++ b/src/cpu/aarch64/acl_thread.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include "cpu/aarch64/acl_thread.hpp"
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "cpu/aarch64/acl_threadpool_scheduler.hpp"
+#endif
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace acl_thread_utils {
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+void acl_thread_bind() {
+    static std::once_flag flag_once;
+    // The threads in Compute Library are bound for the cores 0..max_threads-1
+    // dnnl_get_max_threads() returns OMP_NUM_THREADS
+    const int max_threads = dnnl_get_max_threads();
+    // arm_compute::Scheduler does not support concurrent access thus a
+    // workaround here restricts it to only one call
+    std::call_once(flag_once, [&]() {
+        arm_compute::Scheduler::get().set_num_threads(max_threads);
+    });
+}
+#endif
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+void acl_set_custom_scheduler() {
+    static std::once_flag flag_once;
+    // Create threadpool scheduler
+    std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
+            = std::make_unique<ThreadpoolScheduler>();
+    // set CUSTOM scheduler in ACL
+    std::call_once(flag_once,
+            [&]() { arm_compute::Scheduler::set(threadpool_scheduler); });
+}
+
+void acl_set_threadpool_num_threads() {
+    using namespace dnnl::impl::threadpool_utils;
+    static std::once_flag flag_once;
+    threadpool_interop::threadpool_iface *tp = get_active_threadpool();
+    // Check active threadpool
+    bool is_main = get_active_threadpool() == tp;
+    if (is_main) {
+        // Set num threads based on threadpool size
+        const int num_threads = (tp) ? dnnl_get_max_threads() : 1;
+        std::call_once(flag_once, [&]() {
+            arm_compute::Scheduler::get().set_num_threads(num_threads);
+        });
+    }
+}
+#endif
+
+} // namespace acl_thread_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_thread.hpp
+++ b/src/cpu/aarch64/acl_thread.hpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_THREAD_HPP
+#define CPU_AARCH64_ACL_THREAD_HPP
+
+#include "common/dnnl_thread.hpp"
+
+#include "arm_compute/runtime/Scheduler.h"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace acl_thread_utils {
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+void acl_thread_bind();
+#endif
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+// Retrieve threadpool size during primitive execution and set ThreadpoolScheduler num_threads
+void acl_set_custom_scheduler();
+void acl_set_threadpool_num_threads();
+#endif
+
+} // namespace acl_thread_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_THREAD_HPP

--- a/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+++ b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+
+#include "cpu/aarch64/acl_threadpool_scheduler.hpp"
+#include "cpu/aarch64/acl_thread.hpp"
+
+#include "common/counting_barrier.hpp"
+#include "common/dnnl_thread.hpp"
+
+#include "arm_compute/core/CPP/ICPPKernel.h"
+#include "arm_compute/core/Error.h"
+#include "arm_compute/core/Helpers.h"
+#include "arm_compute/core/Utils.h"
+#include "arm_compute/runtime/IScheduler.h"
+
+// BARRIER
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace arm_compute;
+
+class ThreadFeeder {
+public:
+    explicit ThreadFeeder(unsigned int start = 0, unsigned int end = 0)
+        : _atomic_counter(start), _end(end) {}
+
+    /// Function to check the next element in the range if there is one.
+    bool get_next(unsigned int &next) {
+        next = atomic_fetch_add_explicit(
+                &_atomic_counter, 1u, std::memory_order_relaxed);
+        return next < _end;
+    }
+
+private:
+    std::atomic_uint _atomic_counter;
+    const unsigned int _end;
+};
+
+void process_workloads(std::vector<IScheduler::Workload> &workloads,
+        ThreadFeeder &feeder, const ThreadInfo &info) {
+    unsigned int workload_index = info.thread_id;
+    do {
+        ARM_COMPUTE_ERROR_ON(workload_index >= workloads.size());
+        workloads[workload_index](info);
+    } while (feeder.get_next(workload_index));
+}
+
+ThreadpoolScheduler::ThreadpoolScheduler() {
+    _num_threads = num_threads_hint();
+}
+
+ThreadpoolScheduler::~ThreadpoolScheduler() = default;
+
+unsigned int ThreadpoolScheduler::num_threads() const {
+    return _num_threads;
+}
+
+void ThreadpoolScheduler::set_num_threads(unsigned int num_threads) {
+    arm_compute::lock_guard<std::mutex> lock(this->_run_workloads_mutex);
+    _num_threads = num_threads == 0 ? num_threads_hint() : num_threads;
+}
+
+void ThreadpoolScheduler::schedule(ICPPKernel *kernel, const Hints &hints) {
+    ITensorPack tensors;
+    // Retrieve threadpool size during primitive execution and set ThreadpoolScheduler num_threads
+    acl_thread_utils::acl_set_threadpool_num_threads();
+    schedule_common(kernel, hints, kernel->window(), tensors);
+}
+
+void ThreadpoolScheduler::schedule_op(ICPPKernel *kernel, const Hints &hints,
+        const Window &window, ITensorPack &tensors) {
+    // Retrieve threadpool size during primitive execution and set ThreadpoolScheduler num_threads
+    acl_thread_utils::acl_set_threadpool_num_threads();
+    schedule_common(kernel, hints, window, tensors);
+}
+
+void ThreadpoolScheduler::run_workloads(
+        std::vector<arm_compute::IScheduler::Workload> &workloads) {
+
+    arm_compute::lock_guard<std::mutex> lock(this->_run_workloads_mutex);
+
+    const unsigned int num_threads
+            = std::min(static_cast<unsigned int>(_num_threads),
+                    static_cast<unsigned int>(workloads.size()));
+    if (num_threads < 1) { return; }
+    ThreadFeeder feeder(num_threads, workloads.size());
+    using namespace dnnl::impl::threadpool_utils;
+    dnnl::threadpool_interop::threadpool_iface *tp = get_active_threadpool();
+    bool is_async = tp->get_flags()
+            & dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS;
+    counting_barrier_t b;
+    if (is_async) b.init(num_threads);
+    tp->parallel_for(num_threads, [&](int ithr, int nthr) {
+        bool is_main = get_active_threadpool() == tp;
+        if (is_main) activate_threadpool(tp);
+        // Make ThreadInfo local to avoid race conditions
+        ThreadInfo info;
+        info.cpu_info = &cpu_info();
+        info.num_threads = nthr;
+        info.thread_id = ithr;
+        process_workloads(workloads, feeder, info);
+        if (is_main) deactivate_threadpool();
+        if (is_async) b.notify();
+    });
+    if (is_async) b.wait();
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/acl_threadpool_scheduler.hpp
+++ b/src/cpu/aarch64/acl_threadpool_scheduler.hpp
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+
+#ifndef CPU_AARCH64_ACL_THREADPOOL_SCHEDULER_HPP
+#define CPU_AARCH64_ACL_THREADPOOL_SCHEDULER_HPP
+
+#include "arm_compute/runtime/IScheduler.h"
+#include "support/Mutex.h"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+class ThreadpoolScheduler final : public arm_compute::IScheduler {
+public:
+    ThreadpoolScheduler();
+    ~ThreadpoolScheduler();
+
+    /// Sets the number of threads the scheduler will use to run the kernels.
+    void set_num_threads(unsigned int num_threads) override;
+    /// Returns the number of threads that the ThreadpoolScheduler has in its pool.
+    unsigned int num_threads() const override;
+
+    /// Multithread the execution of the passed kernel if possible.
+    void schedule(arm_compute::ICPPKernel *kernel,
+            const arm_compute::IScheduler::Hints &hints) override;
+
+    /// Multithread the execution of the passed kernel if possible.
+    void schedule_op(arm_compute::ICPPKernel *kernel,
+            const arm_compute::IScheduler::Hints &hints,
+            const arm_compute::Window &window,
+            arm_compute::ITensorPack &tensors) override;
+
+protected:
+    /// Execute workloads in parallel using num_threads
+    void run_workloads(std::vector<Workload> &workloads) override;
+
+private:
+    uint _num_threads {};
+    arm_compute::Mutex _run_workloads_mutex {};
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_THREADPOOL_SCHEDULER_HPP
+
+#endif // DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL

--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -101,18 +101,6 @@ bool acl_act_ok(alg_kind_t eltwise_activation) {
             eltwise_logistic);
 }
 
-void acl_thread_bind() {
-    static std::once_flag flag_once;
-    // The threads in Compute Library are bound for the cores 0..max_threads-1
-    // dnnl_get_max_threads() returns OMP_NUM_THREADS
-    const int max_threads = dnnl_get_max_threads();
-    // arm_compute::Scheduler does not support concurrent access thus a
-    // workaround here restricts it to only one call
-    std::call_once(flag_once, [&]() {
-        arm_compute::Scheduler::get().set_num_threads(max_threads);
-    });
-}
-
 status_t tensor_info(arm_compute::TensorInfo &info, const memory_desc_t &md) {
     const memory_desc_wrapper md_wrap(&md);
     return tensor_info(info, md_wrap);

--- a/src/cpu/aarch64/acl_utils.hpp
+++ b/src/cpu/aarch64/acl_utils.hpp
@@ -25,7 +25,6 @@
 #include "common/memory_tracking.hpp"
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
-#include "cpu/cpu_engine.hpp"
 
 #include "arm_compute/runtime/NEON/NEFunctions.h"
 #include "arm_compute/runtime/Scheduler.h"
@@ -41,7 +40,6 @@ arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
 arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
 arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
 bool acl_act_ok(alg_kind_t eltwise_activation);
-void acl_thread_bind();
 
 // Convert a memory desc to an arm_compute::TensorInfo. Note that memory desc
 // must be blocking format, plain, dense and have no zero dimensions.

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -107,8 +107,6 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
 
             set_default_alg_kind(alg_kind::convolution_winograd);
 
-            acl_utils::acl_thread_bind();
-
             return status::success;
         }
 

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -85,9 +85,6 @@ struct acl_matmul_t : public primitive_t {
                     weights_md_, dst_md_, bias_md_, *desc(), *attr());
 
             if (conf_status != status::success) return status::unimplemented;
-            // Number of threads in Compute Library is set by OMP_NUM_THREADS
-            // dnnl_get_max_threads() == OMP_NUM_THREADS
-            acl_utils::acl_thread_bind();
 
             return status::success;
         }

--- a/src/cpu/gemm/gemm.hpp
+++ b/src/cpu/gemm/gemm.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018-2021 Intel Corporation
+* Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,6 +28,10 @@
 
 #if DNNL_X64
 #include "cpu/x64/cpu_isa_traits.hpp"
+#endif
+
+#if DNNL_AARCH64
+#include "cpu/aarch64/cpu_isa_traits.hpp"
 #endif
 
 namespace dnnl {

--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2022 Intel Corporation
 * Copyright 2020 FUJITSU LIMITED
+* Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +32,10 @@
 #include "cpu/x64/cpu_isa_traits.hpp"
 #elif DNNL_AARCH64
 #include "cpu/aarch64/cpu_isa_traits.hpp"
+#if DNNL_AARCH64_USE_ACL
+// For setting the number of threads for ACL
+#include "src/common/cpuinfo/CpuInfo.h"
+#endif
 #endif
 
 // For DNNL_X64 build we compute the timestamp using rdtsc. Use std::chrono for
@@ -145,6 +150,8 @@ unsigned get_per_core_cache_size(int level) {
 unsigned get_num_cores() {
 #if DNNL_X64
     return x64::cpu().getNumCores(Xbyak::util::CoreLevel);
+#elif DNNL_AARCH64_USE_ACL
+    return arm_compute::cpuinfo::num_threads_hint();
 #else
     return 1;
 #endif


### PR DESCRIPTION
# Description

This PR enables `DNNL_RUNTIME_THREADPOOL` support in oneDNN built with Compute Library for Arm® Architecture (ACL).
The implementation follows the approach detailed in the RFC https://github.com/oneapi-src/oneDNN/pull/1293  and the proof-of-concept implementation https://github.com/oneapi-src/oneDNN/compare/master...cfRod:poc-threadpool.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [X] Have you published an RFC for the new feature?
- [X] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
