### PR TITLE
src: cpu: aarch64 Fixes matmul broadcast on AArch64

### DIFF
--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -81,8 +81,8 @@ struct acl_matmul_t : public primitive_t {
                     && !has_runtime_dims_or_strides();
             if (!ok) return status::unimplemented;
 
-            auto conf_status = acl_matmul_utils::init_conf_matmul(amp_, src_md_,
-                    weights_md_, dst_md_, bias_md_, *desc(), *attr());
+            auto conf_status = acl_matmul_utils::init_conf_matmul(
+                    amp_, src_md_, weights_md_, dst_md_, *desc(), *attr());
 
             if (conf_status != status::success) return status::unimplemented;
 

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -24,59 +24,69 @@ namespace cpu {
 namespace aarch64 {
 
 using namespace alg_kind;
-using namespace cpu::matmul;
-using namespace format_tag;
 
 namespace acl_matmul_utils {
 
 status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
-        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
-        const matmul_desc_t &md, const primitive_attr_t &attr) {
+        memory_desc_t &wei_md, memory_desc_t &dst_md, const matmul_desc_t &md,
+        const primitive_attr_t &attr) {
 
     const memory_desc_wrapper src_d(&src_md);
     const memory_desc_wrapper wei_d(&wei_md);
     const memory_desc_wrapper dst_d(&dst_md);
-    const memory_desc_wrapper bia_d(&bias_md);
 
-    matmul_helper_t helper(src_d, wei_d, dst_d);
+    cpu::matmul::matmul_helper_t helper(src_d, wei_d, dst_d);
     const dim_t M = helper.M();
     const dim_t N = helper.N();
     const dim_t K = helper.K();
-    const dim_t batch = helper.batch();
+    const dim_t dst_batch = helper.batch();
+    const dim_t src_batch = helper.src_batch();
+    const dim_t wei_batch = helper.wei_batch();
+
+    // ACL supports broadcast for 3D shapes, and 4D shapes
+    // for e.g when ab in abcd is 1x1
+    bool batch_ok = IMPLICATION(src_batch > 1, wei_batch == 1)
+            && IMPLICATION(wei_batch > 1, src_batch == 1);
+    ACL_CHECK_SUPPORT(src_d.ndims() == 4 && src_batch != wei_batch && !batch_ok,
+            "matmul broadcast supported only for 3D shapes and 4D shapes when "
+            "ab is 1x1");
 
     // ACL does not support bias
-    amp.with_bias = md.bias_desc.format_kind != format_kind::undef;
-    if (amp.with_bias) return status::unimplemented;
+    bool with_bias = md.bias_desc.format_kind != format_kind::undef;
+    ACL_CHECK_SUPPORT(with_bias, "ACL does not support bias for matmul");
 
+    using namespace format_tag;
     auto src_tag = memory_desc_matches_one_of_tag(
             src_md, abcd, abdc, abc, acb, ab, ba);
     auto wei_tag = memory_desc_matches_one_of_tag(
             wei_md, abcd, abdc, abc, acb, ab, ba);
-    auto dst_tag = memory_desc_matches_one_of_tag(
-            dst_md, abcd, abdc, abc, acb, ab, ba);
-    if (utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag)) {
-        return status::unimplemented;
-    }
+    auto dst_tag
+            = memory_desc_matches_one_of_tag(dst_md, abcd, abc, acb, ab, ba);
+    ACL_CHECK_SUPPORT(
+            utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
+            "Format tag is undefined");
+
+    // Transpose A (src) or B (wei)
     amp.is_transA = helper.transA() == 'T';
     amp.is_transB = helper.transB() == 'T';
     if (amp.is_transA)
         amp.src_acc_info = arm_compute::TensorInfo(
-                arm_compute::TensorShape(M, K, 1, batch), 1,
+                arm_compute::TensorShape(M, K, 1, src_batch), 1,
                 arm_compute::DataType::F32);
     if (amp.is_transB)
-        amp.wei_acc_info
-                = arm_compute::TensorInfo(arm_compute::TensorShape(K, N, batch),
-                        1, arm_compute::DataType::F32);
+        amp.wei_acc_info = arm_compute::TensorInfo(
+                arm_compute::TensorShape(K, N, wei_batch), 1,
+                arm_compute::DataType::F32);
 
-    amp.src_info
-            = arm_compute::TensorInfo(arm_compute::TensorShape(K, M, 1, batch),
-                    1, arm_compute::DataType::F32);
+    amp.src_info = arm_compute::TensorInfo(
+            arm_compute::TensorShape(K, M, 1, src_batch), 1,
+            arm_compute::DataType::F32);
     amp.wei_info
-            = arm_compute::TensorInfo(arm_compute::TensorShape(N, K, batch), 1,
-                    arm_compute::DataType::F32);
-    amp.dst_info
-            = arm_compute::TensorInfo(arm_compute::TensorShape(N, M, 1, batch),
+            = arm_compute::TensorInfo(arm_compute::TensorShape(N, K, wei_batch),
                     1, arm_compute::DataType::F32);
+    amp.dst_info = arm_compute::TensorInfo(
+            arm_compute::TensorShape(N, M, 1, dst_batch), 1,
+            arm_compute::DataType::F32);
 
     // Fast-math mode
     auto math_mode = get_fpmath_mode();

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -38,7 +38,6 @@ struct acl_matmul_obj_t {
 };
 
 struct acl_matmul_conf_t {
-    bool with_bias;
     bool is_transA;
     bool is_transB;
     arm_compute::TensorInfo src_info;
@@ -53,8 +52,8 @@ struct acl_matmul_conf_t {
 namespace acl_matmul_utils {
 
 status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
-        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
-        const matmul_desc_t &md, const primitive_attr_t &attr);
+        memory_desc_t &wei_md, memory_desc_t &dst_md, const matmul_desc_t &md,
+        const primitive_attr_t &attr);
 
 arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
 bool acl_act_ok(alg_kind_t eltwise_activation);

--- a/src/cpu/matmul/matmul_utils.hpp
+++ b/src/cpu/matmul/matmul_utils.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
+* Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,6 +39,13 @@ struct matmul_helper_t {
     dim_t batch() const {
         return utils::array_product(dst_md_.dims(), ndims() - 2);
     };
+    dim_t src_batch() const {
+        return utils::array_product(src_md_.dims(), ndims() - 2);
+    };
+    dim_t wei_batch() const {
+        return utils::array_product(weights_md_.dims(), ndims() - 2);
+    };
+
     dim_t M() const { return dst_md_.dims()[ndims() - 2]; }
     dim_t N() const { return dst_md_.dims()[ndims() - 1]; }
     dim_t K() const { return src_md_.dims()[ndims() - 1]; }

--- a/tests/benchdnn/inputs/matmul/test_matmul_all
+++ b/tests/benchdnn/inputs/matmul/test_matmul_all
@@ -74,3 +74,14 @@
 
 # matmul with strides
 --batch=harness_matmul_strides
+
+# 4d
+
+--reset
+--cfg=f32
+--stag=abcd,abdc --wtag=abcd,abdc --dtag=abcd,abdc
+--bia_dt=undef,f32
+
+--attr-oscale=common:2.25
+--attr-post-ops=,relu,sum,sum+relu+add:f32,binary_mul:f32+sum
+--batch=shapes_4d


### PR DESCRIPTION
# Description

This PR provides a fix for matmul broadcast test cases on AArch64. Test failures were observed at the TensorFlow level associated with oneDNN matmul implementation using ACL. TensorFlow unit test failure list:

```
//tensorflow/python/ops/parallel_for:math_test_cpu
//tensorflow/python/kernel_tests/linalg:linear_operator_householder_test_cpu
//tensorflow/python/kernel_tests/linalg:linear_operator_inversion_test_cpu
//tensorflow/python/kernel_tests/linalg:linear_operator_block_diag_test_cpu
//tensorflow/python/kernel_tests/linalg:linear_operator_block_lower_triangular_test_cpu
//tensorflow/python/kernel_tests/linalg:linear_operator_kronecker_test_cpu
//tensorflow/python/kernel_tests/math_ops:batch_matmul_op_test_cpu
//tensorflow/python/eager:forwardprop_test_cpu
```
It also improves test coverage in test_matmul_all for 4D shapes with/without activation, multiple post ops, broadcast to catch failures for 4D cases before they show up in TensorFlow. Additionally, it also cleans up unused bias code that is not supported on Compute Library for Arm® Architecture.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?