### PR TITLE
Remove assumption of int8 quantisation in ACL-based implementations

### DIFF
--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -96,12 +96,6 @@ struct acl_eltwise_fwd_t : public primitive_t {
                     data_d.nelems() / thread_dim, thread_dim);
             aep.data_info = arm_compute::TensorInfo(shape, 1, acl_data_t);
 
-            const bool is_int8 = one_of(data_d.data_type(), s8, u8);
-            if (is_int8) {
-                aep.data_info.set_quantization_info(
-                        arm_compute::QuantizationInfo(1, 0));
-            }
-
             if (!acl_utils::acl_act_ok(desc()->alg_kind))
                 return status::unimplemented;
 

--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -26,14 +26,23 @@ namespace acl_utils {
 using namespace dnnl::impl::alg_kind;
 using namespace data_type;
 
-arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt) {
+arm_compute::DataType get_acl_data_t(
+        const dnnl_data_type_t dt, const bool is_quantized) {
     switch (dt) {
-        case bf16: return arm_compute::DataType::BFLOAT16; break;
-        case f32: return arm_compute::DataType::F32; break;
-        case s32: return arm_compute::DataType::S32; break;
-        case f16: return arm_compute::DataType::F16; break;
-        case s8: return arm_compute::DataType::QASYMM8_SIGNED; break;
-        case u8: return arm_compute::DataType::QASYMM8; break;
+        case bf16: return arm_compute::DataType::BFLOAT16;
+        case f32: return arm_compute::DataType::F32;
+        case s32: return arm_compute::DataType::S32;
+        case f16: return arm_compute::DataType::F16;
+        case s8:
+            if (is_quantized)
+                return arm_compute::DataType::QASYMM8_SIGNED;
+            else
+                return arm_compute::DataType::S8;
+        case u8:
+            if (is_quantized)
+                return arm_compute::DataType::QASYMM8;
+            else
+                return arm_compute::DataType::U8;
         default: return arm_compute::DataType::UNKNOWN;
     }
 }

--- a/src/cpu/aarch64/acl_utils.hpp
+++ b/src/cpu/aarch64/acl_utils.hpp
@@ -36,7 +36,8 @@ namespace aarch64 {
 
 namespace acl_utils {
 
-arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
+arm_compute::DataType get_acl_data_t(
+        const dnnl_data_type_t dt, const bool is_quantized = false);
 arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
 arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
 bool acl_act_ok(alg_kind_t eltwise_activation);


### PR DESCRIPTION
# Description

This fixes a bug where all ACL-based primitives were assuming int8 types as being quantised types.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
