### PR TITLE
cpu: aarch64: Reorder dims by stride in ACL binary

### DIFF
--- a/src/cpu/aarch64/acl_prelu.hpp
+++ b/src/cpu/aarch64/acl_prelu.hpp
@@ -88,13 +88,15 @@ struct acl_prelu_fwd_t : public primitive_t {
             if (!attr()->has_default_values()) return status::unimplemented;
 
             // ACL pointwise arithmetic operators assume that the innermost
-            // dimensions are dense for src, weights and dst. So we try to permute
-            // the logical dims so that the innermost dim on each desc is dense
-            // (without any data reordering)
+            // dimensions are dense for src, weights and dst. Reordering the
+            // logical dimensions by stride does this (if reordered_dims >= 1 )
+            // and also makes memory accesses contiguous in ACL (without any
+            // data reordering).
             memory_desc_t src_d_permed, weights_d_permed, dst_d_permed;
-            CHECK(permute_common_dense_dimension_to_last(&src_d_permed,
-                    &weights_d_permed, &dst_d_permed, src_md(0), weights_md(0),
-                    dst_md(0)));
+            int reordered_dims = reorder_dimensions_by_stride(
+                    {&src_d_permed, &weights_d_permed, &dst_d_permed},
+                    {src_md(0), weights_md(0), dst_md(0)});
+            if (reordered_dims < 1) return status::unimplemented;
 
             // Create ACL tensor infos with permuted descs
             CHECK(tensor_info(app_.src_info, src_d_permed));

--- a/src/cpu/aarch64/acl_utils.hpp
+++ b/src/cpu/aarch64/acl_utils.hpp
@@ -50,18 +50,14 @@ status_t tensor_info(
 // Insert a dimension of size 1 at the index dim_i of TensorInfo
 status_t insert_singleton_dimension(arm_compute::TensorInfo &ti, size_t dim_i);
 
-// Copy the memory descs {d0, d1, d2} to {d0_perm, d1_perm, d2_perm}, but with
-// the dimensions permuted so that their last logical dimensions are all dense
-// (stride of 1). The function finds the highest indexed dimension with a
-// stride of 1 for all descs (common). Then it permutes this to be the last
-// dimension. Note that the last dimension is the one that is dense in an
-// unpermuted tensor, in this case it would copy the descs unchanged. The
-// function may fail to find a common dense dimension, and will return
-// unimplemented.
-status_t permute_common_dense_dimension_to_last(memory_desc_t *d0_permed,
-        memory_desc_t *d1_permed, memory_desc_t *d2_permed,
-        const memory_desc_t *d0, const memory_desc_t *d1,
-        const memory_desc_t *d2);
+// Reorder the logical dimensions of the memory descriptors (mds) by stride so
+// that accessing the tensor elements in the natural order is dense. Note, this
+// does not reorder the data, it just reorders the logical indices. The
+// permutation is common to all mds, so the function returns when it cannot find
+// a dimension with a common smallest stride. Returns the number of dimensions
+// that we managed to reorder to be dense.
+int reorder_dimensions_by_stride(std::vector<memory_desc_t *> permuted_mds,
+        std::vector<const memory_desc_t *> mds);
 
 // Logs a custom 'info' line describing an unsupported case
 #define LOG_ACL_UNSUPPORTED(msg) \


### PR DESCRIPTION
# Description

Changes the way we pass dimensions into the Compute Library for the Arm® Architecture (ACL) binary/PReLU operators. Instead of just making the innermost dimension dense, we attempt to order the dimensions of all 3 tensors (`src0`, `src1`, `dst`) by stride so that the memory accesses are as contiguous as possible. This speeds up single threaded performance for NHWC (and other non-naturally ordered tensors) by ~2x, with the speed up decreasing gradually as we use more cores, to around ~0.1x speedup for >16 cores. There is no functional or performance change for NCHW.

This, along with #1404, fixes the regressions identified in #1330.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?

