### PR TITLE
Fix simple reorder

### DIFF
--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -144,6 +144,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 & memory_extra_flags::compensation_conv_s8s8;
         const bool req_asymmetric_comp = output_d.extra().flags
                 & memory_extra_flags::compensation_conv_asymmetric_src;
+        const bool req_check_scale_mask = attr->output_scales_.mask_;
 
         auto mask_ok = [&](bool check, int mask) {
             return IMPLICATION(check, mask == (w_groups ? 0x3 : 0x1));
@@ -153,6 +154,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 && output_d.matches_tag(tag_o) && input_d.is_plain()
                 && (req_comp || req_asymmetric_comp)
                 && mask_ok(req_comp, output_d.extra().compensation_mask)
+                && mask_ok(req_check_scale_mask, attr->output_scales_.mask_)
                 && mask_ok(req_asymmetric_comp,
                         output_d.extra().asymm_compensation_mask)
                 && IMPLICATION(
@@ -303,6 +305,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 & memory_extra_flags::compensation_conv_s8s8;
         const bool req_asymmetric_comp = output_d.extra().flags
                 & memory_extra_flags::compensation_conv_asymmetric_src;
+        const bool req_check_scale_mask = attr->output_scales_.mask_ != 0;
 
         auto mask_ok = [&](bool check, int mask) {
             return IMPLICATION(check, mask == (w_groups ? 0x3 : 0x1));
@@ -314,6 +317,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 && mask_ok(req_comp, output_d.extra().compensation_mask)
                 && mask_ok(req_asymmetric_comp,
                         output_d.extra().asymm_compensation_mask)
+                && mask_ok(req_check_scale_mask, attr->output_scales_.mask_)
                 && IMPLICATION(
                         req_comp, one_of(D_mask, (size_t)1, (size_t)g * oc))
                 && one_of(input_d.data_type(), f32, s8, bf16)

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -428,7 +428,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         constexpr dim_t i_mult_oc = ocblksize;
         constexpr dim_t o_mult = 1;
 
-        size_t offset = G * PADDED_OC * pdims[w_groups + 1] * D * H * W;
+        size_t offset = output_d.size() - output_d.additional_buffer_size();
         size_t zp_offset
                 = offset + (req_comp ? G * PADDED_OC * sizeof(int32_t) : 0);
         int32_t *cp = req_comp ? reinterpret_cast<int32_t *>(output + offset)
@@ -575,8 +575,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
             }
         };
 
-        size_t offset
-                = G * pdims[w_groups + 0] * pdims[w_groups + 1] * D * H * W;
+        size_t offset = output_d.size() - output_d.additional_buffer_size();
         int32_t *zp = has_asymmetric_comp
                 ? reinterpret_cast<int32_t *>(output + offset)
                 : nullptr;
@@ -749,8 +748,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
             }
         };
 
-        size_t offset
-                = G * pdims[w_groups + 0] * pdims[w_groups + 1] * D * H * W;
+        size_t offset = output_d.size() - output_d.additional_buffer_size();
         int32_t *zp = has_asymmetric_comp
                 ? reinterpret_cast<int32_t *>(output + offset)
                 : nullptr;

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -176,11 +176,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 = utils::one_of(tag_o, format_tag::dhwio, format_tag::dhwigo);
 
         const auto &dims = input_d.dims();
-        const auto &pdims = input_d.padded_dims();
 
         const dim_t G = w_groups ? dims[0] : 1;
         const dim_t OC = dims[w_groups + 0];
-        const dim_t PADDED_OC = pdims[w_groups + 0];
         const dim_t IC = dims[w_groups + 1];
         const dim_t D = w_depth ? dims[w_groups + 2] : 1;
         const dim_t H = w_height ? dims[w_groups + w_depth + 2] : 1;
@@ -202,8 +200,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 : 1.f;
 
         size_t offset = output_d.size() - output_d.additional_buffer_size();
-        size_t zp_offset
-                = offset + (req_comp ? G * PADDED_OC * sizeof(int32_t) : 0);
+        size_t comp_size = output_d.additional_buffer_size(
+                memory_extra_flags::compensation_conv_s8s8);
+        size_t zp_offset = offset + (req_comp ? comp_size : 0);
         int32_t *cp = req_comp ? reinterpret_cast<int32_t *>(output + offset)
                                : nullptr;
         int32_t *zp = has_asymmetric_comp
@@ -429,8 +428,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         constexpr dim_t o_mult = 1;
 
         size_t offset = output_d.size() - output_d.additional_buffer_size();
-        size_t zp_offset
-                = offset + (req_comp ? G * PADDED_OC * sizeof(int32_t) : 0);
+        size_t comp_size = output_d.additional_buffer_size(
+                memory_extra_flags::compensation_conv_s8s8);
+        size_t zp_offset = offset + (req_comp ? comp_size : 0);
         int32_t *cp = req_comp ? reinterpret_cast<int32_t *>(output + offset)
                                : nullptr;
         int32_t *zp = has_asymmetric_comp
@@ -907,7 +907,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         const auto w_d = order_keep ? output_d : input_d;
         size_t offset = w_d.size() - w_d.additional_buffer_size();
-        size_t zp_offset = offset + (req_comp ? pdims[1] * sizeof(int32_t) : 0);
+        size_t comp_size = output_d.additional_buffer_size(
+                memory_extra_flags::compensation_conv_s8s8);
+        size_t zp_offset = offset + (req_comp ? comp_size : 0);
         int32_t *cp = req_comp ? reinterpret_cast<int32_t *>(output + offset)
                                : nullptr;
         int32_t *zp = has_asymmetric_comp
