### PR TITLE
utils: define maybe_unique_ptr and wrap static unique_ptr's with it

### DIFF
--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -740,12 +740,12 @@ inline bool is_native_runtime(runtime_kind_t kind) {
 template <typename T>
 using maybe_unique_ptr = std::unique_ptr<T>;
 #else
-struct dnnl_nop_deleter {
+struct nop_deleter_t {
     template <typename T>
     void operator()(T const &) const noexcept {}
 };
 template <typename T>
-using maybe_unique_ptr = std::unique_ptr<T, dnnl_nop_deleter>;
+using maybe_unique_ptr = std::unique_ptr<T, nop_deleter_t>;
 #endif // DNNL_MAYBE_UNIQUE_PTR_IS_UNIQUE
 
 } // namespace impl

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -722,6 +722,32 @@ inline bool is_native_runtime(runtime_kind_t kind) {
             runtime_kind::tbb, runtime_kind::threadpool);
 }
 
+// Convenience wrapper to choose at compile-time between std::unique_ptr's
+// default deleter and a no-op one.
+//
+// This is useful for static pointers to objects with non-trivial destructors.
+// In some environments (e.g. tests where not all threads are joined at exit
+// time) these destructors can result in sanitizer failures (e.g. races in
+// thread sanitizer) when destructing unique_ptr's, but not with raw pointers.
+// Of course in a shared library environment using raw pointers (that are
+// therefore never freed) would result in memory leaks; this is why
+// DNNL_MAYBE_UNIQUE_PTR_IS_UNIQUE defaults to 1.
+#ifndef DNNL_MAYBE_UNIQUE_PTR_IS_UNIQUE
+#define DNNL_MAYBE_UNIQUE_PTR_IS_UNIQUE 1
+#endif
+
+#if DNNL_MAYBE_UNIQUE_PTR_IS_UNIQUE
+template <typename T>
+using maybe_unique_ptr = std::unique_ptr<T>;
+#else
+struct dnnl_nop_deleter {
+    template <typename T>
+    void operator()(T const &) const noexcept {}
+};
+template <typename T>
+using maybe_unique_ptr = std::unique_ptr<T, dnnl_nop_deleter>;
+#endif // DNNL_MAYBE_UNIQUE_PTR_IS_UNIQUE
+
 } // namespace impl
 } // namespace dnnl
 

--- a/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
@@ -1562,7 +1562,7 @@ xbyak_gemm_t *get_xbyak_gemm(
     };
 
     // Kernel table [isTransA][isTransB][hasBias][beta (0, 1, other)]
-    static std::unique_ptr<xbyak_gemm_t> kernel_table[2][2][2][3];
+    static maybe_unique_ptr<xbyak_gemm_t> kernel_table[2][2][2][3];
     static std::once_flag initialized;
     static std::atomic<dnnl_status_t> st(dnnl_success);
     std::call_once(initialized, [&] {

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
@@ -727,7 +727,7 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
         const dim_t ldb, const float beta, float *C, const dim_t ldc) {
     using namespace avx512_core_gemm_smalln_tn_f32;
 
-    static std::unique_ptr<xbyak_gemm_smalln_tn_t> kernels[4][3][3];
+    static maybe_unique_ptr<xbyak_gemm_smalln_tn_t> kernels[4][3][3];
     static std::once_flag initialized;
 
     static dnnl_status_t st = dnnl_success;

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -2201,7 +2201,7 @@ xbyak_gemm_t *get_xbyak_gemm(
     };
 
     // Kernel table [isTransA][isTransB][hasBias][beta (0, 1, other)]
-    static std::unique_ptr<xbyak_gemm_t> kernel_table[2][2][2][3];
+    static maybe_unique_ptr<xbyak_gemm_t> kernel_table[2][2][2][3];
     static std::once_flag initialized;
     static std::atomic<dnnl_status_t> st(dnnl_success);
     std::call_once(initialized, [&] {

--- a/src/cpu/x64/gemm/gemm_info.cpp
+++ b/src/cpu/x64/gemm/gemm_info.cpp
@@ -366,8 +366,8 @@ void gemm_info_t<a_t, b_t, c_t>::jit_init(void) {
         bool is_bf16_amx = is_bf16 && mayiuse(avx512_core_bf16_amx_bf16);
         bool is_amx = is_int8_amx || is_bf16_amx;
 
-        static std::unique_ptr<jit_generator> copy_a[2][2] = {{nullptr}};
-        static std::unique_ptr<jit_generator> copy_b[2][2] = {{nullptr}};
+        static maybe_unique_ptr<jit_generator> copy_a[2][2] = {{nullptr}};
+        static maybe_unique_ptr<jit_generator> copy_b[2][2] = {{nullptr}};
 
         switch (data_traits<a_t>::data_type) {
             case data_type::s8:
@@ -569,7 +569,7 @@ void gemm_info_t<a_t, b_t, c_t>::jit_init(void) {
         constexpr bool is_b_s8 = data_traits<b_t>::data_type == data_type::s8;
         constexpr bool is_c_s32 = data_traits<c_t>::data_type == data_type::s32;
 
-        static std::unique_ptr<jit_generator> kernel[2][2][2][2]
+        static maybe_unique_ptr<jit_generator> kernel[2][2][2][2]
                 = {{{{nullptr}}}};
         switch (data_traits<a_t>::data_type) {
             case data_type::s8:
@@ -674,10 +674,10 @@ void gemm_info_t<a_t, b_t, c_t>::jit_init(void) {
             default: break;
         }
 
-        static std::unique_ptr<jit_generator> gemv_kernel[2] = {nullptr};
-        static std::unique_ptr<jit_generator> gemv_s8s8s32_kernel = nullptr;
-        static std::unique_ptr<jit_generator> gemv_s8u8s32_kernel = nullptr;
-        static std::unique_ptr<jit_generator> gemv_u8s8s32_kernel = nullptr;
+        static maybe_unique_ptr<jit_generator> gemv_kernel[2] = {nullptr};
+        static maybe_unique_ptr<jit_generator> gemv_s8s8s32_kernel = nullptr;
+        static maybe_unique_ptr<jit_generator> gemv_s8u8s32_kernel = nullptr;
+        static maybe_unique_ptr<jit_generator> gemv_u8s8s32_kernel = nullptr;
         switch (data_traits<a_t>::data_type) {
             case data_type::s8:
                 if (mayiuse(avx512_core)) {


### PR DESCRIPTION
"5572b2eb6 cpu: x64: gemm: fix memory leak" changed some static pointers
to objects with non-trivial destructors to use unique_ptr's. This
avoided memory leaks when unloading/loading the (shared) library.

However, some environments might prefer not running these destructors
(e.g. tests that never unload the library nor merge all threads before
exiting).

This commit makes the use of unique_ptr vs. raw pointers optional for
these object pointers via a compile-time flag.