### PR TITLE
cpu: aarch64: add arbitrary ACL post ops

### DIFF
--- a/src/cpu/aarch64/acl_binary.cpp
+++ b/src/cpu/aarch64/acl_binary.cpp
@@ -21,11 +21,8 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-status_t acl_binary_t::execute_forward(const exec_ctx_t &ctx) const {
-
-    auto src0 = CTX_IN_MEM(const void *, DNNL_ARG_SRC_0);
-    auto src1 = CTX_IN_MEM(const void *, DNNL_ARG_SRC_1);
-    auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+status_t acl_binary_t::execute_forward(const exec_ctx_t &ctx, const void *src0,
+        const void *src1, void *dst) const {
 
     // Lock here is needed because resource_mapper does not support
     // concurrent multithreaded access.
@@ -47,6 +44,15 @@ status_t acl_binary_t::execute_forward(const exec_ctx_t &ctx) const {
     acl_obj.dst_tensor.allocator()->free();
 
     return status::success;
+}
+
+status_t acl_binary_t::execute_forward(const exec_ctx_t &ctx) const {
+
+    auto src0 = CTX_IN_MEM(const void *, DNNL_ARG_SRC_0);
+    auto src1 = CTX_IN_MEM(const void *, DNNL_ARG_SRC_1);
+    auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+
+    return execute_forward(ctx, src0, src1, dst);
 }
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_binary.hpp
+++ b/src/cpu/aarch64/acl_binary.hpp
@@ -220,6 +220,7 @@ struct acl_binary_t : public primitive_t {
             }
         }
 
+        friend struct acl_post_ops_t;
     }; // pd_t
 
     acl_binary_t(const pd_t *apd) : primitive_t(apd) {}
@@ -245,8 +246,15 @@ struct acl_binary_t : public primitive_t {
 private:
     // To guard the const execute_forward, the mutex must be 'mutable'
     mutable std::mutex mtx;
+
     status_t execute_forward(const exec_ctx_t &ctx) const;
+    // Execute forward with arbitrary src0, src1 and dst, used by acl_post_ops_t
+    status_t execute_forward(const exec_ctx_t &ctx, const void *src0,
+            const void *src1, void *dst) const;
+
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    friend struct acl_post_ops_t;
 
 }; // acl_binary_t
 

--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -212,21 +212,6 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
                 arm_compute::QuantizationInfo(1.0f / scales[0], 0));
     }
 
-    // Post-convolutional operations (post-ops)
-    const auto &post_ops = attr.post_ops_;
-    // is_eltwise(true) here stands for eltwise.scale == 1.f check
-    acp.sum_with_eltwise = (post_ops.len() == 2) && post_ops.entry_[0].is_sum()
-            && post_ops.entry_[1].is_eltwise(true);
-    acp.act_info = acl_utils::get_acl_act(attr);
-
-    if (acp.sum_with_eltwise) {
-        ACL_CHECK_VALID(arm_compute::NEActivationLayer::validate( // eltwise
-                &acp.dst_info, &acp.dst_info, acp.act_info));
-        ACL_CHECK_VALID(arm_compute::NEArithmeticAddition::validate( // sum
-                &acp.dst_info, &acp.dst_info, &acp.dst_info,
-                arm_compute::ConvertPolicy::SATURATE));
-    }
-
     return status::success;
 }
 

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2021 Arm Ltd. and affiliates
+* Copyright 2020-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 
 #include "cpu/cpu_convolution_pd.hpp"
 
