### PR TITLE
cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.hpp: do not include xbyak explicitly

### DIFF
--- a/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.hpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.hpp
@@ -20,7 +20,7 @@
 #include <functional>
 
 #include "common/c_types_map.hpp"
-#include "cpu/x64/xbyak/xbyak.h"
+#include "cpu/x64/cpu_isa_traits.hpp"
 
 namespace dnnl {
 namespace impl {


### PR DESCRIPTION
Include cpu_isa_traits.hpp instead, which includes xbyak.h
after defining several XBYAK_* flags. This way we make sure that
all files are compiled using the same Xbyak configuration.

