### PR TITLE
src: aarch64: add check for zero dims in ACL matmul

### DIFF
--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -75,6 +75,7 @@ struct acl_matmul_t : public primitive_t {
                     && desc()->accum_data_type == data_type::f32
                     && dst_md()->data_type == data_type::f32
                     && platform::has_data_type_support(data_type::f32)
+                    && !has_zero_dim_memory()
                     && attr()->has_default_values(
                             smask_t::oscale | smask_t::post_ops)
                     && post_ops_ok() && attr_oscale_ok()


### PR DESCRIPTION
# Description

Fixes `test_matmul` failing for ACL builds (for example https://cloud.drone.io/oneapi-src/oneDNN/1532/4/2) by returning unimplemented if any tensor has a zero dimension.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests? (N/A - test already exists)

