### PR TITLE
Adding support for Local Response Normalization(LRN) primitive for AMD backend

### DIFF
--- a/src/gpu/amd/miopen_lrn.cpp
+++ b/src/gpu/amd/miopen_lrn.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+#include "gpu/amd/miopen_lrn.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_lrn_fwd_t::execute(const exec_ctx_t &ctx) const {
+
+    if (memory_desc_wrapper(pd()->desc()->data_desc).has_zero_dim())
+        return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_wrksp = CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            void *src_ = arg_src.get_native_pointer(ih);
+            void *dst_ = arg_dst.get_native_pointer(ih);
+            void *ws_ = arg_wrksp.get_native_pointer(ih);
+
+            std::vector<void *> args {src_, dst_, ws_};
+            pd()->lrn_impl_->execute(handle, args);
+        });
+    });
+}
+
+status_t miopen_lrn_bwd_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->desc()->data_desc).has_zero_dim())
+        return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto arg_ws = CTX_IN_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            std::vector<void *> args;
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_ws.get_native_pointer(ih));
+            args.push_back(arg_diff_src.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+
+            pd()->lrn_impl_->execute(handle, args);
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_lrn.hpp
+++ b/src/gpu/amd/miopen_lrn.hpp
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright 2020-2022 Intel Corporation
+ * Copyright 2020 Codeplay Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_LRN_HPP
+#define GPU_AMD_MIOPEN_LRN_HPP
+
+#include <miopen/miopen.h>
+
+#include <CL/sycl.hpp>
+
+#include "common/c_types_map.hpp"
+#include "common/lrn_pd.hpp"
+#include "common/primitive.hpp"
+#include "gpu/amd/miopen_lrn_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_lrn_fwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public lrn_fwd_pd_t {
+        using lrn_fwd_pd_t::lrn_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_lrn_fwd_t);
+
+        status_t init(engine_t *) {
+            using namespace data_type;
+            bool ok = true && is_fwd()
+                    && utils::one_of(desc()->prop_kind,
+                            prop_kind::forward_inference,
+                            prop_kind::forward_training)
+                    && utils::one_of(desc()->alg_kind,
+                            alg_kind::lrn_across_channels,
+                            alg_kind::lrn_within_channel)
+                    // MIOpen LRN implementation within channel supports only 2D spatial.
+                    && IMPLICATION(
+                            desc()->alg_kind == alg_kind::lrn_within_channel,
+                            ndims() == 4)
+                    && utils::one_of(desc()->data_desc.data_type, f32, f16)
+                    && attr()->has_default_values() && desc_.local_size % 2
+                    && check_format();
+
+            if (!ok) return status::unimplemented;
+
+            if (has_zero_dim_memory()) return status::success;
+
+            lrn_impl_.reset(new miopen_lrn_fwd_impl_t());
+            CHECK(lrn_impl_->init(this));
+            return init_ws();
+        }
+
+        status_t init_ws() {
+            if (!is_training()) return status::success;
+            const size_t miopen_ws_size = lrn_impl_->get_workspace_size();
+            const size_t dst_size = memory_desc_wrapper(dst_md()).size();
+            const size_t ws_size = miopen_ws_size + dst_size;
+            dims_t dims = {(dim_t)ws_size};
+            return dnnl_memory_desc_init_by_tag(&ws_md_, ws_size ? 1 : 0, dims,
+                    data_type::u8, format_tag::a);
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(src_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd)
+                    && memory_desc_wrapper(dst_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd));
+        }
+
+        bool is_training() const {
+            return desc_.prop_kind == prop_kind::forward_training;
+        }
+
+        std::shared_ptr<miopen_lrn_impl_base_t> lrn_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+struct miopen_lrn_bwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public lrn_bwd_pd_t {
+        using lrn_bwd_pd_t::lrn_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_lrn_bwd_t);
+
+        status_t init(engine_t *) {
+            bool ok = true && !is_fwd()
+                    && utils::one_of(desc()->alg_kind,
+                            alg_kind::lrn_across_channels,
+                            alg_kind::lrn_within_channel)
+                    // MIOpen LRN implementation within channel supports only 2D spatial.
+                    && IMPLICATION(
+                            desc()->alg_kind == alg_kind::lrn_within_channel,
+                            ndims() == 4)
+                    && utils::one_of(desc()->data_desc.data_type,
+                            data_type::f16, data_type::f32)
+                    && set_default_formats_common()
+                    && attr()->has_default_values() && desc_.local_size % 2
+                    && check_format();
+            if (!ok) return status::unimplemented;
+            if (has_zero_dim_memory()) { return status::success; };
+
+            lrn_impl_.reset(new miopen_lrn_bwd_impl_t());
+            CHECK(lrn_impl_->init(this));
+            CHECK(init_ws());
+            if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;
+            return status::success;
+        }
+
+        status_t init_ws() {
+            const size_t miopen_ws_size = lrn_impl_->get_workspace_size();
+            // XXX: assumption is that src_md() and dst_md() are always the same.
+            const size_t dst_size = memory_desc_wrapper(src_md()).size();
+            const size_t ws_size = miopen_ws_size + dst_size;
+
+            dims_t dims = {(dim_t)ws_size};
+            return dnnl_memory_desc_init_by_tag(&ws_md_, ws_size ? 1 : 0, dims,
+                    data_type::u8, format_tag::a);
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(src_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd)
+                    && memory_desc_wrapper(diff_src_md())
+                               .matches_one_of_tag(format_tag::a,
+                                       format_tag::ab, format_tag::abc,
+                                       format_tag::abcd)
+                    && memory_desc_wrapper(diff_dst_md())
+                               .matches_one_of_tag(format_tag::a,
+                                       format_tag::ab, format_tag::abc,
+                                       format_tag::abcd));
+        }
+
+        std::shared_ptr<miopen_lrn_impl_base_t> lrn_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_lrn_impl.hpp
+++ b/src/gpu/amd/miopen_lrn_impl.hpp
@@ -1,0 +1,226 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_LRN_IMPL_HPP
+#define GPU_AMD_MIOPEN_LRN_IMPL_HPP
+
+#include "gpu/amd/sycl_hip_utils.hpp"
+#include <hip/hip_runtime.h>
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_lrn_impl_base_t {
+
+    virtual ~miopen_lrn_impl_base_t() {
+        if (lrn_desc) {
+            MIOPEN_EXECUTE_FUNC_V(miopenDestroyLRNDescriptor, lrn_desc);
+        }
+        for (size_t i = 0; i < NUM_IO; i++) {
+            if (tensor_descs[i]) {
+                MIOPEN_EXECUTE_FUNC_V(
+                        miopenDestroyTensorDescriptor, tensor_descs[i]);
+            }
+        }
+    }
+
+    virtual status_t init(lrn_pd_t *pd) = 0;
+    virtual void execute(
+            miopenHandle_t handle, const std::vector<void *> &args) const = 0;
+
+    size_t get_workspace_size() const { return workspace_size; }
+
+protected:
+    enum io { src_idx = 0, dst_idx, d_src_idx, d_dst_idx, NUM_IO };
+    miopenDataType_t data_types[NUM_IO];
+    int ndims;
+    int dst_size;
+    int dims[NUM_IO][DNNL_MAX_NDIMS];
+    int strides[NUM_IO][DNNL_MAX_NDIMS];
+    float alpha = 1.0f;
+    float beta = 0.0f;
+    bool is_training;
+    double lrn_alpha;
+    double lrn_beta;
+    double lrn_K;
+    unsigned int lrn_N;
+    size_t workspace_size;
+    miopenLRNMode_t lrn_mode;
+    miopenLRNDescriptor_t lrn_desc = nullptr;
+    miopenTensorDescriptor_t tensor_descs[NUM_IO] = {};
+
+    virtual status_t init_common(lrn_pd_t *pd) {
+        ndims = std::max(4, pd->ndims());
+        if (ndims > 4) { return status::invalid_arguments; }
+
+        const bool do_scaling = pd->src_md()->data_type == data_type_t::dnnl_s8;
+        const auto scales_0 = pd->attr()->scales_.get(1).scales_;
+        const auto lrn_desc = pd->desc();
+        const auto dst_wrap = memory_desc_wrapper(pd->dst_md());
+
+        dst_size = dst_wrap.nelems();
+        alpha = do_scaling ? scales_0[0] : 1.0f;
+        is_training = pd->desc()->prop_kind == prop_kind::forward_training;
+
+        lrn_K = lrn_desc->lrn_k;
+        lrn_N = lrn_desc->local_size;
+        lrn_alpha = lrn_desc->lrn_alpha;
+        lrn_beta = lrn_desc->lrn_beta;
+
+        // Initialise lrn algorithm
+        CHECK(convert_alg_kind(pd->desc()->alg_kind, &lrn_mode));
+
+        convert_dims(pd->src_md()->padded_dims, dims[src_idx], pd->ndims());
+        convert_dims(pd->src_md()->format_desc.blocking.strides,
+                strides[src_idx], pd->ndims());
+
+        // Set datatype
+        CHECK(convert_data_type(pd->src_md(), &data_types[src_idx]));
+
+        // Initialise tensor descriptor
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[src_idx],
+                data_types[src_idx], ndims, dims[src_idx], strides[src_idx]));
+        CHECK(create_and_set_lrn_descriptor());
+
+        return status::success;
+    }
+
+    virtual status_t create_and_set_lrn_descriptor() {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenCreateLRNDescriptor, &lrn_desc));
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetLRNDescriptor, lrn_desc, lrn_mode,
+                lrn_N, lrn_alpha, lrn_beta, lrn_K));
+        return status::success;
+    }
+
+    status_t convert_alg_kind(
+            alg_kind_t alg_kind, miopenLRNMode_t *miopen_alg_kind) {
+        if (alg_kind == alg_kind::lrn_across_channels) {
+            *miopen_alg_kind = miopenLRNMode_t::miopenLRNCrossChannel;
+        } else if (alg_kind == alg_kind::lrn_within_channel) {
+            *miopen_alg_kind = miopenLRNMode_t::miopenLRNWithinChannel;
+        } else {
+            return status::unimplemented;
+        }
+        return status::success;
+    }
+};
+
+struct miopen_lrn_fwd_impl_t : public miopen_lrn_impl_base_t {
+    bool do_backward = false;
+
+    virtual status_t init(lrn_pd_t *pd) override {
+        CHECK(init_common(pd));
+
+        convert_dims(pd->dst_md()->padded_dims, dims[dst_idx], pd->ndims());
+        convert_dims(pd->dst_md()->format_desc.blocking.strides,
+                strides[dst_idx], pd->ndims());
+
+        CHECK(convert_data_type(pd->dst_md(), &data_types[dst_idx]));
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[dst_idx],
+                data_types[dst_idx], ndims, dims[dst_idx], strides[dst_idx]));
+
+        if (is_training) { do_backward = true; }
+        MIOPEN_EXECUTE_FUNC(miopenLRNGetWorkSpaceSize, tensor_descs[dst_idx],
+                &workspace_size);
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle,
+            const std::vector<void *> &args) const override {
+
+        void *ws_miopen = args[2];
+        void *ws_dst_values = (uint8_t *)args[2] + get_workspace_size();
+
+        MIOPEN_EXECUTE_FUNC(miopenLRNForward, handle, lrn_desc, &alpha,
+                tensor_descs[src_idx], args[0], &beta, tensor_descs[dst_idx],
+                args[1], do_backward, ws_miopen);
+
+        if (is_training) {
+            float alpha1 = 1.f;
+            float alpha2 = 0.f;
+            float beta = 0.f;
+
+            MIOPEN_EXECUTE_FUNC(miopenOpTensor, handle, miopenTensorOpAdd,
+                    &alpha1, tensor_descs[dst_idx], args[1], &alpha2,
+                    tensor_descs[dst_idx], args[1], &beta,
+                    tensor_descs[dst_idx], ws_dst_values);
+        }
+    }
+};
+
+struct miopen_lrn_bwd_impl_t : public miopen_lrn_impl_base_t {
+
+    status_t init(lrn_pd_t *pd) override {
+        CHECK(init_common(pd));
+
+        // Set dimensions
+        convert_dims(
+                pd->diff_dst_md()->padded_dims, dims[dst_idx], pd->ndims());
+        convert_dims(
+                pd->diff_src_md()->padded_dims, dims[d_src_idx], pd->ndims());
+        convert_dims(
+                pd->diff_dst_md()->padded_dims, dims[d_dst_idx], pd->ndims());
+
+        // Set strides
+        convert_dims(pd->diff_dst_md()->format_desc.blocking.strides,
+                strides[dst_idx], pd->ndims());
+        convert_dims(pd->diff_src_md()->format_desc.blocking.strides,
+                strides[d_src_idx], pd->ndims());
+        convert_dims(pd->diff_dst_md()->format_desc.blocking.strides,
+                strides[d_dst_idx], pd->ndims());
+
+        // Set datatypes
+        CHECK(convert_data_type(pd->diff_dst_md(), &data_types[dst_idx]));
+        CHECK(convert_data_type(pd->diff_src_md(), &data_types[d_src_idx]));
+        CHECK(convert_data_type(pd->diff_dst_md(), &data_types[d_dst_idx]));
+
+        // Initialise tensor descriptors
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[dst_idx],
+                data_types[dst_idx], ndims, dims[dst_idx], strides[dst_idx]));
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[d_src_idx],
+                data_types[d_src_idx], ndims, dims[d_src_idx],
+                strides[d_src_idx]));
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[d_dst_idx],
+                data_types[d_dst_idx], ndims, dims[d_dst_idx],
+                strides[d_dst_idx]));
+
+        MIOPEN_EXECUTE_FUNC(miopenLRNGetWorkSpaceSize, tensor_descs[dst_idx],
+                &workspace_size);
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle,
+            const std::vector<void *> &args) const override {
+        void *ws_miopen = args[1];
+        void *ws_dst_values = (uint8_t *)args[1] + get_workspace_size();
+
+        MIOPEN_EXECUTE_FUNC_V(miopenLRNBackward, handle, lrn_desc, &alpha,
+                tensor_descs[dst_idx], ws_dst_values, tensor_descs[d_dst_idx],
+                args[d_dst_idx], tensor_descs[src_idx], args[src_idx], &beta,
+                tensor_descs[d_src_idx], args[d_src_idx], ws_miopen);
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -24,6 +24,7 @@
 
 #include "gpu/amd/miopen_binary.hpp"
 #include "gpu/amd/miopen_eltwise.hpp"
+#include "gpu/amd/miopen_lrn.hpp"
 #include "gpu/amd/miopen_softmax.hpp"
 #include "gpu/amd/sycl_hip_compat.hpp"
 #include "gpu/amd/sycl_hip_engine.hpp"
@@ -131,6 +132,9 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         // Softmax
         INSTANCE(miopen_softmax_fwd_t)
         INSTANCE(miopen_softmax_bwd_t)
+        // LRN
+        INSTANCE(miopen_lrn_fwd_t)
+        INSTANCE(miopen_lrn_bwd_t)
         nullptr,
 };
 // clang-format on

