### PR TITLE
gpu: matmul: support --dtag=ba/acb

### DIFF
--- a/src/gpu/nvidia/cudnn_matmul.hpp
+++ b/src/gpu/nvidia/cudnn_matmul.hpp
@@ -54,9 +54,6 @@ struct cudnn_matmul_t : public primitive_t {
             bool s8_case = utils::everyone_is(s8, src_dt, wei_dt)
                     && utils::one_of(dst_dt, s8, f32);
 
-            memory_desc_wrapper dst_mdw(dst_md());
-            auto dst_stride = dst_mdw.blocking_desc().strides;
-
             bool ok = blocking_ok()
                     && attr()->has_default_values(
                             smask_t::oscale_runtime | smask_t::post_ops)
@@ -69,8 +66,7 @@ struct cudnn_matmul_t : public primitive_t {
                                             utils::one_of(bia_dt, f16, f32))
                                     && IMPLICATION(s8_case,
                                             utils::one_of(bia_dt, s8, f32))))
-                    && !(with_bias() && s8_case)
-                    && (dst_stride[dst_md()->ndims - 1] == 1);
+                    && !(with_bias() && s8_case);
             if (!ok) return status::unimplemented;
 
             // Check for uniform batch values across src and wei since

--- a/src/gpu/nvidia/cudnn_matmul_impl.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_impl.hpp
@@ -193,7 +193,6 @@ struct cudnn_matmul_impl_t {
     status_t init_gemm_parameters(const memory_desc_wrapper src_d,
             const memory_desc_wrapper weights_d,
             const memory_desc_wrapper dst_d) {
-        const auto &dst_bd = dst_d.blocking_desc();
 
         if (isbatched_) {
             // Check that user didn't provide broadcast case. See pd_t::init()
@@ -213,6 +212,7 @@ struct cudnn_matmul_impl_t {
         N_ = (int)N;
         K_ = (int)K;
 
+        const auto &dst_strides = &dst_d.blocking_desc().strides[isbatched_];
         const auto &src_strides = &src_d.blocking_desc().strides[isbatched_];
         const auto &weights_strides
                 = &weights_d.blocking_desc().strides[isbatched_];
@@ -226,13 +226,18 @@ struct cudnn_matmul_impl_t {
         transB_ = src_strides[1] == 1 && src_d.dims()[isbatched_ + 0] > 1
                 ? cublasOperation_t::CUBLAS_OP_N
                 : cublasOperation_t::CUBLAS_OP_T;
+        // C matrix is the dst
+        transC_ = dst_strides[1] == 1 && dst_d.dims()[isbatched_ + 0] > 1
+                ? cublasOperation_t::CUBLAS_OP_N
+                : cublasOperation_t::CUBLAS_OP_T;
 
         lda_ = (int)
                 weights_strides[transA_ == cublasOperation_t::CUBLAS_OP_N ? 0
                                                                           : 1];
         ldb_ = (int)
                 src_strides[transB_ == cublasOperation_t::CUBLAS_OP_N ? 0 : 1];
-        ldc_ = (int)dst_bd.strides[isbatched_ + 0];
+        ldc_ = (int)
+                dst_strides[transC_ == cublasOperation_t::CUBLAS_OP_N ? 0 : 1];
 
         if (isbatched_) {
             // These parameters are required for cublasGemmStridedBatchedEx()
@@ -240,7 +245,8 @@ struct cudnn_matmul_impl_t {
                                                                     : lda_ * M_;
             stride_b_ = (transB_ == cublasOperation_t::CUBLAS_OP_N) ? ldb_ * N_
                                                                     : ldb_ * K_;
-            stride_c_ = ldc_ * N_;
+            stride_c_ = (transC_ == cublasOperation_t::CUBLAS_OP_N) ? ldc_ * N_
+                                                                    : ldc_ * M_;
         }
 
         return status::success;
@@ -306,19 +312,40 @@ struct cudnn_matmul_impl_t {
             temp_mem_desc_ = tensor_descs_[io::dst];
             gemm_beta = post_op_sum_;
         }
+        auto flip_op = [](cublasOperation_t op) {
+            return (op == cublasOperation_t::CUBLAS_OP_T)
+                    ? cublasOperation_t::CUBLAS_OP_N
+                    : cublasOperation_t::CUBLAS_OP_T;
+        };
         if (isbatched_) {
             // Calls cublasGemmStridedBatchedEx()
-            CUBLAS_EXECUTE_FUNC(cublasGemmStridedBatchedEx, cublas_handle,
-                    transA_, transB_, M_, N_, K_, &scales, a, weights_type_,
-                    lda_, stride_a_, b, src_type_, ldb_, stride_b_, &gemm_beta,
-                    scratch, dst_type_, ldc_, stride_c_, batch_count_,
-                    acc_type_, gemm_algo_);
+            if (transC_ == cublasOperation_t::CUBLAS_OP_T) {
+                CUBLAS_EXECUTE_FUNC(cublasGemmStridedBatchedEx, cublas_handle,
+                        flip_op(transB_), flip_op(transA_), N_, M_, K_, &scales,
+                        b, src_type_, ldb_, stride_b_, a, weights_type_, lda_,
+                        stride_a_, &gemm_beta, scratch, dst_type_, ldc_,
+                        stride_c_, batch_count_, acc_type_, gemm_algo_);
+
+            } else {
+                CUBLAS_EXECUTE_FUNC(cublasGemmStridedBatchedEx, cublas_handle,
+                        transA_, transB_, M_, N_, K_, &scales, a, weights_type_,
+                        lda_, stride_a_, b, src_type_, ldb_, stride_b_,
+                        &gemm_beta, scratch, dst_type_, ldc_, stride_c_,
+                        batch_count_, acc_type_, gemm_algo_);
+            }
         } else {
             // Calls cublasGemmEx()
-            CUBLAS_EXECUTE_FUNC(cublasGemmEx, cublas_handle, transA_, transB_,
-                    M_, N_, K_, &scales, a, weights_type_, lda_, b, src_type_,
-                    ldb_, &gemm_beta, scratch, dst_type_, ldc_, acc_type_,
-                    gemm_algo_);
+            if (transC_ == cublasOperation_t::CUBLAS_OP_T) {
+                CUBLAS_EXECUTE_FUNC(cublasGemmEx, cublas_handle,
+                        flip_op(transB_), flip_op(transA_), N_, M_, K_, &scales,
+                        b, src_type_, ldb_, a, weights_type_, lda_, &gemm_beta,
+                        scratch, dst_type_, ldc_, acc_type_, gemm_algo_);
+            } else {
+                CUBLAS_EXECUTE_FUNC(cublasGemmEx, cublas_handle, transA_,
+                        transB_, M_, N_, K_, &scales, a, weights_type_, lda_, b,
+                        src_type_, ldb_, &gemm_beta, scratch, dst_type_, ldc_,
+                        acc_type_, gemm_algo_);
+            }
         }
         if (with_bias_) {
             // When bias is specified call cudnnAddTensor()
@@ -384,6 +411,7 @@ private:
     }
     cublasOperation_t transA_;
     cublasOperation_t transB_;
+    cublasOperation_t transC_;
     int M_, N_, K_;
     int lda_, ldb_, ldc_;
     long long int stride_a_, stride_b_, stride_c_;

--- a/src/gpu/nvidia/cudnn_matmul_impl.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_impl.hpp
@@ -137,7 +137,7 @@ struct cudnn_matmul_impl_t {
 
         if (with_eltwise(0, pd) || with_eltwise(1, pd)) {
             with_eltwise_ = true;
-            create_and_set_op_descriptor(pd);
+            CHECK(create_and_set_op_descriptor(pd));
         }
 
         // Set parameter when post-op sum is specified


### PR DESCRIPTION
# Description

This patch allows the gpu matrix multiplication implementation to store results in permuted tensors, i.e., this makes `benchdnn` tests pass when `--dtag` is equal to `ba` or `acb`.

This solves *Transposed destination* in https://github.com/oneapi-src/oneDNN/issues/1292.

Fixes #1292 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
