### PR TITLE
cpu: aarch64: build: update Compute Library version to 22.05

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -29,7 +29,7 @@ steps:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get update && apt-get install -y git build-essential cmake scons gcc-10 g++-10
   - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 1 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 1
-  - .github/automation/build_acl.sh  --version 22.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 22.05 --arch armv8a --multi_isa --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -83,7 +83,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 22.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 22.05 --arch armv8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -114,7 +114,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 22.02 --arch arm64-v8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 22.05 --arch armv8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -18,9 +18,10 @@
 # *******************************************************************************
 
 # Compute Library build defaults
-ACL_VERSION="v22.02"
+ACL_VERSION="v22.05"
 ACL_DIR="${PWD}/ComputeLibrary"
-ACL_ARCH="arm64-v8a"
+ACL_ARCH="armv8a"
+ACL_MULTI_ISA_SUPPORT=0
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -31,6 +32,9 @@ while [[ $# -gt 0 ]]; do
         --arch)
         ACL_ARCH="$2"
         shift
+        ;;
+        --multi_isa)
+        ACL_MULTI_ISA_SUPPORT=1
         ;;
         --root-dir)
         ACL_DIR="$2"
@@ -51,6 +55,6 @@ git clone --branch $ACL_VERSION --depth 1 $ACL_REPO $ACL_DIR
 cd $ACL_DIR
 
 scons --silent $MAKE_NP Werror=0 debug=0 neon=1 opencl=0 embed_kernels=0 \
-  os=linux arch=$ACL_ARCH build=native
+    os=linux arch=$ACL_ARCH build=native multi_isa=$ACL_MULTI_ISA_SUPPORT
 
 exit $?

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ On a CPU based on Arm AArch64 architecture, oneDNN can be built with Arm Compute
 integration. Compute Library is an open-source library for machine learning applications
 and provides AArch64 optimized implementations of core functions. This functionality currently
 requires that Compute Library is downloaded and built separately, see
-[Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html). oneDNN is only
-compatible with Compute Library versions 22.02 or later.
+[Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html). oneDNN only supports
+Compute Library versions 22.05 or later.
 
 > **WARNING**
 >

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -31,7 +31,7 @@ endif()
 
 find_package(ACL REQUIRED)
 
-set(ACL_MINIMUM_VERSION "22.02")
+set(ACL_MINIMUM_VERSION "22.05")
 
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -242,7 +242,7 @@ For a debug build of oneDNN it is advisable to specify a Compute Library build
 which has also been built with debug enabled.
 
 @warning
-oneDNN is only compatible with Compute Library builds v22.02 or later.
+oneDNN only supports builds with Compute Library v22.05 or later.
 
 #### Vendor BLAS libraries
 oneDNN can use a standard BLAS library for GEMM operations.


### PR DESCRIPTION
# Description

Updates the expected Compute Library for the Arm® Architecture (ACL) version for builds on AArch64 with the Compute Library backend.

The ACL version is updated from 22.02 to 22.05 in:
- DroneCI builds
- Docs
- ACL.cmake

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [N/A] Have you formatted the code using clang-format?
