### PR TITLE
Adding support for Eltwise primitive for AMD backend

### DIFF
--- a/src/gpu/amd/miopen_eltwise.cpp
+++ b/src/gpu/amd/miopen_eltwise.cpp
@@ -1,0 +1,85 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_eltwise.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_eltwise_fwd_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->src_md()).has_zero_dim())
+        return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            std::vector<void *> args;
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_dst.get_native_pointer(ih));
+
+            pd()->eltwise_fwd_impl_->execute(handle, args.data(), args.size());
+        });
+    });
+}
+
+status_t miopen_eltwise_bwd_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->src_md()).has_zero_dim())
+        return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            std::vector<void *> args;
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+            args.push_back(arg_diff_src.get_native_pointer(ih));
+
+            pd()->eltwise_bwd_impl_->execute(handle, args.data(), args.size());
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_eltwise.hpp
+++ b/src/gpu/amd/miopen_eltwise.hpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_SYCL_HIP_ELTWISE_HPP
+#define GPU_AMD_SYCL_HIP_ELTWISE_HPP
+
+#include "common/eltwise_pd.hpp"
+#include "common/primitive.hpp"
+#include "gpu/amd/miopen_eltwise_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_eltwise_fwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public eltwise_fwd_pd_t {
+        using eltwise_fwd_pd_t::eltwise_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_eltwise_fwd_t);
+
+        status_t init(engine_t *) {
+            using namespace alg_kind;
+            bool ok = true
+                    && utils::one_of(desc()->prop_kind,
+                            prop_kind::forward_training,
+                            prop_kind::forward_inference)
+                    // Supported algorithms
+                    && utils::one_of(desc()->alg_kind, eltwise_relu,
+                            eltwise_bounded_relu, eltwise_tanh, eltwise_elu,
+                            eltwise_soft_relu, eltwise_abs, eltwise_logistic)
+                    // Supported data types
+                    && utils::one_of(desc()->data_desc.data_type,
+                            data_type::f32, data_type::f16)
+                    // Eltwise does not support blocking
+                    && src_md()->format_desc.blocking.inner_nblks == 0
+                    && attr()->has_default_values();
+            if (!ok) return status::unimplemented;
+
+            eltwise_fwd_impl_.reset(new miopen_eltwise_fwd_impl_t());
+            return eltwise_fwd_impl_->init(this);
+        }
+        std::shared_ptr<miopen_eltwise_impl_base_t> eltwise_fwd_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+struct miopen_eltwise_bwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public eltwise_bwd_pd_t {
+        using eltwise_bwd_pd_t::eltwise_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_eltwise_bwd_t);
+
+        status_t init(engine_t *) {
+            using namespace alg_kind;
+            bool ok = true
+                    && desc()->prop_kind == prop_kind::backward_data
+                    // Supported algorithms
+                    && utils::one_of(desc()->alg_kind, eltwise_relu,
+                            eltwise_bounded_relu, eltwise_soft_relu)
+                    // Supported data types
+                    && (desc()->data_desc.data_type == data_type::f32
+                            || desc()->data_desc.data_type == data_type::f16)
+
+                    && set_default_formats_common()
+                    // Eltwise does not support blocking
+                    && src_md()->format_desc.blocking.inner_nblks == 0
+                    && diff_dst_md()->format_desc.blocking.inner_nblks == 0
+                    && attr()->has_default_values();
+            if (!ok) return status::unimplemented;
+
+            eltwise_bwd_impl_.reset(new miopen_eltwise_bwd_impl_t());
+            return eltwise_bwd_impl_->init(this);
+        }
+        std::shared_ptr<miopen_eltwise_impl_base_t> eltwise_bwd_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_eltwise_impl.hpp
+++ b/src/gpu/amd/miopen_eltwise_impl.hpp
@@ -15,8 +15,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef GPU_AMD_SYCL_HIP_ELTWISE_IMPL_HPP
-#define GPU_AMD_SYCL_HIP_ELTWISE_IMPL_HPP
+#ifndef GPU_AMD_MIOPEN_ELTWISE_IMPL_HPP
+#define GPU_AMD_MIOPEN_ELTWISE_IMPL_HPP
 
 #include <CL/sycl.hpp>
 #include <gpu/amd/sycl_hip_engine.hpp>