@@ -1054,7 +1056,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         };
 
         size_t offset = output_d.size() - output_d.additional_buffer_size();
-        size_t zp_offset = offset + (req_comp ? Gp * OC * sizeof(int32_t) : 0);
+        size_t comp_size = output_d.additional_buffer_size(
+                memory_extra_flags::compensation_conv_s8s8);
+        size_t zp_offset = offset + (req_comp ? comp_size : 0);
         int32_t *cp = req_comp ? reinterpret_cast<int32_t *>(output + offset)
                                : nullptr;
         int32_t *zp = has_asymmetric_comp

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -1355,10 +1355,11 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     for (int c = 0; c < block_i; ++c) {
                         o[o_off + c] = _qz_a1b0<type_i, type_o>()(i[i_off + c]);
                     }
-                    if (order_keep && b + 1 == nb) {
+                    if (b + 1 == nb) {
                         // zero padding
-                        const auto pad_size
-                                = blksize_16 - ((nb - 1) * blksize_i);
+                        const auto pad_size = order_keep
+                                ? blksize_16 - ((nb - 1) * blksize_i)
+                                : blksize_i;
                         const auto pad_start = block_i + o_off;
                         const auto pad_end = pad_size + o_off;
                         PRAGMA_OMP_SIMD()
@@ -1379,10 +1380,11 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                         o[o_off + c] = _qz<type_i, type_o>()(
                                 i[i_off + c], o[o_off + c], alpha, beta);
                     }
-                    if (order_keep && b + 1 == nb) {
+                    if (b + 1 == nb) {
                         // zero padding
-                        const auto pad_size
-                                = blksize_16 - ((nb - 1) * blksize_i);
+                        const auto pad_size = order_keep
+                                ? blksize_16 - ((nb - 1) * blksize_i)
+                                : blksize_i;
                         const auto pad_start = block_i + o_off;
                         const auto pad_end = pad_size + o_off;
                         PRAGMA_OMP_SIMD()

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -361,6 +361,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         const auto &plain_d = order_keep ? input_d : output_d;
         const auto &dims = input_d.dims();
+        const int ndims = input_d.ndims();
         const auto &pdims
                 = order_keep ? output_d.padded_dims() : input_d.padded_dims();
 
@@ -374,9 +375,18 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         const dim_t H = is_1d || is_0d ? 1 : dims[2 + w_groups + is_3d];
         const dim_t W = is_0d ? 1 : dims[w_groups + is_3d + 3 - is_1d];
 
+        int smask = pd->attr()->output_scales_.mask_;
+        // XXX: Currently user can pass a mask that has non-zero values in
+        // dimensions that do not exist in a md. Since attributes are created
+        // separately mask can't be validated.
+        // This line truncates a given mask in range [0, 1 << ndims - 1]
+        // TODO: Such masks can be either prohibited at pd creation step at
+        // API level or checked by each implementation that relies on it.
+        smask &= (1 << ndims) - 1;
         const float *scales = pd->attr()->output_scales_.scales_;
-        const size_t D_mask = utils::array_product(input_d.dims(),
-                math::ilog2q(pd->attr()->output_scales_.mask_ + 1));
+
+        const size_t D_mask
+                = utils::array_product(input_d.dims(), math::ilog2q(smask + 1));
         const bool req_comp = output_d.extra().flags
                 & memory_extra_flags::compensation_conv_s8s8;
         const bool has_asymmetric_comp = output_d.extra().flags
@@ -2005,6 +2015,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         const auto output_d = ctx.memory_mdw(DNNL_ARG_TO, pd()->dst_md());
 
         const size_t nelems = input_d.nelems();
+        const int ndims = input_d.ndims();
 
         // This kernel is used also for tensors with multiple inner
         // blocks for which generic zero padding must be used.
@@ -2013,6 +2024,14 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         int ndims_start = 0, ndims_mask = 0;
         int smask = pd()->attr()->output_scales_.mask_;
+        // XXX: Currently user can pass a mask that has non-zero values in
+        // dimensions that do not exist in a md. Since attributes are created
+        // separately mask can't be validated.
+        // This line truncates a given mask in range [0, 1 << ndims - 1]
+        // TODO: Such masks can be either prohibited at pd creation step at
+        // API level or checked by each implementation that relies on it.
+        smask &= (1 << ndims) - 1;
+
         for (; smask > 0 && !(smask & 0x1); smask >>= 1)
             ++ndims_start;
         for (; smask > 0 && smask & 0x1; smask >>= 1)


### PR DESCRIPTION
# Description

Simple reorder contains a few issues that are not reproducible on x64, because they are disabled. The issues can be reproduced when aarch64 emulation is used:

- Zero padding optimizations bb0f475615097915a17cb0a5cd4a7980d1e84691 introduced an issue by not padding properly in some cases.
- In benchdnn mask is created separately so it doesn't have information about `ndims`. Due to this for `per_tensor` policy the mask is `(1 << DNNL_MAX_NDIMS) - 1` and if implementation relies on the mask this results in an issue. The workaround is to truncate it on the implementation side. An alternative is to forbid to pass such masks and return `invalid_arguments` when `primitive_desc` is being created. Benchdnn should be updated as well to truncate mask on its side.
- Memory descriptor defines size for compensation based on `padded_dims` ( [Link](https://github.com/oneapi-src/oneDNN/blob/682a91bdbcc8e494935f9a4d4b98bcd47ac3bfce/src/common/memory_desc_wrapper.hpp#L121) ), but simple reorder uses logical dims which results in an issue.
- benchdnn contains tests that contains `oscale` mask `per_dim_1`, but it is not supported by `simple_reorder`.

Fixes #1272

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?