### PR TITLE
src: cpu: aarch64 Update acl_threadpool_scheduler to include oneAPI h…

### DIFF
--- a/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+++ b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
@@ -13,9 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 
 #include "cpu/aarch64/acl_threadpool_scheduler.hpp"
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+
 #include "cpu/aarch64/acl_thread.hpp"
 
 #include "common/counting_barrier.hpp"

--- a/src/cpu/aarch64/acl_threadpool_scheduler.hpp
+++ b/src/cpu/aarch64/acl_threadpool_scheduler.hpp
@@ -13,10 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 
 #ifndef CPU_AARCH64_ACL_THREADPOOL_SCHEDULER_HPP
 #define CPU_AARCH64_ACL_THREADPOOL_SCHEDULER_HPP
+
+#include "oneapi/dnnl/dnnl_config.h"
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 
 #include "arm_compute/runtime/IScheduler.h"
 #include "support/Mutex.h"


### PR DESCRIPTION
…eader

# Description

This PR covers minor changes to add relevant oneAPI headers to acl_threadpool_scheduler sources to support bazel builds with threadpool runtime.
Previous PR https://github.com/oneapi-src/oneDNN/pull/1328 added support for threadpool on AArch64.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [X] Have you published an RFC for the new feature?
- [X] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?