### PR TITLE
Removes superfluous line from acl_matmul_utils.cpp

### DIFF
--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -23,8 +23,6 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-using namespace alg_kind;
-
 namespace acl_matmul_utils {
 
 status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,


### PR DESCRIPTION
# Description

`using namespace alg_kind` was added into acl_matmul_utils.cpp here:
https://github.com/oneapi-src/oneDNN/commit/fa93750bfb821fe05e3190b36f52b5bd88a57110#diff-cc9bdf3a73a21454ad71a38156a54c15c3296d283686537051763b606f1780f3

However, it is not required and should have been removed here:
https://github.com/oneapi-src/oneDNN/commit/acb63f4949c9bdf6952f673f55b3dd3102d771b0

This change was most likely lost during a rebase.

This PR corrects that mistake and removes `using namespace alg_kind` from acl_matmul_utils.cpp

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?