### PR TITLE
gpu: convolution: fix CUDNN_FMA_MATH for cuDNN 7.6.x

### DIFF
--- a/src/gpu/nvidia/cudnn_convolution_impl.hpp
+++ b/src/gpu/nvidia/cudnn_convolution_impl.hpp
@@ -30,7 +30,9 @@
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "gpu/nvidia/sycl_cuda_utils.hpp"
 
-#if CUDNN_MAJOR < 8
+// `CUDNN_FMA_MATH` is available starting from cuDNN v8.
+// The behavior is consistent with `CUDNN_DEFAULT_MATH` for v7.
+#if defined(CUDNN_MAJOR) && (CUDNN_MAJOR < 8)
 #define CUDNN_FMA_MATH CUDNN_DEFAULT_MATH
 #endif
 

--- a/src/gpu/nvidia/cudnn_convolution_impl.hpp
+++ b/src/gpu/nvidia/cudnn_convolution_impl.hpp
@@ -30,6 +30,10 @@
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 #include "gpu/nvidia/sycl_cuda_utils.hpp"
 
+#if CUDNN_MAJOR < 8
+#define CUDNN_FMA_MATH CUDNN_DEFAULT_MATH
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace gpu {


### PR DESCRIPTION
# Description

This patch fix an issue that prevents the compilation of oneDNN with cuDNN versions lower than 8, since for these versions the ``CUDNN_FMA_MATH`` math mode is not defined.

Fortunately, in case of cuDNN 7.6.x , the same behavior of ``CUDNN_FMA_MATH`` (i.e., excluding the utilization of the tensor cores) is provided by ``CUDNN_DEFAULT_MATH``, e.g., see [here](https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn_760/cudnn-developer-guide/index.html#cudnnMathType_t).

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
