### PR TITLE
Enable sbgemm on PPC64

### DIFF
--- a/cmake/blas.cmake
+++ b/cmake/blas.cmake
@@ -83,6 +83,11 @@ if(BLAS_FOUND)
          message(FATAL_ERROR "BLAS library does not support CBLAS interface.")
      endif()
 
+     check_function_exists(cblas_sbgemm BLAS_HAS_SBGEMM)
+     if(BLAS_HAS_SBGEMM)
+         add_definitions(-DBLAS_HAS_SBGEMM)
+     endif()
+
      message(STATUS "Found CBLAS: ${BLAS_LIBRARIES}")
      message(STATUS "CBLAS include path: ${BLAS_INCLUDE_DIR}")
      add_definitions(-DUSE_CBLAS)

--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -107,6 +107,10 @@ bool has_data_type_support(data_type_t data_type) {
         case data_type::bf16:
 #if DNNL_X64
             return x64::mayiuse(x64::avx512_core);
+#elif DNNL_PPC64
+#if defined(USE_CBLAS) && defined(BLAS_HAS_SBGEMM) && defined(__MMA__)
+            return true;
+#endif
 #else
             return false;
 #endif


### PR DESCRIPTION
# Description

Access the accelerated bfloat16 matrix multiplication code within OpenBLAS when running on PPC64 machines.

Fixes # (github issue)

# Checklist

## General

- [ yes ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ yes ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
