### PR TITLE
aarch64: eltwise: fix invalidation of unsupported alg. and Log Inf check

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2019-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -855,6 +855,10 @@ void jit_uni_eltwise_injector_f32<isa>::log_compute_vector_fwd(
     h->fcmeq(mask, p_all, t4, 0.0f); // = 0
     h->mov(wt0, 0xff800000); // -Inf
     h->cpy(t0, mask, wt0);
+    h->mov(wt0, 0x7f800000); // Inf
+    h->dup(t1, wt0);
+    h->fcmeq(mask, p_all, t4, t1);
+    h->sel(t0, mask, t1, t0);
 
     h->b(exitL);
     h->L(tbl1L);

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -29,6 +29,32 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
+namespace eltwise_injector {
+
+bool is_isa_supported() {
+    return mayiuse(sve_512);
+}
+
+bool is_alg_supported(alg_kind_t alg) {
+    using namespace alg_kind;
+    return utils::one_of(alg, eltwise_relu, eltwise_tanh, eltwise_elu,
+            eltwise_square, eltwise_abs, eltwise_sqrt, eltwise_linear,
+            eltwise_bounded_relu, eltwise_soft_relu, /*eltwise_soft_relu_v2,*/
+            eltwise_logistic, /*eltwise_logsigmoid, eltwise_mish,*/ eltwise_exp,
+            eltwise_gelu_tanh, /*eltwise_hardswish,*/ eltwise_swish,
+            eltwise_log, eltwise_clip,
+            /*eltwise_clip_v2, eltwise_pow,*/ eltwise_gelu_erf, eltwise_round,
+            eltwise_relu_use_dst_for_bwd, eltwise_tanh_use_dst_for_bwd,
+            eltwise_elu_use_dst_for_bwd, eltwise_sqrt_use_dst_for_bwd,
+            eltwise_logistic_use_dst_for_bwd,
+            eltwise_exp_use_dst_for_bwd /*, eltwise_clip_v2_use_dst_for_bwd*/);
+}
+
+bool is_supported(alg_kind_t alg) {
+    return is_isa_supported() && is_alg_supported(alg);
+}
+
+} // namespace eltwise_injector
 using namespace Xbyak_aarch64;
 
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -841,8 +841,9 @@ void jit_uni_eltwise_injector_f32<isa>::log_compute_vector_fwd(
     h->eor(t2, mask, t2);
     h->fnmsb(t1, p_all, set_imm(z_tmp, float2int(std::log(2))),
             t2); // x = n * log2 - h
-    h->movprfx(t2, p_all, set_imm(z_tmp, float2int(1.0f / 3)));
-    h->fcpy(z_tmp, p_all, -0.5f);
+    set_imm(z_tmp, float2int(0.333332205));
+    h->movprfx(t2, p_all, z_tmp);
+    set_imm(z_tmp, float2int(-0.499999851));
     h->fmad(t2, p_all, t0, z_tmp); // f
     h->fcpy(z_tmp, p_all, 1.0f);
     h->fmad(t2, p_all, t0, z_tmp); // f * y + 1

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2019-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,6 +58,21 @@ struct static_params_t {
     bool is_fwd;
     bool use_dst;
 };
+
+/* Checks if isa is supported by eltwise injector.
+ */
+bool is_isa_supported();
+
+/*
+ * Checks if eltwise algorithm is supported by eltwise injector.
+ */
+bool is_alg_supported(alg_kind_t alg);
+
+/*
+ * Checks if eltwise injection for given args is supported.
+ */
+bool is_supported(alg_kind_t alg);
+
 } // namespace eltwise_injector
 
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
@@ -29,8 +29,8 @@
 #include "cpu/aarch64/cpu_barrier.hpp"
 #include "cpu/platform.hpp"
 
+#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp"
-
 #include "cpu/aarch64/jit_uni_1x1_conv_utils.hpp"
 
 #define GET_OFF(field) \
@@ -609,7 +609,10 @@ bool jit_sve_512_1x1_conv_kernel::post_ops_ok(
 
     const auto &p = attr.post_ops_;
 
-    auto is_eltwise = [&](int idx) { return p.entry_[idx].is_eltwise(); };
+    auto is_eltwise = [&](int idx) {
+        return p.entry_[idx].is_eltwise()
+                && eltwise_injector::is_supported(p.entry_[idx].eltwise.alg);
+    };
     auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(); };
     auto is_convolution
             = [&](int idx) { return p.entry_[idx].is_convolution(); };

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
@@ -925,7 +925,7 @@ status_t jit_sve_512_conv_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
     jcp.with_eltwise = eltwise_ind != -1;
     if (jcp.with_eltwise) {
         jcp.eltwise = p.entry_[eltwise_ind].eltwise;
-        if (jcp.eltwise.alg == alg_kind::eltwise_pow)
+        if (!eltwise_injector::is_supported(jcp.eltwise.alg))
             return status::unimplemented;
         if (dst_d.data_type() == data_type::s32) return status::unimplemented;
     }

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -67,7 +67,10 @@ bool jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::post_ops_ok(
         jit_conv_conf_t &jcp, const primitive_attr_t &attr) {
     const auto &p = attr.post_ops_;
 
-    auto is_eltwise = [&](int idx) { return p.entry_[idx].is_eltwise(); };
+    auto is_eltwise = [&](int idx) {
+        return p.entry_[idx].is_eltwise()
+                && eltwise_injector::is_supported(p.entry_[idx].eltwise.alg);
+    };
     auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(); };
 
     switch (p.len()) {

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -74,9 +74,8 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
             const auto src_dt = src_md()->data_type;
             const auto dst_dt = dst_md()->data_type;
             bool ok = mayiuse(isa) && is_fwd() && !has_zero_dim_memory()
-                    && utils::one_of(src_dt, f32, bf16, s8, u8)
-                    && utils::one_of(dst_dt, f32, bf16, s8, u8)
-                    && mayiuse(sve_512)
+                    && utils::one_of(src_dt, f32, s8, u8)
+                    && utils::one_of(dst_dt, f32, s8, u8) && mayiuse(sve_512)
                     && attr()->has_default_values(skip_mask_t::oscale)
                     && attr_oscale_ok()
                     && set_default_formats() == status::success;


### PR DESCRIPTION
# Description

This patch fixes three bugs for AArch64 JITed eltwise.  
- Correctly disabled eltwise algorithms that are currently not supported by JIT for aarch64.
- Fixed a bug in eltwise:log. Inf was not correctly output when Inf was input.
- Fixed invalidation for non-supported data type.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
```
./benchdnn --eltwise --skip-impl=ref --tag=axb --alg=log --alpha=0 --beta=0 --inplace=true 5x16x3
./benchdnn --softmax --sdt=bf16 --ddt=bf16 --inplace=true 96x1000
./test_convolution_eltwise_forward_f32 --gtest_filter="Convolution_SimpleSmall_Blocked16_eltwise/convolution_test.TestConvolutionEltwise/41"
```
- [Not needed] Have you added relevant regression tests?
