### PR TITLE
Extending support for binary primitive

### DIFF
--- a/src/gpu/sycl/binary_kernels.hpp
+++ b/src/gpu/sycl/binary_kernels.hpp
@@ -38,29 +38,66 @@ struct binary_kernel_vec_t {
 
     [[sycl::reqd_sub_group_size(32)]] void operator()(
             ::sycl::nd_item<1> item) const {
+
         auto sg = item.get_sub_group();
+        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
+        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
+        size_t wi_offset_t = sg.get_local_id();
+        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
 
-        size_t base = ((item.get_group(0) * conf_.wg_size
-                               + sg.get_group_id()[0] * sg.get_local_range()[0])
-                                      * conf_.block_size
-                              + sg.get_local_id() * conf_.block_size)
-                / vec_len;
+        size_t base_idx = offset_t * conf_.block_size;
+        size_t vec_base_idx = base_idx / vec_len;
 
-        for (int i = 0; i < conf_.block_size / vec_len; i++) {
-            auto src0_vec = load_float_vec<vec_len>(
-                    src0_md().data_type(), src0_ptr(), base + i);
-            auto src1_vec = load_float_vec<vec_len>(
-                    src1_md().data_type(), src1_ptr(), base + i);
+        size_t wg_base_idx = wg_offset_t * conf_.block_size;
+        size_t sg_base_idx = (wg_offset_t + sg_offset_t) * conf_.block_size;
 
-            auto dst_vec = load_float_vec<vec_len>(
-                    dst_md().data_type(), dst_ptr(), base + i);
+        if (sg_base_idx + (sg.get_local_range()[0] * conf_.block_size)
+                < conf_.wk_size) {
+            for (int i = 0; i < conf_.block_size / vec_len; i++) {
+                auto src0_vec = load_float_vec<vec_len>(
+                        src0_md().data_type(), src0_ptr(), vec_base_idx + i);
+                auto src1_vec = load_float_vec<vec_len>(
+                        src1_md().data_type(), src1_ptr(), vec_base_idx + i);
+                auto dst_vec = load_float_vec<vec_len>(
+                        dst_md().data_type(), dst_ptr(), vec_base_idx + i);
 
-            auto acc_vec = compute_alg(src0_vec, src1_vec, conf_.alg_kind);
-            // TODO: Adding post-ops seems to be interfering with compiler's
-            // optimizations. Figure out how to make the compiler to generate
-            // the right code.
-            acc_vec = conf_.post_ops.apply(acc_vec, dst_vec);
-            store_float_vec(dst_md().data_type(), acc_vec, dst_ptr(), base + i);
+                if (conf_.do_scale_src0)
+                    src0_vec *= ::sycl::vec<float, vec_len>(conf_.src0_scale);
+                if (conf_.do_scale_src1)
+                    src1_vec *= ::sycl::vec<float, vec_len>(conf_.src1_scale);
+
+                auto acc_vec = compute_alg(src0_vec, src1_vec, conf_.alg_kind);
+                // TODO: Adding post-ops seems to be interfering with compiler's
+                // optimizations. Figure out how to make the compiler to generate
+                // the right code.
+                acc_vec = conf_.post_ops.apply(acc_vec, dst_vec);
+                store_float_vec(dst_md().data_type(), acc_vec, dst_ptr(),
+                        vec_base_idx + i);
+            }
+        } else {
+            auto src0_p = reinterpret_cast<float *>(src0_ptr());
+            auto src1_p = reinterpret_cast<float *>(src1_ptr());
+            auto dst_p = reinterpret_cast<float *>(dst_ptr());
+
+            for (int i = 0; i < conf_.block_size; i++) {
+                int idx = base_idx + i;
+                if (idx < conf_.wk_size) {
+                    auto src0 = load_float_value(
+                            src0_md().data_type(), src0_ptr(), idx);
+                    auto src1 = load_float_value(
+                            src1_md().data_type(), src1_ptr(), idx);
+                    auto dst = load_float_value(
+                            dst_md().data_type(), dst_ptr(), idx);
+
+                    if (conf_.do_scale_src0) src0 *= conf_.src0_scale;
+                    if (conf_.do_scale_src1) src1 *= conf_.src1_scale;
+
+                    auto acc = compute_alg_n(src0, src1, conf_.alg_kind);
+                    acc = conf_.post_ops.apply(acc, dst);
+                    store_float_value(
+                            dst_md().data_type(), acc, dst_ptr(), idx);
+                }
+            }
         }
     }
 
@@ -96,6 +133,25 @@ private:
             case alg_kind::binary_ne:
                 return ((src0 != src1) * -1).template convert<float>();
             default: return ::sycl::vec<float, width> {NAN};
+        }
+    }
+
+    template <typename T>
+    T compute_alg_n(T src0, T src1, alg_kind_t alg) const {
+        switch (alg) {
+            case alg_kind::binary_add: return src0 + src1;
+            case alg_kind::binary_div: return src0 / src1;
+            case alg_kind::binary_max: return std::max(src0, src1);
+            case alg_kind::binary_min: return std::min(src0, src1);
+            case alg_kind::binary_mul: return src0 * src1;
+            case alg_kind::binary_sub: return src0 - src1;
+            case alg_kind::binary_ge: return ((src0 >= src1));
+            case alg_kind::binary_gt: return ((src0 > src1));
+            case alg_kind::binary_le: return ((src0 <= src1));
+            case alg_kind::binary_lt: return ((src0 < src1));
+            case alg_kind::binary_eq: return ((src0 == src1));
+            case alg_kind::binary_ne: return ((src0 != src1));
+            default: return (T)(999);
         }
     }
 

