### PR TITLE
aarch64: shuffle: add jit impl. for sve_256/128 and asimd

### DIFF
--- a/src/cpu/aarch64/cpu_isa_traits.cpp
+++ b/src/cpu/aarch64/cpu_isa_traits.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2021 Intel Corporation
-* Copyright 2020 FUJITSU LIMITED
+* Copyright 2019-2022 Intel Corporation
+* Copyright 2020-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ cpu_isa_t init_max_cpu_isa() {
 
         IF_HANDLE_CASE(isa_all);
         ELSEIF_HANDLE_CASE(asimd);
+        ELSEIF_HANDLE_CASE(sve_128);
+        ELSEIF_HANDLE_CASE(sve_256);
         ELSEIF_HANDLE_CASE(sve_512);
 
 #undef IF_HANDLE_CASE
@@ -71,6 +73,10 @@ struct isa_info_t {
         switch (isa) {
             case sve_512:
                 return static_cast<dnnl_cpu_isa_t>(dnnl_cpu_isa_sve_512);
+            case sve_256:
+                return static_cast<dnnl_cpu_isa_t>(dnnl_cpu_isa_sve_256);
+            case sve_128:
+                return static_cast<dnnl_cpu_isa_t>(dnnl_cpu_isa_sve_128);
             case asimd: return static_cast<dnnl_cpu_isa_t>(dnnl_cpu_isa_asimd);
             default: return dnnl_cpu_isa_all;
         }
@@ -79,6 +85,8 @@ struct isa_info_t {
     const char *get_name() const {
         switch (isa) {
             case sve_512: return "AArch64 SVE (512 bits)";
+            case sve_256: return "AArch64 SVE (256 bits)";
+            case sve_128: return "AArch64 SVE (128 bits)";
             case asimd: return "AArch64 (with Advanced SIMD & floating-point)";
             default: return "AArch64";
         }
@@ -92,6 +100,8 @@ static isa_info_t get_isa_info_t(void) {
 #define HANDLE_CASE(cpu_isa) \
     if (mayiuse(cpu_isa)) return isa_info_t(cpu_isa);
     HANDLE_CASE(sve_512);
+    HANDLE_CASE(sve_256);
+    HANDLE_CASE(sve_128);
     HANDLE_CASE(asimd);
 #undef HANDLE_CASE
     return isa_info_t(isa_any);
@@ -126,6 +136,8 @@ status_t set_max_cpu_isa(dnnl_cpu_isa_t isa) {
     switch (isa) {
         HANDLE_CASE(isa_all);
         HANDLE_CASE(asimd);
+        HANDLE_CASE(sve_128);
+        HANDLE_CASE(sve_256);
         HANDLE_CASE(sve_512);
         default: return invalid_arguments;
     }

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
@@ -1097,11 +1097,14 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_block_unroll() {
 template <cpu_isa_t isa>
 void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::generate() {
     preamble();
-    if (simd_w == 8) {
+
+    if (simd_w == 16)
+        ptrue(P_ALL_ONE.b);
+    else if (simd_w == 8)
         ptrue(P_ALL_ONE.b, VL32);
-    } else {
+    else
         assert(!"Unsupport: simd_w != 16, 8");
-    }
+
     ldr(reg_input_baddr,
             ptr(abi_param1,
                     static_cast<int32_t>(offsetof(jit_dw_conv_call_s, input))));

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
@@ -37,7 +37,7 @@ status_t jit_uni_shuffle_t<isa>::pd_t::init(engine_t *engine) {
 
     conf_.data_type = data_md()->data_type;
 
-    const bool ok = mayiuse(isa)
+    const bool ok = is_superset(get_max_cpu_isa(), isa)
             && utils::one_of(conf_.data_type, f32, s32, bf16)
             && platform::has_data_type_support(conf_.data_type)
             && attr()->has_default_values() && axis() == 1
@@ -202,6 +202,9 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
 }
 
 template struct jit_uni_shuffle_t<sve_512>;
+template struct jit_uni_shuffle_t<sve_256>;
+template struct jit_uni_shuffle_t<sve_128>;
+template struct jit_uni_shuffle_t<asimd>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -45,24 +45,28 @@ jit_uni_shuffle_kernel_t<isa>::jit_uni_shuffle_kernel_t(
     , padding_size_(get_padding_size(conf)) {}
 
 template <cpu_isa_t isa>
-void jit_uni_shuffle_kernel_t<isa>::prepare_mask() {}
-
-template <>
-void jit_uni_shuffle_kernel_t<sve_512>::prepare_mask() {
+void jit_uni_shuffle_kernel_t<isa>::prepare_mask() {
     using namespace data_type;
     if (conf_.simd_tail > 0) {
         assert(utils::one_of(conf_.data_type, f32, s32));
-        assert(conf_.simd_tail < cpu_isa_traits<sve_512>::vlen / sizeof(float));
+        assert(conf_.simd_tail < isa_sveLen / sizeof(float));
         index(vmm_tmp_.s, 0, 1);
         cmplt(k_tail_mask_.s, P_ALL_ONE / T_z, vmm_tmp_.s, conf_.simd_tail);
     }
 
-    /* Implemented only for 32-bit data */
-    ptrue(k_full_mask_.s, VL16);
+    if (isa_sveLen == util::SVE_512)
+        ptrue(k_full_mask_.s, VL16);
+    else if (isa_sveLen == util::SVE_256)
+        ptrue(k_full_mask_.s, VL8);
+    else if (isa_sveLen == util::SVE_128)
+        ptrue(k_full_mask_.s, VL4);
 }
 
 template <>
-void jit_uni_shuffle_kernel_t<sve_512>::gather_data(const XReg &reg_src_addr,
+void jit_uni_shuffle_kernel_t<asimd>::prepare_mask() {}
+
+template <cpu_isa_t isa>
+void jit_uni_shuffle_kernel_t<isa>::gather_data(const XReg &reg_src_addr,
         const int indices_idx, const int data_idx, const bool is_tail) {
     if (conf_.dt_size == sizeof(float)) {
         const PReg &mask = is_tail ? k_tail_mask_ : k_full_mask_;
@@ -75,24 +79,58 @@ void jit_uni_shuffle_kernel_t<sve_512>::gather_data(const XReg &reg_src_addr,
 }
 
 template <>
-void jit_uni_shuffle_kernel_t<sve_512>::store_data(const int data_idx,
+void jit_uni_shuffle_kernel_t<asimd>::gather_data(const XReg &addr,
+        const int indices_idx, const int data_idx, const bool is_tail) {
+    constexpr unsigned xmm_size_elem = 4;
+    const VReg4S v(data_idx);
+
+    const unsigned number_of_values_to_load
+            = is_tail ? conf_.simd_tail : xmm_size_elem;
+
+    for (unsigned j = 0; j < number_of_values_to_load; j++) {
+        mov(W_TMP_0, VReg4S(indices_idx)[j]);
+        add(X_DEFAULT_ADDR, addr, X_TMP_0);
+        ld1(v[j], ptr(X_DEFAULT_ADDR));
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_shuffle_kernel_t<isa>::store_data(const int data_idx,
         const XReg &reg_dst_addr, const int offset, const bool is_tail) {
     const auto extend_for_padding
             = is_tail && padding_size_ + conf_.simd_tail >= conf_.simd_w;
     if (extend_for_padding) {
         sel(vmm_tmp_.s, k_tail_mask_, TRegS(data_idx), vmm_zero_.s);
         add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset, X_TMP_0);
-        str(vmm_tmp_, ptr(X_DEFAULT_ADDR));
+        st1w(vmm_tmp_.s, P_ALL_ONE, ptr(X_DEFAULT_ADDR));
     } else {
         if (is_tail) {
             add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset, X_TMP_0);
             st1w(TRegS(data_idx), k_tail_mask_, ptr(X_DEFAULT_ADDR));
         } else {
             add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset, X_TMP_0);
-            str(ZReg(data_idx), ptr(X_DEFAULT_ADDR));
+            st1w(TRegS(data_idx), P_ALL_ONE, ptr(X_DEFAULT_ADDR));
         }
     }
-    append_zero_padding(reg_dst_, extend_for_padding);
+    append_zero_padding(
+            reg_dst_, isa_sveLen > 128 ? extend_for_padding : false);
+}
+
+template <>
+void jit_uni_shuffle_kernel_t<asimd>::store_data(const int data_idx,
+        const XReg &reg_dst_addr, const int offset, const bool is_tail) {
+    if (is_tail) {
+        for (unsigned i = 0; i < conf_.simd_tail; i++) {
+            add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset + i * conf_.dt_size,
+                    X_TMP_0);
+            st1(VReg4S(data_idx)[i], ptr(X_DEFAULT_ADDR));
+        }
+    } else {
+        add_imm(X_DEFAULT_ADDR, reg_dst_addr, offset, X_TMP_0);
+        str(QReg(data_idx), ptr(X_DEFAULT_ADDR));
+    }
+
+    append_zero_padding(reg_dst_, false);
 }
 
 template <cpu_isa_t isa>
@@ -111,7 +149,14 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
         const int simd_to_process
                 = is_blk_tail ? simd_in_tail_blk : simd_in_blk;
         for (int i = 0; i < simd_to_process; ++i) {
-            ldr(vmm_tmp[i], ptr(reg_indices_, i, Xbyak_aarch64::MUL_VL));
+            if (is_superset(isa, sve_128))
+                ld1w(ZRegS(vmm_tmp[i].getIdx()), P_ALL_ONE,
+                        ptr(addr_off(reg_indices_,
+                                i * conf_.simd_w * conf_.el_size_of_indices,
+                                X_DEFAULT_ADDR, X_TMP_0)));
+            else
+                uni_ldr(vmm_tmp[i], reg_indices_,
+                        i * conf_.simd_w * conf_.el_size_of_indices);
         }
     });
 
@@ -121,8 +166,7 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
         for (int i = 0; i < simd_to_process; ++i) {
             const bool simd_tail_condition = is_blk_tail && conf_.simd_tail > 0
                     && i == simd_to_process - 1;
-            orr(ZRegD(vmm_indices_.getIdx()), ZRegD(vmm_tmp[i].getIdx()),
-                    ZRegD(vmm_tmp[i].getIdx()));
+            uni_orr(TReg(vmm_indices_.getIdx()), vmm_tmp[i], vmm_tmp[i]);
             gather_data(reg_src_, vmm_indices_.getIdx(), vmm_src_.getIdx(),
                     simd_tail_condition);
 
@@ -247,11 +291,16 @@ void jit_uni_shuffle_kernel_t<isa>::append_zero_padding(
     b(EQ, end);
 
     if (simd_w_byte <= padding_to_add) {
-        eor(ZRegD(vmm_zero_.getIdx()), ZRegD(vmm_zero_.getIdx()),
-                ZRegD(vmm_zero_.getIdx()));
+        uni_eor(TReg(vmm_zero_.getIdx()), TReg(vmm_zero_.getIdx()),
+                TReg(vmm_zero_.getIdx()));
+
         for (; off + simd_w_byte < padding_to_add; off += simd_w_byte) {
             add_imm(X_DEFAULT_ADDR, reg_dst_addr, off_start + off, X_TMP_0);
-            str(vmm_zero_, ptr(X_DEFAULT_ADDR));
+
+            if (is_superset(isa, sve_128))
+                st1w(ZRegS(vmm_zero_.getIdx()), P_ALL_ONE, ptr(X_DEFAULT_ADDR));
+            else
+                uni_str(vmm_zero_, X_DEFAULT_ADDR);
         }
     }
 
@@ -274,7 +323,13 @@ template <cpu_isa_t isa>
 void jit_uni_shuffle_kernel_t<isa>::generate() {
     preamble();
 
-    mov(vmm_zero_.s, 0);
+    /* Overwrite P_ALL_ONE, if required sve size < 512. */
+    if (isa_sveLen == util::SVE_128)
+        ptrue(P_ALL_ONE.b, VL16);
+    else if (isa_sveLen == util::SVE_256)
+        ptrue(P_ALL_ONE.b, VL32);
+
+    uni_clear(vmm_zero_);
     prepare_mask();
 
     add_imm(X_DEFAULT_ADDR, reg_param, GET_OFF(input_off_ptr), X_TMP_0);
@@ -293,6 +348,9 @@ void jit_uni_shuffle_kernel_t<isa>::generate() {
 }
 
 template struct jit_uni_shuffle_kernel_t<sve_512>;
+template struct jit_uni_shuffle_kernel_t<sve_256>;
+template struct jit_uni_shuffle_kernel_t<sve_128>;
+template struct jit_uni_shuffle_kernel_t<asimd>;
 
 #undef GET_OFF
 

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
@@ -101,6 +101,8 @@ struct jit_uni_shuffle_kernel_t : public jit_generator {
 
     const jit_shuffle_conf_t conf_;
     const size_t padding_size_;
+    const uint64_t isa_sveLen
+            = is_superset(isa, sve_128) ? cpu_isa_traits<isa>::vlen : 0;
 };
 
 } // namespace aarch64

--- a/src/cpu/cpu_shuffle_list.cpp
+++ b/src/cpu/cpu_shuffle_list.cpp
@@ -41,6 +41,9 @@ constexpr impl_list_item_t impl_list[] = REG_SHUFFLE_P({
         CPU_INSTANCE_X64(jit_uni_shuffle_t<avx>)
         CPU_INSTANCE_X64(jit_uni_shuffle_t<sse41>)
         CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve_512>)
+        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve_256>)
+        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve_128>)
+        CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<asimd>)
         CPU_INSTANCE(ref_shuffle_t)
         /* eol */
         nullptr,


### PR DESCRIPTION
# Description

This patch adds jit implementation of shuffle for AARch64 SVE256/128 and ASIMD.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

