### PR TITLE
change "onednn_verbose" to "dnnl_verbose"  in order to match the form…

### DIFF
--- a/scripts/verbose_converter/src/dnnl_parser.py
+++ b/scripts/verbose_converter/src/dnnl_parser.py
@@ -282,7 +282,7 @@ class LogParser:
                                         notification_level)
             return entry
 
-        verbose_template = "onednn_verbose,operation,engine,primitive," + \
+        verbose_template = "dnnl_verbose,operation,engine,primitive," + \
             "implementation,prop_kind,memory_descriptors,attributes," + \
             "auxiliary,problem_desc"
 
@@ -291,12 +291,12 @@ class LogParser:
             self.__raw_data.append(line.rstrip())
             l_raw = line.split(",")
             marker = l_raw[0]
-            if marker == "onednn_verbose":
+            if marker == "dnnl_verbose":
                 event = l_raw[1]
                 if event == "info":
                     opt = l_raw[2]
                     if opt == "prim_template":
-                        verbose_template = "onednn_verbose," + line.split(':')[1]
+                        verbose_template = "dnnl_verbose," + line.split(':')[1]
                 if event == "exec":
                     l_converted = convert_primitive(l_raw, verbose_template)
                     if l_converted:

--- a/scripts/verbose_converter/tests/benchdnn_test.py
+++ b/scripts/verbose_converter/tests/benchdnn_test.py
@@ -45,8 +45,8 @@ def convert_dir_benchdnn2verbose(dir):
 def generate_verbose(path_to_benchdnn, driver, batch):
     benchdnn_exe = path_to_benchdnn + '/benchdnn'
     sub_env = os.environ.copy()
-    sub_env['ONEDNN_VERBOSE'] = '1'
-    sub_env['ONEDNN_PRIMITIVE_CACHE_CAPACITY'] = '0'
+    sub_env['DNNL_VERBOSE'] = '1'
+    sub_env['DNNL_PRIMITIVE_CACHE_CAPACITY'] = '0'
     sub_args = [
         benchdnn_exe, f"--{driver}", f"--mode=R", f"-v1", f"--batch={batch}"
     ]
@@ -100,7 +100,7 @@ def generate_verbose(path_to_benchdnn, driver, batch):
         # detect driver
         l_s = l.split(',')
         d = benchdnn_gen.convert_driver(l_s[3]) if len(l_s) > 3 else ''
-        if len(l_s) > 3 and l_s[0] == 'onednn_verbose' and d == driver:
+        if len(l_s) > 3 and l_s[0] == 'dnnl_verbose' and d == driver:
             # filter out additional forward calls
             verbose_prop_kind = l_s[5]
             if benchdnn_prop_kind != None and verbose_prop_kind != benchdnn_prop_kind:


### PR DESCRIPTION
# Description
this PR is mainly change the converter to parse "dnnl_verbose" as the header of newest verbose log. and change the other ENV variable name from ONEDNN_PRIMITIVE_CACHE_CAPACITY to DNNL_PRIMITIVE_CACHE_CAPACITY.

since the newest header of oneDNN verbose log is begin with "dnnl_verbose, ...", these converter parse the log as it was the old one like "onednn_verbose, ..", it couldn't work after the version 2.5.0. 


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?



### Bug fixes