--- a/src/gpu/amd/miopen_eltwise_impl.hpp
+++ b/src/gpu/amd/miopen_eltwise_impl.hpp
@@ -1,0 +1,232 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_SYCL_HIP_ELTWISE_IMPL_HPP
+#define GPU_AMD_SYCL_HIP_ELTWISE_IMPL_HPP
+
+#include <CL/sycl.hpp>
+#include <gpu/amd/sycl_hip_engine.hpp>
+#include <gpu/amd/sycl_hip_utils.hpp>
+#include <miopen/miopen.h>
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_eltwise_impl_base_t {
+
+public:
+    virtual status_t init(const eltwise_pd_t *pd) = 0;
+
+    virtual void execute(miopenHandle_t handle, void **x, int size) const = 0;
+
+    virtual status_t create_and_set_act_descriptor() {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(
+                miopenCreateActivationDescriptor, &act_desc_));
+
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetActivationDescriptor, act_desc_,
+                alg_kind, activAlpha, activBeta, activGamma));
+
+        return status::success;
+    }
+
+    // Mapping between dnnl algorithm and miopen activation mode
+    status_t convert_alg_kind(alg_kind_t alg_kind,
+            miopenActivationMode_t *miopen_alg_kind) const {
+        switch (alg_kind) {
+            case alg_kind::eltwise_relu:
+                *miopen_alg_kind
+                        = miopenActivationMode_t::miopenActivationLEAKYRELU;
+                break;
+            case alg_kind::eltwise_bounded_relu:
+                *miopen_alg_kind
+                        = miopenActivationMode_t::miopenActivationCLIPPEDRELU;
+                break;
+            case alg_kind::eltwise_tanh:
+                *miopen_alg_kind = miopenActivationMode_t::miopenActivationTANH;
+                break;
+            case alg_kind::eltwise_elu:
+                *miopen_alg_kind = miopenActivationMode_t::miopenActivationELU;
+                break;
+            case alg_kind::eltwise_logistic:
+                *miopen_alg_kind
+                        = miopenActivationMode_t::miopenActivationLOGISTIC;
+                break;
+            case alg_kind::eltwise_abs:
+                *miopen_alg_kind = miopenActivationMode_t::miopenActivationABS;
+                break;
+            case alg_kind::eltwise_soft_relu:
+                *miopen_alg_kind
+                        = miopenActivationMode_t::miopenActivationSOFTRELU;
+                break;
+            default: return status::unimplemented;
+        }
+        return status::success;
+    }
+
+    virtual ~miopen_eltwise_impl_base_t() {
+        if (act_desc_) {
+            MIOPEN_EXECUTE_FUNC_V(miopenDestroyActivationDescriptor, act_desc_);
+        }
+    }
+
+protected:
+    int ndims;
+    miopenActivationDescriptor_t act_desc_ = nullptr;
+    miopenActivationMode_t alg_kind;
+
+    // alpha and beta are post operation scaling parameters
+    float alpha = 1;
+    float beta = 0;
+    double coef = 1;
+
+    // alpha, beta  and gamma are MIOpen activation parameters
+    float activAlpha;
+    float activBeta;
+    float activGamma;
+};
+
+struct miopen_eltwise_fwd_impl_t : public miopen_eltwise_impl_base_t {
+public:
+    status_t init(const eltwise_pd_t *pd) override {
+        if (has_zero_dims(pd->src_md()->dims, pd->ndims())) {
+            return status::success;
+        }
+        if (pd->ndims() > MIOPEN_DIM_MAX) { return status::invalid_arguments; }
+        ndims = pd->ndims() < 4 ? 4 : pd->ndims();
+
+        // Obtain source and destination dimensions, strides and datatype
+        convert_dims(pd->src_md()->padded_dims, dims_, pd->ndims());
+        convert_dims(pd->src_md()->format_desc.blocking.strides, strides_,
+                pd->ndims());
+        CHECK(convert_data_type(pd->src_md(), &data_type_));
+
+        alg_kind_t alg = pd->desc()->alg_kind;
+        auto alg_ok = convert_alg_kind(alg, &alg_kind);
+
+        if (alg_ok != status::success) { return status::unimplemented; }
+        coef = pd->desc()->alpha;
+
+        if (alg_kind == miopenActivationMode_t::miopenActivationTANH)
+            activAlpha = activBeta = 1;
+        else if (alg_kind == miopenActivationMode_t::miopenActivationELU)
+            activAlpha = coef;
+        else if (alg_kind
+                == miopenActivationMode_t::miopenActivationCLIPPEDRELU)
+            activAlpha = coef;
+        else if (alg_kind == miopenActivationMode_t::miopenActivationLEAKYRELU)
+            activAlpha = coef;
+
+        CHECK(create_and_set_tensor_descriptor(
+                &tensor_desc_, data_type_, ndims, dims_, strides_));
+        CHECK(create_and_set_act_descriptor());
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle, void **x, int size) const override {
+        // Confirm that 2 arguments were passed src and dst
+        assert(size == 2);
+
+        MIOPEN_EXECUTE_FUNC(miopenActivationForward, handle, act_desc_, &alpha,
+                tensor_desc_, x[0], &beta, tensor_desc_, x[1]);
+    }
+
+    ~miopen_eltwise_fwd_impl_t() {
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, tensor_desc_);
+    }
+
+private:
+    int strides_[DNNL_MAX_NDIMS];
+    int dims_[DNNL_MAX_NDIMS];
+    miopenDataType_t data_type_;
+    miopenTensorDescriptor_t tensor_desc_;
+};
+
+struct miopen_eltwise_bwd_impl_t : public miopen_eltwise_impl_base_t {
+
+public:
+    status_t init(const eltwise_pd_t *pd) override {
+        // If any of the dimensions are 0 we should not continue with creating
+        // MIOpen descriptors
+        if (memory_desc_wrapper(pd->desc()->data_desc).has_zero_dim())
+            return status::success;
+
+        if (pd->ndims() > MIOPEN_DIM_MAX) { return status::invalid_arguments; }
+        ndims = pd->ndims() < 4 ? 4 : pd->ndims();
+
+        // Obtain dimension and strides for the backward eltwise operation
+        convert_dims(pd->src_md()->padded_dims, dims_, pd->ndims());
+        convert_dims(pd->src_md()->format_desc.blocking.strides, strides_,
+                pd->ndims());
+
+        alg_kind_t alg = pd->desc()->alg_kind;
+        auto alg_ok = convert_alg_kind(alg, &alg_kind);
+        if (alg_ok != status::success) { return status::unimplemented; }
+        coef = pd->desc()->alpha;
+
+        // Check validity of input
+        assert(pd->diff_dst_md()->data_type == pd->src_md()->data_type);
+        assert(pd->diff_dst_md()->data_type == pd->diff_src_md()->data_type);
+
+        CHECK(convert_data_type(pd->src_md(), &data_type_));
+
+        if (alg_kind == miopenActivationMode_t::miopenActivationCLIPPEDRELU)
+            activAlpha = coef;
+        else if (alg_kind == miopenActivationMode_t::miopenActivationLEAKYRELU)
+            activAlpha = coef;
+
+        CHECK(create_and_set_tensor_descriptor(
+                &tensor_desc_src_, data_type_, ndims, dims_, strides_));
+        CHECK(create_and_set_tensor_descriptor(
+                &tensor_diff_desc_, data_type_, ndims, dims_, strides_));
+        CHECK(create_and_set_act_descriptor());
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle, void **x, int size) const override {
+        // Assert that 3 arguments were passed src, diff_dst and diff_src
+        assert(size == 3);
+        void *dy = x[1];
+        void *dx = x[2];
+
+        MIOPEN_EXECUTE_FUNC(miopenActivationBackward, handle, act_desc_, &alpha,
+                tensor_desc_src_, x[0], tensor_diff_desc_, dy, tensor_desc_src_,
+                x[0], &beta, tensor_diff_desc_, dx);
+    }
+
+    ~miopen_eltwise_bwd_impl_t() {
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, tensor_desc_src_);
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, tensor_diff_desc_);
+    }
+
+private:
+    int dims_[DNNL_MAX_NDIMS];
+    int strides_[DNNL_MAX_NDIMS];
+    miopenTensorDescriptor_t tensor_diff_desc_;
+    miopenDataType_t data_type_;
+    miopenTensorDescriptor_t tensor_desc_src_;
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -23,6 +23,7 @@
 #include "sycl/sycl_utils.hpp"
 
 #include "gpu/amd/miopen_binary.hpp"
