### PR TITLE
src: cpu: x64: int8: 1x1_conv: remove unused param in reduce_loop call

### DIFF
--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -102,7 +102,7 @@ void _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Vmm>::bcast_loop(
         int num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
         for (int i = 0; i < num_substeps; i++) {
-            reduce_loop(load_loop_blk, jcp.ur, i, false);
+            reduce_loop(load_loop_blk, jcp.ur, false);
             if (i < num_substeps - 1) {
                 add(aux1_reg_bcast_data, jcp.bcast_loop_bcast_substep);
                 add(aux_reg_output_data, jcp.bcast_loop_output_substep);
@@ -127,7 +127,7 @@ void _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Vmm>::bcast_loop(
         Label bcast_loop_tail_out;
         cmp(bcast_loop_iter, 0);
         jz(bcast_loop_tail_out, T_NEAR);
-        reduce_loop(load_loop_blk, jcp.ur_tail, 0, true);
+        reduce_loop(load_loop_blk, jcp.ur_tail, true);
         L(bcast_loop_tail_out);
     }
 }
@@ -292,7 +292,7 @@ void _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Vmm>::apply_postops(
 
 template <typename Vmm>
 void _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Vmm>::reduce_loop(
-        int load_loop_blk, int ur, int substep, bool wraparound) {
+        int load_loop_blk, int ur, bool wraparound) {
     auto vreg_load
             = [=](int i_load) { return Vmm(ur * load_loop_blk + i_load); };
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -128,7 +128,7 @@ private:
     inline Vmm_down_t vmm_store() { return Vmm_down_t(ymm_store.getIdx()); };
 
     void bcast_loop(int load_loop_blk);
-    void reduce_loop(int load_loop_blk, int ur, int substep, bool wraparound);
+    void reduce_loop(int load_loop_blk, int ur, bool wraparound);
 
     Xbyak::Address output_ptr(const int i_load, const int i_ur);
     int vreg_accum_idx(const int load_loop_blk, int i_load, int i_ur) const;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -91,7 +91,7 @@ void _jit_uni_x8s8s32x_1x1_conv_kernel<isa, Vmm>::bcast_loop(
     L(bcast_loop);
     {
         assert(jcp.bcast_block == jcp.ur);
-        reduce_loop(load_loop_blk, jcp.ur, 0, false);
+        reduce_loop(load_loop_blk, jcp.ur, false);
         add(aux1_reg_bcast_data, jcp.bcast_loop_bcast_step);
         add(aux_reg_output_data, jcp.bcast_loop_output_step);
 
@@ -105,7 +105,7 @@ void _jit_uni_x8s8s32x_1x1_conv_kernel<isa, Vmm>::bcast_loop(
         Label bcast_loop_tail_out;
         cmp(reg_bcast_loop_iter, 0);
         jz(bcast_loop_tail_out, T_NEAR);
-        reduce_loop(load_loop_blk, jcp.ur_tail, 0, true);
+        reduce_loop(load_loop_blk, jcp.ur_tail, true);
         L(bcast_loop_tail_out);
     }
 }
@@ -226,7 +226,7 @@ void _jit_uni_x8s8s32x_1x1_conv_kernel<isa, Vmm>::apply_postops(const int ur,
 
 template <cpu_isa_t isa, typename Vmm>
 void _jit_uni_x8s8s32x_1x1_conv_kernel<isa, Vmm>::reduce_loop(
-        int load_loop_blk, int ur, int substep, bool wraparound) {
+        int load_loop_blk, int ur, bool wraparound) {
 
     // use 0x10001 to represent 2 words of 0x1
     // and avoid using uni_vpbroadcastb that is missing in jit generator

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -116,7 +116,7 @@ private:
     void apply_postops(const int ur, const int load_loop_blk,
             const bool mask_flag_in, const float *p_sum_scale,
             const int32_t *p_sum_zp);
-    void reduce_loop(int load_loop_blk, int ur, int substep, bool wraparound);
+    void reduce_loop(int load_loop_blk, int ur, bool wraparound);
 
     void generate() override;
     void cvt2ps(data_type_t type_in, const Vmm &vmm_in, const Xbyak::Reg64 &reg,


### PR DESCRIPTION
# Description

When I read the code of conv1x1 int8 implements, I find that the `substep` param in the `reduce_loop` function is not used in the function body. So this PR is trying to remove it.

This PR has run all unit tests, but not benchdnn tests.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