--- a/tests/gtests/test_lrn_backward.cpp
+++ b/tests/gtests/test_lrn_backward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2021 Intel Corporation
+* Copyright 2016-2022 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -215,6 +215,8 @@ protected:
         p = ::testing::TestWithParam<decltype(p)>::GetParam();
         SKIP_IF_CUDA(!cuda_check_format_tags(p.data_format, p.diff_data_format),
                 "Unsupported format tag");
+        SKIP_IF_HIP(!hip_check_format_tags(p.data_format, p.diff_data_format),
+                "Unsupported format tag");
         SKIP_IF_CUDA(p.aalgorithm != algorithm::lrn_across_channels,
                 "Unsupported algorithm");
         ASSERT_TRUE(p.aalgorithm == algorithm::lrn_across_channels
@@ -237,6 +239,13 @@ protected:
                 || diff_data_format == memory::format_tag::ncw
                 || diff_data_format == memory::format_tag::nwc
                 || diff_data_format == memory::format_tag::any;
+
+        return data_ok && diff_data_ok;
+    }
+    bool hip_check_format_tags(memory::format_tag data_format,
+            memory::format_tag diff_data_format) {
+        bool data_ok = data_format == memory::format_tag::nchw;
+        bool diff_data_ok = diff_data_format == memory::format_tag::nchw;
 
         return data_ok && diff_data_ok;
     }