+#include "gpu/amd/miopen_eltwise.hpp"
 #include "gpu/amd/sycl_hip_compat.hpp"
 #include "gpu/amd/sycl_hip_engine.hpp"
 #include "gpu/amd/sycl_hip_scoped_context.hpp"
@@ -123,6 +124,9 @@ using namespace dnnl::impl::data_type;
 constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         // Binary
         INSTANCE(miopen_binary_t)
+        // Elementwise
+        INSTANCE(miopen_eltwise_fwd_t)
+        INSTANCE(miopen_eltwise_bwd_t)
         nullptr,
 };
 // clang-format on

--- a/tests/gtests/api/test_engine.cpp
+++ b/tests/gtests/api/test_engine.cpp
@@ -30,11 +30,6 @@ protected:
 };
 
 HANDLE_EXCEPTIONS_FOR_TEST_P(engine_test_t, TestMultithreading) {
-#ifdef DNNL_SYCL_HIP
-    SKIP_IF(true,
-            "AllEngineKinds/engine_test_t.TestMultithreading/1 is skipped for "
-            "HIP because of unimplemented Eltwise");
-#endif
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_NONE
     if (eng_kind == engine::kind::cpu) {

--- a/tests/gtests/sycl/api/test_memory_buffer.cpp
+++ b/tests/gtests/sycl/api/test_memory_buffer.cpp
@@ -332,9 +332,8 @@ TEST_P(sycl_memory_buffer_test, EltwiseWithUserKernel) {
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
 #ifdef DNNL_SYCL_HIP
-    SKIP_IF(true,
-            "Simple/sycl_memory_buffer_test.EltwiseWithUserKernel/gpu is "
-            "skipped for HIP because of unimplemented Eltwise");
+    SKIP_IF(eng_kind == engine::kind::gpu,
+            "OpenCL features are not supported on HIP backend");
 #endif
 
 #ifdef DNNL_SYCL_CUDA

--- a/tests/gtests/test_eltwise.cpp
+++ b/tests/gtests/test_eltwise.cpp
@@ -409,12 +409,10 @@ protected:
                 && tag != memory::format_tag::aBcde8b
                 && tag != memory::format_tag::aBcde16b);
     }
+
     bool hip_check_format_tag(memory::format_tag tag) {
-        // Blocking is not supported by MIOpen
-        return (tag != memory::format_tag::aBcd8b
-                && tag != memory::format_tag::aBcd16b
-                && tag != memory::format_tag::aBcde8b
-                && tag != memory::format_tag::aBcde16b);
+        // HIP has the same limitations for `tag` as CUDA.
+        return cuda_check_format_tag(tag);
     }
 
     void Test() {

--- a/tests/gtests/test_iface_pd_iter.cpp
+++ b/tests/gtests/test_iface_pd_iter.cpp
@@ -67,6 +67,7 @@ TEST_F(pd_iter_test_t, TestReLUImpls) {
 
 TEST(pd_next_impl, TestEltwiseImpl) {
     SKIP_IF_CUDA(true, "Unsupported memory format for CUDA");
+    SKIP_IF_HIP(true, "Unsupported memory format for HIP");
     auto eng = get_test_engine();
     memory::desc md(
             {8, 32, 4, 4}, memory::data_type::f32, memory::format_tag::nChw8c);


### PR DESCRIPTION
# Description

Introducing AMD backend for the oneDNN Eltwise primitive.

Limitations: 
MIOpen only supports NCHW layout format. MIOpen has limited support for only subset of oneDNN Eltwise algorithms as mentioned below.

We are also attaching output log files for gtests and benchdnn.
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/9006972/test_internals.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/9006973/test_regression.log)
[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/9006967/test_api_buffer.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/9006968/test_api_sycl.log)
[test_eltwise.log](https://github.com/oneapi-src/oneDNN/files/9006969/test_eltwise.log)
[test_eltwise_buffer.log](https://github.com/oneapi-src/oneDNN/files/9006971/test_eltwise_buffer.log)
[benchdnn_test_eltwise_all.log](https://github.com/oneapi-src/oneDNN/files/9006964/benchdnn_test_eltwise_all.log)

Testing scope:
benchdnn: passed
gtest: API tests passed, Eltwise tests passed


Supported scope:
Supported data types: f32, f16
This backend only supports the following algorithms:
Eltwise Forward - RELU, ELU, TANH, LOGISTIC, CLIPPEDRELU, ABS, SOFTRELU
Eltwise Backward - RELU,CLIPPEDRELU, SOFTRELU
No post-ops are supported


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?