--- a/src/gpu/sycl/sycl_io_helper.hpp
+++ b/src/gpu/sycl/sycl_io_helper.hpp
@@ -164,7 +164,7 @@ inline void store_float_vec(data_type_t dt, ::sycl::vec<float, width> vec_f32,
     case dt: { \
         using type = typename impl::gpu::sycl::sycl_prec_traits<dt>::type; \
         global_ptr<type> gptr_dt(reinterpret_cast<type *>(ptr)); \
-        auto vec_dt = vec_f32.template convert<type>(); \
+        auto vec_dt = impl::sycl::saturate_and_round_vec<type>(vec_f32); \
         vec_dt.store(offset, gptr_dt); \
     } break;
 

--- a/src/gpu/sycl/sycl_math_utils.hpp
+++ b/src/gpu/sycl/sycl_math_utils.hpp
@@ -96,7 +96,7 @@ inline ::sycl::vec<float, width> relu_fwd(
     if (alpha == 0.0f) {
         return max_vec(src_vec, zero_vec);
     } else {
-        ::sycl::vec<float, 8> alpha_vec(alpha);
+        ::sycl::vec<float, width> alpha_vec(alpha);
         auto src_copy_vec = src_vec;
         // Mask to nullify elements that are greater than 0 in src_vec.
         auto src_vec_mask = (src_vec < zero_vec) * -1;

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -41,6 +41,7 @@ struct sycl_binary_conf_t {
 
     int block_size;
     int wg_size;
+    int wk_size;
 
     sycl_post_ops_t post_ops;
 };

--- a/src/gpu/sycl/sycl_q10n.hpp
+++ b/src/gpu/sycl/sycl_q10n.hpp
@@ -27,6 +27,78 @@ namespace dnnl {
 namespace impl {
 namespace sycl {
 
+template <typename data_t, typename acc_t, int width>
+inline ::sycl::vec<typename utils::enable_if<!nstl::is_integral<data_t>::value,
+                           typename utils::remove_reference<acc_t>::type>::type,
+        width>
+saturate_vec(const ::sycl::vec<acc_t, width> &src_vec) {
+    ::sycl::vec<acc_t, width> src_copy_vec = src_vec;
+    return src_copy_vec;
+}
+
+template <typename data_t, typename acc_t, int width>
+inline ::sycl::vec<typename utils::enable_if<nstl::is_integral<data_t>::value,
+                           typename utils::remove_reference<acc_t>::type>::type,
+        width>
+saturate_vec(const ::sycl::vec<acc_t, width> &src_vec) {
+    ::sycl::vec<acc_t, width> src_copy_vec = src_vec;
+
+    acc_t lbound = (acc_t)std::numeric_limits<data_t>::lowest();
+    acc_t ubound = (acc_t)std::numeric_limits<data_t>::max();
+    ::sycl::vec<acc_t, width> lbound_vec(lbound);
+    ::sycl::vec<acc_t, width> ubound_vec(ubound);
+
+    // lbound
+    auto src_vec_mask
+            = ((src_vec >= lbound_vec) * -1).template convert<acc_t>();
+    auto i_src_vec_mask
+            = ((src_vec < lbound_vec) * -lbound).template convert<acc_t>();
+
+    src_copy_vec *= src_vec_mask;
+    src_copy_vec += i_src_vec_mask;
+
+    // ubound
+    src_vec_mask
+            = ((src_copy_vec <= ubound_vec) * -1).template convert<acc_t>();
+    i_src_vec_mask
+            = ((src_copy_vec > ubound_vec) * -ubound).template convert<acc_t>();
+
+    src_copy_vec *= src_vec_mask;
+    src_copy_vec += i_src_vec_mask;
+
+    return src_copy_vec;
+}
+
+template <>
+inline ::sycl::vec<uint8_t, 8> saturate_vec<int8_t, uint8_t, 8>(
+        const ::sycl::vec<uint8_t, 8> &src_vec) {
+    ::sycl::vec<uint8_t, 8> ubound_vec(127u);
+
+    auto src_copy_vec = src_vec;
+    // Mask to nullify elements that are greater than ubound in src_vec.
+    auto src_vec_mask = (src_vec <= ubound_vec) * -1;
+    auto i_src_vec_mask = (src_vec > ubound_vec) * -127;
+    // Nullify elements that are greater than ubound.
+    src_copy_vec *= src_vec_mask.template convert<uint8_t>();
+    // Combine ubound scaled elements with the elements that are lesser
+    // than ubound in `src_copy_vec`.
+    return src_copy_vec + i_src_vec_mask.template convert<uint8_t>();
+}
+
+template <>
+inline ::sycl::vec<int8_t, 8> saturate_vec<uint8_t, int8_t, 8>(
+        const ::sycl::vec<int8_t, 8> &src_vec) {
+    ::sycl::vec<int8_t, 8> lbound_vec(0);
+
+    auto src_copy_vec = src_vec;
+    // Mask to nullify elements that are lesser than lbound in src_vec.
+    auto src_vec_mask = (src_vec >= lbound_vec) * -1;
+    // Nullify elements that are lesser than lbound.
+    src_copy_vec *= src_vec_mask.template convert<int8_t>();
+    // Return the `src_copy_vec`.
+    return src_copy_vec;
+}
+
 template <typename data_t, typename acc_t>
 inline typename utils::enable_if<!nstl::is_integral<data_t>::value,
         typename utils::remove_reference<acc_t>::type>::type
@@ -57,6 +129,22 @@ inline int8_t saturate<uint8_t, int8_t>(const int8_t &x) {
     return x >= 0 ? x : 0;
 }
 
+template <typename out_t, int width>
+inline ::sycl::vec<typename utils::enable_if<nstl::is_integral<out_t>::value,
+                           typename utils::remove_reference<out_t>::type>::type,
+        width>
+out_round_vec(::sycl::vec<float, width> src_vec) {
+    return src_vec.template convert<out_t, ::sycl::rounding_mode::rte>();
+}
+
+template <typename out_t, int width>
+inline ::sycl::vec<typename utils::enable_if<!nstl::is_integral<out_t>::value,
+                           typename utils::remove_reference<out_t>::type>::type,
+        width>
+out_round_vec(::sycl::vec<float, width> src_vec) {
+    return src_vec.template convert<out_t>();
+}
+
 template <typename out_t>
 inline typename utils::enable_if<nstl::is_integral<out_t>::value,
         typename utils::remove_reference<out_t>::type>::type
@@ -70,6 +158,20 @@ inline typename utils::enable_if<!nstl::is_integral<out_t>::value,
 out_round(float v) {
     return v;
 }
+
+template <typename out_t, typename acc_t = float, int width = 8>
+inline ::sycl::vec<out_t, width> saturate_and_round_vec(
+        ::sycl::vec<acc_t, width> f_vec) {
+    return out_round_vec<out_t, width>(saturate_vec<out_t, acc_t>(f_vec));
+}
+
+// Quantization with alpha == 1 and beta == 0
+template <typename in_t, typename out_t, int width = 8, typename enabled = void>
+struct qz_a1b0_vec {
+    ::sycl::vec<out_t, width> operator()(::sycl::vec<in_t, width> in) {
+        return saturate_and_round_vec<out_t>(in.template convert<float>());
+    }
+};
 
 template <typename out_t, typename acc_t = float>
 inline out_t saturate_and_round(acc_t f) {


### PR DESCRIPTION
# Description

This PR extends binary SYCL kernel support for non-uniform group sizes. This includes a new logic for work-item config in kernel launch and handling the trailing portions of workspace. 
In addition, the PR adds support for common scales and handles saturation and rounding for vectors.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? 
[test_binary_all.txt](https://github.com/oneapi-src/oneDNN/files/9204352/test_binary_all.txt)
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
[oneDNN Performance Tracker.xlsx](https://github.com/oneapi-src/oneDNN/files/9204341/oneDNN.Performance.Tracker.xlsx)