### PR TITLE
aarch64: binary: add jit impl. for sve_512

### DIFF
--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -183,13 +183,13 @@ static inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
     switch (cpu_isa) {
         case asimd: return cpu().has(Cpu::tADVSIMD);
         case sve_128:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() == SVE_128;
+            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_128;
         case sve_256:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() == SVE_256;
+            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_256;
         case sve_384:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() == SVE_384;
+            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_384;
         case sve_512:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() == SVE_512;
+            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_512;
         case isa_any: return true;
         case isa_all: return false;
     }

--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -1,0 +1,145 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include <numeric>
+#include "common/broadcast_strategy.hpp"
+#include "cpu/aarch64/injectors/injector_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+namespace injector_utils {
+
+template <cpu_isa_t isa>
+register_preserve_guard_t<isa>::register_preserve_guard_t(jit_generator *host,
+        std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
+        std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
+    : host_(host)
+    , reg64_stack_(reg64_to_preserve)
+    , vmm_stack_(vmm_to_preserve)
+    , vmm_to_preserve_size_bytes_(
+              calc_vmm_to_preserve_size_bytes(vmm_to_preserve)) {
+
+    for (const auto &reg : reg64_to_preserve)
+        host_->str(reg, pre_ptr(host_->X_SP, -8));
+
+    if (!vmm_stack_.empty()) {
+        host_->sub(host_->X_SP, host_->X_SP, vmm_to_preserve_size_bytes_);
+
+        uint32_t stack_offset = vmm_to_preserve_size_bytes_;
+        for (const auto &vmm : vmm_to_preserve) {
+            const uint32_t bytes = cpu_isa_traits<isa>::vlen;
+            stack_offset -= bytes;
+            const auto idx = vmm.getIdx();
+            if (is_superset(isa, sve_256)) {
+                if (stack_offset % cpu_sveLen_ == 0) {
+                    host_->st1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
+                            ptr(host_->X_SP, stack_offset / bytes,
+                                    Xbyak_aarch64::MUL_VL));
+                } else {
+                    host_->add_imm(host_->X_DEFAULT_ADDR, host_->X_SP,
+                            stack_offset, host_->X_TMP_0);
+                    host_->st1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
+                            ptr(host_->X_DEFAULT_ADDR));
+                }
+            } else {
+                host_->str(Xbyak_aarch64::QReg(idx),
+                        ptr(host_->X_SP, stack_offset));
+            }
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+register_preserve_guard_t<isa>::~register_preserve_guard_t() {
+
+    uint32_t tmp_stack_offset = 0;
+
+    while (!vmm_stack_.empty()) {
+        const Xbyak_aarch64::VReg &vmm = vmm_stack_.top();
+        const uint32_t bytes = cpu_isa_traits<isa>::vlen;
+        const auto idx = vmm.getIdx();
+        if (is_superset(isa, sve_256)) {
+            if (tmp_stack_offset % cpu_sveLen_ == 0) {
+                host_->ld1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
+                        ptr(host_->X_SP, tmp_stack_offset / bytes,
+                                Xbyak_aarch64::MUL_VL));
+            } else {
+                host_->add_imm(host_->X_DEFAULT_ADDR, host_->X_SP,
+                        tmp_stack_offset, host_->X_TMP_0);
+                host_->ld1w(Xbyak_aarch64::ZRegS(idx), host_->P_ALL_ONE,
+                        ptr(host_->X_SP, host_->X_DEFAULT_ADDR));
+            }
+        } else {
+            host_->ldr(Xbyak_aarch64::QReg(idx),
+                    ptr(host_->X_SP, tmp_stack_offset));
+        }
+
+        tmp_stack_offset += bytes;
+        vmm_stack_.pop();
+    }
+
+    if (vmm_to_preserve_size_bytes_)
+        host_->add_imm(host_->X_SP, host_->X_SP, vmm_to_preserve_size_bytes_,
+                host_->X_TMP_0);
+
+    while (!reg64_stack_.empty()) {
+        host_->ldr(reg64_stack_.top(), post_ptr(host_->X_SP, 8));
+        reg64_stack_.pop();
+    }
+}
+
+template <cpu_isa_t isa>
+size_t register_preserve_guard_t<isa>::calc_vmm_to_preserve_size_bytes(
+        const std::initializer_list<Xbyak_aarch64::VReg> &vmm_to_preserve)
+        const {
+
+    return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
+            std::size_t(0u),
+            [](std::size_t accum, const Xbyak_aarch64::VReg &vmm) {
+                return accum + cpu_isa_traits<isa>::vlen;
+            });
+}
+
+template <cpu_isa_t isa>
+size_t register_preserve_guard_t<isa>::stack_space_occupied() const {
+    constexpr static size_t reg64_size = 8;
+    const size_t stack_space_occupied
+            = vmm_to_preserve_size_bytes_ + reg64_stack_.size() * reg64_size;
+
+    return stack_space_occupied;
+};
+
+template <cpu_isa_t isa>
+conditional_register_preserve_guard_t<
+        isa>::conditional_register_preserve_guard_t(bool condition_to_be_met,
+        jit_generator *host,
+        std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
+        std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
+    : register_preserve_guard_t<isa> {condition_to_be_met
+                    ? register_preserve_guard_t<isa> {host, reg64_to_preserve,
+                            vmm_to_preserve}
+                    : register_preserve_guard_t<isa> {nullptr, {}, {}}} {};
+
+template class register_preserve_guard_t<sve_512>;
+template class conditional_register_preserve_guard_t<sve_512>;
+
+} // namespace injector_utils
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/injectors/injector_utils.hpp
+++ b/src/cpu/aarch64/injectors/injector_utils.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2021-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@
 #ifndef CPU_AARCH64_JIT_INJECTOR_UTILS_HPP
 #define CPU_AARCH64_JIT_INJECTOR_UTILS_HPP
 
+#include <array>
+#include <cstddef>
 #include <set>
+#include <stack>
 
 #include "cpu/aarch64/jit_generator.hpp"
 
