### PR TITLE
github: automation: azure: increase ci timeout

### DIFF
--- a/.github/automation/.azure-pipeline.yml
+++ b/.github/automation/.azure-pipeline.yml
@@ -32,6 +32,7 @@ jobs:
         displayName: 'ClangFormat_Check'
         failOnStderr: true 
   - job: 'Ubuntu20'
+    timeoutInMinutes: 120
     pool:
       vmImage: 'ubuntu-20.04'
     strategy:
@@ -56,6 +57,7 @@ jobs:
         displayName: 'test'
         failOnStderr: true
   - job: 'Ubuntu18'
+    timeoutInMinutes: 120
     pool:
       vmImage: 'ubuntu-18.04'
     strategy:
@@ -104,6 +106,7 @@ jobs:
         displayName: 'test'
         failOnStderr: true
   - job: 'Windows_Server_2022'
+    timeoutInMinutes: 120
     pool:
       vmImage: 'windows-2022'
     steps:
@@ -115,6 +118,7 @@ jobs:
         displayName: 'test'
         failOnStderr: true
   - job: 'Windows_Server_2019'
+    timeoutInMinutes: 120
     pool:
       vmImage: 'windows-2019'
     steps:


### PR DESCRIPTION
# Description

Accordind to [Azure documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts) default timeout limit is 60, while it can be extended to 360 minutes for public repositories using Microsoft-hosted instanses. This PR extends timeout to 2h to keep CI time reasonable and avoid timeouts.

- [ ] Validate that the changes have impact on the actual timeout on Azure side.