### PR TITLE
src: cpu: aarch64: Add acl pooling

### DIFF
--- a/src/cpu/aarch64/acl_pooling.cpp
+++ b/src/cpu/aarch64/acl_pooling.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_pooling.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+status_t acl_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
+    // Lock here is needed because resource_mapper does not support
+    // concurrent access.
+    std::lock_guard<std::mutex> _lock {this->mtx};
+    status_t status = status::success;
+    auto src_base = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    auto dst_base = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+
+    // Retrieve primitive resource and configured Compute Library objects
+    auto *acl_resource
+            = ctx.get_resource_mapper()->get<acl_pooling_resource_t>(this);
+    acl_pooling_obj_t &acl_obj = acl_resource->get_acl_obj();
+
+    // import_memory() and free() methods do not allocate/free any additional
+    // memory, only acquire/release pointers.
+    acl_obj.src_tensor.allocator()->import_memory(const_cast<void *>(src_base));
+    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+
+    acl_obj.pool.run();
+
+    acl_obj.src_tensor.allocator()->free();
+    acl_obj.dst_tensor.allocator()->free();
+
+    return status;
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_pooling.hpp
+++ b/src/cpu/aarch64/acl_pooling.hpp
@@ -1,0 +1,223 @@
+/*******************************************************************************
+* Copyright 2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_POOLING_HPP
+#define CPU_AARCH64_ACL_POOLING_HPP
+
+#include "cpu/aarch64/acl_utils.hpp"
+#include "cpu/cpu_pooling_pd.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct acl_pooling_obj_t {
+    arm_compute::NEPoolingLayer pool;
+    arm_compute::Tensor src_tensor;
+    arm_compute::Tensor dst_tensor;
+};
+
+struct acl_pooling_conf_t {
+    arm_compute::PoolingLayerInfo pool_info;
+    arm_compute::TensorInfo src_info;
+    arm_compute::TensorInfo dst_info;
+};
+
+struct acl_pooling_resource_t : public resource_t {
+    acl_pooling_resource_t()
+        : acl_pooling_obj_(utils::make_unique<acl_pooling_obj_t>()) {}
+
+    status_t configure(const acl_pooling_conf_t &app) {
+        if (!acl_pooling_obj_) return status::out_of_memory;
+
+        // Init Compute Library tensors based on info from descriptor
+        acl_pooling_obj_->src_tensor.allocator()->init(app.src_info);
+        acl_pooling_obj_->dst_tensor.allocator()->init(app.dst_info);
+
+        acl_pooling_obj_->pool.configure(&acl_pooling_obj_->src_tensor,
+                &acl_pooling_obj_->dst_tensor, app.pool_info);
+
+        return status::success;
+    }
+
+    acl_pooling_obj_t &get_acl_obj() const { return *acl_pooling_obj_; }
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_pooling_resource_t);
+
+private:
+    std::unique_ptr<acl_pooling_obj_t> acl_pooling_obj_;
+}; // acl_pooling_resource_t
+
+struct acl_pooling_fwd_t : public primitive_t {
+    struct pd_t : public cpu_pooling_fwd_pd_t {
+        using cpu_pooling_fwd_pd_t::cpu_pooling_fwd_pd_t;
+        pd_t(const pooling_v2_desc_t *adesc, const primitive_attr_t *attr,
+                const pooling_fwd_pd_t *hint_fwd_pd)
+            : cpu_pooling_fwd_pd_t(adesc, attr, hint_fwd_pd), app() {}
+
+        DECLARE_COMMON_PD_T("acl", acl_pooling_fwd_t);
+
+        status_t init(engine_t *engine) {
+            bool ok = set_default_params() == status::success
+                    && is_fwd() // ACL supports forward propagation only
+                    && utils::everyone_is(data_type::f32, src_md()->data_type,
+                            dst_md()->data_type)
+                    && attr()->has_default_values()
+                    && attr_.set_default_formats(dst_md(0)) == status::success
+                    && !is_dilated() && !has_zero_dim_memory();
+            if (!ok) return status::unimplemented;
+
+            const pooling_v2_desc_t *pod = desc();
+
+            // Choose the pooling type
+            const alg_kind_t alg = pod->alg_kind;
+            const bool is_max_pool = (alg == alg_kind::pooling_max);
+            app.pool_info.pool_type = is_max_pool
+                    ? arm_compute::PoolingType::MAX
+                    : arm_compute::PoolingType::AVG;
+
+            // Max forward training requires a worksace tensor.
+            // For this workspace tensor, oneDNN uses pool window coordinates,
+            // Whereas ACL uses absolute image coordinates.
+            // Due to this mismatch, reject max forward training cases
+            ACL_CHECK_SUPPORT(
+                    (is_max_pool
+                            && pod->prop_kind == prop_kind::forward_training),
+                    "ACL does not support training for max pooling in oneDNN");
+
+            // When padding is larger than the kernel, infinite values are
+            // produced.
+            // ACL and oneDNN use different values to represent infinity
+            // which is difficult to account for, so return unimplemented.
+            // See https://github.com/oneapi-src/oneDNN/issues/1205
+            ACL_CHECK_SUPPORT(KH() <= padT() || KH() <= padB() || KW() <= padL()
+                            || KW() <= padR(),
+                    "ACL does not support pooling cases where padding >= kernel"
+                    " in oneDNN");
+
+            auto src_tag = memory_desc_matches_one_of_tag(
+                    *src_md(), format_tag::nhwc, format_tag::nchw);
+            auto dst_tag = memory_desc_matches_one_of_tag(
+                    *dst_md(), format_tag::nhwc, format_tag::nchw);
+
+            ACL_CHECK_SUPPORT(
+                    utils::one_of(format_tag::undef, src_tag, dst_tag),
+                    "src or dst is not format nhwc or nchw");
+            ACL_CHECK_SUPPORT(src_tag != dst_tag,
+                    "src and dst have different memory formats");
+
+            const memory_desc_wrapper src_d(src_md());
+            const memory_desc_wrapper dst_d(dst_md());
+            const int ndims = src_d.ndims();
+            ACL_CHECK_SUPPORT(ndims != 4, "Tensor is not 4d");
+
+            // Pooling window
+            app.pool_info.pool_size = arm_compute::Size2D(KW(), KH());
+            // Choose the data layout
+            bool is_nspc = utils::one_of(src_tag, format_tag::nhwc);
+            const auto acl_layout = is_nspc ? arm_compute::DataLayout::NHWC
+                                            : arm_compute::DataLayout::NCHW;
+            app.pool_info.data_layout = acl_layout;
+            const auto acl_data_t
+                    = acl_utils::get_acl_data_t(src_d.data_type());
+
+            ACL_CHECK_SUPPORT(
+                    !use_acl_heuristic(MB() * IC() * OH() * OW() * KH() * KW(),
+                            dnnl_get_max_threads(), is_max_pool, is_nspc),
+                    "ACL is unoptimal in this case");
+
+            app.pool_info.exclude_padding
+                    = (alg == alg_kind::pooling_avg_exclude_padding);
+
+            app.pool_info.pad_stride_info = arm_compute::PadStrideInfo(KSW(),
+                    KSH(), padL(), padR(), padT(), padB(),
+                    arm_compute::DimensionRoundingType::FLOOR);
+
+            app.src_info = arm_compute::TensorInfo(is_nspc
+                            ? arm_compute::TensorShape(IC(), IW(), IH(), MB())
+                            : arm_compute::TensorShape(IW(), IH(), IC(), MB()),
+                    1, acl_data_t, acl_layout);
+            app.dst_info = arm_compute::TensorInfo(is_nspc
+                            ? arm_compute::TensorShape(OC(), OW(), OH(), MB())
+                            : arm_compute::TensorShape(OW(), OH(), OC(), MB()),
+                    1, acl_data_t, acl_layout);
+
+            ACL_CHECK_VALID(arm_compute::NEPoolingLayer::validate(
+                    &app.src_info, &app.dst_info, app.pool_info));
+
+            return status::success;
+        }
+
+        bool use_acl_heuristic(
+                int problem_size, int thread_count, bool is_max, bool is_nhwc) {
+            // For nhwc, ACL is faster above a certain problem size 'cutoff'
+            // This cutoff scales linearly with thread count (except 1 thread)
+            // So return true iff problem size is larger than this cutoff.
+            // Note: This rule is approximate, Not all problems follow this rule
+            if (is_nhwc) {
+                if (is_max) {
+                    if (thread_count == 1)
+                        return problem_size > 512;
+                    else
+                        return problem_size > 4096 * thread_count;
+                } else { // pooling_alg == avg_p || pooling_alg == avg_np
+                    if (thread_count == 1)
+                        return problem_size > 1024;
+                    else
+                        return problem_size > 8192 * thread_count;
+                }
+            } else { // memory_format == nchw
+                return false;
+            }
+        }
+
+        acl_pooling_conf_t app;
+    };
+
+    acl_pooling_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const override {
+        if (mapper.has_resource(this)) return status::success;
+
+        auto r = utils::make_unique<acl_pooling_resource_t>();
+        if (!r) return status::out_of_memory;
+
+        // Configure the resource based on information from primitive descriptor
+        auto st = r->configure(pd()->app);
+        if (st == status::success) { mapper.add(this, std::move(r)); }
+
+        return st;
+    }
+
+private:
+    // execute_forward has to be const thus mutability of mtx
+    mutable std::mutex mtx;
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+}; // acl_pooling_fwd_t
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_POOLING_HPP

--- a/src/cpu/cpu_pooling_list.cpp
+++ b/src/cpu/cpu_pooling_list.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
 * Copyright 2020 FUJITSU LIMITED
+* Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,6 +30,9 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/jit_uni_i8i8_pooling.hpp"
 #include "cpu/aarch64/jit_uni_pooling.hpp"
 using namespace dnnl::impl::cpu::aarch64;
+#if DNNL_AARCH64_USE_ACL
+#include "cpu/aarch64/acl_pooling.hpp"
+#endif // DNNL_AARCH64_USE_ACL
 #endif
 
 namespace dnnl {
@@ -50,6 +54,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_pooling_fwd_t<avx, f32>)
             CPU_INSTANCE_X64(jit_uni_pooling_fwd_t<sse41, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_pooling_fwd_t<sve_512, f32>)
+            CPU_INSTANCE_AARCH64_ACL(acl_pooling_fwd_t)
             CPU_INSTANCE(nchw_pooling_fwd_t<bf16>)
             CPU_INSTANCE(nchw_pooling_fwd_t<f32>)
             CPU_INSTANCE(nhwc_pooling_fwd_t<bf16>)

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
+* Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -134,6 +135,15 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
         res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
         return;
     }
+
+#if DNNL_AARCH64_USE_ACL
+    // Since ACL supports only forward pass.
+    // Ref: https://github.com/oneapi-src/oneDNN/issues/1205
+    if (prb->dir & FLAG_BWD) {
+        res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
+        return;
+    }
+#endif
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/gtests/test_pooling_backward.cpp
+++ b/tests/gtests/test_pooling_backward.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2016-2021 Intel Corporation
+* Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+#ifndef DNNL_AARCH64_USE_ACL // Ref: https://github.com/oneapi-src/oneDNN/issues/1205
 
 #include "dnnl_test_common.hpp"
 #include "gtest/gtest.h"
@@ -1396,3 +1398,4 @@ GPU_INSTANTIATE_TEST_SUITE_P(TestPooling_ncdhw, pooling_bwd_test_float,
                                 5, 5, 5, 1, 1, 1, 1, 1, 1)}));
 
 } // namespace dnnl
+#endif // DNNL_AARCH64_USE_ACL

--- a/tests/gtests/test_pooling_forward.cpp
+++ b/tests/gtests/test_pooling_forward.cpp
@@ -286,7 +286,6 @@ protected:
             // test construction from a C pd
             pool_prim_desc
                     = pooling_forward::primitive_desc(pool_prim_desc.get());
-
             check_prim_desc<pooling_forward::primitive_desc>(pool_prim_desc);
             if (p.src_format != memory::format_tag::any) {
                 ASSERT_TRUE(p_src_desc == pool_prim_desc.src_desc());
@@ -343,7 +342,6 @@ protected:
                                     {DNNL_ARG_WORKSPACE, workspace}});
         }
         strm.wait();
-
         check_pool_fwd<data_t>(p, p_src, p_dst, workspace);
         check_zero_tail<data_t>(0, p_dst);
     }
@@ -354,6 +352,11 @@ using pooling_test_s8 = pooling_test_t<int8_t>;
 using pooling_test_u8 = pooling_test_t<uint8_t>;
 using pooling_test_s32 = pooling_test_t<int32_t>;
 using pool_test_params_float = pool_test_params_t;
+
+// Since ACL supports only forward, to avoid triggering workspace check which is not available.
+#if DNNL_AARCH64_USE_ACL
+#define forward_training forward_inference
+#endif
 
 // sizes with explicit opposite side paddings
 #define EXPAND_SIZES_3D_XPADD(...) \


### PR DESCRIPTION
src: cpu: aarch64: add ACL pooling primitive

# Description

This patch adds a pooling primitive which makes use of Compute Library for the Arm® architecture (ACL), optimised for AArch64.
This primitive is faster for larger problem sizes and smaller thread counts, up to 64x faster for 1 thread and very large (~2^21) problem sizes (defined as the product of mb, ic, oh, ow, kh, kw). An empirically derived heuristic has been implemented to avoid the cases where this primitive is slower (which is the case below a certain problem size. The particular problem size depends on thread count and pooling algorithm, but for 8 threads and max pooling for example, this primitive is slower for problems sizes less than 2^15)
In order to accommodate a difference in the representation of -inf between ACL and the reference implementation (see https://github.com/oneapi-src/oneDNN/issues/1205), we have added a variable `pool::prb_t::is_acl`. The implementation of this has necessitated a `const_cast<prb_t *>(prb)` in `pool::doit()`. We considered alternatives to this, including changing the reference implementation of -inf for `#DNNL_AARCH64_USE_ACL` and using a non member variable `is_acl` which is passed into `check_correctness()`, then to `compute_ref()`. (this option would involve adding an `is_acl` parameter to `compute_ref()` for all primitives). We ultimately decided this option was the least invasive. Comments / Suggestions on this are invited.

Co-authored by Crefeda Rodrigues <crefeda.rodrigues@arm.com>

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?
