### PR TITLE
Adding support for Softmax primitive for AMD backend

### DIFF
--- a/src/gpu/amd/miopen_softmax.cpp
+++ b/src/gpu/amd/miopen_softmax.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_softmax.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_softmax_fwd_t::execute(const exec_ctx_t &ctx) const {
+
+    if (pd()->has_zero_dim_memory()) return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            std::vector<void *> args;
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+
+            auto handle = hip_stream->get_miopen_handle();
+
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_dst.get_native_pointer(ih));
+
+            pd()->softmax_impl_->execute(handle, args.data(), args.size());
+        });
+    });
+}
+
+status_t miopen_softmax_bwd_t::execute(const exec_ctx_t &ctx) const {
+
+    if (pd()->has_zero_dim_memory()) return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            std::vector<void *> args;
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+
+            auto handle = hip_stream->get_miopen_handle();
+
+            args.push_back(arg_dst.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+            args.push_back(arg_diff_src.get_native_pointer(ih));
+
+            pd()->softmax_impl_->execute(handle, args.data(), args.size());
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_softmax.hpp
+++ b/src/gpu/amd/miopen_softmax.hpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_SOFTMAX_HPP
+#define GPU_AMD_MIOPEN_SOFTMAX_HPP
+
+#include "hip/hip_runtime.h"
+
+#include "miopen/miopen.h"
+
+#include <CL/sycl.hpp>
+
+#include "common/primitive.hpp"
+#include "common/softmax_pd.hpp"
+#include "gpu/amd/miopen_softmax_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_softmax_fwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public softmax_fwd_pd_t {
+        using softmax_fwd_pd_t::softmax_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_softmax_fwd_t);
+
+        status_t init(engine_t *) {
+            const memory_desc_wrapper src_d(src_md());
+            const memory_desc_wrapper dst_d(dst_md());
+            bool ok = is_fwd()
+                    && utils::one_of(
+                            src_d.data_type(), data_type::f32, data_type::f16)
+                    && attr()->has_default_values()
+                    && set_default_formats() == status::success
+                    && src_d.is_plain() && dst_d.is_plain() && dst_d == src_d
+                    && axis() == 1 && check_format();
+
+            if (!ok) return status::unimplemented;
+
+            softmax_impl_.reset(new miopen_softmax_fwd_impl_t());
+
+            return softmax_impl_->init(this);
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(src_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd, format_tag::abcde)
+                    && memory_desc_wrapper(dst_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd, format_tag::abcde));
+        }
+
+        std::shared_ptr<miopen_softmax_impl_base_t> softmax_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+struct miopen_softmax_bwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public softmax_bwd_pd_t {
+        using softmax_bwd_pd_t::softmax_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_softmax_bwd_t);
+
+        status_t init(engine_t *) {
+            const memory_desc_wrapper diff_src_d(diff_src_md());
+            const memory_desc_wrapper diff_dst_d(diff_dst_md());
+            const memory_desc_wrapper dst_d(dst_md());
+
+            bool ok = !is_fwd()
+                    && utils::one_of(
+                            dst_d.data_type(), data_type::f32, data_type::f16)
+                    && attr()->has_default_values()
+                    && set_default_formats() == status::success
+                    && dst_d.is_plain() && diff_dst_d.is_plain()
+                    && diff_src_d.is_plain() && diff_src_d == diff_dst_d
+                    && diff_src_d == dst_d && axis() == 1 && check_format();
+            if (!ok) return status::unimplemented;
+
+            softmax_impl_.reset(new miopen_softmax_bwd_impl_t());
+
+            return softmax_impl_->init(this);
+        }
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(dst_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd, format_tag::abcde)
+                    && memory_desc_wrapper(diff_src_md())
+                               .matches_one_of_tag(format_tag::a,
+                                       format_tag::ab, format_tag::abc,
+                                       format_tag::abcd, format_tag::abcde)
+                    && memory_desc_wrapper(diff_dst_md())
+                               .matches_one_of_tag(format_tag::a,
+                                       format_tag::ab, format_tag::abc,
+                                       format_tag::abcd, format_tag::abcde));
+        }
+
+        std::shared_ptr<miopen_softmax_impl_base_t> softmax_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_softmax_impl.hpp
+++ b/src/gpu/amd/miopen_softmax_impl.hpp
@@ -1,0 +1,269 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited 
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_SOFTMAX_IMPL_HPP
+#define GPU_AMD_MIOPEN_SOFTMAX_IMPL_HPP
+
+#include "gpu/amd/sycl_hip_utils.hpp"
+#include "miopen/miopen.h"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_softmax_impl_base_t {
+    enum io { src = 0, dst, d_src, d_dst, NUM_IO };
+    int strides[NUM_IO][DNNL_MAX_NDIMS];
+    miopenDataType_t data_type;
+    int ndims;
+    miopenSoftmaxAlgorithm_t alg_kind;
+
+    miopenSoftmaxMode_t mode = miopenSoftmaxMode_t::MIOPEN_SOFTMAX_MODE_CHANNEL;
+
+    // oneDNN softmax primitive doesn't support any post-ops or attributes,
+    // hence we can set alpha = 1 and beta = 0 for all cases
+    float alpha = 1.0f;
+    float beta = 0.0f;
+
+    virtual ~miopen_softmax_impl_base_t() {}
+
+    virtual status_t init(const softmax_pd_t *pd) = 0;
+
+    virtual void execute(miopenHandle_t handle, void **x, int size) const = 0;
+
+    // Mapping between dnnl algorithm and cuDNN softmax algorithm
+    status_t convert_alg_kind(bool is_log_softmax,
+            miopenSoftmaxAlgorithm_t *miopen_alg_kind) const {
+        if (is_log_softmax) {
+            *miopen_alg_kind = miopenSoftmaxAlgorithm_t::MIOPEN_SOFTMAX_LOG;
+        } else {
+            *miopen_alg_kind
+                    = miopenSoftmaxAlgorithm_t::MIOPEN_SOFTMAX_ACCURATE;
+        }
+
+        return status::success;
+    }
+
+    status_t convert_dims_softmax(const dims_t &orig_dims, int *modified_dims,
+            int axis, int ndims, format_tag_t tag,
+            miopenTensorFormat_t &format) const {
+
+        // Initialise all dims to 1
+        for (int i = 0; i < 4; i++) {
+            modified_dims[i] = 1;
+        }
+        if (axis == 1) {
+            // Copy dimensions into the new array
+            format = tag == dnnl_nhwc
+                    ? miopenTensorFormat_t::MIOPEN_TENSOR_NHWC
+                    : miopenTensorFormat_t::MIOPEN_TENSOR_NCHW;
+            int num_dims = ndims < 4 ? ndims : 4;
+            for (int i = 0; i < num_dims; i++) {
+                modified_dims[i] = orig_dims[i];
+            }
+            for (int i = 4; i < ndims; i++) {
+                modified_dims[3] *= orig_dims[i];
+            }
+            return status::success;
+        }
+        format = miopenTensorFormat_t::MIOPEN_TENSOR_NCHW;
+        switch (tag) {
+            case dnnl_cn: {
+                modified_dims[0] = orig_dims[1];
+                modified_dims[1] = orig_dims[0];
+                break;
+            }
+            case dnnl_nchw: {
+                switch (axis) {
+                    case 0:
+                        modified_dims[1] = orig_dims[axis];
+                        modified_dims[2] = orig_dims[1];
+                        for (int i = 2; i < ndims; i++) {
+                            modified_dims[3] *= orig_dims[i];
+                        }
+                        break;
+                    default: {
+                        for (int i = 0; i < axis; i++) {
+                            modified_dims[0] *= orig_dims[i];
+                        }
+                        modified_dims[1] = orig_dims[axis];
+                        if (axis == ndims - 1) { return status::success; }
+                        for (int i = axis + 1; i < ndims; i++) {
+                            modified_dims[2] *= orig_dims[i];
+                        }
+                        break;
+                    }
+                }
+                break;
+            }
+            case dnnl_nhwc:
+                switch (axis) {
+                    case 0:
+                        modified_dims[1] = orig_dims[0];
+                        for (int i = 1; i < ndims; i++) {
+                            modified_dims[2] *= orig_dims[i];
+                        }
+                        break;
+                    case 2:
+                        modified_dims[0] = orig_dims[0];
+                        modified_dims[1] = orig_dims[2];
+                        for (int i = 3; i < ndims; i++) {
+                            modified_dims[2] *= orig_dims[i];
+                        }
+                        modified_dims[3] = orig_dims[1];
+                        break;
+                    case 3:
+                        modified_dims[0] = orig_dims[0] * orig_dims[2];
+                        modified_dims[1] = orig_dims[3];
+                        modified_dims[2] = ndims == 4 ? 1 : orig_dims[4];
+                        modified_dims[3] = orig_dims[1];
+                        break;
+                }
+                break;
+            default: return status::unimplemented;
+        }
+        return status::success;
+    }
+
+    status_t convert_tag(const memory_desc_t *md, format_tag_t &tag) const {
+        const memory_desc_wrapper mem_wrapper(md);
+        if (mem_wrapper.matches_one_of_tag(format_tag::ba)) {
+            tag = dnnl_cn;
+        } else if (mem_wrapper.matches_one_of_tag(format_tag::ab,
+                           format_tag::abc, format_tag::abcd, format_tag::abcde,
+                           format_tag::abcdef)) {
+            tag = dnnl_nchw;
+        } else if (mem_wrapper.matches_one_of_tag(format_tag::acb,
+                           format_tag::acdb, format_tag::acdeb)) {
+            tag = dnnl_nhwc;
+        } else {
+            return status::unimplemented;
+        }
+        return status::success;
+    }
+};
+
+struct miopen_softmax_fwd_impl_t : public miopen_softmax_impl_base_t {
+    int dims[NUM_IO][DNNL_MAX_NDIMS];
+    miopenTensorDescriptor_t tensor_desc;
+    miopenTensorFormat_t format;
+
+    status_t init(const softmax_pd_t *pd) override {
+
+        if (pd->has_zero_dim_memory()) return status::success;
+
+        if (pd->ndims() > MIOPEN_DIM_MAX) { return status::invalid_arguments; }
+        ndims = pd->ndims() < 4 ? 4 : pd->ndims();
+
+        format_tag_t tag;
+        CHECK(convert_tag(pd->src_md(), tag));
+        CHECK(convert_dims_softmax(pd->src_md()->padded_dims, dims[src],
+                pd->axis(), pd->ndims(), tag, format));
+        convert_dims(pd->src_md()->format_desc.blocking.strides, strides[src],
+                pd->ndims());
+        convert_dims(pd->dst_md()->format_desc.blocking.strides, strides[dst],
+                pd->ndims());
+
+        convert_alg_kind(pd->is_logsoftmax(), &alg_kind);
+
+        assert(pd->src_md()->data_type == pd->dst_md()->data_type);
+
+        CHECK(convert_data_type(pd->src_md(), &data_type));
+
+        CHECK(create_and_set_tensor_descriptor_ex(
+                &tensor_desc, format, data_type, 4, dims[src], strides[src]));
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle, void **x, int size) const override {
+        // Confirm that 2 arguments were passed, src and dst
+        assert(size == 2);
+
+        MIOPEN_EXECUTE_FUNC(miopenSoftmaxForward_V2, handle, &alpha,
+                tensor_desc, x[0], &beta, tensor_desc, x[1], alg_kind, mode);
+    }
+
+    ~miopen_softmax_fwd_impl_t() {
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, tensor_desc);
+    }
+};
+
+struct miopen_softmax_bwd_impl_t : public miopen_softmax_impl_base_t {
+    int dims[NUM_IO][DNNL_MAX_NDIMS];
+    miopenTensorDescriptor_t tensor_dst_desc;
+    miopenTensorDescriptor_t tensor_diff_desc;
+
+    miopenTensorFormat_t dst_format, diff_src_format;
+
+    status_t init(const softmax_pd_t *pd) override {
+
+        if (pd->has_zero_dim_memory()) return status::success;
+        if (pd->ndims() > MIOPEN_DIM_MAX) { return status::invalid_arguments; }
+        ndims = pd->ndims() < 4 ? 4 : pd->ndims();
+
+        format_tag_t tag;
+        CHECK(convert_tag(pd->dst_md(), tag));
+
+        CHECK(convert_dims_softmax(pd->dst_md()->padded_dims, dims[dst],
+                pd->axis(), pd->ndims(), tag, dst_format));
+        CHECK(convert_dims_softmax(pd->diff_src_md()->padded_dims, dims[d_src],
+                pd->axis(), pd->ndims(), tag, diff_src_format));
+
+        convert_alg_kind(pd->is_logsoftmax(), &alg_kind);
+
+        assert(pd->diff_dst_md()->data_type == pd->dst_md()->data_type);
+        assert(pd->diff_dst_md()->data_type == pd->diff_src_md()->data_type);
+        CHECK(convert_data_type(pd->dst_md(), &data_type));
+
+        convert_dims(pd->dst_md()->format_desc.blocking.strides, strides[dst],
+                pd->ndims());
+        convert_dims(pd->diff_src_md()->format_desc.blocking.strides,
+                strides[d_src], pd->ndims());
+        convert_dims(pd->diff_dst_md()->format_desc.blocking.strides,
+                strides[d_dst], pd->ndims());
+
+        CHECK(create_and_set_tensor_descriptor_ex(&tensor_dst_desc, dst_format,
+                data_type, 4, dims[dst], strides[dst]));
+        CHECK(create_and_set_tensor_descriptor_ex(&tensor_diff_desc,
+                diff_src_format, data_type, 4, dims[d_src], strides[d_src]));
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle, void **x, int size) const override {
+        // Assert that 3 arguments were passed src, diff_dst and diff_src
+        assert(size == 3);
+
+        MIOPEN_EXECUTE_FUNC(miopenSoftmaxBackward_V2, handle, &alpha,
+                tensor_dst_desc, x[0], tensor_diff_desc, x[1], &beta,
+                tensor_diff_desc, x[2], alg_kind, mode);
+    }
+
+    ~miopen_softmax_bwd_impl_t() {
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, tensor_dst_desc);
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, tensor_diff_desc);
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -24,6 +24,7 @@
 
 #include "gpu/amd/miopen_binary.hpp"
 #include "gpu/amd/miopen_eltwise.hpp"