+#include "cpu/aarch64/acl_post_ops.hpp"
 #include "cpu/aarch64/acl_utils.hpp"
 
 namespace dnnl {
@@ -29,20 +30,19 @@ namespace aarch64 {
 template <typename NEConv>
 struct acl_obj_t {
     NEConv conv;
-    arm_compute::NEArithmeticAddition add;
-    arm_compute::NEActivationLayer act;
     arm_compute::Tensor src_tensor;
     arm_compute::Tensor wei_tensor;
     arm_compute::Tensor bia_tensor;
     arm_compute::Tensor dst_tensor;
-    arm_compute::Tensor dst_acc_tensor;
 };
 
 struct acl_conv_conf_t {
     bool with_bias;
     bool is_int8;
-    bool sum_with_eltwise;
     bool fast_math;
+    // If this is true, the result of the convolution goes into a temporarily
+    // allocated ACL tensor to be accumulated into the oneDNN dst during postops
+    bool use_dst_acc;
     arm_compute::TensorInfo src_info;
     arm_compute::TensorInfo wei_info;
     arm_compute::TensorInfo bia_info;
@@ -50,6 +50,7 @@ struct acl_conv_conf_t {
     arm_compute::PadStrideInfo padstride_info;
     arm_compute::Size2D dilation_info;
     arm_compute::WeightsInfo weights_info;
+    // Note: this will default to not enabled, and will do nothing
     arm_compute::ActivationLayerInfo act_info;
 };
 
@@ -78,11 +79,10 @@ template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,
 status_t execute_forward_conv_acl(
         const exec_ctx_t &ctx, conv_obj_t &acl_conv_obj, const conv_pd_t *pd) {
     bool with_bias = pd->acp_.with_bias;
-    bool sum_with_eltwise = pd->acp_.sum_with_eltwise;
+    bool use_dst_acc = pd->acp_.use_dst_acc;
 
     auto src_base = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
     auto wei_base = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
-    auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
 
     // import_memory() and free() methods do not allocate/free any additional
     // memory, only acquire/release pointers.
@@ -90,7 +90,15 @@ status_t execute_forward_conv_acl(
             const_cast<src_data_t *>(src_base));
     acl_conv_obj.wei_tensor.allocator()->import_memory(
             const_cast<wei_data_t *>(wei_base));
-    acl_conv_obj.dst_tensor.allocator()->import_memory(dst_base);
+
+    if (use_dst_acc) {
+        // Put the result in a new tensor, it will be accumalated to the dst
+        // during the post ops
+        acl_conv_obj.dst_tensor.allocator()->allocate();
+    } else {
+        auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+        acl_conv_obj.dst_tensor.allocator()->import_memory(dst_base);
+    }
 
     if (with_bias) {
         auto bia_base = CTX_IN_MEM(const bia_data_t *, DNNL_ARG_BIAS);
@@ -100,15 +108,14 @@ status_t execute_forward_conv_acl(
 
     acl_conv_obj.conv.run();
 
-    if (sum_with_eltwise) {
-        acl_conv_obj.add.run();
-        acl_conv_obj.act.run();
-    }
-
     acl_conv_obj.src_tensor.allocator()->free();
     acl_conv_obj.wei_tensor.allocator()->free();
-    acl_conv_obj.dst_tensor.allocator()->free();
     if (with_bias) { acl_conv_obj.bia_tensor.allocator()->free(); }
+
+    void *dst = acl_conv_obj.dst_tensor.buffer();
+    pd->post_ops.execute(ctx, dst);
+
+    acl_conv_obj.dst_tensor.allocator()->free();
 
     return status::success;
 }

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2021 Arm Ltd. and affiliates
+* Copyright 2020-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021 Arm Ltd. and affiliates
+* Copyright 2021-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -39,32 +39,19 @@ struct acl_indirect_gemm_resource_t : public resource_t {
         acl_obj_->wei_tensor.allocator()->init(acp.wei_info);
         acl_obj_->dst_tensor.allocator()->init(acp.dst_info);
         acl_obj_->bia_tensor.allocator()->init(acp.bia_info);
-        if (acp.sum_with_eltwise) {
-            acl_obj_->dst_acc_tensor.allocator()->init(acp.dst_info);
-        }
+
         // clang-format off
         acl_obj_->conv.configure(
             &acl_obj_->src_tensor,
             &acl_obj_->wei_tensor,
             acp.with_bias ? &acl_obj_->bia_tensor : nullptr,
-            acp.sum_with_eltwise ? &acl_obj_->dst_acc_tensor
-                                 : &acl_obj_->dst_tensor,
+            &acl_obj_->dst_tensor,
             arm_compute::Conv2dInfo(acp.padstride_info,
                                     acp.dilation_info,
-                                    acp.sum_with_eltwise
-                                        ? arm_compute::ActivationLayerInfo()
-                                        : acp.act_info,
+                                    acp.act_info,
                                     acp.fast_math,
                                     1));
         // clang-format on
-        if (acp.sum_with_eltwise) {
-            acl_obj_->add.configure(&acl_obj_->dst_tensor,
-                    &acl_obj_->dst_acc_tensor, &acl_obj_->dst_acc_tensor,
-                    arm_compute::ConvertPolicy::SATURATE);
-            acl_obj_->act.configure(&acl_obj_->dst_acc_tensor,
-                    &acl_obj_->dst_tensor, acp.act_info);
-            acl_obj_->dst_acc_tensor.allocator()->allocate();
-        }
 
         return status::success;
     }
@@ -100,43 +87,22 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
                             data_type::f32, data_type::f32, undef)
                     && !has_zero_dim_memory()
                     && attr()->has_default_values(
-                            smask_t::post_ops, data_type::f32)
-                    && post_ops_ok();
+                            smask_t::post_ops, data_type::f32);
             if (!ok) return status::unimplemented;
 
-            auto conf_status = acl_convolution_utils::init_conf_indirect_gemm(
-                    acp_, src_md_, weights_md_, dst_md_, bias_md_, *desc(),
-                    *attr());
-            if (conf_status != status::success) return status::unimplemented;
+            CHECK(acl_convolution_utils::init_conf_indirect_gemm(acp_, src_md_,
+                    weights_md_, dst_md_, bias_md_, *desc(), *attr()));
+
+            CHECK(post_ops.init(
+                    engine, attr_.post_ops_, dst_md_, acp_.act_info));
+            acp_.use_dst_acc = post_ops.has_sum();
 
             return status::success;
         }
 
         acl_conv_conf_t acp_;
 
-    protected:
-        bool post_ops_ok() const {
-            using namespace data_type;
-            using namespace alg_kind;
-            auto const &po = attr()->post_ops_;
-            // "true" here stands for eltwise.scale == 1.f check
-            auto is_eltwise
-                    = [&](int idx) { return po.entry_[idx].is_eltwise(true); };
-            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
-
-            bool sum_with_eltwise
-                    = (po.len() == 2) && is_sum(0) && is_eltwise(1);
-            bool eltwise_only = (po.len() == 1) ? is_eltwise(0) : false;
-            bool eltwise_ok = false;
-            // Compute Library supports only one eltwise post-op or
-            // sum+eltwise post-ops
-            if (eltwise_only || sum_with_eltwise) {
-                const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
-                eltwise_ok = acl_utils::acl_act_ok(act_type);
-            }
-
-            return eltwise_ok || (po.len() == 0);
-        }
+        acl_post_ops_t post_ops;
     };
 
     acl_indirect_gemm_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
@@ -149,10 +115,12 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
         if (!r) return status::out_of_memory;
 
         // Configure the resource based on information from primitive descriptor
-        auto st = r->configure(pd()->acp_);
-        if (st == status::success) { mapper.add(this, std::move(r)); }
+        CHECK(r->configure(pd()->acp_));
+        mapper.add(this, std::move(r));
 
-        return st;
+        CHECK(pd()->post_ops.create_resource(engine, mapper));
+
+        return status::success;
     }
 
     typedef typename prec_traits<data_type::f32>::type data_t;

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -20,6 +20,8 @@
 #include "cpu/aarch64/acl_utils.hpp"
 #include "cpu/cpu_inner_product_pd.hpp"
 