### PR DESCRIPTION
# Description

Introducing AMD backend for the oneDNN Local Response Normalization(LRN) primitive.

Limitations:
MIOpen only supports NCHW layout format.

We are also attaching output log files for gtests and benchdnn.
[benchdnn_test_lrn_all.log](https://github.com/oneapi-src/oneDNN/files/9253810/benchdnn_test_lrn_all.log)
[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/9253811/test_api_buffer.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/9253812/test_api_sycl.log)
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/9253813/test_internals.log)
[test_lrn_backward.log](https://github.com/oneapi-src/oneDNN/files/9253814/test_lrn_backward.log)
[test_lrn_backward_buffer.log](https://github.com/oneapi-src/oneDNN/files/9253815/test_lrn_backward_buffer.log)
[test_lrn_forward.log](https://github.com/oneapi-src/oneDNN/files/9253816/test_lrn_forward.log)
[test_lrn_forward_buffer.log](https://github.com/oneapi-src/oneDNN/files/9253817/test_lrn_forward_buffer.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/9253818/test_regression.log)


Testing scope:
benchdnn: passed
gtest: API tests passed, Local Response Normalization(LRN) tests passed

Supported scope:
Supported data types : f32, f16

AMD backend supports miopenLRNWithinChannel(Only for 2D spatial)
and miopenLRNCrossChannel modes.

No post-ops are supported


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?








