### PR TITLE
tests: mlp: fix a compile error

### DIFF
--- a/tests/benchdnn_graph/mlp/mlp.cpp
+++ b/tests/benchdnn_graph/mlp/mlp.cpp
@@ -134,7 +134,10 @@ inline int fill_data(data_kind_t kind, const mlp_graph_spec_t *spec,
             rt_dims_masks, attr);
     matmul_prb.scales = scales;
     ::matmul::cfg_t cfg(&matmul_prb, {SRC, WEI, BIA, DST});
-    const auto density = cfg.get_density(kind, matmul_prb.k);
+    cfg_t::density_args_t density_args;
+    density_args.data_kind = kind;
+    density_args.n_acc = matmul_prb.k;
+    const auto density = cfg.get_density(density_args);
 
     /* Do fixed partitioning to have same filling for any number of threads */
     const int64_t n_chunks = 16;


### PR DESCRIPTION
# Description

This PR is used to fix a error when compile tests/benchdnn_graph/mlp/mlp.cpp.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
