### PR TITLE
cpu: aarch64: add eltwise post ops to ACL bnorm

### DIFF
--- a/src/cpu/aarch64/acl_batch_normalization.cpp
+++ b/src/cpu/aarch64/acl_batch_normalization.cpp
@@ -73,11 +73,14 @@ status_t acl_batch_normalization_fwd_t::execute_forward(
     acl_obj.bnorm.run();
 
     acl_obj.src_tensor.allocator()->free();
-    acl_obj.dst_tensor.allocator()->free();
     acl_obj.gamma_tensor.allocator()->free();
     acl_obj.beta_tensor.allocator()->free();
     acl_obj.mean_tensor.allocator()->free();
     acl_obj.var_tensor.allocator()->free();
+
+    pd()->post_ops.execute(ctx, acl_obj.dst_tensor.buffer());
+
+    acl_obj.dst_tensor.allocator()->free();
 
     return status::success;
 }

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -23,8 +23,6 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-using namespace alg_kind;
-
 namespace acl_matmul_utils {
 
 status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,


### PR DESCRIPTION
# Description

This PR adds eltwise post ops to the Compute Library for the Arm® architecture (ACL) batch normalization primitive.
ReLU (including leaky and bounded) are fused into the bnorm operator. Other eltwise ops are handled using `acl_post_ops_t` and so supports any that `acl_eltwise_fwd_t` supports.

Adding this functionality just means that the ACL impl now covers more cases. In the newly supported case where ReLU is passed in as a post op (rather than a flag) batchnorm performance improvements over `nspc:bnorm` will be the same as in #1378. The other eltwise post ops which are now incidentally covered are unimplemented in `nspc:bnorm` and `ref`, so there are no performance considerations there.

This PR requires and includes f6dbe1efdd08c88924d9f0f4368abd435473ffe5 cherry picked from #1330, so this PR should not be merged before #1330. I couldn't target that PR branch directly using GitHub because it is on a fork.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?