@@ -29,6 +32,77 @@ namespace injector_utils {
 
 using vmm_index_set_t = typename std::set<size_t>;
 using vmm_index_set_iterator_t = typename std::set<size_t>::iterator;
+template <cpu_isa_t isa>
+struct vmm_size_t;
+
+template <>
+struct vmm_size_t<sve_512> {
+    static constexpr std::size_t bytes = 64u;
+};
+
+/*
+template <>
+struct vmm_size_t<sve_256> {
+    static constexpr std::size_t bytes = 32u;
+};
+
+template <>
+struct vmm_size_t<sve_128> {
+    static constexpr std::size_t bytes = 16u;
+    };*/
+
+enum class layout_t { ncsp, c_blocked, nspc, cspn, unsupported };
+
+inline layout_t get_layout_type(const memory_desc_wrapper &dst_d) {
+    const auto strides = dst_d.blocking_desc().strides;
+    if (!dst_d.is_plain()) return layout_t::c_blocked;
+    if (strides[0] >= strides[1]
+            && IMPLICATION(dst_d.ndims() >= 3, strides[1] >= strides[2]))
+        return layout_t::ncsp;
+    if (strides[1] == 1) return layout_t::nspc;
+    if (strides[0] == 1) return layout_t::cspn;
+    return layout_t::unsupported;
+}
+
+/*
+ * Scope guard for general purpose register and vector registers preservation.
+ * Pushes registers to stack during construction and pops during destruction.
+ */
+template <cpu_isa_t isa>
+class register_preserve_guard_t {
+
+public:
+    register_preserve_guard_t(jit_generator *host,
+            std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
+            std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve = {});
+    register_preserve_guard_t(register_preserve_guard_t &&other) = default;
+    register_preserve_guard_t &operator=(register_preserve_guard_t &&other)
+            = default;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(register_preserve_guard_t);
+    ~register_preserve_guard_t();
+    size_t calc_vmm_to_preserve_size_bytes(
+            const std::initializer_list<Xbyak_aarch64::VReg> &vmm_to_preserve)
+            const;
+    size_t stack_space_occupied() const;
+
+private:
+    jit_generator *host_;
+    std::stack<Xbyak_aarch64::XReg> reg64_stack_;
+    std::stack<Xbyak_aarch64::VReg> vmm_stack_;
+    const uint64_t cpu_sveLen_ = get_sve_length();
+    size_t vmm_to_preserve_size_bytes_;
+};
+
+template <cpu_isa_t isa>
+class conditional_register_preserve_guard_t
+    : public register_preserve_guard_t<isa> {
+public:
+    conditional_register_preserve_guard_t(bool condition_to_be_met,
+            jit_generator *host,
+            std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
+            std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve = {});
+    DNNL_DISALLOW_COPY_AND_ASSIGN(conditional_register_preserve_guard_t);
+};
 
 } // namespace injector_utils
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1,0 +1,1897 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include <algorithm>
+#include <cmath>
+
+#include "common/primitive.hpp"
+#include "common/primitive_attr.hpp"
+#include "common/primitive_exec_types.hpp"
+#include "common/utils.hpp"
+#include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+namespace binary_injector {
+
+static bcast_set_t get_all_strategies_supported_by_injector() {
+    return bcast_set_t {broadcasting_strategy_t::scalar,
+            broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::per_mb_w, broadcasting_strategy_t::per_w,
+            broadcasting_strategy_t::no_broadcast};
+}
+
+bool is_data_supported(cpu_isa_t isa, data_type_t data_type) {
+    UNUSED(isa);
+    return !(data_type == data_type::bf16);
+}
+
+static bool src1_desc_layout_same_as_dst_d(
+        const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d) {
+    if (dst_d.md_ == nullptr) return false;
+    const auto &lhs = src1_desc;
+    const auto &rhs = *(dst_d.md_);
+
+    using namespace dnnl::impl::utils;
+    const bool is_format_any
+            = one_of(format_kind::any, lhs.format_kind, rhs.format_kind);
+
+    return lhs.ndims == rhs.ndims
+            && (is_format_any
+                    || (lhs.format_kind == rhs.format_kind
+                            && array_cmp(lhs.format_desc.blocking.strides,
+                                    rhs.format_desc.blocking.strides,
+                                    lhs.ndims)))
+            && array_cmp(lhs.dims, rhs.dims, lhs.ndims)
+            && array_cmp(lhs.padded_dims, rhs.padded_dims, lhs.ndims)
+            && array_cmp(lhs.padded_offsets, rhs.padded_offsets, lhs.ndims)
+            && lhs.offset0 == rhs.offset0;
+}
+
+bool is_bcast_supported(const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    const auto bcast_type = get_rhs_arg_broadcasting_strategy(
+            src1_desc, dst_d, supported_strategy_set);
+
+    if (bcast_type == broadcasting_strategy_t::no_broadcast) {
+        // in case of no broadcast data layout of dst and src1 have to be the same
+        if (!src1_desc_layout_same_as_dst_d(src1_desc, dst_d)) return false;
+    }
+
+    return bcast_type != broadcasting_strategy_t::unsupported;
+}
+
+bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    return is_data_supported(isa, src1_desc.data_type)
+            && is_bcast_supported(src1_desc, dst_d, supported_strategy_set);
+}
+
+bool binary_args_broadcast_supported(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+
+    return std::none_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) -> bool {
+                if (entry.is_binary()) {
+                    const auto bcast_type = get_rhs_arg_broadcasting_strategy(
+                            entry.binary.src1_desc, dst_d,
+                            supported_strategy_set);
+                    return bcast_type == broadcasting_strategy_t::unsupported;
+                }
+                return false;
+            });
+}
+
+bool binary_args_tail_supported(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d, int vlen,
+        const bcast_set_t &supported_strategy_set) {
+    const auto channels = dst_d.dims()[1];
+    const int vmm_l_len = vlen / 4;
+
+    return std::none_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) -> bool {
+                if (entry.is_binary()) {
+                    const auto bcast_type = get_rhs_arg_broadcasting_strategy(
+                            entry.binary.src1_desc, dst_d,
+                            supported_strategy_set);
+                    return utils::one_of(bcast_type,
+                                   broadcasting_strategy_t::per_oc,
+                                   broadcasting_strategy_t::per_oc_spatial)
+                            && (channels % vmm_l_len != 0);
+                }
+                return false;
+            });
+}
+
+bool binary_args_matches_tag(format_tag_t tag, const post_ops_t &post_ops) {
+    return std::all_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) {
+                if (entry.is_binary()) {
+                    const memory_desc_wrapper rhs_arg_d(entry.binary.src1_desc);
+                    return rhs_arg_d.matches_tag(tag);
+                }
+                return true;
+            });
+}
+
+bool any_binary_postop_rhs_per_oc_broadcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d) {
+    return any_binary_postop_rhs_per_oc_broadcast(
+            post_ops, dst_d, get_all_strategies_supported_by_injector());
+}
+
+bool any_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    return std::any_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) -> bool {
+                if (entry.is_binary()) {
+                    const auto bcast_type = get_rhs_arg_broadcasting_strategy(
+                            entry.binary.src1_desc, dst_d,
+                            supported_strategy_set);
+                    return bcast_type == broadcasting_strategy_t::per_oc
+                            || bcast_type
+                            == broadcasting_strategy_t::per_oc_spatial;
+                }
+                return false;
+            });
+}
+
+bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const std::function<bool(const memory_desc_wrapper &)> &predicate) {
+    return true;
+}
+
+static_params_t::static_params_t(const Xbyak_aarch64::XReg &param1,
+        const bcast_set_t &supported_strategy_set,
+        const rhs_arg_static_params_t &rhs_arg_static_params)
+    : param1(param1)
+    , supported_strategy_set(supported_strategy_set)
+    , rhs_arg_static_params(rhs_arg_static_params) {}
+
+static_params_t::static_params_t(const Xbyak_aarch64::XReg &param1,
+        const rhs_arg_static_params_t &rhs_arg_static_params)
+    : static_params_t(param1, get_all_strategies_supported_by_injector(),
+            rhs_arg_static_params) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
+            abi_param_offset, 0, dst_d, tail_size, Xbyak_aarch64::PReg(2),
+            use_exact_tail_scalar_bcast, rhs_helper_reg,
+            false /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
+            abi_param_offset, dst_orig_offset, dst_d, tail_size,
+            Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast, rhs_helper_reg,
+            false /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        const Xbyak_aarch64::PReg &tail_opmask,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
+            abi_param_offset, 0, dst_d, tail_size, tail_opmask,
+            use_exact_tail_scalar_bcast, rhs_helper_reg, true /*is_opmask_set*/,
+            false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
+            abi_param_offset, dst_orig_offset, dst_d, tail_size, tail_opmask,
+            use_exact_tail_scalar_bcast, rhs_helper_reg, true /*is_opmask_set*/,
+            true /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &reg_tail_size,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
+            abi_param_offset, 0, dst_d, tail_size, tail_opmask,
+            use_exact_tail_scalar_bcast, reg_tail_size, true /*is_opmask_set*/,
+            false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &reg_tail_size,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
+            abi_param_offset, dst_orig_offset, dst_d, tail_size, tail_opmask,
+            use_exact_tail_scalar_bcast, reg_tail_size, true /*is_opmask_set*/,
+            true /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        bool use_exact_tail_scalar_bcast,
+        const Xbyak_aarch64::XReg &reg_tail_size, bool is_opmask_set,
+        bool is_dst_orig_set)
+    : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
+    , rhs_addr_reg(rhs_addr_reg)
+    , rhs_helper_reg(rhs_helper_reg)
+    , preserve_gpr_helpers(preserve_gpr_helpers)
+    , preserve_vmm_helper(preserve_vmm_helper)
+    , abi_param_offset(abi_param_offset)
+    , dst_orig_offset(dst_orig_offset)
+    , dst_d(dst_d)
+    , tail_size(tail_size)
+    , tail_opmask(tail_opmask)
+    , use_exact_tail_scalar_bcast(use_exact_tail_scalar_bcast)
+    , reg_tail_size(reg_tail_size)
+    , is_tail(tail_size)
+    , is_opmask_set_(is_opmask_set)
+    , is_dst_orig_set_(is_dst_orig_set) {}
+
+template <cpu_isa_t isa>
+jit_uni_binary_injector_t<isa>::jit_uni_binary_injector_t(
+        jit_generator *host, const static_params_t &static_params)
+    : host_(host)
+    , rhs_arg_static_params_(static_params.rhs_arg_static_params)
+    , param1_(static_params.param1)
+    , supported_strategy_set_(static_params.supported_strategy_set) {}
+
+template <typename ParamsMap>
+static bool params_differ(ParamsMap &params,
+        const typename ParamsMap::key_type key1,
+        const typename ParamsMap::key_type key2) {
+    const auto &it1 = params.find(key1);
+    const auto &it2 = params.find(key2);
+    if (utils::one_of(params.end(), it1, it2)) return it1 != it2;
+    return it1->second != it2->second;
+}
+
+static bool params_differ_xreg(const std::map<int, Xbyak_aarch64::XReg> &params,
+        const std::map<int, Xbyak_aarch64::XReg>::key_type key1,
+        const std::map<int, Xbyak_aarch64::XReg>::key_type key2) {
+    const auto &it1 = params.find(key1);
+    const auto &it2 = params.find(key2);
+    if (utils::one_of(params.end(), it1, it2)) return it1 != it2;
+    const Xbyak_aarch64::XReg &it1_second = it1->second;
+    const Xbyak_aarch64::XReg &it2_second = it2->second;
+    return it1_second.getIdx() != it2_second.getIdx();
+}
+
+static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        broadcasting_strategy_t rhs_broadcasting_strategy) {
+
+    const auto &out_addr = rhs_arg_params.vmm_idx_to_out_addr;
+    const auto &out_reg = rhs_arg_params.vmm_idx_to_out_reg;
+
+    const auto &out_elem_off_addr = rhs_arg_params.vmm_idx_to_out_elem_off_addr;
+    const auto &out_elem_off_val = rhs_arg_params.vmm_idx_to_out_elem_off_val;
+    const auto &out_off_oprnd = rhs_arg_params.vmm_idx_to_out_off_oprnd;
+    const auto &oc_off_addr = rhs_arg_params.vmm_idx_to_oc_elem_off_addr;
+    const auto &oc_off_val = rhs_arg_params.vmm_idx_to_oc_elem_off_val;
+    const auto &oc_off_oprnd = rhs_arg_params.vmm_idx_to_oc_off_oprnd;
+    const auto &sp_off_addr = rhs_arg_params.vmm_idx_to_sp_elem_off_addr;
+    const auto &sp_off_val = rhs_arg_params.vmm_idx_to_sp_elem_off_val;
+    const auto &sp_off_oprnd = rhs_arg_params.vmm_idx_to_sp_off_oprnd;
+
+    if (rhs_broadcasting_strategy == broadcasting_strategy_t::scalar) {
+        return false;
+    } else if (rhs_broadcasting_strategy
+            == broadcasting_strategy_t::no_broadcast) {
+        return params_differ(out_addr, vmm_idx1, vmm_idx2)
+                || params_differ_xreg(out_reg, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_addr, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(out_off_oprnd, vmm_idx1, vmm_idx2);
+    } else if (rhs_broadcasting_strategy == broadcasting_strategy_t::per_oc
+            || rhs_broadcasting_strategy
+                    == broadcasting_strategy_t::per_oc_spatial) {
+        return params_differ(out_addr, vmm_idx1, vmm_idx2)
+                || params_differ_xreg(out_reg, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(oc_off_addr, vmm_idx1, vmm_idx2)
+                || params_differ(oc_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(oc_off_oprnd, vmm_idx1, vmm_idx2);
+    } else if (rhs_broadcasting_strategy
+            == broadcasting_strategy_t::per_mb_spatial) {
+        return params_differ(out_addr, vmm_idx1, vmm_idx2)
+                || params_differ_xreg(out_reg, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(sp_off_addr, vmm_idx1, vmm_idx2)
+                || params_differ(sp_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(sp_off_oprnd, vmm_idx1, vmm_idx2);
+    }
+    return true;
+}
+
+template <cpu_isa_t isa>
+int jit_uni_binary_injector_t<isa>::adjust_temp_vmm_hint(
+        int user_hint, int start_idx, int end_idx, int max_vmm_idx) const {
+    const bool user_hint_in_vector_range
+            = user_hint >= start_idx && user_hint <= end_idx;
+    const bool user_hint_exceeded_limit = user_hint > max_vmm_idx;
+    const bool user_hint_invalid
+            = user_hint_in_vector_range || user_hint_exceeded_limit;
+
+    if (user_hint_invalid) {
+        const bool max_vmm_idx_in_vector_range
+                = max_vmm_idx >= start_idx && max_vmm_idx <= end_idx;
+
+        if (max_vmm_idx_in_vector_range || user_hint_exceeded_limit
+                || user_hint == max_vmm_idx)
+            return 0;
+        else
+            return max_vmm_idx;
+    }
+
+    return user_hint;
+}
+
+template <typename Vmm>
+static void push_vmm(jit_generator *host, const Vmm &vmm) {
+    host->sub_imm(host->X_SP, host->X_SP, host->cpu_sveLen * 16, host->X_TMP_0);
+    host->uni_str(vmm, host->X_SP);
+}
+
+template <typename Vmm>
+static void pop_vmm(jit_generator *host, const Vmm &vmm) {
+    host->uni_ldr(vmm, host->X_SP);
+    host->add_imm(host->X_SP, host->X_SP, host->cpu_sveLen * 16, host->X_TMP_0);
+}
+
+static void push_opmask(jit_generator *host, const Xbyak_aarch64::PReg &k) {
+    static constexpr int k_mask_size = 8;
+    host->sub_imm(host->X_SP, host->X_SP, k_mask_size, host->X_TMP_0);
+    host->str(k, Xbyak_aarch64::ptr(host->X_SP));
+}
+
+static void pop_opmask(jit_generator *host, const Xbyak_aarch64::PReg &k) {
+    static constexpr int k_mask_size = 8;
+    host->ldr(k, Xbyak_aarch64::ptr(host->X_SP));
+    host->add_imm(host->X_SP, host->X_SP, k_mask_size, host->X_TMP_0);
+}
+
+template <typename Vmm>
+static void restore_stack(jit_generator *host, const Vmm &vmm) {
+    host->add_imm(host->X_SP, host->X_SP, host->cpu_sveLen * 16, host->X_TMP_0);
+}
+
+template <cpu_isa_t isa>
+std::pair<bool, int> jit_uni_binary_injector_t<isa>::should_preserve_vmm(
+        int curr_idx, int vmm_hint, int max_vmm_idx,
+        bool dt_helper_vmm_needed) const {
+    if (dt_helper_vmm_needed && vmm_hint == curr_idx) {
+        if (curr_idx == 0)
+            return std::make_pair(true, max_vmm_idx);
+        else
+            return std::make_pair(true, 0);
+    }
+    return std::make_pair(false, vmm_hint);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::compute_vector_range(size_t start_idx,
+        size_t end_idx, std::size_t rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params) const {
+    injector_utils::vmm_index_set_t vmm_idxs;
+    for (size_t i = start_idx; i < end_idx; i++)
+        vmm_idxs.emplace(i);
+    compute_vector_range(vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::compute_vector_range(
+        const injector_utils::vmm_index_set_t &vmm_idxs,
+        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params) const {
+
+    if (vmm_idxs.empty()) return;
+    const auto start_idx = *(vmm_idxs.begin());
+    const auto end_idx = *(vmm_idxs.rbegin());
+
+    // Phase 1 Validate temporary vmm user hint
+    static constexpr int max_vmm_idx = cpu_isa_traits<isa>::n_vregs - 1;
+    auto &vmm_hint = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
+    vmm_hint = adjust_temp_vmm_hint(vmm_hint, start_idx, end_idx, max_vmm_idx);
+
+    const auto rhs_broadcasting_strategy
+            = get_rhs_arg_broadcasting_strategy(post_op.binary.src1_desc,
+                    rhs_arg_static_params_.dst_d, supported_strategy_set_);
+    const auto rhs_arg_data_type = post_op.binary.src1_desc.data_type;
+    const auto &vmm_tail_idx = rhs_arg_params.vmm_tail_idx_;
+    const bool tail_exists_in_range = !vmm_tail_idx.empty();
+    const bool should_preserve_vmm_tail = tail_exists_in_range
+            && (!utils::one_of(rhs_broadcasting_strategy,
+                        broadcasting_strategy_t::scalar,
+                        broadcasting_strategy_t::per_oc_spatial)
+                    || rhs_arg_data_type != data_type::f32);
+    const bool dt_helper_vmm_needed
+            = !binary_op_with_unaligned_mem_operand_allowed_
+            || rhs_arg_data_type != data_type::f32 || should_preserve_vmm_tail;
+    const auto tail_load_mode = rhs_arg_params.tail_load_mode;
+
+    // Phase 2 Protect temporary registers content.
+    const injector_utils::register_preserve_guard_t<isa> register_guard {host_,
+            (rhs_arg_static_params_.preserve_gpr_helpers
+                            ? std::initializer_list<Xbyak_aarch64::XReg>(
+                                    {rhs_arg_static_params_.rhs_addr_reg,
+                                            rhs_arg_static_params_
+                                                    .rhs_helper_reg})
+                            : std::initializer_list<Xbyak_aarch64::XReg>()),
+            (rhs_arg_static_params_.preserve_vmm_helper && dt_helper_vmm_needed
+                            ? std::initializer_list<Xbyak_aarch64::VReg>(
+                                    {Xbyak_aarch64::VReg(vmm_hint)})
+                            : std::initializer_list<Xbyak_aarch64::VReg>())};
+
+    bool vmm0_was_preserved = false;
+    static const Vmm zero_vmm(0);
+
+    rhs_address_t rhs_arg_addr(Xbyak_aarch64::XReg(0));
+
+    // Phase 3 Apply binary post-op over all vmms.
+    for (const auto vmm_idx : vmm_idxs) {
+        if (vmm_idx == start_idx
+                || rhs_arg_params_differ(vmm_idx, vmm_idx - 1, rhs_arg_params,
+                        rhs_broadcasting_strategy)) {
+            rhs_arg_addr = prepare_rhs_arg_addr(vmm_idx, rhs_arg_idx, post_op,
+                    rhs_arg_params, rhs_broadcasting_strategy);
+        }
+
+        const auto local_vmm_preservation = should_preserve_vmm(
+                vmm_idx, vmm_hint, max_vmm_idx, dt_helper_vmm_needed);
+        const bool &vmm_preservation_needed = local_vmm_preservation.first;
+        const Vmm dst_vmm(vmm_idx);
+        const bool with_tail = rhs_arg_static_params_.is_tail
+                && vmm_tail_idx.find(vmm_idx) != vmm_tail_idx.cend()
+                && IMPLICATION(rhs_broadcasting_strategy
+                                == broadcasting_strategy_t::scalar,
+                        rhs_arg_static_params_.use_exact_tail_scalar_bcast);
+
+        if (vmm_preservation_needed) {
+            const Vmm vmm_to_preserve(local_vmm_preservation.second);
+            push_vmm(host_, vmm_to_preserve);
+            inject_binary(
+                    post_op, dst_vmm, rhs_arg_addr, with_tail, tail_load_mode);
+            pop_vmm(host_, vmm_to_preserve);
+            // in case all Vmm are occupied, Vmm(0) is chosen for tmp by default,
+            // so it's content needs to be preserved...
+
+            push_vmm(host_, zero_vmm);
+            vmm0_was_preserved = true;
+        } else
+            inject_binary(
+                    post_op, dst_vmm, rhs_arg_addr, with_tail, tail_load_mode);
+    }
+    // ...and restored afterwards
+    if (vmm0_was_preserved) pop_vmm(host_, zero_vmm);
+}
+
+template <cpu_isa_t isa>
+rhs_address_t jit_uni_binary_injector_t<isa>::prepare_rhs_arg_addr(
+        std::size_t vmm_idx, std::size_t rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        const broadcasting_strategy_t rhs_broadcasting_strategy) const {
+
+    static constexpr auto rhs_arg_ptr_size = sizeof(const void *);
+    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
+    const auto &abi_param_offset = rhs_arg_static_params_.abi_param_offset;
+    const auto &rhs_helper_reg = rhs_arg_static_params_.rhs_helper_reg;
+    const auto rhs_arg_elem_size
+            = types::data_type_size(post_op.binary.src1_desc.data_type);
+
+    host_->add_imm(
+            host_->X_DEFAULT_ADDR, param1_, abi_param_offset, host_->X_TMP_0);
+    host_->ldr(rhs_addr_reg, ptr(host_->X_DEFAULT_ADDR));
+    host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr_reg,
+            rhs_arg_idx * rhs_arg_ptr_size, host_->X_TMP_0);
+    host_->ldr(rhs_addr_reg, ptr(host_->X_DEFAULT_ADDR));
+
+    switch (rhs_broadcasting_strategy) {
+        case broadcasting_strategy_t::scalar:
+            return rhs_address_t(rhs_addr_reg, 0, true);
+        case broadcasting_strategy_t::no_broadcast: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_out_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_out_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_no_broadcast_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_address_t(rhs_addr_reg);
+        }
+        case broadcasting_strategy_t::per_oc:
+        case broadcasting_strategy_t::per_oc_spatial: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_oc_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_oc_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_oc_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_oc_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_broadcasting_strategy
+                            == broadcasting_strategy_t::per_oc_spatial
+                    ? rhs_address_t(rhs_addr_reg, 0, true)
+                    : rhs_address_t(rhs_addr_reg);
+        }
+        case broadcasting_strategy_t::per_mb_spatial: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_sp_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_sp_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_sp_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_mb_sp_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_address_t(rhs_addr_reg);
+        }
+        case broadcasting_strategy_t::per_mb_w: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_mb_w_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_mb_w_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_mb_w_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_mb_w_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_address_t(rhs_addr_reg);
+        }
+        case broadcasting_strategy_t::per_w: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_w_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_w_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_w_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_w_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_address_t(rhs_addr_reg);
+        }
+        default: assert(false && "Broadcasting type not supported");
+    }
+
+    return rhs_address_t(rhs_addr_reg, 0, true);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_offset_from_operand(
+        const std::map<int, rhs_operand_t> &vmm_idx_to_elem_operand_off,
+        int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+        const Xbyak_aarch64::XReg &tmp_reg, std::size_t elem_size_bytes) const {
+
+    const auto it_operand_off = vmm_idx_to_elem_operand_off.find(vmm_idx);
+    if (it_operand_off != vmm_idx_to_elem_operand_off.end()
+            && !rhs_arg_static_params_.is_dst_orig_set()) {
+        if (elem_size_bytes == 1) {
+            host_->add(addr_reg, addr_reg,
+                    Xbyak_aarch64::XReg(it_operand_off->second.idx_));
+        } else {
+            const int shift_val = std::log2(elem_size_bytes);
+            const auto &op = it_operand_off->second;
+            if (it_operand_off->second.isAddress_) {
+                host_->ldr(tmp_reg,
+                        Xbyak_aarch64::ptr(host_->addr_off(op.address_.base_,
+                                op.address_.offt_, host_->X_DEFAULT_ADDR,
+                                host_->X_TMP_0)));
+            } else {
+                host_->mov(tmp_reg, Xbyak_aarch64::XReg(op.idx_));
+            }
+            host_->lsl(tmp_reg, tmp_reg, shift_val);
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_offset_under_mem_addr(
+        const std::map<int, rhs_address_t> &vmm_idx_to_elem_addr_off,
+        int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+        const Xbyak_aarch64::XReg &tmp_reg, std::size_t elem_size_bytes) const {
+
+    const auto it_off_addr = vmm_idx_to_elem_addr_off.find(vmm_idx);
+    if (it_off_addr != vmm_idx_to_elem_addr_off.end()
+            && !rhs_arg_static_params_.is_dst_orig_set()) {
+        if (elem_size_bytes == 1) {
+            host_->add(addr_reg, addr_reg,
+                    Xbyak_aarch64::XReg(it_off_addr->second.base_));
+        } else {
+            const int shift_val = std::log2(elem_size_bytes);
+            host_->add_imm(tmp_reg, it_off_addr->second.base_,
+                    it_off_addr->second.offt_, host_->X_TMP_0);
+            host_->lsl(tmp_reg, tmp_reg, shift_val);
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_value_offset(
+        const std::map<int, size_t> &vmm_idx_to_elem_val_off, int vmm_idx,
+        const Xbyak_aarch64::XReg &addr_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_off_val = vmm_idx_to_elem_val_off.find(vmm_idx);
+    if (it_off_val != vmm_idx_to_elem_val_off.end()
+            && !rhs_arg_static_params_.is_dst_orig_set())
+        host_->add_imm(addr_reg, addr_reg, it_off_val->second * elem_size_bytes,
+                host_->X_TMP_0);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_no_broadcast_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_aarch64::XReg &addr_reg, const Xbyak_aarch64::XReg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+
+    if (is_out_addr || is_out_reg) {
+        assert(rhs_arg_static_params_.is_dst_orig_set()
+                && "dst base addr offset not set");
+        rhs_address_t out_addr = is_out_addr
+                ? it_out_addr->second
+                : rhs_address_t(it_out_reg->second);
+        const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+        calculate_no_broadcast(out_addr,
+                it_off_val != vmm_idx_to_out_elem_off_val.end()
+                        ? it_off_val->second
+                        : 0,
+                tmp_reg);
+
+        if (elem_size_bytes > 1) {
+            const int shift_val = std::log2(elem_size_bytes);
+            host_->lsl(tmp_reg, tmp_reg, shift_val);
+        }
+        host_->add(addr_reg, addr_reg, tmp_reg);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_no_broadcast(rhs_address_t addr,
+        std::size_t offset, const Xbyak_aarch64::XReg &out_reg) const {
+    const auto &t0 = host_->X_TMP_0;
+    host_->add_imm(out_reg, addr.getBase(), addr.offt_, t0);
+    if (offset > 0) host_->add_imm(out_reg, out_reg, offset, t0);
+    host_->ldr(t0,
+            Xbyak_aarch64::ptr(host_->addr_off(param1_,
+                    rhs_arg_static_params_.dst_orig_offset,
+                    host_->X_DEFAULT_ADDR, t0)));
+    host_->sub(out_reg, out_reg, t0);
+    host_->lsr(out_reg, out_reg,
+            std::log2(types::data_type_size(
+                    rhs_arg_static_params_.dst_d.data_type())));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_oc_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_aarch64::XReg &addr_reg, const Xbyak_aarch64::XReg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+
+    if (is_out_addr || is_out_reg) {
+        assert(rhs_arg_static_params_.is_dst_orig_set()
+                && "dst base addr offset not set");
+        rhs_address_t out_addr = is_out_addr
+                ? it_out_addr->second
+                : rhs_address_t(it_out_reg->second);
+        const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+        calculate_no_broadcast(out_addr,
+                it_off_val != vmm_idx_to_out_elem_off_val.end()
+                        ? it_off_val->second
+                        : 0,
+                tmp_reg);
+
+        const auto X_TMP_0 = host_->X_TMP_0;
+        const auto dst_d = rhs_arg_static_params_.dst_d;
+        const auto strides = dst_d.blocking_desc().strides;
+        const auto layout = injector_utils::get_layout_type(dst_d);
+
+        // c = X_TMP_0
+        switch (layout) {
+            case injector_utils::layout_t::ncsp:
+                calculate_oc_ncsp(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::c_blocked:
+                calculate_oc_blocked(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::nspc:
+                calculate_oc_nspc(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::cspn:
+                calculate_oc_cspn(strides, tmp_reg);
+                break;
+            default: assert(!"Unknown layout");
+        }
+
+        if (elem_size_bytes == 1) {
+            host_->add(addr_reg, addr_reg, X_TMP_0);
+        } else {
+            const int shift_val = std::log2(elem_size_bytes);
+            host_->mov(tmp_reg, X_TMP_0);
+            host_->lsl(tmp_reg, tmp_reg, shift_val);
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_ncsp(const dim_t *strides,
+        const Xbyak_aarch64::XReg &tmp_reg, const bool residue) const {
+    // c = (offset % strides[0]) / strides[1]
+    // output = X_TMP_0
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+    const auto X_TMP_2 = host_->X_TMP_2;
+    const auto X_TMP_3 = host_->X_TMP_3;
+    const auto X_TMP_4 = host_->X_TMP_4;
+
+    host_->mov_imm(X_TMP_3, strides[0]);
+    host_->mov_imm(X_TMP_4, strides[1]);
+
+    host_->umod(X_TMP_2, tmp_reg, X_TMP_3);
+    if (residue)
+        host_->udiv_mod(X_TMP_0, X_TMP_1, X_TMP_2, X_TMP_4);
+    else
+        host_->udiv(X_TMP_0, X_TMP_2, X_TMP_4);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_blocked(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
+    // output = X_TMP_0
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const int simd_w = cpu_isa_traits<isa>::vlen
+            / types::data_type_size(dst_d.data_type());
+    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+    const auto X_TMP_2 = host_->X_TMP_2;
+    const auto X_TMP_3 = host_->X_TMP_3;
+
+    calculate_oc_ncsp(strides, tmp_reg, blk_size > simd_w);
+
+    if (blk_size > simd_w) {
+        // extract c % blk_size
+        host_->mov_imm(X_TMP_3, blk_size);
+        host_->umod(X_TMP_2, X_TMP_1, X_TMP_3);
+    }
+
+    host_->mov_imm(tmp_reg, blk_size);
+    host_->mul(X_TMP_0, X_TMP_0, tmp_reg);
+    if (blk_size > simd_w) host_->add(X_TMP_0, X_TMP_0, X_TMP_2);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_nspc(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // c = offset % C
+    // output = X_TMP_0
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+    const auto C = rhs_arg_static_params_.dst_d.dims()[1];
+
+    host_->mov_imm(X_TMP_1, C);
+    host_->umod(X_TMP_0, tmp_reg, X_TMP_1);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_cspn(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // c = offset / strides[1]
+    // output = X_TMP_0
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+
+    host_->mov_imm(X_TMP_1, strides[1]);
+    host_->udiv(X_TMP_0, tmp_reg, X_TMP_1);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_mb_sp_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_aarch64::XReg &addr_reg, const Xbyak_aarch64::XReg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+
+    if (is_out_addr || is_out_reg) {
+        assert(rhs_arg_static_params_.is_dst_orig_set()
+                && "dst base addr offset not set");
+        rhs_address_t out_addr = is_out_addr
+                ? it_out_addr->second
+                : rhs_address_t(it_out_reg->second);
+
+        const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+        calculate_no_broadcast(out_addr,
+                it_off_val != vmm_idx_to_out_elem_off_val.end()
+                        ? it_off_val->second
+                        : 0,
+                tmp_reg);
+
+        const auto X_TMP_0 = host_->X_TMP_0;
+        const auto dst_d = rhs_arg_static_params_.dst_d;
+        const auto strides = dst_d.blocking_desc().strides;
+        const auto layout = injector_utils::get_layout_type(dst_d);
+
+        // c = X_TMP_0
+        switch (layout) {
+            case injector_utils::layout_t::ncsp:
+                calculate_mb_sp_ncsp(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::c_blocked:
+                calculate_mb_sp_blocked(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::nspc:
+                calculate_mb_sp_nspc(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::cspn:
+                calculate_mb_sp_cspn(strides, tmp_reg);
+                break;
+            default: assert(!"Unknown layout");
+        }
+
+        if (elem_size_bytes == 1) {
+            host_->add(addr_reg, addr_reg, X_TMP_0);
+        } else {
+            const int shift_val = std::log2(elem_size_bytes);
+            host_->mov(tmp_reg, X_TMP_0);
+            host_->lsl(tmp_reg, tmp_reg, shift_val);
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_sp_ncsp(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
+    // mb_sp_off = (n * (stride_n/C)) + (d * stride_d) + (h * stride_h) + (w * stride_w)
+    // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW)
+    // output = X_TMP_0
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto ndims = dst_d.ndims();
+    const auto C_padded = dst_d.padded_dims()[1];
+    const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
+    const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
+    const auto W = (ndims >= 3) ? dst_d.dims()[ndims - 1] : 1;
+
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+    const auto X_TMP_2 = host_->X_TMP_2;
+    const auto X_TMP_3 = host_->X_TMP_3;
+
+    host_->mov_imm(X_TMP_3, strides[0]);
+    host_->udiv_mod(X_TMP_2, X_TMP_1, tmp_reg, X_TMP_3);
+    // X_TMP_2 = n
+    host_->mov_imm(X_TMP_3, strides[1]);
+    host_->udiv(X_TMP_0, X_TMP_1, X_TMP_3);
+    host_->mul(X_TMP_0, X_TMP_0, X_TMP_3);
+    // X_TMP_0 = c * stride_c
+    host_->sub(tmp_reg, tmp_reg, X_TMP_0);
+    // tmp_reg = offset - c * stride_c
+    host_->mov(X_TMP_0, X_TMP_2);
+    // X_TMP_0 = n
+    host_->mov_imm(X_TMP_3, (C_padded - 1) * D * H * W);
+    // n(C - 1)DHW = nCDHW - nDHW
+    host_->mul(X_TMP_0, X_TMP_0, X_TMP_3);
+    // X_TMP_0 = n(C - 1)DHW
+    host_->sub(X_TMP_0, tmp_reg, X_TMP_0);
+    // X_TMP_0 = offset - (c * stride_c) - (n * (C - 1)DHW)
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_sp_blocked(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
+    // output = X_TMP_0
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const int simd_w = cpu_isa_traits<isa>::vlen
+            / types::data_type_size(dst_d.data_type());
+    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+
+    if (blk_size > simd_w) {
+        // substract c % blk_size
+        host_->mov_imm(X_TMP_1, blk_size);
+        host_->umod(X_TMP_0, tmp_reg, X_TMP_1);
+        host_->sub(tmp_reg, tmp_reg, X_TMP_0);
+    }
+
+    calculate_mb_sp_ncsp(strides, tmp_reg);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_sp_nspc(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = nDHWC + dHWC + hWC + wC + c
+    // mb_sp_off = nDHW + dHW + hW + w
+    // mb_sp_off = offset / C
+    // output = X_TMP_0
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+    const auto C = rhs_arg_static_params_.dst_d.padded_dims()[1];
+
+    host_->mov_imm(X_TMP_1, C);
+    host_->umod(X_TMP_0, tmp_reg, X_TMP_1);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_sp_cspn(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = cDHWN + dHWN + hWN + wN + n
+    // mb_sp_off = dHWN + hWN + wN + n
+    // mb_sp_off = offset % stride_c
+    // output = X_TMP_0
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+
+    host_->mov_imm(X_TMP_1, strides[1]);
+    host_->umod(X_TMP_0, tmp_reg, X_TMP_1);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_mb_w_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_aarch64::XReg &addr_reg, const Xbyak_aarch64::XReg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+
+    if (is_out_addr || is_out_reg) {
+        assert(rhs_arg_static_params_.is_dst_orig_set()
+                && "dst base addr offset not set");
+        rhs_address_t out_addr = is_out_addr
+                ? it_out_addr->second
+                : rhs_address_t(it_out_reg->second);
+        const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+        calculate_no_broadcast(out_addr,
+                it_off_val != vmm_idx_to_out_elem_off_val.end()
+                        ? it_off_val->second
+                        : 0,
+                tmp_reg);
+
+        const auto X_TMP_0 = host_->X_TMP_0;
+        const auto dst_d = rhs_arg_static_params_.dst_d;
+        const auto strides = dst_d.blocking_desc().strides;
+        const auto layout = injector_utils::get_layout_type(dst_d);
+
+        switch (layout) {
+            case injector_utils::layout_t::ncsp:
+                calculate_mb_w_ncsp(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::c_blocked:
+                calculate_mb_w_blocked(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::nspc:
+                calculate_mb_w_nspc(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::cspn:
+                calculate_mb_w_cspn(strides, tmp_reg);
+                break;
+            default: assert(!"Unknown layout");
+        }
+
+        if (elem_size_bytes == 1) {
+            host_->add(addr_reg, addr_reg, X_TMP_0);
+        } else {
+            const int shift_val = std::log2(elem_size_bytes);
+            host_->mov(tmp_reg, X_TMP_0);
+            host_->lsl(tmp_reg, tmp_reg, shift_val);
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_w_ncsp(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
+    // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
+    // output = X_TMP_0
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto ndims = dst_d.ndims();
+    const auto C_padded = dst_d.padded_dims()[1];
+    const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
+    const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
+
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+    const auto X_TMP_2 = host_->X_TMP_2;
+    const auto X_TMP_3 = host_->X_TMP_3;
+    const auto X_TMP_4 = host_->X_TMP_4;
+
+    host_->mov_imm(X_TMP_2, strides[0]);
+    host_->udiv_mod(X_TMP_4, X_TMP_3, tmp_reg, X_TMP_2);
+    // X_TMP_4 = n
+
+    host_->mov_imm(X_TMP_2, strides[1]);
+    host_->umod(X_TMP_0, X_TMP_3, X_TMP_2);
+
+    if (ndims >= 5) {
+        host_->mov_imm(X_TMP_3, strides[ndims - 3]);
+        host_->umod(X_TMP_1, X_TMP_0, X_TMP_3);
+        host_->mov(X_TMP_0, X_TMP_1);
+    }
+    if (ndims >= 4) {
+        host_->mov_imm(X_TMP_3, strides[ndims - 2]);
+        host_->umod(X_TMP_1, X_TMP_0, X_TMP_3);
+        host_->mov(X_TMP_0, X_TMP_1);
+    }
+    if (ndims >= 3) {
+        host_->mov_imm(X_TMP_3, strides[ndims - 1]);
+        host_->udiv(X_TMP_0, X_TMP_0, X_TMP_3);
+        host_->mul(tmp_reg, X_TMP_0, X_TMP_3);
+        // tmp_reg = w * stride_w
+    }
+    // tmp_reg = w * stride_w
+    host_->mov_imm(X_TMP_3, strides[0] / (C_padded * D * H));
+    host_->mul(X_TMP_0, X_TMP_4, X_TMP_3);
+    // X_TMP_0 = n * (stride_n/(C*D*H))
+    if (ndims >= 3) host_->add(X_TMP_0, X_TMP_0, tmp_reg);
+    // X_TMP_0 = (n * (stride_n/(C*D*H))) + (w * stride_w)
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_w_blocked(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
+    // output = X_TMP_0
+    calculate_mb_sp_ncsp(strides, tmp_reg);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_w_nspc(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = nDHWC + dHWC + hWC + wC + c
+    // mb_w_off = nW + w
+    // output = X_TMP_0
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto ndims = dst_d.ndims();
+    const auto C_padded = dst_d.padded_dims()[1];
+    const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
+    const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
+
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+    const auto X_TMP_2 = host_->X_TMP_2;
+    const auto X_TMP_3 = host_->X_TMP_3;
+    const auto X_TMP_4 = host_->X_TMP_4;
+
+    host_->mov_imm(X_TMP_2, strides[0]);
+    host_->udiv_mod(X_TMP_4, X_TMP_0, tmp_reg, X_TMP_2);
+    // X_TMP_4 = n
+    if (ndims >= 5) {
+        host_->mov_imm(X_TMP_3, strides[ndims - 3]);
+        host_->umod(X_TMP_1, X_TMP_0, X_TMP_3);
+        host_->mov(X_TMP_0, X_TMP_1);
+    }
+    if (ndims >= 4) {
+        host_->mov_imm(X_TMP_3, strides[ndims - 2]);
+        host_->umod(X_TMP_1, X_TMP_0, X_TMP_3);
+        host_->mov(X_TMP_0, X_TMP_1);
+    }
+    if (ndims >= 3) {
+        host_->mov_imm(X_TMP_3, strides[ndims - 1]);
+        host_->udiv(tmp_reg, X_TMP_0, X_TMP_3);
+        // tmp_reg = w
+    }
+    host_->mov_imm(X_TMP_3, strides[0] / (D * H * C_padded));
+    host_->mul(X_TMP_0, X_TMP_4, X_TMP_3);
+    // X_TMP_0 = nW
+    if (ndims >= 3) host_->add(X_TMP_0, X_TMP_0, tmp_reg);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_mb_w_cspn(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = cDHWN + dHWN + hWN + wN + n
+    // mb_w_off = wN + n
+    // output = X_TMP_0
+    const auto ndims = rhs_arg_static_params_.dst_d.ndims();
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+
+    host_->mov_imm(X_TMP_1, strides[1]);
+    host_->umod(X_TMP_0, tmp_reg, X_TMP_1);
+    if (ndims >= 5) {
+        host_->mov_imm(X_TMP_1, strides[ndims - 3]);
+        host_->umod(tmp_reg, X_TMP_0, X_TMP_1);
+    }
+    if (ndims >= 4) {
+        host_->mov_imm(X_TMP_1, strides[ndims - 2]);
+        host_->udiv(X_TMP_0, tmp_reg, X_TMP_1);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_w_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_aarch64::XReg &addr_reg, const Xbyak_aarch64::XReg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+
+    if (is_out_addr || is_out_reg) {
+        assert(rhs_arg_static_params_.is_dst_orig_set()
+                && "dst base addr offset not set");
+        rhs_address_t out_addr = is_out_addr
+                ? it_out_addr->second
+                : rhs_address_t(it_out_reg->second);
+        const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+        calculate_no_broadcast(out_addr,
+                it_off_val != vmm_idx_to_out_elem_off_val.end()
+                        ? it_off_val->second
+                        : 0,
+                tmp_reg);
+
+        const auto X_TMP_0 = host_->X_TMP_0;
+        const auto dst_d = rhs_arg_static_params_.dst_d;
+        const auto strides = dst_d.blocking_desc().strides;
+        const auto layout = injector_utils::get_layout_type(dst_d);
+
+        switch (layout) {
+            case injector_utils::layout_t::ncsp:
+                calculate_w_ncsp(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::c_blocked:
+                calculate_w_blocked(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::nspc:
+                calculate_w_nspc(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::cspn:
+                calculate_w_cspn(strides, tmp_reg);
+                break;
+            default: assert(!"Unknown layout");
+        }
+
+        if (elem_size_bytes == 1) {
+            host_->add(addr_reg, addr_reg, X_TMP_0);
+        } else {
+            const int shift_val = std::log2(elem_size_bytes);
+            host_->mov(tmp_reg, X_TMP_0);
+            host_->lsl(tmp_reg, tmp_reg, shift_val);
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_w_ncsp(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
+    // w_off = w * stride_w
+    // output = X_TMP_0
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto ndims = dst_d.ndims();
+
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+
+    assert(ndims >= 3);
+
+    host_->mov_imm(X_TMP_1, strides[ndims - 2]);
+    host_->umod(X_TMP_0, tmp_reg, X_TMP_1);
+
+    host_->mov_imm(X_TMP_1, strides[ndims - 1]);
+    host_->udiv(X_TMP_0, X_TMP_0, X_TMP_1);
+    host_->mul(X_TMP_0, X_TMP_0, X_TMP_1);
+    // X_TMP_0 = w * stride_w
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_w_blocked(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    calculate_w_ncsp(strides, tmp_reg);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_w_nspc(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = nDHWC + dHWC + hWC + wC + c
+    // w_off = w
+    // output = X_TMP_0
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto ndims = dst_d.ndims();
+
+    const auto X_TMP_0 = host_->X_TMP_0;
+    const auto X_TMP_1 = host_->X_TMP_1;
+
+    assert(ndims >= 3);
+
+    host_->mov_imm(X_TMP_1, strides[ndims - 2]);
+    host_->umod(X_TMP_0, tmp_reg, X_TMP_1);
+
+    host_->mov_imm(X_TMP_1, strides[ndims - 1]);
+    host_->udiv(X_TMP_0, X_TMP_0, X_TMP_1);
+    // X_TMP_0 = w
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_w_cspn(
+        const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const {
+    // offset = cDHWN + dHWN + hWN + wN + n
+    // w_off = w
+    // output = X_TMP_0
+    calculate_w_nspc(strides, tmp_reg);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::inject_binary(
+        const dnnl_post_ops::entry_t &post_op, Vmm dst,
+        const rhs_address_t &rhs_addr, bool with_tail,
+        const tail_lode_mode_t tail_load_mode) const {
+
+    const auto &alg = post_op.binary.alg;
+    const bool div_op = alg == alg_kind::binary_div;
+    const auto &rhs_arg_data_type = post_op.binary.src1_desc.data_type;
+    const bool scalar_f32
+            = rhs_addr.isBroadcast() && rhs_arg_data_type == data_type::f32;
+    const bool with_tail_not_fusable_to_binary_op = with_tail && !scalar_f32;
+    const bool process_rhs_arg_using_tmp_vmm
+            = rhs_arg_data_type != data_type::f32
+            || with_tail_not_fusable_to_binary_op
+            || !binary_op_with_unaligned_mem_operand_allowed_ || div_op;
+
+    if (process_rhs_arg_using_tmp_vmm) {
+
+        const Vmm tmp_vmm = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+
+        if (rhs_addr.isBroadcast())
+            execute_broadcast(rhs_arg_data_type, tmp_vmm,
+                    remove_bcast_bit(rhs_addr), tail_load_mode, with_tail);
+        else
+            load_rhs(rhs_arg_data_type, tmp_vmm, rhs_addr, tail_load_mode,
+                    with_tail);
+
+        if (rhs_arg_data_type != data_type::f32) cvt_to_f32(tmp_vmm);
+
+        execute_binary(alg, dst, host_->P_ALL_ONE, dst, tmp_vmm);
+    } else {
+        const auto lhs = dst;
+        const bool with_tail_fusable_to_binary_op = with_tail && scalar_f32;
+        Xbyak_aarch64::PReg mask = host_->P_ALL_ONE;
+        if (with_tail_fusable_to_binary_op) {
+            assert(rhs_arg_static_params_.is_opmask_set()
+                    && "Opmask is not set for tail loading avx512");
+            const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
+            mask = tail_opmask;
+            host_->mov(dst.s, mask / Xbyak_aarch64::T_z, dst.s);
+        }
+
+        execute_binary(alg, dst, mask, lhs, rhs_addr);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::execute_broadcast(
+        const data_type_t &data_type, const Vmm &tmp_reg,
+        const rhs_address_t &rhs_addr, const tail_lode_mode_t tail_load_mode,
+        bool with_tail) const {
+    if (with_tail) {
+        if (tail_load_mode == tail_lode_mode_t::DYNAMIC
+                || (tail_load_mode == tail_lode_mode_t::DEFAULT)) {
+            execute_broadcast_tail_with_opmask(data_type, tmp_reg, rhs_addr);
+        } else
+            assert(!"unsupported mode");
+    } else
+        execute_broadcast_no_tail(data_type, tmp_reg, rhs_addr);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::load_rhs(const data_type_t &data_type,
+        const Vmm &tmp_reg, const rhs_address_t &rhs_addr,
+        const tail_lode_mode_t tail_load_mode, bool with_tail) const {
+    if (with_tail) {
+        if (tail_load_mode == tail_lode_mode_t::DYNAMIC
+                || (tail_load_mode == tail_lode_mode_t::DEFAULT)) {
+            load_rhs_tail_dynamically_with_opmask(data_type, tmp_reg, rhs_addr);
+        } else
+            load_rhs_tail_statically(data_type, tmp_reg, rhs_addr);
+    } else
+        load_rhs_no_tail(data_type, tmp_reg, rhs_addr);
+}
+
+template <cpu_isa_t isa>
+rhs_address_t jit_uni_binary_injector_t<isa>::remove_bcast_bit(
+        const rhs_address_t &rhs_addr) const {
+    return rhs_address_t(rhs_addr.base_, rhs_addr.offt_, false, rhs_addr.bits_);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::cvt_to_f32(const Vmm &tmp_vmm) const {
+    host_->scvtf(tmp_vmm.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, tmp_vmm.s);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::execute_broadcast_no_tail(
+        const data_type_t &data_type, const Vmm &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    switch (data_type) {
+        case data_type::f32:
+            host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_,
+                    rhs_addr.offt_, host_->X_TMP_0);
+            host_->uni_ldr(tmp_vmm, host_->X_DEFAULT_ADDR);
+            break;
+        case data_type::s32:
+            host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_,
+                    rhs_addr.offt_, host_->X_TMP_0);
+            host_->ld1rw(Xbyak_aarch64::ZRegS(tmp_vmm.getIdx()),
+                    host_->P_ALL_ONE / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            execute_broadcast_s8u8_no_tail(data_type, tmp_vmm, rhs_addr);
+            break;
+        default: assert(!"unsupported data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::execute_broadcast_s8u8_no_tail(
+        const data_type_t &data_type, const Vmm &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    assert(utils::one_of(data_type, data_type::s8, data_type::u8)
+            && "unsupported data type");
+
+    const auto &p_all = host_->P_ALL_ONE;
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(rhs_addr.base_,
+            rhs_addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+    if (data_type == data_type::s8)
+        host_->ld1rsb(tmp_vmm.s, p_all / Xbyak_aarch64::T_z,
+                Xbyak_aarch64::ptr(x_addr));
+    else if (data_type == data_type::u8)
+        host_->ld1rb(tmp_vmm.s, p_all / Xbyak_aarch64::T_z,
+                Xbyak_aarch64::ptr(x_addr));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::execute_broadcast_tail_with_opmask(
+        const data_type_t &data_type, const Vmm &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+
+    assert(rhs_arg_static_params_.is_opmask_set()
+            && "Opmask is not set for tail loading sve_512");
+
+    const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
+    Xbyak_aarch64::PReg mask = tail_opmask;
+    const Xbyak_aarch64::XReg x_addr = host_->addr_off(rhs_addr.base_,
+            rhs_addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+
+    switch (data_type) {
+        case data_type::f32:
+            host_->ld1rw(tmp_vmm.s, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(x_addr));
+            break;
+        case data_type::s32:
+            host_->ld1rw(Xbyak_aarch64::ZRegS(tmp_vmm.getIdx()),
+                    mask / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(x_addr));
+            break;
+        case data_type::s8:
+            host_->ld1rsb(tmp_vmm.s, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(x_addr));
+            break;
+        case data_type::u8: {
+            host_->ld1rb(tmp_vmm.s, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(x_addr));
+            break;
+        }
+        default: assert(!"unsupported data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::load_rhs_no_tail(
+        const data_type_t &data_type, const Vmm &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+            host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_,
+                    rhs_addr.offt_, host_->X_TMP_0);
+            host_->uni_ldr(tmp_vmm, host_->X_DEFAULT_ADDR);
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            load_rhs_i8_no_tail(data_type, tmp_vmm, rhs_addr);
+            break;
+        default: assert(!"unsupported data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::load_rhs_i8_no_tail(
+        const data_type_t &data_type, const Vmm &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    if (data_type == data_type::s8) {
+        host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_, rhs_addr.offt_,
+                host_->X_TMP_0);
+        host_->ld1sb(tmp_vmm.s, host_->P_ALL_ONE,
+                Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+    } else if (data_type == data_type::u8) {
+        host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_, rhs_addr.offt_,
+                host_->X_TMP_0);
+        host_->ld1b(tmp_vmm.s, host_->P_ALL_ONE,
+                Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+    } else
+        assert(!"unsupported data type");
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::load_rhs_tail_dynamically_with_opmask(
+        const data_type_t &data_type, const Vmm &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    assert(rhs_arg_static_params_.is_opmask_set()
+            && "Opmask is not set for tail loading sve_512");
+
+    const auto &tail_opmask = rhs_arg_static_params_.tail_opmask;
+    Xbyak_aarch64::PReg mask = tail_opmask;
+
+    host_->add_imm(host_->X_DEFAULT_ADDR, rhs_addr.base_, rhs_addr.offt_,
+            host_->X_TMP_0);
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+            host_->ld1w(tmp_vmm.s, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            break;
+        case data_type::s8:
+            host_->ld1sb(tmp_vmm.s, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            break;
+        case data_type::u8:
+            host_->ld1b(tmp_vmm.s, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(host_->X_DEFAULT_ADDR));
+            break;
+        default: assert(!"unsupported data type");
+    }
+}
+
+/**
+* load_bytes is the utility function to facilitate loading of
+* load_size (0 <= load_size <= 32) many contiguous bytes into the Xmm/Ymm
+* register from the memory referenced by ptr[reg + offset] address.
+*
+* Functionally, invocation of load_bytes is equivalent to
+* the following loop:
+*
+* for (int idx = 0; idx < load_size; ++idx)
+*     vpinsrb(xmm, xmm, ptr[reg + offset + idx], idx);
+*
+* TODO: Add an option to zero-out unloaded bytes in the Xmm register.
+* TODO: Add an option for unsafe_load wherein one could read outside the
+* provided memory buffer so as to minimize the total number of read
+* memory instructions.
+*/
+static void load_bytes(jit_generator *host, const Xbyak_aarch64::ZReg &vmm,
+        const Xbyak_aarch64::XReg reg_addr, int load_size) {
+
+    // Ensure data fits completely inside the Xmm/Ymm register
+    assert(load_size >= 0 && load_size <= 32);
+
+    // Ensure that vector register is compatible with the ISA in hand
+    assert(mayiuse(sve_128));
+
+    if (load_size == 0) {
+        return;
+    } else {
+        host->set_preg(host->P_TMP.b, load_size);
+        host->ld1b(vmm.b, host->P_TMP / Xbyak_aarch64::T_z,
+                Xbyak_aarch64::ptr(reg_addr));
+    }
+}
+
+/**
+* load_bytes_to_dword_extension is the utility function to facilitate
+* loading of load_size (0 <= load_size <= 16) many contiguous bytes in
+* the Xmm register from the memory referenced by ptr[reg + offset]
+* address and then do signed/zero extension of those to double words.
+*
+* Functionally, invocation of load_bytes_to_dword_extension is equivalent
+* to the following:
+*
+* for (int idx = 0; idx < load_size; ++idx)
+*     vpinsrb(xmm, xmm, ptr[reg + offset + idx], idx);
+* if (is_signed) vpmovsxbd(vmm, vmm); else vpmovzxbd(vmm, vmm);
+*
+* Valid values for the load_size variable are:
+* [0..4] for XMM version of the function
+* [0..8] for YMM version of the function.
+* TODO: Implement this routine for every ISA.
+*/
+static void load_bytes_to_dword_extension(jit_generator *host,
+        const Xbyak_aarch64::ZReg &vmm, const Xbyak_aarch64::XReg &reg_addr,
+        bool is_signed, int load_size) {
+    if (host->cpu_sveLen == Xbyak_aarch64::util::SVE_256) {
+        // Ensure extended double words fit inside Ymm (32 * load_size <= 256)
+        assert(load_size >= 0 && load_size <= 8);
+    } else if (host->cpu_sveLen == Xbyak_aarch64::util::SVE_128) {
+        // For Xmm register, load capacity is halved (32 * load_size <= 128)
+        assert(load_size >= 0 && load_size <= 4);
+    } else {
+        assert(!"routine is not supported for the current isa");
+    }
+    // For load_size == 8/4, do load/extension in one go
+    if (load_size == 8) {
+        const Xbyak_aarch64::ZReg z_vmm(vmm.getIdx());
+        if (is_signed) {
+            host->ld1sb(vmm.s, host->P_NOT_256,
+                    Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+        } else {
+            host->ld1b(vmm.s, host->P_NOT_256,
+                    Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+        }
+    } else if (load_size == 4) {
+        const Xbyak_aarch64::ZReg z_vmm(vmm.getIdx());
+        if (is_signed) {
+            host->ld1sb(vmm.s, host->P_NOT_128,
+                    Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+        } else {
+            host->ld1b(vmm.s, host->P_NOT_128,
+                    Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+        }
+    } else {
+        load_bytes(host, vmm, reg_addr, load_size);
+        if (is_signed) {
+            host->mov(
+                    vmm.d, host->P_ALL_ONE, Xbyak_aarch64::ZRegD(vmm.getIdx()));
+            host->sxtl(Xbyak_aarch64::VReg8H(vmm.getIdx()),
+                    Xbyak_aarch64::VReg8B(vmm.getIdx()));
+            host->sxtl(Xbyak_aarch64::VReg4S(vmm.getIdx()),
+                    Xbyak_aarch64::VReg4H(vmm.getIdx()));
+            host->mov(
+                    Xbyak_aarch64::ZRegD(vmm.getIdx()), host->P_NOT_128, vmm.d);
+        } else {
+            host->mov(
+                    vmm.d, host->P_ALL_ONE, Xbyak_aarch64::ZRegD(vmm.getIdx()));
+            host->uxtl(Xbyak_aarch64::VReg8H(vmm.getIdx()),
+                    Xbyak_aarch64::VReg8B(vmm.getIdx()));
+            host->uxtl(Xbyak_aarch64::VReg4S(vmm.getIdx()),
+                    Xbyak_aarch64::VReg4H(vmm.getIdx()));
+            host->mov(
+                    Xbyak_aarch64::ZRegD(vmm.getIdx()), host->P_NOT_128, vmm.d);
+        }
+    }
+}
+
+static void load_data(jit_generator *host, data_type_t type_in,
+        const Xbyak_aarch64::ZReg &vmm, const Xbyak_aarch64::XReg &reg_addr,
+        int offset, int load_size) {
+    host->add_imm(host->X_TMP_4, reg_addr, offset, host->X_TMP_0);
+    switch (type_in) {
+        case data_type::f32:
+        case data_type::s32:
+            load_bytes(host, vmm, host->X_TMP_4, sizeof(int32_t) * load_size);
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            load_bytes_to_dword_extension(host, vmm, host->X_TMP_4,
+                    type_in == data_type::s8, load_size);
+            break;
+        default: assert(!"unsupported source data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::load_rhs_tail_dynamically_with_gpr(
+        const data_type_t &data_type, const Vmm &tmp_vmm) const {
+    const Xbyak_aarch64::XReg &reg_addr = rhs_arg_static_params_.rhs_addr_reg;
+    const Xbyak_aarch64::XReg &reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
+    const Xbyak_aarch64::XReg &reg_tail_size
+            = rhs_arg_static_params_.reg_tail_size;
+    const Xbyak_aarch64::ZReg x = Xbyak_aarch64::ZReg(tmp_vmm.getIdx());
+
+    auto runtime_tail_load = [&](int load_size) {
+        load_data(host_, data_type, x, reg_addr, 0, load_size);
+    };
+
+    host_->runtime_tail_process<isa>(reg_tail_size, reg_tmp, runtime_tail_load);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::load_rhs_tail_statically(
+        const data_type_t &data_type, const Vmm &tmp_vmm,
+        const rhs_address_t &rhs_addr) const {
+    assert(!"unsupported tail load mode");
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::compute_cmp_mask(
+        const Xbyak_aarch64::PReg &cmp_dst, const Xbyak_aarch64::PReg &mask,
+        const Xbyak_aarch64::ZReg &cmp_src, const Xbyak_aarch64::ZReg &cmp_src2,
+        const unsigned int cmp) const {
+
+    switch (cmp) {
+        case jit_generator::_cmp_nlt_us:
+            host_->fcmge(cmp_dst.s, mask / Xbyak_aarch64::T_z, cmp_src.s,
+                    cmp_src2.s);
+            break;
+        case jit_generator::_cmp_nle_us:
+            host_->fcmgt(cmp_dst.s, mask / Xbyak_aarch64::T_z, cmp_src.s,
+                    cmp_src2.s);
+            break;
+        case jit_generator::_cmp_le_os:
+            host_->fcmle(cmp_dst.s, mask / Xbyak_aarch64::T_z, cmp_src.s,
+                    cmp_src2.s);
+            break;
+        case jit_generator::_cmp_lt_os:
+            host_->fcmlt(cmp_dst.s, mask / Xbyak_aarch64::T_z, cmp_src.s,
+                    cmp_src2.s);
+            break;
+        case jit_generator::_cmp_eq_oq:
+            host_->fcmeq(cmp_dst.s, mask / Xbyak_aarch64::T_z, cmp_src.s,
+                    cmp_src2.s);
+            break;
+        case jit_generator::_cmp_neq_uq:
+            host_->fcmne(cmp_dst.s, mask / Xbyak_aarch64::T_z, cmp_src.s,
+                    cmp_src2.s);
+            break;
+        default: assert(!"unsupported compare mode"); break;
+    }
+}
+
+template <typename T>
+void get_z_rhs_value(
+        jit_generator *host, const T &rhs, const Xbyak_aarch64::ZReg &z_tmp) {
+    const bool is_reg = std::is_same<T, Xbyak_aarch64::ZReg>::value;
+    if (is_reg) {
+        const Xbyak_aarch64::ZReg &rst_reg = (Xbyak_aarch64::ZReg &)rhs;
+        host->mov(z_tmp.d, rst_reg.d);
+    } else {
+        const rhs_address_t &rst_adr = (rhs_address_t &)rhs;
+        host->add_imm(host->X_DEFAULT_ADDR, rst_adr.base_, rst_adr.offt_,
+                host->X_TMP_0);
+        if (rst_adr.isBroadcast_)
+            host->ld1rw(z_tmp.s, host->P_ALL_ONE, ptr(host->X_DEFAULT_ADDR));
+        else
+            host->ld1w(z_tmp.s, host->P_ALL_ONE, ptr(host->X_DEFAULT_ADDR));
+    }
+}
+template <typename T>
+void get_v_rhs_value(
+        jit_generator *host, const T &rhs, const Xbyak_aarch64::VReg &v_tmp) {
+    const bool is_reg = std::is_same<T, Xbyak_aarch64::VReg>::value;
+    if (is_reg) {
+        const Xbyak_aarch64::VReg &rst_reg = (Xbyak_aarch64::VReg &)rhs;
+        (void)rst_reg;
+    } else {
+        const rhs_address_t &rst_adr = (rhs_address_t &)rhs;
+        host->add_imm(host->X_DEFAULT_ADDR, rst_adr.base_, rst_adr.offt_,
+                host->X_TMP_0);
+        host->ld1r(v_tmp.s4, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::execute_cmp_binary(const Vmm &dst,
+        const Xbyak_aarch64::PReg &mask, const Vmm &lhs, const Vmm &rhs,
+        const unsigned int cmp_predicate) const {
+    // For GreaterEqual op, replace 0xFFFFFFFF by 1
+    // which was returned by vcmpps.
+    const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;
+
+    push_opmask(host_, cmp_mask);
+    compute_cmp_mask(cmp_mask, mask, lhs, rhs, cmp_predicate);
+    // broadcast 1.0f with mask
+    host_->uni_clear(dst);
+    host_->fmov(dst.s, cmp_mask / Xbyak_aarch64::T_m, 1.0);
+    // pop tail mask from stack
+    pop_opmask(host_, cmp_mask);
+}
+
+template <cpu_isa_t isa>
+template <typename T>
+void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
+        const Vmm &dst, const Xbyak_aarch64::PReg &mask, const Vmm &lhs,
+        const T &rhs) const {
+    const bool isAddr = !std::is_same<T, Xbyak_aarch64::ZReg>::value;
+    Vmm z_rhs(0);
+
+    if (isAddr) {
+        const rhs_address_t &addr = (rhs_address_t &)rhs;
+        for (size_t i = 0; i < 32; i++) {
+            if (lhs.getIdx() != i) {
+                z_rhs = Vmm(i);
+                host_->str(z_rhs,
+                        Xbyak_aarch64::ptr(
+                                host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+
+                Xbyak_aarch64::XReg x_addr = host_->addr_off(addr.base_,
+                        addr.offt_, host_->X_DEFAULT_ADDR, host_->X_TMP_0);
+
+                if (addr.isBroadcast_)
+                    host_->ld1rw(z_rhs.s, mask, Xbyak_aarch64::ptr(x_addr));
+                else
+                    host_->ld1w(z_rhs.s, mask, Xbyak_aarch64::ptr(x_addr));
+
+                break;
+            }
+        }
+    } else {
+        const Vmm vmm = (Vmm &)rhs;
+        z_rhs = vmm;
+    }
+
+    switch (binary_alg) {
+        case alg_kind::binary_add:
+            host_->uni_fadd(dst.s, lhs.s, z_rhs.s);
+            break;
+        case alg_kind::binary_mul:
+            host_->uni_fmul(dst.s, lhs.s, z_rhs.s);
+            break;
+        case alg_kind::binary_max:
+            host_->uni_fmax(dst.s, lhs.s, z_rhs.s);
+            break;
+        case alg_kind::binary_min:
+            host_->uni_fmin(dst.s, lhs.s, z_rhs.s);
+            break;
+        case alg_kind::binary_div:
+            host_->uni_fdiv(
+                    dst.s, lhs.s, z_rhs.s, Vmm(host_->DUMMY_IDX).s, mask);
+            break;
+        case alg_kind::binary_sub:
+            host_->uni_fsub(dst.s, lhs.s, z_rhs.s);
+            break;
+        case alg_kind::binary_ge:
+            execute_cmp_binary(
+                    dst, mask, lhs, z_rhs, jit_generator::_cmp_nlt_us);
+            break;
+        case alg_kind::binary_gt:
+            execute_cmp_binary(
+                    dst, mask, lhs, z_rhs, jit_generator::_cmp_nle_us);
+            break;
+        case alg_kind::binary_le:
+            execute_cmp_binary(
+                    dst, mask, lhs, z_rhs, jit_generator::_cmp_le_os);
+            break;
+        case alg_kind::binary_lt:
+            execute_cmp_binary(
+                    dst, mask, lhs, z_rhs, jit_generator::_cmp_lt_os);
+            break;
+        case alg_kind::binary_eq:
+            execute_cmp_binary(
+                    dst, mask, lhs, z_rhs, jit_generator::_cmp_eq_oq);
+            break;
+        case alg_kind::binary_ne:
+            execute_cmp_binary(
+                    dst, mask, lhs, z_rhs, jit_generator::_cmp_neq_uq);
+            break;
+        default: assert(!"unsupported algorithm");
+    }
+
+    if (isAddr) {
+        host_->ldr(z_rhs,
+                Xbyak_aarch64::ptr(host_->X_SP, -1, Xbyak_aarch64::MUL_VL));
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::compute_vector(size_t idx,
+        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params) const {
+    compute_vector_range({idx}, rhs_arg_idx, post_op, rhs_arg_params);
+}
+
+template class jit_uni_binary_injector_t<sve_512>;
+
+} // namespace binary_injector
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
@@ -1,0 +1,621 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_BINARY_INJECTOR_HPP
+#define CPU_AARCH64_JIT_UNI_BINARY_INJECTOR_HPP
+
+#include <array>
+#include <cassert>
+#include <functional>
+#include <map>
+#include <utility>
+#include <vector>
+#include <unordered_set>
+
+#include "common/broadcast_strategy.hpp"
+#include "common/c_types_map.hpp"
+#include "common/primitive_attr.hpp"
+#include "common/primitive_exec_types.hpp"
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#include "cpu/aarch64/injectors/injector_utils.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/binary_injector_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+namespace binary_injector {
+using dnnl::impl::cpu::binary_injector_utils::prepare_binary_args;
+
+bool binary_args_matches_tag(format_tag_t tag, const post_ops_t &post_ops);
+
+bool binary_args_broadcast_supported(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+
+bool binary_args_tail_supported(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d, int vlen,
+        const bcast_set_t &supported_strategy_set);
+
+bool any_binary_postop_rhs_per_oc_broadcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d);
+bool any_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+
+bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const std::function<bool(const memory_desc_wrapper &)> &predicate);
+bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set,
+        const std::function<bool(const memory_desc_wrapper &)> &predicate);
+
+/*
+ * Represents params related to all binary post-ops right-hand side arguments
+ * (arg1) that don't change during jit_uni_binary_injector_t object lifetime
+ * and between compute_vector_range calls.
+ *
+ * @param rhs_dt_helper_vmm_idx - index of vmm helper used when loading data for
+ * calculations. Treated as hint from user. If inside compute_vector_range hint
+ * turns out to be invalid, it will be overwriten by register preserving logic inside
+ * binary injector.
+ * @param rhs_addr_reg - gpr register, used as the currently processed address of
+ * rhs tensor slice. Data of rhs(arg1) for the binary operation is loaded from address
+ * stored inside rhs_addr_reg.
+ * @param rhs_helper_reg - gpr register used as helper for calculations during data
+ * loading phase.
+ * @param preserve_gpr_helpers - determines whether gpr registers specified above
+ * should be preserved (pushed to stack and poped back afterwords) between
+ * compute_vector_range calls.
+ * @param preserve_vmm_helper - determines whether vmm helper register specified
+ * above should be preserved between compute_vector_range calls.
+ * @param abi_param_offset - offset to rhs tensor from first binary post-op operation
+ * specified by user from runtime structure passed to kernel as abi param 1.
+ * @param dst_orig_offset - offset 0 to destination tensor
+ * @param dst_d - descriptor of destination tensor (result after applying all post-ops
+ * operations).
+ * @param tail_opmask - register with loaded by user mask, used in avx512 for load with
+ * tail handling.
+ * @param tail_size - size of processed tail in elements.
+ * @param use_exact_tail_scalar_bcast - in case of scalar broadcast user can disable
+ * loading data with tail, usually bcast through entire vector is faster (usually 1 instruction)
+ * vs. broadcasting limited by tail size (potentially several instructions). In case
+ * when user during storing ignores values from vmm above tail size, setting this option to
+ * false can result in better performance.
+ * @param reg_tail_size - register with loaded size of tail, used in sse41/avx/avx2
+ * for load with tail in runtime.
+ */
+struct rhs_arg_static_params_t {
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_aarch64::XReg &rhs_addr_reg,
+            const Xbyak_aarch64::XReg &rhs_helper_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+            std::size_t tail_size = 0u,
+            bool use_exact_tail_scalar_bcast = false);
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_aarch64::XReg &rhs_addr_reg,
+            const Xbyak_aarch64::XReg &rhs_helper_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, std::size_t dst_orig_offset,
+            const memory_desc_wrapper &dst_d, std::size_t tail_size = 0u,
+            bool use_exact_tail_scalar_bcast = false);
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_aarch64::XReg &rhs_addr_reg,
+            const Xbyak_aarch64::XReg &rhs_helper_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+            std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+            bool use_exact_tail_scalar_bcast);
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_aarch64::XReg &rhs_addr_reg,
+            const Xbyak_aarch64::XReg &rhs_helper_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, std::size_t dst_orig_offset,
+            const memory_desc_wrapper &dst_d, std::size_t tail_size,
+            const Xbyak_aarch64::PReg &tail_opmask,
+            bool use_exact_tail_scalar_bcast);
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_aarch64::XReg &rhs_addr_reg,
+            const Xbyak_aarch64::XReg &rhs_helper_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+            std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+            const Xbyak_aarch64::XReg &reg_tail_size,
+            bool use_exact_tail_scalar_bcast);
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_aarch64::XReg &rhs_addr_reg,
+            const Xbyak_aarch64::XReg &rhs_helper_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, std::size_t dst_orig_offset,
+            const memory_desc_wrapper &dst_d, std::size_t tail_size,
+            const Xbyak_aarch64::PReg &tail_opmask,
+            const Xbyak_aarch64::XReg &reg_tail_size,
+            bool use_exact_tail_scalar_bcast);
+
+    bool is_opmask_set() const noexcept { return is_opmask_set_; }
+    bool is_dst_orig_set() const noexcept { return is_dst_orig_set_; }
+
+    mutable std::size_t rhs_dt_helper_vmm_idx;
+    Xbyak_aarch64::XReg rhs_addr_reg;
+    Xbyak_aarch64::XReg rhs_helper_reg;
+    bool preserve_gpr_helpers;
+    bool preserve_vmm_helper;
+    std::size_t abi_param_offset;
+    std::size_t dst_orig_offset;
+    memory_desc_wrapper dst_d;
+    std::size_t tail_size;
+    Xbyak_aarch64::PReg tail_opmask;
+    bool use_exact_tail_scalar_bcast;
+    Xbyak_aarch64::XReg reg_tail_size;
+    bool is_tail;
+
+private:
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_aarch64::XReg &rhs_addr_reg,
+            const Xbyak_aarch64::XReg &rhs_helper_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, std::size_t dst_orig_offset,
+            const memory_desc_wrapper &dst_d, std::size_t tail_size,
+            const Xbyak_aarch64::PReg &tail_opmask,
+            bool use_exact_tail_scalar_bcast,
+            const Xbyak_aarch64::XReg &reg_tail_size, bool is_opmask_set,
+            bool is_dst_orig_set);
+
+    bool is_opmask_set_;
+    bool is_dst_orig_set_;
+};
+
+/*
+ * Represents params required by jit_uni_binary_injector_t that don't change
+ * during it's entire lifetime.
+ *
+ * @param param1 - register storing abi param1. At the moment of calling
+ * compute_vector_range method can be different than the default one defined
+ * inside jit_generator.
+ * @param bcast_set_t supported_strategy_set - set allowing disabling particular
+ * bcast strategies
+ * @param rhs_arg_static_params - params related to all binary post-ops right-hand side
+ * arguments that don't change during entire lifetime of jit_uni_binary_injector_t
+ * object.
+ */
+struct static_params_t {
+    static_params_t(const Xbyak_aarch64::XReg &param1,
+            const bcast_set_t &supported_strategy_set,
+            const rhs_arg_static_params_t &rhs_arg_static_params);
+    static_params_t(const Xbyak_aarch64::XReg &param1,
+            const rhs_arg_static_params_t &rhs_arg_static_params);
+
+    Xbyak_aarch64::XReg param1;
+    const bcast_set_t supported_strategy_set;
+    rhs_arg_static_params_t rhs_arg_static_params;
+};
+
+/*
+ * Mode of data load with tail for rhs:
+ * STATIC - load based on given integer.
+ * DYNAMIC - load based on opmask or 64-bit register.
+ * DEFAULT - DYNAMIC for avx512, STATIC for others.
+ */
+
+enum class tail_lode_mode_t { STATIC, DYNAMIC, DEFAULT };
+
+struct rhs_address_t {
+    Xbyak_aarch64::XReg base_;
+    int64_t offt_ = 0;
+    bool isBroadcast_ = false;
+    uint32_t bits_ = 0;
+
+    rhs_address_t(const Xbyak_aarch64::XReg &base, const int64_t offt = 0,
+            bool isBroadcast = false, const uint32_t bits = 0)
+        : base_(base), offt_(offt), isBroadcast_(isBroadcast), bits_(bits) {}
+
+    bool operator==(const rhs_address_t &rhs) const {
+        return getBit() == rhs.getBit()
+                && getBase().getIdx() == rhs.getBase().getIdx()
+                && isBroadcast_ == rhs.isBroadcast();
+    }
+    bool operator!=(const rhs_address_t &rhs) const { return !operator==(rhs); }
+
+    Xbyak_aarch64::XReg getBase() const { return base_; }
+    uint32_t getBit() const { return bits_; }
+    bool isBroadcast() const { return isBroadcast_; }
+};
+
+struct rhs_operand_t {
+
+    bool isAddress_ = false;
+    uint32_t idx_;
+    rhs_address_t address_;
+
+    bool operator==(const rhs_operand_t &rhs) const {
+        if (isAddress_) {
+            if (isAddress_ == rhs.isAddress_ && address_ == rhs.address_)
+                return true;
+            else
+                return false;
+        } else {
+            if (isAddress_ == rhs.isAddress_ && idx_ == rhs.idx_)
+                return true;
+            else
+                return false;
+        }
+    }
+
+    bool operator!=(const rhs_operand_t &rhs) const { return !operator==(rhs); }
+
+    bool isBroadcast() const { return isAddress_ && address_.isBroadcast(); }
+};
+
+/*
+ * Represents params passed to compute_vector_range method of
+ * jit_uni_binary_injector_t that can be different for each call.
+ * Contains configurable std::maps where key is vmm index and value is
+ * offset in elements. The offset value identifies tensor slice in particular
+ * vmm. This is utilized by broadcasting mechanism. Offset, depending on the
+ * implementation particular kernels, can be passed as value (usually during
+ * unrolling), inside operand, under memory address.
+ *
+ * @param vmm_idx_to_out_addr - vmm mapped to address of destination tensor with offset,
+ * used to calculate offset in no_broadcast strategy, but also in other strategies whose
+ * calculations are based on no_broadcast strategy.
+ * @param vmm_idx_to_out_reg - vmm mapped to register containing address of destination
+ * with offset, used to calculate offset in no_broadcast strategy, but also in other
+ * strategies whose calculations are based on no_broadcast strategy.
+ * @param vmm_idx_to_out_elem_off_addr - vmm mapped to offset in elements stored under
+ * memory address intended to use in no_broadcast strategy.
+ * @param vmm_idx_to_out_elem_off_addr - vmm mapped to offset in elements stored under
+ * memory address intended to use in no_broadcast strategy.
+ * @param vmm_idx_to_out_elem_off_val - vmm mapped to offset in elements passed as raw
+ * value intended to use in no_broadcast strategy
+ * @param vmm_idx_to_out_off_oprnd - vmm mapped to offset in elements inside operand
+ * intended to use in no_broadcast strategy
+ * @param vmm_idx_to_oc_elem_off_addr - vmm mapped to output channel offset in elements
+ * stored under memory address intended to use in per_oc broadcast strategies.
+ * @param vmm_idx_to_oc_elem_off_val - vmm mapped to  output channel offset in elements
+ * passed as raw value intended to use in per_oc broadcast strategies.
+ * @param vmm_idx_to_oc_off_oprnd - vmm mapped to output channel offset in elements inside
+ * operand intended to use in per_oc broadcast strategies.
+ * @param vmm_idx_to_sp_elem_off_addr - vmm mapped to proper output spatial offset in
+ * elements stored under memory address intended to use in per_mb_spatial strategies.
+ * @param vmm_idx_to_sp_elem_off_val - vmm mapped to proper output spatial offset in
+ * elements passed as raw value intended to use in per_mb_spatial strategies.
+ * @param vmm_idx_to_sp_off_oprnd - vmm mapped to proper output spatial offset in 
+ * elements inside operand intended to use in per_mb_spatial strategies.
+ * @param vmm_idx_to_mb_w_elem_off_addr - vmm mapped to proper output last dim
+ * per first dim offset in elements stored under memory address intended to use
+ * in per_mb_w strategies.
+ * @param vmm_idx_to_mb_w_elem_off_val - vmm mapped to proper output last dim
+ * per first dim offset in elements passed as raw value intended to use in
+ * per_mb_w strategies.
+ * @param vmm_idx_to_mb_w_off_oprnd - vmm mapped to proper output last dim
+ * per first dim offset in elements inside operand intended to use in per_mb_w
+ * strategies.
+ * @param vmm_idx_to_w_elem_off_addr - vmm mapped to proper output last dim
+ * offset in elements stored under memory address intended to use in per_w strategy.
+ * @param vmm_idx_to_w_elem_off_val - vmm mapped to proper output last dim
+ * offset in elements passed as raw value intended to use in per_w strategy.
+ * @param vmm_idx_to_w_off_oprnd - vmm mapped to proper output last dim offset
+ * in elements inside operand intended to use in per_w strategy.
+ * @param vmm_tail_idx - vmm indices that contains data don't fill the whole vector (tail).
+ * @param is_dynamic_tail_load - determines whether to load with tail in
+ * runtime (based on the value from reg_tail_size or opmask) or based on given
+ * integer.
+ */
+
+struct rhs_arg_dynamic_params_t {
+    std::map<int, rhs_address_t> vmm_idx_to_out_addr;
+    std::map<int, Xbyak_aarch64::XReg> vmm_idx_to_out_reg;
+
+    std::map<int, rhs_address_t> vmm_idx_to_out_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_out_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_out_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_oc_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_oc_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_oc_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_sp_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_sp_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_sp_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_mb_w_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_mb_w_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_mb_w_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_w_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_w_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_w_off_oprnd;
+
+    std::unordered_set<int> vmm_tail_idx_;
+    tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT;
+};
+
+/*
+ * Checks if src1 data type is supported by binary injector.
+ */
+bool is_data_supported(cpu_isa_t isa, data_type_t data_type);
+
+/*
+ * Checks if broadcast of src1 is supported by binary injector.
+ */
+bool is_bcast_supported(const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+
+/*
+ * Checks if binary injection for given args is supported.
+ */
+bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+
+/*
+ * Main mechanism responsible for injecting binary postops supporting various
+ * isa: sve_512
+ * types: f32, s32, u8, s8.
+ */
+template <cpu_isa_t isa>
+class jit_uni_binary_injector_t {
+    using TReg = typename cpu_isa_traits<isa>::TReg;
+    using TRegS = typename cpu_isa_traits<isa>::TRegS;
+    using Vmm = typename cpu_isa_traits<isa>::TReg;
+
+public:
+    jit_uni_binary_injector_t(
+            jit_generator *host, const static_params_t &static_params);
+
+    /*
+     * Generates code of binary post_op injected to host primitive. Applied to
+     * ordered set of vector registers' indexes. Function loads appropriate
+     * slice of rhs tensor for computations based on internally determined
+     * broadcast strategy and information about stored data in particular vmm
+     * described inside rhs_arg_params.
+     */
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
+            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params) const;
+
+    /*
+     * Generates code of binary post_op injected to host primitive. Applied to
+     * range <start_idx, end_idx) of vector registers' indexes. Function loads
+     * appropriate slice of rhs tensor for computations based on internally
+     * determined broadcast strategy and information about stored data in particular
+     * vmm described inside rhs_arg_params.
+     */
+    void compute_vector_range(size_t start_idx, size_t end_idx,
+            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params) const;
+
+    /*
+     * Generates code of binary post_op injected to host primitive. Applied to
+     * a single vector register index. Function loads appropriate slice of rhs tensor
+     * for computations based on internally determined broadcast strategy and information
+     * about stored data in particular vmm described inside rhs_arg_params.
+     */
+    void compute_vector(size_t idx, std::size_t rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params) const;
+
+private:
+    /*
+     * Determines if hint passed by user is valid (is inside range
+     * <start_idx, end_idx>). If not it returns new vmm idx value that will be
+     * used as temporary vmm in future computations.
+     */
+    int adjust_temp_vmm_hint(
+            int user_hint, int start_idx, int end_idx, int max_vmm_idx) const;
+    /*
+     * Taking into account rhs_broadcasting_strategy and information from user
+     * about tensor slice (rhs_arg_params) stored in Vmm(vmm_idx) calculates
+     * address of rhs tensor slice needed for binary operation and returns
+     * ptr to it.
+     */
+    rhs_address_t prepare_rhs_arg_addr(std::size_t vmm_idx,
+            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params,
+            const broadcasting_strategy_t rhs_broadcasting_strategy) const;
+    /*
+     * Loads data and applies particular binary operation.
+     */
+    void inject_binary(const dnnl_post_ops::entry_t &post_op, Vmm dst,
+            const rhs_address_t &rhs_addr, bool with_tail,
+            const tail_lode_mode_t tail_load_mode) const;
+
+    /*
+     * Helper functions responsible for preparing rhs tensor slice address.
+     */
+    void append_offset_from_operand(
+            const std::map<int, rhs_operand_t> &vmm_idx_to_elem_addr_off,
+            int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            std::size_t elem_size_bytes) const;
+    void append_offset_under_mem_addr(
+            const std::map<int, rhs_address_t> &vmm_idx_to_elem_addr_off,
+            int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            std::size_t elem_size_bytes) const;
+    void append_value_offset(
+            const std::map<int, size_t> &vmm_idx_to_elem_val_off, int vmm_idx,
+            const Xbyak_aarch64::XReg &addr_reg,
+            std::size_t elem_size_bytes) const;
+
+    void append_no_broadcast_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            std::size_t elem_size_bytes) const;
+    void calculate_no_broadcast(rhs_address_t addr, std::size_t offset,
+            const Xbyak_aarch64::XReg &out_reg) const;
+
+    void append_oc_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            std::size_t elem_size_bytes) const;
+    void calculate_oc_ncsp(const dim_t *strides,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            const bool residue = false) const;
+    void calculate_oc_blocked(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_oc_nspc(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_oc_cspn(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+
+    void append_mb_sp_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_ncsp(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_mb_sp_blocked(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_mb_sp_nspc(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_mb_sp_cspn(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+
+    void append_mb_w_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_ncsp(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_mb_w_blocked(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_mb_w_nspc(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_mb_w_cspn(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+
+    void append_w_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_aarch64::XReg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_aarch64::XReg &addr_reg,
+            const Xbyak_aarch64::XReg &tmp_reg,
+            std::size_t elem_size_bytes) const;
+    void calculate_w_ncsp(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_w_blocked(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_w_nspc(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+    void calculate_w_cspn(
+            const dim_t *strides, const Xbyak_aarch64::XReg &tmp_reg) const;
+
+    void compute_cmp_mask(const Xbyak_aarch64::PReg &cmp_dst,
+            const Xbyak_aarch64::PReg &mask, const Xbyak_aarch64::ZReg &cmp_src,
+            const Xbyak_aarch64::ZReg &cmp_src2, const unsigned int uimm) const;
+
+    template <typename T>
+    void fdiv(const Vmm &dst, const Xbyak_aarch64::PReg &mask, const Vmm &lhs,
+            const T &rhs) const;
+    template <typename T>
+    void fdiv(const Vmm &dst, const Vmm &lhs, const T &rhs) const;
+
+    void execute_cmp_binary(const Vmm &dst, const Xbyak_aarch64::PReg &mask,
+            const Vmm &lhs, const Vmm &rhs,
+            const unsigned int cmp_predicate) const;
+    template <typename T>
+    void execute_binary(alg_kind_t binary_alg, const Vmm &dst,
+            const Xbyak_aarch64::PReg &mask, const Vmm &lhs,
+            const T &rhs) const;
+    /*
+     * Used in scalar broadcast strategy, broadcasting single value of given
+     * data type over entire vector Vmm register.
+     */
+    void execute_broadcast(const data_type_t &data_type, const Vmm &tmp_reg,
+            const rhs_address_t &rhs_addr,
+            const tail_lode_mode_t tail_load_mode,
+            bool with_tail = false) const;
+    void load_rhs(const data_type_t &data_type, const Vmm &tmp_reg,
+            const rhs_address_t &rhs_addr,
+            const tail_lode_mode_t tail_load_mode,
+            bool with_tail = false) const;
+    void execute_broadcast_tail_with_opmask(const data_type_t &data_type,
+            const Vmm &tmp_reg, const rhs_address_t &rhs_addr) const;
+    void execute_broadcast_tail_statically(const data_type_t &data_type,
+            const Vmm &tmp_reg, const rhs_address_t &rhs_addr,
+            const std::size_t tail_size) const;
+    void execute_broadcast_tail_with_gpr(const data_type_t &data_type,
+            const Vmm &tmp_reg, const rhs_address_t &rhs_addr) const;
+    void load_rhs_tail_dynamically_with_opmask(const data_type_t &data_type,
+            const Vmm &tmp_vmm, const rhs_address_t &rhs_addr) const;
+    void load_rhs_tail_dynamically_with_gpr(
+            const data_type_t &data_type, const Vmm &tmp_vmm) const;
+    void load_rhs_tail_statically(const data_type_t &data_type,
+            const Vmm &tmp_vmm, const rhs_address_t &rhs_addr) const;
+    void execute_broadcast_no_tail(const data_type_t &data_type,
+            const Vmm &tmp_vmm, const rhs_address_t &rhs_addr) const;
+    void execute_broadcast_s8u8_no_tail(const data_type_t &data_type,
+            const Vmm &tmp_vmm, const rhs_address_t &rhs_addr) const;
+    void load_rhs_no_tail(const data_type_t &data_type, const Vmm &tmp_reg,
+            const rhs_address_t &rhs_addr) const;
+    void load_rhs_i8_no_tail(const data_type_t &data_type, const Vmm &tmp_reg,
+            const rhs_address_t &rhs_addr) const;
+    void cvt_to_f32(const Vmm &tmp_reg) const;
+    /*
+     * Returns pair consisting of flag indication preservation is needed for vmm
+     * index in second member that should be used as temporary vmm inside inject
+     * binary.
+     */
+    std::pair<bool, int> should_preserve_vmm(int curr_idx, int vmm_hint,
+            int max_vmm_idx, bool dt_helper_vmm_needed) const;
+    /*
+     * Used in isa != avx512 where m32bcst is not supported, replaces ptr_b
+     * with ptr.
+     */
+    rhs_address_t remove_bcast_bit(const rhs_address_t &rhs_addr) const;
+
+    jit_generator *host_;
+    const rhs_arg_static_params_t rhs_arg_static_params_;
+    const Xbyak_aarch64::XReg param1_;
+    const bcast_set_t supported_strategy_set_;
+
+    static constexpr int sizeof_reg64 = 8;
+    /*
+     * Instructions from SSE/AVX used to compute binary result like vaddps where
+     * second operand is memory, require mem operand to be 16/32 byte explicitly
+     * aligned. (Intel Manual chapter 2.4).
+     * Rule is relaxed from AVX2 (Intel Manual chapter 14.9).
+     * When using benchdnn zmalloc_protect doesn't guarantee that tensor memory
+     * address is 64 byte aligned, which can cause segmentation fault.
+     */
+    static constexpr bool binary_op_with_unaligned_mem_operand_allowed_ = true;
+};
+
+} // namespace binary_injector
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -31,8 +31,8 @@ namespace aarch64 {
 
 namespace eltwise_injector {
 
-bool is_isa_supported() {
-    return mayiuse(sve_512);
+bool is_isa_supported(cpu_isa_t isa) {
+    return is_superset(isa, sve_128);
 }
 
 bool is_alg_supported(alg_kind_t alg) {
@@ -50,11 +50,12 @@ bool is_alg_supported(alg_kind_t alg) {
             eltwise_exp_use_dst_for_bwd /*, eltwise_clip_v2_use_dst_for_bwd*/);
 }
 
-bool is_supported(alg_kind_t alg) {
-    return is_isa_supported() && is_alg_supported(alg);
+bool is_supported(cpu_isa_t isa, alg_kind_t alg) {
+    return is_isa_supported(isa) && is_alg_supported(alg);
 }
 
 } // namespace eltwise_injector
+
 using namespace Xbyak_aarch64;
 
 template <cpu_isa_t isa>

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -1,0 +1,252 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include <cassert>
+#include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+namespace injector {
+
+bool is_supported(const post_ops_ok_args_t &post_ops_ok_args) {
+    const cpu_isa_t isa = post_ops_ok_args.isa;
+    const post_ops_t &post_ops = post_ops_ok_args.post_ops;
+    const memory_desc_wrapper *dst_d = post_ops_ok_args.dst_d;
+    const auto &enabled_bcast_strategy
+            = post_ops_ok_args.enabled_bcast_strategy;
+
+    for (const auto &post_op : post_ops.entry_) {
+        if (post_op.is_eltwise()) {
+            const auto res
+                    = eltwise_injector::is_supported(isa, post_op.eltwise.alg);
+            if (!res) return false;
+        } else if (post_op.is_binary()) {
+            const auto &src1_desc = post_op.binary.src1_desc;
+            const auto res = binary_injector::is_supported(
+                    isa, src1_desc, *dst_d, enabled_bcast_strategy);
+            if (!res) return false;
+        }
+    }
+    return true;
+}
+
+template <cpu_isa_t isa>
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
+        const post_ops_t &post_ops,
+        const binary_injector::static_params_t &binary_static_params,
+        const eltwise_injector::static_params_t &eltwise_static_params,
+        const lambda_jit_injectors_t &lambda_jit_injectors)
+    : post_ops_(post_ops)
+    , host_(host)
+    , binary_injector_(nullptr)
+    , lambda_jit_injectors_(lambda_jit_injectors) {
+
+    const auto &esp = eltwise_static_params;
+    bool is_binary = false;
+    bool is_eltwise = false;
+
+    for (const auto &post_op : post_ops.entry_) {
+        if (post_op.is_eltwise()) {
+            is_eltwise = true;
+            alg_to_eltwise_injector_.emplace(post_op.eltwise.alg,
+                    jit_uni_eltwise_injector_f32<isa>(host_, post_op.eltwise,
+                            esp.save_state, esp.x_table, esp.p_mask, esp.p_tmp0,
+                            esp.p_all, esp.is_fwd, esp.use_dst));
+        } else if (post_op.is_binary()) {
+            is_binary = true;
+        }
+    }
+
+    if (is_superset(isa, sve_128) && is_eltwise && is_binary
+            && binary_static_params.rhs_arg_static_params.tail_size)
+        assert(eltwise_static_params.p_mask.getIdx()
+                != binary_static_params.rhs_arg_static_params.tail_opmask.getIdx() &&
+                "Binary tail opmask should be different than eltwise injector \
+                opmask. Otherwise eltwise injector will overwrite binary tail \
+                opmask.");
+
+    if (is_binary)
+        binary_injector_ = utils::make_unique<
+                binary_injector::jit_uni_binary_injector_t<isa>>(
+                host, binary_static_params);
+}
+
+template <cpu_isa_t isa>
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
+        const post_ops_t &post_ops,
+        const binary_injector::static_params_t &binary_static_params)
+    : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
+            eltwise_injector::static_params_t(), lambda_jit_injectors_t()) {}
+
+template <cpu_isa_t isa>
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
+        const post_ops_t &post_ops,
+        const binary_injector::static_params_t &binary_static_params,
+        const lambda_jit_injectors_t &lambda_jit_injectors)
+    : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
+            eltwise_injector::static_params_t(), lambda_jit_injectors) {}
+
+template <cpu_isa_t isa>
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
+        const post_ops_t &post_ops,
+        const binary_injector::static_params_t &binary_static_params,
+        const eltwise_injector::static_params_t &eltwise_static_params)
+    : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
+            eltwise_static_params, lambda_jit_injectors_t()) {}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector_range(size_t start_idx,
+        size_t end_idx,
+        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
+
+    injector_utils::vmm_index_set_t vmm_idxs;
+    for (size_t i = start_idx; i < end_idx; i++)
+        vmm_idxs.emplace(i);
+    compute_vector_range(vmm_idxs, rhs_arg_params);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector_range(
+        size_t start_idx, size_t end_idx) {
+    compute_vector_range(
+            start_idx, end_idx, binary_injector::rhs_arg_dynamic_params_t());
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector_range(
+        const injector_utils::vmm_index_set_t &vmm_idxs,
+        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
+
+    std::size_t rhs_arg_idx = 0;
+    for (const auto &post_op : post_ops_.entry_) {
+        if (post_op.is_eltwise()) {
+            alg_to_eltwise_injector_.at(post_op.eltwise.alg)
+                    .compute_vector_range(vmm_idxs);
+        } else if (post_op.is_binary()) {
+            binary_injector_->compute_vector_range(
+                    vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);
+            ++rhs_arg_idx;
+        } else {
+            const auto lam = lambda_jit_injectors_.find(post_op.kind);
+            if (lam != lambda_jit_injectors_.end()) lam->second();
+        }
+    }
+}
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector_range(
+        const injector_utils::vmm_index_set_t &vmm_idxs) {
+    compute_vector_range(vmm_idxs, binary_injector::rhs_arg_dynamic_params_t());
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::prepare_table(bool gen_table) {
+    for (auto &alg_elt_inject : alg_to_eltwise_injector_)
+        alg_elt_inject.second.prepare_table(gen_table);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector(size_t idx,
+        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
+    compute_vector_range({idx}, rhs_arg_params);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector(size_t idx) {
+    compute_vector_range({idx});
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::set_lambda_injector(
+        dnnl_primitive_kind_t kind, const std::function<void()> &jit_injector) {
+    lambda_jit_injectors_[kind] = jit_injector;
+}
+
+post_ops_ok_args_t::post_ops_ok_args_t(const cpu_isa_t isa,
+        const std::vector<post_op_type> &accepted_post_op_types,
+        const post_ops_t &post_ops, const memory_desc_wrapper *dst_d,
+        const bool sum_at_pos_0_only, const bool sum_requires_scale_one,
+        const bool sum_requires_zp_zero,
+        const bcast_set_t &enabled_bcast_strategy)
+    : isa(isa)
+    , accepted_post_op_types(accepted_post_op_types)
+    , post_ops(post_ops)
+    , dst_d(dst_d)
+    , sum_at_pos_0_only(sum_at_pos_0_only)
+    , sum_requires_scale_one(sum_requires_scale_one)
+    , sum_requires_zp_zero(sum_requires_zp_zero)
+    , enabled_bcast_strategy(enabled_bcast_strategy) {};
+
+bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
+    const cpu_isa_t isa = post_ops_ok_args.isa;
+    const std::vector<post_op_type> &accepted_post_op_types
+            = post_ops_ok_args.accepted_post_op_types;
+    const post_ops_t &post_ops = post_ops_ok_args.post_ops;
+    const memory_desc_wrapper *dst_d = post_ops_ok_args.dst_d;
+    const bool sum_at_pos_0_only = post_ops_ok_args.sum_at_pos_0_only;
+    const bool sum_requires_scale_one = post_ops_ok_args.sum_requires_scale_one;
+    const bool sum_requires_zp_zero = post_ops_ok_args.sum_requires_zp_zero;
+    const auto &enabled_bcast_strategy
+            = post_ops_ok_args.enabled_bcast_strategy;
+
+    const auto is_accepted_postop = [&](const int idx) {
+        for (const auto &post_op : accepted_post_op_types) {
+            const auto &entry = post_ops.entry_[idx];
+            switch (post_op) {
+                case sum:
+                    if (entry.is_sum(false, false)) {
+                        if (sum_requires_scale_one && entry.sum.scale != 1)
+                            return false;
+                        if (sum_requires_zp_zero && entry.sum.zero_point != 0)
+                            return false;
+                        return IMPLICATION(sum_at_pos_0_only, idx == 0);
+                    }
+                    break;
+                case eltwise:
+                    if (entry.is_eltwise()) {
+                        const auto alg = entry.eltwise.alg;
+                        return eltwise_injector::is_supported(isa, alg);
+                    }
+                    break;
+                case binary:
+                    if (entry.is_binary()) {
+                        assert(dst_d != nullptr && "dst_d is null");
+                        return binary_injector::is_supported(isa,
+                                entry.binary.src1_desc, *dst_d,
+                                enabled_bcast_strategy);
+                    }
+                    break;
+                default: assert(false && "Unhandled post_op type");
+            }
+        }
+        return false;
+    };
+
+    for (int i = 0; i < post_ops.len(); i++) {
+        if (!is_accepted_postop(i)) return false;
+    }
+
+    return true;
+}
+
+template class jit_uni_postops_injector_t<sve_512>;
+
+} // namespace injector
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
@@ -1,0 +1,167 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef CPU_AARCH64_JIT_UNI_POSTOPS_INJECTOR_HPP
+#define CPU_AARCH64_JIT_UNI_POSTOPS_INJECTOR_HPP
+
+#include <functional>
+#include <map>
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/primitive_attr.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "cpu/aarch64/injectors/injector_utils.hpp"
+#include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
+#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include <initializer_list>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+namespace injector {
+
+/*
+ * Allows specifying custom injector function for given post-op type - one
+ * function per primitive. There are post-ops type (example: sum) that don't
+ * have specialized injector. They heavily rely on kernel specific intrnals,
+ * which makes the generalization unreasonable. As so user can prepare internal
+ * kernel lambda and pass it explicitly to injector.
+ */
+using lambda_jit_injectors_t
+        = std::map<dnnl_primitive_kind_t, std::function<void()>>;
+
+struct post_ops_ok_args_t;
+/*
+ * Checks if postops injection for given args is supported.
+ */
+bool is_supported(const post_ops_ok_args_t &post_ops_ok_args);
+
+/*
+ * Main mechanism of handling various post-ops types. It utilizes internally
+ * specialized injectors to generate post-ops code to host primitive. Random
+ * order of post-ops is supported.
+ */
+template <cpu_isa_t isa>
+class jit_uni_postops_injector_t {
+public:
+    /*
+     * @param host <required> - user primitive where post-ops generated code is
+     * injected
+     * @param post_ops <required> - struct representing requested post-ops chain
+     * @binary_static_params <reguired> - static params needed for binary_injector.
+     * see: jit_uni_binary_injector.hpp for more info.
+     * @param eltwise_static_params <optional> - allows user specify non default
+     * params for eltwise_injector
+     * @param lambda_jit_injectors <optional> - allows user specify custom injector
+     * function for given post-op type
+     */
+    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+            const binary_injector::static_params_t &binary_static_params);
+    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+            const binary_injector::static_params_t &binary_static_params,
+            const lambda_jit_injectors_t &lambda_jit_injectors);
+    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+            const binary_injector::static_params_t &binary_static_params,
+            const eltwise_injector::static_params_t &eltwise_static_params);
+    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+            const binary_injector::static_params_t &binary_static_params,
+            const eltwise_injector::static_params_t &eltwise_static_params,
+            const lambda_jit_injectors_t &lambda_jit_injectors);
+
+    /*
+     * Generates code of post_ops chain injected to host primitive. Applied to
+     * ordered set of vector registers' indexes.
+     *
+     * @rhs_arg_params: see jit_uni_binary_injector description
+     */
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs);
+
+    /*
+     * Generates code of post_ops chain injected to host primitive. Applied to
+     * range <start_idx, end_idx) of vector registers' indexes.
+     *
+     * @rhs_arg_params: see jit_uni_binary_injector description
+     */
+    void compute_vector_range(size_t start_idx, size_t end_idx,
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+
+    void compute_vector_range(size_t start_idx, size_t end_idx);
+
+    /*
+     * Generates code of post_ops chain injected to host primitive. Applied to
+     * a single vector register index.
+     *
+     * @rhs_arg_params: see jit_uni_binary_injector description
+     */
+    void compute_vector(size_t idx,
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+    void compute_vector(size_t idx);
+
+    /*
+     * Thin wrapper for eltwise injector specific function
+     */
+    void prepare_table(bool gen_table = true);
+    void set_lambda_injector(lambda_jit_injectors_t::key_type,
+            const lambda_jit_injectors_t::mapped_type &jit_injector);
+
+private:
+    post_ops_t post_ops_;
+    jit_generator *host_;
+    std::map<dnnl::impl::alg_kind_t, jit_uni_eltwise_injector_f32<isa>>
+            alg_to_eltwise_injector_;
+    std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa>>
+            binary_injector_;
+    lambda_jit_injectors_t lambda_jit_injectors_;
+};
+
+enum post_op_type { sum = 0, eltwise, binary };
+
+struct post_ops_ok_args_t {
+    post_ops_ok_args_t(const cpu_isa_t isa,
+            const std::vector<post_op_type> &accepted_post_op_types,
+            const post_ops_t &post_ops,
+            const memory_desc_wrapper *dst_d = nullptr,
+            const bool sum_at_pos_0_only = false,
+            const bool sum_requires_scale_one = false,
+            const bool sum_requires_zp_zero = true,
+            const bcast_set_t &enabled_bcast_strategy = default_strategies());
+
+    const cpu_isa_t isa;
+    const std::vector<post_op_type> &accepted_post_op_types;
+    const post_ops_t &post_ops;
+    const memory_desc_wrapper *dst_d;
+    const bool sum_at_pos_0_only;
+    const bool sum_requires_scale_one;
+    const bool sum_requires_zp_zero;
+    const bcast_set_t enabled_bcast_strategy;
+};
+
+bool post_ops_ok(const post_ops_ok_args_t &args);
+
+} // namespace injector
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -522,6 +522,52 @@ struct jit_shuffle_call_s {
     bool is_padded_block = false;
 };
 
+enum class binary_op_t : unsigned { none, c_blocked, n_spatial_c, n_c_spatial };
+
+enum class binary_bcast_t : unsigned {
+    none, // tensor operation
+    scalar,
+    per_batch,
+    per_c,
+    per_w
+};
+
+struct jit_binary_conf_t {
+    binary_op_t op_type = binary_op_t::none;
+    binary_bcast_t bcast_type = binary_bcast_t::none;
+    bool do_scale_src0 = false;
+    bool do_scale_src1 = false;
+    bool do_sum = false;
+    bool with_eltwise = false;
+    bool with_binary = false;
+    bool with_postops = false;
+    float sum_scale = 0.f;
+    bool use_stride_src1 = false;
+    bool broadcast_src1_value = false;
+    bool use_stride_rhs_postops = false;
+    bool postops_per_oc_broadcast_exists = false;
+    bool is_i8 = false;
+    bool is_bf16 = false;
+    bool is_src_different_layouts = false;
+    dim_t outer_dims = 1;
+    int src1_stride = 1;
+    int not_bcasted_sp_dims = 0;
+
+    data_type_t src0_type = data_type::undef;
+    data_type_t src1_type = data_type::undef;
+    data_type_t dst_type = data_type::undef;
+};
+
+struct jit_binary_call_s {
+    // keep all sizes at 8 bytes -- jit code expects this
+    const void *src0, *src1, *dst, *indices;
+    const float *scales_src0, *scales_src1;
+    size_t spat_offt_count;
+    const void *post_ops_binary_rhs_arg_vec;
+    size_t src1_stride_range;
+    const void *dst_orig;
+};
+
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
@@ -611,7 +611,8 @@ bool jit_sve_512_1x1_conv_kernel::post_ops_ok(
 
     auto is_eltwise = [&](int idx) {
         return p.entry_[idx].is_eltwise()
-                && eltwise_injector::is_supported(p.entry_[idx].eltwise.alg);
+                && eltwise_injector::is_supported(
+                        sve_512, p.entry_[idx].eltwise.alg);
     };
     auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(); };
     auto is_convolution

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
@@ -925,7 +925,7 @@ status_t jit_sve_512_conv_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
     jcp.with_eltwise = eltwise_ind != -1;
     if (jcp.with_eltwise) {
         jcp.eltwise = p.entry_[eltwise_ind].eltwise;
-        if (!eltwise_injector::is_supported(jcp.eltwise.alg))
+        if (!eltwise_injector::is_supported(sve_512, jcp.eltwise.alg))
             return status::unimplemented;
         if (dst_d.data_type() == data_type::s32) return status::unimplemented;
     }

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -1,0 +1,985 @@
+/*******************************************************************************
+* Copyright 2019-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <functional>
+
+#include "cpu/aarch64/jit_uni_binary.hpp"
+#include "cpu/cpu_primitive.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+static bcast_set_t get_supported_postops_bcast_strategies() {
+    return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::no_broadcast};
+}
+
+static bool compare_layouts(const memory_desc_wrapper &src0_md,
+        const memory_desc_wrapper &src1_md) {
+    const strides_t &strides0 = src0_md.blocking_desc().strides;
+    const strides_t &strides1 = src1_md.blocking_desc().strides;
+    const dims_t &dims0 = src0_md.dims();
+    const dims_t &dims1 = src1_md.dims();
+    const int ndims = src0_md.ndims();
+
+    bool is_bcast = false;
+    for (int d = 1; d < ndims; d++)
+        is_bcast = is_bcast || dims0[d] != dims1[d];
+    if (is_bcast) return true;
+
+    bool same_layouts = true;
+    for (int d = 0; d < ndims; ++d)
+        same_layouts = same_layouts && strides0[d] == strides1[d];
+    return same_layouts;
+}
+
+static dim_t get_different_layout_stride(
+        const strides_t &strides0, const strides_t &strides1, const int ndims) {
+    for (int d = 0; d < ndims; d++)
+        if (strides0[d] == 1) return strides1[d];
+    return strides1[ndims - 1];
+}
+
+static dim_t get_outer_dims_product(
+        const strides_t &strides0, const dims_t &dims, const int ndims) {
+    // nchw:nhwc->nchw
+    if (strides0[1] == 1) return dims[1];
+    // nhwc:nchw->nhwc
+    else if (strides0[ndims - 1] == 1)
+        return utils::array_product(dims + 2, ndims - 2);
+    else
+        return dims[ndims - 1];
+}
+
+using namespace data_type;
+
+static bool data_type_supported(const data_type_t dtype) {
+    return utils::one_of(dtype, f32, s8, u8);
+}
+
+status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
+    using sm = primitive_attr_t::skip_mask_t;
+
+    conf_.dst_type = dst_md()->data_type;
+    conf_.src0_type = src_md(0)->data_type;
+    conf_.src1_type = src_md(1)->data_type;
+
+    memory_desc_wrapper dst_md_(dst_md());
+    memory_desc_wrapper src0_md_(src_md(0));
+    memory_desc_wrapper src1_md_(src_md(1));
+
+    const auto &po = attr()->post_ops_;
+    const int elt_idx = po.find(primitive_kind::eltwise);
+    conf_.is_i8 = utils::one_of(conf_.dst_type, s8, u8);
+
+    bool ok = mayiuse(sve_512) && data_type_supported(conf_.dst_type)
+            && data_type_supported(conf_.src0_type)
+            && data_type_supported(conf_.src1_type)
+            && set_default_params() == status::success && !has_zero_dim_memory()
+            && IMPLICATION(!conf_.is_i8, src0_md_ == dst_md_) && is_applicable()
+            && attr()->has_default_values(sm::post_ops | sm::scales_runtime)
+            && attr_.set_default_formats(dst_md(0)) == status::success;
+    if (!ok) return status::unimplemented;
+
+    // All operations over blocking descriptors should have md initialized.
+    conf_.is_src_different_layouts = !compare_layouts(src0_md_, src1_md_);
+    ok = post_ops_ok(
+                 attr(), src_md(0), dst_md(), conf_.is_src_different_layouts)
+            && (conf_.is_i8 || elt_idx == -1
+                    || IMPLICATION(!dst_md_.is_dense(),
+                            cpu_eltwise_fwd_pd_t::eltwise_preserves_zero(
+                                    po.entry_[elt_idx].eltwise)))
+            && IMPLICATION((!attr()->scales_.has_default_values()),
+                    check_scales_mask());
+
+    if (!ok) return status::unimplemented;
+
+    conf_.postops_per_oc_broadcast_exists
+            = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
+                    po, src0_md_, get_supported_postops_bcast_strategies());
+    conf_.op_type = get_op_type(src0_md_);
+    assert(conf_.op_type != op_t::none);
+    conf_.do_scale_src0 = !attr()->scales_.get(DNNL_ARG_SRC_0).defined()
+            || !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_src1 = !attr()->scales_.get(DNNL_ARG_SRC_1).defined()
+            || !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
+    const auto sum_idx = po.find(primitive_kind::sum);
+    conf_.do_sum = sum_idx != -1 && po.entry_[sum_idx].sum.scale != 0.f;
+    conf_.with_eltwise = po.find(primitive_kind::eltwise) != -1;
+    conf_.with_binary = po.find(primitive_kind::binary) != -1;
+    conf_.with_postops
+            = conf_.with_binary || conf_.with_eltwise || conf_.do_sum;
+    conf_.sum_scale = conf_.do_sum ? po.entry_[sum_idx].sum.scale : 0.f;
+    const auto &bcast_dims = broadcast_dims();
+    conf_.bcast_type = is_tensor_op() ? bcast_t::none
+                                      : get_bcast_type(src1_md_, bcast_dims);
+    conf_.broadcast_src1_value = (conf_.op_type == op_t::n_c_spatial
+                                         && conf_.bcast_type == bcast_t::per_c)
+            || (utils::one_of(conf_.op_type, op_t::n_spatial_c, op_t::c_blocked)
+                    && conf_.bcast_type == bcast_t::per_w)
+            || conf_.bcast_type == bcast_t::scalar;
+    conf_.use_stride_src1 = !conf_.broadcast_src1_value
+            && (utils::one_of(
+                        conf_.bcast_type, bcast_t::none, bcast_t::per_batch)
+                    || (conf_.op_type == op_t::n_spatial_c
+                            && conf_.bcast_type == bcast_t::per_c)
+                    || (conf_.op_type == op_t::n_c_spatial
+                            && conf_.bcast_type == bcast_t::per_w));
+    conf_.use_stride_rhs_postops = conf_.postops_per_oc_broadcast_exists
+            && conf_.op_type == op_t::n_spatial_c;
+
+    const auto ndims = src0_md_.ndims();
+    if (conf_.is_src_different_layouts) {
+        const auto &strides0 = src0_md_.blocking_desc().strides;
+        const auto &strides1 = src1_md_.blocking_desc().strides;
+        conf_.src1_stride
+                = get_different_layout_stride(strides0, strides1, ndims);
+        conf_.outer_dims
+                = get_outer_dims_product(strides0, src0_md_.dims(), ndims);
+    }
+    if (conf_.bcast_type == bcast_t::per_w) {
+        for (int d = 2; d < ndims; ++d)
+            conf_.not_bcasted_sp_dims += !bcast_dims[d];
+    }
+
+    return status::success;
+}
+
+op_t jit_uni_binary_t::pd_t::get_op_type(const memory_desc_wrapper &src0_d) {
+    const auto &strides = src0_d.blocking_desc().strides;
+    const auto ndims = src0_d.ndims();
+
+    if (!src0_d.is_plain())
+        return op_t::c_blocked;
+    else if (strides[1] == 1)
+        return op_t::n_spatial_c;
+    else if (strides[0] >= strides[1]
+            && IMPLICATION(ndims >= 3, strides[1] >= strides[2]))
+        return op_t::n_c_spatial;
+    return op_t::none;
+}
+
+bool jit_uni_binary_t::pd_t::is_only_dim0_bcasted(
+        const dims_t &bcast_dims, const int ndims) {
+    bool only_dim0_bcasted = true;
+    for (int d = 1; d < ndims; d++)
+        only_dim0_bcasted = only_dim0_bcasted && bcast_dims[d] == 0;
+    return only_dim0_bcasted;
+}
+
+// non-blocked: nxc || ncx
+bool jit_uni_binary_t::pd_t::is_format_non_blocked(
+        const memory_desc_wrapper &mdw) const {
+    const auto &dims = mdw.dims();
+    const auto &strides = mdw.blocking_desc().strides;
+    const auto &ndims = mdw.ndims();
+
+    const bool is_ncx
+            = IMPLICATION(strides[0] != 0,
+                      strides[0] >= utils::array_product(dims + 1, ndims - 1))
+            && IMPLICATION(ndims >= 3 && strides[1] != 0,
+                    strides[1] >= utils::array_product(dims + 2, ndims - 2))
+            && IMPLICATION(ndims >= 4 && strides[2] != 0,
+                    strides[2] >= utils::array_product(dims + 3, ndims - 3))
+            && IMPLICATION(ndims >= 5 && strides[3] != 0,
+                    strides[3] >= utils::array_product(dims + 4, ndims - 4))
+            && IMPLICATION(strides[ndims - 1] != 0, strides[ndims - 1] == 1);
+    const bool is_nxc
+            = IMPLICATION(strides[0] != 0,
+                      strides[0] >= utils::array_product(dims + 1, ndims - 1))
+            && IMPLICATION(ndims >= 3 && strides[2] != 0,
+                    strides[2] >= dims[1]
+                                    * utils::array_product(dims + 3, ndims - 3))
+            && IMPLICATION(ndims >= 4 && strides[3] != 0,
+                    strides[3] >= dims[1]
+                                    * utils::array_product(dims + 4, ndims - 4))
+            && IMPLICATION(ndims >= 5 && strides[4] != 0,
+                    strides[4] >= dims[1]
+                                    * utils::array_product(dims + 5, ndims - 5))
+            && IMPLICATION(strides[1] != 0, strides[1] == 1);
+    return is_nxc || is_ncx;
+}
+
+bcast_t jit_uni_binary_t::pd_t::get_bcast_type(
+        const memory_desc_wrapper &src1_d, const dims_t &bcast_dims) {
+    if (src1_d.nelems() == 1)
+        return bcast_t::scalar;
+    else if (bcast_dims[1] == 1)
+        return bcast_t::per_w;
+    else if (is_only_dim0_bcasted(bcast_dims, src1_d.ndims()))
+        return bcast_t::per_batch;
+    else
+        return bcast_t::per_c;
+}
+
+bool jit_uni_binary_t::pd_t::alg_preserves_zero() const {
+    using namespace utils;
+    using namespace alg_kind;
+    return utils::one_of(desc()->alg_kind, binary_add, binary_max, binary_min,
+            binary_mul, binary_sub, binary_ge, binary_gt, binary_le, binary_lt,
+            binary_eq, binary_ne);
+}
+
+bool jit_uni_binary_t::pd_t::check_scales_mask() const {
+    for (const auto &s : attr()->scales_.scales_) {
+        if (s.second.mask_ != 0) return false;
+    }
+    return true;
+}
+
+bool jit_uni_binary_t::pd_t::is_bcast_pattern(const dims_t &bcast_dims,
+        const dim_t ndims, const dim_t N_bcast, const dim_t C_bcast,
+        const dim_t W_bcast) const {
+    return bcast_dims[0] == N_bcast && bcast_dims[1] == C_bcast
+            && bcast_dims[ndims - 1] == W_bcast;
+}
+
+bool jit_uni_binary_t::pd_t::is_bcast_allowed(const int ndims) const {
+    // supported cases: NxCxDxHxW:{NxCx1x1x1,1xCx1x1x1,Nx1xDxHxW,Nx1x1xHxW,
+    //                            Nx1x1x1xW,1xCxDxHxW,1x1xDxHxW,1x1x1xHxW,
+    //                            1x1x1x1xW,1x1x1x1x1}
+    const auto &bcast_dims = broadcast_dims();
+    // check if there is continuous broadcast between non-broadcast dims
+    // if next_bcast_expected == 1, not broadcast dim not met
+    int next_bcast_expected = 1;
+    bool sp_not_bcasted = true;
+    bool ok = true;
+    for (int d = 2; d < ndims; ++d) {
+        if (bcast_dims[d] == 0)
+            next_bcast_expected = 0;
+        else
+            sp_not_bcasted = false;
+        ok = ok && bcast_dims[d] == next_bcast_expected;
+    }
+
+#define BCAST_PATTERN(N, C, W, condition) \
+    (is_bcast_pattern(bcast_dims, ndims, N, C, W) && (condition))
+    if (ndims > 2)
+        ok = ok
+                && (BCAST_PATTERN(0, 1, 0, true) || BCAST_PATTERN(1, 1, 0, true)
+                        || BCAST_PATTERN(1, 0, 0, sp_not_bcasted)
+                        || BCAST_PATTERN(0, 0, 1, !!next_bcast_expected)
+                        || BCAST_PATTERN(1, 0, 1, !!next_bcast_expected)
+                        || BCAST_PATTERN(1, 1, 1, !!next_bcast_expected));
+#undef BCAST_PATTERN
+    return ok;
+}
+
+// check for different src formats with same dims
+// broadcast can be accepted if src_dim == src1_dims (1 == 1)
+bool jit_uni_binary_t::pd_t::is_different_layouts_allowed(
+        const memory_desc_wrapper &src0_d,
+        const memory_desc_wrapper &src1_d) const {
+    const dims_t &src0_dims = src0_d.dims();
+    const dims_t &src1_dims = src1_d.dims();
+    const int ndims = src0_d.ndims();
+
+    bool without_bcast = true;
+    for (int d = 0; d < ndims; d++)
+        without_bcast = without_bcast && src0_dims[d] == src1_dims[d];
+    if (!without_bcast) return false;
+
+    // allow nchw:nhwc and nhwc:nchw and disable for blocked layouts
+    return src0_d.is_plain() && src1_d.is_plain()
+            && is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d);
+}
+
+bool jit_uni_binary_t::pd_t::is_applicable() {
+    const memory_desc_wrapper src0_d(src_md(0));
+    const memory_desc_wrapper src1_d(src_md(1));
+    const memory_desc_wrapper dst_d(dst_md());
+    const auto ndims = src0_d.ndims();
+
+    // check density first to avoid same non-dense src0 and src1 to pass
+    // the next check
+    bool ok = src0_d.is_dense(true) && src1_d.is_dense(true)
+            && dst_d.is_dense(true);
+    if (!ok) return false;
+
+    // TODO: fix implementation for tensor with paddings to work with any block
+    // size. For now return unimplemented if more than single blocking
+    // or `block size > 16`.
+    const auto &blk_d = dst_d.blocking_desc();
+    if (!dst_d.is_dense()
+            && (blk_d.inner_nblks > 1 || blk_d.inner_blks[0] > 16))
+        return false;
+
+    const bool is_src_different_layouts = !compare_layouts(src0_d, src1_d);
+    const bool different_layouts_allowed
+            = is_different_layouts_allowed(src0_d, src1_d);
+    if (!conf_.is_i8) {
+        const bool has_padding = utils::one_of(true,
+                src0_d.nelems(true) != src0_d.nelems(false),
+                src1_d.nelems(true) != src1_d.nelems(false),
+                dst_d.nelems(true) != dst_d.nelems(false));
+        ok = IMPLICATION(has_padding, alg_preserves_zero());
+        if (!ok) return false;
+
+        // full tensor operation
+        bool same_dims = true;
+        const auto &src0_dims = src0_d.dims();
+        const auto &src1_dims = src1_d.dims();
+        for (int d = 0; d < ndims; d++)
+            same_dims = same_dims && src0_dims[d] == src1_dims[d];
+        if (same_dims
+                && IMPLICATION(
+                        is_src_different_layouts, different_layouts_allowed))
+            return true;
+    } else {
+        const dim_t C = ndims >= 2 ? src0_d.dims()[1] : 1;
+        const bool has_oc_tail = C != src0_d.padded_dims()[1];
+        const bool has_outer_dims_tail = is_src_different_layouts
+                && get_outer_dims_product(src0_d.blocking_desc().strides,
+                        src0_d.dims(), src0_d.ndims());
+
+        // Disable compare operations when blocked tag with tail.
+        // Tail processing is not supported and the vcmps instruction
+        // overwrites the output vector.
+        if (utils::one_of(desc()->alg_kind, alg_kind::binary_ge,
+                    alg_kind::binary_gt, alg_kind::binary_le,
+                    alg_kind::binary_lt, alg_kind::binary_eq,
+                    alg_kind::binary_ne)
+                && (has_oc_tail || has_outer_dims_tail))
+            return false;
+
+        // full tensor operation
+        if (src0_d.similar_to(src1_d, true, false, 0)
+                || different_layouts_allowed)
+            return true;
+        // source0 broadcast not supported
+        if (!src0_d.similar_to(dst_d, true, false, 0)) return false;
+    }
+    // broadcast or different layouts operation
+    if (!(is_bcast_allowed(ndims)
+                && IMPLICATION(
+                        is_src_different_layouts, different_layouts_allowed)))
+        return false;
+
+    // only nspc and ncsp formats are supported for bcast
+    if (src0_d.is_plain() && src1_d.is_plain())
+        return is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d);
+
+    // blocked formats
+    if (!conf_.is_i8) {
+        // check blocking_desc consistency
+        const auto valid_bd = [&](const memory_desc_wrapper &mdw) {
+            int blksize = 8;
+            if (mayiuse(sve_512)) blksize = 16;
+            const auto &bd = mdw.blocking_desc();
+
+            return bd.inner_nblks == 1 && bd.inner_blks[0] == blksize
+                    && bd.inner_idxs[0] == 1;
+        };
+
+        return valid_bd(src0_d) && valid_bd(src1_d);
+    } else {
+        const auto &bd0 = src0_d.blocking_desc();
+        const auto &bd1 = src1_d.blocking_desc();
+        const auto &bcast_dims = broadcast_dims();
+        // disable blocked tag for source1 when W is not broadcast
+        return bd0.strides[1] == 1 && bd0.inner_nblks == 0
+                && IMPLICATION(
+                        bcast_dims[ndims - 1] == 0, bd1.inner_nblks == 0);
+    }
+}
+
+bool jit_uni_binary_t::post_ops_ok(const primitive_attr_t *attr,
+        const memory_desc_wrapper &src0_d, const memory_desc_wrapper &dst_d,
+        const bool is_src_different_layouts) {
+    using namespace primitive_kind;
+
+    const auto &p = attr->post_ops_;
+    const auto is_eltwise = [&](int idx) {
+        if (p.entry_[idx].is_eltwise()) {
+            const auto alg = p.entry_[idx].eltwise.alg;
+            return eltwise_injector::is_alg_supported(alg);
+        }
+        return false;
+    };
+    const auto is_binary = [&](int idx) { return p.entry_[idx].is_binary(); };
+    const auto is_binary_bf16 = [&](int idx) {
+        return is_binary(idx)
+                && p.entry_[idx].binary.src1_desc.data_type == data_type::bf16;
+    };
+    const bool is_sve = mayiuse(sve_128);
+    if (!is_sve) return false;
+
+    const auto supported_strategies = get_supported_postops_bcast_strategies();
+    for (int i = 0; i < p.len(); i++) {
+        if (is_binary_bf16(i)) return false;
+        if (p.contain(primitive_kind::sum, i)) {
+            if (p.entry_[i].sum.zero_point != 0) return false;
+            if (src0_d.data_type() != dst_d.data_type()) return false;
+        } else if (!(is_eltwise(i) || is_binary(i))) {
+            return false;
+        } else if (is_binary(i)) {
+            const auto &post_ops_mem = p.entry_[i].binary.src1_desc;
+            if (get_rhs_arg_broadcasting_strategy(
+                        post_ops_mem, dst_d, supported_strategies)
+                    == broadcasting_strategy_t::no_broadcast) {
+                const memory_desc_wrapper post_op_mem_d(post_ops_mem);
+                if (!post_op_mem_d.similar_to(dst_d, true, false)) return false;
+            }
+        }
+    }
+
+    const int vlen = get_sve_length();
+    const bool postops_per_oc_broadcast_exists
+            = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
+                    p, src0_d, supported_strategies);
+    if (postops_per_oc_broadcast_exists && is_src_different_layouts)
+        return false;
+    const int blksize = vlen / sizeof(float);
+
+    const bool blocked_format = !src0_d.is_plain() && src0_d.is_blocking_desc();
+
+    if (postops_per_oc_broadcast_exists && blocked_format) {
+        /*
+         * check blocking_desc consistency, currently when among postops exists
+         * per_oc broadcast, binary kernel doesn't support situations when blocked
+         * format size is smaller then vlen. example: sse41 vlen size is 4 and format
+         * is nChw8c - not supported, avx2 vlen size is 8 and format is
+         * nChw8c - supported.
+         */
+        const auto blocking_desc = src0_d.blocking_desc();
+        if (blocking_desc.inner_nblks != 1
+                || blocking_desc.inner_blks[0] != blksize
+                || blocking_desc.inner_idxs[0] != 1)
+            return false;
+    }
+
+    const dim_t n_dims = src0_d.ndims();
+    const dim_t &oc = n_dims >= 2 ? src0_d.dims()[1] : 1;
+
+    /*
+     * TODO: Remove limitation supporting tail with blocked format for i8i8
+     */
+    const bool blocked_tail = p.len() && blocked_format && oc % blksize;
+
+    return binary_injector::binary_args_broadcast_supported(
+                   p, src0_d, get_supported_postops_bcast_strategies())
+            && IMPLICATION(
+                    utils::one_of(src0_d.data_type(), s8, u8), !blocked_tail);
+}
+
+binary_kernel_t *create_binary_kernel(
+        const jit_uni_binary_t::pd_t *pd, bool tail_kernel) {
+    const auto &conf = pd->get_conf();
+    if (mayiuse(sve_512)) {
+        using kernel_t = jit_uni_binary_kernel_t<sve_512>;
+        return new kernel_t(pd, conf, tail_kernel && !conf.is_i8);
+    } else {
+        assert(!"unsupported isa");
+        return nullptr;
+    }
+}
+
+jit_uni_binary_t::jit_uni_binary_t(const pd_t *apd) : primitive_t(apd) {}
+
+status_t jit_uni_binary_t::init(engine_t *engine) {
+    CHECK(safe_ptr_assign(
+            kernel_, create_binary_kernel(pd(), false /*tail_kernel*/)));
+
+    if (utils::one_of(pd()->dst_md(0)->data_type, f32)) {
+        const memory_desc_wrapper src0_d(pd_->src_md(0));
+        const auto &simd_w = kernel_->simd_w();
+        const auto oc = src0_d.ndims() >= 2 ? src0_d.dims()[1] : 1;
+
+        if (op_t::c_blocked == pd()->get_conf().op_type && oc % simd_w) {
+            CHECK(safe_ptr_assign(kernel_tail_,
+                    create_binary_kernel(pd(), true /*tail_kernel*/)));
+            CHECK(kernel_tail_->create_kernel());
+        }
+    }
+
+    return kernel_->create_kernel();
+}
+
+void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
+        const data_t *src1, data_t *dst, const float *scale0,
+        const float *scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const bcast_t bcast_type) const {
+    const auto kernel = kernel_.get();
+    const auto &simd_w = kernel_->simd_w();
+
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+    const memory_desc_wrapper dst_d(pd()->dst_md(0));
+    const int src0_type_size = types::data_type_size(src0_d.data_type());
+    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int dst_type_size = types::data_type_size(dst_d.data_type());
+
+    const auto &conf = pd()->get_conf();
+    const bool is_src_different_layouts = conf.is_src_different_layouts;
+
+    if (is_src_different_layouts) {
+        std::vector<unsigned> indices;
+
+        const dim_t src1_different_layout_stride = conf.src1_stride;
+        for (size_t i = 0; i < simd_w; i++)
+            indices.push_back(
+                    i * src1_different_layout_stride * src1_type_size);
+
+        const dim_t batch = src0_d.dims()[0];
+        const dim_t batch_stride = src1_d.blocking_desc().strides[0];
+        const dim_t outer_dims = conf.outer_dims;
+        const size_t src1_stride_range
+                = outer_dims * src1_different_layout_stride * src1_type_size;
+
+        const dim_t nelems_per_aligned_dims
+                = src0_d.nelems(true) / (batch * outer_dims);
+        const dim_t nelems0_simd = nelems_per_aligned_dims / simd_w;
+        const dim_t nelems0_tail = nelems_per_aligned_dims % simd_w;
+        const bool has_tail = nelems0_tail > 0;
+
+        const int nthr = dnnl_get_current_num_threads();
+        const dim_t thr_per_nelems_group = nstl::min(
+                nstl::max(nthr / batch, (dim_t)1), nelems0_simd + has_tail);
+
+        // Compute strategy:
+        // Iterate over batch and over outer dims.
+        // Divide number of threads by batch size and limiting it by a number
+        // of outer_dims nelems to parallel over it when needed.
+        parallel_nd(
+                batch, thr_per_nelems_group, [&](dim_t b, dim_t nelems_group) {
+                    dim_t start = 0, end = 0;
+                    balance211(nelems0_simd + has_tail, thr_per_nelems_group,
+                            nelems_group, start, end);
+                    if (start >= end) return;
+
+                    const bool ithr_does_tail = has_tail
+                            && utils::one_of(nelems0_simd + has_tail, end, 0);
+                    const dim_t n_simd_to_do
+                            = (end - start - ithr_does_tail) * simd_w;
+                    const dim_t tail_to_do = ithr_does_tail * nelems0_tail;
+                    const size_t batch_off = batch_stride * b;
+
+                    if (nelems0_simd != 0) {
+                        start *= outer_dims;
+                        end *= outer_dims;
+                    }
+
+                    start *= simd_w;
+                    jit_binary_call_s p;
+                    p.spat_offt_count = (n_simd_to_do + tail_to_do) * outer_dims
+                            * dst_type_size;
+                    p.src0 = src0 + (start + batch_off) * src0_type_size;
+                    p.src1 = src1
+                            + (start / outer_dims + batch_off) * src1_type_size;
+                    p.dst = dst + (start + batch_off) * dst_type_size;
+                    p.indices = &indices[0];
+                    p.src1_stride_range = src1_stride_range;
+                    p.scales_src0 = scale0;
+                    p.scales_src1 = scale1;
+                    p.post_ops_binary_rhs_arg_vec
+                            = post_ops_binary_rhs_arg_vec.data();
+                    p.dst_orig = dst;
+                    (*kernel)(&p);
+                });
+    } else {
+        const dim_t nelems0 = src0_d.nelems(true);
+        const dim_t nelems0_simd = nelems0 / simd_w;
+        const dim_t nelems0_tail = nelems0 % simd_w;
+        const bool has_tail = nelems0_tail > 0;
+
+        const bool point_broadcast = bcast_type == bcast_t::scalar;
+
+        // Compute strategy:
+        // Compute number of vectors, divide it equally between all threads.
+        // Last one will also handle a tail if present.
+        parallel(0, [&](const int ithr, const int nthr) {
+            dim_t start = 0, end = 0;
+            balance211(nelems0_simd + has_tail, nthr, ithr, start, end);
+            if (start >= end) return;
+
+            const bool ithr_does_tail
+                    = has_tail && end == nelems0_simd + has_tail;
+            const dim_t n_simd_to_do = (end - start - ithr_does_tail) * simd_w;
+            const dim_t tail_to_do = ithr_does_tail * nelems0_tail;
+
+            jit_binary_call_s p;
+            p.spat_offt_count = (n_simd_to_do + tail_to_do) * dst_type_size;
+            p.src0 = src0 + start * simd_w * src0_type_size;
+            p.src1 = src1
+                    + (point_broadcast ? 0 : (start * simd_w * src1_type_size));
+            p.dst = dst + start * simd_w * dst_type_size;
+            p.scales_src0 = scale0;
+            p.scales_src1 = scale1;
+            p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+            p.dst_orig = dst;
+            (*kernel)(&p);
+        });
+    }
+}
+
+void jit_uni_binary_t::execute_bcast_per_batch_strategy(const data_t *src0,
+        const data_t *src1, data_t *dst, const float *scale0,
+        const float *scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec) const {
+
+    const auto kernel = kernel_.get();
+    const auto &simd_w = kernel_->simd_w();
+
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+    const memory_desc_wrapper dst_d(pd()->dst_md(0));
+    const int src0_type_size = types::data_type_size(src0_d.data_type());
+    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int dst_type_size = types::data_type_size(dst_d.data_type());
+
+    const dim_t MB = src0_d.dims()[0];
+    const dim_t nelems0_per_b = src0_d.nelems(true) / MB;
+    const dim_t nelems0_simd = nelems0_per_b / simd_w;
+    const dim_t nelems0_tail = nelems0_per_b % simd_w;
+    const bool has_tail = nelems0_tail > 0;
+
+    // Compute strategy:
+    // Compute number of vectors per batch, divide it equally between all
+    // threads. Last one will also handle a tail if present.
+    const dim_t nthr = nstl::min(
+            nelems0_simd + has_tail, (dim_t)dnnl_get_current_num_threads());
+    parallel_nd(MB, nthr, [&](dim_t b, dim_t ithr) {
+        dim_t start = 0, end = 0;
+        balance211(nelems0_simd + has_tail, nthr, ithr, start, end);
+        if (start >= end) return;
+
+        const bool ithr_does_tail = has_tail && end == nelems0_simd + has_tail;
+        const dim_t n_simd_to_do = (end - start - ithr_does_tail) * simd_w;
+        const dim_t tail_to_do = ithr_does_tail * nelems0_tail;
+
+        jit_binary_call_s p;
+        p.spat_offt_count = (n_simd_to_do + tail_to_do) * dst_type_size;
+        const dim_t off = start * simd_w;
+        p.src0 = src0 + (off + b * nelems0_per_b) * src0_type_size;
+        p.src1 = src1 + off * src1_type_size;
+        p.dst = dst + (off + b * nelems0_per_b) * dst_type_size;
+        p.scales_src0 = scale0;
+        p.scales_src1 = scale1;
+        p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+        p.dst_orig = dst;
+        (*kernel)(&p);
+    });
+}
+
+void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
+        const data_t *src1, data_t *dst, const float *scale0,
+        const float *scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const op_t op_type, const bcast_t bcast_type,
+        const bool blocked_oc_tail) const {
+    const auto kernel = kernel_.get();
+    const auto kernel_tail = kernel_tail_.get();
+    const auto &simd_w = kernel_->simd_w();
+
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+    const memory_desc_wrapper dst_d(pd()->dst_md(0));
+    const int src0_type_size = types::data_type_size(src0_d.data_type());
+    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const auto ndims = src0_d.ndims();
+    const auto &dims = src0_d.dims();
+    const dim_t MB = dims[0];
+    const dim_t C = ndims >= 2 ? dims[1] : 1;
+    const dim_t SP = ndims >= 3 ? utils::array_product(dims + 2, ndims - 2) : 1;
+
+    const auto &bcast_dims = pd()->broadcast_dims();
+
+    const dim_t nelems_slice_src0
+            = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
+    const dim_t nelems_slice_src1 = bcast_type == bcast_t::none
+            ? nelems_slice_src0
+            : ((bcast_dims[0] == 0) ? utils::array_product(
+                       src1_d.padded_dims() + 1, ndims - 1)
+                                    : 0);
+
+    if (op_type == op_t::c_blocked) {
+        const dim_t C_blocks = std::ceil(
+                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        // Compute strategy:
+        // Each block is individual - parallel over MB and C_blocks safely.
+
+        const std::function<void(jit_binary_call_s *, dim_t)>
+                kernel_blocked_no_tail
+                = [&](jit_binary_call_s *p, dim_t C_blk) { (*kernel)(p); };
+        const std::function<void(jit_binary_call_s *, dim_t)>
+                kernel_blocked_tail = [&](jit_binary_call_s *p, dim_t C_blk) {
+                    if (C_blk == (C_blocks - 1))
+                        (*kernel_tail)(p);
+                    else
+                        (*kernel)(p);
+                };
+        const auto &kernel_blocked = blocked_oc_tail ? kernel_blocked_tail
+                                                     : kernel_blocked_no_tail;
+        const auto src1_off = [&](dim_t mb, dim_t C_blk, dim_t off) -> dim_t {
+            switch (bcast_type) {
+                case bcast_t::scalar: return mb * nelems_slice_src1;
+                case bcast_t::per_batch: return C_blk * SP * simd_w;
+                case bcast_t::none: return off;
+                default: return mb * nelems_slice_src1 + C_blk * simd_w;
+            }
+        };
+
+        parallel_nd(MB, C_blocks, [&](dim_t mb, dim_t C_blk) {
+            jit_binary_call_s p;
+            p.spat_offt_count = SP * simd_w * dst_type_size;
+            const dim_t off = mb * nelems_slice_src0 + C_blk * SP * simd_w;
+            p.dst = dst + off * dst_type_size;
+            p.src0 = src0 + off * src0_type_size;
+            p.src1 = src1 + src1_off(mb, C_blk, off) * src1_type_size;
+            p.scales_src0 = scale0;
+            p.scales_src1 = scale1;
+            p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+            p.dst_orig = dst;
+            kernel_blocked(&p, C_blk);
+        });
+    } else if (op_type == op_t::n_spatial_c) {
+        const auto src1_off = [&](dim_t mb, dim_t sp, dim_t off) -> dim_t {
+            switch (bcast_type) {
+                case bcast_t::per_batch: return sp * C;
+                case bcast_t::none: return off;
+                default: return mb * nelems_slice_src1;
+            }
+        };
+
+        // Compute strategy:
+        // Each line of channels is individual, parallel over MB and spatial.
+        parallel_nd(MB, SP, [&](dim_t mb, dim_t sp) {
+            jit_binary_call_s p;
+            p.spat_offt_count = C * dst_type_size;
+            const auto off = mb * nelems_slice_src0 + sp * C;
+            p.dst = dst + off * dst_type_size;
+            p.src0 = src0 + off * src0_type_size;
+            p.src1 = src1 + src1_off(mb, sp, off) * src1_type_size;
+            p.scales_src0 = scale0;
+            p.scales_src1 = scale1;
+            p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+            p.dst_orig = dst;
+            (*kernel)(&p);
+        });
+    } else if (op_type == op_t::n_c_spatial) {
+        const auto src1_off = [&](dim_t mb, dim_t c, dim_t off) -> dim_t {
+            switch (bcast_type) {
+                case bcast_t::scalar: return mb * nelems_slice_src1;
+                case bcast_t::per_batch: return c * SP;
+                case bcast_t::none: return off;
+                default: return mb * nelems_slice_src1 + c;
+            }
+        };
+
+        // Compute strategy:
+        // Each line of spatial is individual, parallel over MB and C.
+        parallel_nd(MB, C, [&](dim_t mb, dim_t c) {
+            jit_binary_call_s p;
+            p.spat_offt_count = SP * dst_type_size;
+            const auto off = mb * nelems_slice_src0 + c * SP;
+            p.dst = dst + off * dst_type_size;
+            p.src0 = src0 + off * src0_type_size;
+            p.src1 = src1 + src1_off(mb, c, off) * src1_type_size;
+            p.scales_src0 = scale0;
+            p.scales_src1 = scale1;
+            p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+            p.dst_orig = dst;
+            (*kernel)(&p);
+        });
+    }
+}
+
+void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
+        const data_t *src1, data_t *dst, const float *scale0,
+        const float *scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const op_t op_type, const bool blocked_oc_tail) const {
+    const auto kernel = kernel_.get();
+    const auto kernel_tail = kernel_tail_.get();
+    const auto &simd_w = kernel_->simd_w();
+
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+    const memory_desc_wrapper dst_d(pd()->dst_md(0));
+    const int src0_type_size = types::data_type_size(src0_d.data_type());
+    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const auto ndims = src0_d.ndims();
+    const auto &dims = src0_d.dims();
+    const auto &bcast_dims = pd()->broadcast_dims();
+
+    const int not_bcasted_sp_dims = pd()->get_conf().not_bcasted_sp_dims;
+    const dim_t MB = dims[0];
+    // array product of outer dimensions that are not broadcast
+    const dim_t SP_no_bcast = ndims >= 3
+            ? utils::array_product(
+                    dims + (ndims - not_bcasted_sp_dims), not_bcasted_sp_dims)
+            : 1;
+    const dim_t C = ndims >= 2 ? dims[1] : 1;
+    const dim_t SP = ndims >= 3 ? utils::array_product(dims + 2, ndims - 2) : 1;
+    // spatial without dimensions that are not broadcasted by src1
+    const dim_t N = SP / SP_no_bcast;
+
+    const dim_t nelems_slice_src0
+            = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
+
+    if (op_type == op_t::c_blocked) {
+        const dim_t C_blocks = std::ceil(
+                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        // Compute strategy:
+        // Each line of channels is individual, parallel over MB, C_blocks
+        // and spatial (broadcasted and not broadcasted spatial dims
+        // separately).
+
+        const std::function<void(jit_binary_call_s *, dim_t)>
+                kernel_blocked_no_tail
+                = [&](jit_binary_call_s *p, dim_t C_blk) { (*kernel)(p); };
+        const std::function<void(jit_binary_call_s *, dim_t)>
+                kernel_blocked_tail = [&](jit_binary_call_s *p, dim_t C_blk) {
+                    if (C_blk == (C_blocks - 1))
+                        (*kernel_tail)(p);
+                    else
+                        (*kernel)(p);
+                };
+        const auto &kernel_blocked = blocked_oc_tail ? kernel_blocked_tail
+                                                     : kernel_blocked_no_tail;
+
+        parallel_nd(MB, C_blocks, N, SP_no_bcast,
+                [&](dim_t mb, dim_t C_blk, dim_t n, dim_t sp) {
+                    jit_binary_call_s p;
+                    p.spat_offt_count = simd_w * dst_type_size;
+                    const auto off = mb * nelems_slice_src0
+                            + simd_w * (C_blk * SP + n * SP_no_bcast + sp);
+                    p.dst = dst + off * dst_type_size;
+                    p.src0 = src0 + off * src0_type_size;
+                    // check if mb is broadcast
+                    const dim_t src1_off = bcast_dims[0] == 1
+                            ? sp * simd_w
+                            : (mb * SP_no_bcast + sp) * simd_w;
+                    p.src1 = src1 + src1_off * src1_type_size;
+                    p.scales_src0 = scale0;
+                    p.scales_src1 = scale1;
+                    p.post_ops_binary_rhs_arg_vec
+                            = post_ops_binary_rhs_arg_vec.data();
+                    p.dst_orig = dst;
+                    kernel_blocked(&p, C_blk);
+                });
+    } else if (op_type == op_t::n_spatial_c) {
+        // Compute strategy:
+        // Each line of channels is individual, parallel over MB and spatial
+        // (broadcasted and not broadcasted spatial dims separately).
+
+        parallel_nd(MB, N, SP_no_bcast, [&](dim_t mb, dim_t n, dim_t sp) {
+            jit_binary_call_s p;
+            p.spat_offt_count = C * dst_type_size;
+            const auto off
+                    = mb * nelems_slice_src0 + n * SP_no_bcast * C + sp * C;
+            p.dst = dst + off * dst_type_size;
+            p.src0 = src0 + off * src0_type_size;
+            const dim_t src1_off
+                    = bcast_dims[0] == 1 ? sp : mb * SP_no_bcast + sp;
+            p.src1 = src1 + src1_off * src1_type_size;
+            p.scales_src0 = scale0;
+            p.scales_src1 = scale1;
+            p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+            p.dst_orig = dst;
+            (*kernel)(&p);
+        });
+    } else if (op_type == op_t::n_c_spatial) {
+        // Compute strategy:
+        // Each line of width is individual, parallel over MB, C and spatial
+        // without not broadcasted dims. Use a kernel which broadcasts c_i
+        // value into a vector register.
+
+        parallel_nd(MB, C, N, [&](dim_t mb, dim_t c, dim_t n) {
+            jit_binary_call_s p;
+            p.spat_offt_count = SP_no_bcast * dst_type_size;
+            const auto off = mb * nelems_slice_src0 + c * N * SP_no_bcast
+                    + n * SP_no_bcast;
+            p.dst = dst + off * dst_type_size;
+            p.src0 = src0 + off * src0_type_size;
+            const dim_t src1_off = bcast_dims[0] == 1 ? 0 : mb * SP_no_bcast;
+            p.src1 = src1 + src1_off * src1_type_size;
+            p.scales_src0 = scale0;
+            p.scales_src1 = scale1;
+            p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+            p.dst_orig = dst;
+            (*kernel)(&p);
+        });
+    }
+}
+
+status_t jit_uni_binary_t::execute(const exec_ctx_t &ctx) const {
+    const auto src0 = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC_0);
+    const auto src1 = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC_1);
+    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+    const auto &post_ops = pd()->attr()->post_ops_;
+    const auto &post_ops_binary_rhs_arg_vec
+            = binary_injector::prepare_binary_args(post_ops, ctx);
+    const float *scales[2];
+    ASSIGN_INPUT_SCALE_VALUE(scales[0], DNNL_ARG_SRC_0);
+    ASSIGN_INPUT_SCALE_VALUE(scales[1], DNNL_ARG_SRC_1);
+
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+    const auto ndims = src0_d.ndims();
+    const auto &dims = src0_d.dims();
+    const dim_t C = ndims >= 2 ? dims[1] : 0;
+
+    const bool postops_per_oc_broadcast_exists
+            = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
+                    post_ops, src0_d, get_supported_postops_bcast_strategies());
+    const auto &bcast_type = pd()->get_conf().bcast_type;
+    const bool point_broadcast = bcast_type == bcast_t::scalar;
+    const auto &op_type = pd()->get_conf().op_type;
+    const bool with_postops = !post_ops.entry_.empty();
+    const auto &simd_w = kernel_->simd_w();
+    const bool has_oc_tail = C % simd_w;
+    const bool point_broadcast_no_oc_tail = point_broadcast && !has_oc_tail;
+    const auto alg = pd()->desc()->alg_kind;
+    // Use strategy with kernel_tail for GreaterEqual op with oc_tail and
+    // blocked format due to overwriting the vector tail by vcmpps.
+    const bool vector_overwrite = utils::one_of(alg, alg_kind::binary_ge,
+            alg_kind::binary_gt, alg_kind::binary_le, alg_kind::binary_lt,
+            alg_kind::binary_eq, alg_kind::binary_ne);
+    const bool blocked_oc_tail = op_type == op_t::c_blocked && has_oc_tail
+            && (with_postops || point_broadcast || bcast_type == bcast_t::per_w
+                    || vector_overwrite);
+
+    if ((bcast_type == bcast_t::none || point_broadcast_no_oc_tail)
+            && !postops_per_oc_broadcast_exists && !blocked_oc_tail)
+        execute_no_bcast_strategy(src0, src1, dst, scales[0], scales[1],
+                post_ops_binary_rhs_arg_vec, bcast_type);
+    else if (bcast_type == bcast_t::per_batch
+            && !postops_per_oc_broadcast_exists && !blocked_oc_tail)
+        execute_bcast_per_batch_strategy(src0, src1, dst, scales[0], scales[1],
+                post_ops_binary_rhs_arg_vec);
+    else if (bcast_type == bcast_t::per_w)
+        execute_bcast_per_w_strategy(src0, src1, dst, scales[0], scales[1],
+                post_ops_binary_rhs_arg_vec, op_type, blocked_oc_tail);
+    else
+        execute_bcast_per_c_strategy(src0, src1, dst, scales[0], scales[1],
+                post_ops_binary_rhs_arg_vec, op_type, bcast_type,
+                blocked_oc_tail);
+
+    return status::success;
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_uni_binary.hpp
+++ b/src/cpu/aarch64/jit_uni_binary.hpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+* Copyright 2019-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_UNI_BINARY_HPP
+#define CPU_AARCH64_JIT_UNI_BINARY_HPP
+
+#include "common/primitive.hpp"
+
+#include "cpu/aarch64/jit_uni_binary_kernel.hpp"
+#include "cpu/cpu_eltwise_pd.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct binary_kernel_t;
+
+using op_t = binary_op_t;
+using bcast_t = binary_bcast_t;
+
+struct jit_uni_binary_t : public primitive_t {
+    struct pd_t : public cpu_binary_pd_t {
+        using cpu_binary_pd_t::cpu_binary_pd_t;
+
+        DECLARE_COMMON_PD_T("jit:uni", jit_uni_binary_t);
+
+        status_t init(engine_t *engine);
+
+        jit_binary_conf_t get_conf() const { return conf_; };
+
+    private:
+        op_t get_op_type(const memory_desc_wrapper &src0_d);
+        bool is_only_dim0_bcasted(const dims_t &bcast_dims, const int ndims);
+        bcast_t get_bcast_type(
+                const memory_desc_wrapper &src1_d, const dims_t &bcast_dims);
+
+        // alg_preserves_zero returns true if operation preserves zero in case
+        // of both inputs contain zero.
+        bool alg_preserves_zero() const;
+        bool check_scales_mask() const;
+        bool is_bcast_pattern(const dims_t &bcast_dims, const dim_t ndims,
+                const dim_t N_bcast, const dim_t C_bcast,
+                const dim_t W_bcast) const;
+        bool is_bcast_pattern(const dims_t &bcast_dims, const dim_t N_bcast,
+                const dim_t C_bcast) const;
+        bool is_bcast_allowed(const int ndims) const;
+        bool is_format_non_blocked(const memory_desc_wrapper &mdw) const;
+        bool is_different_layouts_allowed(const memory_desc_wrapper &src0_d,
+                const memory_desc_wrapper &src1_d) const;
+        bool is_applicable();
+
+        jit_binary_conf_t conf_;
+    };
+
+    jit_uni_binary_t(const pd_t *apd);
+    ~jit_uni_binary_t() = default;
+
+    status_t init(engine_t *engine) override;
+
+    using data_t = int8_t;
+
+    void execute_no_bcast_strategy(const data_t *src0, const data_t *src1,
+            data_t *dst, const float *scale0, const float *scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+            const bcast_t bcast_type) const;
+    void execute_bcast_per_batch_strategy(const data_t *src0,
+            const data_t *src1, data_t *dst, const float *scale0,
+            const float *scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec) const;
+    void execute_bcast_per_c_strategy(const data_t *src0, const data_t *src1,
+            data_t *dst, const float *scale0, const float *scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+            const op_t op_type, const bcast_t bcast_type,
+            const bool blocked_oc_tail) const;
+    void execute_bcast_per_w_strategy(const data_t *src0, const data_t *src1,
+            data_t *dst, const float *scale0, const float *scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+            const op_t op_type, const bool blocked_oc_tail) const;
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    static bool post_ops_ok(const primitive_attr_t *attr,
+            const memory_desc_wrapper &src0_d, const memory_desc_wrapper &dst_d,
+            const bool is_src1_different_layouts);
+
+    std::unique_ptr<binary_kernel_t> kernel_;
+    // used only in bcast_c_blocked strategy if tail exists
+    std::unique_ptr<binary_kernel_t> kernel_tail_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -1,0 +1,766 @@
+/*******************************************************************************
+* Copyright 2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/dnnl_thread.hpp"
+
+#include "cpu/aarch64/jit_uni_binary_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+#define PARAM_OFF(x) ((int32_t)offsetof(jit_binary_call_s, x))
+
+static bcast_set_t get_supported_postops_bcast_strategies() {
+    return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::no_broadcast};
+}
+
+binary_kernel_t::binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
+        const jit_binary_conf_t conf, bool tail_kernel)
+    : jit_generator()
+    , vlen_(vlen)
+    , simd_w_(vlen / sizeof(float))
+    , pd_(pd)
+    , conf_(conf)
+    , is_tail_kernel_(tail_kernel)
+    , is_src1_outer_dims_tail_(
+              conf_.is_src_different_layouts && conf_.outer_dims % simd_w_)
+    , tail_size_(get_tail_size())
+    , padding_tail_size_(
+              pd->src_md(0)->padded_dims[1] - pd->src_md(0)->dims[1]) {}
+
+size_t binary_kernel_t::get_tail_size() const {
+    memory_desc_wrapper src0_d(pd_->src_md(0));
+    const auto &dims = src0_d.dims();
+    const auto &ndims = src0_d.ndims();
+
+    dim_t nelems = 0;
+
+    if (ndims == 1)
+        nelems = dims[0];
+    else if (is_src1_outer_dims_tail_)
+        nelems = conf_.outer_dims;
+    else if (!conf_.is_i8 && conf_.op_type == op_t::c_blocked
+            && (is_tail_kernel_ || conf_.bcast_type == bcast_t::per_w))
+        nelems = dims[1];
+    else if (conf_.bcast_type == bcast_t::none
+            && !conf_.postops_per_oc_broadcast_exists)
+        nelems = src0_d.nelems(true);
+    else if (conf_.bcast_type == bcast_t::per_batch
+            && !conf_.postops_per_oc_broadcast_exists)
+        nelems = src0_d.nelems(true) / dims[0];
+    else {
+        if (conf_.op_type == op_t::n_spatial_c)
+            nelems = dims[1];
+        else if (conf_.op_type == op_t::n_c_spatial && ndims >= 3)
+            nelems = conf_.bcast_type == bcast_t::per_w
+                    ? utils::array_product(
+                            dims + (ndims - conf_.not_bcasted_sp_dims),
+                            conf_.not_bcasted_sp_dims)
+                    : utils::array_product(dims + 2, ndims - 2);
+    }
+    // it's float due to for bfloat16 we still load 16 elements, not 32.
+    return nelems % simd_w_;
+}
+
+template <cpu_isa_t isa>
+jit_uni_binary_kernel_t<isa>::jit_uni_binary_kernel_t(
+        const binary_pd_t *pd, const jit_binary_conf_t conf, bool tail_kernel)
+    : binary_kernel_t(cpu_isa_traits<isa>::vlen, pd, conf, tail_kernel)
+    , offt_src0_(vlen_)
+    , offt_src1_(conf_.use_stride_src1 ? offt_src0_ : 0)
+    , io_(this, isa, {conf_.src0_type, conf_.src1_type, conf_.dst_type},
+              {false},
+              io::io_tail_conf_t {simd_w_, tail_size_, tail_opmask_,
+                      static_cast<int>(vmm_tail_vmask_.getIdx()), reg_tmp_,
+                      reg_tmp1_},
+              create_saturation_vmm_map(),
+              io::io_gather_conf_t {simd_w_, full_mask_,
+                      static_cast<int>(vmm_full_mask_.getIdx()), reg_tmp_,
+                      reg_tmp1_, static_cast<int>(vmm_tmp_gather_.getIdx())}) {
+    init();
+}
+
+template <cpu_isa_t isa>
+std::map<data_type_t, io::io_saturation_conf_t>
+jit_uni_binary_kernel_t<isa>::create_saturation_vmm_map() const {
+
+    std::map<data_type_t, io::io_saturation_conf_t> saturation_map {};
+
+    if (conf_.is_i8)
+        saturation_map.emplace(conf_.dst_type,
+                io::io_saturation_conf_t {static_cast<int>(vreg_zero_.getIdx()),
+                        static_cast<int>(vreg_saturation_ubound_.getIdx()),
+                        reg_tmp_});
+
+    return saturation_map;
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::init() {
+    if (conf_.with_postops) init_post_ops_injector();
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::init_post_ops_injector() {
+    const memory_desc_wrapper dst_d(pd_->dst_md(0));
+    const auto &po = pd_->attr()->post_ops_;
+
+    const eltwise_injector::static_params_t esp(true /*save_state*/,
+            reg_elt_inj_table_, elt_inj_opmask_, elt_inj_p_tmp0_,
+            elt_inj_p_all_, true /*is_fwd*/, false /*use_dst*/);
+    const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
+            reg_elt_inj_table_, true /*preserve gpr*/, true /*preserve vmm*/,
+            PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig), dst_d,
+            tail_size_, tail_opmask_, false /*use_exact_tail_scalar_bcast*/};
+    const binary_injector::static_params_t bsp(this->param1,
+            get_supported_postops_bcast_strategies(), rhs_arg_bsp);
+
+    postops_injector_ = utils::make_unique<
+            injector::jit_uni_postops_injector_t<inject_isa>>(
+            this, po, bsp, esp);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::apply_postops(int unroll, bool tail) {
+    const auto sum_injector = [&]() {
+        for (int i = 0; i < unroll; i++) {
+            const int offt = simd_w_ * i;
+            const Vmm vreg_tmp_src0 = Vmm(i + vmm_start_idx_);
+            const Vmm vreg_tmp = conf_.is_src_different_layouts
+                    ? vmm_gathered_src_
+                    : Vmm(unroll + i + vmm_start_idx_);
+            io_.at(conf_.dst_type)
+                    ->load(dst_ptr(offt
+                                   * types::data_type_size(conf_.dst_type)),
+                            offt, vreg_tmp, tail);
+            fmla(ZRegS(vreg_tmp_src0.getIdx()), P_ALL_ONE / Xbyak_aarch64::T_m,
+                    ZRegS(vreg_tmp.getIdx()), ZRegS(vreg_sum_scale_.getIdx()));
+        }
+    };
+
+    if (conf_.do_sum)
+        postops_injector_->set_lambda_injector(
+                primitive_kind::sum, sum_injector);
+
+    if (conf_.with_binary) {
+        binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
+        const XReg &reg_offt_dst = conf_.is_i8 ? reg_offt_dst_ : reg_offt_src0_;
+
+        const injector_utils::register_preserve_guard_t<isa> register_guard {
+                this, {reg_tmp1_}};
+
+        mov(reg_tmp1_, reg_dst_);
+        add(reg_tmp1_, reg_tmp1_, reg_offt_dst);
+
+        for (int vmm_idx = 1; vmm_idx < unroll + vmm_start_idx_; vmm_idx++) {
+            rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_tmp1_);
+            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(vmm_idx,
+                    (vmm_idx - vmm_start_idx_) * simd_w_
+                            * types::data_type_size(conf_.dst_type));
+            if (tail) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
+        }
+        postops_injector_->compute_vector_range(
+                1, unroll + vmm_start_idx_, rhs_arg_params);
+    } else {
+        postops_injector_->compute_vector_range(1, unroll + vmm_start_idx_);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::load_kernel_params() {
+    mov(W_TMP_0, float2int(conf_.sum_scale));
+    dup(vreg_sum_scale_.s, W_TMP_0);
+
+    assert(sizeof(jit_binary_call_s) <= 255);
+
+    if (is_src1_outer_dims_tail_)
+        ldr(reg_outer_dims_range_, ptr(reg_param_, PARAM_OFF(spat_offt_count)));
+    else
+        ldr(reg_reverse_spat_offt_,
+                ptr(reg_param_, PARAM_OFF(spat_offt_count)));
+
+    ldr(reg_src0_, ptr(reg_param_, PARAM_OFF(src0)));
+    ldr(reg_src1_, ptr(reg_param_, PARAM_OFF(src1)));
+    mov(reg_offt_src0_, reg_src0_);
+    mov(reg_offt_src1_, reg_src1_);
+    ldr(reg_dst_, ptr(reg_param_, PARAM_OFF(dst)));
+    mov(reg_offt_dst_, reg_dst_);
+
+    if (conf_.is_src_different_layouts) {
+        ldr(X_DEFAULT_ADDR, Xbyak_aarch64::ptr(reg_param_, PARAM_OFF(indices)));
+        ld1w(vmm_indices_.s, P_ALL_ONE / Xbyak_aarch64::T_z,
+                ptr(X_DEFAULT_ADDR));
+        ldr(reg_src1_stride_range_,
+                ptr(reg_param_, PARAM_OFF(src1_stride_range)));
+        mov(reg_reverse_src1_stride_range_, reg_src1_stride_range_);
+    }
+    if (conf_.do_scale_src0)
+        ldr(reg_scales_src0_, ptr(reg_param_, PARAM_OFF(scales_src0)));
+    if (conf_.do_scale_src1)
+        ldr(reg_scales_src1_, ptr(reg_param_, PARAM_OFF(scales_src1)));
+}
+
+template <cpu_isa_t isa>
+XReg jit_uni_binary_kernel_t<isa>::src0_ptr(size_t offt) {
+    add_imm(X_DEFAULT_ADDR, reg_offt_src0_, offt, X_TMP_0);
+    add(X_DEFAULT_ADDR, reg_src0_, X_DEFAULT_ADDR);
+    return X_DEFAULT_ADDR;
+}
+
+template <cpu_isa_t isa>
+XReg jit_uni_binary_kernel_t<isa>::src1_ptr(size_t offt) {
+    add_imm(X_DEFAULT_ADDR, reg_offt_src1_, offt, X_TMP_0);
+    add(X_DEFAULT_ADDR, reg_src1_, X_DEFAULT_ADDR);
+    return X_DEFAULT_ADDR;
+}
+
+template <cpu_isa_t isa>
+XReg jit_uni_binary_kernel_t<isa>::dst_ptr(size_t offt) {
+    const XReg &reg_offt_dst = conf_.is_i8 ? reg_offt_dst_ : reg_offt_src0_;
+    add_imm(X_DEFAULT_ADDR, reg_offt_dst, offt, X_TMP_0);
+    add(X_DEFAULT_ADDR, reg_dst_, X_DEFAULT_ADDR);
+    return X_DEFAULT_ADDR;
+}
+
+template <cpu_isa_t isa>
+unsigned int jit_uni_binary_kernel_t<isa>::cmp_predicate(alg_kind_t alg) {
+    using namespace alg_kind;
+    switch (alg) {
+        case binary_ge: return _cmp_nlt_us;
+        case binary_gt: return _cmp_nle_us;
+        case binary_le: return _cmp_le_os;
+        case binary_lt: return _cmp_lt_os;
+        case binary_eq: return _cmp_eq_oq;
+        case binary_ne: return _cmp_neq_uq;
+        default: assert(!"not supported operation!"); return -1;
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::compute_cmp_mask(
+        const Xbyak_aarch64::PReg &dst, const Vmm &src, const Vmm &src2,
+        const unsigned int uimm) {
+    enum {
+        EQ_OQ = 0,
+        LT_OS = 1,
+        LE_OS = 2,
+        UNORD_Q = 3,
+        NEQ_UQ = 4,
+        NLT_US = 5,
+        NLE_US = 6,
+        ORD_Q = 7,
+        EQ_UQ = 8,
+        NGE_US = 9,
+        NGT_US = 10,
+        FALSE_OQ = 11,
+        NEQ_OQ = 12,
+        GE_OS = 13,
+        GT_OS = 14,
+        TRUE_UQ = 15,
+        EQ_OS = 16,
+        LT_OQ = 17,
+        LE_OQ = 18,
+        UNORD_S = 19,
+        NEQ_US = 20,
+        NLT_UQ = 21,
+        NLE_UQ = 22,
+        ORD_S = 23,
+        EQ_US = 24,
+        NGE_UQ = 25,
+        NGT_UQ = 26,
+        FALSE_OS = 27,
+        NEQ_OS = 28,
+        GE_OQ = 29,
+        GT_OQ = 30,
+        TRUE_US = 31,
+    };
+
+    switch (uimm) {
+        case EQ_OQ:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case LT_OS:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case LE_OS:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NEQ_UQ:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NLT_US:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NLE_US:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case EQ_UQ:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NGE_US:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NGT_US:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NEQ_OQ:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case GE_OS:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case GT_OS:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case EQ_OS:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case LT_OQ:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case LE_OQ:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NEQ_US:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NLT_UQ:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NLE_UQ:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case EQ_US:
+            fcmeq(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NGE_UQ:
+            fcmlt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NGT_UQ:
+            fcmle(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case NEQ_OS:
+            fcmne(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case GE_OQ:
+            fcmge(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case GT_OQ:
+            fcmgt(dst.s, P_ALL_ONE / Xbyak_aarch64::T_z, src.s, src2.s);
+            break;
+        case UNORD_Q:
+        case ORD_Q:
+        case FALSE_OQ:
+        case TRUE_UQ:
+        case UNORD_S:
+        case ORD_S:
+        case FALSE_OS:
+        case TRUE_US: assert(!"unsupported compare mode"); break;
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::perform_op(
+        const Vmm &v0, const Vmm &v1, const Vmm &s_src0, const Vmm &s_src1) {
+    using namespace alg_kind;
+    const auto alg = pd_->desc()->alg_kind;
+    const bool cmp_op = utils::one_of(alg, alg_kind::binary_ge,
+            alg_kind::binary_gt, alg_kind::binary_le, alg_kind::binary_lt,
+            alg_kind::binary_eq, alg_kind::binary_ne);
+    if (conf_.do_scale_src0) uni_fmul(v0.s, v0.s, s_src0.s);
+    if (conf_.do_scale_src1 && offt_src1_ != 0 && !conf_.broadcast_src1_value)
+        uni_fmul(v1.s, v1.s, s_src1.s);
+
+    if (alg == binary_add)
+        uni_fadd(v0.s, v0.s, v1.s);
+    else if (alg == binary_mul)
+        uni_fmul(v0.s, v0.s, v1.s);
+    else if (alg == binary_max)
+        uni_fmax(v0.s, v0.s, v1.s);
+    else if (alg == binary_min)
+        uni_fmin(v0.s, v0.s, v1.s);
+    else if (alg == binary_div) {
+        const Vmm v_dummy(DUMMY_IDX);
+        uni_fdiv(v0.s, v0.s, v1.s, v_dummy.s, P_ALL_ONE);
+    } else if (alg == binary_sub)
+        uni_fsub(v0.s, v0.s, v1.s);
+    else if (cmp_op) {
+        const unsigned int predicate = cmp_predicate(alg);
+        if (is_superset(isa, sve_128)) {
+            compute_cmp_mask(cmp_mask, v0, v1, predicate);
+            eor(v0.d, v0.d, v0.d);
+            fmov(v0.s, cmp_mask / Xbyak_aarch64::T_m, 1.0);
+        } else {
+            assert(!"not supported isa!");
+        }
+    } else
+        assert(!"not supported operation!");
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::prepare_isa_kernel() {
+    if (tail_size_ > 0) io_.prepare_tail_mask();
+    if (conf_.is_src_different_layouts && is_superset(isa, sve_128)) {
+        io_.init_full_mask();
+        io_.prepare_full_mask();
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::compute_bcast(bool tail) {
+    if (conf_.broadcast_src1_value) {
+        if (conf_.is_i8) uni_clear(xreg_bcast_src1_);
+        int offt = 0;
+        io_.at(conf_.src1_type)->broadcast(src1_ptr(), offt, vreg_bcast_src1_);
+    } else if (!conf_.is_i8 && offt_src1_ == 0) {
+        int offt = 0;
+        io_.at(conf_.src1_type)->load(src1_ptr(), offt, vreg_bcast_src1_, tail);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::push(const Xbyak_aarch64::XReg &reg) {
+    str(reg, pre_ptr(X_SP, -(reg.getBit() / 8)));
+}
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::pop(const Xbyak_aarch64::XReg &reg) {
+    ldr(reg, post_ptr(X_SP, (reg.getBit() / 8)));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::uni_broadcast(
+        const Vmm &dst, const Xbyak_aarch64::XReg &addr) {
+    ld1rw(ZRegS(dst.getIdx()), P_ALL_ONE, Xbyak_aarch64::ptr(addr));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::load_src1(
+        const Vmm &vreg_src1, const int offt, bool tail) {
+    if (conf_.is_src_different_layouts) {
+        // if different layouts, gather data with strides
+        // after getting to stride range, offset is restored and
+        // increased
+        io_.at(conf_.src1_type)
+                ->gather(reg_src1_, vmm_indices_, vreg_src1, tail);
+        // gather is using register instead of operand to read address
+        // use reg_src1_ directly, without offset stored in second
+        // register
+        add_imm(reg_src1_, reg_src1_,
+                types::data_type_size(conf_.src1_type) * conf_.src1_stride
+                        * simd_w_,
+                X_TMP_0);
+        sub_imm(reg_reverse_src1_stride_range_, reg_reverse_src1_stride_range_,
+                types::data_type_size(conf_.src1_type) * conf_.src1_stride
+                        * simd_w_,
+                X_TMP_1);
+
+        Label src1_stride_range_not_exceed, src1_C_tail_end;
+
+        cmp(reg_reverse_src1_stride_range_, 0);
+        b(GT, src1_stride_range_not_exceed);
+        {
+            pop(reg_src1_);
+            add_imm(reg_src1_, reg_src1_,
+                    types::data_type_size(conf_.src1_type), X_TMP_0);
+            push(reg_src1_);
+            mov(reg_reverse_src1_stride_range_, reg_src1_stride_range_);
+        }
+        L(src1_stride_range_not_exceed);
+    } else {
+        io_.at(conf_.src1_type)
+                ->load(src1_ptr(offt * types::data_type_size(conf_.src1_type)),
+                        offt, vreg_src1, tail);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::compute_dst(int unroll, bool tail) {
+    for (int i = 0; i < unroll; i++) {
+        const Vmm vreg_tmp_src0 = Vmm(i + vmm_start_idx_);
+        const Vmm vreg_tmp = conf_.is_src_different_layouts
+                ? vmm_gathered_src_
+                : Vmm(unroll + i + vmm_start_idx_);
+        const Vmm vreg_tmp_src1 = offt_src1_ ? vreg_tmp : vreg_bcast_src1_;
+        const int offt = simd_w_ * i;
+        io_.at(conf_.src0_type)
+                ->load(src0_ptr(offt * types::data_type_size(conf_.src0_type)),
+                        offt, vreg_tmp_src0, tail);
+        if (offt_src1_) load_src1(vreg_tmp_src1, offt, tail);
+
+        // avoid multiple multiplication on input scale for broadcasted vreg
+        // not needed for different layouts
+        if (!conf_.is_src_different_layouts) {
+            uint8_t dstIdx = vreg_tmp.getIdx();
+            uint8_t srcIdx = vreg_tmp_src1.getIdx();
+            mov(ZRegD(dstIdx), ZRegD(srcIdx));
+        }
+        perform_op(
+                vreg_tmp_src0, vreg_tmp, vreg_scales_src0_, vreg_scales_src1_);
+    }
+    if (postops_injector_) apply_postops(unroll, tail);
+
+    for (int i = 0; i < unroll; i++) {
+        const Vmm vreg_tmp_src0 = Vmm(i + vmm_start_idx_);
+        const int offt = simd_w_ * i;
+        const auto dt_size = types::data_type_size(conf_.dst_type);
+
+        if (is_tail_kernel_ && padding_tail_size_) {
+            // apply zero-padding
+            Label end;
+            auto off_base = 0;
+            auto zero_pad_left = padding_tail_size_;
+
+            // inplace data is assumed to be zero-padded
+            cmp(reg_src0_, reg_dst_);
+            b(EQ, end);
+
+            if (zero_pad_left >= simd_w_ - tail_size_) {
+                uni_clear(vreg_zero_);
+                movprfx(vreg_zero_.s, tail_opmask_ / Xbyak_aarch64::T_m,
+                        vreg_tmp_src0.s);
+                io_.at(conf_.dst_type)
+                        ->store(vreg_zero_, dst_ptr(offt * dt_size), offt,
+                                false);
+                off_base = simd_w_ * dt_size;
+                zero_pad_left -= simd_w_ - tail_size_;
+            } else {
+                io_.at(conf_.dst_type)
+                        ->store(vreg_tmp_src0, dst_ptr(offt * dt_size), offt,
+                                true);
+                off_base = tail_size_ * dt_size;
+            }
+
+            if (zero_pad_left) {
+                const auto off_start = off_base;
+                const auto off_end = off_start + zero_pad_left * dt_size;
+                const int off_ = offt * dt_size + off_start;
+                int count_end = off_end - off_start;
+                for (int count = 0; count < count_end;) {
+                    const int off = off_ + count;
+                    if (count >= 8) {
+                        assert(off % 8 == 0 && offt < (1 << 15));
+                        str(X_TMP_1, ptr(reg_offt_dst_, off));
+                        count += 8;
+                    } else if (count >= 4) {
+                        assert(off % 4 == 0 && offt < (1 << 14));
+                        str(W_TMP_1, ptr(reg_offt_dst_, off));
+                        count += 4;
+                    } else if (count >= 2) {
+                        assert(off % 2 == 0 && offt < (1 << 13));
+                        strh(W_TMP_1, ptr(reg_offt_dst_, off));
+                        count += 2;
+                    } else {
+                        assert(offt < (1 << 12));
+                        strb(W_TMP_1, ptr(reg_offt_dst_, off));
+                        count += 1;
+                    }
+                }
+            }
+            L(end);
+        } else {
+            io_.at(conf_.dst_type)
+                    ->store(vreg_tmp_src0, dst_ptr(offt * dt_size), offt, tail);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::forward() {
+    Label unroll_loop, unroll_loop_tail, nelems_tail, end;
+
+    const auto src0_type_size = types::data_type_size(conf_.src0_type);
+    const auto src1_type_size = types::data_type_size(conf_.src1_type);
+    const auto dst_type_size = types::data_type_size(conf_.dst_type);
+
+    if (conf_.is_src_different_layouts) push(reg_src1_);
+
+    // if outer dims tail, do it outside outer dims loop
+    if (!is_src1_outer_dims_tail_) {
+        if (conf_.is_i8) {
+
+            uint8_t idx = vreg_zero_.getIdx();
+            eor(ZRegD(idx), ZRegD(idx), ZRegD(idx));
+            io_.init_saturate_f32({conf_.dst_type});
+            eor(reg_offt_dst_, reg_offt_dst_,
+                    reg_offt_dst_); // offt_dst to get addr of dst
+        }
+
+        eor(reg_offt_src0_, reg_offt_src0_,
+                reg_offt_src0_); // offt_src0 to get addr of src0/dst
+        if (!conf_.is_src_different_layouts)
+            eor(reg_offt_src1_, reg_offt_src1_,
+                    reg_offt_src1_); // offt_src1 to get addr of src1
+        if (conf_.use_stride_rhs_postops && !conf_.is_i8)
+            eor(reg_off_rhs_postops_, reg_off_rhs_postops_,
+                    reg_off_rhs_postops_);
+    }
+
+    compute_bcast(false); // bcast/load vreg just one time per a kernel call
+
+    // used in c_blocked strategy for last blocked if tail exists
+    const bool treat_each_compute_step_as_tail
+            = !conf_.is_i8 && is_tail_kernel_ && tail_size_;
+
+    if (conf_.do_scale_src0) {
+        uni_broadcast(vreg_scales_src0_, reg_scales_src0_);
+    }
+    if (conf_.do_scale_src1) {
+        uni_broadcast(vreg_scales_src1_, reg_scales_src1_);
+        if (conf_.broadcast_src1_value || offt_src1_ == 0) {
+            uni_fmul(vreg_bcast_src1_.s, vreg_bcast_src1_.s,
+                    vreg_scales_src1_.s);
+        }
+    }
+
+    L(unroll_loop);
+    {
+        const size_t offt = unroll_regs_ * simd_w_;
+        mov_imm(X_TMP_0, offt * dst_type_size);
+        cmp(reg_reverse_spat_offt_, X_TMP_0);
+        b(LT, unroll_loop_tail);
+
+        compute_dst(unroll_regs_, treat_each_compute_step_as_tail);
+        sub_imm(reg_reverse_spat_offt_, reg_reverse_spat_offt_,
+                offt * dst_type_size, X_TMP_0);
+        add_imm(reg_offt_src0_, reg_offt_src0_, offt * src0_type_size, X_TMP_1);
+        if (conf_.is_i8) {
+            if (!conf_.broadcast_src1_value && !conf_.is_src_different_layouts)
+                add_imm(reg_offt_src1_, reg_offt_src1_, offt * src1_type_size,
+                        X_TMP_0);
+            add_imm(reg_offt_dst_, reg_offt_dst_, offt, X_TMP_0);
+        } else {
+            if (conf_.use_stride_src1 && !conf_.is_src_different_layouts)
+                add_imm(reg_offt_src1_, reg_offt_src1_, offt * src1_type_size,
+                        X_TMP_0);
+            if (conf_.use_stride_rhs_postops)
+                add_imm(reg_off_rhs_postops_, reg_off_rhs_postops_, offt,
+                        X_TMP_0);
+        }
+        b(unroll_loop);
+    }
+
+    L(unroll_loop_tail);
+    {
+        mov_imm(X_TMP_0, simd_w_ * dst_type_size);
+        cmp(reg_reverse_spat_offt_, X_TMP_0);
+        b(LT, nelems_tail);
+
+        compute_dst(1, treat_each_compute_step_as_tail);
+        sub_imm(reg_reverse_spat_offt_, reg_reverse_spat_offt_,
+                simd_w_ * dst_type_size, X_TMP_0);
+        add_imm(reg_offt_src0_, reg_offt_src0_, simd_w_ * src0_type_size,
+                X_TMP_1);
+        if (conf_.is_i8) {
+            if (!conf_.broadcast_src1_value && !conf_.is_src_different_layouts)
+                add_imm(reg_offt_src1_, reg_offt_src1_,
+                        simd_w_ * src1_type_size, X_TMP_0);
+            add_imm(reg_offt_dst_, reg_offt_dst_, simd_w_, X_TMP_0);
+        } else {
+            if (conf_.use_stride_src1 && !conf_.is_src_different_layouts)
+                add_imm(reg_offt_src1_, reg_offt_src1_,
+                        simd_w_ * src1_type_size, X_TMP_0);
+            if (conf_.use_stride_rhs_postops)
+                add_imm(reg_off_rhs_postops_, reg_off_rhs_postops_, simd_w_,
+                        X_TMP_0);
+        }
+
+        b(unroll_loop_tail);
+    }
+
+    L(nelems_tail);
+    {
+        cmp_imm(reg_reverse_spat_offt_, 1, X_TMP_0);
+        b(LT, end);
+
+        compute_dst(1, true);
+        // need to increase if forward over outer dims
+        if (is_src1_outer_dims_tail_) {
+            add_imm(reg_offt_src0_, reg_offt_src0_, tail_size_ * src0_type_size,
+                    X_TMP_0);
+            if (conf_.is_i8)
+                add_imm(reg_offt_dst_, reg_offt_dst_, tail_size_, X_TMP_0);
+            else {
+                if (conf_.use_stride_rhs_postops)
+                    add_imm(reg_off_rhs_postops_, reg_off_rhs_postops_,
+                            tail_size_, X_TMP_0);
+            }
+        }
+    }
+
+    L(end);
+    if (conf_.is_src_different_layouts) pop(reg_src1_);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::forward_over_outer_dims() {
+    const auto outer_dims_size
+            = conf_.outer_dims * types::data_type_size(conf_.dst_type);
+
+    if (conf_.is_i8) {
+        uint8_t idx = vreg_zero_.getIdx();
+        eor(ZRegD(idx), ZRegD(idx), ZRegD(idx));
+        io_.init_saturate_f32({conf_.dst_type});
+        eor(reg_offt_dst_, reg_offt_dst_,
+                reg_offt_dst_); // offt_dst to get addr of dst
+    }
+
+    eor(reg_offt_src0_, reg_offt_src0_,
+            reg_offt_src0_); // offt_src0 to get addr of src0/dst
+    if (conf_.use_stride_rhs_postops && !conf_.is_i8)
+        eor(reg_off_rhs_postops_, reg_off_rhs_postops_, reg_off_rhs_postops_);
+
+    Label c_loop;
+    L(c_loop);
+    {
+        mov_imm(reg_reverse_spat_offt_, outer_dims_size);
+        forward();
+        sub_imm(reg_outer_dims_range_, reg_outer_dims_range_, outer_dims_size,
+                X_TMP_0);
+        cmp(reg_outer_dims_range_, 0);
+        b(GT, c_loop);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_kernel_t<isa>::generate() {
+    preamble();
+    load_kernel_params();
+    prepare_isa_kernel();
+    // if outer dims is not aligned to simd_w, iterate over it to avoid
+    // modifying the gather indices
+    if (is_src1_outer_dims_tail_)
+        forward_over_outer_dims();
+    else
+        forward();
+    postamble();
+
+    if ((conf_.with_eltwise || conf_.is_i8) && postops_injector_)
+        postops_injector_->prepare_table();
+}
+
+#undef PARAM_OFF
+
+template struct jit_uni_binary_kernel_t<sve_512>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.hpp
@@ -1,0 +1,164 @@
+/*******************************************************************************
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_UNI_BINARY_KERNEL_HPP
+#define CPU_AARCH64_UNI_BINARY_KERNEL_HPP
+
+#include <cassert>
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+#include "cpu/aarch64/utils/jit_io_helper.hpp"
+
+#include "cpu/cpu_binary_pd.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace Xbyak_aarch64;
+
+struct binary_kernel_t : public jit_generator {
+    using op_t = binary_op_t;
+    using bcast_t = binary_bcast_t;
+
+    binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
+            const jit_binary_conf_t conf, bool tail_kernel = false);
+    ~binary_kernel_t() override = default;
+
+    void operator()(jit_binary_call_s *p) { jit_generator::operator()(p); }
+
+    size_t simd_w() const noexcept { return simd_w_; }
+    size_t vlen() const noexcept { return vlen_; }
+
+protected:
+    size_t get_tail_size() const;
+
+    const size_t vlen_;
+    const size_t simd_w_;
+    constexpr static int vmm_start_idx_ = 1;
+    const binary_pd_t *pd_;
+    const jit_binary_conf_t conf_;
+    const bool is_tail_kernel_;
+    const bool is_src1_outer_dims_tail_;
+    const size_t tail_size_;
+    const size_t padding_tail_size_;
+};
+
+template <cpu_isa_t isa>
+struct jit_uni_binary_kernel_t : public binary_kernel_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_binary_kernel_t)
+
+    using Vmm = typename cpu_isa_traits<isa>::TReg;
+
+    const XReg reg_param_ = abi_param1;
+    const XReg reg_src0_ = x8;
+    const XReg reg_src1_ = x9;
+    const XReg reg_dst_ = x10;
+    const XReg reg_offt_src0_ = x11;
+    const XReg reg_outer_dims_range_ = x12;
+    const XReg reg_offt_src1_ = x1;
+    const XReg reg_src1_stride_range_ = x15;
+    const XReg reg_reverse_src1_stride_range_ = x1;
+    const XReg reg_reverse_spat_offt_ = x13;
+    const XReg reg_tmp_ = x14;
+    const XReg reg_tmp1_ = x6;
+    const XReg reg_elt_inj_table_ = x15;
+    const XReg reg_off_rhs_postops_ = x2;
+    const XReg reg_scales_src0_ = x3;
+    const XReg reg_scales_src1_ = x5;
+    const XReg reg_offt_dst_ = x2;
+    const PReg tail_opmask_ = p2;
+    const PReg cmp_mask = p3;
+    const PReg full_mask_ = p4;
+    const Vmm vmm_tail_vmask_ = Vmm(0);
+    const Vmm vreg_sum_scale_ = Vmm(17);
+    const VReg xreg_sum_scale_ = VReg(9);
+    const Vmm vreg_zero_ = Vmm(18);
+    const Vmm vreg_one_ = Vmm(19);
+    const Vmm vreg_saturation_ubound_ = Vmm(20);
+    const Vmm vreg_bcast_src1_ = Vmm(21);
+    const VReg xreg_bcast_src1_ = VReg(13);
+    const Vmm vreg_scales_src0_ = Vmm(22);
+    const Vmm vreg_scales_src1_ = Vmm(23);
+
+    const Vmm vmm_full_mask_ = Vmm(24);
+    const Vmm vmm_tmp_gather_ = Vmm(25);
+    const Vmm vmm_indices_ = Vmm(30);
+    const Vmm vmm_gathered_src_ = Vmm(31);
+
+    const size_t unroll_regs_ = 8;
+
+    const size_t offt_src0_;
+    const size_t offt_src1_;
+
+    static constexpr cpu_isa_t inject_isa = isa;
+    io::jit_io_multi_dt_helper_t<Vmm> io_;
+    std::unique_ptr<injector::jit_uni_postops_injector_t<inject_isa>>
+            postops_injector_;
+    const PReg elt_inj_opmask_ = p1;
+    const PReg elt_inj_p_tmp0_ = p2;
+    const PReg elt_inj_p_all_ = p3;
+
+    void init();
+    void init_post_ops_injector();
+    void apply_postops(int unroll, bool tail);
+    void load_kernel_params();
+    XReg src0_ptr(size_t offt = 0);
+    XReg src1_ptr(size_t offt = 0);
+    XReg dst_ptr(size_t offt = 0);
+    unsigned int cmp_predicate(alg_kind_t alg);
+    void perform_op(
+            const Vmm &v0, const Vmm &v1, const Vmm &s_src0, const Vmm &s_src1);
+    void prepare_isa_kernel();
+    void compute_bcast(bool tail);
+    void load_src1(const Vmm &vreg_src1, const int offt, bool tail);
+    void compute_dst(int unroll, bool tail);
+    void forward();
+    void forward_over_outer_dims();
+    void generate() override;
+
+    void compute_cmp_mask(const Xbyak_aarch64::PReg &cmp_dst,
+            const Vmm &cmp_src, const Vmm &cmp_src2, const unsigned int uimm);
+
+    void push(const XReg &reg);
+    void pop(const XReg &reg);
+
+    void uni_broadcast(const Vmm &dst, const Xbyak_aarch64::XReg &addr);
+
+    jit_uni_binary_kernel_t(const binary_pd_t *pd, const jit_binary_conf_t conf,
+            bool tail_kernel = false);
+    ~jit_uni_binary_kernel_t() override = default;
+
+    jit_generator *host_;
+    std::map<data_type_t, io::io_saturation_conf_t>
+    create_saturation_vmm_map() const;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -69,7 +69,8 @@ bool jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::post_ops_ok(
 
     auto is_eltwise = [&](int idx) {
         return p.entry_[idx].is_eltwise()
-                && eltwise_injector::is_supported(p.entry_[idx].eltwise.alg);
+                && eltwise_injector::is_supported(
+                        isa, p.entry_[idx].eltwise.alg);
     };
     auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(); };
 

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -151,9 +151,9 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
 
             using namespace data_type;
             bool ok = mayiuse(isa) && !is_fwd() && !has_zero_dim_memory()
-                    && utils::one_of(dst_md()->data_type, f32, bf16)
-                    && utils::one_of(diff_dst_md()->data_type, f32, bf16)
-                    && utils::one_of(diff_src_md()->data_type, f32, bf16)
+                    && utils::one_of(dst_md()->data_type, f32)
+                    && utils::one_of(diff_dst_md()->data_type, f32)
+                    && utils::one_of(diff_src_md()->data_type, f32)
                     && mayiuse(sve_512) && attr()->has_default_values()
                     && set_default_formats() == status::success;
             if (!ok) return status::unimplemented;

--- a/src/cpu/aarch64/utils/jit_io_helper.cpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.cpp
@@ -1,0 +1,815 @@
+/*******************************************************************************
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cassert>
+
+#include "cpu/aarch64/utils/jit_io_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+namespace io {
+
+io_conf_t::io_conf_t(const bool nt_stores_enabled)
+    : nt_stores_enabled_(nt_stores_enabled) {}
+
+io_tail_conf_t::io_tail_conf_t(const std::size_t simd_w,
+        const std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        const int tail_vmm_mask_idx, const Xbyak_aarch64::XReg &reg_tmp,
+        const Xbyak_aarch64::XReg &reg_tmp1)
+    : simd_w_(simd_w)
+    , tail_size_(tail_size)
+    , tail_opmask_(tail_opmask)
+    , tail_vmm_mask_idx_(tail_vmm_mask_idx)
+    , reg_tmp_(reg_tmp)
+    , reg_tmp1_(reg_tmp1) {}
+
+io_saturation_conf_t::io_saturation_conf_t(const int vreg_zero_saturation_idx,
+        const int vreg_saturation_ubound_idx,
+        const Xbyak_aarch64::XReg &reg_tmp)
+    : vreg_zero_saturation_idx_(vreg_zero_saturation_idx)
+    , vreg_saturation_ubound_idx_(vreg_saturation_ubound_idx)
+    , reg_tmp_(reg_tmp) {}
+
+io_gather_conf_t::io_gather_conf_t(const std::size_t simd_w,
+        const Xbyak_aarch64::PReg &full_opmask, const int full_vmm_mask_idx,
+        const Xbyak_aarch64::XReg &reg_tmp, const Xbyak_aarch64::XReg &reg_tmp1,
+        const utils::optional_t<int> &vmm_tmp_idx)
+    : simd_w_(simd_w)
+    , full_opmask_(full_opmask)
+    , full_vmm_mask_idx_(full_vmm_mask_idx)
+    , reg_tmp_(reg_tmp)
+    , reg_tmp1_(reg_tmp1)
+    , vmm_tmp_idx_(vmm_tmp_idx) {}
+
+template <typename Vmm>
+jit_io_helper_t<Vmm>::jit_io_helper_t(jit_generator *host, const cpu_isa_t &isa,
+        const data_type_t &data_type, const io_conf_t &io_conf,
+        const utils::optional_t<io_tail_conf_t> &tail_conf,
+        const utils::optional_t<io_saturation_conf_t> &saturation_conf,
+        const utils::optional_t<io_gather_conf_t> &gather_conf)
+    : host_(host)
+    , isa_(isa)
+    , data_type_(data_type)
+    , io_conf_(io_conf)
+    , tail_conf_(tail_conf)
+    , saturation_conf_(saturation_conf)
+    , gather_conf_(gather_conf) {
+
+    assert(utils::one_of(data_type_, data_type::f32, data_type::s8,
+                   data_type::u8, data_type::s32)
+            && "Supported data types f32, s8, u8, s32");
+
+    static constexpr bool is_zmm
+            = std::is_same<Vmm, Xbyak_aarch64::ZReg>::value;
+    MAYBE_UNUSED(is_zmm);
+    assert(IMPLICATION(!is_superset(isa_, sve_128), !is_zmm)
+            && "This architecture does not support z registers.");
+}
+
+template <typename Vmm>
+jit_io_helper_t<Vmm>::~jit_io_helper_t() = default;
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::prepare_opmask(
+        const std::size_t how_many_bits_to_set,
+        const Xbyak_aarch64::XReg &reg_tmp0,
+        const Xbyak_aarch64::XReg &reg_tmp1, const Xbyak_aarch64::PReg &mask) {
+    host_->mov_imm(reg_tmp0, 0);
+
+    host_->mov_imm(host_->X_TMP_2, how_many_bits_to_set);
+    host_->whilelt(mask.s, reg_tmp0, host_->X_TMP_2);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::prepare_tail_mask() {
+    assert(tail_conf_.has_value() && "Config for tail processing is not set.");
+
+    if (!tail_conf_->tail_size_) return;
+
+    assert(is_superset(isa_, sve_128));
+
+    prepare_opmask(tail_conf_->tail_size_, tail_conf_->reg_tmp_,
+            tail_conf_->reg_tmp1_, tail_conf_->tail_opmask_);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::prepare_full_mask() {
+    assert(gather_conf_.has_value() && "Config for loading with the use of gather instruction is not set.");
+
+    assert(is_superset(isa_, sve_128));
+
+    prepare_opmask(gather_conf_->simd_w_, gather_conf_->reg_tmp_,
+            gather_conf_->reg_tmp1_, gather_conf_->full_opmask_);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::init_full_mask() {
+    assert(gather_conf_.has_value() && "Config for loading with the use of gather instruction is not set.");
+
+    if (isa_ == sve_256) {
+        const Vmm vmm_mask = Vmm(gather_conf_->full_vmm_mask_idx_);
+        host_->eor(Xbyak_aarch64::ZReg(vmm_mask.getIdx()).d,
+                Xbyak_aarch64::ZReg(vmm_mask.getIdx()).d,
+                Xbyak_aarch64::ZReg(vmm_mask.getIdx()).d);
+        host_->mov(Xbyak_aarch64::ZReg(vmm_mask.getIdx()).s,
+                host_->P_NOT_256 / Xbyak_aarch64::T_m, 0);
+    }
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::init_saturate_f32() const {
+    assert(saturation_conf_.has_value() && "Config for saturation is not set.");
+
+    if (utils::one_of(data_type_, data_type::u8, data_type::s8, data_type::s32))
+        host_->init_saturate_f32(
+                Vmm(saturation_conf_->vreg_zero_saturation_idx_),
+                Vmm(saturation_conf_->vreg_saturation_ubound_idx_),
+                saturation_conf_->reg_tmp_, data_type::f32, data_type_);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::gather(const Xbyak_aarch64::XReg &src_reg,
+        const Vmm &indices_vmm, const Vmm &dst_vmm, const bool tail) {
+    assert(gather_conf_.has_value() && "Config for loading with the use of gather instruction is not set.");
+    assert(IMPLICATION(tail, tail_conf_.has_value())
+            && "Config for tail processing is not set.");
+
+    const Xbyak_aarch64::PReg mask
+            = tail ? tail_conf_->tail_opmask_ : gather_conf_->full_opmask_;
+
+    switch (data_type_) {
+        case data_type::f32:
+        case data_type::s32:
+            host_->ld1w({dst_vmm.s}, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(
+                            src_reg, indices_vmm.s, Xbyak_aarch64::SXTW));
+            if (data_type_ == data_type::s32)
+                convert_to_f32(dst_vmm, dst_vmm, data_type_);
+            break;
+        case data_type::s8:
+            host_->ld1sb({dst_vmm.s}, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(
+                            src_reg, indices_vmm.s, Xbyak_aarch64::SXTW));
+            break;
+        case data_type::u8:
+            host_->ld1b({dst_vmm.s}, mask / Xbyak_aarch64::T_z,
+                    Xbyak_aarch64::ptr(
+                            src_reg, indices_vmm.s, Xbyak_aarch64::SXTW));
+            break;
+        default: assert(!"Unsupported data type.");
+    }
+
+    if (data_type_ != data_type::f32)
+        convert_to_f32(dst_vmm, dst_vmm, data_type::s32);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::load(const Xbyak_aarch64::XReg &src_addr,
+        const int offt, const Vmm &dst_raw_vmm, const bool tail) {
+    assert(IMPLICATION(tail, tail_conf_.has_value())
+            && "Config for tail processing is not set.");
+
+    Xbyak_aarch64::PReg mask
+            = tail ? tail_conf_->tail_opmask_ : host_->P_ALL_ONE;
+
+    switch (data_type_) {
+        case data_type::f32:
+            load_f32(src_addr, offt, dst_raw_vmm, tail, mask);
+            break;
+        case data_type::s32:
+            load_s32(src_addr, offt, dst_raw_vmm, tail, mask);
+            break;
+        case data_type::s8:
+        case data_type::u8: load_i8(src_addr, offt, dst_raw_vmm, mask); break;
+        default: assert(!"Unsupported data type.");
+    }
+}
+
+#if 0
+/**
+* load_bytes is the utility function to facilitate loading of
+* load_size (0 <= load_size <= 32) many contiguous bytes into the Xmm/Ymm
+* register from the memory referenced by ptr[reg + offset] address.
+*
+* Functionally, invocation of load_bytes is equivalent to
+* the following loop:
+*
+* for (int idx = 0; idx < load_size; ++idx)
+*     vpinsrb(xmm, xmm, ptr[reg + offset + idx], idx);
+*
+* TODO: Add an option to zero-out unloaded bytes in the Xmm register.
+* TODO: Add an option for unsafe_load wherein one could read outside the
+* provided memory buffer so as to minimize the total number of read
+* memory instructions.
+*/
+static void load_bytes(jit_generator *host, const Xbyak_aarch64::VReg &vmm,
+        const Xbyak_aarch64::XReg reg_addr, int load_size) {
+    if (load_size == 32) {
+        host->not_(host->P_TMP.b, host->P_ALL_ONE / Xbyak_aarch64::T_z,
+                host->P_NOT_256.b);
+        host->ld1w(Xbyak_aarch64::ZRegS(vmm.getIdx()),
+                host->P_TMP / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(reg_addr));
+        return;
+    }
+    int start_bytes = 0;
+    int bytes_to_load = load_size;
+
+    if (load_size > 16) {
+        start_bytes = 16;
+        bytes_to_load -= 16;
+    }
+
+    if (bytes_to_load >= 8 && bytes_to_load < 16) {
+        host->add_imm(
+                host->X_DEFAULT_ADDR, reg_addr, start_bytes, host->X_TMP_0);
+        host->ldr(host->X_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+        host->mov(vmm.b16, vmm.b16);
+        host->ins(Xbyak_aarch64::VReg2D(vmm.getIdx())[0], host->X_TMP_0);
+    } else if (bytes_to_load == 16) {
+        host->add_imm(
+                host->X_DEFAULT_ADDR, reg_addr, start_bytes, host->X_TMP_0);
+        host->ldr(Xbyak_aarch64::QReg(vmm.getIdx()),
+                Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+    }
+
+    host->add_imm(host->X_DEFAULT_ADDR, reg_addr, start_bytes, host->X_TMP_0);
+    switch (bytes_to_load) {
+        case 0: break;
+        case 1:
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[0], host->W_TMP_0);
+            break;
+        case 2:
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[0], host->W_TMP_0);
+            break;
+        case 3:
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[0], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 2);
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[2], host->W_TMP_0);
+            break;
+        case 4:
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[0], host->W_TMP_0);
+            break;
+        case 5:
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[0], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 4);
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[4], host->W_TMP_0);
+            break;
+        case 6:
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[0], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 4);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[2], host->W_TMP_0);
+            break;
+        case 7:
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_DEFAULT_ADDR));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[0], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 4);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[2], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 6);
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[6], host->W_TMP_0);
+            break;
+        case 8: break;
+        case 9:
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 8);
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[8], host->W_TMP_0);
+            break;
+        case 10:
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 8);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[4], host->W_TMP_0);
+            break;
+        case 11:
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 8);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[4], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 10);
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[10], host->W_TMP_0);
+            break;
+        case 12:
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 8);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[2], host->W_TMP_0);
+            break;
+        case 13:
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 8);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[2], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 12);
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[12], host->W_TMP_0);
+            break;
+        case 14:
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 8);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[2], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 12);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[6], host->W_TMP_0);
+            break;
+        case 15:
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 8);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->ins(Xbyak_aarch64::VReg4S(vmm.getIdx())[2], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 12);
+            host->ldr(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(Xbyak_aarch64::VReg8H(vmm.getIdx())[6], host->W_TMP_0);
+            host->add(host->X_TMP_1, host->X_DEFAULT_ADDR, 14);
+            host->ldrb(host->W_TMP_0, Xbyak_aarch64::ptr(host->X_TMP_1));
+            host->mov(vmm.b16, vmm.b16);
+            host->ins(vmm.b16[14], host->W_TMP_0);
+            break;
+        case 16: break;
+        default: assert(!"improper load size");
+    }
+
+    if (load_size > 16) {
+        host->str(host->z31,
+                Xbyak_aarch64::ptr(
+                        host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+        const Xbyak_aarch64::ZReg z_vmm(vmm.getIdx());
+        const Xbyak_aarch64::ZReg z_tmp(host->z31.getIdx());
+        host->ptrue(host->P_TMP.d, Xbyak_aarch64::VL2);
+        host->mov(z_tmp.d, z_vmm.d);
+        host->splice(z_tmp.d, host->P_TMP.d, z_vmm.d);
+        host->mov(z_vmm.d, z_tmp.d);
+        host->mov(z_vmm.s, host->P_NOT_256 / Xbyak_aarch64::T_m, 0);
+        host->ld1w(z_tmp.d, host->P_ALL_ONE / Xbyak_aarch64::T_z,
+                Xbyak_aarch64::ptr(reg_addr));
+        host->ptrue(host->P_TMP.d, Xbyak_aarch64::VL2);
+        host->sel(z_vmm.d, host->P_TMP, z_tmp.d, z_vmm.d);
+        host->mov(z_vmm.s, host->P_NOT_256 / Xbyak_aarch64::T_m, 0);
+        host->ldr(host->z31,
+                Xbyak_aarch64::ptr(
+                        host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+    }
+}
+
+/**
+* load_bytes_to_dword_extension is the utility function to facilitate
+* loading of load_size (0 <= load_size <= 16) many contiguous bytes in
+* the Xmm register from the memory referenced by ptr[reg + offset]
+* address and then do signed/zero extension of those to double words.
+*
+* Functionally, invocation of load_bytes_to_dword_extension is equivalent
+* to the following:
+*
+* for (int idx = 0; idx < load_size; ++idx)
+*     vpinsrb(xmm, xmm, ptr[reg + offset + idx], idx);
+* if (is_signed) vpmovsxbd(vmm, vmm); else vpmovzxbd(vmm, vmm);
+*
+* Valid values for the load_size variable are:
+* [0..4] for XMM version of the function
+* [0..8] for YMM version of the function.
+* TODO: Implement this routine for every ISA.
+*/
+static void load_bytes_to_dword_extension(jit_generator *host,
+        const Xbyak_aarch64::VReg &vmm, const Xbyak_aarch64::XReg &reg_addr,
+        bool is_signed, int load_size) {
+    if (host->cpu_sveLen == Xbyak_aarch64::util::SVE_128) {
+        assert(load_size >= 0 && load_size <= 8);
+    } else if (host->cpu_sveLen == Xbyak_aarch64::util::SVE_256) {
+        assert(load_size >= 0 && load_size <= 4);
+    } else {
+        assert(!"routine is not supported for the current isa");
+    }
+    host->str(host->z31,
+            Xbyak_aarch64::ptr(
+                    host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+    // For load_size == 8/4, do load/extension in one go
+    const Xbyak_aarch64::ZReg z_tmp(host->z31.getIdx());
+    if (load_size == 8) {
+        const Xbyak_aarch64::ZReg z_vmm(vmm.getIdx());
+        if (is_signed) {
+            host->ld1sb(z_tmp.s, host->P_NOT_256, Xbyak_aarch64::ptr(reg_addr));
+        } else {
+            host->ld1b(z_tmp.s, host->P_NOT_256, Xbyak_aarch64::ptr(reg_addr));
+        }
+    } else if (load_size == 4) {
+        const Xbyak_aarch64::ZReg z_vmm(vmm.getIdx());
+        if (is_signed) {
+            host->ld1sb(z_tmp.s, host->P_NOT_128, Xbyak_aarch64::ptr(reg_addr));
+        } else {
+            host->ld1b(z_tmp.s, host->P_NOT_128, Xbyak_aarch64::ptr(reg_addr));
+        }
+    } else {
+        load_bytes(host, vmm, reg_addr, load_size);
+        if (is_signed) {
+            host->mov(z_tmp.d, host->P_ALL_ONE,
+                    Xbyak_aarch64::ZRegD(vmm.getIdx()));
+            host->sxtl(Xbyak_aarch64::VReg8H(vmm.getIdx()),
+                    Xbyak_aarch64::VReg8B(vmm.getIdx()));
+            host->sxtl(Xbyak_aarch64::VReg4S(vmm.getIdx()),
+                    Xbyak_aarch64::VReg4H(vmm.getIdx()));
+            host->mov(Xbyak_aarch64::ZRegD(vmm.getIdx()), host->P_NOT_128,
+                    z_tmp.d);
+        } else {
+            host->mov(z_tmp.d, host->P_ALL_ONE,
+                    Xbyak_aarch64::ZRegD(vmm.getIdx()));
+            host->uxtl(Xbyak_aarch64::VReg8H(vmm.getIdx()),
+                    Xbyak_aarch64::VReg8B(vmm.getIdx()));
+            host->uxtl(Xbyak_aarch64::VReg4S(vmm.getIdx()),
+                    Xbyak_aarch64::VReg4H(vmm.getIdx()));
+            host->mov(Xbyak_aarch64::ZRegD(vmm.getIdx()), host->P_NOT_128,
+                    z_tmp.d);
+        }
+    }
+    host->ldr(host->z31,
+            Xbyak_aarch64::ptr(
+                    host->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+}
+template <typename Vmm>
+void load_data(jit_generator *host, data_type_t type_in, const Vmm &vmm,
+        const Xbyak_aarch64::XReg &src_addr, int load_size) {
+
+    switch (type_in) {
+        case data_type::f32:
+        case data_type::s32:
+            load_bytes(host, Xbyak_aarch64::VReg(vmm.getIdx()), src_addr,
+                    sizeof(int32_t) * load_size);
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            load_bytes_to_dword_extension(host,
+                    Xbyak_aarch64::VReg(vmm.getIdx()), src_addr,
+                    type_in == data_type::s8, load_size);
+            break;
+        default: assert(!"unsupported source data type");
+    }
+}
+#endif
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::load_f32(const Xbyak_aarch64::XReg &src_addr,
+        const int offt, const Vmm &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+
+    host_->ld1w(
+            dst_vmm.s, mask / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(src_addr));
+}
+
+template <>
+void jit_io_helper_t<Xbyak_aarch64::VReg>::load_f32(
+        const Xbyak_aarch64::XReg &src_addr, const int offt,
+        const Xbyak_aarch64::VReg &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    UNUSED(src_addr);
+    UNUSED(offt);
+    UNUSED(dst_vmm);
+    UNUSED(tail);
+
+    assert(!"under construction");
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::load_s32(const Xbyak_aarch64::XReg &src_addr,
+        const int offt, const Vmm &dst_vmm, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    host_->ld1w(
+            dst_vmm.s, mask / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(src_addr));
+    host_->scvtf(dst_vmm.s, host_->P_TMP / Xbyak_aarch64::T_m, dst_vmm.s);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::load_i8(const Xbyak_aarch64::XReg &src_addr,
+        const int offt, const Vmm &dst_vmm, const Xbyak_aarch64::PReg &mask) {
+
+    if (data_type_ == data_type::s8)
+        host_->ld1sb(dst_vmm.s, mask / Xbyak_aarch64::T_z,
+                Xbyak_aarch64::ptr(src_addr));
+    else
+        host_->ld1b(dst_vmm.s, mask / Xbyak_aarch64::T_z,
+                Xbyak_aarch64::ptr(src_addr));
+
+    convert_to_f32(dst_vmm, dst_vmm, data_type::s32);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::store(const Vmm &src_raw_vmm,
+        const Xbyak_aarch64::XReg &dst_raw_addr, const int offt,
+        const bool tail) {
+    assert(IMPLICATION(tail, tail_conf_.has_value())
+            && "Config for tail processing is not set.");
+    assert(!(tail && io_conf_.nt_stores_enabled_)
+            && "Usage of non-temporal stores with tail leads to a general-protection exception.");
+
+    Xbyak_aarch64::PReg mask
+            = tail ? tail_conf_->tail_opmask_ : host_->P_ALL_ONE;
+    const bool is_i8 = utils::one_of(data_type_, data_type::s8, data_type::u8);
+
+    if (data_type_ == data_type::s32 || is_i8) saturate(src_raw_vmm);
+
+    switch (data_type_) {
+        case data_type::f32:
+        case data_type::s32:
+            store_f32(src_raw_vmm, dst_raw_addr, offt, tail, mask);
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            store_i8(src_raw_vmm, dst_raw_addr, offt, mask);
+            break;
+        default: assert(!"Unsupported data type.");
+    }
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::saturate(const Vmm &vmm) {
+    assert(saturation_conf_.has_value() && "Config for saturation is not set.");
+
+    host_->saturate_f32(vmm, Vmm(saturation_conf_->vreg_zero_saturation_idx_),
+            Vmm(saturation_conf_->vreg_saturation_ubound_idx_), data_type_,
+            host_->P_ALL_ONE);
+    host_->frintn(vmm.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m,
+            vmm.s); // Round to nearest even
+    host_->fcvtzs(vmm.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, vmm.s);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::store_f32(const Vmm &src_vmm,
+        const Xbyak_aarch64::XReg &dst_addr, const int offt, const bool tail,
+        const Xbyak_aarch64::PReg &mask) {
+    if (io_conf_.nt_stores_enabled_) {
+        host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
+                Xbyak_aarch64::ptr(dst_addr));
+    } else if (!is_superset(isa_, sve_512) && tail) {
+        const Xbyak_aarch64::ZReg src(tail_conf_->tail_vmm_mask_idx_);
+        const Xbyak_aarch64::ZReg src2(src_vmm.getIdx());
+        host_->cmplt(host_->P_TMP.s, mask / Xbyak_aarch64::T_z, src.s, 0);
+        host_->st1w(src2.s, host_->P_TMP / Xbyak_aarch64::T_m,
+                Xbyak_aarch64::ptr(dst_addr));
+    } else {
+        host_->st1w(Xbyak_aarch64::ZRegS(src_vmm.getIdx()), mask,
+                Xbyak_aarch64::ptr(dst_addr));
+    }
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::store_i8_sdb(Xbyak_aarch64::XReg addr,
+        const Vmm &src_vmm, const Xbyak_aarch64::PReg &mask) {
+    host_->str(host_->z31,
+            Xbyak_aarch64::ptr(
+                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+    const Xbyak_aarch64::ZReg z_tmp(host_->z31.getIdx());
+    host_->mov(z_tmp.d, Xbyak_aarch64::ZRegD(src_vmm.getIdx()));
+    host_->smin(z_tmp.s, 127);
+    host_->smax(z_tmp.s, -128);
+    host_->st1b(z_tmp.s, mask, Xbyak_aarch64::ptr(addr));
+    host_->ldr(host_->z31,
+            Xbyak_aarch64::ptr(
+                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+}
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::store_i8_udb(Xbyak_aarch64::XReg addr,
+        const Vmm &src_vmm, const Xbyak_aarch64::PReg &mask) {
+    host_->str(host_->z31,
+            Xbyak_aarch64::ptr(
+                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+    const Xbyak_aarch64::ZReg z_tmp(host_->z31.getIdx());
+    host_->mov(z_tmp.d, Xbyak_aarch64::ZRegD(src_vmm.getIdx()));
+    host_->umin(z_tmp.s, 255);
+    host_->st1b(z_tmp.s, mask, Xbyak_aarch64::ptr(addr));
+    host_->ldr(host_->z31,
+            Xbyak_aarch64::ptr(
+                    host_->X_TRANSLATOR_STACK, -1, Xbyak_aarch64::MUL_VL));
+}
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::store_i8(const Vmm &src_vmm,
+        const Xbyak_aarch64::XReg &dst_addr, const int offt,
+        const Xbyak_aarch64::PReg &mask) {
+    using namespace std::placeholders;
+    static constexpr bool is_zmm
+            = std::is_same<Vmm, Xbyak_aarch64::ZReg>::value;
+
+    auto store_i8_fn = data_type_ == data_type::s8
+            ? std::bind(&jit_io_helper_t::store_i8_sdb, this, _1, _2, _3)
+            : std::bind(&jit_io_helper_t::store_i8_udb, this, _1, _2, _3);
+
+    if (io_conf_.nt_stores_enabled_ && is_zmm) {
+        host_->not_(
+                host_->P_TMP.b, mask / Xbyak_aarch64::T_z, host_->P_NOT_128.b);
+        host_->stnt1d(Xbyak_aarch64::ZRegD(src_vmm.getIdx()), mask,
+                Xbyak_aarch64::ptr(dst_addr));
+    } else {
+        store_i8_fn(dst_addr, src_vmm, mask);
+    }
+}
+
+template <typename Vmm>
+void uni_vpmovsxbd(jit_generator *host_, const Vmm &dst, const Vmm &src) {
+    Xbyak_aarch64::ZReg z_dst(dst.getIdx());
+    Xbyak_aarch64::ZReg z_src(src.getIdx());
+    host_->zip1(z_dst.b, z_src.b, z_src.b);
+    host_->zip1(z_dst.h, z_dst.h, z_dst.h);
+    host_->sxtb(z_dst.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, z_dst.s);
+}
+
+template <typename Vmm>
+void uni_vpmovzxbd(jit_generator *host_, const Vmm &dst, const Vmm &src) {
+    Xbyak_aarch64::ZReg z_dst(dst.getIdx());
+    Xbyak_aarch64::ZReg z_src(src.getIdx());
+    host_->zip1(z_dst.b, z_src.b, z_src.b);
+    host_->zip1(z_dst.h, z_dst.h, z_dst.h);
+    host_->uxtb(z_dst.s, host_->P_ALL_ONE / Xbyak_aarch64::T_m, z_dst.s);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::convert_to_f32(const Vmm &dst_vmm,
+        const Vmm &src_vmm, const data_type_t src_data_type) {
+    switch (src_data_type) {
+        case data_type::f32: // Do nothing
+            break;
+        case data_type::s32: {
+            assert(dst_vmm.getIdx() == src_vmm.getIdx());
+            host_->uni_scvtf(dst_vmm.s, dst_vmm.s);
+            break;
+        }
+        case data_type::s8: {
+            uni_vpmovsxbd(host_, dst_vmm, src_vmm);
+            host_->uni_scvtf(dst_vmm.s, dst_vmm.s);
+            break;
+        }
+        case data_type::u8: {
+            uni_vpmovzxbd(host_, dst_vmm, src_vmm);
+            host_->uni_scvtf(dst_vmm.s, dst_vmm.s);
+            break;
+        }
+        default: assert(!"Unsupported data type.");
+    }
+}
+
+template <typename Vmm>
+void uni_vbroadcastss(
+        jit_generator *host_, const Vmm &dst, const Xbyak_aarch64::XReg &src) {
+    uint8_t dstIdx = dst.getIdx();
+    host_->ld1rw(Xbyak_aarch64::ZRegS(dstIdx),
+            host_->P_ALL_ONE / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(src));
+}
+template <typename Vmm>
+void uni_vbroadcastss(
+        jit_generator *host_, const Vmm &dst, const Xbyak_aarch64::VReg &src) {
+    uint8_t dstIdx = dst.getIdx();
+    uint8_t srcIdx = src.getIdx();
+    host_->dup(Xbyak_aarch64::ZRegS(dstIdx), Xbyak_aarch64::ZRegS(srcIdx)[0]);
+}
+
+template <typename Vmm>
+void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
+        const int offt, const Vmm &dst_vmm) {
+    switch (data_type_) {
+        case data_type::f32: uni_vbroadcastss(host_, dst_vmm, src_addr); break;
+        case data_type::s32: {
+            if (is_superset(isa_, sve_512)) {
+                if (host_->cpu_sveLen == sve_128) {
+                    host_->ld1(Xbyak_aarch64::VReg(dst_vmm.getIdx()).s4,
+                            Xbyak_aarch64::ptr(src_addr));
+                } else {
+                    host_->ld1w(Xbyak_aarch64::ZRegD(dst_vmm.getIdx()),
+                            host_->P_ALL_ONE / Xbyak_aarch64::T_z,
+                            Xbyak_aarch64::ptr(src_addr));
+                    host_->mov(host_->P_TMP.b, host_->P_ALL_ONE.b);
+                    host_->scvtf(Xbyak_aarch64::ZReg(dst_vmm.getIdx()).s,
+                            host_->P_TMP / Xbyak_aarch64::T_m,
+                            Xbyak_aarch64::ZReg(dst_vmm.getIdx()).s);
+                    ;
+                    if (host_->cpu_sveLen == sve_256)
+                        host_->mov(Xbyak_aarch64::ZReg(dst_vmm.getIdx()).s,
+                                host_->P_NOT_256 / Xbyak_aarch64::T_m, 0);
+                }
+            } else {
+                uni_vbroadcastss(host_, dst_vmm, src_addr);
+                convert_to_f32(dst_vmm, dst_vmm, data_type_);
+            }
+            break;
+        }
+        case data_type::s8:
+        case data_type::u8: {
+            const Xbyak_aarch64::VReg dst_xmm {dst_vmm.getIdx()};
+            host_->ldrb(host_->W_TMP_0, Xbyak_aarch64::ptr(src_addr));
+            host_->mov(dst_xmm.b16, dst_xmm.b16);
+            host_->ins(dst_xmm.b16[0], host_->W_TMP_0);
+            convert_to_f32(dst_vmm, dst_vmm, data_type_);
+            uni_vbroadcastss(host_, dst_vmm, dst_xmm);
+
+            break;
+        }
+        default: assert(!"Unsupported data type.");
+    }
+}
+
+template <typename Vmm>
+jit_io_multi_dt_helper_t<Vmm>::jit_io_multi_dt_helper_t(jit_generator *host,
+        const cpu_isa_t &isa, const data_types_t &data_types,
+        const io_conf_t &io_conf,
+        const utils::optional_t<io_tail_conf_t> &tail_conf,
+        const std::map<data_type_t, io_saturation_conf_t> &saturation_confs,
+        const utils::optional_t<io_gather_conf_t> &gather_conf) {
+    assert(!data_types.empty());
+    for (const auto &dt : data_types) {
+        // can be replaced by try_emplace from C++17
+        if (storage_.find(dt) == storage_.cend()) {
+
+            const auto saturation_conf = saturation_confs.find(dt);
+            const bool store_saturation_needed
+                    = saturation_conf != saturation_confs.cend();
+
+            storage_.emplace(dt,
+                    std::make_shared<jit_io_helper_t<Vmm>>(host, isa, dt,
+                            io_conf, tail_conf,
+                            store_saturation_needed ? utils::optional_t<
+                                    io_saturation_conf_t> {saturation_conf
+                                                                   ->second}
+                                                    : utils::nullopt,
+                            gather_conf));
+        }
+    }
+}
+
+template <typename Vmm>
+std::shared_ptr<jit_io_helper_t<Vmm>> jit_io_multi_dt_helper_t<Vmm>::at(
+        const data_type_t dt) const {
+    const auto it = storage_.find(dt);
+    if (it != storage_.cend()) return it->second;
+
+    return nullptr;
+}
+
+template <typename Vmm>
+void jit_io_multi_dt_helper_t<Vmm>::prepare_tail_mask() {
+    return storage_.cbegin()->second->prepare_tail_mask();
+}
+
+template <typename Vmm>
+void jit_io_multi_dt_helper_t<Vmm>::prepare_full_mask() {
+    return storage_.cbegin()->second->prepare_full_mask();
+}
+
+template <typename Vmm>
+void jit_io_multi_dt_helper_t<Vmm>::init_saturate_f32(
+        const data_types_t &store_data_types) {
+    for (const auto &dt : store_data_types) {
+        const auto it = storage_.find(dt);
+        if (it != storage_.cend()) {
+            if (it->second->saturation_conf_.has_value())
+                it->second->init_saturate_f32();
+        }
+    }
+}
+
+template <typename Vmm>
+void jit_io_multi_dt_helper_t<Vmm>::init_full_mask() {
+    return storage_.cbegin()->second->init_full_mask();
+}
+
+template <typename Vmm>
+jit_io_multi_dt_helper_t<Vmm>::~jit_io_multi_dt_helper_t() = default;
+
+template class jit_io_helper_t<Xbyak_aarch64::ZReg>;
+template class jit_io_multi_dt_helper_t<Xbyak_aarch64::ZReg>;
+
+} // namespace io
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/utils/jit_io_helper.hpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.hpp
@@ -1,0 +1,211 @@
+/*******************************************************************************
+* Copyright 2021-2022 Intel Corporation
+* Copyright 2022 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_UTILS_JIT_IO_HELPER_HPP
+#define CPU_AARCH64_UTILS_JIT_IO_HELPER_HPP
+
+#include <map>
+#include <memory>
+#include <unordered_set>
+
+#include "common/optional.hpp"
+
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace io {
+
+class io_conf_t {
+public:
+    io_conf_t() = default;
+    io_conf_t(const bool nt_stores_enabled);
+    io_conf_t(const io_conf_t &other) = default;
+
+    io_conf_t &operator=(const io_conf_t &other) = default;
+
+    bool nt_stores_enabled_ = false;
+};
+
+class io_tail_conf_t {
+public:
+    io_tail_conf_t(const std::size_t simd_w, const std::size_t tail_size,
+            const Xbyak_aarch64::PReg &tail_opmask, const int tail_vmm_mask_idx,
+            const Xbyak_aarch64::XReg &reg_tmp,
+            const Xbyak_aarch64::XReg &reg_tmp1);
+    io_tail_conf_t(const io_tail_conf_t &other) = default;
+
+    io_tail_conf_t &operator=(const io_tail_conf_t &other) = default;
+
+    std::size_t simd_w_ = 0;
+    std::size_t tail_size_ = 0;
+    Xbyak_aarch64::PReg tail_opmask_ = Xbyak_aarch64::PReg(1);
+    int tail_vmm_mask_idx_ = 0;
+    Xbyak_aarch64::XReg reg_tmp_ = Xbyak_aarch64::XReg(26);
+    Xbyak_aarch64::XReg reg_tmp1_ = Xbyak_aarch64::XReg(25);
+};
+
+class io_saturation_conf_t {
+public:
+    io_saturation_conf_t(const int vreg_zero_saturation_idx,
+            const int vreg_saturation_ubound_idx,
+            const Xbyak_aarch64::XReg &reg_tmp);
+    io_saturation_conf_t(const io_saturation_conf_t &other) = default;
+
+    io_saturation_conf_t &operator=(const io_saturation_conf_t &other)
+            = default;
+
+    int vreg_zero_saturation_idx_ = 0;
+    int vreg_saturation_ubound_idx_ = 0;
+    Xbyak_aarch64::XReg reg_tmp_ = Xbyak_aarch64::XReg(26);
+};
+
+class io_gather_conf_t {
+public:
+    io_gather_conf_t(const std::size_t simd_w,
+            const Xbyak_aarch64::PReg &full_opmask, const int full_vmm_mask_idx,
+            const Xbyak_aarch64::XReg &reg_tmp,
+            const Xbyak_aarch64::XReg &reg_tmp1,
+            const utils::optional_t<int> &vmm_tmp_idx = utils::nullopt);
+    io_gather_conf_t(const io_gather_conf_t &other) = default;
+
+    io_gather_conf_t &operator=(const io_gather_conf_t &other) = default;
+
+    std::size_t simd_w_ = 0;
+    Xbyak_aarch64::PReg full_opmask_ = Xbyak_aarch64::PReg(0);
+    int full_vmm_mask_idx_ = 0;
+    Xbyak_aarch64::XReg reg_tmp_ = Xbyak_aarch64::XReg(26);
+    Xbyak_aarch64::XReg reg_tmp1_ = Xbyak_aarch64::XReg(25);
+    // It is needed, when io_helper use emulation for gather
+    // and it is not needed for sse.
+    utils::optional_t<int> vmm_tmp_idx_ = utils::nullopt;
+};
+
+template <typename Vmm>
+class jit_io_multi_dt_helper_t;
+
+template <typename Vmm>
+class jit_io_helper_t {
+public:
+    friend class jit_io_multi_dt_helper_t<Vmm>;
+
+    jit_io_helper_t(jit_generator *host, const cpu_isa_t &isa,
+            const data_type_t &data_type, const io_conf_t &io_conf,
+            const utils::optional_t<io_tail_conf_t> &tail_conf = utils::nullopt,
+            const utils::optional_t<io_saturation_conf_t> &saturation_conf
+            = utils::nullopt,
+            const utils::optional_t<io_gather_conf_t> &gather_conf
+            = utils::nullopt);
+    jit_io_helper_t(jit_io_helper_t &&) = default;
+    jit_io_helper_t &operator=(jit_io_helper_t &&) = default;
+
+    ~jit_io_helper_t();
+    void prepare_tail_mask();
+    void prepare_full_mask();
+    /*
+     * Sometimes the values in the register can be nan at the
+     * beginning of the kernel, then using vcmpps(vmm, vmm, vmm)
+     * will not set all bits to 1, instead of that this instruction will
+     * return zero. At the beginning, it is worth to zeroing
+     * full mask vmm to be sure, that vcmpps work properly.
+     */
+    void init_full_mask();
+    void init_saturate_f32() const;
+    void gather(const Xbyak_aarch64::XReg &src_reg, const Vmm &indices_vmm,
+            const Vmm &dst_vmm, const bool tail);
+    void broadcast(const Xbyak_aarch64::XReg &src_addr, const int src_offt,
+            const Vmm &dst_vmm);
+    void load(const Xbyak_aarch64::XReg &src_addr, const int src_offt,
+            const Vmm &dst_vmm, const bool tail);
+    void store(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
+            const int offt, const bool tail);
+
+private:
+    void compute_cmp_mask(const Vmm &cmp_dst, const Vmm &cmp_src,
+            const Vmm &cmp_src2, const unsigned int uimm);
+    void prepare_opmask(const std::size_t how_many_bits_to_set,
+            const Xbyak_aarch64::XReg &reg_tmp0,
+            const Xbyak_aarch64::XReg &reg_tmp1,
+            const Xbyak_aarch64::PReg &mask);
+
+    void load_f32(const Xbyak_aarch64::XReg &src_addr, const int offt,
+            const Vmm &dst_vmm, const bool tail,
+            const Xbyak_aarch64::PReg &mask);
+    void load_s32(const Xbyak_aarch64::XReg &src_addr, const int offt,
+            const Vmm &dst_vmm, const bool tail,
+            const Xbyak_aarch64::PReg &mask);
+    void load_i8(const Xbyak_aarch64::XReg &src_addr, const int offt,
+            const Vmm &dst_vmm, const Xbyak_aarch64::PReg &mask);
+    void saturate(const Vmm &vmm);
+    void store_f32(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
+            const int offt, const bool tail, const Xbyak_aarch64::PReg &mask);
+    void store_i8(const Vmm &src_vmm, const Xbyak_aarch64::XReg &dst_addr,
+            const int offt, const Xbyak_aarch64::PReg &mask);
+    void convert_to_f32(const Vmm &dst_vmm, const Vmm &src_vmm,
+            const data_type_t src_data_type);
+
+    void store_i8_sdb(Xbyak_aarch64::XReg addr, const Vmm &src_vmm,
+            const Xbyak_aarch64::PReg &mask);
+    void store_i8_udb(Xbyak_aarch64::XReg addr, const Vmm &src_vmm,
+            const Xbyak_aarch64::PReg &mask);
+
+    jit_generator *host_;
+    const cpu_isa_t isa_;
+    const data_type_t data_type_;
+    const io_conf_t io_conf_;
+    const utils::optional_t<io_tail_conf_t> tail_conf_;
+    const utils::optional_t<io_saturation_conf_t> saturation_conf_;
+    const utils::optional_t<io_gather_conf_t> gather_conf_;
+};
+
+template <typename Vmm>
+class jit_io_multi_dt_helper_t {
+public:
+    using data_types_t = std::unordered_set<data_type_t, std::hash<int>>;
+
+    jit_io_multi_dt_helper_t(jit_generator *host, const cpu_isa_t &isa,
+            const data_types_t &data_types, const io_conf_t &io_conf,
+            const utils::optional_t<io_tail_conf_t> &tail_conf = utils::nullopt,
+            const std::map<data_type_t, io_saturation_conf_t> &saturation_confs
+            = std::map<data_type_t, io_saturation_conf_t> {},
+            const utils::optional_t<io_gather_conf_t> &gather_conf
+            = utils::nullopt);
+    ~jit_io_multi_dt_helper_t();
+    void prepare_tail_mask();
+    void prepare_full_mask();
+    void init_saturate_f32(const data_types_t &store_data_types);
+    void init_full_mask();
+
+    std::shared_ptr<jit_io_helper_t<Vmm>> at(const data_type_t dt) const;
+
+private:
+    std::unordered_map<data_type_t, std::shared_ptr<jit_io_helper_t<Vmm>>,
+            std::hash<int>>
+            storage_;
+};
+
+} // namespace io
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/cpu_binary_list.cpp
+++ b/src/cpu/cpu_binary_list.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
 * Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,8 +23,11 @@
 #if DNNL_X64
 #include "cpu/x64/jit_uni_binary.hpp"
 using namespace dnnl::impl::cpu::x64;
-#elif DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
+#elif DNNL_AARCH64
+#include "cpu/aarch64/jit_uni_binary.hpp"
+#if DNNL_AARCH64_USE_ACL
 #include "cpu/aarch64/acl_binary.hpp"
+#endif
 using namespace dnnl::impl::cpu::aarch64;
 #endif
 
@@ -37,6 +41,7 @@ using namespace dnnl::impl::data_type;
 // clang-format off
 constexpr impl_list_item_t impl_list[] = REG_BINARY_P({
         CPU_INSTANCE_X64(jit_uni_binary_t)
+        CPU_INSTANCE_AARCH64(jit_uni_binary_t)
         CPU_INSTANCE_AARCH64_ACL(acl_binary_t)
         CPU_INSTANCE(ref_binary_t)
         /* eol */


### PR DESCRIPTION
# Description

This patch adds jit implementation of binary for AArch64 SVE512.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