+#include "gpu/amd/miopen_softmax.hpp"
 #include "gpu/amd/sycl_hip_compat.hpp"
 #include "gpu/amd/sycl_hip_engine.hpp"
 #include "gpu/amd/sycl_hip_scoped_context.hpp"
@@ -127,6 +128,9 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         // Elementwise
         INSTANCE(miopen_eltwise_fwd_t)
         INSTANCE(miopen_eltwise_bwd_t)
+        // Softmax
+        INSTANCE(miopen_softmax_fwd_t)
+        INSTANCE(miopen_softmax_bwd_t)
         nullptr,
 };
 // clang-format on

--- a/src/gpu/amd/sycl_hip_utils.hpp
+++ b/src/gpu/amd/sycl_hip_utils.hpp
@@ -211,6 +211,15 @@ inline status_t create_and_set_tensor_descriptor(
     return status::success;
 }
 
+static status_t create_and_set_tensor_descriptor_ex(
+        miopenTensorDescriptor_t *tensor_desc, miopenTensorFormat_t format,
+        miopenDataType_t data_type, int ndims, int *dims, int *strides) {
+    CHECK(MIOPEN_EXECUTE_FUNC_S(miopenCreateTensorDescriptor, tensor_desc));
+    CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetTensorDescriptor, *tensor_desc,
+            data_type, ndims, dims, strides));
+    return status::success;
+}
+
 class miopen_error : virtual public std::runtime_error {
 
 protected:

--- a/src/gpu/amd/sycl_hip_utils.hpp
+++ b/src/gpu/amd/sycl_hip_utils.hpp
@@ -211,15 +211,6 @@ inline status_t create_and_set_tensor_descriptor(
     return status::success;
 }
 
-static status_t create_and_set_tensor_descriptor_ex(
-        miopenTensorDescriptor_t *tensor_desc, miopenTensorFormat_t format,
-        miopenDataType_t data_type, int ndims, int *dims, int *strides) {
-    CHECK(MIOPEN_EXECUTE_FUNC_S(miopenCreateTensorDescriptor, tensor_desc));
-    CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetTensorDescriptor, *tensor_desc,
-            data_type, ndims, dims, strides));
-    return status::success;
-}
-
 class miopen_error : virtual public std::runtime_error {
 
 protected:

--- a/tests/gtests/test_logsoftmax.cpp
+++ b/tests/gtests/test_logsoftmax.cpp
@@ -56,13 +56,18 @@ protected:
 
         SKIP_IF_CUDA(!cuda_check_format_tag(p.memory_format),
                 "Unsupported format tag");
+        SKIP_IF_HIP(!hip_check_format_tag(p.memory_format),
+                "Unsupported format tag");
         if (!is_fwd) {
             SKIP_IF_CUDA(!cuda_check_format_tag(p.diff_memory_format),
+                    "Unsupported format tag");
+            SKIP_IF_HIP(!hip_check_format_tag(p.diff_memory_format),
                     "Unsupported format tag");
         }
         SKIP_IF(unsupported_data_type(data_dt),
                 "Engine does not support this data type.");
         SKIP_IF_CUDA(p.axis != 1, "Unsupported axis values for CUDA");
+        SKIP_IF_HIP(p.axis != 1, "Unsupported axis values for CUDA");
 
         const bool is_gpu = get_test_engine_kind() == engine::kind::gpu;
         if (!is_fwd && is_gpu) {
@@ -84,6 +89,12 @@ protected:
     bool cuda_check_format_tag(memory::format_tag tag) {
         return (tag != memory::format_tag::aBcd8b
                 && tag != memory::format_tag::aBc16b);
+    }
+    bool hip_check_format_tag(memory::format_tag tag) {
+        return (tag == memory::format_tag::a || tag == memory::format_tag::ab
+                || tag == memory::format_tag::abc
+                || tag == memory::format_tag::abcd
+                || tag == memory::format_tag::abcde);
     }
 
     void Forward() {

--- a/tests/gtests/test_softmax.cpp
+++ b/tests/gtests/test_softmax.cpp
@@ -51,13 +51,20 @@ protected:
 
         SKIP_IF_CUDA(!cuda_check_format_tag(p.memory_format),
                 "Unsupported format tag");
+        SKIP_IF_HIP(!hip_check_format_tag(p.memory_format),
+                "Unsupported format tag");
         if (!is_fwd) {
             SKIP_IF_CUDA(!cuda_check_format_tag(p.diff_memory_format),
+                    "Unsupported format tag");
+            SKIP_IF_HIP(!hip_check_format_tag(p.diff_memory_format),
                     "Unsupported format tag");
         }
         SKIP_IF_CUDA(data_traits<data_t>::data_type == memory::data_type::bf16,
                 "Unsupported datatype for CUDA");
         SKIP_IF_CUDA(p.axis != 1, "Unsupported axis values for CUDA");
+        SKIP_IF_HIP(data_traits<data_t>::data_type == memory::data_type::bf16,
+                "Unsupported datatype for HIP");
+        SKIP_IF_HIP(p.axis != 1, "Unsupported axis values for HIP");
 
         const bool is_gpu = get_test_engine_kind() == engine::kind::gpu;
         if (!is_fwd && is_gpu) {
@@ -74,6 +81,12 @@ protected:
     bool cuda_check_format_tag(memory::format_tag tag) {
         return (tag != memory::format_tag::aBcd8b
                 && tag != memory::format_tag::aBc16b);
+    }
+    bool hip_check_format_tag(memory::format_tag tag) {
+        return (tag == memory::format_tag::a || tag == memory::format_tag::ab
+                || tag == memory::format_tag::abc
+                || tag == memory::format_tag::abcd
+                || tag == memory::format_tag::abcde);
     }
 
     void Forward() {


### PR DESCRIPTION
# Description

Introducing AMD backend for the oneDNN Softmax primitive.

Limitations:
MIOpen only supports NCHW layout format.

We are also attaching output log files for gtests and benchdnn.

[test_softmax.log](https://github.com/oneapi-src/oneDNN/files/9039909/test_softmax.log)
[test_softmax_v2.log](https://github.com/oneapi-src/oneDNN/files/9039910/test_softmax_v2.log)
[test_softmax_buffer.log](https://github.com/oneapi-src/oneDNN/files/9039911/test_softmax_buffer.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/9039912/test_regression.log)
[test_logsoftmax.log](https://github.com/oneapi-src/oneDNN/files/9039913/test_logsoftmax.log)
[test_logsoftmax_buffer.log](https://github.com/oneapi-src/oneDNN/files/9039914/test_logsoftmax_buffer.log)
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/9039915/test_internals.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/9039916/test_api_sycl.log)
[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/9039917/test_api_buffer.log)
[test_softmax_v2.log](https://github.com/oneapi-src/oneDNN/files/9039920/test_softmax_v2.log)
[benchdnn_test_softmax_all.log](https://github.com/oneapi-src/oneDNN/files/9039932/benchdnn_test_softmax_all.log)

Testing scope:
benchdnn: passed
gtest: API tests passed, Softmax tests passed

Supported scope:
Supported data types : f32, f16
AMD backend supports MIOPEN_SOFTMAX_LOG for Logsoftmax and MIOPEN_SOFTMAX_ACCURATE for Softmax primitives

No post-ops are supported


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?