+#include "cpu/aarch64/acl_post_ops.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -27,24 +29,23 @@ namespace aarch64 {
 
 struct acl_ip_obj_t {
     arm_compute::NEFullyConnectedLayer fc;
-    arm_compute::NEArithmeticAddition add;
     arm_compute::Tensor src_tensor;
     arm_compute::Tensor wei_tensor;
     arm_compute::Tensor bia_tensor;
     arm_compute::Tensor dst_tensor;
-    arm_compute::Tensor dst_acc_tensor;
 };
 
 struct acl_ip_conf_t {
     bool with_bias;
-    bool with_sum;
+    // If this is true, the result of the inner product goes into a temporarily
+    // allocated ACL tensor to be accumulated into the oneDNN dst during postops
+    bool use_dst_acc;
     arm_compute::TensorInfo src_info;
     arm_compute::TensorInfo wei_info;
     arm_compute::TensorInfo bia_info;
     arm_compute::TensorInfo dst_info;
     arm_compute::FullyConnectedLayerInfo fc_info;
 };
-
 struct acl_ip_resource_t : public resource_t {
     acl_ip_resource_t() : acl_ip_obj_(utils::make_unique<acl_ip_obj_t>()) {}
 
@@ -56,24 +57,15 @@ struct acl_ip_resource_t : public resource_t {
         acl_ip_obj_->wei_tensor.allocator()->init(aip.wei_info);
         acl_ip_obj_->dst_tensor.allocator()->init(aip.dst_info);
         acl_ip_obj_->bia_tensor.allocator()->init(aip.bia_info);
-        if (aip.with_sum) {
-            acl_ip_obj_->dst_acc_tensor.allocator()->init(aip.dst_info);
-        }
 
         // clang-format off
         acl_ip_obj_->fc.configure(
             &acl_ip_obj_->src_tensor,
             &acl_ip_obj_->wei_tensor,
             aip.with_bias ? &acl_ip_obj_->bia_tensor : nullptr,
-            aip.with_sum ? &acl_ip_obj_->dst_acc_tensor : &acl_ip_obj_->dst_tensor,
+            &acl_ip_obj_->dst_tensor,
             aip.fc_info);
         // clang-format on
-        if (aip.with_sum) {
-            acl_ip_obj_->add.configure(&acl_ip_obj_->dst_tensor,
-                    &acl_ip_obj_->dst_acc_tensor, &acl_ip_obj_->dst_tensor,
-                    arm_compute::ConvertPolicy::SATURATE);
-            acl_ip_obj_->dst_acc_tensor.allocator()->allocate();
-        }
 
         return status::success;
     }
@@ -90,6 +82,10 @@ struct acl_inner_product_fwd_t : public primitive_t {
     struct pd_t : public cpu_inner_product_fwd_pd_t {
         using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
 
+        pd_t(const inner_product_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_inner_product_fwd_pd_t(adesc, attr, hint_fwd_pd), aip() {}
+
         DECLARE_COMMON_PD_T("acl", acl_inner_product_fwd_t);
 
         status_t init(engine_t *engine) {
@@ -99,46 +95,25 @@ struct acl_inner_product_fwd_t : public primitive_t {
                     && attr()->has_default_values(
                             primitive_attr_t::skip_mask_t::post_ops,
                             data_type::f32)
-                    && set_default_params() == status::success && post_ops_ok();
+                    && set_default_params() == status::success;
 
             if (!ok) return status::unimplemented;
 
-            CHECK(init_conf_ip(aip, src_md_, weights_md_, dst_md_, bias_md_,
-                    *desc(), *attr()));
+            CHECK(init_conf_ip(engine));
 
             return status::success;
         }
 
         acl_ip_conf_t aip;
 
-    protected:
-        bool post_ops_ok() const {
-            auto const &po = attr()->post_ops_;
-            // "true" here stands for eltwise.scale == 1.f check
-            auto is_eltwise
-                    = [&](int idx) { return po.entry_[idx].is_eltwise(true); };
-            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
+        acl_post_ops_t post_ops;
 
-            bool eltwise_ok = false;
-            // Compute Library supports here only one eltwise post-op or sum
-            if (po.len() == 1 && is_eltwise(0)) {
-                const auto act_type = po.entry_[0].eltwise.alg;
-                eltwise_ok = acl_utils::acl_act_ok(act_type);
-            }
+        status_t init_conf_ip(engine_t *engine) {
 
-            return eltwise_ok || (po.len() == 1 && is_sum(0))
-                    || (po.len() == 0);
-        }
-
-        status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
-                memory_desc_t &wei_md, memory_desc_t &dst_md,
-                memory_desc_t &bias_md, const inner_product_desc_t &ipd,
-                const primitive_attr_t &attr) {
-
-            ACL_CHECK_SUPPORT(src_md.ndims != wei_md.ndims,
+            ACL_CHECK_SUPPORT(src_md()->ndims != weights_md()->ndims,
                     "source and weights dimensions must match");
 
-            const int ndims = src_md.ndims;
+            const int ndims = src_md()->ndims;
 
             const bool is_2d = (ndims == 2);
             const bool is_4d = (ndims == 4);
@@ -147,27 +122,27 @@ struct acl_inner_product_fwd_t : public primitive_t {
                     !(is_2d || is_4d), "ACL supports only 2d or 4d cases");
 
             // batch size
-            const int n = src_md.dims[0];
+            const int n = src_md()->dims[0];
 
             // input and output channels
-            const int ic = src_md.dims[1];
-            const int oc = dst_md.dims[1];
+            const int ic = src_md()->dims[1];
+            const int oc = dst_md()->dims[1];
 
             // source spatial dimensions
-            const int ih = is_4d ? src_md.dims[ndims - 2] : 0;
-            const int iw = is_4d ? src_md.dims[ndims - 1] : 0;
+            const int ih = is_4d ? src_md()->dims[ndims - 2] : 0;
+            const int iw = is_4d ? src_md()->dims[ndims - 1] : 0;
 
             // weights spatial dimensions
-            const int kh = is_4d ? wei_md.dims[ndims - 2] : 0;
-            const int kw = is_4d ? wei_md.dims[ndims - 1] : 0;
+            const int kh = is_4d ? weights_md()->dims[ndims - 2] : 0;
+            const int kw = is_4d ? weights_md()->dims[ndims - 1] : 0;
 
             // Only NCHW or NHWC derivatives supported by ACL kernels
             using namespace format_tag;
             auto src_tag = memory_desc_matches_one_of_tag(
-                    src_md, nhwc, nchw, nc, cn);
+                    src_md_, nhwc, nchw, nc, cn);
             auto wei_tag = memory_desc_matches_one_of_tag(
-                    wei_md, ohwi, oihw, oi, io);
-            auto dst_tag = memory_desc_matches_one_of_tag(dst_md, nc, cn);
+                    weights_md_, ohwi, oihw, oi, io);
+            auto dst_tag = memory_desc_matches_one_of_tag(dst_md_, nc, cn);
 
             ACL_CHECK_SUPPORT(
                     utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
@@ -212,7 +187,7 @@ struct acl_inner_product_fwd_t : public primitive_t {
                     = arm_compute::TensorInfo(arm_compute::TensorShape(oc, n),
                             1, arm_compute::DataType::F32);
 
-            aip.with_bias = ipd.bias_desc.format_kind != format_kind::undef;
+            aip.with_bias = desc()->bias_desc.format_kind != format_kind::undef;
             aip.bia_info = arm_compute::TensorInfo(aip.with_bias
                             ? arm_compute::TensorShape(oc)
                             : arm_compute::TensorShape(),
@@ -223,22 +198,21 @@ struct acl_inner_product_fwd_t : public primitive_t {
                 // weights are already transposed
                 aip.fc_info.transpose_weights = false;
 
-                if (ipd.prop_kind == dnnl_forward_training) {
+                if (desc()->prop_kind == dnnl_forward_training) {
                     aip.wei_info.set_are_values_constant(false);
                     aip.fc_info.are_weights_reshaped = true;
                 }
             }
-
-            // Either activation or sum is supported as post-op at the moment
-            aip.fc_info.activation_info = acl_utils::get_acl_act(attr);
-            const auto &post_ops = attr.post_ops_;
-            aip.with_sum = (post_ops.len() == 1) && post_ops.entry_[0].is_sum();
 
             // Fast math mode
             auto math_mode = get_fpmath_mode();
             bool is_fastmath_enabled = utils::one_of(
                     math_mode, fpmath_mode::bf16, fpmath_mode::any);
             aip.fc_info.enable_fast_math = is_fastmath_enabled;
+
+            CHECK(post_ops.init(engine, attr_.post_ops_, dst_md_,
+                    aip.fc_info.activation_info));
+            aip.use_dst_acc = post_ops.has_sum();
 
             // clang-format off
             // Validate fully connected layer manually to check for return status
@@ -248,17 +222,7 @@ struct acl_inner_product_fwd_t : public primitive_t {
                 aip.with_bias ? &aip.bia_info : nullptr,
                 &aip.dst_info,
                 aip.fc_info));
-
-            if (aip.with_sum) {
-                // Validate arithmetic addition manually to check for return status
-                ACL_CHECK_VALID(arm_compute::NEArithmeticAddition::validate(
-                    &aip.dst_info,
-                    &aip.dst_info,
-                    &aip.dst_info,
-                    arm_compute::ConvertPolicy::SATURATE));
-                // clang-format on
-            }
-
+            // clang-format on
             return status::success;
         }
     }; // pd_t
@@ -273,10 +237,12 @@ struct acl_inner_product_fwd_t : public primitive_t {
         if (!r) return status::out_of_memory;
 
         // Configure the resource based on information from primitive descriptor
-        auto st = r->configure(pd()->aip);
-        if (st == status::success) { mapper.add(this, std::move(r)); }
+        CHECK(r->configure(pd()->aip));
+        mapper.add(this, std::move(r));
 
-        return st;
+        CHECK(pd()->post_ops.create_resource(engine, mapper));
+
+        return status::success;
     }
 
     using data_t = typename prec_traits<data_type::f32>::type;

--- a/src/cpu/aarch64/acl_post_ops.cpp
+++ b/src/cpu/aarch64/acl_post_ops.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_gemm_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+status_t acl_post_ops_t::execute(const exec_ctx_t &ctx, void *src_orig) const {
+
+    int post_op_index = 0;
+
+    // As these are post ops, this src will also be our dst. If we have a sum
+    // post op, the src/dst will start off in a temporary, then change to
+    // DNNL_ARG_DST after the sum.
+    void *src = src_orig;
+
+    // Post ops must operate in place on dst, unless when we have a sum op
+    if (!has_sum() && src != CTX_OUT_MEM(void *, DNNL_ARG_DST)) {
+        return status::runtime_error;
+    }
+
+    for (auto &post_op : post_op_primitives) {
+        if (post_op->kind() == primitive_kind::binary) {
+            auto binary_post_op = dynamic_cast<acl_binary_t *>(post_op.get());
+            if (binary_post_op == nullptr) return status::runtime_error;
+
+            // Sum post op accumulates to dst and changes future dst
+            if (post_op_index == sum_index) {
+                // Change src to final dst, then add orig source to it
+                src = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+                CHECK(binary_post_op->execute_forward(ctx, src_orig, src, src));
+            } else {
+                const void *src1 = CTX_IN_MEM(const void *,
+                        (DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_op_index)
+                                | DNNL_ARG_SRC_1));
+                CHECK(binary_post_op->execute_forward(ctx, src, src1, src));
+            }
+        } else if (post_op->kind() == primitive_kind::eltwise) {
+            // The post op at the sum index must be binary
+            if (post_op_index == sum_index) return status::runtime_error;
+
+            auto eltwise_post_op
+                    = dynamic_cast<acl_eltwise_fwd_t *>(post_op.get());
+            if (eltwise_post_op == nullptr) return status::runtime_error;
+
+            CHECK(eltwise_post_op->execute_forward(ctx, src, src));
+        } else {
+            return status::runtime_error;
+        }
+
+        ++post_op_index;
+    }
+
+    return status::success;
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -1,0 +1,184 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_POST_OPS_HPP
+#define CPU_AARCH64_ACL_POST_OPS_HPP
+
+#include "cpu/aarch64/acl_binary.hpp"
+#include "cpu/aarch64/acl_eltwise.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct acl_post_ops_t {
+
+    acl_post_ops_t() = default;
+
+    // init the acl_post_ops_t. Note that this function modifies the passed in
+    // post ops by setting the preferred memory formats
+    status_t init(engine_t *engine, post_ops_t &post_ops,
+            const memory_desc_t &dst_md) {
+
+        CHECK(post_ops.set_default_formats(&dst_md));
+
+        // Reset properties derived from post_ops
+        sum_index = -1;
+        post_op_primitives = {};
+
+        for (int i = 0; i < post_ops.len(); i++) {
+            auto &po = post_ops.entry_[i];
+
+            if (po.is_sum()) {
+                ACL_CHECK_SUPPORT(po.sum.scale != 1.0f,
+                        "sum post op scale must be 1 (no scale)");
+
+                ACL_CHECK_SUPPORT(po.sum.zero_point != 0,
+                        "sum post op zero point must be 0 (no shift)");
+
+                // >= 0 means we had one already
+                ACL_CHECK_SUPPORT(sum_index >= 0,
+                        "there must not be more than 1 sum post op");
+
+                sum_index = i;
+
+                // Sum is an add primitive where dst = temp_dst + dst
+                binary_desc_t po_desc;
+                po_desc.primitive_kind = primitive_kind::binary;
+                po_desc.alg_kind = alg_kind::binary_add;
+                po_desc.src_desc[0] = dst_md;
+                po_desc.src_desc[1] = dst_md;
+                po_desc.dst_desc = dst_md;
+                auto empty_attr = dnnl_primitive_attr();
+                typename acl_binary_t::pd_t acl_binary_pd(
+                        &po_desc, &empty_attr, nullptr);
+                CHECK(acl_binary_pd.init(engine));
+
+                auto acl_binary
+                        = std::make_shared<acl_binary_t>(&acl_binary_pd);
+                CHECK(acl_binary->init(engine));
+                post_op_primitives.push_back(acl_binary);
+
+            } else if (po.is_binary()) {
+                binary_desc_t po_desc;
+                po_desc.primitive_kind = primitive_kind::binary;
+                po_desc.alg_kind = po.binary.alg;
+                po_desc.src_desc[0] = dst_md;
+                po_desc.src_desc[1] = po.binary.src1_desc;
+                po_desc.dst_desc = dst_md;
+                auto empty_attr = dnnl_primitive_attr();
+                typename acl_binary_t::pd_t acl_binary_pd(
+                        &po_desc, &empty_attr, nullptr);
+                CHECK(acl_binary_pd.init(engine));
+
+                auto acl_binary
+                        = std::make_shared<acl_binary_t>(&acl_binary_pd);
+                CHECK(acl_binary->init(engine));
+                post_op_primitives.push_back(acl_binary);
+
+            } else if (po.is_eltwise()) {
+                ACL_CHECK_SUPPORT(po.eltwise.scale != 1.0f,
+                        "eltwise post op scale must be 1 (no scale)");
+
+                eltwise_desc_t eltwise_desc;
+                eltwise_desc.primitive_kind = primitive_kind::eltwise;
+                eltwise_desc.alg_kind = po.eltwise.alg;
+                eltwise_desc.alpha = po.eltwise.alpha;
+                eltwise_desc.beta = po.eltwise.beta;
+                eltwise_desc.data_desc = dst_md;
+                eltwise_desc.prop_kind = prop_kind_t::dnnl_forward;
+                auto empty_attr = dnnl_primitive_attr();
+                typename acl_eltwise_fwd_t::pd_t acl_eltwise_pd(
+                        &eltwise_desc, &empty_attr, nullptr);
+                CHECK(acl_eltwise_pd.init(engine));
+
+                auto acl_eltwise
+                        = std::make_shared<acl_eltwise_fwd_t>(&acl_eltwise_pd);
+                CHECK(acl_eltwise->init(engine));
+                post_op_primitives.push_back(acl_eltwise);
+
+            } else {
+                // Unsupported catchall
+                return status::unimplemented;
+            }
+        }
+
+        return status::success;
+    }
+
+    // init acl_post_ops_t, ignoring the first post op if it is an eltwise so
+    // that it can be fused, placing it in act_info_to_fuse. Note that this
+    // function modifies the passed in post ops by setting the preferred memory
+    // formats
+    status_t init(engine_t *engine, post_ops_t &base_post_ops,
+            const memory_desc_t &dst_md,
+            arm_compute::ActivationLayerInfo &act_info_to_fuse) {
+
+        CHECK(base_post_ops.set_default_formats(&dst_md));
+
+        // If the first entry is eltwise, we fuse it
+        if (base_post_ops.len() >= 1 && base_post_ops.entry_[0].is_eltwise()) {
+
+            const auto &first_po = base_post_ops.entry_[0].eltwise;
+            ACL_CHECK_SUPPORT(first_po.scale != 1.0f,
+                    "eltwise post op scale must be 1 (no scale)");
+            CHECK(acl_utils::convert_to_acl_act(first_po, act_info_to_fuse));
+
+            // Copy all but the first, because it has been fused
+            post_ops_t post_ops;
+            for (int idx = 1; idx < base_post_ops.len(); ++idx) {
+                // Construct empty entry then copy, so that we can check for failure
+                post_ops.entry_.emplace_back();
+                CHECK(post_ops.entry_.back().copy_from(
+                        base_post_ops.entry_[idx]));
+            }
+            return init(engine, post_ops, dst_md);
+
+        } else {
+            // Nothing to fuse, just copy all post ops
+            return init(engine, base_post_ops, dst_md);
+        }
+    }
+
+    bool has_sum() const { return sum_index >= 0; }
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const {
+        for (const auto &post_op : post_op_primitives) {
+            CHECK(post_op->create_resource(engine, mapper));
+        }
+        return status::success;
+    }
+
+    status_t execute(const exec_ctx_t &ctx, void *src) const;
+
+private:
+    // Index of the sum post op if there is one, < 0 means no sum
+    int sum_index = -1;
+
+    // Vector of primitives used to execute the post ops. They are constructed
+    // in init to be either acl_binary_t (for sum, add, sub, div, mul, min and
+    // max) or acl_eltwise_fwd_t (for relu, elu, tanh, square, abs etc)
+    std::vector<std::shared_ptr<primitive_t>> post_op_primitives;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/acl_utils.hpp
+++ b/src/cpu/aarch64/acl_utils.hpp
@@ -39,9 +39,22 @@ namespace acl_utils {
 
 arm_compute::DataType get_acl_data_t(
         const dnnl_data_type_t dt, const bool is_quantized = false);
-arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
-arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
-bool acl_act_ok(alg_kind_t eltwise_activation);
+
+// Convert alg_kind_t, alpha and beta into an ACL ActivationLayerInfo. Will
+// return unimplemented and a disabled ActivationLayerInfo if the conversion
+// fails
+status_t convert_to_acl_act(alg_kind_t eltwise_alg, float alpha, float beta,
+        arm_compute::ActivationLayerInfo &act_info);
+
+// Convert an eltwise_desc_t into an ACL ActivationLayerInfo. Will return
+// unimplemented and a disabled ActivationLayerInfo if the conversion fails
+status_t convert_to_acl_act(
+        const eltwise_desc_t &ed, arm_compute::ActivationLayerInfo &act_info);
+
+// Convert an eltwise post op into an ACL ActivationLayerInfo. Will return
+// unimplemented and a disabled ActivationLayerInfo if the conversion fails
+status_t convert_to_acl_act(const post_ops_t::entry_t::eltwise_t &elt,
+        arm_compute::ActivationLayerInfo &act_info);
 
 // Convert a memory desc to an arm_compute::TensorInfo. Note that memory desc
 // must be blocking format, plain, dense and have no zero dimensions.

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2021 Arm Ltd. and affiliates
+* Copyright 2020-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -40,30 +40,16 @@ struct acl_wino_resource_t : public resource_t {
         acl_wino_obj_->dst_tensor.allocator()->init(acp.dst_info);
         acl_wino_obj_->bia_tensor.allocator()->init(acp.bia_info);
 
-        if (acp.sum_with_eltwise) {
-            acl_wino_obj_->dst_acc_tensor.allocator()->init(acp.dst_info);
-        }
         // clang-format off
         acl_wino_obj_->conv.configure(
             &acl_wino_obj_->src_tensor,
             &acl_wino_obj_->wei_tensor,
             acp.with_bias ? &acl_wino_obj_->bia_tensor : nullptr,
-            acp.sum_with_eltwise ? &acl_wino_obj_->dst_acc_tensor
-                                 : &acl_wino_obj_->dst_tensor,
+            &acl_wino_obj_->dst_tensor,
             acp.padstride_info,
-            acp.sum_with_eltwise ? arm_compute::ActivationLayerInfo()
-                                 : acp.act_info,
+            acp.act_info,
             true); // to support 5x5, 7x7 filter shapes in addition to 3x3
         // clang-format on
-        if (acp.sum_with_eltwise) {
-            acl_wino_obj_->add.configure(&acl_wino_obj_->dst_tensor,
-                    &acl_wino_obj_->dst_acc_tensor,
-                    &acl_wino_obj_->dst_acc_tensor,
-                    arm_compute::ConvertPolicy::SATURATE);
-            acl_wino_obj_->act.configure(&acl_wino_obj_->dst_acc_tensor,
-                    &acl_wino_obj_->dst_tensor, acp.act_info);
-            acl_wino_obj_->dst_acc_tensor.allocator()->allocate();
-        }
 
         return status::success;
     }
@@ -83,7 +69,9 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
     struct pd_t : public cpu_convolution_fwd_pd_t {
         pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
                 const typename pd_t::base_class *hint_fwd_pd)
-            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), acp_() {}
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
+            , acp_()
+            , post_ops() {}
 
         DECLARE_COMMON_PD_T(
                 "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
@@ -98,41 +86,23 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
                     && attr()->has_default_values(
                             primitive_attr_t::skip_mask_t::post_ops,
                             data_type::f32)
-                    && !has_zero_dim_memory() && post_ops_ok();
+                    && !has_zero_dim_memory();
             if (!ok) return status::unimplemented;
 
-            auto conf_status = acl_convolution_utils::init_conf_wino(acp_,
-                    src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
-            if (conf_status != status::success) return status::unimplemented;
+            CHECK(acl_convolution_utils::init_conf_wino(acp_, src_md_,
+                    weights_md_, dst_md_, bias_md_, *desc(), *attr()));
 
             set_default_alg_kind(alg_kind::convolution_winograd);
+
+            CHECK(post_ops.init(
+                    engine, attr_.post_ops_, dst_md_, acp_.act_info));
+            acp_.use_dst_acc = post_ops.has_sum();
 
             return status::success;
         }
 
         acl_conv_conf_t acp_;
-
-    protected:
-        bool post_ops_ok() const {
-            auto const &po = attr()->post_ops_;
-            // "true" here stands for eltwise.scale == 1.f check
-            auto is_eltwise
-                    = [&](int idx) { return po.entry_[idx].is_eltwise(true); };
-            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
-
-            bool sum_with_eltwise
-                    = (po.len() == 2) && is_sum(0) && is_eltwise(1);
-            bool eltwise_only = (po.len() == 1) ? is_eltwise(0) : false;
-            bool eltwise_ok = false;
-            // Compute Library supports only one eltwise post-op or
-            // sum+eltwise post-ops
-            if (eltwise_only || sum_with_eltwise) {
-                const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
-                eltwise_ok = acl_utils::acl_act_ok(act_type);
-            }
-
-            return eltwise_ok || (po.len() == 0);
-        }
+        acl_post_ops_t post_ops;
     };
 
     acl_wino_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
@@ -145,10 +115,12 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
         if (!r) return status::out_of_memory;
 
         // Configure the resource based on information from primitive descriptor
-        auto st = r->configure(pd()->acp_);
-        if (st == status::success) { mapper.add(this, std::move(r)); }
+        CHECK(r->configure(pd()->acp_));
+        mapper.add(this, std::move(r));
 
-        return st;
+        CHECK(pd()->post_ops.create_resource(engine, mapper));
+
+        return status::success;
     }
 
     ~acl_wino_convolution_fwd_t() {}
@@ -164,7 +136,6 @@ private:
     mutable std::mutex mtx;
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-
 }; // acl_wino_convolution_fwd_t
 
 } // namespace aarch64

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -29,10 +29,10 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
     status_t status = status::success;
     auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
     auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
-    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
 
     bool is_transA = pd()->amp_.is_transA;
     bool is_transB = pd()->amp_.is_transB;
+    bool use_dst_acc = pd()->amp_.use_dst_acc;
 
     std::lock_guard<std::mutex> _lock {this->mtx};
     auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
@@ -68,15 +68,27 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
                 const_cast<data_t *>(wei_base));
     }
 
-    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+    if (use_dst_acc) {
+        // Put the result in a new tensor, it will be accumalated to the dst
+        // during the post ops
+        acl_obj.dst_tensor.allocator()->allocate();
+    } else {
+        auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+        acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+    }
 
     acl_obj.gemm.run();
 
     acl_obj.src_tensor.allocator()->free();
     acl_obj.wei_tensor.allocator()->free();
-    acl_obj.dst_tensor.allocator()->free();
     if (is_transA) acl_obj.src_acc_tensor.allocator()->free();
     if (is_transB) acl_obj.wei_acc_tensor.allocator()->free();
+
+    void *dst = acl_obj.dst_tensor.buffer();
+    pd()->post_ops.execute(ctx, dst);
+
+    acl_obj.dst_tensor.allocator()->free();
+
     return status;
 }
 

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -40,6 +40,9 @@ struct acl_matmul_obj_t {
 struct acl_matmul_conf_t {
     bool is_transA;
     bool is_transB;
+    // If this is true, the result of the matmul goes into a temporarily
+    // allocated ACL tensor to be accumulated into the oneDNN dst during postops
+    bool use_dst_acc;
     arm_compute::TensorInfo src_info;
     arm_compute::TensorInfo src_acc_info;
     arm_compute::TensorInfo wei_info;
@@ -55,8 +58,6 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
         memory_desc_t &wei_md, memory_desc_t &dst_md, const matmul_desc_t &md,
         const primitive_attr_t &attr);
 
-arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
-bool acl_act_ok(alg_kind_t eltwise_activation);
 } // namespace acl_matmul_utils
 
 } // namespace aarch64


### PR DESCRIPTION
# Description

Adds class `acl_post_ops_t` which enables Compute Library for the Arm® Architecture (ACL) based primitives to have an arbitrary number and type of post ops by composing `acl_binary_t` and `acl_eltwise_fwd_t`.
This class has been added to:
- `acl_inner_product_fwd_t`
- `acl_matmul_t`
- Convolution: `acl_gemm_convolution_fwd_t`, `acl_wino_convolution_fwd_t` and `acl_indirect_gemm_convolution_fwd_t`

This replaces functionality in these classes which previously supported up to sum+eltwise with a more generalised approach. The primitives still fuse eltwise operations where possible, as before.

This patch also modifies the `acl_eltwise_fwd_t` primitive to support any number of dimensions of input/output tensor.

These changes are covered by existing tests for eltwise and the base primitives (which include post-ops).

The overhead of the post ops is small, so the performance improvement for the newly supported cases is similar to the performance improvement of each base primitive over the reference implementations. Furthermore, `acl_binary_t` and `acl_eltwise_fwd_t` are several times faster than the reference implementation of binary and eltwise post ops.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?
