### PR TITLE
rfc: v3 API cleanup

### DIFF
--- a/rfcs/20220815-v3.0-API-cleanup/README.md
+++ b/rfcs/20220815-v3.0-API-cleanup/README.md
@@ -1,0 +1,93 @@
+# RFC: v3.0 API cleanup
+
+## Introduction
+Major v3 oneDNN release is coming [soon](https://github.com/oneapi-src/oneDNN/milestone/16).
+This is a perfect opportunity to provide API improvements.
+To decrease maintenance pressure on the library, outdated APIs will be removed from the library which affects user integration code of oneDNN.
+oneDNN v3.0 will not be API/ABI backward compatible with oneDNN v2.x.
+Hence, user will need to modify their code to use oneDNN v3.0.
+Below one may find a comprehensive list of targeted changes:
+
+## List of changes
+Disclaimer: header files are copied in this folder are from oneDNN v2.7 to preserve lines to refer to exact spots.
+
+* Build:
+    * Build time option `DNNL_USE_RT_OBJECTS_IN_PRIMITIVE_CACHE` and all code supporting the `false` value will be removed.
+
+* C/C++ types:
+    * Eltwise algorithm types:
+        - [`soft_relu`](dnnl.hpp#L563) will be removed. [`soft_relu_v2`](dnnl.hpp#L565) will be renamed into `soft_relu`.
+            * End user must specify `alpha` value in a correspondent call.
+        - [`logsigmoid`](dnnl.hpp#L567) will be removed. It can be used as current [`soft_relu_v2`](dnnl.hpp#L565) with `alpha` equal to `-1`.
+            * End user must replace the algorithm with another one.
+        - [`bounded_relu`](dnnl.hpp#L561) will be removed. It can be used as current [`clip`](dnnl.hpp#L584) with `alpha` equal to `0` and `beta` equal to former `alpha`.
+            * End user must replace the algorithm with another one.
+        - [`hardswish`](dnnl.hpp#L592) will get an extension with `alpha` and `beta` parameters and follow [`hardsigmoid`](dnnl.hpp#L594) algorithm, since in many frameworks `hardswish` is defined as `x * hardsigmoid(x)`, but current version of `hardswish` has hard coded `alpha` and `beta` values to `1/6` and `1/2` while different frameworks may utilize other values.
+            * End user must specify `alpha` and `beta` values in a correspondent call.
+        - [`eltwise_gelu`](dnnl.hpp#576) will be removed as an alias to `eltwise_gelu_tanh`.
+            * End user must replace one type with another one.
+        - C enum type algorithm values will be modified.
+            * No impact for end user.
+    * Memory format tags:
+        - Values of certain plain tags will change to group them together.
+            * No impact for end user.
+    * Normalization [`use_scaleshift`](dnnl.hpp#L724) flag will be removed. This functionality is [supported](https://github.com/oneapi-src/oneDNN/tree/rfcs/rfcs/20210223-batch-norm-scale-only) through two different flags [`use_scale`](dnnl.hpp#L740) and [`use_shift`](dnnl.hpp#L745).
+        - End user must replace integration code tied to `use_scaleshift` with a new one to follow split arguments.
+    * ISA enum:
+        - [`avx512_mic`](dnnl.hpp#L13039) and [`avx512_mic_4ops`](dnnl.hpp#L13041) ISA values will be removed as no longer supported in the library.
+            * End user must replace their code if values specified were used directly.
+        - ISA enum values will be changed to better reflect an order of features supported.
+            * No impact for end user.
+        - ISA enum value `dnnl_cpu_isa_all` and its `cpu_isa::all` counterpart are renamed into `dnnl_cpu_isa_default` and its `cpu_isa::isa_default` counterpart.
+            * End user must replace their code if values specified were used directly.
+    * Propagation kind:
+        - [`forward_scoring`](dnnl.hpp#507) will be removed as an alias for `forward_inference`.
+            * End user must replace one type with another one.
+    * Algorithm types:
+        - [`pooling_avg`](dnnl.hpp#617) will be removed as an alias for `pooling_avg_exclude_padding`.
+            * End user must replace one type with another one.
+    * RNN direction type:
+        - [`unidirectional`](dnnl.hpp#827) will be removed as an alias for `unidirectional_left2right`.
+            * End user must replace one type with another one.
+
+* Attributes:
+    * Sum post-op (C API affected only):
+        - [`dnnl_post_ops_append_sum`](dnnl.h#L655) and [`dnnl_post_ops_append_sum_v2`](dnnl.h#L690) will be removed. [`dnnl_post_ops_append_sum_v3`](dnnl.h#L726) will be renamed into `dnnl_post_ops_append_sum`.
+            * End user must add `zero_point` and `data_type` arguments in a correspondent call.
+    * Depthwise post-op:
+        - [`append_dw_k3s1p1`](dnnl.hpp#L3240), [`append_dw_k3s2p1`](dnnl.hpp#L3306), [`get_params_dw_k3s1p1`](dnnl.hpp#L3262), and [`get_params_dw_k3s2p1`](dnnl.hpp#L3327) and their C API counterparts ([`dnnl_post_ops_append_dw_k3s1p1`](dnnl.h#L899), [`dnnl_post_ops_append_dw_k3s2p1`](dnnl.h#L959), [`dnnl_post_ops_get_params_dw_k3s1p1`](dnnl.h#L920), and [`dnnl_post_ops_get_params_dw_k3s2p1`](dnnl.h#L980)) will be removed.
+            * End user must replace these calls with [`append_dw`](dnnl.hpp#L3144) and [`get_params_dw`](dnnl.hpp#3176) ([`dnnl_post_ops_append_dw`](dnnl.h#L837) and [`dnnl_post_ops_get_params_dw`](dnnl.h#862) in C API) with additional arguments for `kernel`, `stride`, and `padding`.
+
+* Primitives (C++ changes only, as C changes are covered by [this RFC](https://github.com/oneapi-src/oneDNN/pull/1391)):
+    * [`pooling_forward`](dnnl.hpp#L6388) and [`pooling_backward`](dnnl.hpp#L6508) will be removed. [`pooling_v2_forward`](dnnl.hpp#L12372) and [`pooling_v2_backward`](dnnl.hpp#L12502) will be renamed into `pooling_forward` and `pooling_backward`.
+        * End user must update `pooling_forward` and `pooling_backward` classes with proper calls to primitive descriptor constructors or replace `pooling_v2_forward` and `pooling_v2_backward` calls.
+    * [`softmax_forward`](dnnl.hpp#L6878) and [`softmax_backward`](dnnl.hpp#L6976) will be removed. [`softmax_v2_forward`](dnnl.hpp#L7094) and [`softmax_v2_backward`](dnnl.hpp#L7199) will be renamed into `softmax_forward` and `softmax_backward`.
+        * End user must update `softmax_forward` and `softmax_backward` classes with proper calls to primitive descriptor constructors or replace `softmax_v2_forward` and `softmax_v2_backward` calls.
+    * [`logsoftmax_forward`](dnnl.hpp#L7322) and [`logsoftmax_backward`](dnnl.hpp#L7425) will be removed. Logsoftmax functionality is [supported](https://github.com/oneapi-src/oneDNN/tree/rfcs/rfcs/20211207-softmax-v2) through new softmax classes using a [specific algorithm](dnnl_types.h#L1587).
+        * End user must replace `logsoftmax_forward` and `logsoftmax_backward` calls with future `softmax_forward` and `softmax_backward` constructors.
+    * `layer_normalization_forward` [this](dnnl.hpp#L7875) and [this](dnnl.hpp#L7897) constructors and `layer_normalization_backward` [this](dnnl.hpp#L8056) and [this](dnnl.hpp#L8081) constructors relying on a single data descriptor instead of separate source and destination descriptors will be removed. Note that new constructors providing support for two memory descriptors may have same signature as former ones.
+        * End user must update `layer_normalization_forward` and `layer_normalization_backward` classes with proper calls to primitive descriptor constructors.
+    * [`batch_normalization_forward`](dnnl.hpp#L7561) and [`batch_normalization_backward`](dnnl.hpp#L7699) constructors relying on a single data descriptor instead of source and destination will be replaced with constructors providing separate source and destination memory descriptors.
+        * End user must update calls to `batch_normalization_forward::primitive_desc` and `batch_normalization_backward::primitive_desc` constructors accordingly.
+    * [`shuffle_forward`](dnnl.hpp#L11687) and [`shuffle_backward`](dnnl.hpp#L11769) constructors relying on a single data descriptor instead of source and destination will be replaced with constructors providing separate source and destination memory descriptors.
+        * End user must update calls to `shuffle_forward::primitive_desc` and `shuffle_backward::primitive_desc` constructors accordingly.
+    * [`eltwise_forward`](dnnl.hpp#L6656) and [`eltwise_backward`](dnnl.hpp#L6757) constructors relying on a single data descriptor instead of source and destination will be replaced with constructors providing separate source and destination memory descriptors.
+        * End user must update calls to `eltwise_forward::primitive_desc` and `eltwise_backward::primitive_desc` constructors accordingly.
+    * [`prelu_forward`](dnnl.hpp#L12647) and [`prelu_backward`](dnnl.hpp#L12742) constructors relying on a single data descriptor instead of source and destination will be replaced with constructors providing separate source and destination memory descriptors.
+        * End user must update calls to `prelu_forward::primitive_desc` and `prelu_backward::primitive_desc` constructors accordingly.
+    * [`lrn_forward`](dnnl.hpp#L6165) and [`lrn_backward`](dnnl.hpp#L6268) constructors relying on a single data descriptor instead of source and destination will be replaced with constructors providing separate source and destination memory descriptors.
+        * End user must update calls to `lrn_forward::primitive_desc` and `lrn_backward::primitive_desc` constructors accordingly.
+        * **NOTE!** `lrn_backward::primitive_desc` changes the order of memory descriptors provided.
+
+* Primitive descriptors:
+    * C API [`dnnl_convolution_forward_desc_init`](dnnl.h#1512), [`dnnl_convolution_backward_data_desc_init`](dnnl.h#1589), and [`dnnl_convolution_backward_weights_desc_init`](dnnl.h#1663) calls will be removed. [`dnnl_dilated_convolution_forward_desc_init`](dnnl.h#1555), [`dnnl_dilated_convolution_backward_data_desc_init`](dnnl.h#1626), and [`dnnl_dilated_convolution_backward_weights_desc_init`](dnnl.h#1704) will be renamed to `dnnl_convolution_forward_desc_init`, `dnnl_convolution_backward_data_desc_init`, and `dnnl_convolution_backward_weights_desc_init` correspondently. Note that these API calls will be updated to have two argument for forward propagation kind (engine and attributes) and three arguments for backward propagation kind (engine, attributes, and hint) according to [this RFC](https://github.com/oneapi-src/oneDNN/pull/1391).
+        * End user must update calls that will be removed with dilation parameter or change the name of modified calls.
+    * Sum [`primitive_desc`](dnnl.hpp#4519) constructors, Concat [`primitive_desc`](dnnl.hpp#4422) constructors, and Shuffle [`primitive_desc`](dnnl.hpp#11727) constructor will change a signature, where attributes and engine will be swapped, to align with rest primitive_desc constructors from other classes.
+        * End user must update calls to mentioned constructors according to the change.
+    * RNN [`constructors`](dnnl.hpp#8900) will drop `beta` and `flags` arguments as not used. C API remains as is.
+        * End user must update constructor call if non-zero `alpha` argument was provided.
+
+* Auxiliary:
+    * C++ API [`void set_data_handle(void *handle, const stream &astream)`](dnnl.hpp#L2808) will be removed as stream is no longer necessary when setting data handle.
+        * End user must update `set_data_handle` API to the one without `stream` input argument.
+    * C++ API [`stream(const engine &aengine, flags aflags = flags::default_flags)`](dnnl.hpp#L1116) will receive `explicit` keyword to avoid implicit conversions leading to API misuse.

--- a/rfcs/20220815-v3.0-API-cleanup/dnnl.h
+++ b/rfcs/20220815-v3.0-API-cleanup/dnnl.h
@@ -1,0 +1,4257 @@
+/*******************************************************************************
+* Copyright 2016-2022 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/// @file
+/// C API
+
+#ifndef ONEAPI_DNNL_DNNL_H
+#define ONEAPI_DNNL_DNNL_H
+
+#include "oneapi/dnnl/dnnl_config.h"
+#include "oneapi/dnnl/dnnl_types.h"
+#include "oneapi/dnnl/dnnl_version.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @addtogroup dnnl_api
+/// @{
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// Creates a primitive descriptor iterator.
+///
+/// @param iterator Output primitive descriptor iterator.
+/// @param op_desc Operation descriptor.
+/// @param attr Primitive attributes (can be NULL).
+/// @param engine Engine to use.
+/// @param hint_forward_primitive_desc For backward propagation: primitive
+///     descriptor for a respective forward propagation primitive. Pass NULL
+///     for forward propagation.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_desc_iterator_create(
+        dnnl_primitive_desc_iterator_t *iterator, const_dnnl_op_desc_t op_desc,
+        const_dnnl_primitive_attr_t attr, dnnl_engine_t engine,
+        const_dnnl_primitive_desc_t hint_forward_primitive_desc);
+
+/// Advances the primitive descriptor iterator to point to the next available
+/// implementation.
+///
+/// @param iterator A primitive descriptor iterator to advance.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+/// @returns #dnnl_iterator_ends if no more implementations available.
+dnnl_status_t DNNL_API dnnl_primitive_desc_iterator_next(
+        dnnl_primitive_desc_iterator_t iterator);
+
+/// Fetches the current primitive descriptor from a primitive descriptor
+/// iterator.
+///
+/// @note
+///     The user is responsible for deleting the resulting primitive
+///     descriptor using dnnl_primitive_desc_destroy().
+///
+/// @param iterator A primitive descriptor iterator.
+/// @returns A primitive descriptor.
+dnnl_primitive_desc_t DNNL_API dnnl_primitive_desc_iterator_fetch(
+        const_dnnl_primitive_desc_iterator_t iterator);
+
+/// Destroys a primitive descriptor iterator.
+///
+/// @param iterator Primitive descriptor iterator to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_desc_iterator_destroy(
+        dnnl_primitive_desc_iterator_t iterator);
+
+/// Creates a primitive descriptor. This function is equivalent to a sequence
+/// of #dnnl_primitive_desc_iterator_create() and
+/// #dnnl_primitive_desc_iterator_fetch(). In other words, the library will
+/// pick the first suitable implementation.
+///
+/// @param primitive_desc Output primitive descriptor.
+/// @param op_desc Operation descriptor.
+/// @param attr Primitive attributes (can be NULL).
+/// @param engine Engine to use.
+/// @param hint_forward_primitive_desc For backward propagation: primitive
+///     descriptor for a respective forward propagation primitive. Pass NULL
+///     for forward propagation.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_desc_create(
+        dnnl_primitive_desc_t *primitive_desc, const_dnnl_op_desc_t op_desc,
+        const_dnnl_primitive_attr_t attr, dnnl_engine_t engine,
+        const_dnnl_primitive_desc_t hint_forward_primitive_desc);
+
+/// Clones a primitive descriptor. The resulting primitive descriptor must be
+/// destroyed separately.
+///
+/// @param primitive_desc Output primitive descriptor.
+/// @param existing_primitive_desc Primitive descriptor to clone.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_desc_clone(
+        dnnl_primitive_desc_t *primitive_desc,
+        const_dnnl_primitive_desc_t existing_primitive_desc);
+
+/// Returns a constant reference to the attributes of a primitive descriptor.
+///
+/// @warning
+///     It is an error to destroy the resulting @p attr.
+///
+/// @warning
+///     The lifetime of an @p attr is the same as that of a @p
+///     primitive_desc, so it is an error to use the @p attr once the @p
+///     primitive_desc has been destroyed.
+///
+/// @param primitive_desc Primitive descriptor.
+/// @param attr Output primitive attributes.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_desc_get_attr(
+        const_dnnl_primitive_desc_t primitive_desc,
+        const_dnnl_primitive_attr_t *attr);
+
+/// Destroys a primitive descriptor.
+///
+/// @param primitive_desc Primitive descriptor to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_desc_destroy(
+        dnnl_primitive_desc_t primitive_desc);
+
+/// Queries a primitive descriptor for various pieces of information.
+///
+/// The most common use case is to query a primitive descriptor, created with
+/// source, weights, and destination memory descriptors with format tags set
+/// to #dnnl_format_tag_any, for the corresponding memory descriptors (in this
+/// case the @p what is set to #dnnl_query_src_md, #dnnl_query_weights_md, and
+/// #dnnl_query_dst_md respectively) so that it is possible to create memory
+/// objects and reorder primitives if necessary.
+///
+/// Another typical use case is to query a primitive descriptor for workspace
+/// memory descriptor (with @p what set to #dnnl_query_workspace_md). If this
+/// query returns #dnnl_not_required status, then workspace memory is not
+/// required.
+///
+/// @note
+///     When querying for a memory descriptor for a scratchpad, a workspace,
+///     or an optional parameter, the query will return a pointer to a zero
+///     memory descriptor if the parameter is not needed.
+///
+/// A few other use cases:
+///  - query a primitive descriptor for the underlying operation descriptor
+///    (#dnnl_query_convolution_d, #dnnl_query_eltwise_d, #dnnl_query_rnn_d,
+///    etc.)
+///  - query a primitive descriptor for the implementation information string
+///    (#dnnl_query_impl_info_str)
+///  - query a primitive descriptor for the number of inputs and outputs
+///    (#dnnl_query_num_of_inputs_s32 and #dnnl_query_num_of_outputs_s32
+///    respectively)
+///
+/// @sa dnnl_query_t for more options
+///
+/// @param primitive_desc Primitive descriptor.
+/// @param what Parameter to query.
+/// @param index Index of the parameter to query for.
+/// @param result Output result. The type depends on the query. For example,
+///     it must be a @c dnnl_memory_desc_t* if querying for a memory
+///     descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_desc_query(
+        const_dnnl_primitive_desc_t primitive_desc, dnnl_query_t what,
+        int index, void *result);
+
+/// Queries primitive descriptor for a memory descriptor.
+///
+/// @note
+///     This function is a convenience version of
+///     #dnnl_primitive_desc_query().
+///
+/// @param primitive_desc Primitive descriptor.
+/// @param what Kind of memory descriptor parameter to query for.
+/// @param index Index of the parameter to query.
+/// @returns A pointer to the requested memory descriptor.
+/// @returns A pointer to a zero memory descriptor if the parameter is not
+///          needed.
+/// @returns NULL in case of any error.
+///
+const dnnl_memory_desc_t DNNL_API *dnnl_primitive_desc_query_md(
+        const_dnnl_primitive_desc_t primitive_desc, dnnl_query_t what,
+        int index);
+
+/// Queries primitive descriptor for a signed 32bit int.
+///
+/// @note
+///     This function is a convenience version of
+///     #dnnl_primitive_desc_query().
+///
+/// @param primitive_desc Primitive descriptor.
+/// @param what Kind of the value to query for.
+/// @param index Index of the parameter to query.
+/// @returns The requested value.
+/// @returns 0 in case of any error (in particular if the queried entity is
+///     not of type int32_t). Note that 0 may also be the actual returned
+///     value.
+int DNNL_API dnnl_primitive_desc_query_s32(
+        const_dnnl_primitive_desc_t primitive_desc, dnnl_query_t what,
+        int index);
+
+/// Creates a primitive.
+///
+/// @param primitive Output primitive.
+/// @param primitive_desc Primitive descriptor used to create the primitive.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_create(dnnl_primitive_t *primitive,
+        const_dnnl_primitive_desc_t primitive_desc);
+
+/// Creates a primitive from a cache blob.
+///
+/// @param primitive Output primitive.
+/// @param primitive_desc Primitive descriptor used to create the primitive.
+/// @param size Size of the cache blob in bytes.
+/// @param cache_blob Cache blob of size @p size.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_create_from_cache_blob(
+        dnnl_primitive_t *primitive, const_dnnl_primitive_desc_t primitive_desc,
+        size_t size, const uint8_t *cache_blob);
+
+/// Executes a primitive.
+///
+/// @param primitive Primitive to execute.
+/// @param stream Stream to use.
+/// @param nargs Number of arguments.
+/// @param args Array of arguments. Each argument is an
+///     <index, #dnnl_memory_t> pair. The index is one of the `DNNL_ARG_*`
+///     values such as `DNNL_ARG_SRC`. Unless runtime shapes are used (see
+///     #DNNL_RUNTIME_DIM_VAL), the memory object must have the same memory
+///     descriptor as that returned by
+///     #dnnl_primitive_desc_query_md(#dnnl_query_exec_arg_md, index).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+
+/// @note If any argument in @param args is padded (padded_dims >
+/// dims), the primitive execution will assume properly zero-padded
+/// input arguments, and produce zero-padded output arguments.
+dnnl_status_t DNNL_API dnnl_primitive_execute(const_dnnl_primitive_t primitive,
+        dnnl_stream_t stream, int nargs, const dnnl_exec_arg_t *args);
+
+/// Retrieves a constant reference to the primitive descriptor of a given
+/// primitive.
+///
+/// @warning
+///     It is an error to destroy the returned object. It is owned by the
+///     primitive. The @c const qualifier of the returned object prevents
+///     such attempts.
+///
+/// @param primitive Primitive to query for the primitive descriptor.
+/// @param primitive_desc Output primitive descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_get_primitive_desc(
+        const_dnnl_primitive_t primitive,
+        const_dnnl_primitive_desc_t *primitive_desc);
+
+/// Retrieves a cache blob associated with the given primitive.
+///
+/// @param primitive Primitive to query for the cache blob.
+/// @param size Size of the cache blob in bytes.
+/// @param cache_blob Cache blob of size @p size. If the @p cache_blob is
+///     nullptr then the size of the cache blob is returned in @p size.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+///
+/// @note The cache blob can be empty. It's the user's responsibility to check
+///     whether it's empty prior to passing it to
+///     #dnnl_primitive_create_from_cache_blob().
+dnnl_status_t DNNL_API dnnl_primitive_get_cache_blob(
+        const_dnnl_primitive_t primitive, size_t *size, uint8_t *cache_blob);
+
+/// Destroys a primitive.
+///
+/// @param primitive The primitive to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_destroy(dnnl_primitive_t primitive);
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_attributes
+/// @{
+
+/// Creates an empty (default) primitive attributes with all the parameters
+/// set to their default values.
+///
+/// Empty attributes are implied whenever the respective argument is NULL.
+///
+/// @param attr Output primitive attributes.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_create(dnnl_primitive_attr_t *attr);
+
+/// Clones primitive attributes.
+///
+/// @param attr Output primitive attributes.
+/// @param existing_attr Primitive attributes to clone.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_clone(
+        dnnl_primitive_attr_t *attr, const_dnnl_primitive_attr_t existing_attr);
+
+/// Destroys primitive attributes.
+///
+/// @param attr Primitive attributes to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_destroy(dnnl_primitive_attr_t attr);
+
+/// Returns the floating-point math mode primitive attribute.
+///
+/// @param attr Primitive attributes.
+/// @param mode Output FP math mode.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_fpmath_mode(
+        const_dnnl_primitive_attr_t attr, dnnl_fpmath_mode_t *mode);
+
+/// Sets the floating-point math mode primitive attributes.
+///
+/// @param attr Primitive attributes.
+/// @param mode FP math mode. The possible values are:
+///     #dnnl_fpmath_mode_strict (default),
+///     #dnnl_fpmath_mode_bf16,
+///     #dnnl_fpmath_mode_f16,
+///     #dnnl_fpmath_mode_tf32,
+///     #dnnl_fpmath_mode_any.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_fpmath_mode(
+        dnnl_primitive_attr_t attr, dnnl_fpmath_mode_t mode);
+
+/// Returns the primitive attributes scratchpad mode.
+///
+/// @param attr Primitive attributes.
+/// @param mode Output scratchpad mode.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_scratchpad_mode(
+        const_dnnl_primitive_attr_t attr, dnnl_scratchpad_mode_t *mode);
+
+/// Sets primitive attributes scratchpad mode.
+///
+/// @param attr Primitive attributes.
+/// @param mode Scratchpad mode. The possible values are:
+///     #dnnl_scratchpad_mode_library (default) and
+///     #dnnl_scratchpad_mode_user.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_scratchpad_mode(
+        dnnl_primitive_attr_t attr, dnnl_scratchpad_mode_t mode);
+
+/// Returns primitive attributes output scaling factors correspondence mask
+/// and values.
+///
+/// @warning
+///     The @p scales array is an internal part of the primitive attributes
+///     @p attr, so it is an error to modify or destroy the @p scales array.
+///
+/// @warning
+///     The lifetime of @p scales array is the same as that of the primitive
+///     attributes @p attr to which it belongs, so it is an error to use
+///     @p scales after @p attr is destroyed.
+///
+/// @param attr Primitive attributes.
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p scales
+///     vector. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of
+///     0 implies a common output scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_output_scales(
+        const_dnnl_primitive_attr_t attr, dnnl_dim_t *count, int *mask,
+        const float **scales);
+
+/// Sets output scaling factors correspondence mask and values.
+///
+/// @note
+///     The order of dimensions does not depend on how elements are laid
+///     out in memory. For example:
+///     - for a 2D CNN activations tensor the order is always (n, c)
+///     - for a 4D CNN activations tensor the order is always (n, c, h, w)
+///     - for a 5D CNN weights tensor the order is always
+///        (g, oc, ic, kh, kw)
+///
+/// Example usage:
+/// @code
+///     int mb = 32, oc = 32, oh = 14, ow = 14; // convolution output params
+///     float scales[oc] = { ... }; // unique output scales per output channel
+///     int oc_dim = 1; // mb_dim = 0, channel_dim = 1, height_dim = 2, ...
+///
+///     dnnl_convolution_desc_t conv_d; // create a convolution descriptor
+///
+///     dnnl_primitive_attr_t attr;
+///     dnnl_primitive_attr_create(&attr); // create primitive attributes
+///     dnnl_primitive_attr_set_output_scales(attr, oc, 1 << oc_dim, scales);
+///
+///     dnnl_primitive_desc_t conv_pd;
+///     dnnl_primitive_desc_create(&conv_pd, &conv_d, attr, engine, NULL);
+/// @endcode
+///
+/// @param attr Primitive attributes.
+/// @param count Length of the array of scaling factors @p scales.
+/// @param mask Scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p scales
+///     array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of
+///     0 implies a common output scaling factor for the whole output tensor.
+/// @param scales Array of output scaling factors. If the output scaling
+///     factors are known at the time of this call, this array must contain @p
+///     count values and the following equality must hold:
+///     \f[count = \prod\limits_{d \in mask} output.dims[d].\f]
+///     Violations can only be detected when the attributes are used to create
+///     a primitive descriptor.
+///     If the output scaling factors are not known at the time of the call,
+///     this array must contain a single #DNNL_RUNTIME_F32_VAL value and the
+///     output scaling factors must be passed at execution time as an argument
+///     with index #DNNL_ARG_ATTR_OUTPUT_SCALES.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_output_scales(
+        dnnl_primitive_attr_t attr, dnnl_dim_t count, int mask,
+        const float *scales);
+
+/// Returns primitive attributes scaling factors correspondence mask and values
+/// for a given memory argument.
+///
+/// @warning
+///     The output @p scales array is an internal part of the primitive
+///     attributes @p attr, so it is an error to modify or destroy the @p
+///     scales array.
+///
+/// @warning
+///     The lifetime of the @p scales array is the same as that of the primitive
+///     attributes @p attr to which it belongs, so it is an error to use @p
+///     scales after @p attr is destroyed.
+///
+///
+/// @param attr Primitive attributes.
+/// @param arg Parameter argument index as passed to the
+///     dnnl_primitive_execute() call.
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of 0
+///     implies a common scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of float scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_scales(
+        dnnl_primitive_attr_t attr, int arg, dnnl_dim_t *count, int *mask,
+        const float **scales);
+
+/// Sets primitive attributes scaling factors for primitive operations for a
+/// given memory argument.
+///
+/// @sa dnnl_primitive_attr_set_output_scales
+///
+///
+/// @param attr Primitive attributes.
+/// @param arg Parameter argument index as passed to the
+///     dnnl_primitive_execute() call.
+/// @param count Length of the array of scaling factors @p scales.
+/// @param mask Scaling factors correspondence mask that defines the
+///     correspondence between the tensor dimensions and the @p scales array.
+///     The set i-th bit indicates that a dedicated scaling factor is used for
+///     each index along that dimension. Set the mask to 0 to use a common
+///     scaling factor for the whole output tensor.
+/// @param scales Constant array of float scaling factors. This array must
+///     contain @p count scales and the following equality must hold:
+///     \f[count = \prod\limits_{d \in mask} output.dims[d].\f]
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_scales(
+        dnnl_primitive_attr_t attr, int arg, dnnl_dim_t count, int mask,
+        const float *scales);
+
+/// Returns @p count, correspondence zero point @p mask, and a pointer to a
+/// constant int32_t array of @p zero_points for given @p attr and memory
+/// argument (index), previously set by dnnl_primitive_attr_set_zero_points.
+///
+/// @warning
+///     The output @p zero_points array is an internal part of the primitive
+///     attributes @p attr, so it is an error to modify or destroy the @p
+///     zero_points array.
+///
+/// @warning
+///     The lifetime of @p zero_points array is the same as that of the
+///     primitive attributes @p attr to which it belongs, so it is an error
+///     to use @p zero_points after @p attr is destroyed.
+///
+///
+/// @param attr Primitive attributes.
+/// @param arg Parameter argument index as passed to the
+///     dnnl_primitive_execute() call.
+/// @param count Output length of the array of zero points @p zero_points.
+/// @param mask Output zero points correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     zero_points array. The set i-th bit indicates that a dedicated output
+///     zero point is used for each index along that dimension. The mask
+///     value of 0 implies a common zero point for the whole output tensor.
+/// @param zero_points Output pointer to a constant array of int32_t zero
+///     points.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_zero_points(
+        const_dnnl_primitive_attr_t attr, int arg, dnnl_dim_t *count, int *mask,
+        const int32_t **zero_points);
+
+/// Sets primitive attributes zero points for primitive operations for a given
+/// memory argument.
+///
+/// @sa dnnl_primitive_attr_set_output_scales
+///
+///
+/// @param attr Primitive attributes.
+/// @param arg Parameter argument index as passed to the
+///     dnnl_primitive_execute() call.
+/// @param count Length of the array of zero points @p zero_points.
+/// @param mask Zero point correspondence mask that defines the
+///     correspondence between the tensor dimensions and the @p
+///     zero_points array. The set i-th bit indicates that a dedicated
+///     zero point is used for each index along that dimension. Set the
+///     mask to 0 to use a common zero point for the whole output tensor.
+/// @param zero_points Constant array of int32_t zero points. If the zero
+///     points are known at the time of this call, this array must contain @p
+///     count zero points and the following equality must hold:
+///     \f[count = \prod\limits_{d \in mask} output.dims[d].\f]
+///     If the zero points are not known at the time of the call, this array
+///     must contain a single #DNNL_RUNTIME_S32_VAL and the zero points must
+///     be passed at execution time as an argument with index
+///     #DNNL_ARG_ATTR_ZERO_POINTS.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_zero_points(
+        dnnl_primitive_attr_t attr, int arg, dnnl_dim_t count, int mask,
+        const int32_t *zero_points);
+
+/// Returns primitive attributes post-ops.
+///
+/// @warning
+///     The output @p post_ops points to the internal @p attr field, so it is
+///     an error to modify or destroy them. The lifetime of @p post_ops is
+///     the same as that of the @p attr it belongs to, so it is an error to
+///     use @p post_ops after @p attr has been destroyed.
+///
+/// @param attr Primitive attributes.
+/// @param post_ops Output post-ops.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_post_ops(
+        const_dnnl_primitive_attr_t attr, const_dnnl_post_ops_t *post_ops);
+
+/// Sets primitive attributes post-ops.
+///
+/// @note
+///     There is no way to check whether the post-ops would be supported by
+///     the target primitive. Any error will be reported by the
+///     dnnl_primitive_desc_create() function call.
+///
+/// @param attr Primitive attributes.
+/// @param post_ops Post-ops to set.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_post_ops(
+        dnnl_primitive_attr_t attr, const_dnnl_post_ops_t post_ops);
+
+/// Creates empty post-ops sequence.
+///
+/// @param post_ops Output post-ops.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_create(dnnl_post_ops_t *post_ops);
+
+/// Clones post-ops primitive attribute.
+///
+/// @param post_ops Output post-ops primitive attribute.
+/// @param existing_post_ops Post-ops primitive attribute to clone.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_clone(
+        dnnl_post_ops_t *post_ops, const_dnnl_post_ops_t existing_post_ops);
+
+/// Destroys post-ops.
+///
+/// @param post_ops Post-ops to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_destroy(dnnl_post_ops_t post_ops);
+
+/// Returns the length of post-ops.
+///
+/// @param post_ops Post-ops.
+/// @returns The number of post-ops entries.
+int DNNL_API dnnl_post_ops_len(const_dnnl_post_ops_t post_ops);
+
+/// Returns the kind of a post-op entry.
+///
+/// @param post_ops Post-ops.
+/// @param index Post-op entry index.
+/// @returns The kind of the post-op with the specified index.
+/// @returns #dnnl_undefined_primitive if there is no post-op at the specified
+///     index.
+dnnl_primitive_kind_t DNNL_API dnnl_post_ops_get_kind(
+        const_dnnl_post_ops_t post_ops, int index);
+
+/// Appends an accumulation (sum) to post-ops. Prior to accumulating the
+/// result, the previous value is multiplied by a scale.
+///
+/// The kind of this post-op is #dnnl_sum.
+///
+/// This feature may improve performance for cases like residual learning
+/// blocks, where the result of convolution is accumulated to the previously
+/// computed activations. The parameter @p scale may be used for the
+/// integer-based computations when the result and previous activations have
+/// different logical scaling factors.
+///
+/// In the simplest case where the accumulation is the only post-op, the
+/// computations will be:
+///
+///     dst[:] <- scale * dst[:] + op(...) // instead of dst[:] <- op(...)
+///
+/// @note
+///     This post-op executes in-place and does not change the
+///     destination layout.
+///
+/// @param post_ops Post-ops.
+/// @param scale Accumulation scaling factor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_sum(
+        dnnl_post_ops_t post_ops, float scale);
+
+/// Appends an accumulation v2 (sum) to post-ops. Prior to accumulating the
+/// result, the previous value is multiplied by a scale.
+///
+/// The kind of this post-op is #dnnl_sum.
+///
+/// This feature may improve performance for cases like residual learning
+/// blocks, where the result of convolution is accumulated to the previously
+/// computed activations. The parameter @p scale may be used for the
+/// integer-based computations when the result and previous activations have
+/// different logical scaling factors.
+///
+/// In the simplest case where the accumulation is the only post-op, the
+/// computations will be:
+///
+///     dst[:] <- scale * dst[:] + op(...) // instead of dst[:] <- op(...)
+///
+/// If @p data_type is specified, original dst tensor will be reinterpreted
+/// as a tensor with provided data type. Since it is reinterpretation,
+/// data_type and dst data type should have the same size.
+/// As a result, computations will be:
+///
+///     dst[:] <- scale * as_data_type(dst[:]) + op(...)
+///                                        // instead of dst[:] <- op(...)
+/// @note
+///     This post-op executes in-place and does not change the
+///     destination layout.
+///
+/// @param post_ops Post-ops.
+/// @param scale Accumulation scaling factor.
+/// @param data_type Accumulation data_type.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_sum_v2(
+        dnnl_post_ops_t post_ops, float scale, dnnl_data_type_t data_type);
+
+/// Appends an accumulation v3 (sum) to post-ops. Prior to accumulating the
+/// result, a zero point is subtracted from the previous value and is
+/// multiplied by the scale.
+///
+/// The kind of this post-op is #dnnl_sum.
+///
+/// This feature may improve performance for cases like dequantize the
+/// asymmetrically quantized sum's src1 tensor to f32 domain before performing
+/// the sum operation by subtracting the @p zero_point before the scaling.
+///
+/// In the simplest case where accumulation is the only post-op, the
+/// computations will be:
+///
+///     dst[:] <- scale * (dst[:] - zero_point) + op(...)
+///                                             // instead of dst[:] <- op(...)
+///
+/// If @p data_type is specified, original dst tensor will be reinterpreted
+/// as a tensor with provided data type. Since it is reinterpretation,
+/// data_type and dst data type should have the same size.
+/// As a result, computations will be:
+///
+///     dst[:] <- scale * (as_data_type(dst[:]) - zero_point) + op(...)
+///                                        // instead of dst[:] <- op(...)
+/// @note
+///     This post-op executes in-place and does not change the
+///     destination layout.
+///
+/// @param post_ops Post-ops.
+/// @param scale Accumulation scaling factor.
+/// @param zero_point Single scalar int32_t value of zero point.
+/// @param data_type Accumulation data_type.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_sum_v3(dnnl_post_ops_t post_ops,
+        float scale, int32_t zero_point, dnnl_data_type_t data_type);
+
+/// Returns the parameters of an accumulation (sum) post-op.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the sum post-op.
+/// @param scale Output accumulation scaling factor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+/// @returns #dnnl_invalid_arguments if @p index does not refer to a sum
+///     post-op.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_sum(
+        const_dnnl_post_ops_t post_ops, int index, float *scale);
+
+/// Returns the parameters of an accumulation (sum) post-op with
+/// a data type parameter.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the sum post-op.
+/// @param scale Output accumulation scaling factor.
+/// @param data_type Data type for accumulation.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_sum_v2(
+        const_dnnl_post_ops_t post_ops, int index, float *scale,
+        dnnl_data_type_t *data_type);
+
+/// Returns the parameters of an accumulation (sum) post-op with
+/// zero point and data type parameter.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the sum post-op.
+/// @param scale Output accumulation scaling factor.
+/// @param zero_point Zero point.
+/// @param data_type Data type for accumulation.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_sum_v3(
+        const_dnnl_post_ops_t post_ops, int index, float *scale,
+        int32_t *zero_point, dnnl_data_type_t *data_type);
+
+/// Appends an elementwise post-op.
+///
+/// The kind of this post operation is #dnnl_eltwise.
+///
+/// In the simplest case when the elementwise is the only post operation, the
+/// computations would be:
+///
+///     dst[:] <- scale * eltwise_op (op(...)) // instead of dst[:] <- op(...)
+///
+/// where eltwise_op is configured with the given parameters.
+///
+/// @param post_ops Post-ops.
+/// @param scale Scaling factor.
+/// @param alg_kind Elementwise algorithm for the post-op.
+/// @param alpha Alpha parameter for the elementwise algorithm.
+/// @param beta Beta parameter for the elementwise algorithm.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_eltwise(dnnl_post_ops_t post_ops,
+        float scale, dnnl_alg_kind_t alg_kind, float alpha, float beta);
+
+/// Returns the parameters of an elementwise post-op.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the elementwise post-op.
+/// @param scale Output scaling factor.
+/// @param alg_kind Output elementwise algorithm kind.
+/// @param alpha Output alpha parameter for the elementwise algorithm.
+/// @param beta Output beta parameter for the elementwise algorithm.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+/// @returns #dnnl_invalid_arguments if @p index does not refer to an
+///     elementwise post-op.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_eltwise(
+        const_dnnl_post_ops_t post_ops, int index, float *scale,
+        dnnl_alg_kind_t *alg_kind, float *alpha, float *beta);
+
+/// Appends a depthwise post-op convolution.
+///
+/// This post-op can only be fused with a 2D 1x1 convolution (convolution with
+/// weights spatial dimensions equal to 1 i.e., kh=kw=1).
+///
+/// The kind of this post-op is #dnnl_convolution.
+///
+/// The number of outputs for primitive with fusion is one. The output spatial
+/// size can be derived as below:
+///
+/// output_height = ceil(output_height_1x1_convolution, stride)
+/// output_width = ceil(output_width_1x1_convolution, stride)
+///
+/// See @ref dev_guide_attributes_post_ops_depthwise and
+/// @ref dev_guide_attributes_post_ops_depthwise_fusion for more info.
+///
+/// @param post_ops Post-ops.
+/// @param weights_data_type Weights data type of depthwise post-op
+/// @param bias_data_type Bias data type of depthwise post-op
+/// @param dst_data_type Output data type of depthwise post-op
+/// @param kernel_size Size of kernel of depthwise post-op
+/// @param stride_size Size of stride of depthwise post-op
+/// @param padding_l_size Size of left and top paddings of depthwise post-op
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of 0
+///     implies a common scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of float scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise
+dnnl_status_t DNNL_API dnnl_post_ops_append_dw(dnnl_post_ops_t post_ops,
+        dnnl_data_type_t weights_data_type, dnnl_data_type_t bias_data_type,
+        dnnl_data_type_t dst_data_type, dnnl_dim_t kernel_size,
+        dnnl_dim_t stride_size, dnnl_dim_t padding_l_size, dnnl_dim_t count,
+        int mask, const float *scales);
+
+/// Returns the parameters of an depthwise post-op.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the elementwise post-op.
+/// @param weights_data_type Weights data type of depthwise post-op
+/// @param bias_data_type Bias data type of depthwise post-op
+/// @param dst_data_type Output data type of depthwise post-op
+/// @param kernel_size Size of kernel of depthwise post-op
+/// @param stride_size Size of stride of depthwise post-op
+/// @param padding_l_size Size of left and top paddings of depthwise post-op
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of 0
+///     implies a common scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of float scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_dw(
+        const_dnnl_post_ops_t post_ops, int index,
+        dnnl_data_type_t *weights_data_type, dnnl_data_type_t *bias_data_type,
+        dnnl_data_type_t *dst_data_type, dnnl_dim_t *kernel_size,
+        dnnl_dim_t *stride_size, dnnl_dim_t *padding_l_size, dnnl_dim_t *count,
+        int *mask, const float **scales);
+
+/// Appends a depthwise post-op convolution with stride 1.
+///
+/// This post-op can only be fused with a 2D 1x1 convolution (convolution with
+/// weights spatial dimension equal to 1 i.e., kh=kw=1).
+///
+/// The kind of this post-op is #dnnl_convolution.
+///
+/// The number of outputs for primitive remain same as before. The output size
+/// remain same as the original primitive due to stride=1.
+///
+/// The Post-op can be defined as:
+///
+///      dst[:] <- scales * (conv_dw(conv_1x1))
+///
+/// See @ref dev_guide_attributes_post_ops_depthwise and
+/// @ref dev_guide_attributes_post_ops_depthwise_fusion for more info.
+///
+/// @param post_ops Post-ops.
+/// @param weights_data_type Weights data type of depthwise post-op
+/// @param bias_data_type Bias data type of depthwise post-op
+/// @param dst_data_type Output data type of depthwise post-op
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of 0
+///     implies a common scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of float scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise
+dnnl_status_t DNNL_API dnnl_post_ops_append_dw_k3s1p1(dnnl_post_ops_t post_ops,
+        dnnl_data_type_t weights_data_type, dnnl_data_type_t bias_data_type,
+        dnnl_data_type_t dst_data_type, dnnl_dim_t count, int mask,
+        const float *scales);
+
+/// Returns the parameters of an depthwise post-op with stride 1.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the elementwise post-op.
+/// @param weights_data_type Weights data type of depthwise post-op
+/// @param bias_data_type Bias data type of depthwise post-op
+/// @param dst_data_type Output data type of depthwise post-op
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of 0
+///     implies a common scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of float scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_dw_k3s1p1(
+        const_dnnl_post_ops_t post_ops, int index,
+        dnnl_data_type_t *weights_data_type, dnnl_data_type_t *bias_data_type,
+        dnnl_data_type_t *dst_data_type, dnnl_dim_t *count, int *mask,
+        const float **scales);
+
+/// Appends a depthwise post-op convolution with stride 2.
+///
+/// This post-op can only be fused with a 2D 1x1 convolution (convolution with
+/// weights spatial dimension equal to 1 i.e., kh=kw=1).
+///
+/// The kind of this post-op is #dnnl_convolution.
+///
+/// The number of outputs for primitive remain same as before. The output
+/// spatial size can be derived as below:
+///
+/// output_height = ceil(output_height_1x1_convolution, stride)
+/// output_width = ceil(output_width_1x1_convolution, stride)
+///
+/// The Post-op can be defined as:
+///
+///      dst[:] <- scales * (conv_dw(conv_1x1))
+///
+/// See @ref dev_guide_attributes_post_ops_depthwise and
+/// @ref dev_guide_attributes_post_ops_depthwise_fusion for more info.
+///
+/// @param post_ops Post-ops.
+/// @param weights_data_type Weights data type of depthwise post-op
+/// @param bias_data_type Bias data type of depthwise post-op
+/// @param dst_data_type Output data type of depthwise post-op
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of 0
+///     implies a common scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of float scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise
+dnnl_status_t DNNL_API dnnl_post_ops_append_dw_k3s2p1(dnnl_post_ops_t post_ops,
+        dnnl_data_type_t weights_data_type, dnnl_data_type_t bias_data_type,
+        dnnl_data_type_t dst_data_type, dnnl_dim_t count, int mask,
+        const float *scales);
+
+/// Returns the parameters of an depthwise post-op with stride 2.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the elementwise post-op.
+/// @param weights_data_type Weights data type of depthwise post-op
+/// @param bias_data_type Bias data type of depthwise post-op
+/// @param dst_data_type Output data type of depthwise post-op
+/// @param count Output length of the array of scaling factors @p scales.
+/// @param mask Output scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales array. The set i-th bit indicates that a dedicated output scaling
+///     factor is used for each index along that dimension. The mask value of 0
+///     implies a common scaling factor for the whole output tensor.
+/// @param scales Output pointer to a constant array of float scaling factors.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_dw_k3s2p1(
+        const_dnnl_post_ops_t post_ops, int index,
+        dnnl_data_type_t *weights_data_type, dnnl_data_type_t *bias_data_type,
+        dnnl_data_type_t *dst_data_type, dnnl_dim_t *count, int *mask,
+        const float **scales);
+
+/// Appends a binary post-op.
+///
+/// The kind of this post operation is #dnnl_binary.
+///
+/// In the simplest case when the binary is the only post operation, the
+/// computations would be:
+///
+///     dst[:] <- binary_op (dst[:], another_input[:])
+///
+/// where binary_op is configured with the given parameters. binary_op supports
+/// broadcast semantics for a second operand.
+///
+/// @param post_ops Post-ops.
+/// @param alg_kind Binary algorithm for the post-op.
+/// @param src1_desc Memory descriptor of a second operand.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_binary(dnnl_post_ops_t post_ops,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src1_desc);
+
+/// Returns the parameters of a binary post-op.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the binary post-op.
+/// @param alg_kind Output binary algorithm kind.
+/// @param src1_desc Output memory descriptor of a second operand.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+/// @returns #dnnl_invalid_arguments if @p index does not refer to a binary
+///     post-op.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_binary(
+        const_dnnl_post_ops_t post_ops, int index, dnnl_alg_kind_t *alg_kind,
+        const dnnl_memory_desc_t **src1_desc);
+
+/// Appends a prelu forward post-op.
+///
+/// The kind of this post-op is #dnnl::primitive::kind::prelu.
+///
+/// The post-op can be defined as:
+///
+///      dst[:] <- prelu(dst[:], weights[:])
+///      prelu:
+///      dst[:] <- dst[:] if dst[:] > 0
+///      dst[:] <- dst[:] * weights[:] if dst[:] <= 0
+///
+///
+/// @note
+///     The order of dimensions does not depend on how elements are laid
+///     out in memory. For example:
+///     - for a 2D CNN activations tensor the order is always (n, c)
+///     - for a 4D CNN activations tensor the order is always (n, c, h, w)
+///     - for a 5D CNN weights tensor the order is always
+///        (g, oc, ic, kh, kw)
+///
+///    Prelu weights tensor is passed in runtime execution phase. Prelu
+///    weights tensor data type is implicitly assumed as f32 using plain
+///    layout (a, ab, acb, acdb, acdeb)
+///
+/// @param post_ops Post-ops.
+/// @param mask Defines the correspondence between the output tensor
+///     dimensions and the prelu weights tensor. The set i-th bit indicates
+///     that a dedicated weights value is used for each index along that
+///     dimension. Set the mask to 0 to use a common weights value
+///     for the whole output tensor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_prelu(
+        dnnl_post_ops_t post_ops, int mask);
+
+/// Returns the parameters of a prelu post-op.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the prelu post-op.
+/// @param mask Mask of the prelu post-op.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_prelu(
+        const_dnnl_post_ops_t post_ops, int index, int *mask);
+
+/// @} dnnl_api_attributes
+
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_memory
+/// @{
+
+/// Initializes a memory descriptor using dimensions and strides.
+///
+/// @note
+///     As always, the logical order of dimensions corresponds to the `abc...`
+///     format tag, and the physical meaning of the dimensions depends on both
+///     the primitive that consumes the memory and the context of that
+///     consumption.
+///
+/// @param memory_desc Output memory descriptor.
+/// @param ndims Number of dimensions
+/// @param dims Array of dimensions.
+/// @param data_type Elements data type.
+/// @param strides Strides in each dimension.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_desc_init_by_strides(
+        dnnl_memory_desc_t *memory_desc, int ndims, const dnnl_dims_t dims,
+        dnnl_data_type_t data_type, const dnnl_dims_t strides);
+
+/// Initializes a memory descriptor using dimensions and memory format tag.
+///
+/// @note
+///     As always, the logical order of dimensions corresponds to the `abc...`
+///     format tag, and the physical meaning of the dimensions depends on both
+///     the primitive that consumes the memory and the context of that
+///     consumption.
+///
+/// @param memory_desc Output memory descriptor.
+/// @param ndims Number of dimensions
+/// @param dims Array of dimensions.
+/// @param data_type Elements data type.
+/// @param tag Memory format tag. Can be #dnnl_format_tag_any which would
+///     allow a primitive to chose the final memory format. In this case the
+///     format_kind field of the memory descriptor would be set to
+///     #dnnl_format_kind_any.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_desc_init_by_tag(
+        dnnl_memory_desc_t *memory_desc, int ndims, const dnnl_dims_t dims,
+        dnnl_data_type_t data_type, dnnl_format_tag_t tag);
+
+/// Initializes a memory descriptor for a region inside an area
+/// described by an existing memory descriptor.
+///
+/// @warning
+///     Some combinations of physical memory layout and/or offsets or dims may
+///     result in a failure to create a submemory.
+//
+/// @param memory_desc Output memory descriptor.
+/// @param parent_memory_desc An existing memory descriptor.
+/// @param dims Sizes of the region.
+/// @param offsets Offsets to the region from the encompassing
+///     memory object in each dimension
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_desc_init_submemory(
+        dnnl_memory_desc_t *memory_desc,
+        const dnnl_memory_desc_t *parent_memory_desc, const dnnl_dims_t dims,
+        const dnnl_dims_t offsets);
+
+/// Initializes a memory descriptor by reshaping an existing one. The new
+/// memory descriptor inherits the data type. This operation is valid only for
+/// memory descriptors that have format_kind set to #dnnl_blocked or
+/// #dnnl_format_kind_any.
+///
+/// The operation ensures the transformation of the physical memory format
+/// corresponds to the transformation of the logical dimensions. If such
+/// transformation is impossible, the function returns #dnnl_invalid_arguments.
+///
+/// The reshape operation can be described as a combination of the following
+/// basic operations:
+/// 1. Add a dimension of size `1`. This is always possible.
+/// 2. Remove a dimension of size `1`. This is possible only if the dimension
+///    has no padding (i.e. `padded_dims[dim] == dims[dim] && dims[dim] == 1`).
+/// 3. Split a dimension into multiple ones. This is possible only if the size
+///    of the dimension is exactly equal to the product of the split ones and
+///    the dimension does not have padding (i.e.
+///    `padded_dims[dim] = dims[dim]`).
+/// 4. Joining multiple consecutive dimensions into a single one. As in the
+///    cases above, this requires that the dimensions do not have padding and
+///    that the memory format is such that in physical memory these dimensions
+///    are dense and have the same order as their logical counterparts. This
+///    also assumes that these dimensions are not blocked.
+///    - Here, dense means:
+///      `stride for dim[i] == (stride for dim[i + 1]) * dim[i + 1]`;
+///    - And same order means:
+///      `i < j` if and only if `stride for dim[j] <= stride for dim[i]`.
+///
+/// @warning
+///     Some combinations of physical memory layout and/or offsets or
+///     dimensions may result in a failure to make a reshape.
+///
+/// @param out_memory_desc Output memory descriptor.
+/// @param in_memory_desc An existing memory descriptor. Must have format_kind
+///     set to #dnnl_blocked or #dnnl_format_kind_any.
+/// @param ndims Number of dimensions for the output memory descriptor.
+/// @param dims Dimensions for the output memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_desc_reshape(
+        dnnl_memory_desc_t *out_memory_desc,
+        const dnnl_memory_desc_t *in_memory_desc, int ndims,
+        const dnnl_dims_t dims);
+
+/// Initializes a memory descriptor by permuting axes in an existing one.
+///
+/// The physical memory layout representation is adjusted accordingly to
+/// maintain the consistency between the logical and physical parts of the
+/// memory descriptor.
+///
+/// The new memory descriptor inherits the data type. This operation is valid
+/// only for memory descriptors that have format_kind set to #dnnl_blocked or
+/// #dnnl_format_kind_any.
+///
+/// The logical axes will be permuted in the following manner:
+/// ```
+/// for (i: 0 .. in_memory_desc->ndims)
+///     out_memory_desc->dims[permutation[i]] = in_memory_desc->dims[i];
+/// ```
+///
+/// Example:
+/// @code
+///     dnnl_memory_desc_t in_md, out_md, expect_out_md;
+///
+///     const int permutation[] = {1, 0}; // swap the first and the second axes
+///
+///     dnnl_dims_t in_dims = {2, 3}, out_dims = {3, 2};
+///     dnnl_format_tag_t in_tag = dnnl_ab, out_tag = dnnl_ba;
+///
+///     dnnl_memory_desc_init_by_tag(
+///             &in_md, 2, in_dims, data_type, in_tag);
+///     dnnl_memory_desc_init_by_tag(
+///             &expect_out_md, 2, out_dims, data_type, out_tag);
+///
+///     dnnl_memory_desc_permute_axes(&out_md, in_md, permutation);
+///     assert(dnnl_memory_desc_equal(&out_md, &expect_out_md));
+/// @endcode
+///
+/// @param out_memory_desc Output memory descriptor.
+/// @param in_memory_desc An existing memory descriptor. Must have format_kind
+///     set to #dnnl_blocked or #dnnl_format_kind_any.
+/// @param permutation Axes permutation (of size `in_memory_desc->ndims`).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_desc_permute_axes(
+        dnnl_memory_desc_t *out_memory_desc,
+        const dnnl_memory_desc_t *in_memory_desc, const int *permutation);
+
+/// Compares two memory descriptors.
+///
+/// Use this function to identify whether a reorder is required between the
+/// two memories
+///
+/// @param lhs Left-hand side of the comparison.
+/// @param rhs Right-hand side of the comparison.
+/// @returns 1 if the descriptors are the same.
+/// @returns 0 if the descriptors are different.
+int DNNL_API dnnl_memory_desc_equal(
+        const dnnl_memory_desc_t *lhs, const dnnl_memory_desc_t *rhs);
+
+/// Returns the size of a memory descriptor.
+///
+/// @param memory_desc Memory descriptor.
+/// @returns The number of bytes required for memory described by a memory
+///     descriptor.
+size_t DNNL_API dnnl_memory_desc_get_size(
+        const dnnl_memory_desc_t *memory_desc);
+
+/// Returns the size of data type.
+///
+/// @param data_type Data type.
+/// @returns The number of bytes occupied by data type.
+size_t DNNL_API dnnl_data_type_size(dnnl_data_type_t data_type);
+
+/// Creates a memory object.
+///
+/// Unless @p handle is equal to DNNL_MEMORY_NONE, the constructed memory
+/// object will have the underlying buffer set. In this case, the buffer will
+/// be initialized as if dnnl_memory_set_data_handle() had been called.
+///
+/// @sa dnnl_memory_set_data_handle()
+///
+/// @param memory Output memory object.
+/// @param memory_desc Memory descriptor.
+/// @param engine Engine to use.
+/// @param handle Handle of the memory buffer to use as an underlying storage.
+///     - A pointer to the user-allocated buffer. In this case the library
+///       doesn't own the buffer.
+///     - The DNNL_MEMORY_ALLOCATE special value. Instructs the library to
+///       allocate the buffer for the memory object. In this case the library
+///       owns the buffer.
+///     - DNNL_MEMORY_NONE to create dnnl_memory without an underlying buffer.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_create(dnnl_memory_t *memory,
+        const dnnl_memory_desc_t *memory_desc, dnnl_engine_t engine,
+        void *handle);
+
+/// Returns the memory descriptor for a memory object.
+///
+/// @param memory Memory object.
+/// @param memory_desc Output memory descriptor (a copy).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_get_memory_desc(
+        const_dnnl_memory_t memory, const dnnl_memory_desc_t **memory_desc);
+
+/// Returns the engine of a memory object.
+///
+/// @param memory Memory object.
+/// @param engine Output engine on which the memory is located.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_get_engine(
+        const_dnnl_memory_t memory, dnnl_engine_t *engine);
+
+/// Maps a memory object and returns a host-side pointer to a memory buffer
+/// with a copy of its contents.
+///
+/// Mapping enables explicit direct access to memory contents for the engines
+/// that do not support it implicitly.
+///
+/// Mapping is an exclusive operation - a memory object cannot be used in
+/// other operations until this memory object is unmapped.
+///
+/// @note
+///     Any primitives working with @p memory should be completed before
+///     the memory is mapped. Use dnnl_stream_wait to synchronize the
+///     corresponding execution stream.
+///
+/// @note
+///     The dnnl_memory_map_data() and dnnl_memory_unmap_data() functions are
+///     mainly provided for debug and testing purposes, and their performance
+///     may be suboptimal.
+///
+/// @param memory Memory object.
+/// @param mapped_ptr Output pointer to the mapped buffer.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_map_data(
+        const_dnnl_memory_t memory, void **mapped_ptr);
+
+/// Unmaps a memory object and writes back any changes made to the previously
+/// mapped memory buffer. The pointer to the mapped buffer must be obtained
+/// via the dnnl_memory_map_data() call.
+///
+/// @note
+///     The dnnl_memory_map_data() and dnnl_memory_unmap_data() functions are
+///     mainly provided for debug and testing purposes, and their performance
+///     may be suboptimal.
+///
+/// @param memory Memory object.
+/// @param mapped_ptr Pointer to the mapped buffer that must have been
+///     obtained using the dnnl_memory_map_data() function.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_unmap_data(
+        const_dnnl_memory_t memory, void *mapped_ptr);
+
+/// Returns memory object's data handle.
+///
+/// @param memory Memory object.
+/// @param handle Output data handle. For the CPU engine, the data handle is a
+///     pointer to the actual data. For OpenCL it is a cl_mem.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_get_data_handle(
+        const_dnnl_memory_t memory, void **handle);
+
+/// Sets the underlying memory buffer.
+///
+/// See the description of dnnl_memory_set_data_handle_v2() for more details.
+///
+/// @param memory Memory object.
+/// @param handle Data handle. For the CPU engine, the data handle is a
+///     pointer to the actual data. For OpenCL it is a `cl_mem`.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_set_data_handle(
+        dnnl_memory_t memory, void *handle);
+
+/// Sets the underlying memory buffer.
+///
+/// @param memory Memory object.
+/// @param handle Data handle. For the CPU engine, the data handle is a
+///     pointer to the actual data. For OpenCL it is a `cl_mem`.
+/// @param stream Stream to use to execute padding in.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_set_data_handle_v2(
+        dnnl_memory_t memory, void *handle, dnnl_stream_t stream);
+
+/// Destroys a memory object.
+///
+/// @param memory Memory object to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_memory_destroy(dnnl_memory_t memory);
+
+/// @} dnnl_api_memory
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+
+/// @addtogroup dnnl_api_reorder
+/// @{
+
+/// Creates a primitive descriptor for a reorder primitive.
+///
+/// @param reorder_primitive_desc Output primitive descriptor.
+/// @param src_desc Source memory descriptor.
+/// @param src_engine Engine on which the source memory object will be
+///     located.
+/// @param dst_desc Destination memory descriptor.
+/// @param dst_engine Engine on which the destination memory object
+///     will be located.
+/// @param attr Primitive attributes to use (can be NULL).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_reorder_primitive_desc_create(
+        dnnl_primitive_desc_t *reorder_primitive_desc,
+        const dnnl_memory_desc_t *src_desc, dnnl_engine_t src_engine,
+        const dnnl_memory_desc_t *dst_desc, dnnl_engine_t dst_engine,
+        const_dnnl_primitive_attr_t attr);
+
+/// @} dnnl_api_reorder
+
+/// @addtogroup dnnl_api_concat
+/// @{
+
+/// Creates a primitive descriptor for an out-of-place concatenation
+/// primitive.
+///
+/// @param concat_primitive_desc Output primitive descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @param n Number of source parameters.
+/// @param concat_dimension Source tensors will be concatenated over
+///     dimension with this index. Note that order of dimensions does
+///     not depend on memory format.
+/// @param src_descs Array of source memory descriptors with @p n elements.
+/// @param attr Primitive attributes to use (can be NULL).
+/// @param engine Engine to use.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_concat_primitive_desc_create(
+        dnnl_primitive_desc_t *concat_primitive_desc,
+        const dnnl_memory_desc_t *dst_desc, int n, int concat_dimension,
+        const dnnl_memory_desc_t *src_descs, const_dnnl_primitive_attr_t attr,
+        dnnl_engine_t engine);
+
+/// @} dnnl_api_concat
+
+/// @addtogroup dnnl_api_sum
+/// @{
+
+/// Creates a primitive descriptor for an (out-of-place) sum primitive.
+///
+/// @param sum_primitive_desc Output primitive descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @param n Number of source parameters.
+/// @param scales Vector of scales to multiply data in each source
+///     memory by.
+/// @param src_descs Array of source memory descriptors having @p n elements.
+/// @param attr Primitive attributes to use (can be NULL).
+/// @param engine Engine to use.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_sum_primitive_desc_create(
+        dnnl_primitive_desc_t *sum_primitive_desc,
+        const dnnl_memory_desc_t *dst_desc, int n, const float *scales,
+        const dnnl_memory_desc_t *src_descs, const_dnnl_primitive_attr_t attr,
+        dnnl_engine_t engine);
+
+/// @} dnnl_api_sum
+
+/// @addtogroup dnnl_api_binary
+/// @{
+
+/// Initializes a descriptor for a binary primitive.
+///
+/// @note
+///     Memory descriptor @p dst_desc is allowed to be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @note
+///     Both memory descriptors must have the same number of dimensions.
+///     Element broadcasting is supported for memory descriptor @p src1_desc
+///     and are applied to @ src1_desc dimensions that have size equal to 1.
+///
+/// @param binary_desc Output descriptor for a binary primitive.
+/// @param alg_kind Algorithm kind. Valid values are #dnnl_binary_add,
+///     #dnnl_binary_mul, #dnnl_binary_max, #dnnl_binary_min, #dnnl_binary_div,
+///     #dnnl_binary_sub, #dnnl_binary_ge, #dnnl_binary_gt, #dnnl_binary_le,
+///     #dnnl_binary_lt, #dnnl_binary_eq and #dnnl_binary_ne.
+/// @param src0_desc Source 0 memory descriptor.
+/// @param src1_desc Source 1 memory descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_binary_desc_init(dnnl_binary_desc_t *binary_desc,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src0_desc,
+        const dnnl_memory_desc_t *src1_desc,
+        const dnnl_memory_desc_t *dst_desc);
+
+/// @} dnnl_api_binary
+
+/// @addtogroup dnnl_api_convolution
+/// @{
+
+/// Initializes a descriptor for a convolution forward propagation primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p padding_l, and @p padding_r contain values for
+/// spatial dimensions only and hence must have the same number of elements as
+/// there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param conv_desc Output descriptor for a convolution primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Convolution algorithm. Possible values are
+///     #dnnl_convolution_direct, #dnnl_convolution_winograd,
+///     #dnnl_convolution_auto.
+/// @param src_desc Source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param bias_desc Bias memory descriptor. Passing NULL, a zero memory
+///     descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param dst_desc Destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is assumed to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_convolution_forward_desc_init(
+        dnnl_convolution_desc_t *conv_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *bias_desc, const dnnl_memory_desc_t *dst_desc,
+        const dnnl_dims_t strides, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a dilated convolution forward propagation
+/// primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r contain
+/// values for spatial dimensions only and hence must have the same number of
+/// elements as there are spatial dimensions. The order of values is the same
+/// as in the tensor: depth (for 3D tensors), height (for 3D and 2D tensors),
+/// and width.
+///
+/// @param conv_desc Output descriptor for a convolution primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Convolution algorithm. Possible values are
+///     #dnnl_convolution_direct, #dnnl_convolution_winograd,
+///     #dnnl_convolution_auto.
+/// @param src_desc Source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param bias_desc Bias memory descriptor. Passing NULL, a zero memory
+///     descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param dst_desc Destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param dilates Array of dilations for spatial dimension. A zero value
+///     means no dilation in the corresponding dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_dilated_convolution_forward_desc_init(
+        dnnl_convolution_desc_t *conv_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *bias_desc, const dnnl_memory_desc_t *dst_desc,
+        const dnnl_dims_t strides, const dnnl_dims_t dilates,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a convolution backward propagation primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p padding_l, and @p padding_r contain values for
+/// spatial dimensions only and hence must have the same number of elements as
+/// there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param conv_desc Output descriptor for a convolution primitive.
+/// @param alg_kind Convolution algorithm. Possible values are
+///     #dnnl_convolution_direct, #dnnl_convolution_winograd,
+///     #dnnl_convolution_auto.
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is assumed to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_convolution_backward_data_desc_init(
+        dnnl_convolution_desc_t *conv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a dilated convolution backward propagation
+/// primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r contain
+/// values for spatial dimensions only and hence must have the same number of
+/// elements as there are spatial dimensions. The order of values is the same
+/// as in the tensor: depth (for 3D tensors), height (for 3D and 2D tensors),
+/// and width.
+///
+/// @param conv_desc Output descriptor for a convolution primitive.
+/// @param alg_kind Convolution algorithm. Possible values are
+///     #dnnl_convolution_direct, #dnnl_convolution_winograd,
+///     #dnnl_convolution_auto.
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param dilates Array of dilations for spatial dimension. A zero value
+///     means no dilation in the corresponding dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_dilated_convolution_backward_data_desc_init(
+        dnnl_convolution_desc_t *conv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t dilates, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a convolution weights gradient primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p padding_l, and @p padding_r contain values for
+/// spatial dimensions only and hence must have the same number of elements as
+/// there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param conv_desc Output descriptor for a convolution primitive.
+/// @param alg_kind Convolution algorithm. Possible values are
+///     #dnnl_convolution_direct, #dnnl_convolution_winograd,
+///     #dnnl_convolution_auto.
+/// @param src_desc Source memory descriptor.
+/// @param diff_weights_desc Diff weights memory descriptor.
+/// @param diff_bias_desc Diff bias memory descriptor. Passing NULL, a zero
+///     memory descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_convolution_backward_weights_desc_init(
+        dnnl_convolution_desc_t *conv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *diff_weights_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a dilated convolution weights gradient
+/// primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r contain
+/// values for spatial dimensions only and hence must have the same number of
+/// elements as there are spatial dimensions. The order of values is the same
+/// as in the tensor: depth (for 3D tensors), height (for 3D and 2D tensors),
+/// and width.
+///
+/// @param conv_desc Output descriptor for a convolution primitive.
+/// @param alg_kind Convolution algorithm. Possible values are
+///     #dnnl_convolution_direct, #dnnl_convolution_winograd,
+///     #dnnl_convolution_auto.
+/// @param src_desc Source memory descriptor.
+/// @param diff_weights_desc Diff weights memory descriptor.
+/// @param diff_bias_desc Diff bias memory descriptor. Passing NULL, a zero
+///     memory descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param dilates Array of dilations for spatial dimension. A zero value
+///     means no dilation in the corresponding dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_dilated_convolution_backward_weights_desc_init(
+        dnnl_convolution_desc_t *conv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *diff_weights_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t dilates, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// @} dnnl_api_convolution
+
+/// @addtogroup dnnl_api_deconvolution
+/// @{
+
+/// Initializes a descriptor for a deconvolution forward propagation primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p padding_l, and @p padding_r contain values for
+/// spatial dimensions only and hence must have the same number of elements as
+/// there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param deconv_desc Output descriptor for a deconvolution primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Deconvolution algorithm. Possible values are
+///     #dnnl_deconvolution_direct, #dnnl_deconvolution_winograd.
+/// @param src_desc Source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param bias_desc Bias memory descriptor. Passing NULL, a zero memory
+///     descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param dst_desc Destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_deconvolution_forward_desc_init(
+        dnnl_deconvolution_desc_t *deconv_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *bias_desc, const dnnl_memory_desc_t *dst_desc,
+        const dnnl_dims_t strides, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a dilated deconvolution forward propagation
+/// primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r contain
+/// values for spatial dimensions only and hence must have the same number of
+/// elements as there are spatial dimensions. The order of values is the same
+/// as in the tensor: depth (for 3D tensors), height (for 3D and 2D tensors),
+/// and width.
+///
+/// @param deconv_desc Output descriptor for a deconvolution primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Deconvolution algorithm. Possible values are
+///     #dnnl_deconvolution_direct, #dnnl_deconvolution_winograd.
+/// @param src_desc Source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param bias_desc Bias memory descriptor. Passing NULL, a zero memory
+///     descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param dst_desc Destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param dilates Array of dilations for spatial dimension. A zero value
+///     means no dilation in the corresponding dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_dilated_deconvolution_forward_desc_init(
+        dnnl_deconvolution_desc_t *deconv_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *bias_desc, const dnnl_memory_desc_t *dst_desc,
+        const dnnl_dims_t strides, const dnnl_dims_t dilates,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a deconvolution backward propagation primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p padding_l, and @p padding_r contain values for
+/// spatial dimensions only and hence must have the same number of elements as
+/// there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param deconv_desc Output descriptor for a deconvolution primitive.
+/// @param alg_kind Deconvolution algorithm. Possible values are
+///     #dnnl_deconvolution_direct, #dnnl_deconvolution_winograd.
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_deconvolution_backward_data_desc_init(
+        dnnl_deconvolution_desc_t *deconv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a dilated deconvolution backward propagation
+/// primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r contain
+/// values for spatial dimensions only and hence must have the same number of
+/// elements as there are spatial dimensions. The order of values is the same
+/// as in the tensor: depth (for 3D tensors), height (for 3D and 2D tensors),
+/// and width.
+///
+/// @param deconv_desc Output descriptor for a deconvolution primitive.
+/// @param alg_kind Deconvolution algorithm. Possible values are
+///     #dnnl_deconvolution_direct, #dnnl_deconvolution_winograd.
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param dilates Array of dilations for spatial dimension. A zero value
+///     means no dilation in the corresponding dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_dilated_deconvolution_backward_data_desc_init(
+        dnnl_deconvolution_desc_t *deconv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t dilates, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a deconvolution weights gradient primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p padding_l, and @p padding_r contain values for
+/// spatial dimensions only and hence must have the same number of elements as
+/// there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param deconv_desc Output descriptor for a deconvolution primitive.
+/// @param alg_kind Deconvolution algorithm. Possible values are
+///     #dnnl_deconvolution_direct, #dnnl_deconvolution_winograd.
+/// @param src_desc Source memory descriptor.
+/// @param diff_weights_desc Diff weights memory descriptor.
+/// @param diff_bias_desc Diff bias memory descriptor. Passing NULL, a zero
+///     memory descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_deconvolution_backward_weights_desc_init(
+        dnnl_deconvolution_desc_t *deconv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *diff_weights_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for a dilated deconvolution weights gradient
+/// primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r contain
+/// values for spatial dimensions only and hence must have the same number of
+/// elements as there are spatial dimensions. The order of values is the same
+/// as in the tensor: depth (for 3D tensors), height (for 3D and 2D tensors),
+/// and width.
+///
+/// @param deconv_desc Output descriptor for a deconvolution primitive.
+/// @param alg_kind Deconvolution algorithm. Possible values are
+///     #dnnl_deconvolution_direct, #dnnl_deconvolution_winograd.
+/// @param src_desc Source memory descriptor.
+/// @param diff_weights_desc Diff weights memory descriptor.
+/// @param diff_bias_desc Diff bias memory descriptor. Passing NULL, a zero
+///     memory descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param dilates Array of dilations for spatial dimension. A zero value
+///     means no dilation in the corresponding dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_dilated_deconvolution_backward_weights_desc_init(
+        dnnl_deconvolution_desc_t *deconv_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *diff_weights_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t dilates, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// @} dnnl_api_deconvolution
+
+/// @addtogroup dnnl_api_shuffle
+/// @{
+
+/// Initializes a descriptor for shuffle forward propagation primitive.
+///
+/// @param shuffle_desc Output descriptor for a shuffle primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param data_desc Source and destination memory descriptor.
+/// @param axis The axis along which the data is shuffled.
+/// @param group_size Shuffle group size.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_shuffle_forward_desc_init(
+        dnnl_shuffle_desc_t *shuffle_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *data_desc, int axis, dnnl_dim_t group_size);
+
+/// Initializes a descriptor for shuffle backward propagation primitive.
+///
+/// @param shuffle_desc Output descriptor for a shuffle primitive.
+/// @param diff_data_desc Diff source and diff destination memory descriptor.
+/// @param axis The axis along which the data is shuffled.
+/// @param group_size Shuffle group size.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_shuffle_backward_desc_init(
+        dnnl_shuffle_desc_t *shuffle_desc,
+        const dnnl_memory_desc_t *diff_data_desc, int axis,
+        dnnl_dim_t group_size);
+
+/// @} dnnl_api_shuffle
+
+/// @addtogroup dnnl_api_eltwise
+/// @{
+
+/// Initializes a descriptor for eltwise forward propagation primitive.
+///
+/// @param eltwise_desc Output descriptor for an eltwise primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Elementwise algorithm kind.
+/// @param data_desc Source and destination memory descriptor.
+/// @param alpha The alpha parameter for the elementwise operation. Specific
+///     meaning depends on the algorithm.
+/// @param beta The beta parameter for the elementwise operation. Specific
+///     meaning depends on the algorithm.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_eltwise_forward_desc_init(
+        dnnl_eltwise_desc_t *eltwise_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *data_desc,
+        float alpha, float beta);
+
+/// Initializes a descriptor for eltwise backward propagation primitive.
+///
+/// @param eltwise_desc Output descriptor for an eltwise primitive.
+/// @param alg_kind Elementwise algorithm kind.
+/// @param diff_data_desc Diff source and diff destination memory descriptors.
+/// @param data_desc Source and destination memory descriptor.
+/// @param alpha The alpha parameter for the elementwise operation. Specific
+///     meaning depends on the algorithm.
+/// @param beta The beta parameter for the elementwise operation. Specific
+///     meaning depends on the algorithm.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_eltwise_backward_desc_init(
+        dnnl_eltwise_desc_t *eltwise_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_data_desc,
+        const dnnl_memory_desc_t *data_desc, float alpha, float beta);
+
+/// @} dnnl_api_eltwise
+
+/// @addtogroup dnnl_api_softmax
+/// @{
+
+/// Initializes a descriptor for softmax forward propagation primitive.
+///
+/// @param softmax_desc Output descriptor for a softmax primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param data_desc Source and destination memory descriptor.
+/// @param softmax_axis Axis over which softmax is computed.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_softmax_forward_desc_init(
+        dnnl_softmax_desc_t *softmax_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *data_desc, int softmax_axis);
+
+/// Initializes a descriptor for softmax backward propagation primitive.
+///
+/// @param softmax_desc Output descriptor for a softmax primitive.
+/// @param diff_data_desc Diff source and diff destination memory descriptors.
+/// @param data_desc Destination memory descriptor.
+/// @param softmax_axis Axis over which softmax is computed.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_softmax_backward_desc_init(
+        dnnl_softmax_desc_t *softmax_desc,
+        const dnnl_memory_desc_t *diff_data_desc,
+        const dnnl_memory_desc_t *data_desc, int softmax_axis);
+
+/// @} dnnl_api_softmax
+
+/// @addtogroup dnnl_api_softmax_v2
+/// @{
+
+/// Initializes a descriptor for softmax v2 forward propagation primitive.
+///
+/// @param softmax_desc Output descriptor for a softmax primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Softmax algorithm kind: either #dnnl_softmax_accurate, or
+///     #dnnl_softmax_log.
+/// @param src_desc Source memory descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @param softmax_axis Axis over which softmax is computed.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_softmax_v2_forward_desc_init(
+        dnnl_softmax_v2_desc_t *softmax_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *dst_desc, int softmax_axis);
+
+/// Initializes a descriptor for softmax v2 backward propagation primitive.
+///
+/// @param softmax_desc Output descriptor for a softmax primitive.
+/// @param alg_kind Softmax algorithm kind: either #dnnl_softmax_accurate, or
+///     #dnnl_softmax_log.
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @param softmax_axis Axis over which softmax is computed.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_softmax_v2_backward_desc_init(
+        dnnl_softmax_v2_desc_t *softmax_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *diff_dst_desc,
+        const dnnl_memory_desc_t *dst_desc, int softmax_axis);
+
+/// @} dnnl_api_softmax_v2
+
+/// @addtogroup dnnl_api_logsoftmax
+/// @{
+
+/// Initializes a descriptor for logsoftmax forward propagation primitive.
+///
+/// @param logsoftmax_desc Output descriptor for a logsoftmax primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param data_desc Source and destination memory descriptor.
+/// @param logsoftmax_axis Axis over which logsoftmax is computed.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_logsoftmax_forward_desc_init(
+        dnnl_logsoftmax_desc_t *logsoftmax_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *data_desc, int logsoftmax_axis);
+
+/// Initializes a descriptor for logsoftmax backward propagation primitive.
+///
+/// @param logsoftmax_desc Output descriptor for a logsoftmax primitive.
+/// @param diff_data_desc Diff source and diff destination memory descriptors.
+/// @param data_desc Destination memory descriptor.
+/// @param logsoftmax_axis Axis over which softmax is computed.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_logsoftmax_backward_desc_init(
+        dnnl_logsoftmax_desc_t *logsoftmax_desc,
+        const dnnl_memory_desc_t *diff_data_desc,
+        const dnnl_memory_desc_t *data_desc, int logsoftmax_axis);
+
+/// @} dnnl_api_logsoftmax
+
+/// @addtogroup dnnl_api_pooling
+/// @{
+
+/// Initializes a descriptor for pooling forward propagation primitive.
+///
+/// Arrays @p strides, @p kernel, @p padding_l, and @p padding_r contain values
+/// for spatial dimensions only and hence must have the same number of elements
+/// as there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param pool_desc Output descriptor for a pooling primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Pooling algorithm kind: either #dnnl_pooling_max,
+///     #dnnl_pooling_avg_include_padding, or #dnnl_pooling_avg (same as
+///     #dnnl_pooling_avg_exclude_padding).
+/// @param src_desc Source memory descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param kernel Array of kernel spatial dimensions.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_pooling_forward_desc_init(
+        dnnl_pooling_desc_t *pool_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t kernel, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for pooling backward propagation primitive.
+///
+/// Arrays @p strides, @p kernel, @p padding_l, and @p padding_r contain values
+/// for spatial dimensions only and hence must have the same number of elements
+/// as there are spatial dimensions. The order of values is the same as in the
+/// tensor: depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+///
+/// @param pool_desc Output descriptor for a pooling primitive.
+/// @param alg_kind Pooling algorithm kind: either #dnnl_pooling_max,
+///     #dnnl_pooling_avg_include_padding, or #dnnl_pooling_avg (same as
+///     #dnnl_pooling_avg_exclude_padding).
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param kernel Array of kernel spatial dimensions.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_pooling_backward_desc_init(
+        dnnl_pooling_desc_t *pool_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t kernel, const dnnl_dims_t padding_l,
+        const dnnl_dims_t padding_r);
+
+/// @} dnnl_api_pooling
+
+/// @addtogroup dnnl_api_pooling_v2
+/// @{
+
+/// Initializes a descriptor for pooling v2 (pooling with dilation support)
+/// forward propagation primitive.
+///
+/// Arrays @p strides, @p kernel, @p dilation, @p padding_l and @p padding_r
+/// contain values for spatial dimensions only and hence must have the same
+/// number of elements as there are spatial dimensions. The order of values
+/// is the same as in the tensor: depth (for 3D tensors),
+/// height (for 3D and 2D tensors), and width.
+///
+/// @param pool_desc Output descriptor for a pooling primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind Pooling algorithm kind: either #dnnl_pooling_max,
+///     #dnnl_pooling_avg_include_padding, or #dnnl_pooling_avg (same as
+///     #dnnl_pooling_avg_exclude_padding).
+/// @param src_desc Source memory descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param kernel Array of kernel spatial dimensions.
+/// @param dilation Array of dilations for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_pooling_v2_forward_desc_init(
+        dnnl_pooling_v2_desc_t *pool_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t kernel, const dnnl_dims_t dilation,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// Initializes a descriptor for pooling v2 (pooling with dilation support)
+/// backward propagation primitive.
+///
+/// Arrays @p strides, @p kernel, @p dilation, @p padding_l and @p padding_r
+/// contain values for spatial dimensions only and hence must have the same
+/// number of elements as there are spatial dimensions. The order of values
+/// is the same as in the tensor: depth (for 3D tensors),
+/// height (for 3D and 2D tensors), and width.
+///
+/// @param pool_desc Output descriptor for a pooling primitive.
+/// @param alg_kind Pooling algorithm kind: either #dnnl_pooling_max,
+///     #dnnl_pooling_avg_include_padding, or #dnnl_pooling_avg (same as
+///     #dnnl_pooling_avg_exclude_padding).
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param strides Array of strides for spatial dimension.
+/// @param kernel Array of kernel spatial dimensions.
+/// @param dilation Array of dilations for spatial dimension.
+/// @param padding_l Array of padding values for low indices for each spatial
+///     dimension `([[front,] top,] left)`.
+/// @param padding_r Array of padding values for high indices for each spatial
+///     dimension `([[back,] bottom,] right)`. Can be NULL in which case
+///     padding is considered to be symmetrical.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_pooling_v2_backward_desc_init(
+        dnnl_pooling_v2_desc_t *pool_desc, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *diff_dst_desc, const dnnl_dims_t strides,
+        const dnnl_dims_t kernel, const dnnl_dims_t dilation,
+        const dnnl_dims_t padding_l, const dnnl_dims_t padding_r);
+
+/// @} dnnl_api_pooling_v2
+
+/// @addtogroup dnnl_api_prelu
+/// @{
+
+/// Initializes a descriptor for PReLU
+/// (leaky ReLU with trainable alpha parameter)
+/// forward propagation primitive.
+///
+/// @note
+///     weights descriptor is allowed to be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param prelu_desc Output descriptor for a prelu primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param data_desc Source and destination memory descriptor.
+/// @param weights_desc Alpha parameters memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_prelu_forward_desc_init(
+        dnnl_prelu_desc_t *prelu_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *data_desc,
+        const dnnl_memory_desc_t *weights_desc);
+
+/// Initializes a descriptor for PReLU
+/// (leaky ReLU with trainable alpha parameter)
+/// backward propagation primitive.
+///
+/// @note
+///     weights descriptor and diff_weights descriptor are allowed
+///     to be initialized with #dnnl_format_tag_any or with format_kind
+///     set to #dnnl_format_kind_any.
+///
+/// @param prelu_desc Output descriptor for a prelu primitive.
+/// @param data_desc Source and destination memory descriptor.
+/// @param weights_desc Alpha parameters memory descriptor.
+/// @param diff_data_desc Diff source and destination memory descriptor.
+/// @param diff_weights_desc Diff alpha parameters memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_prelu_backward_desc_init(
+        dnnl_prelu_desc_t *prelu_desc, const dnnl_memory_desc_t *data_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *diff_data_desc,
+        const dnnl_memory_desc_t *diff_weights_desc);
+
+/// @} dnnl_api_prelu
+
+/// @addtogroup dnnl_api_lrn
+/// @{
+
+/// Initializes a descriptor for LRN forward propagation primitive.
+///
+/// @param lrn_desc Output descriptor for a LRN primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind LRN algorithm kind: either #dnnl_lrn_across_channels or
+///     #dnnl_lrn_within_channel.
+/// @param data_desc Source and destination memory descriptor.
+/// @param local_size Regularization local size.
+/// @param alpha The alpha regularization parameter.
+/// @param beta The beta regularization parameter.
+/// @param k The k regularization parameter.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lrn_forward_desc_init(dnnl_lrn_desc_t *lrn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_alg_kind_t alg_kind,
+        const dnnl_memory_desc_t *data_desc, dnnl_dim_t local_size, float alpha,
+        float beta, float k);
+
+/// Initializes a descriptor for LRN backward propagation primitive.
+///
+/// @param lrn_desc Output descriptor for a LRN primitive.
+/// @param alg_kind LRN algorithm kind: either #dnnl_lrn_across_channels or
+///     #dnnl_lrn_within_channel.
+/// @param diff_data_desc Diff source and diff destination memory descriptor.
+/// @param data_desc Source memory descriptor.
+/// @param local_size Regularization local size.
+/// @param alpha The alpha regularization parameter.
+/// @param beta The beta regularization parameter.
+/// @param k The k regularization parameter.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lrn_backward_desc_init(dnnl_lrn_desc_t *lrn_desc,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *diff_data_desc,
+        const dnnl_memory_desc_t *data_desc, dnnl_dim_t local_size, float alpha,
+        float beta, float k);
+
+/// @} dnnl_api_lrn
+
+/// @addtogroup dnnl_api_batch_normalization
+/// @{
+
+/// Initializes a descriptor for a batch normalization forward propagation
+/// primitive.
+///
+/// @note
+///     In-place operation is supported: the dst can refer to the same memory
+///     as the src.
+///
+/// @param bnrm_desc Output descriptor for batch normalization primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param data_desc Source and destination memory descriptor.
+/// @param epsilon Batch normalization epsilon parameter.
+/// @param flags Batch normalization flags (@ref dnnl_normalization_flags_t).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_batch_normalization_forward_desc_init(
+        dnnl_batch_normalization_desc_t *bnrm_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *data_desc, float epsilon, unsigned flags);
+
+/// Initializes a descriptor for a batch normalization backward propagation
+/// primitive.
+///
+/// @note
+///     In-place operation is supported: the diff_dst can refer to the same
+///     memory as the diff_src.
+///
+/// @param bnrm_desc Output descriptor for batch normalization primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_backward_data and #dnnl_backward (diffs for all parameters are
+///     computed in this case).
+/// @param diff_data_desc Diff source and diff destination memory descriptor.
+/// @param data_desc Source memory descriptor.
+/// @param epsilon Batch normalization epsilon parameter.
+/// @param flags Batch normalization flags (@ref dnnl_normalization_flags_t).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_batch_normalization_backward_desc_init(
+        dnnl_batch_normalization_desc_t *bnrm_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *diff_data_desc,
+        const dnnl_memory_desc_t *data_desc, float epsilon, unsigned flags);
+
+/// @} dnnl_api_batch_normalization
+
+/// @addtogroup dnnl_api_layer_normalization
+/// @{
+
+/// Initializes a descriptor for layer normalization forward propagation
+/// primitive.
+///
+/// @note
+///     In-place operation is supported: the dst can refer to the same memory
+///     as the src.
+///
+/// @param lnrm_desc Output descriptor for layer normalization primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param data_desc Source and destination memory descriptor.
+/// @param stat_desc Memory descriptor for mean and variance. If this
+///     parameter is NULL, a zero memory descriptor, or a memory descriptor
+///     with format_kind set to #dnnl_format_kind_undef, then the memory
+///     descriptor for stats is derived from @p data_desc by removing the last
+///     dimension.
+/// @param epsilon Layer normalization epsilon parameter.
+/// @param flags Layer normalization flags (@ref dnnl_normalization_flags_t).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_layer_normalization_forward_desc_init(
+        dnnl_layer_normalization_desc_t *lnrm_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *data_desc,
+        const dnnl_memory_desc_t *stat_desc, float epsilon, unsigned flags);
+
+/// Initializes a descriptor for a layer normalization backward propagation
+/// primitive.
+///
+/// @note
+///     In-place operation is supported: the diff_dst can refer to the same
+///     memory as the diff_src.
+///
+/// @param lnrm_desc Output descriptor for layer normalization primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_backward_data and #dnnl_backward (diffs for all parameters are
+///     computed in this case).
+/// @param diff_data_desc Diff source and diff destination memory descriptor.
+/// @param data_desc Source memory descriptor.
+/// @param stat_desc Memory descriptor for mean and variance. If this
+///     parameter is NULL, a zero memory descriptor, or a memory descriptor
+///     with format_kind set to #dnnl_format_kind_undef, then the memory
+///     descriptor for stats is derived from @p data_desc by removing the last
+///     dimension.
+/// @param epsilon Layer normalization epsilon parameter.
+/// @param flags Layer normalization flags (@ref dnnl_normalization_flags_t).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_layer_normalization_backward_desc_init(
+        dnnl_layer_normalization_desc_t *lnrm_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *diff_data_desc,
+        const dnnl_memory_desc_t *data_desc,
+        const dnnl_memory_desc_t *stat_desc, float epsilon, unsigned flags);
+
+/// @} dnnl_api_layer_normalization
+
+/// @addtogroup dnnl_api_inner_product
+/// @{
+
+/// Initializes descriptor for inner product forward propagation.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param ip_desc Output descriptor for inner product primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param src_desc Source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param bias_desc Bias memory descriptor. Passing NULL, a zero memory
+///     descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param dst_desc Destination memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_inner_product_forward_desc_init(
+        dnnl_inner_product_desc_t *ip_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_desc);
+
+/// Initializes descriptor for inner product backward propagation.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param ip_desc Output descriptor for inner product primitive.
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param weights_desc Weights memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_inner_product_backward_data_desc_init(
+        dnnl_inner_product_desc_t *ip_desc,
+        const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *diff_dst_desc);
+
+/// Initializes descriptor for inner product weights gradient primitive.
+///
+/// @note
+///     Memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param ip_desc Output descriptor for inner product primitive.
+/// @param src_desc Source memory descriptor.
+/// @param diff_weights_desc Diff weights memory descriptor.
+/// @param diff_bias_desc Diff bias memory descriptor. Passing NULL, a zero
+///     memory descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_inner_product_backward_weights_desc_init(
+        dnnl_inner_product_desc_t *ip_desc, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *diff_weights_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_desc);
+
+/// @} dnnl_api_inner_product
+
+/// @addtogroup dnnl_api_attributes
+/// @{
+
+/// Set quantization scale and shift parameters for RNN data tensors.
+///
+/// For performance reasons, the low-precision configuration of the RNN
+/// primitives expects input activations to have the unsigned 8-bit integer
+/// data type. The scale and shift parameters are used to quantize
+/// floating-point data to unsigned integer and must be passed to the RNN
+/// primitive using attributes.
+///
+/// The quantization formula is `scale * data + shift`.
+///
+/// @note
+///     Quantization scale and shift are common for src_layer, src_iter,
+///     dst_iter, and dst_layer.
+///
+/// Example usage:
+/// @code
+///     // RNN parameters
+///     int l = 2, t = 2, mb = 32, sic = 32, slc = 32, dic = 32, dlc = 32;
+///     // Activations quantization parameters
+///     float scale = 63.f, shift = 64.f;
+///
+///     dnnl_primitive_attr_t rnn_attr;
+///     // Create default attributes
+///     dnnl_primitive_attr_create(&rnn_attr);
+///
+///     // Set scale and shift for int8 quantization of activation
+///     dnnl_primitive_attr_set_rnn_data_qparams(rnn_attr, scale, shift);
+///
+///     // Create and configure rnn op_desc
+///     dnnl_rnn_desc_t rnn_d;
+///     dnnl_primitive_desc_t rnn_pd;
+///     dnnl_primitive_desc_create(&rnn_pd, &rnn_d, attr, engine, NULL);
+/// @endcode
+///
+/// @param attr Primitive attributes.
+/// @param scale The value to scale the data by.
+/// @param shift The value to shift the data by.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_rnn_data_qparams(
+        dnnl_primitive_attr_t attr, const float scale, const float shift);
+
+/// Returns the quantization scale and shift parameters for RNN data tensors.
+///
+/// @note
+///     Quantization scale and shift are common for src_layer, src_iter,
+///     dst_iter, and dst_layer.
+///
+/// @param attr Primitive attributes.
+/// @param scale The value to scale the data by.
+/// @param shift The value to shift the data by.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_rnn_data_qparams(
+        const_dnnl_primitive_attr_t attr, float *scale, float *shift);
+
+/// Sets quantization scaling factors for RNN weights tensors. The
+/// low-precision configuration of the RNN primitives expects input weights to
+/// use the signed 8-bit integer data type. The scaling factors are used to
+/// quantize floating-point data to signed integer and must be passed to RNN
+/// primitives using attributes.
+///
+/// @note
+///     The dimension order is always native and does not depend on the actual
+///     layout used. For example, five-dimensional weights always have (l, d,
+///     i, g, o) logical dimension ordering.
+///
+/// @note
+///     Quantization scales are common for weights_layer and weights_iteration
+///
+/// @param attr Primitive attributes.
+/// @param count Number of elements in the @p scales array.
+/// @param mask Scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales vector. The set i-th bit indicates that a dedicated scaling
+///     factor should be used for each index along that dimension. Set the
+///     mask to 0 to use a common scaling factor for the whole output
+///     tensor.
+/// @param scales Array of output scaling factors that must contain @p count
+///     values and the following equality must hold:
+///     \f[count = \prod\limits_{d \in mask} weights.dims[d].\f]
+///     Violations can only be detected when the attributes are used to create
+///     a primitive descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_rnn_weights_qparams(
+        dnnl_primitive_attr_t attr, dnnl_dim_t count, int mask,
+        const float *scales);
+
+/// Returns the quantization scaling factors for RNN weights tensors.
+///
+/// @param attr Primitive attributes.
+/// @param count Number of elements in the @p scales array.
+/// @param mask Scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales vector. The set i-th bit indicates that a dedicated scaling
+///     factor should be used for each index along that dimension. Set the
+///     mask to 0 to use a common scaling factor for the whole output
+///     tensor.
+/// @param scales Array of output scaling factors that contain @p count
+///     values and the following equality must hold:
+///     \f[count = \prod\limits_{d \in mask} weights.dims[d].\f]
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_rnn_weights_qparams(
+        const_dnnl_primitive_attr_t attr, dnnl_dim_t *count, int *mask,
+        const float **scales);
+
+/// Sets quantization scaling factors for RNN projection weights tensors. The
+/// low-precision configuration of the RNN primitives expects input weights to
+/// use the signed 8-bit integer data type. The scaling factors are used to
+/// quantize floating-point data to signed integer and must be passed to RNN
+/// primitives using attributes.
+///
+/// @note
+///     The dimension order is always native and does not depend on the actual
+///     layout used. For example, five-dimensional weights always have (l, d,
+///     i, g, o) logical dimension ordering.
+///
+/// @param attr Primitive attributes.
+/// @param count Number of elements in the @p scales array.
+/// @param mask Scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales vector. The set i-th bit indicates that a dedicated scaling
+///     factor should be used for each index along that dimension. Set the
+///     mask to 0 to use a common scaling factor for the whole output
+///     tensor.
+/// @param scales Array of output scaling factors that must contain @p count
+///     values and the following equality must hold:
+///     \f[count = \prod\limits_{d \in mask} weights.dims[d].\f]
+///     Violations can only be detected when the attributes are used to create
+///     a primitive descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_set_rnn_weights_projection_qparams(
+        dnnl_primitive_attr_t attr, dnnl_dim_t count, int mask,
+        const float *scales);
+
+/// Returns the quantization scaling factors for RNN projection weights tensors.
+///
+/// @param attr Primitive attributes.
+/// @param count Number of elements in the @p scales array.
+/// @param mask Scaling factors correspondence mask that defines the
+///     correspondence between the output tensor dimensions and the @p
+///     scales vector. The set i-th bit indicates that a dedicated scaling
+///     factor should be used for each index along that dimension. Set the
+///     mask to 0 to use a common scaling factor for the whole output
+///     tensor.
+/// @param scales Array of output scaling factors that contain @p count
+///     values and the following equality must hold:
+///     \f[count = \prod\limits_{d \in mask} weights.dims[d].\f]
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_primitive_attr_get_rnn_weights_projection_qparams(
+        const_dnnl_primitive_attr_t attr, dnnl_dim_t *count, int *mask,
+        const float **scales);
+
+/// @} dnnl_api_attributes
+
+/// @addtogroup dnnl_api_rnn
+/// @{
+
+/// Initializes a descriptor for vanilla RNN forward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc.
+///
+/// This would then indicate that the RNN forward propagation primitive should
+/// not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for vanilla RNN primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param activation Activation kind. Possible values are #dnnl_eltwise_relu,
+///     #dnnl_eltwise_tanh or #dnnl_eltwise_logistic.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param flags Unused.
+/// @param alpha Negative slope if activation is #dnnl_eltwise_relu.
+/// @param beta Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_vanilla_rnn_forward_desc_init(
+        dnnl_rnn_desc_t *rnn_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_alg_kind_t activation, const dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc, unsigned flags, float alpha,
+        float beta);
+
+/// Initializes a descriptor for vanilla RNN backward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p diff_src_iter_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+///
+/// This would then indicate that the RNN backward propagation primitive should
+/// not use the respective data and should use zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for vanilla RNN primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param activation Activation kind. Possible values are #dnnl_eltwise_relu,
+///     #dnnl_eltwise_tanh or #dnnl_eltwise_logistic.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param flags Unused.
+/// @param alpha Negative slope if activation is #dnnl_eltwise_relu.
+/// @param beta Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_vanilla_rnn_backward_desc_init(
+        dnnl_rnn_desc_t *rnn_desc, dnnl_prop_kind_t prop_kind,
+        const dnnl_alg_kind_t activation, const dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc, unsigned flags,
+        float alpha, float beta);
+
+/// Initializes a descriptor for LSTM forward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p src_iter_c_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc together with @p dst_iter_c_desc.
+///
+/// This would then indicate that the LSTM forward propagation primitive should
+/// not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @sa dnnl_lstm_forward_desc_init_v2 to initialize forward LSTM with and
+///     without peephole
+/// @sa dnnl_lstm_forward_desc_init_v3 to initialize forward LSTM with and
+///     without peephole / recurrent projection layer
+///
+/// @param rnn_desc Output descriptor for LSTM primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param src_iter_c_desc Memory descriptor for the input recurrent cell
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param dst_iter_c_desc Memory descriptor for the output recurrent cell
+///     state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lstm_forward_desc_init(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *src_iter_c_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *dst_iter_c_desc, unsigned flags);
+
+/// Initializes a descriptor for an LSTM (with or without peephole) forward
+/// propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p src_iter_c_desc,
+/// - @p weights_peephole_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc together with @p dst_iter_c_desc.
+///
+/// This would then indicate that the LSTM forward propagation primitive should
+/// not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with #dnnl_format_tag_any or
+///     with format_kind set to #dnnl_format_kind_any.
+///
+/// @sa dnnl_lstm_forward_desc_init_v3 to initialize forward LSTM with and
+///     without peephole / recurrent projection layer
+///
+/// @param rnn_desc Output descriptor for LSTM primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param src_iter_c_desc Memory descriptor for the input recurrent cell
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param weights_peephole_desc Memory descriptor for the weights applied to
+///     the cell states (according to the Peephole LSTM formula).
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param dst_iter_c_desc Memory descriptor for the output recurrent cell
+///     state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lstm_forward_desc_init_v2(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *src_iter_c_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *weights_peephole_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *dst_iter_c_desc, unsigned flags);
+
+/// Initializes a descriptor for an LSTM (with or without peephole and with
+/// or without recurrent projection layer) forward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p src_iter_c_desc,
+/// - @p weights_peephole_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc together with @p dst_iter_c_desc.
+///
+/// This would then indicate that the LSTM forward propagation primitive should
+/// not use them and should default to zero values instead.
+///
+/// The @p weights_projection_desc could either be @c NULL or point to a zero
+/// memory descriptor. This would then indicate that the LSTM doesn't have
+/// recurrent projection layer.
+///
+/// @note
+///     All memory descriptors can be initialized with #dnnl_format_tag_any or
+///     with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for LSTM primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param src_iter_c_desc Memory descriptor for the input recurrent cell
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param weights_peephole_desc Memory descriptor for the weights applied to
+///     the cell states (according to the Peephole LSTM formula).
+/// @param weights_projection_desc Memory descriptor for the weights applied to
+///     the hidden states to get the recurrent projection (according to the
+///     Projection LSTM formula).
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param dst_iter_c_desc Memory descriptor for the output recurrent cell
+///     state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lstm_forward_desc_init_v3(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *src_iter_c_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *weights_peephole_desc,
+        const dnnl_memory_desc_t *weights_projection_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *dst_iter_c_desc, unsigned flags);
+
+/// Initializes a descriptor for an LSTM backward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p src_iter_c_desc, @p diff_src_iter_desc,
+///   and @p diff_src_iter_c_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p dst_iter_c_desc, @p diff_dst_iter_desc,
+///   and @p diff_dst_iter_c_desc.
+///
+/// This would then indicate that the LSTM backward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @sa dnnl_lstm_backward_desc_init_v2 to initialize backward LSTM with and
+///     without peephole
+/// @sa dnnl_lstm_backward_desc_init_v3 to initialize backward LSTM with and
+///     without peephole / recurrent projection layer
+///
+/// @param rnn_desc Output descriptor for LSTM primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param src_iter_c_desc Memory descriptor for the input recurrent cell
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param dst_iter_c_desc Memory descriptor for the output recurrent cell
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_src_iter_c_desc Memory descriptor for the diff of input
+/// recurrent cell state vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param diff_dst_iter_c_desc Memory descriptor for the diff of output
+///     recurrent cell state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lstm_backward_desc_init(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *src_iter_c_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *dst_iter_c_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_src_iter_c_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_c_desc, unsigned flags);
+
+/// Initializes a descriptor for an LSTM (with or without peephole) backward
+/// propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p src_iter_c_desc, @p diff_src_iter_desc,
+///   and @p diff_src_iter_c_desc,
+/// - @p weights_peephole_desc together with @p diff_weights_peephole_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p dst_iter_c_desc, @p diff_dst_iter_desc,
+///   and @p diff_dst_iter_c_desc.
+///
+/// This would then indicate that the LSTM backward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with #dnnl_format_tag_any or
+///     with format_kind set to #dnnl_format_kind_any.
+///
+/// @sa dnnl_lstm_backward_desc_init_v3 to initialize backward LSTM with and
+///     without peephole / recurrent projection layer
+///
+/// @param rnn_desc Output descriptor for LSTM primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param src_iter_c_desc Memory descriptor for the input recurrent cell
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param weights_peephole_desc Memory descriptor for the weights applied to
+///     the cell states (according to the Peephole LSTM formula).
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param dst_iter_c_desc Memory descriptor for the output recurrent cell
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_src_iter_c_desc Memory descriptor for the diff of input
+/// recurrent cell state vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_weights_peephole_desc Memory descriptor for the diff of weights
+///     applied to the cell states (according to the Peephole LSTM formula).
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param diff_dst_iter_c_desc Memory descriptor for the diff of output
+///     recurrent cell state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lstm_backward_desc_init_v2(
+        dnnl_rnn_desc_t *rnn_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *src_iter_c_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *weights_peephole_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *dst_iter_c_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_src_iter_c_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_weights_peephole_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_c_desc, unsigned flags);
+
+/// Initializes a descriptor for an LSTM (with or without peephole and with or
+/// with out recurrent projection layer) backward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p src_iter_c_desc, @p diff_src_iter_desc,
+///   and @p diff_src_iter_c_desc,
+/// - @p weights_peephole_desc together with @p diff_weights_peephole_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p dst_iter_c_desc, @p diff_dst_iter_desc,
+///   and @p diff_dst_iter_c_desc.
+///
+/// This would then indicate that the LSTM backward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// The @p weights_projection_desc together with @p
+/// diff_weights_projection_desc could either be @c NULL or point to a zero
+/// memory descriptor. This would then indicate that the LSTM doesn't have
+/// recurrent projection layer.
+///
+/// @note
+///     All memory descriptors can be initialized with #dnnl_format_tag_any or
+///     with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for LSTM primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param src_iter_c_desc Memory descriptor for the input recurrent cell
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param weights_peephole_desc Memory descriptor for the weights applied to
+///     the cell states (according to the Peephole LSTM formula).
+/// @param weights_projection_desc Memory descriptor for the weights applied to
+///     the hidden states to get the recurrent projection (according to the
+///     Projection LSTM formula).
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param dst_iter_c_desc Memory descriptor for the output recurrent cell
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_src_iter_c_desc Memory descriptor for the diff of input
+/// recurrent cell state vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_weights_peephole_desc Memory descriptor for the diff of weights
+///     applied to the cell states (according to the Peephole LSTM formula).
+/// @param diff_weights_projection_desc Memory descriptor for the diff of
+///     weights applied to the hidden states to get the recurrent projection
+///     (according to the Projection LSTM formula).
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param diff_dst_iter_c_desc Memory descriptor for the diff of output
+///     recurrent cell state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lstm_backward_desc_init_v3(
+        dnnl_rnn_desc_t *rnn_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *src_iter_c_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *weights_peephole_desc,
+        const dnnl_memory_desc_t *weights_projection_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *dst_iter_c_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_src_iter_c_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_weights_peephole_desc,
+        const dnnl_memory_desc_t *diff_weights_projection_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_c_desc, unsigned flags);
+
+/// Initializes a descriptor for GRU forward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc.
+///
+/// This would then indicate that the GRU forward propagation primitive should
+/// not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for GRU primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_gru_forward_desc_init(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc, unsigned flags);
+
+/// Initializes a descriptor for GRU backward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p diff_src_iter_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+///
+/// This would then indicate that the GRU backward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for GRU primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_gru_backward_desc_init(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc, unsigned flags);
+
+/// Initializes a descriptor for LBR GRU forward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc.
+///
+/// This would then indicate that the LBR GRU forward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @param rnn_desc Output descriptor for LBR GRU primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lbr_gru_forward_desc_init(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc, unsigned flags);
+
+/// Initializes a descriptor for LBR GRU backward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p diff_src_iter_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+///
+/// This would then indicate that the LBR GRU backward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for LBR GRU primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lbr_gru_backward_desc_init(
+        dnnl_rnn_desc_t *rnn_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc, unsigned flags);
+
+/// Initializes a descriptor for AUGRU forward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc.
+///
+/// This would then indicate that the AUGRU forward propagation primitive should
+/// not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for AUGRU primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param attention_desc Memory descriptor for the attention vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_augru_forward_desc_init(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *attention_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc, unsigned flags);
+
+/// Initializes a descriptor for AUGRU backward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p diff_src_iter_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+///
+/// This would then indicate that the AUGRU backward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for AUGRU primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param attention_desc Memory descriptor for the attention vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_attention_desc Memory descriptor for the diff of attention vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_augru_backward_desc_init(dnnl_rnn_desc_t *rnn_desc,
+        dnnl_prop_kind_t prop_kind, dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *attention_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_attention_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc, unsigned flags);
+
+/// Initializes a descriptor for LBR AUGRU forward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc,
+/// - @p bias_desc,
+/// - @p dst_iter_desc.
+///
+/// This would then indicate that the LBR AUGRU forward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @param rnn_desc Output descriptor for LBR AUGRU primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param attention_desc Memory descriptor for the attention vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lbr_augru_forward_desc_init(
+        dnnl_rnn_desc_t *rnn_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *attention_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc, unsigned flags);
+
+/// Initializes a descriptor for LBR AUGRU backward propagation primitive.
+///
+/// The following arguments may either be @c NULL or point to a zero memory
+/// descriptor:
+/// - @p src_iter_desc together with @p diff_src_iter_desc,
+/// - @p bias_desc together with @p diff_bias_desc,
+/// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+///
+/// This would then indicate that the LBR AUGRU backward propagation primitive
+/// should not use them and should default to zero values instead.
+///
+/// @note
+///     All memory descriptors can be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+/// @param rnn_desc Output descriptor for LBR AUGRU primitive.
+/// @param prop_kind Propagation kind. Must be #dnnl_backward.
+/// @param direction RNN direction. See @ref dnnl_rnn_direction_t for more
+///     info.
+/// @param src_layer_desc Memory descriptor for the input vector.
+/// @param src_iter_desc Memory descriptor for the input recurrent hidden
+///     state vector.
+/// @param attention_desc Memory descriptor for the attention vector.
+/// @param weights_layer_desc Memory descriptor for the weights applied to the
+///     layer input.
+/// @param weights_iter_desc Memory descriptor for the weights applied to the
+///     recurrent input.
+/// @param bias_desc Bias memory descriptor.
+/// @param dst_layer_desc Memory descriptor for the output vector.
+/// @param dst_iter_desc Memory descriptor for the output recurrent hidden
+///     state vector.
+/// @param diff_src_layer_desc Memory descriptor for the diff of input vector.
+/// @param diff_src_iter_desc Memory descriptor for the diff of input recurrent
+///     hidden state vector.
+/// @param diff_attention_desc Memory descriptor for the diff of attention vector.
+/// @param diff_weights_layer_desc Memory descriptor for the diff of weights
+///     applied to the layer input.
+/// @param diff_weights_iter_desc Memory descriptor for the diff of weights
+///     applied to the recurrent input.
+/// @param diff_bias_desc Diff bias memory descriptor.
+/// @param diff_dst_layer_desc Memory descriptor for the diff of output
+///     vector.
+/// @param diff_dst_iter_desc Memory descriptor for the diff of output
+///     recurrent hidden state vector.
+/// @param flags Unused.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_lbr_augru_backward_desc_init(
+        dnnl_rnn_desc_t *rnn_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_rnn_direction_t direction,
+        const dnnl_memory_desc_t *src_layer_desc,
+        const dnnl_memory_desc_t *src_iter_desc,
+        const dnnl_memory_desc_t *attention_desc,
+        const dnnl_memory_desc_t *weights_layer_desc,
+        const dnnl_memory_desc_t *weights_iter_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_layer_desc,
+        const dnnl_memory_desc_t *dst_iter_desc,
+        const dnnl_memory_desc_t *diff_src_layer_desc,
+        const dnnl_memory_desc_t *diff_src_iter_desc,
+        const dnnl_memory_desc_t *diff_attention_desc,
+        const dnnl_memory_desc_t *diff_weights_layer_desc,
+        const dnnl_memory_desc_t *diff_weights_iter_desc,
+        const dnnl_memory_desc_t *diff_bias_desc,
+        const dnnl_memory_desc_t *diff_dst_layer_desc,
+        const dnnl_memory_desc_t *diff_dst_iter_desc, unsigned flags);
+
+/// @} dnnl_api_rnn
+
+/// @addtogroup dnnl_api_matmul
+/// @{
+
+/// Initializes a matrix multiplication descriptor.
+///
+/// @param matmul_desc Output descriptor for matmul primitive.
+/// @param src_desc Source memory descriptor (matrix A)
+/// @param weights_desc Weights memory descriptor (matrix B)
+/// @param bias_desc Bias memory descriptor. Passing NULL, a zero memory
+///     descriptor, or a memory descriptor with format_kind set to
+///     #dnnl_format_kind_undef disables the bias term.
+/// @param dst_desc Destination memory descriptor (matrix C).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_matmul_desc_init(dnnl_matmul_desc_t *matmul_desc,
+        const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *weights_desc,
+        const dnnl_memory_desc_t *bias_desc,
+        const dnnl_memory_desc_t *dst_desc);
+
+/// @} dnnl_api_matmul
+
+/// @addtogroup dnnl_api_resampling Resampling
+/// @{
+
+/// Initializes a descriptor for a resampling forward propagation primitive.
+///
+/// @note
+///     Destination memory descriptor is allowed to be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+///
+/// @param resampling_desc Output descriptor for a resampling primitive.
+/// @param prop_kind Propagation kind. Possible values are
+///     #dnnl_forward_training and #dnnl_forward_inference.
+/// @param alg_kind resampling algorithm kind: either #dnnl_resampling_nearest,
+///     or #dnnl_resampling_linear.
+/// @param factors Array of scaling factors for spatial dimension.
+/// @param src_desc Source memory descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_resampling_forward_desc_init(
+        dnnl_resampling_desc_t *resampling_desc, dnnl_prop_kind_t prop_kind,
+        dnnl_alg_kind_t alg_kind, const float *factors,
+        const dnnl_memory_desc_t *src_desc, const dnnl_memory_desc_t *dst_desc);
+
+/// Initializes a descriptor for resampling backward propagation primitive.
+///
+/// @param resampling_desc Output descriptor for a resampling primitive.
+/// @param alg_kind resamplinging algorithm kind: either
+///     #dnnl_resampling_nearest, or #dnnl_resampling_linear.
+/// @param diff_src_desc Diff source memory descriptor.
+/// @param diff_dst_desc Diff destination memory descriptor.
+/// @param factors Array of scaling factors for spatial dimension.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+///
+dnnl_status_t DNNL_API dnnl_resampling_backward_desc_init(
+        dnnl_resampling_desc_t *resampling_desc, dnnl_alg_kind_t alg_kind,
+        const float *factors, const dnnl_memory_desc_t *diff_src_desc,
+        const dnnl_memory_desc_t *diff_dst_desc);
+
+/// @} dnnl_api_resampling
+
+/// @addtogroup dnnl_api_reduction Reduction
+/// @{
+
+/// Initializes a descriptor for a reduction primitive.
+///
+/// @note
+///     Destination memory descriptor is allowed to be initialized with
+///     #dnnl_format_tag_any or with format_kind set to #dnnl_format_kind_any.
+///
+///
+/// @param desc Output descriptor for a reduction primitive.
+/// @param alg_kind reduction algorithm kind. Possible values:
+///     #dnnl_reduction_max, #dnnl_reduction_min, #dnnl_reduction_sum,
+///     #dnnl_reduction_mul, #dnnl_reduction_mean, #dnnl_reduction_norm_lp_max,
+///     #dnnl_reduction_norm_lp_sum, #dnnl_reduction_norm_lp_power_p_max,
+///     #dnnl_reduction_norm_lp_power_p_sum.
+/// @param p Algorithm specific parameter.
+/// @param eps Algorithm specific parameter.
+/// @param src_desc Source memory descriptor.
+/// @param dst_desc Destination memory descriptor.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+///
+dnnl_status_t DNNL_API dnnl_reduction_desc_init(dnnl_reduction_desc_t *desc,
+        dnnl_alg_kind_t alg_kind, const dnnl_memory_desc_t *src_desc,
+        const dnnl_memory_desc_t *dst_desc, float p, float eps);
+
+/// @} dnnl_api_reduction
+
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_engine
+/// @{
+
+/// Returns the number of engines of a particular kind.
+///
+/// @param kind Kind of engines to count.
+/// @returns Count of the engines.
+size_t DNNL_API dnnl_engine_get_count(dnnl_engine_kind_t kind);
+
+/// Creates an engine.
+///
+/// @param engine Output engine.
+/// @param kind Engine kind.
+/// @param index Engine index that should be between 0 and the count of
+///     engines of the requested kind.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_engine_create(
+        dnnl_engine_t *engine, dnnl_engine_kind_t kind, size_t index);
+
+/// Returns the kind of an engine.
+///
+/// @param engine Engine to query.
+/// @param kind Output engine kind.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_engine_get_kind(
+        dnnl_engine_t engine, dnnl_engine_kind_t *kind);
+
+/// Destroys an engine.
+///
+/// @param engine Engine to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_engine_destroy(dnnl_engine_t engine);
+
+/// @} dnnl_api_engine
+
+/// @addtogroup dnnl_api_stream
+/// @{
+
+/// Creates an execution stream.
+///
+/// @param stream Output execution stream.
+/// @param engine Engine to create the execution stream on.
+/// @param flags Stream behavior flags (@sa dnnl_stream_flags_t).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_stream_create(
+        dnnl_stream_t *stream, dnnl_engine_t engine, unsigned flags);
+
+/// Returns the engine of a stream object.
+///
+/// @param stream Stream object.
+/// @param engine Output engine on which the stream is created.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_stream_get_engine(
+        const_dnnl_stream_t stream, dnnl_engine_t *engine);
+
+/// Waits for all primitives in the execution stream to finish computations.
+///
+/// @param stream Execution stream.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_stream_wait(dnnl_stream_t stream);
+
+/// Destroys an execution stream.
+///
+/// @param stream Execution stream to destroy.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_stream_destroy(dnnl_stream_t stream);
+
+/// @} dnnl_api_stream
+
+/// @addtogroup dnnl_api_primitive_cache
+/// @{
+
+/// Returns the number of primitives that can be held in the primitive cache
+/// at the same time.
+///
+/// @param capacity Primitive cache capacity to query. Concurrently
+/// accessing @p capacity is safe.
+/// @returns #dnnl_invalid_arguments/#dnnl::status::invalid_arguments if the
+///     @p capacity value is invalid, and #dnnl_success/#dnnl::status::success on
+///     success.
+dnnl_status_t DNNL_API dnnl_get_primitive_cache_capacity(int *capacity);
+
+/// Sets a number of primitives that can be held in the primitive cache
+/// at a time.
+///
+/// @param capacity Primitive cache capacity to set. If a new @p capacity is
+/// less than a number of primitives that the primitive cache already has
+/// then the excess entries will be evicted. Setting the @p capacity to 0
+/// clears the primitive cache and disables it. Concurrently modifying
+/// @p capacity is safe.
+/// @returns #dnnl_invalid_arguments/#dnnl::status::invalid_arguments if the
+///     @p capacity value is invalid, and #dnnl_success/#dnnl::status::success on
+///     success.
+dnnl_status_t DNNL_API dnnl_set_primitive_cache_capacity(int capacity);
+
+/// @} dnnl_api_primitive_cache
+
+/// @addtogroup dnnl_api_mathmode Floating-point Math Mode
+/// @{
+
+/// Returns the floating-point math mode that will be used by default
+/// for all subsequently created primitives.
+///
+/// @param mode Output FP math mode.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_get_default_fpmath_mode(dnnl_fpmath_mode_t *mode);
+
+/// Sets the floating-point math mode that will be used by default
+/// for all subsequently created primitives.
+///
+/// @param mode FP math mode. The possible values are:
+///     #dnnl_fpmath_mode_strict,
+///     #dnnl_fpmath_mode_bf16,
+///     #dnnl_fpmath_mode_f16,
+///     #dnnl_fpmath_mode_tf32,
+///     #dnnl_fpmath_mode_any.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_set_default_fpmath_mode(dnnl_fpmath_mode_t mode);
+
+/// @} dnnl_api_mathmode
+
+/// @addtogroup dnnl_api_service
+/// @{
+
+/// Configures verbose output to stdout.
+///
+/// @note
+///     Enabling verbose output affects performance.
+///     This setting overrides the ONEDNN_VERBOSE environment variable.
+///
+/// @param level Verbosity level:
+///  - 0: no verbose output (default),
+///  - 1: primitive information at execution,
+///  - 2: primitive information at creation and execution.
+/// @returns #dnnl_invalid_arguments/#dnnl::status::invalid_arguments if the
+///     @p level value is invalid, and #dnnl_success/#dnnl::status::success on
+///     success.
+dnnl_status_t DNNL_API dnnl_set_verbose(int level);
+
+/// Configures dumping of JIT-generated code.
+///
+/// @note
+///     This setting overrides the DNNL_JIT_DUMP environment variable.
+///
+/// @param enable Flag value. Set to 0 to disable and set to 1 to enable.
+/// @returns #dnnl_invalid_arguments/#dnnl::status::invalid_arguments if the
+///     @p flag value is invalid, and #dnnl_success/#dnnl::status::success on
+///     success.
+dnnl_status_t DNNL_API dnnl_set_jit_dump(int enable);
+
+/// Returns library version information.
+/// @returns Pointer to a constant structure containing
+///  - major: major version number,
+///  - minor: minor version number,
+///  - patch: patch release number,
+///  - hash: git commit hash.
+const dnnl_version_t DNNL_API *dnnl_version(void);
+
+/// Sets library profiling flags. The flags define which profilers are
+/// supported.
+///
+/// @note
+///     This setting overrides DNNL_JIT_PROFILE environment variable.
+///
+/// @sa @ref dev_guide_profilers
+///
+/// @param flags Profiling flags that can contain the following bits:
+///     - @ref DNNL_JIT_PROFILE_VTUNE -- integration with VTune Amplifier
+///         (on by default)
+///     - @ref DNNL_JIT_PROFILE_LINUX_JITDUMP -- produce Linux-specific
+///         jit-pid.dump output (off by default). The location of the output
+///         is controlled via JITDUMPDIR environment variable or via
+///         dnnl_set_jit_profiling_jitdumpdir() function.
+///     - @ref DNNL_JIT_PROFILE_LINUX_PERFMAP -- produce Linux-specific
+///         perf-pid.map output (off by default). The output is always placed
+///         into /tmp.
+///
+///     Passing @ref DNNL_JIT_PROFILE_NONE disables profiling completely.
+///
+/// @returns #dnnl_invalid_arguments/#dnnl::status::invalid_arguments if the
+///     @p flags value is invalid, and #dnnl_success/#dnnl::status::success on
+///     success.
+dnnl_status_t DNNL_API dnnl_set_jit_profiling_flags(unsigned flags);
+
+/// Sets JIT dump output path. Only applicable to Linux and is only
+/// used when profiling flags have DNNL_JIT_PROFILE_LINUX_PERF bit set.
+///
+/// After the first JIT kernel is generated, the jitdump output will be placed
+/// into temporary directory created using the mkdtemp template
+/// 'dir/.debug/jit/dnnl.XXXXXX'.
+///
+/// @sa @ref dev_guide_profilers
+///
+/// @note
+///     This setting overrides JITDUMPDIR environment variable.  If
+///     JITDUMPDIR is not set, and this function is never called, the path
+///     defaults to HOME. Passing NULL reverts the value to default.
+///
+/// @note
+///     The directory is accessed only when the first JIT kernel is being
+///     created. JIT profiling will be disabled in case of any errors
+///     accessing or creating this directory.
+///
+/// @param dir JIT dump output path.
+/// @returns #dnnl_success/#dnnl::status::success if the
+///     output directory was set correctly and an error status otherwise.
+/// @returns #dnnl_unimplemented/#dnnl::status::unimplemented on Windows.
+dnnl_status_t DNNL_API dnnl_set_jit_profiling_jitdumpdir(const char *dir);
+
+/// Sets the maximal ISA the library can dispatch to on the CPU. See
+/// #dnnl_cpu_isa_t and #dnnl::cpu_isa for the list of the values accepted by
+/// the C and C++ API functions respectively.
+///
+/// This function has effect only once, and returns an error on subsequent
+/// calls. It should also be invoked before any other oneDNN API call, otherwise
+/// it may return an error.
+///
+/// This function overrides the DNNL_MAX_CPU_ISA environment variable. The
+/// environment variable can be set to the desired maximal ISA name in upper
+/// case and with dnnl_cpu_isa prefix removed. For example:
+/// `DNNL_MAX_CPU_ISA=AVX2`.
+///
+/// @note
+///     The ISAs are only partially ordered:
+///         - SSE41 < AVX < AVX2,
+///         - AVX2 < AVX512_CORE < AVX512_CORE_VNNI < AVX512_CORE_BF16
+///           < AVX512_CORE_AMX,
+///         - AVX2 < AVX2_VNNI.
+///
+/// @sa @ref dev_guide_cpu_dispatcher_control for more details
+///
+/// @param isa Maximal ISA the library should dispatch to. Pass
+///     #dnnl_cpu_isa_all/#dnnl::cpu_isa::all to remove ISA restrictions
+///     (except for ISAs with initial support in the library).
+/// @returns #dnnl_success/#dnnl::status::success on success and a
+///     #dnnl_invalid_arguments/#dnnl::status::invalid_arguments if the @p isa
+///     parameter is invalid or the ISA cannot be changed at this time.
+/// @returns #dnnl_unimplemented/#dnnl::status::unimplemented if the feature
+///     was disabled at build time (see @ref dev_guide_build_options for more
+///     details).
+dnnl_status_t DNNL_API dnnl_set_max_cpu_isa(dnnl_cpu_isa_t isa);
+
+/// Gets the maximal ISA the library can dispatch to on the CPU. See
+/// #dnnl_cpu_isa_t and #dnnl::cpu_isa for the list of the values returned by
+/// the C and C++ API functions respectively.
+///
+/// @sa @ref dev_guide_cpu_dispatcher_control for more details
+///
+/// @returns #dnnl_cpu_isa_t value reflecting the maximal ISA the library may
+///     dispatch to.
+dnnl_cpu_isa_t DNNL_API dnnl_get_effective_cpu_isa(void);
+
+/// Sets the hints flag for the CPU ISA. See #dnnl_cpu_isa_hints_t and
+/// #dnnl::cpu_isa_hints for the list of the values accepted by the C and C++
+/// API functions respectively.
+///
+/// This function has effect only once, and returns an error on subsequent
+/// calls. It should also be invoked before any other oneDNN API call, otherwise
+/// it may return an error.
+///
+/// This function overrides the DNNL_CPU_ISA_HINTS environment variable.
+/// @sa @ref dev_guide_cpu_isa_hints for more details
+///
+/// @param isa_hints CPU ISA hints to be passed over to the implementation.
+///     Pass #dnnl_cpu_isa_no_hints/#dnnl::cpu_isa_hints::no_hints to use
+///     default features i.e. no hints.
+/// @returns #dnnl_success/#dnnl::status::success on success and a
+///     #dnnl_runtime_error/#dnnl::status::runtime_error if the ISA hints cannot
+///     be specified at the current time.
+/// @returns #dnnl_unimplemented/#dnnl::status::unimplemented if the feature
+///     was disabled at build time (see @ref dev_guide_build_options for more
+///     details).
+dnnl_status_t DNNL_API dnnl_set_cpu_isa_hints(dnnl_cpu_isa_hints_t isa_hints);
+
+/// Gets the ISA specific hints that library can follow. See
+/// #dnnl_cpu_isa_hints_t and #dnnl::cpu_isa_hints for the list of the values
+///  returned by the C and C++ API functions respectively.
+///
+/// @sa @ref dev_guide_cpu_isa_hints for more details
+///
+/// @returns #dnnl_cpu_isa_hints_t value reflecting the ISA specific hints the
+/// library can follow.
+dnnl_cpu_isa_hints_t DNNL_API dnnl_get_cpu_isa_hints(void);
+
+/// @} dnnl_api_service
+
+/// @addtogroup dnnl_api_blas
+/// @{
+
+/// Performs single-precision matrix-matrix multiply.
+///
+/// The operation is defined as:
+///
+/// `C := alpha * op( A ) * op( B ) + beta * C`
+///
+/// where
+///  - `op( X ) = X` or `op( X ) = X**T`,
+///  - `alpha` and `beta` are scalars, and
+///  - `A`, `B`, and `C` are matrices:
+///     - `op( A )` is an `MxK` matrix,
+///     - `op( B )` is an `KxN` matrix,
+///     - `C` is an `MxN` matrix.
+///
+/// The matrices are assumed to be stored in row-major order (the elements in
+/// each of the matrix rows are contiguous in memory).
+///
+/// @note
+///     This API does not support XERBLA. Instead, unlike the standard BLAS
+///     functions, this one returns a dnnl_status_t value to allow error
+///     handling.
+///
+/// @param transa Transposition flag for matrix A: 'N' or 'n' means A is not
+///     transposed, and 'T' or 't' means that A is transposed.
+/// @param transb Transposition flag for matrix B: 'N' or 'n' means B is not
+///     transposed, and 'T' or 't' means that B is transposed.
+/// @param M The M dimension.
+/// @param N The N dimension.
+/// @param K The K dimension.
+/// @param alpha The alpha parameter that is used to scale the product of
+///     matrices A and B.
+/// @param A A pointer to the A matrix data.
+/// @param lda The leading dimension for the matrix A.
+/// @param B A pointer to the B matrix data.
+/// @param ldb The leading dimension for the matrix B.
+/// @param beta The beta parameter that is used to scale the matrix C.
+/// @param C A pointer to the C matrix data.
+/// @param ldc The leading dimension for the matrix C.
+/// @returns #dnnl_success/#dnnl::status::success on success and a status
+///     describing the error otherwise.
+dnnl_status_t DNNL_API dnnl_sgemm(char transa, char transb, dnnl_dim_t M,
+        dnnl_dim_t N, dnnl_dim_t K, float alpha, const float *A, dnnl_dim_t lda,
+        const float *B, dnnl_dim_t ldb, float beta, float *C, dnnl_dim_t ldc);
+
+/// Performs integer matrix-matrix multiply on 8-bit unsigned matrix A, 8-bit
+/// signed matrix B, and 32-bit signed resulting matrix C.
+///
+/// The operation is defined as:
+///
+/// `C := alpha * (op(A) - A_offset) * (op(B) - B_offset) + beta * C + C_offset`
+///
+/// where
+///  - `op( X ) = X` or `op( X ) = X**T`,
+///  - `alpha` and `beta` are scalars, and
+///  - `A`, `B`, and `C` are matrices:
+///     - `op( A )` is an `MxK` matrix,
+///     - `op( B )` is an `KxN` matrix,
+///     - `C` is an `MxN` matrix.
+///  - `A_offset` is an `MxK` matrix with every element equal the `ao` value,
+///  - `B_offset` is an `KxN` matrix with every element equal the `bo` value,
+///  - `C_offset` is an `MxN` matrix which is defined by the `co` array of size `len`:
+///    - if `offsetc = F`: the `len` must be at least `1`,
+///    - if `offsetc = C`: the `len` must be at least `max(1, m)`,
+///    - if `offsetc = R`: the `len` must be at least `max(1, n)`,
+///
+/// The matrices are assumed to be stored in row-major order (the elements in
+/// each of the matrix rows are contiguous in memory).
+///
+/// @note
+///     This API does not support XERBLA. Instead, unlike the standard BLAS
+///     functions, this one returns a dnnl_status_t value to allow error
+///     handling.
+///
+/// @warning
+///     On some architectures saturation may happen during intermediate
+///     computations, which would lead to unexpected results. For more
+///     details, refer to @ref dev_guide_int8_computations.
+///
+/// @param transa Transposition flag for matrix A: 'N' or 'n' means A is not
+///     transposed, and 'T' or 't' means that A is transposed.
+/// @param transb Transposition flag for matrix B: 'N' or 'n' means B is not
+///     transposed, and 'T' or 't' means that B is transposed.
+/// @param offsetc Flag specifying how offsets should be applied to matrix C:
+///     - 'F' means that the same offset will be applied to each element of
+///         the matrix C,
+///     - 'C' means that individual offset will be applied to each element
+///         within each column,
+///     - 'R' means that individual offset will be applied to each element
+///         within each row.
+/// @param M The M dimension.
+/// @param N The N dimension.
+/// @param K The K dimension.
+/// @param alpha The alpha parameter that is used to scale the product of
+///     matrices A and B.
+/// @param A A pointer to the A matrix data.
+/// @param lda The leading dimension for the matrix A.
+/// @param ao The offset value for the matrix A.
+/// @param B A pointer to the B matrix data.
+/// @param ldb The leading dimension for the matrix B.
+/// @param bo The offset value for the matrix B.
+/// @param beta The beta parameter that is used to scale the matrix C.
+/// @param C A pointer to the C matrix data.
+/// @param ldc The leading dimension for the matrix C.
+/// @param co An array of offset values for the matrix C. The number of
+///     elements in the array depends on the value of @p offsetc.
+/// @returns #dnnl_success/#dnnl::status::success on success and a status
+///     describing the error otherwise.
+dnnl_status_t DNNL_API dnnl_gemm_u8s8s32(char transa, char transb, char offsetc,
+        dnnl_dim_t M, dnnl_dim_t N, dnnl_dim_t K, float alpha, const uint8_t *A,
+        dnnl_dim_t lda, uint8_t ao, const int8_t *B, dnnl_dim_t ldb, int8_t bo,
+        float beta, int32_t *C, dnnl_dim_t ldc, const int32_t *co);
+
+/// Performs integer matrix-matrix multiply on 8-bit signed matrix A, 8-bit
+/// signed matrix B, and 32-bit signed resulting matrix C.
+///
+/// The operation is defined as:
+///
+/// `C := alpha * (op(A) - A_offset) * (op(B) - B_offset) + beta * C + C_offset`
+///
+/// where
+///  - `op( X ) = X` or `op( X ) = X**T`,
+///  - `alpha` and `beta` are scalars, and
+///  - `A`, `B`, and `C` are matrices:
+///     - `op( A )` is an `MxK` matrix,
+///     - `op( B )` is an `KxN` matrix,
+///     - `C` is an `MxN` matrix.
+///  - `A_offset` is an `MxK` matrix with every element equal the `ao` value,
+///  - `B_offset` is an `KxN` matrix with every element equal the `bo` value,
+///  - `C_offset` is an `MxN` matrix which is defined by the `co` array of size `len`:
+///    - if `offsetc = F`: the `len` must be at least `1`,
+///    - if `offsetc = C`: the `len` must be at least `max(1, m)`,
+///    - if `offsetc = R`: the `len` must be at least `max(1, n)`,
+///
+/// The matrices are assumed to be stored in row-major order (the elements in
+/// each of the matrix rows are contiguous in memory).
+///
+/// @note
+///     This API does not support XERBLA. Instead, unlike the standard BLAS
+///     functions, this one returns a dnnl_status_t value to allow error
+///     handling.
+///
+/// @warning
+///     On some architectures saturation may happen during intermediate
+///     computations, which would lead to unexpected results. For more
+///     details, refer to @ref dev_guide_int8_computations.
+///
+/// @param transa Transposition flag for matrix A: 'N' or 'n' means A is not
+///     transposed, and 'T' or 't' means that A is transposed.
+/// @param transb Transposition flag for matrix B: 'N' or 'n' means B is not
+///     transposed, and 'T' or 't' means that B is transposed.
+/// @param offsetc Flag specifying how offsets should be applied to matrix C:
+///     - 'F' means that the same offset will be applied to each element of
+///         the matrix C,
+///     - 'C' means that individual offset will be applied to each element
+///         within each column,
+///     - 'R' means that individual offset will be applied to each element
+///         within each row.
+/// @param M The M dimension.
+/// @param N The N dimension.
+/// @param K The K dimension.
+/// @param alpha The alpha parameter that is used to scale the product of
+///     matrices A and B.
+/// @param A A pointer to the A matrix data.
+/// @param lda The leading dimension for the matrix A.
+/// @param ao The offset value for the matrix A.
+/// @param B A pointer to the B matrix data.
+/// @param ldb The leading dimension for the matrix B.
+/// @param bo The offset value for the matrix B.
+/// @param beta The beta parameter that is used to scale the matrix C.
+/// @param C A pointer to the C matrix data.
+/// @param ldc The leading dimension for the matrix C.
+/// @param co An array of offset values for the matrix C. The number of
+///     elements in the array depends on the value of @p offsetc.
+/// @returns #dnnl_success/#dnnl::status::success on success and a status
+///     describing the error otherwise.
+dnnl_status_t DNNL_API dnnl_gemm_s8s8s32(char transa, char transb, char offsetc,
+        dnnl_dim_t M, dnnl_dim_t N, dnnl_dim_t K, float alpha, const int8_t *A,
+        dnnl_dim_t lda, int8_t ao, const int8_t *B, dnnl_dim_t ldb, int8_t bo,
+        float beta, int32_t *C, dnnl_dim_t ldc, const int32_t *co);
+
+/// @} dnnl_api_blas
+
+/// @} dnnl_api
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ONEAPI_DNNL_DNNL_H */

--- a/rfcs/20220815-v3.0-API-cleanup/dnnl.hpp
+++ b/rfcs/20220815-v3.0-API-cleanup/dnnl.hpp
@@ -1,0 +1,13204 @@
+/*******************************************************************************
+* Copyright 2016-2022 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/// @file
+/// C++ API
+
+#ifndef ONEAPI_DNNL_DNNL_HPP
+#define ONEAPI_DNNL_DNNL_HPP
+
+#include "oneapi/dnnl/dnnl_config.h"
+
+/// @cond DO_NOT_DOCUMENT_THIS
+#include <algorithm>
+#include <cstdlib>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#include "oneapi/dnnl/dnnl.h"
+
+/// @endcond
+
+// __cpp_exceptions is referred from
+// https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_exceptions.html
+// gcc < 5 does not define __cpp_exceptions but __EXCEPTIONS,
+// Microsoft C++ Compiler does not provide an option to disable exceptions
+#ifndef DNNL_ENABLE_EXCEPTIONS
+#if __cpp_exceptions || __EXCEPTIONS \
+        || (defined(_MSC_VER) && !defined(__clang__))
+#define DNNL_ENABLE_EXCEPTIONS 1
+#else
+#define DNNL_ENABLE_EXCEPTIONS 0
+#endif
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define DNNL_TRAP() __builtin_trap()
+#elif defined(__INTEL_COMPILER) || defined(_MSC_VER)
+#define DNNL_TRAP() __debugbreak()
+#else
+#error "unknown compiler"
+#endif
+
+#if DNNL_ENABLE_EXCEPTIONS
+#define DNNL_THROW_ERROR(status, msg) throw error(status, msg)
+#else
+#include <cstdio>
+#define DNNL_THROW_ERROR(status, msg) \
+    do { \
+        fputs(msg, stderr); \
+        DNNL_TRAP(); \
+    } while (0)
+#endif
+
+/// @addtogroup dnnl_api oneDNN API
+/// @{
+
+/// oneDNN namespace
+namespace dnnl {
+
+/// @addtogroup dnnl_api_utils Utilities
+/// Utility types and definitions.
+/// @{
+
+/// oneDNN exception class.
+///
+/// This class captures the status returned by a failed C API function and
+/// the error message from the call site.
+struct error : public std::exception {
+    dnnl_status_t status;
+    const char *message;
+
+    /// Constructs an instance of an exception class.
+    ///
+    /// @param status The error status returned by a C API function.
+    /// @param message The error message.
+    error(dnnl_status_t status, const char *message)
+        : status(status), message(message) {}
+
+    /// Returns the explanatory string.
+    const char *what() const noexcept override { return message; }
+
+    /// A convenience function for wrapping calls to C API functions. Checks
+    /// the return status and throws an dnnl::error in case of failure.
+    ///
+    /// @param status The error status returned by a C API function.
+    /// @param message The error message.
+    static void wrap_c_api(dnnl_status_t status, const char *message) {
+        if (status != dnnl_success) DNNL_THROW_ERROR(status, message);
+    }
+};
+
+/// @cond DO_NOT_DOCUMENT_THIS
+template <typename T>
+void validate_container_size(const T &v, const char *error_message,
+        int min_size = 1, int max_size = -1) {
+    const int size = (int)v.size();
+    if (size < min_size || (max_size >= 0 && size > max_size))
+        DNNL_THROW_ERROR(dnnl_invalid_arguments, error_message);
+}
+/// @endcond
+
+/// A class that provides the destructor for a oneDNN C API handle.
+template <typename T>
+struct handle_traits {};
+
+/// oneDNN C API handle wrapper class.
+///
+/// This class is used as the base class for primitive (dnnl::primitive),
+/// engine (dnnl::engine), and stream (dnnl::stream) classes, as well as
+/// others. An object of the dnnl::handle class can be passed by value.
+///
+/// A handle can be weak, in which case it follows std::weak_ptr semantics.
+/// Otherwise, it follows `std::shared_ptr` semantics.
+///
+/// @note
+///     The implementation stores oneDNN C API handles in a `std::shared_ptr`
+///     with deleter set to a dummy function in the weak mode.
+///
+template <typename T, typename traits = handle_traits<T>>
+struct handle {
+private:
+    static dnnl_status_t dummy_destructor(T) { return dnnl_success; }
+    std::shared_ptr<typename std::remove_pointer<T>::type> data_ {0};
+
+protected:
+    bool operator==(const T other) const { return other == data_.get(); }
+    bool operator!=(const T other) const { return !(*this == other); }
+
+public:
+    /// Constructs an empty handle object.
+    ///
+    /// @warning
+    ///     Uninitialized object cannot be used in most library calls and is
+    ///     equivalent to a null pointer. Any attempt to use its methods, or
+    ///     passing it to the other library function, will cause an exception
+    ///     to be thrown.
+    handle() = default;
+
+    /// Copy constructor.
+    handle(const handle<T, traits> &) = default;
+    /// Assignment operator.
+    handle<T, traits> &operator=(const handle<T, traits> &) = default;
+    /// Move constructor.
+    handle(handle<T, traits> &&) = default;
+    /// Move assignment operator.
+    handle<T, traits> &operator=(handle<T, traits> &&) = default;
+
+    /// Constructs a handle wrapper object from a C API handle.
+    ///
+    /// @param t The C API handle to wrap.
+    /// @param weak A flag specifying whether to construct a weak wrapper;
+    ///     defaults to @c false.
+    explicit handle(T t, bool weak = false) { reset(t, weak); }
+
+    /// Resets the handle wrapper objects to wrap a new C API handle.
+    ///
+    /// @param t The new value of the C API handle.
+    /// @param weak A flag specifying whether the wrapper should be weak;
+    ///     defaults to @c false.
+    void reset(T t, bool weak = false) {
+        data_.reset(t, weak ? &dummy_destructor : traits::destructor);
+    }
+
+    /// Returns the underlying C API handle.
+    ///
+    /// @param allow_empty A flag signifying whether the method is allowed to
+    ///     return an empty (null) object without throwing an exception.
+    /// @returns The underlying C API handle.
+    T get(bool allow_empty = false) const {
+        T result = data_.get();
+        if (allow_empty == false && result == nullptr)
+            DNNL_THROW_ERROR(
+                    dnnl_invalid_arguments, "object is not initialized");
+        return result;
+    }
+
+    /// Converts a handle to the underlying C API handle type. Does not throw
+    /// and returns `nullptr` if the object is empty.
+    ///
+    /// @returns The underlying C API handle.
+    explicit operator T() const { return get(true); }
+
+    /// Checks whether the object is not empty.
+    ///
+    /// @returns Whether the object is not empty.
+    explicit operator bool() const { return get(true) != nullptr; }
+
+    /// Equality operator.
+    ///
+    /// @param other Another handle wrapper.
+    /// @returns @c true if this and the other handle wrapper manage the same
+    ///     underlying C API handle, and @c false otherwise. Empty handle
+    ///     objects are considered to be equal.
+    bool operator==(const handle<T, traits> &other) const {
+        return other.data_.get() == data_.get();
+    }
+
+    /// Inequality operator.
+    ///
+    /// @param other Another handle wrapper.
+    /// @returns @c true if this and the other handle wrapper manage different
+    ///     underlying C API handles, and @c false otherwise. Empty handle
+    ///     objects are considered to be equal.
+    bool operator!=(const handle &other) const { return !(*this == other); }
+};
+
+/// @cond DO_NOT_DOCUMENT_THIS
+template <>
+struct handle_traits<dnnl_memory_t> {
+    static dnnl_status_t destructor(dnnl_memory_t p) {
+        return dnnl_memory_destroy(p);
+    }
+};
+
+template <>
+struct handle_traits<dnnl_primitive_desc_t> {
+    static dnnl_status_t destructor(dnnl_primitive_desc_t p) {
+        return dnnl_primitive_desc_destroy(p);
+    }
+};
+
+template <>
+struct handle_traits<dnnl_primitive_t> {
+    static dnnl_status_t destructor(dnnl_primitive_t p) {
+        return dnnl_primitive_destroy(p);
+    }
+};
+
+template <>
+struct handle_traits<dnnl_primitive_desc_iterator_t> {
+    static dnnl_status_t destructor(dnnl_primitive_desc_iterator_t p) {
+        return dnnl_primitive_desc_iterator_destroy(p);
+    }
+};
+/// @endcond
+
+/// @} dnnl_api_utils
+
+struct stream;
+struct memory;
+struct primitive_desc;
+
+/// @addtogroup dnnl_api_primitives Primitives
+/// Compute primitives
+/// @sa @ref dev_guide_basic_concepts
+/// @{
+
+/// @addtogroup dnnl_api_primitives_common Common
+/// Common operations to create, destroy and inspect primitives
+/// @{
+
+/// Base class for all computational primitives.
+struct primitive : public handle<dnnl_primitive_t> {
+    /// Kinds of primitives supported by the library.
+    enum class kind {
+        /// Undefined primitive
+        undef = dnnl_undefined_primitive,
+        /// A reorder primitive.
+        reorder = dnnl_reorder,
+        /// A shuffle primitive.
+        shuffle = dnnl_shuffle,
+        /// A (out-of-place) tensor concatenation primitive.
+        concat = dnnl_concat,
+        /// A summation primitive.
+        sum = dnnl_sum,
+        /// A convolution primitive.
+        convolution = dnnl_convolution,
+        /// A deconvolution primitive.
+        deconvolution = dnnl_deconvolution,
+        /// An element-wise primitive.
+        eltwise = dnnl_eltwise,
+        /// A softmax primitive.
+        softmax = dnnl_softmax,
+        /// A pooling primitive.
+        pooling = dnnl_pooling,
+        /// An LRN primitive.
+        lrn = dnnl_lrn,
+        /// A batch normalization primitive.
+        batch_normalization = dnnl_batch_normalization,
+        /// A layer normalization primitive.
+        layer_normalization = dnnl_layer_normalization,
+        /// An inner product primitive.
+        inner_product = dnnl_inner_product,
+        /// An RNN primitive.
+        rnn = dnnl_rnn,
+        /// A binary primitive.
+        binary = dnnl_binary,
+        /// A logsoftmax primitive.
+        logsoftmax = dnnl_logsoftmax,
+        /// A matmul (matrix multiplication) primitive.
+        matmul = dnnl_matmul,
+        /// A resampling primitive.
+        resampling = dnnl_resampling,
+        /// A pooling version 2 primitive.
+        pooling_v2 = dnnl_pooling_v2,
+        /// A reduction primitive.
+        reduction = dnnl_reduction,
+        /// A PReLU primitive.
+        prelu = dnnl_prelu,
+        /// A softmax version 2 primitive.
+        softmax_v2 = dnnl_softmax_v2,
+        /// A layer normalization version 2 primitive.
+        layer_normalization_v2 = dnnl_layer_normalization_v2,
+    };
+
+    using handle::handle;
+
+    /// Default constructor. Constructs an empty object.
+    primitive() = default;
+
+    /// Constructs a primitive from a C API primitive descriptor.
+    ///
+    /// @param c_pd C API primitive descriptor.
+    primitive(const_dnnl_primitive_desc_t c_pd);
+
+    /// Constructs a primitive from a C API primitive descriptor and a cache blob.
+    ///
+    /// @param c_pd C API primitive descriptor.
+    /// @param cache_blob Cache blob.
+    primitive(const_dnnl_primitive_desc_t c_pd,
+            const std::vector<uint8_t> &cache_blob);
+
+    /// Constructs a primitive from a primitive descriptor.
+    ///
+    /// @param pd Primitive descriptor.
+    primitive(const primitive_desc &pd);
+
+    /// Constructs a primitive from a primitive descriptor and a cache blob.
+    ///
+    /// @param pd Primitive descriptor.
+    /// @param cache_blob Cache blob.
+    primitive(const primitive_desc &pd, const std::vector<uint8_t> &cache_blob);
+
+    /// Returns the C API primitive descriptor of the underlying C API
+    /// primitive.
+    ///
+    /// @returns The underlying C API primitive descriptor.
+    inline const_dnnl_primitive_desc_t get_primitive_desc() const;
+
+    /// Returns the kind of the primitive.
+    ///
+    /// @returns The primitive kind.
+    inline kind get_kind() const;
+
+    /// Returns a cache blob for the primitive.
+    ///
+    /// @returns Vector containing the cache blob.
+    ///
+    /// @note The cache blob can be empty. It's the user's responsibility to
+    ///     check whether it's empty prior to passing it to the primitive
+    ///     constructor.
+    inline std::vector<uint8_t> get_cache_blob() const;
+
+    /// Executes computations specified by the primitive in a specified stream.
+    ///
+    /// Arguments are passed via an arguments map containing <index,
+    /// memory object> pairs. The index must be one of the `DNNL_ARG_*` values
+    /// such as `DNNL_ARG_SRC`, and the memory must have a memory descriptor
+    /// matching the one returned by
+    /// primitive_desc::query_md(#query::exec_arg_md, index) unless using
+    /// dynamic shapes (see #DNNL_RUNTIME_DIM_VAL).
+    ///
+    /// @param astream Stream object. The stream must belong to the same engine
+    ///     as the primitive.
+    /// @param args Arguments map.
+    void execute(const stream &astream,
+            const std::unordered_map<int, memory> &args) const;
+};
+
+/// Converts primitive kind enum value from C++ API to C API type.
+///
+/// @param akind C++ API primitive kind enum value.
+/// @returns Corresponding C API primitive kind enum value.
+inline dnnl_primitive_kind_t convert_to_c(primitive::kind akind) {
+    return static_cast<dnnl_primitive_kind_t>(akind);
+}
+
+const_dnnl_primitive_desc_t primitive::get_primitive_desc() const {
+    const_dnnl_primitive_desc_t pd;
+    error::wrap_c_api(dnnl_primitive_get_primitive_desc(get(), &pd),
+            "could not get a primitive descriptor from a primitive");
+    return pd;
+}
+
+dnnl::primitive::kind primitive::get_kind() const {
+    const_dnnl_primitive_desc_t pd = get_primitive_desc();
+    // TODO (Roma): the code below is only needed because get_primitive_desc
+    // returns a C type.
+    dnnl_primitive_kind_t kind;
+    error::wrap_c_api(dnnl_primitive_desc_query(
+                              pd, dnnl_query_primitive_kind, 0, (void *)&kind),
+            "could not get a primitive kind from a primitive descriptor");
+    return static_cast<dnnl::primitive::kind>(kind);
+}
+
+std::vector<uint8_t> primitive::get_cache_blob() const {
+    size_t size;
+    error::wrap_c_api(dnnl_primitive_get_cache_blob(get(), &size, nullptr),
+            "could not get cache blob size from a primitive");
+
+    std::vector<uint8_t> cache_blob(size);
+    error::wrap_c_api(
+            dnnl_primitive_get_cache_blob(get(), &size, cache_blob.data()),
+            "could not get a cache blob from a primitive");
+    return cache_blob;
+}
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_attributes
+///
+/// A container for parameters that extend primitives behavior.
+///
+/// Attributes can also contain Post-ops, which are computations executed
+/// after the primitive.
+///
+/// @sa @ref dev_guide_attributes
+/// @sa @ref dev_guide_attributes_post_ops
+///
+/// @{
+
+/// Floating-point math mode
+enum class fpmath_mode {
+    /// Default behavior, no downconversions allowed
+    strict = dnnl_fpmath_mode_strict,
+    /// Implicit f32->bf16 conversions allowed
+    bf16 = dnnl_fpmath_mode_bf16,
+    /// Implicit f32->f16 conversions allowed
+    f16 = dnnl_fpmath_mode_f16,
+    /// Implicit f32->tf32 conversions allowed
+    tf32 = dnnl_fpmath_mode_tf32,
+    /// Implicit f32->f16 or f32->bf16 conversions allowed
+    any = dnnl_fpmath_mode_any
+};
+
+/// Converts an fpmath mode enum value from C++ API to C API type.
+///
+/// @param mode C++ API fpmath mode enum value.
+/// @returns Corresponding C API fpmath mode enum value.
+inline dnnl_fpmath_mode_t convert_to_c(fpmath_mode mode) {
+    return static_cast<dnnl_fpmath_mode_t>(mode);
+}
+
+/// Scratchpad mode
+enum class scratchpad_mode {
+    /// The library manages the scratchpad allocation according to the policy
+    /// specified by the `DNNL_ENABLE_CONCURRENT_EXEC`
+    /// [build option](@ref dev_guide_build_options) (default).
+    ///
+    /// When `DNNL_ENABLE_CONCURRENT_EXEC=OFF` (default), the library
+    /// scratchpad is common to all primitives to reduce the memory footprint.
+    /// This configuration comes with limited thread-safety properties, namely
+    /// primitives can be created and executed in parallel but cannot migrate
+    /// between threads (in other words, each primitive should be executed in
+    /// the same thread it was created in).
+    ///
+    /// When `DNNL_ENABLE_CONCURRENT_EXEC=ON`, the library scratchpad is
+    /// private to each primitive. The memory footprint is larger than when
+    /// using `DNNL_ENABLE_CONCURRENT_EXEC=OFF` but different primitives can be
+    /// created and run concurrently (the same primitive cannot be run
+    /// concurrently from two different threads though).
+    library = dnnl_scratchpad_mode_library,
+    /// The user manages the scratchpad allocation by querying and providing
+    /// the scratchpad memory to primitives. This mode is thread-safe as long
+    /// as the scratchpad buffers are not used concurrently by two primitive
+    /// executions.
+    user = dnnl_scratchpad_mode_user,
+};
+
+/// Converts a scratchpad mode enum value from C++ API to C API type.
+///
+/// @param mode C++ API scratchpad mode enum value.
+/// @returns Corresponding C API scratchpad mode enum value.
+inline dnnl_scratchpad_mode_t convert_to_c(scratchpad_mode mode) {
+    return static_cast<dnnl_scratchpad_mode_t>(mode);
+}
+
+/// Propagation kind.
+enum class prop_kind {
+    /// Undefined propagation kind.
+    undef = dnnl_prop_kind_undef,
+    /// Forward data propagation (training mode). In this mode, primitives
+    /// perform computations necessary for subsequent backward propagation.
+    forward_training = dnnl_forward_training,
+    /// Forward data propagation (inference mode). In this mode, primitives
+    /// perform only computations that are necessary for inference and omit
+    /// computations that are necessary only for backward propagation.
+    forward_inference = dnnl_forward_inference,
+    /// Forward data propagation,
+    /// alias for #dnnl::prop_kind::forward_inference.
+    forward_scoring = dnnl_forward_scoring,
+    /// Forward data propagation,
+    /// alias for #dnnl::prop_kind::forward_training.
+    forward = dnnl_forward,
+    /// Backward propagation (with respect to all parameters).
+    backward = dnnl_backward,
+    /// Backward data propagation.
+    backward_data = dnnl_backward_data,
+    /// Backward weights propagation.
+    backward_weights = dnnl_backward_weights,
+    /// Backward bias propagation.
+    backward_bias = dnnl_backward_bias
+};
+
+/// Converts propagation kind enum value from C++ API to C API type.
+///
+/// @param akind C++ API propagation kind enum value.
+/// @returns Corresponding C API propagation kind enum value.
+inline dnnl_prop_kind_t convert_to_c(prop_kind akind) {
+    return static_cast<dnnl_prop_kind_t>(akind);
+}
+
+/// Kinds of algorithms.
+enum class algorithm {
+    /// Undefined algorithm
+    undef = dnnl_alg_kind_undef,
+    /// Convolution algorithm that is chosen to be either direct or Winograd
+    /// automatically
+    convolution_auto = dnnl_convolution_auto,
+    /// Direct convolution
+    convolution_direct = dnnl_convolution_direct,
+    /// Winograd convolution
+    convolution_winograd = dnnl_convolution_winograd,
+    /// Direct deconvolution
+    deconvolution_direct = dnnl_deconvolution_direct,
+    /// Winograd deconvolution
+    deconvolution_winograd = dnnl_deconvolution_winograd,
+    /// Elementwise: rectified linear unit (ReLU)
+    eltwise_relu = dnnl_eltwise_relu,
+    /// Elementwise: hyperbolic tangent non-linearity (tanh)
+    eltwise_tanh = dnnl_eltwise_tanh,
+    /// Elementwise: exponential linear unit (ELU)
+    eltwise_elu = dnnl_eltwise_elu,
+    /// Elementwise: square
+    eltwise_square = dnnl_eltwise_square,
+    /// Elementwise: abs
+    eltwise_abs = dnnl_eltwise_abs,
+    /// Elementwise: square root
+    eltwise_sqrt = dnnl_eltwise_sqrt,
+    /// Elementwise: swish (\f$x \cdot sigmoid(a \cdot x)\f$)
+    eltwise_swish = dnnl_eltwise_swish,
+    /// Elementwise: linear
+    eltwise_linear = dnnl_eltwise_linear,
+    /// Elementwise: bounded_relu
+    eltwise_bounded_relu = dnnl_eltwise_bounded_relu,
+    /// Elementwise: soft_relu
+    eltwise_soft_relu = dnnl_eltwise_soft_relu,
+    /// Elementwise: soft_relu version 2
+    eltwise_soft_relu_v2 = dnnl_eltwise_soft_relu_v2,
+    /// Elementwise: logsigmoid
+    eltwise_logsigmoid = dnnl_eltwise_logsigmoid,
+    /// Elementwise: mish
+    eltwise_mish = dnnl_eltwise_mish,
+    /// Elementwise: logistic
+    eltwise_logistic = dnnl_eltwise_logistic,
+    /// Elementwise: exponent
+    eltwise_exp = dnnl_eltwise_exp,
+    /// Elementwise: gelu
+    /// alias for #dnnl::algorithm::eltwise_gelu_tanh
+    eltwise_gelu = dnnl_eltwise_gelu,
+    /// Elementwise: tanh-based gelu
+    eltwise_gelu_tanh = dnnl_eltwise_gelu_tanh,
+    /// Elementwise: erf-based gelu
+    eltwise_gelu_erf = dnnl_eltwise_gelu_erf,
+    /// Elementwise: natural logarithm
+    eltwise_log = dnnl_eltwise_log,
+    /// Elementwise: clip
+    eltwise_clip = dnnl_eltwise_clip,
+    /// Eltwise: clip version 2
+    eltwise_clip_v2 = dnnl_eltwise_clip_v2,
+    /// Elementwise: pow
+    eltwise_pow = dnnl_eltwise_pow,
+    /// Elementwise: round
+    eltwise_round = dnnl_eltwise_round,
+    /// Elementwise: hardswish
+    eltwise_hardswish = dnnl_eltwise_hardswish,
+    /// Elementwise: hardsigmoid
+    eltwise_hardsigmoid = dnnl_eltwise_hardsigmoid,
+    /// Elementwise: rectified linar unit (ReLU) (dst for backward)
+    eltwise_relu_use_dst_for_bwd = dnnl_eltwise_relu_use_dst_for_bwd,
+    /// Elementwise: hyperbolic tangent non-linearity (tanh) (dst for backward)
+    eltwise_tanh_use_dst_for_bwd = dnnl_eltwise_tanh_use_dst_for_bwd,
+    /// Elementwise: exponential linear unit (ELU) (dst for backward)
+    eltwise_elu_use_dst_for_bwd = dnnl_eltwise_elu_use_dst_for_bwd,
+    /// Elementwise: square root (dst for backward)
+    eltwise_sqrt_use_dst_for_bwd = dnnl_eltwise_sqrt_use_dst_for_bwd,
+    /// Elementwise: logistic (dst for backward)
+    eltwise_logistic_use_dst_for_bwd = dnnl_eltwise_logistic_use_dst_for_bwd,
+    /// Elementwise: exponent (dst for backward)
+    eltwise_exp_use_dst_for_bwd = dnnl_eltwise_exp_use_dst_for_bwd,
+    /// Elementwise: clip version 2 (dst for backward)
+    eltwise_clip_v2_use_dst_for_bwd = dnnl_eltwise_clip_v2_use_dst_for_bwd,
+    /// Local response normalization (LRN) across multiple channels
+    lrn_across_channels = dnnl_lrn_across_channels,
+    /// LRN within a single channel
+    lrn_within_channel = dnnl_lrn_within_channel,
+    /// Max pooling
+    pooling_max = dnnl_pooling_max,
+    /// Average pooling exclude padding,
+    /// alias for #dnnl::algorithm::pooling_avg_exclude_padding
+    pooling_avg = dnnl_pooling_avg,
+    /// Average pooling include padding
+    pooling_avg_include_padding = dnnl_pooling_avg_include_padding,
+    /// Average pooling exclude padding
+    pooling_avg_exclude_padding = dnnl_pooling_avg_exclude_padding,
+    /// RNN cell
+    vanilla_rnn = dnnl_vanilla_rnn,
+    /// LSTM cell
+    vanilla_lstm = dnnl_vanilla_lstm,
+    /// GRU cell
+    vanilla_gru = dnnl_vanilla_gru,
+    /// GRU cell with linear before reset. Differs from the vanilla GRU
+    /// in how the new memory gate is calculated:
+    /// \f$c_t = tanh(W_c*x_t + b_{c_x} + r_t*(U_c*h_{t-1}+b_{c_h})) \f$
+    /// LRB GRU expects 4 bias tensors on input:
+    /// \f$[b_{u}, b_{r}, b_{c_x}, b_{c_h}]\f$
+    lbr_gru = dnnl_lbr_gru,
+    /// AUGRU cell
+    vanilla_augru = dnnl_vanilla_augru,
+    /// AUGRU cell with linear before reset
+    lbr_augru = dnnl_lbr_augru,
+    /// Binary add
+    binary_add = dnnl_binary_add,
+    /// Binary mul
+    binary_mul = dnnl_binary_mul,
+    /// Binary max
+    binary_max = dnnl_binary_max,
+    /// Binary min
+    binary_min = dnnl_binary_min,
+    /// Binary div
+    binary_div = dnnl_binary_div,
+    /// Binary sub
+    binary_sub = dnnl_binary_sub,
+    /// Binary greater than or equal
+    binary_ge = dnnl_binary_ge,
+    /// Binary greater than
+    binary_gt = dnnl_binary_gt,
+    /// Binary less than or equal
+    binary_le = dnnl_binary_le,
+    /// Binary less than
+    binary_lt = dnnl_binary_lt,
+    /// Binary equal
+    binary_eq = dnnl_binary_eq,
+    /// Binary not equal
+    binary_ne = dnnl_binary_ne,
+    /// Nearest Neighbor resampling method
+    resampling_nearest = dnnl_resampling_nearest,
+    /// Linear (Bilinear, Trilinear) resampling method
+    resampling_linear = dnnl_resampling_linear,
+    /// Reduction using max operation
+    reduction_max = dnnl_reduction_max,
+    /// Reduction using min operation
+    reduction_min = dnnl_reduction_min,
+    /// Reduction using sum operation
+    reduction_sum = dnnl_reduction_sum,
+    /// Reduction using mul operation
+    reduction_mul = dnnl_reduction_mul,
+    /// Reduction using mean operation
+    reduction_mean = dnnl_reduction_mean,
+    /// Reduction using norm_lp_max operation
+    reduction_norm_lp_max = dnnl_reduction_norm_lp_max,
+    /// Reduction using norm_lp_sum operation
+    reduction_norm_lp_sum = dnnl_reduction_norm_lp_sum,
+    /// Reduction using norm_lp_power_p_max operation
+    reduction_norm_lp_power_p_max = dnnl_reduction_norm_lp_power_p_max,
+    /// Reduction using norm_lp_power_p_sum operation
+    reduction_norm_lp_power_p_sum = dnnl_reduction_norm_lp_power_p_sum,
+    /// Softmax, numerically stable
+    softmax_accurate = dnnl_softmax_accurate,
+    /// LogSoftmax, numerically stable
+    softmax_log = dnnl_softmax_log,
+};
+
+/// Converts algorithm kind enum value from C++ API to C API type.
+/// @param aalgorithm C++ API algorithm kind enum value.
+/// @returns Corresponding C API algorithm kind enum value.
+inline dnnl_alg_kind_t convert_to_c(algorithm aalgorithm) {
+    return static_cast<dnnl_alg_kind_t>(aalgorithm);
+}
+
+/// @} dnnl_api_attributes
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// Flags for normalization primitives.
+enum class normalization_flags : unsigned {
+    /// Use no normalization flags. If specified, the library computes mean and
+    /// variance on forward propagation for training and inference, outputs them
+    /// on forward propagation for training, and computes the respective
+    /// derivatives on backward propagation.
+    none = dnnl_normalization_flags_none,
+
+    /// Use global statistics. If specified, the library uses mean and
+    /// variance provided by the user as an input on forward propagation and
+    /// does not compute their derivatives on backward propagation. Otherwise,
+    /// the library computes mean and variance on forward propagation for
+    /// training and inference, outputs them on forward propagation for
+    /// training, and computes the respective derivatives on backward
+    /// propagation.
+    use_global_stats = dnnl_use_global_stats,
+
+    /// Use scale and shift parameters. If specified, the user is expected to
+    /// pass scale and shift as inputs on forward propagation. On backward
+    /// propagation of type #dnnl::prop_kind::backward, the library computes
+    /// their derivatives. If not specified, the scale and shift parameters
+    /// are not used by the library in any way.
+    use_scale_shift = dnnl_use_scaleshift,
+
+    /// Fuse normalization with ReLU. On training, normalization will require
+    /// the workspace to implement backward propagation. On inference, the
+    /// workspace is not required and behavior is the same as when normalization
+    /// is fused with ReLU using the post-ops API.
+    fuse_norm_relu = dnnl_fuse_norm_relu,
+
+    /// Fuse normalization with elementwise binary Add and then fuse with ReLU.
+    /// On training, normalization will require the workspace to implement
+    /// backward propagation. On inference, the workspace is not required.
+    fuse_norm_add_relu = dnnl_fuse_norm_add_relu,
+
+    /// Use scale parameter. If specified, the user is expected to pass scale as
+    /// input on forward propagation. On backward propagation of type
+    /// #dnnl::prop_kind::backward, the library computes its derivative.
+    use_scale = dnnl_use_scale,
+
+    /// Use shift parameter. If specified, the user is expected to pass shift as
+    /// input on forward propagation. On backward propagation of type
+    /// #dnnl::prop_kind::backward, the library computes its derivative.
+    use_shift = dnnl_use_shift,
+};
+
+/// Converts normalization flags enum value from C++ API to C API type.
+/// @param flags C++ API normalization flags enum value.
+/// @returns Corresponding C API normalization flags enum value.
+inline dnnl_normalization_flags_t convert_to_c(normalization_flags flags) {
+    return static_cast<dnnl_normalization_flags_t>(flags);
+}
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_rnn
+/// @{
+
+/// RNN cell flags.
+enum class rnn_flags : unsigned {
+    /// Undefined RNN flags
+    undef = dnnl_rnn_flags_undef
+};
+
+/// Converts RNN cell flags enum value from C++ API to C API type.
+/// @param flags C++ API RNN cell flags enum value.
+/// @returns Corresponding C API RNN cell flags enum value.
+inline dnnl_rnn_flags_t convert_to_c(rnn_flags flags) {
+    return static_cast<dnnl_rnn_flags_t>(flags);
+}
+
+#define DNNL_DEFINE_BITMASK_OPS(enum_name) \
+    inline enum_name operator|(enum_name lhs, enum_name rhs) { \
+        return static_cast<enum_name>( \
+                static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs)); \
+    } \
+\
+    inline enum_name operator&(enum_name lhs, enum_name rhs) { \
+        return static_cast<enum_name>( \
+                static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs)); \
+    } \
+\
+    inline enum_name operator^(enum_name lhs, enum_name rhs) { \
+        return static_cast<enum_name>( \
+                static_cast<unsigned>(lhs) ^ static_cast<unsigned>(rhs)); \
+    } \
+\
+    inline enum_name &operator|=(enum_name &lhs, enum_name rhs) { \
+        lhs = static_cast<enum_name>( \
+                static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs)); \
+        return lhs; \
+    } \
+\
+    inline enum_name &operator&=(enum_name &lhs, enum_name rhs) { \
+        lhs = static_cast<enum_name>( \
+                static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs)); \
+        return lhs; \
+    } \
+\
+    inline enum_name &operator^=(enum_name &lhs, enum_name rhs) { \
+        lhs = static_cast<enum_name>( \
+                static_cast<unsigned>(lhs) ^ static_cast<unsigned>(rhs)); \
+        return lhs; \
+    } \
+\
+    inline enum_name operator~(enum_name rhs) { \
+        return static_cast<enum_name>(~static_cast<unsigned>(rhs)); \
+    }
+
+DNNL_DEFINE_BITMASK_OPS(normalization_flags)
+DNNL_DEFINE_BITMASK_OPS(rnn_flags)
+
+/// A direction of RNN primitive execution
+enum class rnn_direction {
+    /// Unidirectional execution of RNN primitive from left to right.
+    unidirectional_left2right = dnnl_unidirectional_left2right,
+    /// Unidirectional execution of RNN primitive from right to left.
+    unidirectional_right2left = dnnl_unidirectional_right2left,
+    /// Bidirectional execution of RNN primitive with concatenation of the
+    /// results.
+    bidirectional_concat = dnnl_bidirectional_concat,
+    /// Bidirectional execution of RNN primitive with summation of the
+    /// results.
+    bidirectional_sum = dnnl_bidirectional_sum,
+    /// Alias for #dnnl::rnn_direction::unidirectional_left2right
+    unidirectional = dnnl_unidirectional,
+};
+
+/// Converts RNN direction enum value from C++ API to C API type.
+/// @param dir C++ API RNN direction enum value.
+/// @returns Corresponding C API RNN direction enum value.
+inline dnnl_rnn_direction_t convert_to_c(rnn_direction dir) {
+    return static_cast<dnnl_rnn_direction_t>(dir);
+}
+
+/// @} dnnl_api_rnn
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// Primitive descriptor query specification.
+///
+/// In general, queries are not used with the C++ API because most queries are
+/// implemented as class members.
+///
+/// See @ref dnnl_query_t for more information.
+enum class query {
+    /// no query
+    undef = dnnl_query_undef,
+
+    /// execution engine
+    engine = dnnl_query_engine,
+    /// primitive kind
+    primitive_kind = dnnl_query_primitive_kind,
+
+    /// number of inputs expected
+    num_of_inputs_s32 = dnnl_query_num_of_inputs_s32,
+    /// number of outputs expected
+    num_of_outputs_s32 = dnnl_query_num_of_outputs_s32,
+
+    /// runtime estimation (seconds), unimplemented
+    time_estimate_f64 = dnnl_query_time_estimate_f64,
+    /// memory required for scratchpad (bytes)
+    ///
+    /// @sa @ref dev_guide_attributes_scratchpad
+    memory_consumption_s64 = dnnl_query_memory_consumption_s64,
+
+    /// scratchpad engine
+    ///
+    /// engine to be used for creating scratchpad memory
+    scratchpad_engine = dnnl_query_scratchpad_engine,
+
+    /// reorder source engine
+    reorder_src_engine = dnnl_query_reorder_src_engine,
+    /// reorder destination engine
+    reorder_dst_engine = dnnl_query_reorder_dst_engine,
+
+    /// implementation name
+    impl_info_str = dnnl_query_impl_info_str,
+
+    /// propagation kind
+    prop_kind = dnnl_query_prop_kind,
+
+    /// size of cache blob ID in bytes
+    cache_blob_id_size_s64 = dnnl_query_cache_blob_id_size_s64,
+
+    /// cache blob ID (pointer to array)
+    cache_blob_id = dnnl_query_cache_blob_id,
+
+    /// operation descriptor
+    op_d = dnnl_query_op_d,
+    /// convolution descriptor
+    convolution_d = dnnl_query_convolution_d,
+    /// deconvolution descriptor
+    deconvolution_d = dnnl_query_deconvolution_d,
+    /// shuffle descriptor
+    shuffle_d = dnnl_query_shuffle_d,
+    /// eltwise descriptor
+    eltwise_d = dnnl_query_eltwise_d,
+    /// softmax descriptor
+    softmax_d = dnnl_query_softmax_d,
+    /// pooling descriptor
+    pooling_d = dnnl_query_pooling_d,
+    /// lrn descriptor
+    lrn_d = dnnl_query_lrn_d,
+    /// batch normalization descriptor
+    batch_normalization_d = dnnl_query_batch_normalization_d,
+    /// layer normalization descriptor
+    layer_normalization_d = dnnl_query_layer_normalization_d,
+    /// inner product descriptor
+    inner_product_d = dnnl_query_inner_product_d,
+    /// rnn descriptor
+    rnn_d = dnnl_query_rnn_d,
+    /// binary descriptor
+    binary_d = dnnl_query_binary_d,
+    /// logsoftmax descriptor
+    logsoftmax_d = dnnl_query_logsoftmax_d,
+    /// matmul descriptor
+    matmul_d = dnnl_query_matmul_d,
+    /// resampling descriptor
+    resampling_d = dnnl_query_resampling_d,
+    /// reduction descriptor
+    reduction_d = dnnl_query_reduction_d,
+
+    /// source memory desc
+    src_md = dnnl_query_src_md,
+    /// source gradient (diff) memory desc
+    diff_src_md = dnnl_query_diff_src_md,
+    /// weights memory descriptor desc
+    weights_md = dnnl_query_weights_md,
+    /// weights gradient (diff) memory desc
+    diff_weights_md = dnnl_query_diff_weights_md,
+    /// destination memory desc
+    dst_md = dnnl_query_dst_md,
+    /// destination gradient (diff) memory desc
+    diff_dst_md = dnnl_query_diff_dst_md,
+    /// workspace memory desc
+    workspace_md = dnnl_query_workspace_md,
+    /// scratchpad memory desc
+    scratchpad_md = dnnl_query_scratchpad_md,
+    /// memory desc of an execute argument
+    exec_arg_md = dnnl_query_exec_arg_md,
+};
+
+/// Converts query enum value from C++ API to C API type.
+/// @param aquery C++ API query enum value.
+/// @returns Corresponding C API query enum value.
+inline dnnl_query_t convert_to_c(query aquery) {
+    return static_cast<dnnl_query_t>(aquery);
+}
+
+/// @} dnnl_api_primitives_common
+
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_engine Engine
+///
+/// An abstraction of a computational device: a CPU, a specific GPU
+/// card in the system, etc. Most primitives are created to execute
+/// computations on one specific engine. The only exceptions are reorder
+/// primitives that transfer data between two different engines.
+///
+/// @sa @ref dev_guide_basic_concepts
+///
+/// @{
+
+/// @cond DO_NOT_DOCUMENT_THIS
+template <>
+struct handle_traits<dnnl_engine_t> {
+    static dnnl_status_t destructor(dnnl_engine_t p) {
+        return dnnl_engine_destroy(p);
+    }
+};
+/// @endcond
+
+/// An execution engine.
+struct engine : public handle<dnnl_engine_t> {
+    friend struct primitive;
+    friend struct reorder;
+
+    /// Kinds of engines.
+    enum class kind {
+        /// An unspecified engine
+        any = dnnl_any_engine,
+        /// CPU engine
+        cpu = dnnl_cpu,
+        /// GPU engine
+        gpu = dnnl_gpu,
+    };
+
+    using handle::handle;
+
+    /// Constructs an empty engine. An empty engine cannot be used in any
+    /// operations.
+    engine() = default;
+
+    /// Returns the number of engines of a certain kind.
+    ///
+    /// @param akind The kind of engines to count.
+    /// @returns The number of engines of the specified kind.
+    static size_t get_count(kind akind) {
+        return dnnl_engine_get_count(convert_to_c(akind));
+    }
+
+    /// Constructs an engine.
+    ///
+    /// @param akind The kind of engine to construct.
+    /// @param index The index of the engine. Must be less than the value
+    ///     returned by #get_count() for this particular kind of engine.
+    engine(kind akind, size_t index) {
+        dnnl_engine_t engine;
+        error::wrap_c_api(
+                dnnl_engine_create(&engine, convert_to_c(akind), index),
+                "could not create an engine");
+        reset(engine);
+    }
+
+    /// Constructs an engine based on a primitive from the primitive
+    /// descriptor @p pd by querying its engine.
+    ///
+    /// @param pd The primitive descriptor to query.
+    engine(const handle<dnnl_primitive_desc_t> &pd) {
+        dnnl_engine_t c_engine;
+        error::wrap_c_api(
+                dnnl_primitive_desc_query(pd.get(),
+                        dnnl::convert_to_c(dnnl::query::engine), 0, &c_engine),
+                "could not get an engine from a primitive_desc");
+        reset(c_engine, true);
+    }
+
+    /// Returns the kind of the engine.
+    /// @returns The kind of the engine.
+    kind get_kind() const {
+        dnnl_engine_kind_t kind;
+        error::wrap_c_api(dnnl_engine_get_kind(get(), &kind),
+                "could not get kind of an engine");
+        return static_cast<engine::kind>(kind);
+    }
+
+    /// Returns the engine of a primitive descriptor.
+    ///
+    /// @param pd The primitive descriptor to query.
+    /// @returns A weak handle to the engine that the primitive descriptor was
+    ///     created with.
+    template <typename primitive_desc>
+    static engine query(const primitive_desc &pd) {
+        return query(pd, dnnl::query::engine);
+    }
+
+private:
+    static dnnl_engine_kind_t convert_to_c(kind akind) {
+        return static_cast<dnnl_engine_kind_t>(akind);
+    }
+
+    template <typename primitive_desc>
+    static engine query(const primitive_desc &pd, dnnl::query what) {
+        dnnl_engine_t c_engine;
+        error::wrap_c_api(dnnl_primitive_desc_query(pd.get(),
+                                  dnnl::convert_to_c(what), 0, &c_engine),
+                "could not get an engine from a primitive_desc");
+        return engine(c_engine, true);
+    }
+};
+
+/// Converts engine kind enum value from C++ API to C API type.
+///
+/// @param akind C++ API engine kind enum value.
+/// @returns Corresponding C API engine kind enum value.
+inline dnnl_engine_kind_t convert_to_c(engine::kind akind) {
+    return static_cast<dnnl_engine_kind_t>(akind);
+}
+
+/// @} dnnl_api_engine
+
+/// @addtogroup dnnl_api_stream Stream
+///
+/// An encapsulation of execution context tied to a particular engine.
+///
+/// @sa @ref dev_guide_basic_concepts
+///
+/// @{
+
+/// @cond DO_NOT_DOCUMENT_THIS
+template <>
+struct handle_traits<dnnl_stream_t> {
+    static dnnl_status_t destructor(dnnl_stream_t p) {
+        return dnnl_stream_destroy(p);
+    }
+};
+/// @endcond
+
+/// An execution stream.
+struct stream : public handle<dnnl_stream_t> {
+    using handle::handle;
+
+    /// Stream flags. Can be combined using the bitwise OR operator.
+    enum class flags : unsigned {
+        /// In-order execution.
+        in_order = dnnl_stream_in_order,
+        /// Out-of-order execution.
+        out_of_order = dnnl_stream_out_of_order,
+        /// Default stream configuration.
+        default_flags = dnnl_stream_default_flags,
+    };
+
+    /// Constructs an empty stream. An empty stream cannot be used in any
+    /// operations.
+    stream() = default;
+
+    /// Constructs a stream for the specified engine and with behavior
+    /// controlled by the specified flags.
+    ///
+    /// @param aengine Engine to create the stream on.
+    /// @param aflags Flags controlling stream behavior.
+    stream(const engine &aengine, flags aflags = flags::default_flags) {
+        dnnl_stream_t stream;
+        error::wrap_c_api(dnnl_stream_create(&stream, aengine.get(),
+                                  static_cast<dnnl_stream_flags_t>(aflags)),
+                "could not create a stream");
+        reset(stream);
+    }
+
+    /// Returns the associated engine.
+    engine get_engine() const {
+        dnnl_engine_t c_engine;
+        error::wrap_c_api(dnnl_stream_get_engine(get(), &c_engine),
+                "could not get an engine from a stream object");
+        return engine(c_engine, true);
+    }
+
+    /// Waits for all primitives executing in the stream to finish.
+    /// @returns The stream itself.
+    stream &wait() {
+        error::wrap_c_api(
+                dnnl_stream_wait(get()), "could not wait on a stream");
+        return *this;
+    }
+};
+
+DNNL_DEFINE_BITMASK_OPS(stream::flags)
+
+/// @} dnnl_api_stream
+
+/// @addtogroup dnnl_api_memory Memory
+///
+/// A container that describes and stores data. Memory objects can contain
+/// data of various types and formats. There are two levels of abstraction:
+///
+/// 1. **Memory descriptor** -- engine-agnostic logical description of data
+///     (number of dimensions, dimension sizes, and data type), and,
+///     optionally, the information about the physical format of data in
+///     memory. If this information is not known yet, a memory descriptor can
+///     be created with #dnnl::memory::format_tag::any. This allows
+///     compute-intensive primitives to choose the best format for
+///     computation. The user is responsible for reordering the data into the
+///     chosen format when formats do not match.
+///
+///     A memory descriptor can be initialized either by specifying dimensions
+///     and a memory format tag or strides for each of them, or by
+///     manipulating the dnnl_memory_desc_t structure directly.
+///
+///     @warning
+///         The latter approach requires understanding how the physical data
+///         representation is mapped to the structure and is discouraged. This
+///         topic is discussed in @ref dev_guide_understanding_memory_formats.
+///
+///     The user can query the amount of memory required by a memory
+///     descriptor using the #dnnl::memory::desc::get_size() function. The
+///     size of data in general cannot be computed as the product of
+///     dimensions multiplied by the size of the data type. So users are
+///     required to use this function for better code portability.
+///
+///     Two memory descriptors can be compared using the equality and
+///     inequality operators.  The comparison is especially useful when
+///     checking whether it is necessary to reorder data from the user's data
+///     format to a primitive's format.
+///
+/// 2. **Memory object** -- an engine-specific object that handles the memory
+///     buffer and its description (a memory descriptor). For the CPU engine or
+///     with USM, the memory buffer handle is simply a pointer to @c void. The
+///     memory buffer can be queried using #dnnl::memory::get_data_handle() and
+///     set using #dnnl::memory::set_data_handle(). The underlying SYCL buffer,
+///     when used, can be queried using #dnnl::sycl_interop::get_buffer and set
+///     using #dnnl::sycl_interop::set_buffer. A memory object can also be
+///     queried for the underlying memory descriptor and for its engine using
+///     #dnnl::memory::get_desc() and dnnl::memory::get_engine().
+///
+/// Along with ordinary memory descriptors with all dimensions being positive,
+/// the library supports *zero-volume*  memory descriptors with one or more
+/// dimensions set to zero. This is used to support the NumPy\* convention.
+/// If a zero-volume memory is passed to a primitive, the primitive typically
+/// does not perform any computations with this memory. For example:
+///
+/// - A concatenation primitive would ignore all memory object with zeroes in
+///   the concat dimension / axis.
+///
+/// - A forward convolution with a source memory object with zero in the
+///   minibatch dimension would always produce a destination memory object
+///   with a zero in the minibatch dimension and perform no computations.
+///
+/// - However, a forward convolution with a zero in one of the weights
+///   dimensions is ill-defined and is considered to be an error by the
+///   library because there is no clear definition of what the output values
+///   should be.
+///
+/// Memory buffer of a zero-volume memory is never accessed.
+///
+/// @{
+
+/// Memory object.
+///
+/// A memory object encapsulates a handle to a memory buffer allocated on a
+/// specific engine, tensor dimensions, data type, and memory format, which is
+/// the way tensor indices map to offsets in linear memory space. Memory
+/// objects are passed to primitives during execution.
+struct memory : public handle<dnnl_memory_t> {
+    using handle::handle;
+
+    /// Integer type for representing dimension sizes and indices.
+    typedef dnnl_dim_t dim;
+    /// Vector of dimensions. Implementations are free to force a limit on the
+    /// vector's length.
+    typedef std::vector<dim> dims;
+
+    /// Helper function that validates that an `std::vector` of dimensions can
+    /// be safely converted to the C API array ::dnnl_dims_t. Throws if
+    /// validation fails.
+    ///
+    /// @param v Vector of dimensions.
+    /// @param min_size Minimum expected size of the vector.
+    template <typename T>
+    static void validate_dims(const std::vector<T> &v, int min_size = 0) {
+        validate_container_size(
+                v, "dimensions are invalid", min_size, DNNL_MAX_NDIMS);
+    }
+
+    /// Data type specification.
+    enum class data_type {
+        /// Undefined data type (used for empty memory descriptors).
+        undef = dnnl_data_type_undef,
+        /// [16-bit/half-precision floating point](https://en.wikipedia.org/wiki/Half-precision_floating-point_format).
+        f16 = dnnl_f16,
+        /// non-standard
+        /// [16-bit floating point with 7-bit mantissa](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format).
+        bf16 = dnnl_bf16,
+        /// [32-bit/single-precision floating point](https://en.wikipedia.org/wiki/Single-precision_floating-point_format).
+        f32 = dnnl_f32,
+        //// [64-bit/double-precision floating point](https://en.wikipedia.org/wiki/Double-precision_floating-point_format).
+        f64 = dnnl_f64,
+        /// 32-bit signed integer.
+        s32 = dnnl_s32,
+        /// 8-bit signed integer.
+        s8 = dnnl_s8,
+        /// 8-bit unsigned integer.
+        u8 = dnnl_u8,
+    };
+
+    /// Returns size of data type in bytes.
+    /// @returns The number of bytes occupied by data type.
+    static size_t data_type_size(data_type adata_type) {
+        return dnnl_data_type_size(convert_to_c(adata_type));
+    }
+
+    /// Memory format kind
+    enum class format_kind {
+        /// Undefined memory format kind, used for empty memory descriptors.
+        undef = dnnl_format_kind_undef,
+        /// Unspecified format kind.
+        /// The primitive selects a format automatically.
+        any = dnnl_format_kind_any,
+        /// A tensor in a generic format described by the stride and blocking
+        /// values in each dimension. See @ref dnnl_blocking_desc_t for more
+        /// information.
+        blocked = dnnl_blocked,
+        /// Weights format used in 8-bit Winograd convolution.
+        wino = dnnl_format_kind_wino,
+        /// Packed weights format used in RNN.
+        packed = dnnl_format_kind_rnn_packed,
+    };
+
+    /// Memory format tag specification.
+    ///
+    /// Memory format tags can be further divided into two categories:
+    ///
+    ///  - Domain-agnostic names, i.e. names that do not depend on the tensor
+    ///    usage in the specific primitive. These names use letters from `a`
+    ///    to `f` to denote logical dimensions and form the order in which the
+    ///    dimensions are laid in memory. For example,
+    ///    #dnnl::memory::format_tag::ab is used to denote a 2D tensor where the
+    ///    second logical dimension (denoted as `b`) is the innermost, i.e.
+    ///    has stride = 1, and the first logical dimension (`a`) is laid out in
+    ///    memory with stride equal to the size of the second dimension. On the
+    ///    other hand, #dnnl::memory::format_tag::ba is the transposed version
+    ///    of the same tensor: the outermost dimension (`a`) becomes the
+    ///    innermost one.
+    ///
+    ///  - Domain-specific names, i.e. names that make sense only in the
+    ///    context of a certain domain, such as CNN. These names are
+    ///    aliases to the corresponding domain-agnostic tags and used mostly
+    ///    for convenience. For example, #dnnl::memory::format_tag::nc
+    ///    is used to denote 2D CNN activations tensor memory format, where
+    ///    the channels dimension is the innermost one and the batch dimension
+    ///    is the outermost one. Moreover, #dnnl::memory::format_tag::nc is
+    ///    an alias for #dnnl::memory::format_tag::ab, because for
+    ///    CNN primitives the logical dimensions of activations tensors come
+    ///    in order: batch, channels, spatial.  In other words, batch
+    ///    corresponds to the first logical dimension (`a`), and channels
+    ///    correspond to the second one (`b`).
+    ///
+    /// The following domain-specific notation applies to memory format tags:
+    ///  - @c 'n' denotes the mini-batch dimension
+    ///  - @c 'c' denotes a channels dimension
+    ///  - When there are multiple channel dimensions (for example,
+    ///    in convolution weights tensor), @c 'i' and @c 'o' denote dimensions
+    ///    of input and output channels
+    ///  - @c 'g' denotes a groups dimension for convolution weights
+    ///  - @c 'd', @c 'h', and @c 'w' denote spatial depth, height, and width
+    ///    respectively
+    ///
+    /// See @ref dnnl_format_tag_t for a detailed description.
+    enum class format_tag {
+        /// Undefined memory format tag
+        undef = dnnl_format_tag_undef,
+        /// Placeholder memory format tag. Used to instruct the primitive to
+        /// select a format automatically.
+        any = dnnl_format_tag_any,
+
+        /// plain 1D tensor
+        a = dnnl_a,
+
+        /// plain 2D tensor
+        ab = dnnl_ab,
+        /// permuted 2D tensor
+        ba = dnnl_ba,
+
+        /// plain 3D tensor
+        abc = dnnl_abc,
+        /// permuted 3D tensor
+        acb = dnnl_acb,
+        /// permuted 3D tensor
+        bac = dnnl_bac,
+        /// permuted 3D tensor
+        bca = dnnl_bca,
+        /// permuted 3D tensor
+        cba = dnnl_cba,
+
+        /// plain 4D tensor
+        abcd = dnnl_abcd,
+        /// permuted 4D tensor
+        abdc = dnnl_abdc,
+        /// permuted 4D tensor
+        acbd = dnnl_acbd,
+        /// permuted 4D tensor
+        acdb = dnnl_acdb,
+        /// permuted 4D tensor
+        adbc = dnnl_adbc,
+        /// permuted 4D tensor
+        bacd = dnnl_bacd,
+        /// permuted 4D tensor
+        bcda = dnnl_bcda,
+        /// permuted 4D tensor
+        cdba = dnnl_cdba,
+        /// permuted 4D tensor
+        dcab = dnnl_dcab,
+
+        /// plain 5D tensor
+        abcde = dnnl_abcde,
+        /// permuted 5D tensor
+        abdec = dnnl_abdec,
+        /// permuted 5D tensor
+        acbde = dnnl_acbde,
+        /// permuted 5D tensor
+        acdeb = dnnl_acdeb,
+        /// permuted 5D tensor
+        bacde = dnnl_bacde,
+        /// permuted 5D tensor
+        bcdea = dnnl_bcdea,
+        /// permuted 5D tensor
+        cdeba = dnnl_cdeba,
+        /// permuted 5D tensor
+        decab = dnnl_decab,
+        /// permuted 5D tensor
+        abced = dnnl_abced,
+
+        /// plain 6D tensor
+        abcdef = dnnl_abcdef,
+        /// permuted 6D tensor
+        abdfce = dnnl_abdfce,
+        /// permuted 6D tensor
+        acbdef = dnnl_acbdef,
+        /// permuted 6D tensor
+        abdefc = dnnl_abdefc,
+        /// permuted 6D tensor
+        defcab = dnnl_defcab,
+        /// permuted 6D tensor
+        abcdfe = dnnl_abcdfe,
+
+        /// plain 7D tensor
+        abcdefg = dnnl_abcdefg,
+        /// permuted 7D tensor
+        abcdegf = dnnl_abcdegf,
+
+        /// plain 8D tensor
+        abcdefgh = dnnl_abcdefgh,
+        /// permuted 8D tensor
+        abcdefhg = dnnl_abcdefhg,
+
+        /// plain 9D tensor
+        abcdefghi = dnnl_abcdefghi,
+        /// permuted 9D tensor
+        abcdefgih = dnnl_abcdefgih,
+
+        /// plain 10D tensor
+        abcdefghij = dnnl_abcdefghij,
+        /// permuted 10D tensor
+        abcdefghji = dnnl_abcdefghji,
+
+        /// plain 11D tensor
+        abcdefghijk = dnnl_abcdefghijk,
+        /// permuted 11D tensor
+        abcdefghikj = dnnl_abcdefghikj,
+
+        /// plain 12D tensor
+        abcdefghijkl = dnnl_abcdefghijkl,
+        /// permuted 12D tensor
+        abcdefghijlk = dnnl_abcdefghijlk,
+
+        /// 1D tensor; an alias for #dnnl::memory::format_tag::a
+        x = a,
+        /// 2D CNN activations tensor; an alias for #dnnl::memory::format_tag::ab
+        nc = ab,
+        /// 2D CNN activations tensor; an alias for #dnnl::memory::format_tag::ba
+        cn = ba,
+        /// 2D RNN statistics tensor; an alias for #dnnl::memory::format_tag::ab
+        tn = ab,
+        /// 2D RNN statistics tensor; an alias for #dnnl::memory::format_tag::ba
+        nt = ba,
+        /// 3D CNN activations tensor; an alias for #dnnl::memory::format_tag::abc
+        ncw = abc,
+        /// 3D CNN activations tensor; an alias for #dnnl::memory::format_tag::acb
+        nwc = acb,
+        /// 4D CNN activations tensor; an alias for #dnnl::memory::format_tag::abcd
+        nchw = abcd,
+        /// 4D CNN activations tensor; an alias for #dnnl::memory::format_tag::acdb
+        nhwc = acdb,
+        /// 4D CNN activations tensor; an alias for #dnnl::memory::format_tag::bcda
+        chwn = bcda,
+        /// 5D CNN activations tensor; an alias for #dnnl::memory::format_tag::abcde
+        ncdhw = abcde,
+        /// 5D CNN activations tensor; an alias for #dnnl::memory::format_tag::acdeb
+        ndhwc = acdeb,
+
+        /// 2D CNN weights tensor; an alias for #dnnl::memory::format_tag::ab
+        oi = ab,
+        /// 2D CNN weights tensor; an alias for #dnnl::memory::format_tag::ba
+        io = ba,
+        /// 3D CNN weights tensor; an alias for #dnnl::memory::format_tag::abc
+        oiw = abc,
+        /// 3D CNN weights tensor; an alias for #dnnl::memory::format_tag::acb
+        owi = acb,
+        /// 3D CNN weights tensor; an alias for #dnnl::memory::format_tag::cba
+        wio = cba,
+        /// 3D CNN weights tensor; an alias for #dnnl::memory::format_tag::bca
+        iwo = bca,
+        /// 4D CNN weights tensor; an alias for #dnnl::memory::format_tag::abcd
+        oihw = abcd,
+        /// 4D CNN weights tensor; an alias for #dnnl::memory::format_tag::cdba
+        hwio = cdba,
+        /// 4D CNN weights tensor; an alias for #dnnl::memory::format_tag::acdb
+        ohwi = acdb,
+        /// 4D CNN weights tensor; an alias for #dnnl::memory::format_tag::bcda
+        ihwo = bcda,
+        /// 4D CNN weights tensor; an alias for #dnnl::memory::format_tag::bacd
+        iohw = bacd,
+        /// 5D CNN weights tensor; an alias for #dnnl::memory::format_tag::abcde
+        oidhw = abcde,
+        /// 5D CNN weights tensor; an alias for #dnnl::memory::format_tag::cdeba
+        dhwio = cdeba,
+        /// 5D CNN weights tensor; an alias for #dnnl::memory::format_tag::acdeb
+        odhwi = acdeb,
+        /// 5D CNN weights tensor; an alias for #dnnl::memory::format_tag::bacde
+        iodhw = bacde,
+        /// 5D CNN weights tensor; an alias for #dnnl::memory::format_tag::bcdea
+        idhwo = bcdea,
+
+        /// 4D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abcd
+        goiw = abcd,
+        /// 4D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abdc
+        gowi = abdc,
+        /// 4D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::dcab
+        wigo = dcab,
+        /// 5D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abdec
+        gohwi = abdec,
+        /// 5D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abcde
+        goihw = abcde,
+        /// 5D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::decab
+        hwigo = decab,
+        /// 5D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::acbde
+        giohw = acbde,
+        /// 6D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abcdef
+        goidhw = abcdef,
+        /// 6D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abcdef
+        giodhw = acbdef,
+        /// 6D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::abdefc
+        godhwi = abdefc,
+        /// 6D CNN weights tensor with groups; an alias for #dnnl::memory::format_tag::defcab
+        dhwigo = defcab,
+
+        /// 3D RNN data tensor in the format (seq_length, batch, input
+        /// channels); an alias for #dnnl::memory::format_tag::abc.
+        tnc = abc,
+        /// 3D RNN data tensor in the format (batch, seq_length, input
+        /// channels); an alias for #dnnl::memory::format_tag::bac.
+        ntc = bac,
+        /// 4D RNN states tensor in the format (num_layers, num_directions,
+        /// batch, state channels); an alias for #dnnl::memory::format_tag::abcd.
+        ldnc = abcd,
+        /// 5D RNN weights tensor in the format (num_layers, num_directions,
+        /// input_channels, num_gates, output_channels);
+        /// an alias for #dnnl::memory::format_tag::abcde.
+        ///
+        ///  - For LSTM cells, the gates order is input, forget, candidate
+        ///    and output gate.
+        ///  - For GRU cells, the gates order is update, reset and output gate.
+        ldigo = abcde,
+        /// 5D RNN weights tensor in the format (num_layers, num_directions,
+        /// num_gates, output_channels, input_channels);
+        /// an alias for #dnnl::memory::format_tag::abdec.
+        ///
+        ///  - For LSTM cells, the gates order is input, forget, candidate
+        ///    and output gate.
+        ///  - For GRU cells, the gates order is update, reset and output gate.
+        ldgoi = abdec,
+        /// 4D LSTM projection tensor in the format (num_layers, num_directions,
+        /// num_channels_in_hidden_state, num_channels_in_recurrent_projection);
+        /// an alias for #dnnl::memory::format_tag::abcd.
+        ldio = abcd,
+        /// 4D LSTM projection tensor in the format (num_layers, num_directions,
+        /// num_channels_in_recurrent_projection, num_channels_in_hidden_state);
+        /// an alias for #dnnl::memory::format_tag::abdc.
+        ldoi = abdc,
+        /// 4D RNN bias tensor in the format (num_layers, num_directions,
+        /// num_gates, output_channels);
+        /// an alias for #dnnl::memory::format_tag::abcd.
+        ///
+        ///  - For LSTM cells, the gates order is input, forget, candidate
+        ///    and output gate.
+        ///  - For GRU cells, the gates order is update, reset and output gate.
+        ldgo = abcd,
+
+        // Opaque blocked formats
+
+        AB16b16a = dnnl_AB16b16a,
+        AB16b32a = dnnl_AB16b32a,
+        AB16b64a = dnnl_AB16b64a,
+        AB8b16a2b = dnnl_AB8b16a2b,
+        AB8b32a2b = dnnl_AB8b32a2b,
+        AB8b64a2b = dnnl_AB8b64a2b,
+        AB4b16a4b = dnnl_AB4b16a4b,
+        AB4b32a4b = dnnl_AB4b32a4b,
+        AB4b64a4b = dnnl_AB4b64a4b,
+        AB16b16a4b = dnnl_AB16b16a4b,
+        AB16b32a4b = dnnl_AB16b32a4b,
+        AB16b48a4b = dnnl_AB16b48a4b,
+        AB16b64a4b = dnnl_AB16b64a4b,
+        AB16b16a2b = dnnl_AB16b16a2b,
+        AB16b32a2b = dnnl_AB16b32a2b,
+        AB16b48a2b = dnnl_AB16b48a2b,
+        AB16b64a2b = dnnl_AB16b64a2b,
+        Abc16a = dnnl_Abc16a,
+        ABc16a16b = dnnl_ABc16a16b,
+        ABc4a4b = dnnl_ABc4a4b,
+        aBc16b = dnnl_aBc16b,
+        aBc32b = dnnl_aBc32b,
+        ABc16b16a = dnnl_ABc16b16a,
+        ABc16b32a = dnnl_ABc16b32a,
+        ABc16b64a = dnnl_ABc16b64a,
+        Abc4a = dnnl_Abc4a,
+        aBc4b = dnnl_aBc4b,
+        ABc4b16a4b = dnnl_ABc4b16a4b,
+        ABc4b32a4b = dnnl_ABc4b32a4b,
+        ABc4b64a4b = dnnl_ABc4b64a4b,
+        ABc2b8a4b = dnnl_ABc2b8a4b,
+        ABc16a16b2a = dnnl_ABc16a16b2a,
+        ABc16b16a4b = dnnl_ABc16b16a4b,
+        ABc16b32a4b = dnnl_ABc16b32a4b,
+        ABc16b48a4b = dnnl_ABc16b48a4b,
+        ABc16b64a4b = dnnl_ABc16b64a4b,
+        ABc16b16a2b = dnnl_ABc16b16a2b,
+        ABc16b32a2b = dnnl_ABc16b32a2b,
+        ABc16b48a2b = dnnl_ABc16b48a2b,
+        ABc16b64a2b = dnnl_ABc16b64a2b,
+        ABc4b4a = dnnl_ABc4b4a,
+        ABc8a16b2a = dnnl_ABc8a16b2a,
+        ABc8a8b = dnnl_ABc8a8b,
+        ABc8a4b = dnnl_ABc8a4b,
+        aBc8b = dnnl_aBc8b,
+        ABc8b16a2b = dnnl_ABc8b16a2b,
+        ABc8b32a2b = dnnl_ABc8b32a2b,
+        ABc8b64a2b = dnnl_ABc8b64a2b,
+        ABc8b8a = dnnl_ABc8b8a,
+        Abcd8a = dnnl_Abcd8a,
+        Abcd16a = dnnl_Abcd16a,
+        Abcd32a = dnnl_Abcd32a,
+        ABcd16a16b = dnnl_ABcd16a16b,
+        aBcd16b = dnnl_aBcd16b,
+        aBcd32b = dnnl_aBcd32b,
+        ABcd16b16a = dnnl_ABcd16b16a,
+        ABcd16b32a = dnnl_ABcd16b32a,
+        ABcd16b64a = dnnl_ABcd16b64a,
+        aBCd16b16c = dnnl_aBCd16b16c,
+        aBCd16c16b = dnnl_aBCd16c16b,
+        Abcd4a = dnnl_Abcd4a,
+        aBcd4b = dnnl_aBcd4b,
+        ABcd4b16a4b = dnnl_ABcd4b16a4b,
+        ABcd4b32a4b = dnnl_ABcd4b32a4b,
+        ABcd4b64a4b = dnnl_ABcd4b64a4b,
+        ABcd2b8a4b = dnnl_ABcd2b8a4b,
+        ABcd4b4a = dnnl_ABcd4b4a,
+        ABcd4a4b = dnnl_ABcd4a4b,
+        aBCd4c16b4c = dnnl_aBCd4c16b4c,
+        aBCd2c8b4c = dnnl_aBCd2c8b4c,
+        ABcd16a16b2a = dnnl_ABcd16a16b2a,
+        ABcd16b16a4b = dnnl_ABcd16b16a4b,
+        ABcd16b32a4b = dnnl_ABcd16b32a4b,
+        ABcd16b48a4b = dnnl_ABcd16b48a4b,
+        ABcd16b64a4b = dnnl_ABcd16b64a4b,
+        ABcd16b16a2b = dnnl_ABcd16b16a2b,
+        ABcd16b32a2b = dnnl_ABcd16b32a2b,
+        ABcd16b48a2b = dnnl_ABcd16b48a2b,
+        ABcd16b64a2b = dnnl_ABcd16b64a2b,
+        aBCd16b16c2b = dnnl_aBCd16b16c2b,
+        aBCd16c16b4c = dnnl_aBCd16c16b4c,
+        aBCd16c16b2c = dnnl_aBCd16c16b2c,
+        aBCd4c4b = dnnl_aBCd4c4b,
+        aBCd4b4c = dnnl_aBCd4b4c,
+        ABcd8a16b2a = dnnl_ABcd8a16b2a,
+        ABcd8a8b = dnnl_ABcd8a8b,
+        ABcd8a4b = dnnl_ABcd8a4b,
+        ABcd8a2b = dnnl_ABcd8a2b,
+        /// 4D tensor blocked by 2nd dimension with block size 8
+        aBcd8b = dnnl_aBcd8b,
+        ABcd8b16a2b = dnnl_ABcd8b16a2b,
+        ABcd8b32a2b = dnnl_ABcd8b32a2b,
+        ABcd8b64a2b = dnnl_ABcd8b64a2b,
+        aBCd8b16c2b = dnnl_aBCd8b16c2b,
+        /// 4D tensor blocked by 1st and 2nd dimension with block size 8
+        ABcd8b8a = dnnl_ABcd8b8a,
+        aBCd8b8c = dnnl_aBCd8b8c,
+        aBCd8b4c = dnnl_aBCd8b4c,
+        aBCd8c16b2c = dnnl_aBCd8c16b2c,
+        aBCd8c8b = dnnl_aBCd8c8b,
+        Abcde16a = dnnl_Abcde16a,
+        Abcde32a = dnnl_Abcde32a,
+        ABcde16a16b = dnnl_ABcde16a16b,
+        aBcde16b = dnnl_aBcde16b,
+        aBcde32b = dnnl_aBcde32b,
+        ABcde16b16a = dnnl_ABcde16b16a,
+        ABcde16b32a = dnnl_ABcde16b32a,
+        ABcde16b64a = dnnl_ABcde16b64a,
+        aBCde16b16c = dnnl_aBCde16b16c,
+        aBCde16c16b = dnnl_aBCde16c16b,
+        aBCde2c8b4c = dnnl_aBCde2c8b4c,
+        Abcde4a = dnnl_Abcde4a,
+        aBcde4b = dnnl_aBcde4b,
+        ABcde4b4a = dnnl_ABcde4b4a,
+        ABcde4a4b = dnnl_ABcde4a4b,
+        aBCde4b4c = dnnl_aBCde4b4c,
+        aBCde4c16b4c = dnnl_aBCde4c16b4c,
+        aBCde16b16c2b = dnnl_aBCde16b16c2b,
+        aBCde16c16b4c = dnnl_aBCde16c16b4c,
+        aBCde16c16b2c = dnnl_aBCde16c16b2c,
+        aBCdef16c16b2c = dnnl_aBCdef16c16b2c,
+        aBCde4c4b = dnnl_aBCde4c4b,
+        Abcde8a = dnnl_Abcde8a,
+        ABcde8a8b = dnnl_ABcde8a8b,
+        ABcde8a4b = dnnl_ABcde8a4b,
+        aBcde8b = dnnl_aBcde8b,
+        ABcde8b16a2b = dnnl_ABcde8b16a2b,
+        ABcde8b32a2b = dnnl_ABcde8b32a2b,
+        ABcde8b64a2b = dnnl_ABcde8b64a2b,
+        ABcde4b16a4b = dnnl_ABcde4b16a4b,
+        ABcde4b32a4b = dnnl_ABcde4b32a4b,
+        ABcde4b64a4b = dnnl_ABcde4b64a4b,
+        ABcde16b16a4b = dnnl_ABcde16b16a4b,
+        ABcde16b32a4b = dnnl_ABcde16b32a4b,
+        ABcde16b48a4b = dnnl_ABcde16b48a4b,
+        ABcde16b64a4b = dnnl_ABcde16b64a4b,
+        ABcde16b16a2b = dnnl_ABcde16b16a2b,
+        ABcde16b32a2b = dnnl_ABcde16b32a2b,
+        ABcde16b48a2b = dnnl_ABcde16b48a2b,
+        ABcde16b64a2b = dnnl_ABcde16b64a2b,
+        ABcde2b8a4b = dnnl_ABcde2b8a4b,
+        aBCde8b16c2b = dnnl_aBCde8b16c2b,
+        ABcde8b8a = dnnl_ABcde8b8a,
+        aBCde8b8c = dnnl_aBCde8b8c,
+        aBCde8b4c = dnnl_aBCde8b4c,
+        ABcd4a8b8a4b = dnnl_ABcd4a8b8a4b,
+        ABcd2a8b8a2b = dnnl_ABcd2a8b8a2b,
+        aBCde4b8c8b4c = dnnl_aBCde4b8c8b4c,
+        aBCde2b8c8b2c = dnnl_aBCde2b8c8b2c,
+        aBCde8c16b2c = dnnl_aBCde8c16b2c,
+        aBCde8c8b = dnnl_aBCde8c8b,
+        aBcdef16b = dnnl_aBcdef16b,
+        aBCdef16b16c = dnnl_aBCdef16b16c,
+        aBCdef16c16b = dnnl_aBCdef16c16b,
+        aBcdef4b = dnnl_aBcdef4b,
+        aBCdef2c8b4c = dnnl_aBCdef2c8b4c,
+        aBCdef4c4b = dnnl_aBCdef4c4b,
+        aBCdef4b4c = dnnl_aBCdef4b4c,
+        aBCdef8b8c = dnnl_aBCdef8b8c,
+        aBCdef8b4c = dnnl_aBCdef8b4c,
+        aBCdef8c16b2c = dnnl_aBCdef8c16b2c,
+        aBCdef4c16b4c = dnnl_aBCdef4c16b4c,
+        aBCdef8c8b = dnnl_aBCdef8c8b,
+        aBdc16b = dnnl_aBdc16b,
+        aBdc4b = dnnl_aBdc4b,
+        aBdc8b = dnnl_aBdc8b,
+        aBdec16b = dnnl_aBdec16b,
+        aBdec4b = dnnl_aBdec4b,
+        aBdec8b = dnnl_aBdec8b,
+        aBdefc16b = dnnl_aBdefc16b,
+        aCBdef16c16b = dnnl_aCBdef16c16b,
+        aCBdef16b16c = dnnl_aCBdef16b16c,
+        aBdefc4b = dnnl_aBdefc4b,
+        aBdefc8b = dnnl_aBdefc8b,
+        Acb16a = dnnl_Acb16a,
+        Acb4a = dnnl_Acb4a,
+        Acb8a = dnnl_Acb8a,
+        aCBd16b16c = dnnl_aCBd16b16c,
+        aCBd16c16b = dnnl_aCBd16c16b,
+        aCBde16b16c = dnnl_aCBde16b16c,
+        aCBde16c16b = dnnl_aCBde16c16b,
+        Acdb16a = dnnl_Acdb16a,
+        Acdb4a = dnnl_Acdb4a,
+        Acdb8a = dnnl_Acdb8a,
+        Acdeb16a = dnnl_Acdeb16a,
+        Acdeb4a = dnnl_Acdeb4a,
+        Acdeb8a = dnnl_Acdeb8a,
+        BAc16a16b = dnnl_BAc16a16b,
+        BAc16b16a = dnnl_BAc16b16a,
+        BAcd16a16b = dnnl_BAcd16a16b,
+        BAcd16b16a = dnnl_BAcd16b16a,
+        ABcd32a32b = dnnl_ABcd32a32b,
+        BAcde16b16a = dnnl_BAcde16b16a,
+        BAcde16a16b = dnnl_BAcde16a16b,
+        aBdec32b = dnnl_aBdec32b,
+        Abcdef16a = dnnl_Abcdef16a,
+        Abcdef32a = dnnl_Abcdef32a,
+        Acdb32a = dnnl_Acdb32a,
+        aBCd2b4c2b = dnnl_aBCd2b4c2b,
+        aBCde2b4c2b = dnnl_aBCde2b4c2b,
+        aBCdef2b4c2b = dnnl_aBCdef2b4c2b,
+        aBCd2c4b2c = dnnl_aBCd2c4b2c,
+        aBCde2c4b2c = dnnl_aBCde2c4b2c,
+        aBCdef2c4b2c = dnnl_aBCdef2c4b2c,
+        aBCd4b8c2b = dnnl_aBCd4b8c2b,
+        aBCde4b8c2b = dnnl_aBCde4b8c2b,
+        aBCdef4b8c2b = dnnl_aBCdef4b8c2b,
+        aBCd4c8b2c = dnnl_aBCd4c8b2c,
+        aBCde4c8b2c = dnnl_aBCde4c8b2c,
+        aBCdef4c8b2c = dnnl_aBCdef4c8b2c,
+        AB32a32b8a4b = dnnl_AB32a32b8a4b,
+        AB32a32b8a2b = dnnl_AB32a32b8a2b,
+        AB8a4b = dnnl_AB8a4b,
+        AB8a2b = dnnl_AB8a2b,
+        abDc32d = dnnl_abDc32d,
+        abDC32d4c = dnnl_abDC32d4c,
+        abCd32c = dnnl_abCd32c,
+        abdEc32e = dnnl_abdEc32e,
+        abdEC32e2c = dnnl_abdEC32e2c,
+        abdEC32e4c = dnnl_abdEC32e4c,
+        abdCe32c = dnnl_abdCe32c,
+        abdCE32c2e = dnnl_abdCE32c2e,
+        aBCdef16c16b4c = dnnl_aBCdef16c16b4c,
+        aBdC16b4c = dnnl_aBdC16b4c,
+        aBdeC16b4c = dnnl_aBdeC16b4c,
+        AcB16a4b = dnnl_AcB16a4b,
+        AcdB16a2b = dnnl_AcdB16a2b,
+        aBdefC16b4c = dnnl_aBdefC16b4c,
+        AcdeB16a4b = dnnl_AcdeB16a4b,
+
+        Acb32a = dnnl_Acb32a,
+        AcB32a2b = dnnl_AcB32a2b,
+        AcB32a4b = dnnl_AcB32a4b,
+        Acb48a = dnnl_Acb48a,
+        AcB48a2b = dnnl_AcB48a2b,
+        AcB48a4b = dnnl_AcB48a4b,
+        Acb64a = dnnl_Acb64a,
+        AcB64a2b = dnnl_AcB64a2b,
+        AcB64a4b = dnnl_AcB64a4b,
+        cBa2b = dnnl_cBa2b,
+        cBa4b = dnnl_cBa4b,
+        aBdc32b = dnnl_aBdc32b,
+        aBdC32b2c = dnnl_aBdC32b2c,
+        aBdC32b4c = dnnl_aBdC32b4c,
+        aBdc48b = dnnl_aBdc48b,
+        aBdC48b2c = dnnl_aBdC48b2c,
+        aBdC48b4c = dnnl_aBdC48b4c,
+        aBdc64b = dnnl_aBdc64b,
+        aBdC64b2c = dnnl_aBdC64b2c,
+        aBdC64b4c = dnnl_aBdC64b4c,
+        adcb = dnnl_adcb,
+        adCb2c = dnnl_adCb2c,
+        adCb4c = dnnl_adCb4c,
+        AcdB32a2b = dnnl_AcdB32a2b,
+        AcdB32a4b = dnnl_AcdB32a4b,
+        Acdb48a = dnnl_Acdb48a,
+        AcdB48a2b = dnnl_AcdB48a2b,
+        AcdB48a4b = dnnl_AcdB48a4b,
+        Acdb64a = dnnl_Acdb64a,
+        AcdB64a2b = dnnl_AcdB64a2b,
+        AcdB64a4b = dnnl_AcdB64a4b,
+        cdBa2b = dnnl_cdBa2b,
+        cdBa4b = dnnl_cdBa4b,
+        aBdeC32b2c = dnnl_aBdeC32b2c,
+        aBdeC32b4c = dnnl_aBdeC32b4c,
+        aBdec48b = dnnl_aBdec48b,
+        aBdeC48b2c = dnnl_aBdeC48b2c,
+        aBdeC48b4c = dnnl_aBdeC48b4c,
+        aBdec64b = dnnl_aBdec64b,
+        aBdeC64b2c = dnnl_aBdeC64b2c,
+        aBdeC64b4c = dnnl_aBdeC64b4c,
+        adecb = dnnl_adecb,
+        adeCb2c = dnnl_adeCb2c,
+        adeCb4c = dnnl_adeCb4c,
+        Acdeb32a = dnnl_Acdeb32a,
+        AcdeB32a2b = dnnl_AcdeB32a2b,
+        AcdeB32a4b = dnnl_AcdeB32a4b,
+        Acdeb48a = dnnl_Acdeb48a,
+        AcdeB48a2b = dnnl_AcdeB48a2b,
+        AcdeB48a4b = dnnl_AcdeB48a4b,
+        Acdeb64a = dnnl_Acdeb64a,
+        AcdeB64a2b = dnnl_AcdeB64a2b,
+        AcdeB64a4b = dnnl_AcdeB64a4b,
+        cdeBa2b = dnnl_cdeBa2b,
+        cdeBa4b = dnnl_cdeBa4b,
+        aBdefc32b = dnnl_aBdefc32b,
+        aBdefC32b2c = dnnl_aBdefC32b2c,
+        aBdefC32b4c = dnnl_aBdefC32b4c,
+        aBdefc48b = dnnl_aBdefc48b,
+        aBdefC48b2c = dnnl_aBdefC48b2c,
+        aBdefC48b4c = dnnl_aBdefC48b4c,
+        aBdefc64b = dnnl_aBdefc64b,
+        aBdefC64b2c = dnnl_aBdefC64b2c,
+        aBdefC64b4c = dnnl_aBdefC64b4c,
+        adefcb = dnnl_adefcb,
+        adefCb2c = dnnl_adefCb2c,
+        adefCb4c = dnnl_adefCb4c,
+        ABc32a32b = dnnl_ABc32a32b,
+        BAc8a16b2a = dnnl_BAc8a16b2a,
+        BAcd8a16b2a = dnnl_BAcd8a16b2a,
+        ABcde8a16b2a = dnnl_ABcde8a16b2a,
+        aCBd8b16c2b = dnnl_aCBd8b16c2b,
+        BAcde8a16b2a = dnnl_BAcde8a16b2a,
+        aCBde8b16c2b = dnnl_aCBde8b16c2b,
+        ABcde32a32b = dnnl_ABcde32a32b,
+        ABc4a8b8a4b = dnnl_ABc4a8b8a4b,
+        ABcde4a8b8a4b = dnnl_ABcde4a8b8a4b,
+        BAc4b8a8b4a = dnnl_BAc4b8a8b4a,
+        BAcd4b8a8b4a = dnnl_BAcd4b8a8b4a,
+        BAcde4b8a8b4a = dnnl_BAcde4b8a8b4a,
+        aBCd4b8c8b4c = dnnl_aBCd4b8c8b4c,
+        aBCdef4b8c8b4c = dnnl_aBCdef4b8c8b4c,
+        aBCdef8b16c2b = dnnl_aBCdef8b16c2b,
+        aCBdef8b16c2b = dnnl_aCBdef8b16c2b,
+        aBdC16b2c = dnnl_aBdC16b2c,
+        aBdeC16b2c = dnnl_aBdeC16b2c,
+        aBdefC16b2c = dnnl_aBdefC16b2c,
+        aBedc16b = dnnl_aBedc16b,
+        AcB16a2b = dnnl_AcB16a2b,
+        AcdB16a4b = dnnl_AcdB16a4b,
+        AcdeB16a2b = dnnl_AcdeB16a2b,
+        Adcb16a = dnnl_Adcb16a,
+        aCBd4c8b8c4b = dnnl_aCBd4c8b8c4b,
+        aCBde4c8b8c4b = dnnl_aCBde4c8b8c4b,
+        aCBdef4c8b8c4b = dnnl_aCBdef4c8b8c4b,
+        ABc32a16b = dnnl_ABc32a16b,
+        ABcd32a16b = dnnl_ABcd32a16b,
+        ABcde32a16b = dnnl_ABcde32a16b,
+        AB48a16b = dnnl_AB48a16b,
+        AB48a32b = dnnl_AB48a32b,
+        ABc40a16b = dnnl_ABc40a16b,
+        ABc40a32b = dnnl_ABc40a32b,
+        aBC48b16c = dnnl_aBC48b16c,
+        aBC48b32c = dnnl_aBC48b32c,
+        ABcd40a16b = dnnl_ABcd40a16b,
+        ABcd40a32b = dnnl_ABcd40a32b,
+        BA16a16b = dnnl_BA16a16b,
+        BA16a32b = dnnl_BA16a32b,
+        BA16a48b = dnnl_BA16a48b,
+        BA16a64b = dnnl_BA16a64b,
+        BA16a16b2a = dnnl_BA16a16b2a,
+        BA16a32b2a = dnnl_BA16a32b2a,
+        BA16a48b2a = dnnl_BA16a48b2a,
+        BA16a64b2a = dnnl_BA16a64b2a,
+        BA16a16b4a = dnnl_BA16a16b4a,
+        BA16a32b4a = dnnl_BA16a32b4a,
+        BA16a48b4a = dnnl_BA16a48b4a,
+        BA16a64b4a = dnnl_BA16a64b4a,
+        decbA16a = dnnl_decbA16a,
+
+        format_tag_last = dnnl_format_tag_last,
+
+        nCdhw16c = dnnl_nCdhw16c,
+        nCdhw4c = dnnl_nCdhw4c,
+        nCdhw8c = dnnl_nCdhw8c,
+        nChw16c = dnnl_nChw16c,
+        nChw4c = dnnl_nChw4c,
+        nChw8c = dnnl_nChw8c,
+        nCw16c = dnnl_nCw16c,
+        nCw4c = dnnl_nCw4c,
+        nCw8c = dnnl_nCw8c,
+        NCw16n16c = dnnl_NCw16n16c,
+        NChw16n16c = dnnl_NChw16n16c,
+        NCdhw16n16c = dnnl_NCdhw16n16c,
+        NCdhw32n32c = dnnl_NCdhw32n32c,
+        NChw32n32c = dnnl_NChw32n32c,
+        IOhw16i16o = dnnl_IOhw16i16o,
+        OI16i16o = dnnl_OI16i16o,
+        OI16i32o = dnnl_OI16i32o,
+        OI16i64o = dnnl_OI16i64o,
+        OI8i16o2i = dnnl_OI8i16o2i,
+        OI8i32o2i = dnnl_OI8i32o2i,
+        OI8i64o2i = dnnl_OI8i64o2i,
+        OI4i16o4i = dnnl_OI4i16o4i,
+        OI4i32o4i = dnnl_OI4i32o4i,
+        OI4i64o4i = dnnl_OI4i64o4i,
+        Ohwi32o = dnnl_Ohwi32o,
+        IOdhw16i16o = dnnl_IOdhw16i16o,
+        gIOhw16i16o = dnnl_gIOhw16i16o,
+        gOhwi32o = dnnl_gOhwi32o,
+        Goidhw16g = dnnl_Goidhw16g,
+        IOw16o16i = dnnl_IOw16o16i,
+        OIw16i16o = dnnl_OIw16i16o,
+        OIw16i32o = dnnl_OIw16i32o,
+        OIw16i64o = dnnl_OIw16i64o,
+        IOw16i16o = dnnl_IOw16i16o,
+        gIOw16i16o = dnnl_gIOw16i16o,
+        OIw16o16i = dnnl_OIw16o16i,
+        Oiw16o = dnnl_Oiw16o,
+        OIw4i16o4i = dnnl_OIw4i16o4i,
+        OIw4i32o4i = dnnl_OIw4i32o4i,
+        OIw4i64o4i = dnnl_OIw4i64o4i,
+        OIw2i8o4i = dnnl_OIw2i8o4i,
+        OIw4i4o = dnnl_OIw4i4o,
+        OIw4o4i = dnnl_OIw4o4i,
+        Oiw4o = dnnl_Oiw4o,
+        OIw8i16o2i = dnnl_OIw8i16o2i,
+        OIw8i32o2i = dnnl_OIw8i32o2i,
+        OIw8i64o2i = dnnl_OIw8i64o2i,
+        OIw8i8o = dnnl_OIw8i8o,
+        OIw8o16i2o = dnnl_OIw8o16i2o,
+        OIw8o8i = dnnl_OIw8o8i,
+        OIw8o4i = dnnl_OIw8o4i,
+        OIw16i16o4i = dnnl_OIw16i16o4i,
+        OIw16i32o4i = dnnl_OIw16i32o4i,
+        OIw16i48o4i = dnnl_OIw16i48o4i,
+        OIw16i64o4i = dnnl_OIw16i64o4i,
+        OIw16i16o2i = dnnl_OIw16i16o2i,
+        OIw16i32o2i = dnnl_OIw16i32o2i,
+        OIw16i48o2i = dnnl_OIw16i48o2i,
+        OIw16i64o2i = dnnl_OIw16i64o2i,
+        OIw16o16i2o = dnnl_OIw16o16i2o,
+        Owi16o = dnnl_Owi16o,
+        OwI16o2i = dnnl_OwI16o2i,
+        Owi4o = dnnl_Owi4o,
+        Owi8o = dnnl_Owi8o,
+        IOhw16o16i = dnnl_IOhw16o16i,
+        Ohwi16o = dnnl_Ohwi16o,
+        OhwI16o2i = dnnl_OhwI16o2i,
+        Ohwi4o = dnnl_Ohwi4o,
+        Ohwi8o = dnnl_Ohwi8o,
+        OIhw16i16o = dnnl_OIhw16i16o,
+        OIhw16i32o = dnnl_OIhw16i32o,
+        OIhw16i64o = dnnl_OIhw16i64o,
+        OIhw16o16i = dnnl_OIhw16o16i,
+        Oihw16o = dnnl_Oihw16o,
+        OIhw4i16o4i = dnnl_OIhw4i16o4i,
+        OIhw4i32o4i = dnnl_OIhw4i32o4i,
+        OIhw4i64o4i = dnnl_OIhw4i64o4i,
+        OIhw4i4o = dnnl_OIhw4i4o,
+        OIhw4o4i = dnnl_OIhw4o4i,
+        Oihw4o = dnnl_Oihw4o,
+        OIhw8i16o2i = dnnl_OIhw8i16o2i,
+        OIhw8i32o2i = dnnl_OIhw8i32o2i,
+        OIhw8i64o2i = dnnl_OIhw8i64o2i,
+        OIhw8i8o = dnnl_OIhw8i8o,
+        OIhw8o16i2o = dnnl_OIhw8o16i2o,
+        OIhw8o8i = dnnl_OIhw8o8i,
+        OIhw8o4i = dnnl_OIhw8o4i,
+        OIhw2i8o4i = dnnl_OIhw2i8o4i,
+        IOdhw16o16i = dnnl_IOdhw16o16i,
+        Odhwi16o = dnnl_Odhwi16o,
+        OdhwI16o2i = dnnl_OdhwI16o2i,
+        Odhwi4o = dnnl_Odhwi4o,
+        Odhwi8o = dnnl_Odhwi8o,
+        OIdhw16i16o = dnnl_OIdhw16i16o,
+        OIdhw16i32o = dnnl_OIdhw16i32o,
+        OIdhw16i64o = dnnl_OIdhw16i64o,
+        OIdhw16o16i = dnnl_OIdhw16o16i,
+        OIdhw16o16i2o = dnnl_OIdhw16o16i2o,
+        Oidhw16o = dnnl_Oidhw16o,
+        OIdhw4i4o = dnnl_OIdhw4i4o,
+        OIdhw4o4i = dnnl_OIdhw4o4i,
+        Oidhw4o = dnnl_Oidhw4o,
+        OIdhw8i16o2i = dnnl_OIdhw8i16o2i,
+        OIdhw8i32o2i = dnnl_OIdhw8i32o2i,
+        OIdhw8i64o2i = dnnl_OIdhw8i64o2i,
+        OIdhw4i16o4i = dnnl_OIdhw4i16o4i,
+        OIdhw16i16o4i = dnnl_OIdhw16i16o4i,
+        OIdhw16i32o4i = dnnl_OIdhw16i32o4i,
+        OIdhw16i48o4i = dnnl_OIdhw16i48o4i,
+        OIdhw16i64o4i = dnnl_OIdhw16i64o4i,
+        OIdhw16i16o2i = dnnl_OIdhw16i16o2i,
+        OIdhw16i32o2i = dnnl_OIdhw16i32o2i,
+        OIdhw16i48o2i = dnnl_OIdhw16i48o2i,
+        OIdhw16i64o2i = dnnl_OIdhw16i64o2i,
+        OIdhw4i32o4i = dnnl_OIdhw4i32o4i,
+        OIdhw4i64o4i = dnnl_OIdhw4i64o4i,
+        OIdhw2i8o4i = dnnl_OIdhw2i8o4i,
+        OIdhw8i8o = dnnl_OIdhw8i8o,
+        OIdhw8o8i = dnnl_OIdhw8o8i,
+        OIdhw8o4i = dnnl_OIdhw8o4i,
+        gIOw16o16i = dnnl_gIOw16o16i,
+        gOIw16i16o = dnnl_gOIw16i16o,
+        gOIw16o16i = dnnl_gOIw16o16i,
+        gOiw16o = dnnl_gOiw16o,
+        gOIw4i16o4i = dnnl_gOIw4i16o4i,
+        gOIw2i8o4i = dnnl_gOIw2i8o4i,
+        gOIw4i4o = dnnl_gOIw4i4o,
+        gOIw4o4i = dnnl_gOIw4o4i,
+        gOiw4o = dnnl_gOiw4o,
+        gOIw8i16o2i = dnnl_gOIw8i16o2i,
+        gOIw8i8o = dnnl_gOIw8i8o,
+        gOIw8o16i2o = dnnl_gOIw8o16i2o,
+        gOIw8o8i = dnnl_gOIw8o8i,
+        gOIw8o4i = dnnl_gOIw8o4i,
+        gOIw16i16o4i = dnnl_gOIw16i16o4i,
+        gOIw16i16o2i = dnnl_gOIw16i16o2i,
+        gOIw16o16i2o = dnnl_gOIw16o16i2o,
+        gOwi16o = dnnl_gOwi16o,
+        gOwI16o2i = dnnl_gOwI16o2i,
+        gOwi4o = dnnl_gOwi4o,
+        gOwi8o = dnnl_gOwi8o,
+        Goiw8g = dnnl_Goiw8g,
+        Goiw16g = dnnl_Goiw16g,
+        gIOhw16o16i = dnnl_gIOhw16o16i,
+        gOhwi16o = dnnl_gOhwi16o,
+        gOhwI16o2i = dnnl_gOhwI16o2i,
+        gOhwi4o = dnnl_gOhwi4o,
+        gOhwi8o = dnnl_gOhwi8o,
+        Goihw16g = dnnl_Goihw16g,
+        gOIhw16i16o = dnnl_gOIhw16i16o,
+        gOIhw16o16i = dnnl_gOIhw16o16i,
+        gOihw16o = dnnl_gOihw16o,
+        gOIhw4i16o4i = dnnl_gOIhw4i16o4i,
+        gOIhw2i8o4i = dnnl_gOIhw2i8o4i,
+        gOIhw4i4o = dnnl_gOIhw4i4o,
+        gOIhw4o4i = dnnl_gOIhw4o4i,
+        gOihw4o = dnnl_gOihw4o,
+        Goihw8g = dnnl_Goihw8g,
+        gOIhw8i16o2i = dnnl_gOIhw8i16o2i,
+        gOIhw8i8o = dnnl_gOIhw8i8o,
+        gOIhw8o16i2o = dnnl_gOIhw8o16i2o,
+        OIw4o8i8o4i = dnnl_OIw4o8i8o4i,
+        OIdhw4o8i8o4i = dnnl_OIdhw4o8i8o4i,
+        OIhw4o8i8o4i = dnnl_OIhw4o8i8o4i,
+        OIhw2o8i8o2i = dnnl_OIhw2o8i8o2i,
+        gOIw4o8i8o4i = dnnl_gOIw4o8i8o4i,
+        gOIdhw4o8i8o4i = dnnl_gOIdhw4o8i8o4i,
+        gOIhw4o8i8o4i = dnnl_gOIhw4o8i8o4i,
+        gOIhw2o8i8o2i = dnnl_gOIhw2o8i8o2i,
+        OIhw16i16o4i = dnnl_OIhw16i16o4i,
+        OIhw16i32o4i = dnnl_OIhw16i32o4i,
+        OIhw16i48o4i = dnnl_OIhw16i48o4i,
+        OIhw16i64o4i = dnnl_OIhw16i64o4i,
+        OIhw16i16o2i = dnnl_OIhw16i16o2i,
+        OIhw16i32o2i = dnnl_OIhw16i32o2i,
+        OIhw16i48o2i = dnnl_OIhw16i48o2i,
+        OIhw16i64o2i = dnnl_OIhw16i64o2i,
+        OIhw16o16i2o = dnnl_OIhw16o16i2o,
+        gOIhw16i16o4i = dnnl_gOIhw16i16o4i,
+        gOIhw16i16o2i = dnnl_gOIhw16i16o2i,
+        gOIhw16o16i2o = dnnl_gOIhw16o16i2o,
+        gOIhw8o8i = dnnl_gOIhw8o8i,
+        gOIhw8o4i = dnnl_gOIhw8o4i,
+        gIOdhw16i16o = dnnl_gIOdhw16i16o,
+        gIOdhw16o16i = dnnl_gIOdhw16o16i,
+        gOdhwi16o = dnnl_gOdhwi16o,
+        gOdhwI16o2i = dnnl_gOdhwI16o2i,
+        gOdhwi4o = dnnl_gOdhwi4o,
+        gOdhwi8o = dnnl_gOdhwi8o,
+        gOIdhw16i16o = dnnl_gOIdhw16i16o,
+        gOIdhw16o16i = dnnl_gOIdhw16o16i,
+        gOIdhw16o16i2o = dnnl_gOIdhw16o16i2o,
+        gOidhw16o = dnnl_gOidhw16o,
+        gOIdhw4i4o = dnnl_gOIdhw4i4o,
+        gOIdhw4o4i = dnnl_gOIdhw4o4i,
+        gOidhw4o = dnnl_gOidhw4o,
+        gOIdhw8i16o2i = dnnl_gOIdhw8i16o2i,
+        gOIdhw4i16o4i = dnnl_gOIdhw4i16o4i,
+        gOIdhw16i16o4i = dnnl_gOIdhw16i16o4i,
+        gOIdhw16i16o2i = dnnl_gOIdhw16i16o2i,
+        gOIdhw2i8o4i = dnnl_gOIdhw2i8o4i,
+        gOIdhw8i8o = dnnl_gOIdhw8i8o,
+        gOIdhw8o8i = dnnl_gOIdhw8o8i,
+        gOIdhw8o4i = dnnl_gOIdhw8o4i,
+        gOIw2i4o2i = dnnl_gOIw2i4o2i,
+        gOIhw2i4o2i = dnnl_gOIhw2i4o2i,
+        gOIdhw2i4o2i = dnnl_gOIdhw2i4o2i,
+        gOIw2o4i2o = dnnl_gOIw2o4i2o,
+        gOIhw2o4i2o = dnnl_gOIhw2o4i2o,
+        gOIdhw2o4i2o = dnnl_gOIdhw2o4i2o,
+        gOIw4i8o2i = dnnl_gOIw4i8o2i,
+        gOIhw4i8o2i = dnnl_gOIhw4i8o2i,
+        gOIdhw4i8o2i = dnnl_gOIdhw4i8o2i,
+        gOIw4o8i2o = dnnl_gOIw4o8i2o,
+        gOIhw4o8i2o = dnnl_gOIhw4o8i2o,
+        gOIdhw4o8i2o = dnnl_gOIdhw4o8i2o,
+        ldOi32o = abDc32d,
+        ldOI32o4i = abDC32d4c,
+        ldgOi32o = abdEc32e,
+        ldgOI32o2i = abdEC32e2c,
+        ldgOI32o4i = abdEC32e4c,
+        OwI16o4i = dnnl_OwI16o4i,
+        OhwI16o4i = dnnl_OhwI16o4i,
+        gOwI16o4i = dnnl_gOwI16o4i,
+        gOhwI16o4i = dnnl_gOhwI16o4i,
+        OdhwI16o4i = dnnl_OdhwI16o4i,
+        gOdhwI16o4i = dnnl_gOdhwI16o4i,
+
+        Owi32o = dnnl_Owi32o,
+        OwI32o2i = dnnl_OwI32o2i,
+        OwI32o4i = dnnl_OwI32o4i,
+        Owi48o = dnnl_Owi48o,
+        OwI48o2i = dnnl_OwI48o2i,
+        OwI48o4i = dnnl_OwI48o4i,
+        Owi64o = dnnl_Owi64o,
+        OwI64o2i = dnnl_OwI64o2i,
+        OwI64o4i = dnnl_OwI64o4i,
+        wIo2i = dnnl_wIo2i,
+        wIo4i = dnnl_wIo4i,
+        gOwi32o = dnnl_gOwi32o,
+        gOwI32o2i = dnnl_gOwI32o2i,
+        gOwI32o4i = dnnl_gOwI32o4i,
+        gOwi48o = dnnl_gOwi48o,
+        gOwI48o2i = dnnl_gOwI48o2i,
+        gOwI48o4i = dnnl_gOwI48o4i,
+        gOwi64o = dnnl_gOwi64o,
+        gOwI64o2i = dnnl_gOwI64o2i,
+        gOwI64o4i = dnnl_gOwI64o4i,
+        gwio = dnnl_gwio,
+        gwIo2i = dnnl_gwIo2i,
+        gwIo4i = dnnl_gwIo4i,
+        OhwI32o = dnnl_OhwI32o,
+        OhwI32o2i = dnnl_OhwI32o2i,
+        OhwI32o4i = dnnl_OhwI32o4i,
+        Ohwi48o = dnnl_Ohwi48o,
+        OhwI48o2i = dnnl_OhwI48o2i,
+        OhwI48o4i = dnnl_OhwI48o4i,
+        Ohwi64o = dnnl_Ohwi64o,
+        OhwI64o2i = dnnl_OhwI64o2i,
+        OhwI64o4i = dnnl_OhwI64o4i,
+        hwIo2i = dnnl_hwIo2i,
+        hwIo4i = dnnl_hwIo4i,
+        gOhwI32o = dnnl_gOhwI32o,
+        gOhwI32o2i = dnnl_gOhwI32o2i,
+        gOhwI32o4i = dnnl_gOhwI32o4i,
+        gOhwi48o = dnnl_gOhwi48o,
+        gOhwI48o2i = dnnl_gOhwI48o2i,
+        gOhwI48o4i = dnnl_gOhwI48o4i,
+        gOhwi64o = dnnl_gOhwi64o,
+        gOhwI64o2i = dnnl_gOhwI64o2i,
+        gOhwI64o4i = dnnl_gOhwI64o4i,
+        ghwio = dnnl_ghwio,
+        ghwIo2i = dnnl_ghwIo2i,
+        ghwIo4i = dnnl_ghwIo4i,
+        Odhwi32o = dnnl_Odhwi32o,
+        OdhwI32o2i = dnnl_OdhwI32o2i,
+        OdhwI32o4i = dnnl_OdhwI32o4i,
+        Odhwi48o = dnnl_Odhwi48o,
+        OdhwI48o2i = dnnl_OdhwI48o2i,
+        OdhwI48o4i = dnnl_OdhwI48o4i,
+        Odhwi64o = dnnl_Odhwi64o,
+        OdhwI64o2i = dnnl_OdhwI64o2i,
+        OdhwI64o4i = dnnl_OdhwI64o4i,
+        dhwIo2i = dnnl_dhwIo2i,
+        dhwIo4i = dnnl_dhwIo4i,
+        gOdhwi32o = dnnl_gOdhwi32o,
+        gOdhwI32o2i = dnnl_gOdhwI32o2i,
+        gOdhwI32o4i = dnnl_gOdhwI32o4i,
+        gOdhwi48o = dnnl_gOdhwi48o,
+        gOdhwI48o2i = dnnl_gOdhwI48o2i,
+        gOdhwI48o4i = dnnl_gOdhwI48o4i,
+        gOdhwi64o = dnnl_gOdhwi64o,
+        gOdhwI64o2i = dnnl_gOdhwI64o2i,
+        gOdhwI64o4i = dnnl_gOdhwI64o4i,
+        gdhwio = dnnl_gdhwio,
+        gdhwIo2i = dnnl_gdhwIo2i,
+        gdhwIo4i = dnnl_gdhwIo4i,
+        ldIo32i = dnnl_ldIo32i,
+        ldgIo32i = dnnl_ldgIo32i,
+        ldgIO32i2o = dnnl_ldgIO32i2o,
+        nCdhw32c = dnnl_nCdhw32c,
+        nChw32c = dnnl_nChw32c,
+        nCw32c = dnnl_nCw32c,
+        NCw32n16c = dnnl_NCw32n16c,
+        NChw32n16c = dnnl_NChw32n16c,
+        NCdhw32n16c = dnnl_NCdhw32n16c,
+        NCw32n32c = dnnl_NCw32n32c,
+        OI16i16o4i = dnnl_OI16i16o4i,
+        IOw8o16i2o = dnnl_IOw8o16i2o,
+        IOhw8o16i2o = dnnl_IOhw8o16i2o,
+        Owhi16o = dnnl_Owhi16o,
+        OIdhw8o16i2o = dnnl_OIdhw8o16i2o,
+        IOdhw8o16i2o = dnnl_IOdhw8o16i2o,
+        Goiw4g = dnnl_Goiw4g,
+        gIOw8o16i2o = dnnl_gIOw8o16i2o,
+        Goiw32g = dnnl_Goiw32g,
+        Goihw4g = dnnl_Goihw4g,
+        gIOhw8o16i2o = dnnl_gIOhw8o16i2o,
+        Goihw32g = dnnl_Goihw32g,
+        gOwhi16o = dnnl_gOwhi16o,
+        IOw4i8o8i4o = dnnl_IOw4i8o8i4o,
+        IOhw4i8o8i4o = dnnl_IOhw4i8o8i4o,
+        IOdhw4i8o8i4o = dnnl_IOdhw4i8o8i4o,
+        gIOw4i8o8i4o = dnnl_gIOw4i8o8i4o,
+        gIOhw4i8o8i4o = dnnl_gIOhw4i8o8i4o,
+        gIOdhw4i8o8i4o = dnnl_gIOdhw4i8o8i4o,
+        gOIdhw8o16i2o = dnnl_gOIdhw8o16i2o,
+        gIOdhw8o16i2o = dnnl_gIOdhw8o16i2o,
+        Goidhw32g = dnnl_Goidhw32g,
+        OI16i32o4i = dnnl_OI16i32o4i,
+        OI16i48o4i = dnnl_OI16i48o4i,
+        OI16i64o4i = dnnl_OI16i64o4i,
+        OI16i16o2i = dnnl_OI16i16o2i,
+        OI16i32o2i = dnnl_OI16i32o2i,
+        OI16i48o2i = dnnl_OI16i48o2i,
+        OI16i64o2i = dnnl_OI16i64o2i,
+        aBdeC16c16b4c = dnnl_aBdeC16c16b4c,
+        AcB16b16a2b = dnnl_AcB16b16a2b,
+        aBdC16c16b2c = dnnl_aBdC16c16b2c,
+        AcB16b16a4b = dnnl_AcB16b16a4b,
+        aBdC16c16b4c = dnnl_aBdC16c16b4c,
+        AcdB16b16a2b = dnnl_AcdB16b16a2b,
+        aBdefC16c16b4c = dnnl_aBdefC16c16b4c,
+        AcdeB16b16a4b = dnnl_AcdeB16b16a4b,
+        AcB16b32a2b = dnnl_AcB16b32a2b,
+        AcB16b32a4b = dnnl_AcB16b32a4b,
+        AcB16b48a2b = dnnl_AcB16b48a2b,
+        AcB16b48a4b = dnnl_AcB16b48a4b,
+        AcB16b64a2b = dnnl_AcB16b64a2b,
+        AcB16b64a4b = dnnl_AcB16b64a4b,
+        aBdC16c32b2c = dnnl_aBdC16c32b2c,
+        aBdC16c32b4c = dnnl_aBdC16c32b4c,
+        aBdC16c48b2c = dnnl_aBdC16c48b2c,
+        aBdC16c48b4c = dnnl_aBdC16c48b4c,
+        aBdC16c64b2c = dnnl_aBdC16c64b2c,
+        aBdC16c64b4c = dnnl_aBdC16c64b4c,
+        AcdB16b32a2b = dnnl_AcdB16b32a2b,
+        AcdB16b32a4b = dnnl_AcdB16b32a4b,
+        AcdB16b48a2b = dnnl_AcdB16b48a2b,
+        AcdB16b48a4b = dnnl_AcdB16b48a4b,
+        AcdB16b64a2b = dnnl_AcdB16b64a2b,
+        AcdB16b64a4b = dnnl_AcdB16b64a4b,
+        aBdeC16c32b2c = dnnl_aBdeC16c32b2c,
+        aBdeC16c32b4c = dnnl_aBdeC16c32b4c,
+        aBdeC16c48b2c = dnnl_aBdeC16c48b2c,
+        aBdeC16c48b4c = dnnl_aBdeC16c48b4c,
+        aBdeC16c64b2c = dnnl_aBdeC16c64b2c,
+        aBdeC16c64b4c = dnnl_aBdeC16c64b4c,
+        AcdeB16b32a2b = dnnl_AcdeB16b32a2b,
+        AcdeB16b32a4b = dnnl_AcdeB16b32a4b,
+        AcdeB16b48a2b = dnnl_AcdeB16b48a2b,
+        AcdeB16b48a4b = dnnl_AcdeB16b48a4b,
+        AcdeB16b64a2b = dnnl_AcdeB16b64a2b,
+        AcdeB16b64a4b = dnnl_AcdeB16b64a4b,
+        aBdefC16c32b2c = dnnl_aBdefC16c32b2c,
+        aBdefC16c32b4c = dnnl_aBdefC16c32b4c,
+        aBdefC16c48b2c = dnnl_aBdefC16c48b2c,
+        aBdefC16c48b4c = dnnl_aBdefC16c48b4c,
+        aBdefC16c64b2c = dnnl_aBdefC16c64b2c,
+        aBdefC16c64b4c = dnnl_aBdefC16c64b4c,
+        OwI16i16o2i = dnnl_OwI16i16o2i,
+        gOwI16i16o2i = dnnl_gOwI16i16o2i,
+        OhwI16i16o2i = dnnl_OhwI16i16o2i,
+        gOhwI16i16o2i = dnnl_gOhwI16i16o2i,
+        OdhwI16i16o2i = dnnl_OdhwI16i16o2i,
+        gOdhwI16i16o2i = dnnl_gOdhwI16i16o2i,
+        OwI16i16o4i = dnnl_OwI16i16o4i,
+        gOwI16i16o4i = dnnl_gOwI16i16o4i,
+        OhwI16i16o4i = dnnl_OhwI16i16o4i,
+        gOhwI16i16o4i = dnnl_gOhwI16i16o4i,
+        OdhwI16i16o4i = dnnl_OdhwI16i16o4i,
+        gOdhwI16i16o4i = dnnl_gOdhwI16i16o4i,
+        OwI16i32o2i = dnnl_OwI16i32o2i,
+        OwI16i32o4i = dnnl_OwI16i32o4i,
+        OwI16i48o2i = dnnl_OwI16i48o2i,
+        OwI16i48o4i = dnnl_OwI16i48o4i,
+        OwI16i64o2i = dnnl_OwI16i64o2i,
+        OwI16i64o4i = dnnl_OwI16i64o4i,
+        gOwI16i32o2i = dnnl_gOwI16i32o2i,
+        gOwI16i32o4i = dnnl_gOwI16i32o4i,
+        gOwI16i48o2i = dnnl_gOwI16i48o2i,
+        gOwI16i48o4i = dnnl_gOwI16i48o4i,
+        gOwI16i64o2i = dnnl_gOwI16i64o2i,
+        gOwI16i64o4i = dnnl_gOwI16i64o4i,
+        OhwI16i32o2i = dnnl_OhwI16i32o2i,
+        OhwI16i32o4i = dnnl_OhwI16i32o4i,
+        OhwI16i48o2i = dnnl_OhwI16i48o2i,
+        OhwI16i48o4i = dnnl_OhwI16i48o4i,
+        OhwI16i64o2i = dnnl_OhwI16i64o2i,
+        OhwI16i64o4i = dnnl_OhwI16i64o4i,
+        gOhwI16i32o2i = dnnl_gOhwI16i32o2i,
+        gOhwI16i32o4i = dnnl_gOhwI16i32o4i,
+        gOhwI16i48o2i = dnnl_gOhwI16i48o2i,
+        gOhwI16i48o4i = dnnl_gOhwI16i48o4i,
+        gOhwI16i64o2i = dnnl_gOhwI16i64o2i,
+        gOhwI16i64o4i = dnnl_gOhwI16i64o4i,
+        OdhwI16i32o2i = dnnl_OdhwI16i32o2i,
+        OdhwI16i32o4i = dnnl_OdhwI16i32o4i,
+        OdhwI16i48o2i = dnnl_OdhwI16i48o2i,
+        OdhwI16i48o4i = dnnl_OdhwI16i48o4i,
+        OdhwI16i64o2i = dnnl_OdhwI16i64o2i,
+        OdhwI16i64o4i = dnnl_OdhwI16i64o4i,
+        gOdhwI16i32o2i = dnnl_gOdhwI16i32o2i,
+        gOdhwI16i32o4i = dnnl_gOdhwI16i32o4i,
+        gOdhwI16i48o2i = dnnl_gOdhwI16i48o2i,
+        gOdhwI16i48o4i = dnnl_gOdhwI16i48o4i,
+        gOdhwI16i64o2i = dnnl_gOdhwI16i64o2i,
+        gOdhwI16i64o4i = dnnl_gOdhwI16i64o4i,
+        aBdeC16c16b2c = dnnl_aBdeC16c16b2c,
+        aBdefC16c16b2c = dnnl_aBdefC16c16b2c,
+        AcdB16b16a4b = dnnl_AcdB16b16a4b,
+        AcdeB16b16a2b = dnnl_AcdeB16b16a2b,
+        hwioG16g = dnnl_hwioG16g,
+        ABc4a2b = dnnl_ABc4a2b,
+        ABc8a2b = dnnl_ABc8a2b,
+        ABcd4a2b = dnnl_ABcd4a2b,
+        ABcde4a2b = dnnl_ABcde4a2b,
+        ABcde8a2b = dnnl_ABcde8a2b,
+        ABcd4a8b8a2b = dnnl_ABcd4a8b8a2b,
+        NCdhw40n32c = dnnl_NCdhw40n32c,
+        NChw40n32c = dnnl_NChw40n32c,
+        NCw40n32c = dnnl_NCw40n32c,
+        OIdhw4o8i8o2i = dnnl_OIdhw4o8i8o2i,
+        OIhw4o8i8o2i = dnnl_OIhw4o8i8o2i,
+        OIw4o8i8o2i = dnnl_OIw4o8i8o2i,
+        gOIdhw4o8i8o2i = dnnl_gOIdhw4o8i8o2i,
+        gOIhw4o8i8o2i = dnnl_gOIhw4o8i8o2i,
+        gOIw4o8i8o2i = dnnl_gOIw4o8i8o2i,
+        IOdhw4i8o8i2o = dnnl_IOdhw4i8o8i2o,
+        IOhw4i8o8i2o = dnnl_IOhw4i8o8i2o,
+        IOw4i8o8i2o = dnnl_IOw4i8o8i2o,
+        gIOdhw4i8o8i2o = dnnl_gIOdhw4i8o8i2o,
+        gIOhw4i8o8i2o = dnnl_gIOhw4i8o8i2o,
+        gIOw4i8o8i2o = dnnl_gIOw4i8o8i2o,
+        aBCd8b2c = dnnl_aBCd8b2c,
+        ABcde40a16b = dnnl_ABcde40a16b,
+        ABcde40a32b = dnnl_ABcde40a32b,
+        aBCde8b2c = dnnl_aBCde8b2c,
+        ABcde4a8b8a2b = dnnl_ABcde4a8b8a2b,
+        ABc4a8b8a2b = dnnl_ABc4a8b8a2b,
+        aBCdef4b8c8b2c = dnnl_aBCdef4b8c8b2c,
+        aBCde4b8c8b2c = dnnl_aBCde4b8c8b2c,
+        aBCd4b8c8b2c = dnnl_aBCd4b8c8b2c,
+        BAcde4b8a8b2a = dnnl_BAcde4b8a8b2a,
+        BAcd4b8a8b2a = dnnl_BAcd4b8a8b2a,
+        BAc4b8a8b2a = dnnl_BAc4b8a8b2a,
+        aCBdef4c8b8c2b = dnnl_aCBdef4c8b8c2b,
+        aCBde4c8b8c2b = dnnl_aCBde4c8b8c2b,
+        aCBd4c8b8c2b = dnnl_aCBd4c8b8c2b,
+        aBCdef8b2c = dnnl_aBCdef8b2c,
+        AB32a16b = dnnl_AB32a16b,
+        AB32a32b = dnnl_AB32a32b,
+        BA4b8a8b2a = dnnl_BA4b8a8b2a,
+        BA4b8a8b4a = dnnl_BA4b8a8b4a,
+        aBC32b16c = dnnl_aBC32b16c,
+        aBC32b32c = dnnl_aBC32b32c,
+        aCB4c8b8c2b = dnnl_aCB4c8b8c2b,
+        aCB4c8b8c4b = dnnl_aCB4c8b8c4b,
+        ABc2b8a16b4a = dnnl_ABc2b8a16b4a,
+        ABcd2b8a16b4a = dnnl_ABcd2b8a16b4a,
+        ABcde2b8a16b4a = dnnl_ABcde2b8a16b4a,
+        ABc2a8b16a4b = dnnl_ABc2a8b16a4b,
+        ABc2a8b16a2b = dnnl_ABc2a8b16a2b,
+        ABc2b32a8b = dnnl_ABc2b32a8b,
+        ABcd2a8b16a4b = dnnl_ABcd2a8b16a4b,
+        ABcd2a8b16a2b = dnnl_ABcd2a8b16a2b,
+        aCBd2c8b16c2b = dnnl_aCBd2c8b16c2b,
+        ABcd2b32a8b = dnnl_ABcd2b32a8b,
+        aBCd2c8b16c2b = dnnl_aBCd2c8b16c2b,
+        ABcde2a8b16a4b = dnnl_ABcde2a8b16a4b,
+        ABcde2a8b16a2b = dnnl_ABcde2a8b16a2b,
+        aCBde2c8b16c2b = dnnl_aCBde2c8b16c2b,
+        ABcde2b32a8b = dnnl_ABcde2b32a8b,
+        aBC2b8c16b2c = dnnl_aBC2b8c16b2c,
+        aBCd2b8c16b2c = dnnl_aBCd2b8c16b2c,
+        aBCde2b8c16b2c = dnnl_aBCde2b8c16b2c,
+        aBCdef2b8c16b2c = dnnl_aBCdef2b8c16b2c,
+        BAcde2b8a16b4a = dnnl_BAcde2b8a16b4a,
+        BAcd2b8a16b4a = dnnl_BAcd2b8a16b4a,
+        BAc2b8a16b4a = dnnl_BAc2b8a16b4a,
+        BAcde2b8a16b2a = dnnl_BAcde2b8a16b2a,
+        BAcd2b8a16b2a = dnnl_BAcd2b8a16b2a,
+        BAc2b8a16b2a = dnnl_BAc2b8a16b2a,
+        aBCde2c8b16c2b = dnnl_aBCde2c8b16c2b,
+        aBCdef2c8b16c2b = dnnl_aBCdef2c8b16c2b,
+        aCBdef2c8b16c2b = dnnl_aCBdef2c8b16c2b,
+        aBCd2b8c16b4c = dnnl_aBCd2b8c16b4c,
+        aBCde2b8c16b4c = dnnl_aBCde2b8c16b4c,
+        NCdhw40n16c = dnnl_NCdhw40n16c,
+        NCw40n16c = dnnl_NCw40n16c,
+        NChw40n16c = dnnl_NChw40n16c,
+        NCw2c32n8c = dnnl_NCw2c32n8c,
+        NChw2c32n8c = dnnl_NChw2c32n8c,
+        NCdhw2c32n8c = dnnl_NCdhw2c32n8c,
+        OIw2i8o16i4o = dnnl_OIw2i8o16i4o,
+        OIhw2i8o16i4o = dnnl_OIhw2i8o16i4o,
+        OIdhw2i8o16i4o = dnnl_OIdhw2i8o16i4o,
+        OIw2o8i16o4i = dnnl_OIw2o8i16o4i,
+        OIw2o8i16o2i = dnnl_OIw2o8i16o2i,
+        IOw2i8o16i4o = dnnl_IOw2i8o16i4o,
+        IOw2i8o16i2o = dnnl_IOw2i8o16i2o,
+        OIhw2o8i16o4i = dnnl_OIhw2o8i16o4i,
+        OIhw2o8i16o2i = dnnl_OIhw2o8i16o2i,
+        IOhw2i8o16i4o = dnnl_IOhw2i8o16i4o,
+        IOhw2i8o16i2o = dnnl_IOhw2i8o16i2o,
+        OIdhw2o8i16o4i = dnnl_OIdhw2o8i16o4i,
+        OIdhw2o8i16o2i = dnnl_OIdhw2o8i16o2i,
+        IOdhw2i8o16i4o = dnnl_IOdhw2i8o16i4o,
+        IOdhw2i8o16i2o = dnnl_IOdhw2i8o16i2o,
+        gOIw2o8i16o2i = dnnl_gOIw2o8i16o2i,
+        gIOw2i8o16i2o = dnnl_gIOw2i8o16i2o,
+        gIOhw2i8o16i2o = dnnl_gIOhw2i8o16i2o,
+        gIOdhw2i8o16i2o = dnnl_gIOdhw2i8o16i2o,
+        gOIhw2o8i16o2i = dnnl_gOIhw2o8i16o2i,
+        gOIdhw2o8i16o2i = dnnl_gOIdhw2o8i16o2i,
+        gOIw2o8i16o4i = dnnl_gOIw2o8i16o4i,
+        gOIhw2o8i16o4i = dnnl_gOIhw2o8i16o4i,
+        BA4b8a16b2a = dnnl_BA4b8a16b2a,
+        BA4b8a16b4a = dnnl_BA4b8a16b4a,
+        aCB4c8b16c2b = dnnl_aCB4c8b16c2b,
+        aCB4c8b16c4b = dnnl_aCB4c8b16c4b,
+        aCB16c2b = dnnl_aCB16c2b,
+        aCB16c4b = dnnl_aCB16c4b,
+        BA16b2a = dnnl_BA16b2a,
+        BA16b4a = dnnl_BA16b4a,
+        aBC16b16c = dnnl_aBC16b16c,
+        aBC16b32c = dnnl_aBC16b32c,
+        AB16a16b = dnnl_AB16a16b,
+        AB16a32b = dnnl_AB16a32b,
+        ABcde16a16b2a = dnnl_ABcde16a16b2a,
+        aBCdef16b16c2b = dnnl_aBCdef16b16c2b,
+        Acedb16a = dnnl_Acedb16a,
+        aBdfec16b = dnnl_aBdfec16b,
+        Odwhi16o = dnnl_Odwhi16o,
+        gOdwhi16o = dnnl_gOdwhi16o,
+        abdEC64e2c = dnnl_abdEC64e2c,
+        abdEC64e4c = dnnl_abdEC64e4c,
+        ldgOI64o2i = abdEC64e2c,
+        ldgOI64o4i = abdEC64e4c,
+    };
+
+    /// A memory descriptor.
+    struct desc {
+        friend struct memory;
+        /// The underlying C API data structure.
+        dnnl_memory_desc_t data;
+
+        /// Constructs a zero (empty) memory descriptor. Such a memory
+        /// descriptor can be used to indicate absence of an argument.
+        desc() : data() {}
+
+        /// Constructs a memory descriptor.
+        ///
+        /// @note
+        ///     The logical order of dimensions corresponds to the `abc...`
+        ///     format tag, and the physical meaning of the dimensions depends
+        ///     both on the primitive that would operate on this memory and
+        ///     the operation context.
+        ///
+        /// @param adims Tensor dimensions.
+        /// @param adata_type Data precision/type.
+        /// @param aformat_tag Memory format tag.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be constructed. This flag is
+        ///     optional and defaults to false.
+        desc(const dims &adims, data_type adata_type, format_tag aformat_tag,
+                bool allow_empty = false)
+            : data() {
+            validate_dims(adims);
+            dnnl_status_t status = dnnl_memory_desc_init_by_tag(&data,
+                    (int)adims.size(), adims.data(), convert_to_c(adata_type),
+                    convert_to_c(aformat_tag));
+            if (!allow_empty)
+                error::wrap_c_api(status,
+                        "could not construct a memory descriptor using a "
+                        "format tag");
+        }
+
+        /// Constructs a memory descriptor by strides.
+        ///
+        /// @note
+        ///     The logical order of dimensions corresponds to the `abc...`
+        ///     format tag, and the physical meaning of the dimensions depends
+        ///     both on the primitive that would operate on this memory and
+        ///     the operation context.
+        ///
+        /// @param adims Tensor dimensions.
+        /// @param adata_type Data precision/type.
+        /// @param strides Strides for each dimension.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be constructed. This flag is
+        ///     optional and defaults to false.
+        desc(const dims &adims, data_type adata_type, const dims &strides,
+                bool allow_empty = false)
+            : data() {
+            validate_dims(adims);
+            if (!strides.empty()) validate_dims(strides, (int)adims.size());
+            dnnl_status_t status = dnnl_memory_desc_init_by_strides(&data,
+                    (int)adims.size(), adims.data(), convert_to_c(adata_type),
+                    strides.empty() ? nullptr : &strides[0]);
+            if (!allow_empty)
+                error::wrap_c_api(status,
+                        "could not construct a memory descriptor using "
+                        "strides");
+        }
+
+        /// Constructs a memory descriptor from a C API data structure.
+        ///
+        /// @param data A C API ::dnnl_memory_desc_t structure.
+        desc(const dnnl_memory_desc_t &data) : data(data) {}
+
+        /// Constructs a memory descriptor for a region inside an area
+        /// described by this memory descriptor.
+        //
+        /// @param adims Sizes of the region.
+        /// @param offsets Offsets to the region from the encompassing
+        ///     memory object in each dimension.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be returned. This flag is optional
+        ///     and defaults to false.
+        /// @returns A memory descriptor for the region.
+        desc submemory_desc(const dims &adims, const dims &offsets,
+                bool allow_empty = false) const {
+            validate_dims(adims, data.ndims);
+            validate_dims(offsets, data.ndims);
+            dnnl_memory_desc_t sub_md = dnnl_memory_desc_t();
+            dnnl_status_t status = dnnl_memory_desc_init_submemory(
+                    &sub_md, &data, adims.data(), offsets.data());
+            if (!allow_empty)
+                error::wrap_c_api(status, "could not construct a sub-memory");
+            return desc(sub_md);
+        }
+
+        /// Constructs a memory descriptor by reshaping an existing one. The
+        /// new memory descriptor inherits the data type. This operation is
+        /// valid only for memory descriptors that have format_kind set to
+        /// #dnnl::memory::format_kind::blocked or
+        /// #dnnl::memory::format_kind::any.
+        ///
+        /// The operation ensures that the transformation of the physical memory
+        /// format corresponds to the transformation of the logical dimensions.
+        /// If such transformation is impossible, the function either throws an
+        /// exception (default) or returns a zero memory descriptor depending on
+        /// the `allow_empty` flag.
+        ///
+        /// The reshape operation can be described as a combination of the
+        /// following basic operations:
+        /// 1. Add a dimension of size `1`. This is always possible.
+        /// 2. Remove a dimension of size `1`. This is possible only if the
+        ///    dimension has no padding (i.e.
+        ///    `padded_dims[dim] == dims[dim] && dims[dim] == 1`).
+        /// 3. Split a dimension into multiple ones. This is possible only if
+        ///    the product of all tensor dimensions stays constant and the
+        ///    dimension being split does not have padding (i.e.
+        ///    `padded_dims[dim] = dims[dim]`).
+        /// 4. Join multiple consecutive dimensions into a single one. As in
+        ///    the cases above, this requires that the dimensions do not have
+        ///    padding and that the memory format is such that in physical
+        ///    memory these dimensions are dense and have the same order as
+        ///    their logical counterparts. This also assumes that these
+        ///    dimensions are not blocked.
+        ///    - Here, 'dense' means:
+        ///      `stride for dim[i] == (stride for dim[i + 1]) * dim[i + 1]`;
+        ///    - And 'same order' means:
+        ///      `i < j` if and only if `stride for dim[j] <= stride for dim[i]`.
+        ///
+        /// @warning
+        ///     Some combinations of physical memory layout and/or offsets or
+        ///     dimensions may result in a failure to make a reshape.
+        ///
+        /// @param adims New dimensions. The product of dimensions must
+        ///     remain constant.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be returned. This flag is optional
+        ///     and defaults to false.
+        /// @returns A new memory descriptor with new dimensions.
+        desc reshape(const dims &adims, bool allow_empty = false) const {
+            if (data.ndims) validate_dims(adims, 1);
+            dnnl_memory_desc_t out_md = dnnl_memory_desc_t();
+            dnnl_status_t status = dnnl_memory_desc_reshape(
+                    &out_md, &data, (int)adims.size(), adims.data());
+            if (!allow_empty)
+                error::wrap_c_api(
+                        status, "could not reshape a memory descriptor");
+            return desc(out_md);
+        }
+
+        /// Constructs a memory descriptor by permuting axes in an existing
+        /// one.
+        ///
+        /// The physical memory layout representation is adjusted accordingly
+        /// to maintain the consistency between the logical and physical parts
+        /// of the memory descriptor. The new memory descriptor inherits the
+        /// data type.
+        ///
+        /// The new memory descriptor inherits the data type. This operation is
+        /// valid only for memory descriptors that have format_kind set to
+        /// #dnnl::memory::format_kind::blocked or
+        /// #dnnl::memory::format_kind::any.
+        ///
+        /// The logical axes will be permuted in the following manner:
+        /// @code
+        /// for (i = 0; i < ndims(); i++)
+        ///     new_desc.dims()[permutation[i]] = dims()[i];
+        /// @endcode
+        ///
+        /// Example:
+        /// @code
+        ///     std::vector<int> permutation = {1, 0}; // swap the first and
+        ///                                            // the second axes
+        ///     dnnl::memory::desc in_md(
+        ///             {2, 3}, data_type, memory::format_tag::ab);
+        ///     dnnl::memory::desc expect_out_md(
+        ///             {3, 2}, data_type, memory::format_tag::ba);
+        ///
+        ///     assert(in_md.permute_axes(permutation) == expect_out_md);
+        /// @endcode
+        ///
+        /// @param permutation Axes permutation.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case a
+        ///     zero memory descriptor will be returned. This flag is optional
+        ///     and defaults to false.
+        /// @returns A new memory descriptor with new dimensions.
+        desc permute_axes(const std::vector<int> &permutation,
+                bool allow_empty = false) const {
+            validate_dims(permutation, data.ndims);
+            dnnl_memory_desc_t out_md = dnnl_memory_desc_t();
+            dnnl_status_t status = dnnl_memory_desc_permute_axes(
+                    &out_md, &data, permutation.data());
+            if (!allow_empty)
+                error::wrap_c_api(status,
+                        "could not permute axes of a memory descriptor");
+            return desc(out_md);
+        }
+
+        /// Returns the data type of the memory descriptor.
+        /// @returns The data type.
+        memory::data_type data_type() const {
+            return static_cast<memory::data_type>(data.data_type);
+        }
+
+        /// Returns dimensions of the memory descriptor.
+        ///
+        /// Potentially expensive due to the data copy involved.
+        /// @returns A copy of the dimensions vector.
+        memory::dims dims() const {
+            return memory::dims(data.dims, data.dims + data.ndims);
+        }
+
+        /// Returns size of the memory descriptor in bytes.
+        /// @returns The number of bytes required to allocate a memory buffer
+        ///     for the memory object described by this memory descriptor
+        ///     including the padding area.
+        size_t get_size() const { return dnnl_memory_desc_get_size(&data); }
+
+        /// Checks whether the memory descriptor is zero (empty).
+        /// @returns @c true if the memory descriptor describes an empty
+        ///     memory and @c false otherwise.
+        bool is_zero() const { return data.ndims == 0; }
+
+        /// An equality operator.
+        /// @param other Another memory descriptor.
+        /// @returns Whether this and the other memory descriptors have
+        ///     the same format tag, dimensions, strides, blocking, etc.
+        bool operator==(const desc &other) const {
+            return dnnl_memory_desc_equal(&data, &other.data) != 0;
+        }
+
+        /// An inequality operator.
+        /// @param other Another memory descriptor.
+        /// @returns Whether this and the other memory descriptors describe
+        ///     different memory.
+        bool operator!=(const desc &other) const { return !operator==(other); }
+
+        /// Checks whether the object is not empty.
+        ///
+        /// @returns Whether the object is not empty.
+        explicit operator bool() const { return data.ndims != 0; }
+    };
+
+    /// Default constructor.
+    ///
+    /// Constructs an empty memory object, which can be used to indicate
+    /// absence of a parameter.
+    memory() = default;
+
+    /// Constructs a memory object.
+    ///
+    /// Unless @p handle is equal to #DNNL_MEMORY_NONE, the constructed memory
+    /// object will have the underlying buffer set. In this case, the buffer
+    /// will be initialized as if #dnnl::memory::set_data_handle() had been
+    /// called.
+    ///
+    /// @sa memory::set_data_handle()
+    ///
+    /// @param md Memory descriptor.
+    /// @param aengine Engine to store the data on.
+    /// @param handle Handle of the memory buffer to use.
+    ///     - A pointer to the user-allocated buffer. In this case the library
+    ///       doesn't own the buffer.
+    ///     - The #DNNL_MEMORY_ALLOCATE special value. Instructs the library to
+    ///       allocate the buffer for the memory object. In this case the
+    ///       library owns the buffer.
+    ///     - #DNNL_MEMORY_NONE to create dnnl::memory without an underlying
+    ///       buffer.
+    memory(const desc &md, const engine &aengine, void *handle) {
+        dnnl_memory_t result;
+        error::wrap_c_api(
+                dnnl_memory_create(&result, &md.data, aengine.get(), handle),
+                "could not create a memory object");
+        reset(result);
+    }
+
+    /// Constructs a memory object.
+    ///
+    /// The underlying buffer for the memory will be allocated by the library.
+    ///
+    /// @param md Memory descriptor.
+    /// @param aengine Engine to store the data on.
+    memory(const desc &md, const engine &aengine)
+        : memory(md, aengine, DNNL_MEMORY_ALLOCATE) {}
+
+    /// Returns the associated memory descriptor.
+    desc get_desc() const {
+        const dnnl_memory_desc_t *cdesc;
+        error::wrap_c_api(dnnl_memory_get_memory_desc(get(), &cdesc),
+                "could not get a memory descriptor from a memory object");
+        return desc(*cdesc);
+    }
+
+    /// Returns the associated engine.
+    engine get_engine() const {
+        dnnl_engine_t c_engine;
+        error::wrap_c_api(dnnl_memory_get_engine(get(), &c_engine),
+                "could not get an engine from a memory object");
+        return engine(c_engine, true);
+    }
+
+    /// Returns the underlying memory buffer.
+    ///
+    /// On the CPU engine, or when using USM, this is a pointer to the
+    /// allocated memory.
+    void *get_data_handle() const {
+        void *handle;
+        error::wrap_c_api(dnnl_memory_get_data_handle(get(), &handle),
+                "could not get a native handle from a memory object");
+        return handle;
+    }
+
+    /// Sets the underlying memory buffer.
+    ///
+    /// This function may write zero values to the memory specified by the @p
+    /// handle if the memory object has a zero padding area. This may be time
+    /// consuming and happens each time this function is called. The
+    /// operation is always blocking and the stream parameter is a hint.
+    ///
+    /// @note
+    ///     The zero padding is required by memory objects created with
+    ///     blocked memory format tags like #dnnl_aBcd8b when any of the
+    ///     dimensions is not a multiple of the corresponding block size. For
+    ///     "plain" formats like #dnnl::memory::format_tag::nchw or
+    ///     #dnnl::memory::format_tag::nhwc zero padding area needs to be set
+    ///     up explicitly when creating the corresponding memory descriptors.
+    ///     See @ref dev_guide_understanding_memory_formats for more details.
+    ///
+    /// @note
+    ///     Even when the memory object is used to hold values that stay
+    ///     constant during the execution of the program (pre-packed weights
+    ///     during inference, for example), the function will still write
+    ///     zeroes to the padding area if it exists. Hence, the @p handle
+    ///     parameter cannot and does not have a const qualifier.
+    ///
+    /// @param handle Memory buffer to use. On the CPU engine or when USM is
+    ///     used, the memory buffer is a pointer to the actual data. For OpenCL
+    ///     it is a cl_mem. It must have at least
+    ///     #dnnl::memory::desc::get_size() bytes allocated.
+    /// @param astream Stream to use to execute padding in.
+    void set_data_handle(void *handle, const stream &astream) const {
+        error::wrap_c_api(dnnl_memory_set_data_handle_v2(
+                                  get(), handle, astream.get(true)),
+                "could not set native handle of a memory object");
+    }
+
+    /// Sets the underlying memory buffer.
+    ///
+    /// See documentation for
+    /// #dnnl::memory::set_data_handle(void *, const stream &) const
+    /// for more information.
+    ///
+    /// @param handle Memory buffer to use. For the CPU engine, the memory
+    ///     buffer is a pointer to the actual data. For OpenCL it is a cl_mem.
+    ///     It must have at least #dnnl::memory::desc::get_size() bytes
+    ///     allocated.
+    void set_data_handle(void *handle) const {
+        error::wrap_c_api(
+                dnnl_memory_set_data_handle_v2(get(), handle, nullptr),
+                "could not set native handle of a memory object");
+    }
+
+    /// Maps a memory object and returns a host-side pointer to a memory
+    /// buffer with a copy of its contents.
+    ///
+    /// Mapping enables read/write directly from/to the memory contents for
+    /// engines that do not support direct memory access.
+    ///
+    /// Mapping is an exclusive operation - a memory object cannot be used in
+    /// other operations until it is unmapped via #dnnl::memory::unmap_data()
+    /// call.
+    ///
+    /// @note
+    ///     Any primitives working with the memory should be completed before
+    ///     the memory is mapped. Use #dnnl::stream::wait() to synchronize the
+    ///     corresponding execution stream.
+    ///
+    /// @note
+    ///     The map_data and unmap_data functions are provided mainly for
+    ///     debug and testing purposes and their performance may be suboptimal.
+    ///
+    /// @tparam T Data type to return a pointer to.
+    /// @returns Pointer to the mapped memory.
+    template <typename T = void>
+    T *map_data() const {
+        void *mapped_ptr;
+        error::wrap_c_api(dnnl_memory_map_data(get(), &mapped_ptr),
+                "could not map memory object data");
+        return static_cast<T *>(mapped_ptr);
+    }
+
+    /// Unmaps a memory object and writes back any changes made to the
+    /// previously mapped memory buffer.
+    ///
+    /// @note
+    ///     The map_data and unmap_data functions are provided mainly for
+    ///     debug and testing purposes and their performance may be
+    ///     suboptimal.
+    ///
+    /// @param mapped_ptr A pointer previously returned by
+    ///     #dnnl::memory::map_data().
+    void unmap_data(void *mapped_ptr) const {
+        error::wrap_c_api(dnnl_memory_unmap_data(get(), mapped_ptr),
+                "could not unmap memory object data");
+    }
+
+    static dnnl_data_type_t convert_to_c(data_type adata_type) {
+        return static_cast<dnnl_data_type_t>(adata_type);
+    }
+    static dnnl_format_tag_t convert_to_c(format_tag format) {
+        return static_cast<dnnl_format_tag_t>(format);
+    }
+};
+
+inline bool operator==(dnnl_data_type_t a, memory::data_type b) {
+    return a == memory::convert_to_c(b);
+}
+inline bool operator!=(dnnl_data_type_t a, memory::data_type b) {
+    return !(a == b);
+}
+inline bool operator==(memory::data_type a, dnnl_data_type_t b) {
+    return b == a;
+}
+inline bool operator!=(memory::data_type a, dnnl_data_type_t b) {
+    return !(a == b);
+}
+
+inline bool operator==(dnnl_format_tag_t a, memory::format_tag b) {
+    return a == memory::convert_to_c(b);
+}
+inline bool operator!=(dnnl_format_tag_t a, memory::format_tag b) {
+    return !(a == b);
+}
+inline bool operator==(memory::format_tag a, dnnl_format_tag_t b) {
+    return b == a;
+}
+inline bool operator!=(memory::format_tag a, dnnl_format_tag_t b) {
+    return !(a == b);
+}
+
+/// @} dnnl_api_memory
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+/// @addtogroup dnnl_api_attributes Attributes
+///
+/// A container for parameters that extend primitives behavior.
+///
+/// @{
+
+/// @cond DO_NOT_DOCUMENT_THIS
+template <>
+struct handle_traits<dnnl_post_ops_t> {
+    static dnnl_status_t destructor(dnnl_post_ops_t p) {
+        return dnnl_post_ops_destroy(p);
+    }
+};
+/// @endcond
+
+/// Post-ops.
+///
+/// Post-ops are computations executed after the main primitive computations
+/// and are attached to the primitive via primitive attributes.
+///
+/// @sa @ref dev_guide_attributes_post_ops
+///
+struct post_ops : public handle<dnnl_post_ops_t> {
+    using handle<dnnl_post_ops_t>::handle;
+
+    /// Constructs an empty sequence of post-ops.
+    post_ops() {
+        dnnl_post_ops_t result;
+        error::wrap_c_api(
+                dnnl_post_ops_create(&result), "could not create post-ops");
+        reset(result);
+    }
+
+    /// Creates post-ops primitive attribute from a C API ::dnnl_post_ops_t
+    /// handle. The resulting handle is not weak and the C handle will be
+    /// destroyed during the destruction of the C++ object.
+    ///
+    /// @param post_ops The C API post-ops primitive attribute.
+    post_ops(dnnl_post_ops_t post_ops) : handle<dnnl_post_ops_t>(post_ops) {}
+
+    /// Returns the number of post-ops entries.
+    int len() const { return dnnl_post_ops_len(get()); }
+
+    /// Returns the primitive kind of post-op at entry with a certain index.
+    /// @param index Index of the post-op to return the kind for.
+    /// @returns Primitive kind of the post-op at the specified index.
+    primitive::kind kind(int index) const {
+        error::wrap_c_api(index < len() ? dnnl_success : dnnl_invalid_arguments,
+                "post-ops index is out of range");
+        return static_cast<primitive::kind>(
+                dnnl_post_ops_get_kind(get(), index));
+    }
+
+    /// Appends an accumulation (sum) post-op. Prior to accumulating the
+    /// result, the previous value would be multiplied by a scaling factor
+    /// @p scale.
+    ///
+    /// The kind of this post-op is #dnnl::primitive::kind::sum.
+    ///
+    /// This feature may improve performance for cases like residual learning
+    /// blocks, where the result of convolution is accumulated to the
+    /// previously computed activations. The parameter @p scale may be used
+    /// for the integer-based computations when the result and previous
+    /// activations have different logical scaling factors.
+    ///
+    /// In the simplest case when the accumulation is the only post-op,
+    /// the computations will be `dst[:] := scale * dst[:] + op(...)`
+    /// instead of `dst[:] := op(...)`.
+    ///
+    /// If @p data_type is specified, the original dst tensor will be
+    /// reinterpreted as a tensor with the provided data type. Because it is a
+    /// reinterpretation, data_type and dst data type should have the same size.
+    /// As a result, computations will be `dst[:] <- scale *
+    /// as_data_type(dst[:]) + op(...)` instead of `dst[:] <- op(...)`.
+    ///
+    /// @note
+    ///     This post-op executes in-place and does not change the
+    ///     destination layout.
+    ///
+    /// @param scale Scaling factor.
+    /// @param data_type Data type.
+    void append_sum(float scale = 1.f,
+            memory::data_type data_type = memory::data_type::undef) {
+        if (data_type == memory::data_type::undef)
+            error::wrap_c_api(dnnl_post_ops_append_sum(get(), scale),
+                    "could not append a sum post-op");
+        else
+            error::wrap_c_api(dnnl_post_ops_append_sum_v2(get(), scale,
+                                      memory::convert_to_c(data_type)),
+                    "could not append a sum post-op");
+    }
+
+    /// Appends an accumulation (sum) post-op. Prior to accumulating the
+    /// result, the previous value will be will be reduced by zero point
+    /// @p zero_point and multiplied by a scaling factor @p scale.
+    ///
+    /// The kind of this post-op is #dnnl::primitive::kind::sum.
+    ///
+    /// This feature may improve performance for cases like dequantize the
+    /// asymmetrically quantized sum's src1 tensor to f32 domain before
+    /// performing the sum operation by subtracting @p zero_point before the
+    /// scaling.
+    ///
+    /// In the simplest case when the accumulation is the only post-op,
+    /// the computations will be `dst[:] := scale * (dst[:] - zero_point) +
+    /// op(...)` instead of `dst[:] := op(...)`.
+    ///
+    /// If @p data_type is specified, the original dst tensor will be
+    /// reinterpreted as a tensor with the provided data type. Because it is a
+    /// reinterpretation, data_type and dst data type should have the same size.
+    /// As a result, computations will be `dst[:] <- scale *
+    /// (as_data_type(dst[:]) - zero_point) + op(...)` instead of
+    /// `dst[:] <- op(...)`.
+    ///
+    /// @note
+    ///     This post-op executes in-place and does not change the
+    ///     destination layout.
+    ///
+    /// @param scale Scaling factor.
+    /// @param zero_point Zero point.
+    /// @param data_type Data type.
+    void append_sum(float scale, int32_t zero_point,
+            memory::data_type data_type = memory::data_type::undef) {
+        error::wrap_c_api(dnnl_post_ops_append_sum_v3(get(), scale, zero_point,
+                                  memory::convert_to_c(data_type)),
+                "could not append a sum post-op");
+    }
+
+    /// Returns the parameters of an accumulation (sum) post-op.
+    ///
+    /// @param index Index of the sum post-op.
+    /// @param scale Scaling factor of the sum post-op.
+    void get_params_sum(int index, float &scale) const {
+        error::wrap_c_api(dnnl_post_ops_get_params_sum(get(), index, &scale),
+                "could not get parameters of a sum post-op");
+    }
+
+    /// Returns the parameters of an accumulation (sum) post-op.
+    ///
+    /// @param index Index of the sum post-op.
+    /// @param scale Scaling factor of the sum post-op.
+    /// @param data_type Data type of the sum post-op.
+    void get_params_sum(
+            int index, float &scale, memory::data_type &data_type) const {
+        dnnl_data_type_t c_data_type;
+        error::wrap_c_api(dnnl_post_ops_get_params_sum_v2(
+                                  get(), index, &scale, &c_data_type),
+                "could not get parameters of a sum post-op");
+        data_type = static_cast<memory::data_type>(c_data_type);
+    }
+
+    /// Returns the parameters of an accumulation (sum) post-op.
+    ///
+    /// @param index Index of the sum post-op.
+    /// @param scale Scaling factor of the sum post-op.
+    /// @param zero_point Single scalar int32_t value of zeropoint.
+    /// @param data_type Data type of the sum post-op.
+    void get_params_sum(int index, float &scale, int32_t &zero_point,
+            memory::data_type &data_type) const {
+        dnnl_data_type_t c_data_type;
+        error::wrap_c_api(dnnl_post_ops_get_params_sum_v3(get(), index, &scale,
+                                  &zero_point, &c_data_type),
+                "could not get parameters of a sum post-op");
+        data_type = static_cast<memory::data_type>(c_data_type);
+    }
+
+    /// Appends an elementwise post-op.
+    ///
+    /// The kind of this post-op is #dnnl::primitive::kind::eltwise.
+    ///
+    /// In the simplest case when the elementwise is the only post-op, the
+    /// computations would be `dst[:] := scale * eltwise_op (op(...))` instead
+    /// of `dst[:] <- op(...)`, where eltwise_op is configured with the given
+    /// parameters.
+    ///
+    /// @param scale Scaling factor.
+    /// @param aalgorithm Elementwise algorithm.
+    /// @param alpha Alpha parameter for the elementwise algorithm.
+    /// @param beta Beta parameter for the elementwise algorithm.
+    void append_eltwise(
+            float scale, algorithm aalgorithm, float alpha, float beta) {
+        error::wrap_c_api(dnnl_post_ops_append_eltwise(get(), scale,
+                                  convert_to_c(aalgorithm), alpha, beta),
+                "could not append an elementwise post-op");
+    }
+
+    /// Returns parameters of an elementwise post-op.
+    ///
+    /// @param index Index of the post-op.
+    /// @param scale Output scaling factor.
+    /// @param aalgorithm Output elementwise algorithm kind.
+    /// @param alpha Output alpha parameter for the elementwise algorithm.
+    /// @param beta Output beta parameter for the elementwise algorithm.
+    void get_params_eltwise(int index, float &scale, algorithm &aalgorithm,
+            float &alpha, float &beta) const {
+        dnnl_alg_kind_t c_alg;
+        error::wrap_c_api(dnnl_post_ops_get_params_eltwise(
+                                  get(), index, &scale, &c_alg, &alpha, &beta),
+                "could not get parameters of an elementwise post-op");
+        aalgorithm = static_cast<dnnl::algorithm>(c_alg);
+    }
+
+    /// Appends a depthwise post-op convolution.
+    ///
+    /// This post-op can only be fused with a 2D 1x1 convolution (convolution
+    /// with weights spatial dimension equal to 1 i.e., kh=kw=1).
+    ///
+    /// The kind of this post-op is #dnnl_convolution.
+    ///
+    /// The number of outputs for primitive remain same as before. The output
+    /// spatial size can be derived as below:
+    ///
+    /// output_height = ceil(output_height_1x1_convolution, stride)
+    /// output_width = ceil(output_width_1x1_convolution, stride)
+    ///
+    /// See @ref dev_guide_attributes_post_ops_depthwise and
+    /// @ref dev_guide_attributes_post_ops_depthwise_fusion for more info.
+    ///
+    /// @param weights_data_type Weights data type of depthwise post-op
+    /// @param bias_data_type Bias data type of depthwise post-op
+    /// @param dst_data_type Output data type of depthwise post-op
+    /// @param kernel_size Size of kernel of depthwise post-op
+    /// @param stride_size Size of stride of depthwise post-op
+    /// @param padding_l_size Size of left and top paddings of depthwise post-op
+    /// @param mask Output scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the
+    ///     @p scales array. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The mask
+    ///     value of 0 implies a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Output pointer to a constant array of float scaling
+    ///     factors.
+    void append_dw(memory::data_type weights_data_type,
+            memory::data_type bias_data_type, memory::data_type dst_data_type,
+            memory::dim kernel_size, memory::dim stride_size,
+            memory::dim padding_l_size, int mask,
+            const std::vector<float> &scales) {
+
+        error::wrap_c_api(dnnl_post_ops_append_dw(get(),
+                                  memory::convert_to_c(weights_data_type),
+                                  memory::convert_to_c(bias_data_type),
+                                  memory::convert_to_c(dst_data_type),
+                                  kernel_size, stride_size, padding_l_size,
+                                  scales.size(), mask, scales.data()),
+                "could not append depthwise post-op");
+    }
+
+    /// Returns the parameters of an depthwise post-op.
+    ///
+    /// @param index Index of the elementwise post-op.
+    /// @param weights_data_type Weights data type of depthwise post-op
+    /// @param bias_data_type Bias data type of depthwise post-op
+    /// @param dst_data_type Output data type of depthwise post-op
+    /// @param kernel_size Size of kernel of depthwise post-op
+    /// @param stride_size Size of stride of depthwise post-op
+    /// @param padding_l_size Size of left and top paddings of depthwise post-op
+    /// @param mask Output scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the
+    ///     @p scales array. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The mask
+    ///     value of 0 implies a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Output pointer to a constant array of float scaling
+    ///     factors.
+    void get_params_dw(int index, memory::data_type &weights_data_type,
+            memory::data_type &bias_data_type, memory::data_type &dst_data_type,
+            memory::dim &kernel_size, memory::dim &stride_size,
+            memory::dim &padding_l_size, int &mask,
+            std::vector<float> &scales) const {
+
+        dnnl_data_type_t c_weights_data_type;
+        dnnl_data_type_t c_bias_data_type;
+        dnnl_data_type_t c_dst_data_type;
+        dnnl_dim_t c_kernel_size;
+        dnnl_dim_t c_stride_size;
+        dnnl_dim_t c_padding_l_size;
+        dnnl_dim_t count;
+        int c_mask;
+        const float *c_scales;
+        error::wrap_c_api(
+                dnnl_post_ops_get_params_dw(get(), index, &c_weights_data_type,
+                        &c_bias_data_type, &c_dst_data_type, &c_kernel_size,
+                        &c_stride_size, &c_padding_l_size, &count, &c_mask,
+                        &c_scales),
+                "could not get parameters of depthwise post-op");
+
+        weights_data_type = static_cast<memory::data_type>(c_weights_data_type);
+        bias_data_type = static_cast<memory::data_type>(c_bias_data_type);
+        dst_data_type = static_cast<memory::data_type>(c_dst_data_type);
+        kernel_size = c_kernel_size;
+        stride_size = c_stride_size;
+        padding_l_size = c_padding_l_size;
+        scales.resize(count);
+
+        mask = c_mask;
+        for (dnnl_dim_t c = 0; c < count; ++c)
+            scales[c] = c_scales[c];
+        return;
+    }
+
+    /// Appends a depthwise post-op convolution with stride 1.
+    ///
+    /// This post-op can only be fused with a 2D 1x1 convolution (convolution
+    /// with weights spatial dimension equal to 1 i.e., kh=kw=1).
+    ///
+    /// The kind of this post-op is #dnnl_convolution.
+    ///
+    /// The number of outputs for primitive remain same as before. The output
+    /// size remain same as the original primitive due to stride=1.
+    ///
+    /// The Post-op can be defined as:
+    ///
+    ///      dst[:] <- scales * (conv_dw(conv_1x1))
+    ///
+    /// See @ref dev_guide_attributes_post_ops_depthwise and
+    /// @ref dev_guide_attributes_post_ops_depthwise_fusion for more info.
+    ///
+    /// @param weights_data_type Weights data type of depthwise post-op
+    /// @param bias_data_type Bias data type of depthwise post-op
+    /// @param dst_data_type Output data type of depthwise post-op
+    /// @param mask Output scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the
+    ///     @p scales array. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The mask
+    ///     value of 0 implies a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Output pointer to a constant array of float scaling
+    ///     factors.
+    void append_dw_k3s1p1(memory::data_type weights_data_type,
+            memory::data_type bias_data_type, memory::data_type dst_data_type,
+            int mask, const std::vector<float> &scales) {
+
+        append_dw(weights_data_type, bias_data_type, dst_data_type, 3, 1, 1,
+                mask, scales);
+    }
+
+    /// Returns the parameters of an depthwise post-op with stride 1.
+    ///
+    /// @param index Index of the elementwise post-op.
+    /// @param weights_data_type Weights data type of depthwise post-op
+    /// @param bias_data_type Bias data type of depthwise post-op
+    /// @param dst_data_type Output data type of depthwise post-op
+    /// @param mask Output scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the
+    ///     @p scales array. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The mask
+    ///     value of 0 implies a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Output pointer to a constant array of float scaling
+    ///     factors.
+    void get_params_dw_k3s1p1(int index, memory::data_type &weights_data_type,
+            memory::data_type &bias_data_type, memory::data_type &dst_data_type,
+            int &mask, std::vector<float> &scales) const {
+
+        memory::dim kernel_size;
+        memory::dim stride_size;
+        memory::dim padding_l_size;
+        get_params_dw(index, weights_data_type, bias_data_type, dst_data_type,
+                kernel_size, stride_size, padding_l_size, mask, scales);
+    }
+
+    /// Appends a depthwise post-op convolution with stride 2.
+    ///
+    /// This post-op can only be fused with a 2D 1x1 convolution (convolution
+    /// with weights spatial dimension equal to 1 i.e., kh=kw=1).
+    ///
+    /// The kind of this post-op is #dnnl_convolution.
+    ///
+    /// The number of outputs for primitive remain same as before. The output
+    /// spatial size can be derived as below:
+    ///
+    /// output_height = ceil(output_height_1x1_convolution, stride)
+    /// output_width = ceil(output_width_1x1_convolution, stride)
+    ///
+    /// The Post-op can be defined as:
+    ///
+    ///      dst[:] <- scales * (conv_dw(conv_1x1))
+    ///
+    /// See @ref dev_guide_attributes_post_ops_depthwise and
+    /// @ref dev_guide_attributes_post_ops_depthwise_fusion for more info.
+    ///
+    /// @param weights_data_type Weights data type of depthwise post-op
+    /// @param bias_data_type Bias data type of depthwise post-op
+    /// @param dst_data_type Output data type of depthwise post-op
+    /// @param mask Output scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the
+    ///     @p scales array. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The mask
+    ///     value of 0 implies a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Output pointer to a constant array of float scaling
+    ///     factors.
+    /// @returns #dnnl_success on success and a status describing the error
+    ///     otherwise
+    void append_dw_k3s2p1(memory::data_type weights_data_type,
+            memory::data_type bias_data_type, memory::data_type dst_data_type,
+            int mask, const std::vector<float> &scales) {
+        append_dw(weights_data_type, bias_data_type, dst_data_type, 3, 2, 1,
+                mask, scales);
+    }
+
+    /// Returns the parameters of an depthwise post-op with stride 2.
+    ///
+    /// @param index Index of the elementwise post-op.
+    /// @param weights_data_type Weights data type of depthwise post-op
+    /// @param bias_data_type Bias data type of depthwise post-op
+    /// @param dst_data_type Output data type of depthwise post-op
+    /// @param mask Output scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the
+    ///     @p scales array. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The mask
+    ///     value of 0 implies a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Output pointer to a constant array of float scaling
+    ///     factors.
+    void get_params_dw_k3s2p1(int index, memory::data_type &weights_data_type,
+            memory::data_type &bias_data_type, memory::data_type &dst_data_type,
+            int &mask, std::vector<float> &scales) const {
+
+        memory::dim kernel_size;
+        memory::dim stride_size;
+        memory::dim padding_l_size;
+        get_params_dw(index, weights_data_type, bias_data_type, dst_data_type,
+                kernel_size, stride_size, padding_l_size, mask, scales);
+    }
+
+    /// Appends a binary post-op.
+    ///
+    /// The kind of this post operation is #dnnl_binary.
+    ///
+    /// In the simplest case when the binary is the only post operation, the
+    /// computations would be:
+    ///
+    ///     dst[:] <- binary_op (dst[:], another_input[:])
+    ///
+    /// where binary_op is configured with the given parameters. binary_op
+    /// supports broadcast semantics for a second operand.
+    ///
+    /// @param aalgorithm Binary algorithm for the post-op.
+    /// @param src1_desc Memory descriptor of a second operand.
+    void append_binary(algorithm aalgorithm, const memory::desc &src1_desc) {
+        error::wrap_c_api(dnnl_post_ops_append_binary(get(),
+                                  convert_to_c(aalgorithm), &src1_desc.data),
+                "could not append a binary post-op");
+    }
+
+    /// Returns the parameters of a binary post-op.
+    ///
+    /// @param index Index of the binary post-op.
+    /// @param aalgorithm Output binary algorithm kind.
+    /// @param src1_desc Output memory descriptor of a second operand.
+    void get_params_binary(
+            int index, algorithm &aalgorithm, memory::desc &src1_desc) const {
+        dnnl_alg_kind_t c_alg;
+        const dnnl_memory_desc_t *data;
+        error::wrap_c_api(
+                dnnl_post_ops_get_params_binary(get(), index, &c_alg, &data),
+                "could not get parameters of a binary post-op");
+        aalgorithm = static_cast<dnnl::algorithm>(c_alg);
+        src1_desc.data = *data;
+    }
+
+    /// Appends a prelu forward post-op.
+    ///
+    /// The kind of this post-op is #dnnl::primitive::kind::prelu.
+    ///
+    /// The post-op can be defined as:
+    ///
+    ///      dst[:] <- prelu(dst[:], weights[:])
+    ///      prelu:
+    ///      dst[:] <- dst[:] if dst[:] > 0
+    ///      dst[:] <- dst[:] * weights[:] if dst[:] <= 0
+    ///
+    ///
+    /// Example usage:
+    /// @code
+    ///     int mb = 32, oc = 32,
+    ///         oh = 14, ow = 14; // convolution output params
+    ///     // unique weights per output channel
+    ///     vector<float> weights = { ... };
+    ///     int oc_dim = 1; // mb_dim = 0, channel_dim = 1, height_dim = 2, ...
+    ///
+    ///     // construct a convolution descriptor
+    ///     dnnl::convolution::desc conv_d;
+    ///
+    ///     dnnl::primitive_attr attr;
+    ///     attr.append_prelu(1 << oc_dim);
+    ///
+    ///     dnnl::primitive_desc conv_pd(conv_d, attr, engine);
+    ///     memory prelu_weights({{1}, dt::f32, {1}}, eng, weights.data());
+    ///
+    ///     std::unordered_map<int, memory> conv_args;
+    ///
+    ///     conv_args.insert(
+    ///      {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_WEIGHTS, prelu_weights})
+    /// @endcode
+    ///
+    /// @note
+    ///     The order of dimensions does not depend on how elements are laid
+    ///     out in memory. For example:
+    ///     - for a 2D CNN activations tensor the order is always (n, c)
+    ///     - for a 4D CNN activations tensor the order is always (n, c, h, w)
+    ///     - for a 5D CNN weights tensor the order is always
+    ///        (g, oc, ic, kh, kw)
+    ///
+    ///    Prelu weights tensor is passed in runtime execution phase. Prelu
+    ///    weights tensor data type is implicitly assumed as f32 using plain
+    ///    layout (a, ab, acb, acdb, acdeb).
+    ///
+    /// @param mask Defines the correspondence between the output tensor
+    ///     dimensions and the prelu weights tensor. The set i-th bit indicates
+    ///     that a dedicated weights value is used for each index along that
+    ///     dimension. Set the mask to 0 to use a common weights value
+    ///     for the whole output tensor.
+    void append_prelu(int mask) {
+        error::wrap_c_api(dnnl_post_ops_append_prelu(get(), mask),
+                "could not append a prelu post-op");
+    }
+
+    /// Returns the parameters of a prelu post-op.
+    ///
+    /// @param index Index of the prelu post-op.
+    /// @param mask Weights mask of prelu post-op.
+    void get_params_prelu(int index, int &mask) const {
+        error::wrap_c_api(dnnl_post_ops_get_params_prelu(get(), index, &mask),
+                "could not get parameters of a binary post-op");
+    }
+};
+
+/// @cond DO_NOT_DOCUMENT_THIS
+template <>
+struct handle_traits<dnnl_primitive_attr_t> {
+    static dnnl_status_t destructor(dnnl_primitive_attr_t p) {
+        return dnnl_primitive_attr_destroy(p);
+    }
+};
+/// @endcond
+
+/// Primitive attributes.
+///
+/// @sa @ref dev_guide_attributes
+struct primitive_attr : public handle<dnnl_primitive_attr_t> {
+    using handle<dnnl_primitive_attr_t>::handle;
+
+    /// Constructs default (empty) primitive attributes.
+    primitive_attr() {
+        dnnl_primitive_attr_t result;
+        error::wrap_c_api(dnnl_primitive_attr_create(&result),
+                "could not create primitive attribute");
+        reset(result);
+    }
+
+    /// Creates primitive attributes from a C API ::dnnl_primitive_attr_t
+    /// handle. The resulting handle is not weak and the C handle will be
+    /// destroyed during the destruction of the C++ object.
+    ///
+    /// @param attr The C API primitive attributes.
+    primitive_attr(dnnl_primitive_attr_t attr)
+        : handle<dnnl_primitive_attr_t>(attr) {}
+
+    /// Returns the fpmath mode
+    fpmath_mode get_fpmath_mode() const {
+        dnnl_fpmath_mode_t result;
+        error::wrap_c_api(dnnl_primitive_attr_get_fpmath_mode(get(), &result),
+                "could not get fpmath mode primitive attribute");
+        return fpmath_mode(result);
+    }
+
+    /// Sets fpmath mode.
+    ///
+    /// @param mode Specified fpmath mode.
+    void set_fpmath_mode(fpmath_mode mode) {
+        error::wrap_c_api(dnnl_primitive_attr_set_fpmath_mode(
+                                  get(), dnnl::convert_to_c(mode)),
+                "could not set fpmath mode primitive attribute");
+    }
+
+    /// Returns the scratchpad mode.
+    scratchpad_mode get_scratchpad_mode() const {
+        dnnl_scratchpad_mode_t result;
+        error::wrap_c_api(
+                dnnl_primitive_attr_get_scratchpad_mode(get(), &result),
+                "could not get scratchpad mode primitive attribute");
+        return scratchpad_mode(result);
+    }
+
+    /// Sets scratchpad mode.
+    ///
+    /// @param mode Specified scratchpad mode.
+    void set_scratchpad_mode(scratchpad_mode mode) {
+        error::wrap_c_api(dnnl_primitive_attr_set_scratchpad_mode(
+                                  get(), dnnl::convert_to_c(mode)),
+                "could not set scratchpad mode primitive attribute");
+    }
+
+    /// Returns output scaling factors correspondence mask and values.
+    ///
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated output
+    ///     scaling factor is used for each index along that dimension. The
+    ///     mask value of 0 implies a common output scaling factor for the
+    ///     whole output tensor.
+    /// @param scales Vector of output scaling factors.
+    void get_output_scales(int &mask, std::vector<float> &scales) const {
+        dnnl_dim_t count;
+        int c_mask;
+        const float *c_scales;
+        error::wrap_c_api(dnnl_primitive_attr_get_output_scales(
+                                  get(), &count, &c_mask, &c_scales),
+                "could not get output scales primitive attribute");
+        scales.resize(count);
+
+        mask = c_mask;
+        for (dnnl_dim_t c = 0; c < count; ++c)
+            scales[c] = c_scales[c];
+    }
+
+    /// Sets output scaling factors correspondence mask and values.
+    ///
+    /// Example usage:
+    /// @code
+    ///     int mb = 32, oc = 32,
+    ///         oh = 14, ow = 14; // convolution output params
+    ///     // unique output scales per output channel
+    ///     vector<float> scales = { ... };
+    ///     int oc_dim = 1; // mb_dim = 0, channel_dim = 1, height_dim = 2, ...
+    ///
+    ///     // construct a convolution descriptor
+    ///     dnnl::convolution::desc conv_d;
+    ///
+    ///     dnnl::primitive_attr attr;
+    ///     attr.set_output_scales(attr, oc, 1 << oc_dim, scales);
+    ///
+    ///     dnnl::primitive_desc conv_pd(conv_d, attr, engine);
+    /// @endcode
+    ///
+    /// @note
+    ///     The order of dimensions does not depend on how elements are laid
+    ///     out in memory. For example:
+    ///     - for a 2D CNN activations tensor the order is always (n, c)
+    ///     - for a 4D CNN activations tensor the order is always (n, c, h, w)
+    ///     - for a 5D CNN weights tensor the order is always
+    ///        (g, oc, ic, kh, kw)
+    ///
+    /// @param mask Defines the correspondence between the output tensor
+    ///     dimensions and the @p scales vector. The set i-th bit indicates
+    ///     that a dedicated scaling factor is used for each index along that
+    ///     dimension. Set the mask to 0 to use a common output scaling factor
+    ///     for the whole output tensor.
+    /// @param scales Constant vector of output scaling factors. If the
+    ///     scaling factors are known at the time of this call, the following
+    ///     equality must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} output.dims[d].\f$
+    ///     Violations can only be detected when the attributes
+    ///     are used to create a primitive descriptor.
+    ///     If the scaling factors are not known at the time of the call,
+    ///     this vector must contain a single #DNNL_RUNTIME_F32_VAL value and
+    ///     the output scaling factors must be passed at execution time as an
+    ///     argument with index #DNNL_ARG_ATTR_OUTPUT_SCALES.
+    void set_output_scales(int mask, const std::vector<float> &scales) {
+        error::wrap_c_api(
+                dnnl_primitive_attr_set_output_scales(
+                        get(), (dnnl_dim_t)scales.size(), mask, scales.data()),
+                "could not set output scales primitive attribute");
+    }
+
+    /// Returns scaling factors correspondence mask and values for a given
+    /// memory argument.
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated scaling
+    ///     factor is used for each index along that dimension. Set the mask to
+    ///     0 to use a common scaling factor for the whole output tensor.
+    /// @param scales Output vector of scaling factors.
+    void get_scales(int arg, int &mask, std::vector<float> &scales) const {
+        dnnl_dim_t count;
+        int c_mask;
+        const float *c_scales;
+        error::wrap_c_api(dnnl_primitive_attr_get_scales(
+                                  get(), arg, &count, &c_mask, &c_scales),
+                "could not get scales primitive attributes");
+        scales.resize(count);
+
+        mask = c_mask;
+        for (dnnl_dim_t c = 0; c < count; ++c)
+            scales[c] = c_scales[c];
+    }
+
+    /// Sets scaling factors for primitive operations for a given memory
+    /// argument.
+    ///
+    /// @sa dnnl_primitive_attr_set_scales
+    /// @sa dnnl::primitive_attr::set_output_scales
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the tensor dimensions and the @p scales
+    ///     vector. The set i-th bit indicates that a dedicated scaling factor
+    ///     is used for each index along that dimension. Set the mask to 0 to
+    ///     use a common scaling factor for the whole output tensor.
+    /// @param scales Constant vector of scaling factors. The following equality
+    ///     must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} argument.dims[d].\f$
+    void set_scales(int arg, int mask, const std::vector<float> &scales) {
+        error::wrap_c_api(
+                dnnl_primitive_attr_set_scales(get(), arg,
+                        (dnnl_dim_t)scales.size(), mask, scales.data()),
+                "could not set scales primitive attribute");
+    }
+
+    /// Returns zero points correspondence mask and values.
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Zero points correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     zero_points vector. The set i-th bit indicates that a dedicated
+    ///     zero point is used for each index along that dimension. Set the
+    ///     mask to 0 to use a common zero point for the whole output tensor.
+    /// @param zero_points Output vector of zero points.
+    void get_zero_points(
+            int arg, int &mask, std::vector<int32_t> &zero_points) const {
+        dnnl_dim_t count;
+        int c_mask;
+        const int32_t *c_zero_points;
+        error::wrap_c_api(dnnl_primitive_attr_get_zero_points(
+                                  get(), arg, &count, &c_mask, &c_zero_points),
+                "could not get zero points primitive attribute");
+        zero_points.resize(count);
+
+        mask = c_mask;
+        for (dnnl_dim_t c = 0; c < count; ++c)
+            zero_points[c] = c_zero_points[c];
+    }
+
+    /// Sets zero points for primitive operations for a given memory argument.
+    ///
+    /// @sa dnnl_primitive_attr_set_zero_points
+    /// @sa dnnl::primitive_attr::set_output_scales
+    ///
+    /// @param arg Parameter argument index as passed to the
+    ///     primitive::execute() call.
+    /// @param mask Zero point correspondence mask that defines the
+    ///     correspondence between the tensor dimensions and the @p
+    ///     zero_points vector. The set i-th bit indicates that a dedicated
+    ///     zero point is used for each index along that dimension. Set the
+    ///     mask to 0 to use a common zero point for the whole output tensor.
+    /// @param zero_points Constant vector of zero points. If the zero points
+    ///     are known at the time of this call, the following equality must
+    ///     hold: \f$zero\_points.size() = \prod\limits_{d \in mask}
+    ///     argument.dims[d].\f$ If the zero points are not known at the time
+    ///     of the call, this vector must contain a single
+    ///     #DNNL_RUNTIME_S32_VAL value and the zero points must be passed at
+    ///     execution time as an argument with index
+    ///     #DNNL_ARG_ATTR_ZERO_POINTS.
+    void set_zero_points(
+            int arg, int mask, const std::vector<int32_t> &zero_points) {
+        error::wrap_c_api(dnnl_primitive_attr_set_zero_points(get(), arg,
+                                  (dnnl_dim_t)zero_points.size(), mask,
+                                  zero_points.data()),
+                "could not set zero points primitive attribute");
+    }
+
+    /// Returns post-ops previously set via set_post_ops().
+    ///
+    /// @returns Post-ops.
+    const post_ops get_post_ops() const {
+        const_dnnl_post_ops_t const_c_post_ops;
+        error::wrap_c_api(
+                dnnl_primitive_attr_get_post_ops(get(), &const_c_post_ops),
+                "could not get post-ops primitive attribute");
+        dnnl_post_ops_t c_post_ops;
+        error::wrap_c_api(dnnl_post_ops_clone(&c_post_ops, const_c_post_ops),
+                "could not clone post-ops primitive attribute");
+        return post_ops(c_post_ops);
+    }
+
+    /// Sets post-ops.
+    ///
+    /// @note
+    ///     There is no way to check whether the post-ops would be supported
+    ///     by the target primitive. Any error will be reported
+    ///     by the respective primitive descriptor constructor.
+    ///
+    /// @param ops Post-ops object to copy post-ops from.
+    void set_post_ops(const post_ops ops) {
+        error::wrap_c_api(dnnl_primitive_attr_set_post_ops(get(), ops.get()),
+                "could not set post-ops primitive attribute");
+    }
+
+    /// Sets quantization scale and shift parameters for RNN data tensors.
+    ///
+    /// For performance reasons, the low-precision configuration of the RNN
+    /// primitives expect input activations to have the unsigned 8-bit integer
+    /// data type. The scale and shift parameters are used to quantize
+    /// floating-point data to unsigned integer and must be passed to the RNN
+    /// primitive using attributes.
+    ///
+    /// The quantization formula is `scale * data + shift`.
+    ///
+    /// Example usage:
+    /// @code
+    ///     // RNN parameters
+    ///     int l = 2, t = 2, mb = 32, sic = 32, slc = 32, dic = 32, dlc = 32;
+    ///     // Activations quantization parameters
+    ///     float scale = 63.f, shift = 64.f;
+    ///
+    ///     primitive_attr attr;
+    ///
+    ///     // Set scale and shift for int8 quantization of activation
+    ///     attr.set_rnn_data_qparams(scale, shift);
+    ///
+    ///     // Create and configure rnn op_desc
+    ///     vanilla_rnn_forward::desc rnn_d(/* arguments */);
+    ///     vanilla_rnn_forward::primitive_desc rnn_d(rnn_d, attr, engine);
+    /// @endcode
+    ///
+    /// @note
+    ///     Quantization scale and shift are common for src_layer, src_iter,
+    ///     dst_iter, and dst_layer.
+    ///
+    /// @param scale The value to scale the data by.
+    /// @param shift The value to shift the data by.
+    void set_rnn_data_qparams(float scale, float shift) {
+        error::wrap_c_api(
+                dnnl_primitive_attr_set_rnn_data_qparams(get(), scale, shift),
+                "could not set RNN data quantization parameters primitive "
+                "attribute");
+    }
+
+    /// Returns the quantization scale and shift parameters for RNN data
+    /// tensors.
+    ///
+    /// @note
+    ///     Quantization scale and shift are common for src_layer, src_iter,
+    ///     dst_iter, and dst_layer.
+    ///
+    /// @param scale The value to scale the data by.
+    /// @param shift The value to shift the data by.
+    void get_rnn_data_qparams(float &scale, float &shift) {
+        float c_scale, c_shift;
+        error::wrap_c_api(dnnl_primitive_attr_get_rnn_data_qparams(
+                                  get(), &c_scale, &c_shift),
+                "could not set RNN data quantization parameters primitive "
+                "attribute");
+        scale = c_scale;
+        shift = c_shift;
+    }
+
+    /// Sets quantization scaling factors for RNN weights tensors. The
+    /// low-precision configuration of the RNN primitives expect input weights
+    /// to use the signed 8-bit integer data type. The scaling factors are
+    /// used to quantize floating-point data to signed integer and must be
+    /// passed to RNN primitives using attributes.
+    ///
+    /// @note
+    ///     The dimension order is always native and does not depend on the
+    ///     actual layout used. For example, five-dimensional weights always
+    ///     have (l, d, i, g, o) logical dimension ordering.
+    ///
+    /// @note
+    ///     Quantization scales are common for weights_layer and
+    ///     weights_iteration
+    ///
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated scaling
+    ///     factor should be used each index along that dimension. Set the
+    ///     mask to 0 to use a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Constant vector of output scaling factors. The following
+    ///     equality must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} weights.dims[d].\f$
+    ///     Violations can only be detected when the attributes are used to
+    ///     create a primitive descriptor.
+    void set_rnn_weights_qparams(int mask, const std::vector<float> &scales) {
+        error::wrap_c_api(dnnl_primitive_attr_set_rnn_weights_qparams(get(),
+                                  (int)scales.size(), mask, scales.data()),
+                "could not set RNN weights quantization parameters primitive "
+                "attribute");
+    }
+
+    /// Returns the quantization scaling factors for RNN projection weights
+    /// tensors.
+    ///
+    /// @note
+    ///     The dimension order is always native and does not depend on the
+    ///     actual layout used. For example, five-dimensional weights always
+    ///     have (l, d, i, g, o) logical dimension ordering.
+    ///
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated scaling
+    ///     factor should be used each index along that dimension. Set the
+    ///     mask to 0 to use a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Constant vector of output scaling factors. The following
+    ///     equality must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} weights.dims[d].\f$
+    ///     Violations can only be detected when the attributes are used to
+    ///     create a primitive descriptor.
+    void get_rnn_weights_qparams(int &mask, std::vector<float> &scales) {
+        dnnl_dim_t count;
+        int c_mask;
+        const float *c_scales;
+        error::wrap_c_api(dnnl_primitive_attr_get_rnn_weights_qparams(
+                                  get(), &count, &c_mask, &c_scales),
+                "could not get primitive RNN weights quantization "
+                "parameters attributes");
+        scales.resize(count);
+
+        mask = c_mask;
+        for (dnnl_dim_t c = 0; c < count; c++)
+            scales[c] = c_scales[c];
+    }
+
+    /// Sets quantization scaling factors for RNN projection weights tensors.
+    //  The low-precision configuration of the RNN primitives expect input
+    //  weights to use the signed 8-bit integer data type. The scaling factors
+    //  are used to quantize floating-point data to signed integer and must be
+    /// passed to RNN primitives using attributes.
+    ///
+    /// @note
+    ///     The dimension order is always native and does not depend on the
+    ///     actual layout used. For example, five-dimensional weights always
+    ///     have (l, d, i, g, o) logical dimension ordering.
+    ///
+    /// @note
+    ///     Quantization scales are common for weights_layer and
+    ///     weights_iteration
+    ///
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated scaling
+    ///     factor should be used each index along that dimension. Set the
+    ///     mask to 0 to use a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Constant vector of output scaling factors. The following
+    ///     equality must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} weights.dims[d].\f$
+    ///     Violations can only be detected when the attributes are used to
+    ///     create a primitive descriptor.
+    void set_rnn_weights_projection_qparams(
+            int mask, const std::vector<float> &scales) {
+        error::wrap_c_api(
+                dnnl_primitive_attr_set_rnn_weights_projection_qparams(
+                        get(), (int)scales.size(), mask, scales.data()),
+                "could not set primitive RNN weights projection quantization "
+                "parameters attributes");
+    }
+
+    /// Returns the quantization scaling factors for RNN projection weights
+    /// tensors.
+    ///
+    /// @note
+    ///     The dimension order is always native and does not depend on the
+    ///     actual layout used. For example, five-dimensional weights always
+    ///     have (l, d, i, g, o) logical dimension ordering.
+    ///
+    /// @param mask Scaling factors correspondence mask that defines the
+    ///     correspondence between the output tensor dimensions and the @p
+    ///     scales vector. The set i-th bit indicates that a dedicated scaling
+    ///     factor should be used each index along that dimension. Set the
+    ///     mask to 0 to use a common scaling factor for the whole output
+    ///     tensor.
+    /// @param scales Constant vector of output scaling factors. The following
+    ///     equality must hold:
+    ///     \f$scales.size() = \prod\limits_{d \in mask} weights.dims[d].\f$
+    ///     Violations can only be detected when the attributes are used to
+    ///     create a primitive descriptor.
+    void get_rnn_weights_projection_qparams(
+            int &mask, std::vector<float> &scales) {
+        dnnl_dim_t count;
+        int c_mask;
+        const float *c_scales;
+        error::wrap_c_api(
+                dnnl_primitive_attr_get_rnn_weights_projection_qparams(
+                        get(), &count, &c_mask, &c_scales),
+                "could not get primitive RNN weights projection quantization "
+                "parameters attributes");
+        scales.resize(count);
+
+        mask = c_mask;
+        for (dnnl_dim_t c = 0; c < count; c++)
+            scales[c] = c_scales[c];
+    }
+};
+
+/// @} dnnl_api_attributes
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// Base class for all primitive descriptors.
+struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
+    using handle<dnnl_primitive_desc_t>::handle;
+
+    /// Default constructor. Produces an empty object.
+    primitive_desc_base() = default;
+
+    /// Returns the engine of the primitive descriptor.
+    /// @returns The engine of the primitive descriptor.
+    engine get_engine() const { return engine::query(*this); }
+
+    /// Returns implementation name.
+    /// @returns The implementation name.
+    const char *impl_info_str() const {
+        const char *res;
+        error::wrap_c_api(dnnl_primitive_desc_query(
+                                  get(), dnnl_query_impl_info_str, 0, &res),
+                "could not retrieve implementation info string from a "
+                "primitive descriptor");
+        return res;
+    }
+
+    /// Returns a memory::dim value (same as int64_t).
+    /// @param what The value to query.
+    /// @returns The result of the query.
+    memory::dim query_s64(query what) const {
+        memory::dim res;
+        dnnl_status_t status = dnnl_primitive_desc_query(
+                get(), dnnl::convert_to_c(what), 0, &res);
+        return status == dnnl_success ? res : 0;
+    }
+
+    /// Returns a memory descriptor.
+    ///
+    /// @note
+    ///     There are also convenience methods
+    ///     #dnnl::primitive_desc_base::src_desc(),
+    ///     #dnnl::primitive_desc_base::dst_desc(), and others.
+    ///
+    /// @param what The kind of parameter to query; can be
+    ///     #dnnl::query::src_md, #dnnl::query::dst_md, etc.
+    /// @param idx Index of the parameter. For example, convolution bias can
+    ///     be queried with what = #dnnl::query::weights_md and idx = 1.
+    /// @returns The requested memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     parameter of the specified kind or index.
+    memory::desc query_md(query what, int idx = 0) const {
+        std::vector<query> valid_q {query::src_md, query::diff_src_md,
+                query::weights_md, query::diff_weights_md, query::dst_md,
+                query::diff_dst_md, query::workspace_md, query::scratchpad_md,
+                query::exec_arg_md};
+        if (!std::any_of(valid_q.cbegin(), valid_q.cend(),
+                    [=](query q) { return what == q; }))
+            DNNL_THROW_ERROR(dnnl_invalid_arguments,
+                    "memory descriptor query is invalid");
+
+        const dnnl_memory_desc_t *cdesc = dnnl_primitive_desc_query_md(
+                get(), dnnl::convert_to_c(what), idx);
+        return cdesc ? memory::desc(*cdesc) : memory::desc();
+    }
+
+    /// Returns a source memory descriptor.
+    /// @param idx Source index.
+    /// @returns Source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     source parameter with index @p idx.
+    memory::desc src_desc(int idx) const {
+        return query_md(query::src_md, idx);
+    }
+
+    /// Returns a destination memory descriptor.
+    /// @param idx Destination index.
+    /// @returns Destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     destination parameter with index @p idx.
+    memory::desc dst_desc(int idx) const {
+        return query_md(query::dst_md, idx);
+    }
+
+    /// Returns a weights memory descriptor.
+    /// @param idx Weights index.
+    /// @returns Weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     weights parameter with index @p idx.
+    memory::desc weights_desc(int idx) const {
+        return query_md(query::weights_md, idx);
+    }
+
+    /// Returns a diff source memory descriptor.
+    /// @param idx Diff source index.
+    /// @returns Diff source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff source parameter with index @p idx.
+    memory::desc diff_src_desc(int idx) const {
+        return query_md(query::diff_src_md, idx);
+    }
+
+    /// Returns a diff destination memory descriptor.
+    /// @param idx Diff destination index.
+    /// @returns Diff destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff destination parameter with index @p idx.
+    memory::desc diff_dst_desc(int idx) const {
+        return query_md(query::diff_dst_md, idx);
+    }
+
+    /// Returns a diff weights memory descriptor.
+    /// @param idx Diff weights index.
+    /// @returns Diff weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff weights parameter with index @p idx.
+    memory::desc diff_weights_desc(int idx) const {
+        return query_md(query::diff_weights_md, idx);
+    }
+
+    // Separate versions without the index argument for documentation
+    // purposes.
+
+    /// Returns a source memory descriptor.
+    /// @returns Source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     source parameter.
+    memory::desc src_desc() const { return src_desc(0); }
+
+    /// Returns a destination memory descriptor.
+    /// @returns Destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     destination parameter.
+    memory::desc dst_desc() const { return dst_desc(0); }
+
+    /// Returns a weights memory descriptor.
+    /// @returns Weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     weights parameter.
+    memory::desc weights_desc() const { return weights_desc(0); }
+
+    /// Returns a diff source memory descriptor.
+    /// @returns Diff source memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff source memory with.
+    memory::desc diff_src_desc() const { return diff_src_desc(0); }
+
+    /// Returns a diff destination memory descriptor.
+    /// @returns Diff destination memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff destination parameter.
+    memory::desc diff_dst_desc() const { return diff_dst_desc(0); }
+
+    /// Returns a diff weights memory descriptor.
+    /// @returns Diff weights memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///     diff weights parameter.
+    memory::desc diff_weights_desc() const { return diff_weights_desc(0); }
+
+    /// Returns the workspace memory descriptor.
+    /// @returns Workspace memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not require
+    ///     workspace parameter.
+    memory::desc workspace_desc() const {
+        return query_md(query::workspace_md, 0);
+    }
+
+    /// Returns the scratchpad memory descriptor.
+    /// @returns scratchpad memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not require
+    ///     scratchpad parameter.
+    /// @sa @ref dev_guide_attributes_scratchpad
+    memory::desc scratchpad_desc() const {
+        return query_md(query::scratchpad_md, 0);
+    }
+
+    /// Returns the engine on which the scratchpad memory is located.
+    /// @returns The engine on which the scratchpad memory is located.
+    engine scratchpad_engine() const {
+        dnnl_engine_t c_engine;
+        error::wrap_c_api(dnnl_primitive_desc_query(get(),
+                                  dnnl::convert_to_c(query::scratchpad_engine),
+                                  0, &c_engine),
+                "could not retrieve scratchpad engine from a primitive "
+                "descriptor");
+        return engine(c_engine, true);
+    }
+
+    /// Returns the primitive attributes.
+    /// @returns The primitive attributes.
+    primitive_attr get_primitive_attr() const {
+        const_dnnl_primitive_attr_t const_c_attr;
+        error::wrap_c_api(dnnl_primitive_desc_get_attr(get(), &const_c_attr),
+                "could not get attributes from a primitive descriptor");
+        dnnl_primitive_attr_t c_attr;
+        error::wrap_c_api(dnnl_primitive_attr_clone(&c_attr, const_c_attr),
+                "could not clone primitive attributes");
+        return primitive_attr(c_attr);
+    }
+
+    /// Returns the kind of the primitive descriptor.
+    /// @returns The kind of the primitive descriptor.
+    dnnl::primitive::kind get_kind() const {
+        dnnl_primitive_kind_t kind;
+        error::wrap_c_api(dnnl_primitive_desc_query(get(),
+                                  dnnl_query_primitive_kind, 0, (void *)&kind),
+                "could not get primitive kind from a primitive descriptor");
+        return static_cast<dnnl::primitive::kind>(kind);
+    }
+
+    /// Returns the cache blob ID of the primitive descriptor.
+    /// @returns The cache blob ID of the primitive descriptor.
+    std::vector<uint8_t> get_cache_blob_id() const {
+        dnnl_dim_t count;
+        const uint8_t *c_id;
+        error::wrap_c_api(
+                dnnl_primitive_desc_query(get(),
+                        dnnl::convert_to_c(query::cache_blob_id_size_s64), 0,
+                        (void *)&count),
+                "could not get size of cache blob ID from a primitive "
+                "descriptor");
+        error::wrap_c_api(dnnl_primitive_desc_query(get(),
+                                  dnnl::convert_to_c(query::cache_blob_id), 0,
+                                  (void **)&c_id),
+                "could not get cache blob ID from a primitive descriptor");
+        std::vector<uint8_t> id(c_id, c_id + count);
+        return id;
+    }
+
+protected:
+    /// Resets the value of the handle to a clone of a C API primitive
+    /// descriptor.
+    /// @param pd A C API primitive descriptor to clone.
+    void reset_with_clone(const_dnnl_primitive_desc_t pd) {
+        dnnl_primitive_desc_t new_pd;
+        error::wrap_c_api(dnnl_primitive_desc_clone(&new_pd, pd),
+                "could not clone a primitive descriptor");
+        reset(new_pd);
+    }
+
+    /// Constructs a primitive descriptor base object from a clone of a C API
+    /// primitive descriptor after verifying that it is what the caller
+    /// expects.
+    ///
+    /// @note
+    ///     The @p prim_kind should map to a primitive that does not have
+    ///     different values of propagation kind (e.g. #dnnl::binary).
+    /// @note
+    ///     Primitive descriptor base constructed this way does not support
+    ///     next_impl() (will throw).
+    ///
+    /// @param pd C API primitive descriptor to clone.
+    /// @param prim_kind Expected primitive kind.
+    primitive_desc_base(
+            dnnl_primitive_desc_t pd, dnnl::primitive::kind prim_kind)
+        : primitive_desc_base(pd, prim_kind, dnnl::prop_kind::undef) {}
+
+    /// Constructs a primitive descriptor base object from a clone of a C API
+    /// primitive descriptor after verifying that it is what the caller
+    /// expects.
+    ///
+    /// @note
+    ///     Primitive descriptor base constructed this way does not support
+    ///     next_impl() (will throw).
+    ///
+    /// @param pd C API primitive descriptor to clone.
+    /// @param prim_kind Expected primitive kind.
+    /// @param aprop_kind Expected propagation kind.
+    primitive_desc_base(dnnl_primitive_desc_t pd,
+            dnnl::primitive::kind prim_kind, dnnl::prop_kind aprop_kind)
+        : primitive_desc_base(pd, prim_kind, aprop_kind, aprop_kind) {}
+
+    /// Constructs a primitive descriptor base object from a clone of a C API
+    /// primitive descriptor after verifying that it is what the caller
+    /// expects.
+    ///
+    /// @note
+    ///     Primitive descriptor base constructed this way does not support
+    ///     next_impl() (will throw).
+    ///
+    /// @param pd C API primitive descriptor to clone.
+    /// @param prim_kind Expected primitive kind.
+    /// @param prop_kind1 Expected propagation kind (option 1).
+    /// @param prop_kind2 Expected propagation kind (option 2). This value is
+    ///     checked if the check with @p prop_kind1 fails.
+    primitive_desc_base(dnnl_primitive_desc_t pd,
+            dnnl::primitive::kind prim_kind, dnnl::prop_kind prop_kind1,
+            dnnl::prop_kind prop_kind2) {
+        // It is OK to pass an empty primitive descriptor
+        if (pd == nullptr) return;
+
+        dnnl_status_t rc;
+
+        dnnl_primitive_kind_t c_prim_kind = convert_to_c(prim_kind);
+        dnnl_prop_kind_t c_prop_kind1 = convert_to_c(prop_kind1);
+        dnnl_prop_kind_t c_prop_kind2 = convert_to_c(prop_kind2);
+
+        // Check that primitive kind matches
+        dnnl_primitive_kind_t pd_kind;
+        rc = dnnl_primitive_desc_query(
+                pd, dnnl_query_primitive_kind, 0, (void *)&pd_kind);
+        error::wrap_c_api(
+                rc, "could not get primitive kind from a primitive descriptor");
+        if (pd_kind != c_prim_kind)
+            DNNL_THROW_ERROR(dnnl_invalid_arguments,
+                    "primitive descriptor operation kind mismatch");
+
+        // Check that propagation kind matches
+        dnnl_prop_kind_t pd_prop_kind;
+        rc = dnnl_primitive_desc_query(
+                pd, dnnl_query_prop_kind, 0, (void *)&pd_prop_kind);
+
+        // Something went wrong
+        if (rc != dnnl_success && rc != dnnl_unimplemented)
+            DNNL_THROW_ERROR(dnnl_invalid_arguments,
+                    "could not get propagation kind from the primitive "
+                    "descriptor");
+
+        // Everything is fine
+        if ((rc == dnnl_unimplemented && c_prop_kind1 == dnnl_prop_kind_undef)
+                || (rc == dnnl_success
+                        && (pd_prop_kind == c_prop_kind1
+                                || pd_prop_kind == c_prop_kind2))) {
+            reset_with_clone(pd);
+            return;
+        }
+
+        // We could get the propagation kind but there is a mismatch
+        DNNL_THROW_ERROR(dnnl_invalid_arguments,
+                "primitive descriptor propagation kind mismatch");
+    }
+
+    using base = primitive_desc_base;
+};
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_reorder Reorder
+///
+/// A primitive to copy data between two memory objects. This primitive is
+/// typically used to change the way the data is laid out in memory.
+///
+/// @sa @ref dev_guide_reorder in developer guide
+///
+/// @{
+
+/// Reorder primitive.
+struct reorder : public primitive {
+    /// Primitive descriptor for a reorder primitive.
+    struct primitive_desc : public primitive_desc_base {
+        using primitive_desc_base::primitive_desc_base;
+
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for reorder primitive.
+        ///
+        /// @note
+        ///     If @p allow_empty is true, the constructor does not throw if a
+        ///     primitive descriptor cannot be created.
+        ///
+        /// @param src_engine Engine on which the source memory object will be
+        ///     located.
+        /// @param src_md Source memory descriptor.
+        /// @param dst_engine Engine on which the destination memory object
+        ///     will be located.
+        /// @param dst_md Destination memory descriptor.
+        /// @param attr Primitive attributes to use (optional).
+        /// @param allow_empty A flag signifying whether construction is allowed
+        ///     to fail without throwing an exception. In this case an empty
+        ///     object will be produced. This flag is optional and defaults to
+        ///     false.
+        primitive_desc(const engine &src_engine, const memory::desc &src_md,
+                const engine &dst_engine, const memory::desc &dst_md,
+                const primitive_attr &attr = primitive_attr(),
+                bool allow_empty = false) {
+            dnnl_primitive_desc_t result;
+            dnnl_status_t status = dnnl_reorder_primitive_desc_create(&result,
+                    &src_md.data, src_engine.get(), &dst_md.data,
+                    dst_engine.get(), attr.get());
+            if (!allow_empty)
+                error::wrap_c_api(status,
+                        "could not create a primitive descriptor for a reorder "
+                        "primitive");
+            reset(status == dnnl_success ? result : dnnl_primitive_desc_t());
+        }
+
+        /// Constructs a primitive descriptor for reorder primitive.
+        ///
+        /// @param src Source memory object. It is used to obtain the source
+        ///     memory descriptor and engine.
+        /// @param dst Destination memory object. It is used to obtain the
+        ///     destination memory descriptor and engine.
+        /// @param attr Primitive attributes to use (optional).
+        /// @param allow_empty A flag signifying whether construction is allowed
+        ///     to fail without throwing an exception. In this case an empty
+        ///     object will be produced. This flag is optional and defaults to
+        ///     false.
+        primitive_desc(const memory &src, const memory &dst,
+                const primitive_attr &attr = primitive_attr(),
+                bool allow_empty = false) {
+            dnnl_primitive_desc_t result;
+            auto src_md = src.get_desc();
+            auto dst_md = dst.get_desc();
+            dnnl_status_t status = dnnl_reorder_primitive_desc_create(&result,
+                    &src_md.data, src.get_engine().get(), &dst_md.data,
+                    dst.get_engine().get(), attr.get());
+            if (!allow_empty)
+                error::wrap_c_api(status,
+                        "could not create a primitive descriptor for a reorder "
+                        "primitive");
+            reset(status == dnnl_success ? result : dnnl_primitive_desc_t());
+        }
+
+        /// Constructs a primitive descriptor for reorder primitive from a C
+        /// API primitive descriptor which must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for reorder primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : primitive_desc_base(pd, dnnl::primitive::kind::reorder) {}
+
+        /// Returns the engine on which the source memory is allocated.
+        /// @returns The engine on which the source memory is allocated.
+        engine get_src_engine() const {
+            return engine::query(*this, dnnl::query::reorder_src_engine);
+        }
+
+        /// Returns the engine on which the destination memory is allocated.
+        /// @returns The engine on which the destination memory is allocated.
+        engine get_dst_engine() const {
+            return engine::query(*this, dnnl::query::reorder_dst_engine);
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    reorder() = default;
+
+    /// Constructs a reorder primitive.
+    /// @param pd Primitive descriptor for reorder primitive.
+    reorder(const primitive_desc &pd) : primitive(pd.get()) {}
+
+    /// Constructs a reorder primitive from a cache blob.
+    /// @param pd Primitive descriptor for reorder primitive.
+    /// @param cache_blob Cache blob.
+    reorder(const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd.get(), cache_blob) {}
+
+    /// Constructs a reorder primitive that would reorder data between memory
+    /// objects having the same memory descriptors as memory objects @p src and
+    /// @p dst.
+    ///
+    /// @param src Source memory object.
+    /// @param dst Destination memory object.
+    /// @param attr Primitive attributes to use (optional).
+    reorder(const memory &src, const memory &dst,
+            const primitive_attr &attr = primitive_attr())
+        : primitive(primitive_desc(src, dst, attr).get()) {}
+
+    using primitive::execute;
+
+    /// Executes the reorder primitive.
+    ///
+    /// @param astream Stream object. The stream must belong to the same engine
+    ///     as the primitive.
+    /// @param src Source memory object.
+    /// @param dst Destination memory object.
+    void execute(const stream &astream, memory &src, memory &dst) const {
+        primitive::execute(astream, {{DNNL_ARG_FROM, src}, {DNNL_ARG_TO, dst}});
+    }
+};
+
+/// @} dnnl_api_reorder
+
+/// @addtogroup dnnl_api_concat Concat
+///
+/// A primitive to concatenate data by arbitrary dimension.
+///
+/// @sa @ref dev_guide_concat in developer guide
+///
+/// @{
+
+/// @cond DO_NOT_DOCUMENT_THIS
+inline std::vector<dnnl_memory_desc_t> convert_to_c(
+        const std::vector<memory::desc> &mems) {
+    std::vector<dnnl_memory_desc_t> c_mems;
+    c_mems.reserve(mems.size());
+    for (const auto &s : mems)
+        c_mems.push_back(s.data);
+    return c_mems;
+}
+/// @endcond
+
+/// Tensor concatenation (concat) primitive.
+struct concat : public primitive {
+    /// Primitive descriptor for a concat primitive.
+    struct primitive_desc : public primitive_desc_base {
+        using primitive_desc_base::primitive_desc_base;
+
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an out-of-place concatenation
+        /// primitive.
+        ///
+        /// @param dst Destination memory descriptor.
+        /// @param concat_dimension Source tensors will be concatenated over
+        ///     dimension with this index. Note that order of dimensions does
+        ///     not depend on memory format.
+        /// @param srcs Vector of source memory descriptors.
+        /// @param aengine Engine to perform the operation on.
+        /// @param attr Primitive attributes to use (optional).
+        primitive_desc(const memory::desc &dst, int concat_dimension,
+                const std::vector<memory::desc> &srcs, const engine &aengine,
+                const primitive_attr &attr = primitive_attr()) {
+            auto c_srcs = convert_to_c(srcs);
+
+            dnnl_primitive_desc_t result;
+            error::wrap_c_api(
+                    dnnl_concat_primitive_desc_create(&result, &dst.data,
+                            (int)c_srcs.size(), concat_dimension, c_srcs.data(),
+                            attr.get(), aengine.get()),
+                    "could not create a primitive descriptor for a concat "
+                    "primitive");
+            reset(result);
+        }
+
+        /// Constructs a primitive descriptor for an out-of-place concatenation
+        /// primitive.
+        ///
+        /// This version derives the destination memory descriptor
+        /// automatically.
+        ///
+        /// @param concat_dimension Source tensors will be concatenated over
+        ///     dimension with this index. Note that order of dimensions does
+        ///     not depend on memory format.
+        /// @param srcs Vector of source memory descriptors.
+        /// @param aengine Engine to perform the operation on.
+        /// @param attr Primitive attributes to use (optional).
+        primitive_desc(int concat_dimension,
+                const std::vector<memory::desc> &srcs, const engine &aengine,
+                const primitive_attr &attr = primitive_attr()) {
+            auto c_api_srcs = convert_to_c(srcs);
+
+            dnnl_primitive_desc_t result;
+            error::wrap_c_api(
+                    dnnl_concat_primitive_desc_create(&result, nullptr,
+                            (int)c_api_srcs.size(), concat_dimension,
+                            c_api_srcs.data(), attr.get(), aengine.get()),
+                    "could not create a primitive descriptor for a concat "
+                    "primitive");
+            reset(result);
+        }
+
+        /// Constructs a primitive descriptor for concat primitive from a C
+        /// API primitive descriptor which must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for concat primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : primitive_desc_base(pd, dnnl::primitive::kind::concat) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
+        memory::desc src_desc(int idx = 0) const { return base::src_desc(idx); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    concat() = default;
+
+    /// Constructs a concatenation primitive.
+    /// @param pd Primitive descriptor for concatenation primitive.
+    concat(const primitive_desc &pd) : primitive(pd.get()) {}
+
+    /// Constructs a concatenation primitive from a cache blob.
+    /// @param pd Primitive descriptor for concatenation primitive.
+    /// @param cache_blob Cache blob.
+    concat(const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd.get(), cache_blob) {}
+};
+
+/// @} dnnl_api_concat
+
+/// @addtogroup dnnl_api_sum Sum
+///
+/// A primitive to sum multiple tensors.
+///
+/// @sa @ref dev_guide_sum in developer guide
+///
+/// @{
+
+/// Out-of-place summation (sum) primitive.
+struct sum : public primitive {
+    /// Primitive descriptor for a sum primitive.
+    struct primitive_desc : public primitive_desc_base {
+        using primitive_desc_base::primitive_desc_base;
+
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a sum primitive.
+        ///
+        /// @param dst Destination memory descriptor.
+        /// @param scales Vector of scales to multiply data in each source
+        ///     memory by.
+        /// @param srcs Vector of source memory descriptors.
+        /// @param aengine Engine to perform the operation on.
+        /// @param attr Primitive attributes to use (optional).
+        primitive_desc(const memory::desc &dst,
+                const std::vector<float> &scales,
+                const std::vector<memory::desc> &srcs, const engine &aengine,
+                const primitive_attr &attr = primitive_attr()) {
+            validate_container_size(scales,
+                    "counts of scales and sources are not equal",
+                    (int)srcs.size(), (int)srcs.size());
+
+            auto c_api_srcs = convert_to_c(srcs);
+
+            dnnl_primitive_desc_t result;
+            error::wrap_c_api(
+                    dnnl_sum_primitive_desc_create(&result, &dst.data,
+                            (int)c_api_srcs.size(), scales.data(),
+                            c_api_srcs.data(), attr.get(), aengine.get()),
+                    "could not create a primitive descriptor for a sum "
+                    "primitive");
+            reset(result);
+        }
+
+        /// Constructs a primitive descriptor for a sum primitive.
+        ///
+        /// This version derives the destination memory descriptor
+        /// automatically.
+        ///
+        /// @param scales Vector of scales by which to multiply data in each
+        ///     source memory object.
+        /// @param srcs Vector of source memory descriptors.
+        /// @param aengine Engine on which to perform the operation.
+        /// @param attr Primitive attributes to use (optional).
+        primitive_desc(const std::vector<float> &scales,
+                const std::vector<memory::desc> &srcs, const engine &aengine,
+                const primitive_attr &attr = primitive_attr()) {
+            validate_container_size(scales,
+                    "counts of scales and sources are not equal",
+                    (int)srcs.size(), (int)srcs.size());
+
+            auto c_api_srcs = convert_to_c(srcs);
+            dnnl_primitive_desc_t result;
+            error::wrap_c_api(
+                    dnnl_sum_primitive_desc_create(&result, nullptr,
+                            (int)c_api_srcs.size(), scales.data(),
+                            c_api_srcs.data(), attr.get(), aengine.get()),
+                    "could not create a primitive descriptor for a sum "
+                    "primitive");
+            reset(result);
+        }
+
+        /// Constructs a primitive descriptor for sum primitive from a C API
+        /// primitive descriptor which must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for reorder primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : primitive_desc_base(pd, dnnl::primitive::kind::sum) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
+        memory::desc src_desc(int idx = 0) const { return base::src_desc(idx); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    sum() = default;
+
+    /// Constructs a sum primitive.
+    /// @param pd Primitive descriptor for sum primitive.
+    sum(const primitive_desc &pd) : primitive(pd.get()) {}
+
+    /// Constructs a sum primitive from a cache blob.
+    /// @param pd Primitive descriptor for sum primitive.
+    /// @param cache_blob Cache blob.
+    sum(const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd.get(), cache_blob) {}
+};
+
+/// @} dnnl_api_sum
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// A base class for descriptors of all primitives that have an operation
+/// descriptor and that support iteration over multiple implementations.
+struct primitive_desc : public primitive_desc_base {
+    using primitive_desc_base::primitive_desc_base;
+
+    primitive_desc() = default;
+
+    /// Constructs a primitive descriptor.
+    ///
+    /// @note
+    ///     If @p allow_empty is true, the constructor does not throw if a
+    ///     primitive descriptor cannot be created. But calling next_impl() in
+    ///     this case will throw.
+    ///
+    /// @note
+    ///     This is a low-level implementation detail that is typically not
+    ///     needed in application code.
+    ///
+    /// @param desc Constant C API operation descriptor.
+    /// @param attr Pointer to primitive attributes. It is safe to pass
+    ///     nullptr to indicate absence of attributes.
+    /// @param aengine Engine to use.
+    /// @param hint_fwd_pd C API primitive descriptor for a forward
+    ///     propagation primitive. It is used as a hint for deciding which
+    ///     memory format to use for backward propagation or weights gradient.
+    /// @param allow_empty A flag signifying whether construction is allowed
+    ///     to fail without throwing an exception. In this case an empty
+    ///     object will be produced. This flag is optional and defaults to
+    ///     false.
+    primitive_desc(const_dnnl_op_desc_t desc, const primitive_attr *attr,
+            const engine &aengine, const_dnnl_primitive_desc_t hint_fwd_pd,
+            bool allow_empty = false)
+        : allow_empty_(allow_empty) {
+        dnnl_primitive_desc_iterator_t iterator = nullptr;
+        dnnl_status_t status = dnnl_primitive_desc_iterator_create(&iterator,
+                desc, attr ? attr->get() : nullptr, aengine.get(), hint_fwd_pd);
+        if (!allow_empty)
+            error::wrap_c_api(
+                    status, "could not create a primitive descriptor");
+        pd_iterator.reset(iterator);
+        fetch_impl();
+    }
+
+    /// Advances the primitive iterator to the next implementation.
+    ///
+    /// @returns @c true on success, and @c false if the last implementation
+    ///     reached, and the primitive descriptor itself is kept unchanged
+    bool next_impl() {
+        dnnl_status_t status
+                = dnnl_primitive_desc_iterator_next(pd_iterator.get());
+        if (status == dnnl_iterator_ends) return false;
+        error::wrap_c_api(
+                status, "could not advance a primitive descriptor iterator");
+        fetch_impl();
+        return true;
+    }
+
+private:
+    bool allow_empty_ = false;
+    handle<dnnl_primitive_desc_iterator_t> pd_iterator;
+    void fetch_impl() {
+        dnnl_primitive_desc_t pd = dnnl_primitive_desc_iterator_fetch(
+                pd_iterator.get(allow_empty_));
+        error::wrap_c_api(pd != nullptr || allow_empty_ ? dnnl_success
+                                                        : dnnl_out_of_memory,
+                "could not fetch a primitive descriptor from a primitive "
+                "descriptor iterator");
+        reset(pd);
+    }
+};
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_convolution Convolution
+///
+/// A primitive to perform 1D, 2D or 3D convolution. Supported variants are
+/// forward propagation, backward propagation, and weights gradient with or
+/// without bias.
+///
+/// @sa @ref dev_guide_convolution in developer guide
+///
+/// @{
+
+/// Convolution forward propagation primitive.
+struct convolution_forward : public primitive {
+    /// Descriptor for a convolution forward propagation primitive.
+    struct desc {
+        dnnl_convolution_desc_t data;
+
+        /// Constructs a descriptor for a convolution forward propagation
+        /// primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &bias_desc, const memory::desc &dst_desc,
+                const memory::dims &strides, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_convolution_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &weights_desc.data, &bias_desc.data, &dst_desc.data,
+                            &strides[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a convolution forward "
+                    "propagation primitive");
+        }
+
+        /// Constructs a descriptor for a convolution forward propagation
+        /// primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_convolution_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &weights_desc.data, nullptr, &dst_desc.data,
+                            &strides[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a convolution forward "
+                    "propagation primitive");
+        }
+
+        /// Constructs a descriptor for a dilated convolution forward
+        /// propagation primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &bias_desc, const memory::desc &dst_desc,
+                const memory::dims &strides, const memory::dims &dilates,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_dilated_convolution_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), &src_desc.data,
+                                      &weights_desc.data, &bias_desc.data,
+                                      &dst_desc.data, &strides[0], &dilates[0],
+                                      &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated convolution "
+                    "forward propagation primitive");
+        }
+
+        /// Constructs a descriptor for a dilated convolution forward
+        /// propagation primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_dilated_convolution_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), &src_desc.data,
+                                      &weights_desc.data, nullptr,
+                                      &dst_desc.data, &strides[0], &dilates[0],
+                                      &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated convolution "
+                    "forward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a convolution forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a convolution forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a convolution forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a convolution forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a convolution forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a convolution forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a convolution forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::convolution,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// Returns the bias memory descriptor.
+        /// @returns The bias memory descriptor.
+        /// @returns A zero memory descriptor of the primitive does not have a
+        ///     bias parameter.
+        memory::desc bias_desc() const { return base::weights_desc(1); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    convolution_forward() = default;
+
+    /// Constructs a convolution forward propagation primitive.
+    /// @param pd Primitive descriptor for a convolution forward propagation
+    ///     primitive.
+    convolution_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a convolution forward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a convolution forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    convolution_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Convolution backward propagation primitive.
+struct convolution_backward_data : public primitive {
+
+    /// Descriptor for a convolution backward propagation primitive.
+    struct desc {
+        dnnl_convolution_desc_t data;
+
+        /// Constructs a descriptor for a convolution backward propagation
+        /// primitive.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, diff_src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_convolution_backward_data_desc_init(&data,
+                            convert_to_c(aalgorithm), &diff_src_desc.data,
+                            &weights_desc.data, &diff_dst_desc.data,
+                            &strides[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a convolution backward "
+                    "propagation primitive");
+        }
+
+        /// Constructs a descriptor for dilated convolution backward
+        /// propagation primitive.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, diff_src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_dilated_convolution_backward_data_desc_init(&data,
+                            convert_to_c(aalgorithm), &diff_src_desc.data,
+                            &weights_desc.data, &diff_dst_desc.data,
+                            &strides[0], &dilates[0], &padding_l[0],
+                            &padding_r[0]),
+                    "could not create a descriptor for a dilated convolution "
+                    "backward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a convolution backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a convolution backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a convolution backward propagation
+        ///     primitive.
+        /// @param aengine Engine to perform the operation on.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const convolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a convolution backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a convolution backward propagation
+        ///     primitive.
+        /// @param aengine Engine to perform the operation on.
+        /// @param attr Primitive attributes to use.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const convolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a convolution backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a convolution backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::convolution,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    convolution_backward_data() = default;
+
+    /// Constructs a convolution backward propagation primitive.
+    /// @param pd Primitive descriptor for a convolution backward propagation
+    ///     primitive.
+    convolution_backward_data(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a convolution backward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a convolution backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    convolution_backward_data(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Convolution weights gradient primitive.
+struct convolution_backward_weights : public primitive {
+    /// Descriptor for a convolution weights gradient primitive.
+    struct desc {
+        dnnl_convolution_desc_t data;
+
+        /// Constructs a descriptor for a convolution weights gradient primitive
+        /// with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_convolution_backward_weights_desc_init(&data,
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &diff_weights_desc.data, &diff_bias_desc.data,
+                            &diff_dst_desc.data, &strides[0], &padding_l[0],
+                            &padding_r[0]),
+                    "could not create a descriptor for a convolution weights "
+                    "update primitive");
+        }
+
+        /// Constructs a descriptor for a convolution weights gradient primitive
+        /// without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_convolution_backward_weights_desc_init(&data,
+                                      convert_to_c(aalgorithm), &src_desc.data,
+                                      &diff_weights_desc.data, nullptr,
+                                      &diff_dst_desc.data, &strides[0],
+                                      &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a convolution weights "
+                    "update primitive");
+        }
+
+        /// Constructs a descriptor for a dilated convolution weights gradient
+        /// primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_dilated_convolution_backward_weights_desc_init(&data,
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &diff_weights_desc.data, &diff_bias_desc.data,
+                            &diff_dst_desc.data, &strides[0], &dilates[0],
+                            &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated convolution "
+                    "weights gradient primitive");
+        }
+
+        /// Constructs a descriptor for a dilated convolution weights gradient
+        /// primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Convolution algorithm. Possible values are
+        ///     #dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd, and
+        ///     #dnnl::algorithm::convolution_auto.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_dilated_convolution_backward_weights_desc_init(&data,
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &diff_weights_desc.data, nullptr,
+                            &diff_dst_desc.data, &strides[0], &dilates[0],
+                            &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated convolution "
+                    "weights gradient primitive");
+        }
+    };
+
+    /// Primitive descriptor for a convolution weights gradient primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a convolution weights gradient
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for a convolution weights gradient primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const convolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a convolution weights gradient
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for a convolution weights gradient primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a convolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case
+        ///     an empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const convolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a convolution weights gradient
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a convolution weights
+        ///     gradient primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::convolution,
+                    dnnl::prop_kind::backward_weights) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
+        memory::desc diff_weights_desc() const {
+            return base::diff_weights_desc(0);
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// Returns the diff bias memory descriptor.
+        /// @returns The diff bias memory descriptor.
+        /// @returns A zero memory descriptor of the primitive does not have a
+        ///          diff bias parameter.
+        memory::desc diff_bias_desc() const {
+            return base::diff_weights_desc(1);
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    convolution_backward_weights() = default;
+
+    /// Constructs a convolution weights gradient primitive.
+    /// @param pd Primitive descriptor for a convolution weights gradient
+    ///     primitive.
+    convolution_backward_weights(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a convolution weights gradient primitive from a cache blob.
+    /// @param pd Primitive descriptor for a convolution weights gradient
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    convolution_backward_weights(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_convolution
+//
+/// @addtogroup dnnl_api_deconvolution Deconvolution
+///
+/// A primitive to perform 1D, 2D or 3D deconvolution. Supported variants are
+/// forward propagation, backward propagation, and weights gradient with or
+/// without bias.
+///
+/// @{
+
+/// Deconvolution forward propagation primitive.
+struct deconvolution_forward : public primitive {
+    /// Descriptor for a deconvolution forward propagation primitive.
+    struct desc {
+        dnnl_deconvolution_desc_t data;
+
+        /// Constructs a descriptor for a deconvolution forward propagation
+        /// primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &bias_desc, const memory::desc &dst_desc,
+                const memory::dims &strides, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_deconvolution_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &weights_desc.data, &bias_desc.data, &dst_desc.data,
+                            &strides[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a deconvolution forward "
+                    "propagation primitive");
+        }
+
+        /// Constructs a descriptor for a deconvolution forward propagation
+        /// primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_deconvolution_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &weights_desc.data, nullptr, &dst_desc.data,
+                            &strides[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a deconvolution forward "
+                    "propagation primitive");
+        }
+
+        /// Constructs a descriptor for a dilated deconvolution forward
+        /// propagation primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param bias_desc Bias memory descriptor. Passing zero memory
+        ///     descriptor disables the bias term.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &bias_desc, const memory::desc &dst_desc,
+                const memory::dims &strides, const memory::dims &dilates,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_dilated_deconvolution_forward_desc_init(
+                                      &data, dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), &src_desc.data,
+                                      &weights_desc.data, &bias_desc.data,
+                                      &dst_desc.data, &strides[0], &dilates[0],
+                                      &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated deconvolution "
+                    "forward propagation primitive");
+        }
+
+        /// Constructs a descriptor for a dilated deconvolution forward
+        /// propagation primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Deconvolution algorithm:
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_dilated_deconvolution_forward_desc_init(
+                                      &data, dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), &src_desc.data,
+                                      &weights_desc.data, nullptr,
+                                      &dst_desc.data, &strides[0], &dilates[0],
+                                      &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated deconvolution "
+                    "forward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a deconvolution forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a deconvolution forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a deconvolution forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a deconvolution forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a deconvolution forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a deconvolution forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a deconvolution forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::deconvolution,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
+        memory::desc bias_desc() const { return base::weights_desc(1); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    deconvolution_forward() = default;
+
+    /// Constructs a deconvolution forward propagation primitive.
+    /// @param pd Primitive descriptor for a deconvolution forward propagation
+    ///     primitive.
+    deconvolution_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a deconvolution forward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a deconvolution forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    deconvolution_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Deconvolution backward propagation primitive.
+struct deconvolution_backward_data : public primitive {
+    /// Descriptor for a deconvolution backward propagation primitive.
+    struct desc {
+        dnnl_deconvolution_desc_t data;
+
+        /// Constructs a descriptor for a deconvolution backward propagation
+        /// primitive.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Deconvolution algorithm
+        ///     (#dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, diff_src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_deconvolution_backward_data_desc_init(&data,
+                            convert_to_c(aalgorithm), &diff_src_desc.data,
+                            &weights_desc.data, &diff_dst_desc.data,
+                            &strides[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a deconvolution "
+                    "backward propagation primitive");
+        }
+
+        /// Constructs a descriptor for a dilated deconvolution backward
+        /// propagation primitive.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Deconvolution algorithm
+        ///     (#dnnl::algorithm::convolution_direct,
+        ///     #dnnl::algorithm::convolution_winograd).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param weights_desc Weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, diff_src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_dilated_deconvolution_backward_data_desc_init(&data,
+                            convert_to_c(aalgorithm), &diff_src_desc.data,
+                            &weights_desc.data, &diff_dst_desc.data,
+                            &strides[0], &dilates[0], &padding_l[0],
+                            &padding_r[0]),
+                    "could not create a descriptor for a dilated deconvolution "
+                    "backward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a deconvolution backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a deconvolution backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a deconvolution backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const deconvolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a deconvolution backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a deconvolution backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const deconvolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a deconvolution backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a deconvolution backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::deconvolution,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    deconvolution_backward_data() = default;
+
+    /// Constructs a deconvolution backward propagation primitive.
+    /// @param pd Primitive descriptor for a deconvolution backward propagation
+    ///     primitive.
+    deconvolution_backward_data(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a deconvolution backward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a deconvolution backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    deconvolution_backward_data(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Deconvolution weights gradient primitive.
+struct deconvolution_backward_weights : public primitive {
+    /// Descriptor for a deconvolution weights gradient primitive.
+    struct desc {
+        dnnl_deconvolution_desc_t data;
+
+        /// Constructs a descriptor for a deconvolution weights gradient
+        /// primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_deconvolution_backward_weights_desc_init(&data,
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &diff_weights_desc.data, &diff_bias_desc.data,
+                            &diff_dst_desc.data, &strides[0], &padding_l[0],
+                            &padding_r[0]),
+                    "could not create a descriptor for a deconvolution weights "
+                    "update primitive");
+        }
+
+        /// Constructs a descriptor for a deconvolution weights gradient
+        /// primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p padding_l, and @p padding_r contain values
+        /// for spatial dimensions only and hence must have the same number of
+        /// elements as there are spatial dimensions. The order of values is
+        /// the same as in the tensor: depth (for 3D tensors), height (for 3D
+        /// and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_deconvolution_backward_weights_desc_init(
+                                      &data, convert_to_c(aalgorithm),
+                                      &src_desc.data, &diff_weights_desc.data,
+                                      nullptr, &diff_dst_desc.data, &strides[0],
+                                      &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a deconvolution weights "
+                    "update primitive");
+        }
+
+        /// Constructs a descriptor for a dilated deconvolution weights gradient
+        /// primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_bias_desc Diff bias memory descriptor. Passing zero
+        ///     memory descriptor disables the bias term.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_dilated_deconvolution_backward_weights_desc_init(&data,
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &diff_weights_desc.data, &diff_bias_desc.data,
+                            &diff_dst_desc.data, &strides[0], &dilates[0],
+                            &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated deconvolution "
+                    "weights gradient primitive");
+        }
+
+        /// Constructs a descriptor for a dilated deconvolution weights gradient
+        /// primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// Arrays @p strides, @p dilates, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Deconvolution algorithm. Possible values are
+        ///     #dnnl::algorithm::deconvolution_direct, and
+        ///     #dnnl::algorithm::deconvolution_winograd.
+        /// @param src_desc Source memory descriptor.
+        /// @param diff_weights_desc Diff weights memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Strides for each spatial dimension.
+        /// @param dilates Dilations for each spatial dimension. A zero value
+        ///     means no dilation in the corresponding dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &dilates, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(dilates, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_dilated_deconvolution_backward_weights_desc_init(&data,
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &diff_weights_desc.data, nullptr,
+                            &diff_dst_desc.data, &strides[0], &dilates[0],
+                            &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a dilated deconvolution "
+                    "weights gradient primitive");
+        }
+    };
+
+    /// Primitive descriptor for a deconvolution weights gradient primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a deconvolution weights
+        /// update primitive.
+        ///
+        /// @param adesc Descriptor for a deconvolution weights gradient
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception.  In this case
+        ///     an empty object will be produced.  This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const deconvolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a deconvolution weights
+        /// update primitive.
+        ///
+        /// @param adesc Descriptor for a deconvolution weights gradient
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a deconvolution forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const deconvolution_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a deconvolution weights
+        /// gradient primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a deconvolution weights
+        ///     gradient primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::deconvolution,
+                    dnnl::prop_kind::backward_weights) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
+        memory::desc diff_weights_desc() const {
+            return base::diff_weights_desc(0);
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// @copydoc dnnl::convolution_backward_weights::primitive_desc::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return base::diff_weights_desc(1);
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    deconvolution_backward_weights() = default;
+
+    /// Constructs a deconvolution weights gradient primitive.
+    /// @param pd Primitive descriptor for a deconvolution weights gradient
+    ///     primitive.
+    deconvolution_backward_weights(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a deconvolution weights gradient primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a deconvolution weights gradient
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    deconvolution_backward_weights(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_deconvolution
+
+/// @addtogroup dnnl_api_lrn LRN
+///
+/// A primitive to perform local response normalization (LRN) across or within
+/// channels.
+///
+/// @sa @ref dev_guide_lrn in developer guide
+///
+/// @{
+
+/// Local response normalization (LRN) forward propagation primitive.
+struct lrn_forward : public primitive {
+    /// Descriptor for an LRN forward propagation primitive.
+    struct desc {
+        dnnl_lrn_desc_t data;
+
+        /// Constructs a descriptor for a LRN forward propagation primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm LRN algorithm kind: either
+        ///     #dnnl::algorithm::lrn_across_channels, or
+        ///     #dnnl::algorithm::lrn_within_channel.
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param local_size Regularization local size.
+        /// @param alpha The alpha regularization parameter.
+        /// @param beta The beta regularization parameter.
+        /// @param k The k regularization parameter.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &data_desc, memory::dim local_size,
+                float alpha, float beta, float k = 1.f) {
+            error::wrap_c_api(dnnl_lrn_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), &data_desc.data,
+                                      local_size, alpha, beta, k),
+                    "could not create a descriptor for a lrn forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LRN forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an LRN forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an LRN forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LRN forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an LRN forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LRN forward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an LRN forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::lrn,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lrn_forward() = default;
+
+    /// Constructs an LRN forward propagation primitive.
+    /// @param pd Primitive descriptor for an LRN forward propagation
+    ///     primitive.
+    lrn_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LRN forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LRN forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lrn_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Local response normalization (LRN) backward propagation primitive.
+struct lrn_backward : public primitive {
+    /// Descriptor for an LRN backward propagation primitive.
+    struct desc {
+        dnnl_lrn_desc_t data;
+
+        /// Constructs a descriptor for an LRN backward propagation primitive.
+        ///
+        /// @param aalgorithm LRN algorithm kind: either
+        ///     #dnnl::algorithm::lrn_across_channels, or
+        ///     #dnnl::algorithm::lrn_within_channel.
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param local_size Regularization local size.
+        /// @param alpha The alpha regularization parameter.
+        /// @param beta The beta regularization parameter.
+        /// @param k The k regularization parameter.
+        desc(algorithm aalgorithm, const memory::desc &data_desc,
+                const memory::desc &diff_data_desc, memory::dim local_size,
+                float alpha, float beta, float k = 1.f) {
+            error::wrap_c_api(
+                    dnnl_lrn_backward_desc_init(&data, convert_to_c(aalgorithm),
+                            &diff_data_desc.data, &data_desc.data, local_size,
+                            alpha, beta, k),
+                    "could not create a descriptor for a lrn backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LRN backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an LRN backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an LRN backward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LRN forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const lrn_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LRN backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an LRN backward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LRN forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const lrn_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LRN backward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an LRN backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::lrn,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lrn_backward() = default;
+
+    /// Constructs an LRN backward propagation primitive.
+    /// @param pd Primitive descriptor for an LRN backward propagation
+    ///     primitive.
+    lrn_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LRN backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LRN backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lrn_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_lrn
+
+/// @addtogroup dnnl_api_pooling Pooling
+///
+/// A primitive to perform max or average pooling.
+///
+/// @sa @ref dev_guide_pooling in developer guide
+///
+/// @{
+
+/// Pooling forward propagation primitive.
+struct pooling_forward : public primitive {
+    /// Descriptor for a pooling forward propagation primitive.
+    struct desc {
+        dnnl_pooling_desc_t data;
+
+        /// Constructs a descriptor for pooling forward propagation primitive.
+        ///
+        /// Arrays @p strides, @p kernel, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Pooling algorithm kind: either
+        ///     #dnnl::algorithm::pooling_max,
+        ///     #dnnl::algorithm::pooling_avg_include_padding,
+        ///     or #dnnl::algorithm::pooling_avg (same as
+        ///     #dnnl::algorithm::pooling_avg_exclude_padding).
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param kernel Vector of kernel spatial dimensions.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &dst_desc,
+                const memory::dims &strides, const memory::dims &kernel,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(kernel, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_pooling_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), &src_desc.data,
+                                      &dst_desc.data, &strides[0], &kernel[0],
+                                      &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a pooling forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a pooling forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a pooling forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a pooling forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::pooling,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    pooling_forward() = default;
+
+    /// Constructs a pooling forward propagation primitive.
+    /// @param pd Primitive descriptor for a pooling forward propagation
+    ///     primitive.
+    pooling_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a pooling forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a pooling forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    pooling_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Pooling backward propagation primitive.
+struct pooling_backward : public primitive {
+    /// Descriptor for a pooling backward propagation primitive.
+    struct desc {
+        dnnl_pooling_desc_t data;
+
+        /// Constructs a descriptor for pooling backward propagation primitive.
+        ///
+        /// Arrays @p strides, @p kernel, @p padding_l, and @p padding_r
+        /// contain values for spatial dimensions only and hence must have the
+        /// same number of elements as there are spatial dimensions. The order
+        /// of values is the same as in the tensor: depth (for 3D tensors),
+        /// height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Pooling algorithm kind: either
+        ///     #dnnl::algorithm::pooling_max,
+        ///     #dnnl::algorithm::pooling_avg_include_padding,
+        ///     or #dnnl::algorithm::pooling_avg (same as
+        ///     #dnnl::algorithm::pooling_avg_exclude_padding).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param kernel Vector of kernel spatial dimensions.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &kernel, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(kernel, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, diff_src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_pooling_backward_desc_init(&data,
+                            convert_to_c(aalgorithm), &diff_src_desc.data,
+                            &diff_dst_desc.data, &strides[0], &kernel[0],
+                            &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a pooling backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a pooling backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a pooling backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling backward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a pooling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const pooling_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling backward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a pooling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const pooling_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a pooling backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::pooling,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    pooling_backward() = default;
+
+    /// Constructs a pooling backward propagation primitive.
+    /// @param pd Primitive descriptor for a pooling backward propagation
+    ///     primitive.
+    pooling_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a pooling backward propagation primitive froma cache blob.
+    /// @param pd Primitive descriptor for a pooling backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    pooling_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_pooling
+
+/// @addtogroup dnnl_api_eltwise Eltwise
+///
+/// A primitive to perform elementwise operations such as the
+/// rectifier linear unit (ReLU).
+///
+/// Both forward and backward propagation primitives support in-place
+/// operation; that is, src and dst can refer to the same memory for forward
+/// propagation, and diff_dst and diff_src can refer to the same memory for
+/// backward propagation.
+///
+/// @warning
+///     Because the original source data is required for backward propagation,
+///     in-place forward propagation is not generally supported in the
+///     training mode. However, for algorithms supporting destination as input
+///     memory, dst can be used for the backward propagation, which makes it
+///     possible to get performance benefit even in the training mode.
+///
+/// @sa @ref dev_guide_eltwise in developer guide
+///
+/// @{
+
+/// Elementwise unary operation forward propagation primitive.
+struct eltwise_forward : public primitive {
+    /// Descriptor for an elementwise forward propagation primitive.
+    struct desc {
+        dnnl_eltwise_desc_t data;
+
+        /// Constructs a descriptor for an elementwise forward propagation
+        /// primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Elementwise algorithm kind.
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param alpha The alpha parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
+        /// @param beta The beta parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &data_desc, float alpha = 0,
+                float beta = 0) {
+            error::wrap_c_api(dnnl_eltwise_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      dnnl::convert_to_c(aalgorithm),
+                                      &data_desc.data, alpha, beta),
+                    "could not create a descriptor for an eltwise forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an elementwise forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an elementwise forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an elementwise forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an elementwise forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an elementwise forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an eltwise forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an eltwise forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::eltwise,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    eltwise_forward() = default;
+
+    /// Constructs an eltwise forward propagation primitive.
+    /// @param pd Primitive descriptor for an eltwise forward propagation
+    ///     primitive.
+    eltwise_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an eltwise forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an eltwise forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    eltwise_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Elementwise unary operation backward propagation primitive.
+struct eltwise_backward : public primitive {
+    /// Descriptor for an elementwise backward propagation primitive.
+    struct desc {
+        dnnl_eltwise_desc_t data;
+
+        /// Constructs a descriptor for an elementwise backward propagation
+        /// primitive.
+        ///
+        /// @param aalgorithm Elementwise algorithm kind.
+        /// @param diff_data_desc Diff source and destination memory
+        ///     descriptors.
+        /// @param data_desc Source memory descriptor.
+        /// @param alpha The alpha parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
+        /// @param beta The beta parameter for the elementwise operation.
+        ///     Specific meaning depends on the algorithm.
+        desc(algorithm aalgorithm, const memory::desc &diff_data_desc,
+                const memory::desc &data_desc, float alpha = 0,
+                float beta = 0) {
+            error::wrap_c_api(
+                    dnnl_eltwise_backward_desc_init(&data,
+                            dnnl::convert_to_c(aalgorithm),
+                            &diff_data_desc.data, &data_desc.data, alpha, beta),
+                    "could not create a descriptor for an eltwise backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for eltwise backward propagation.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an elementwise backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an elementwise backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an elementwise forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const eltwise_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an elementwise backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an elementwise backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an elementwise forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const eltwise_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an eltwise backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an eltwise backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::eltwise,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    eltwise_backward() = default;
+
+    /// Constructs an eltwise backward propagation primitive.
+    /// @param pd Primitive descriptor for an eltwise backward propagation
+    ///     primitive.
+    eltwise_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an eltwise backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an eltwise backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    eltwise_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_eltwise
+
+/// @addtogroup dnnl_api_softmax Softmax
+///
+/// A primitive to perform softmax.
+///
+/// @sa @ref dev_guide_softmax in developer guide
+///
+/// @{
+
+/// Softmax forward propagation primitive.
+struct softmax_forward : public primitive {
+    /// Descriptor for a softmax forward propagation primitive.
+    struct desc {
+        dnnl_softmax_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for a softmax forward propagation
+        /// primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param softmax_axis Axis over which softmax is computed.
+        desc(prop_kind aprop_kind, const memory::desc &data_desc,
+                int softmax_axis) {
+            error::wrap_c_api(dnnl_softmax_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      &data_desc.data, softmax_axis),
+                    "could not create a descriptor for a softmax forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a softmax forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a softmax forward
+        /// propagation primitive.
+        ///
+        /// @param adesc descriptor for a softmax forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a softmax forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a softmax forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::softmax,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    softmax_forward() = default;
+
+    /// Constructs a softmax forward propagation primitive.
+    /// @param pd Primitive descriptor for a softmax forward propagation
+    ///     primitive.
+    softmax_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a softmax forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a softmax forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    softmax_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Softmax backward propagation primitive.
+struct softmax_backward : public primitive {
+    /// Descriptor for a softmax backward propagation primitive.
+    struct desc {
+        dnnl_softmax_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for a softmax backward propagation
+        /// primitive.
+        ///
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Destination memory descriptor.
+        /// @param softmax_axis Axis over which softmax is computed.
+        desc(const memory::desc &diff_data_desc, const memory::desc &data_desc,
+                int softmax_axis) {
+            error::wrap_c_api(
+                    dnnl_softmax_backward_desc_init(&data, &diff_data_desc.data,
+                            &data_desc.data, softmax_axis),
+                    "could not create a descriptor for a softmax backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a softmax backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a softmax backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a softmax backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a softmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const softmax_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a softmax backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a softmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const softmax_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a softmax backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::softmax,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    softmax_backward() = default;
+
+    /// Constructs a softmax backward propagation primitive.
+    /// @param pd Primitive descriptor for a softmax backward propagation
+    ///     primitive.
+    softmax_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a softmax backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a softmax backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    softmax_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_softmax
+
+/// @addtogroup dnnl_api_softmax_v2 Softmax_v2
+///
+/// A primitive to perform softmax.
+///
+/// @sa @ref dev_guide_softmax in developer guide
+///
+/// @{
+
+/// Softmax forward propagation primitive.
+struct softmax_v2_forward : public primitive {
+    /// Descriptor for a softmax forward propagation primitive.
+    struct desc {
+        dnnl_softmax_v2_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for a softmax forward propagation
+        /// primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Softmax algorithm kind: either
+        ///     #dnnl::algorithm::softmax_accurate,
+        ///     or #dnnl::algorithm::softmax_log.
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param softmax_axis Axis over which softmax is computed.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &dst_desc,
+                int softmax_axis) {
+            error::wrap_c_api(
+                    dnnl_softmax_v2_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(aalgorithm), &src_desc.data,
+                            &dst_desc.data, softmax_axis),
+                    "could not create a descriptor for a softmax forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a softmax forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a softmax forward
+        /// propagation primitive.
+        ///
+        /// @param adesc descriptor for a softmax forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a softmax forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a softmax forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::softmax_v2,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    softmax_v2_forward() = default;
+
+    /// Constructs a softmax forward propagation primitive.
+    /// @param pd Primitive descriptor for a softmax forward propagation
+    ///     primitive.
+    softmax_v2_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a softmax forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a softmax forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    softmax_v2_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Softmax backward propagation primitive.
+struct softmax_v2_backward : public primitive {
+    /// Descriptor for a softmax backward propagation primitive.
+    struct desc {
+        dnnl_softmax_v2_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for a softmax backward propagation
+        /// primitive.
+        ///
+        /// @param aalgorithm Softmax algorithm kind: either
+        ///     #dnnl::algorithm::softmax_accurate,
+        ///     or #dnnl::algorithm::softmax_log.
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param softmax_axis Axis over which softmax is computed.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc, const memory::desc &dst_desc,
+                int softmax_axis) {
+            error::wrap_c_api(
+                    dnnl_softmax_v2_backward_desc_init(&data,
+                            dnnl::convert_to_c(aalgorithm), &diff_src_desc.data,
+                            &diff_dst_desc.data, &dst_desc.data, softmax_axis),
+                    "could not create a descriptor for a softmax backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a softmax backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a softmax backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a softmax backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a softmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const softmax_v2_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a softmax backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a softmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const softmax_v2_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a softmax backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a softmax backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::softmax_v2,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    softmax_v2_backward() = default;
+
+    /// Constructs a softmax backward propagation primitive.
+    /// @param pd Primitive descriptor for a softmax backward propagation
+    ///     primitive.
+    softmax_v2_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a softmax backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a softmax backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    softmax_v2_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_softmax_v2
+
+/// @addtogroup dnnl_api_logsoftmax LogSoftmax
+///
+/// A primitive to perform logsoftmax.
+///
+/// @sa @ref dev_guide_logsoftmax in developer guide
+///
+/// @{
+
+/// Logsoftmax forward propagation primitive.
+struct logsoftmax_forward : public primitive {
+    /// Descriptor for a logsoftmax forward propagation primitive.
+    struct desc {
+        dnnl_logsoftmax_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for a logsoftmax forward propagation
+        /// primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param logsoftmax_axis Axis over which softmax is computed.
+        desc(prop_kind aprop_kind, const memory::desc &data_desc,
+                int logsoftmax_axis) {
+            error::wrap_c_api(dnnl_logsoftmax_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      &data_desc.data, logsoftmax_axis),
+                    "could not create a descriptor for a logsoftmax forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a logsoftmax forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a logsoftmax forward
+        /// propagation primitive.
+        ///
+        /// @param adesc descriptor for a logsoftmax forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a logsoftmax forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a logsoftmax forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a logsoftmax forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a logsoftmax forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd,
+                    // Logsoftmax and softmax share the implementation and
+                    // currently report the same primitive kind. Hence this
+                    // must be softmax and not logsoftmax.
+                    dnnl::primitive::kind::softmax,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    logsoftmax_forward() = default;
+
+    /// Constructs a logsoftmax forward propagation primitive.
+    /// @param pd Primitive descriptor for a logsoftmax forward propagation
+    ///     primitive.
+    logsoftmax_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a logsoftmax forward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a logsoftmax forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    logsoftmax_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Logsoftmax backward propagation primitive.
+struct logsoftmax_backward : public primitive {
+    /// Descriptor for a logsoftmax backward propagation primitive.
+    struct desc {
+        dnnl_logsoftmax_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for a logsoftmax backward propagation
+        /// primitive.
+        ///
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptors.
+        /// @param data_desc Destination memory descriptor.
+        /// @param logsoftmax_axis Axis over which softmax is computed.
+        desc(const memory::desc &diff_data_desc, const memory::desc &data_desc,
+                int logsoftmax_axis) {
+            error::wrap_c_api(dnnl_logsoftmax_backward_desc_init(&data,
+                                      &diff_data_desc.data, &data_desc.data,
+                                      logsoftmax_axis),
+                    "could not create a descriptor for a logsoftmax backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a logsoftmax backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a logsoftmax backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a logsoftmax backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a logsoftmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const logsoftmax_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a logsoftmax backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a logsoftmax backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a logsoftmax forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const logsoftmax_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a logsoftmax backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a logsoftmax backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd,
+                    // Logsoftmax and softmax share the implementation and
+                    // currently report the same primitive kind. Hence this
+                    // must be softmax and not logsoftmax.
+                    dnnl::primitive::kind::softmax,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    logsoftmax_backward() = default;
+
+    /// Constructs a logsoftmax backward propagation primitive.
+    /// @param pd Primitive descriptor for a logsoftmax backward propagation
+    ///     primitive.
+    logsoftmax_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a logsoftmax backward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a logsoftmax backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    logsoftmax_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_logsoftmax
+
+/// @addtogroup dnnl_api_batch_normalization Batch Normalization
+///
+/// A primitive to perform batch normalization.
+///
+/// Both forward and backward propagation primitives support in-place
+/// operation; that is, src and dst can refer to the same memory for forward
+/// propagation, and diff_dst and diff_src can refer to the same memory for
+/// backward propagation.
+///
+/// The batch normalization primitives computations can be controlled by
+/// specifying different @ref dnnl::normalization_flags values. For example,
+/// batch normalization forward propagation can be configured to either
+/// compute the mean and variance or take them as arguments. It can either
+/// perform scaling and shifting using gamma and beta parameters or not.
+/// Optionally, it can also perform a fused ReLU, which in case of training
+/// would also require a workspace.
+///
+/// @sa @ref dev_guide_batch_normalization in developer guide
+///
+/// @{
+
+/// Batch normalization forward propagation primitive.
+struct batch_normalization_forward : public primitive {
+    /// Descriptor for a batch normalization forward propagation primitive.
+    struct desc {
+        dnnl_batch_normalization_desc_t data;
+
+        /// Constructs a batch normalization descriptor for forward
+        /// propagation.
+        ///
+        /// @note
+        ///     In-place operation is supported: the dst can refer to the same
+        ///     memory as the src.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param epsilon Batch normalization epsilon parameter.
+        /// @param flags Batch normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &data_desc, float epsilon,
+                normalization_flags flags) {
+            error::wrap_c_api(
+                    dnnl_batch_normalization_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind), &data_desc.data,
+                            epsilon, convert_to_c(flags)),
+                    "could not create a descriptor for a batch normalization "
+                    "forward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a batch normalization forward propagation
+    /// primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a batch normalization forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a batch normalization forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a batch normalization forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a batch normalization forward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a batch normalization
+        /// forward propagation primitive from a C API primitive descriptor
+        /// that must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a batch normalization
+        ///     forward propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd,
+                    dnnl::primitive::kind::batch_normalization,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+
+        /// Returns memory descriptor for mean.
+        /// @returns Memory descriptor for mean.
+        memory::desc mean_desc() const { return stat_desc(mean); }
+
+        /// Returns memory descriptor for variance.
+        /// @returns Memory descriptor for variance.
+        memory::desc variance_desc() const { return stat_desc(var); }
+
+    private:
+        enum {
+            mean = 1,
+            var = 2,
+        };
+        memory::desc stat_desc(int kind) const {
+            dnnl_batch_normalization_desc_t *p;
+            error::wrap_c_api(
+                    dnnl_primitive_desc_query(get(),
+                            dnnl::convert_to_c(query::batch_normalization_d), 0,
+                            &p),
+                    "could not retrieve a descriptor from a primitive "
+                    "descriptor for batch normalization forward propagation "
+                    "primitive");
+            return query_md(p->flags & dnnl_use_global_stats ? query::src_md
+                                                             : query::dst_md,
+                    kind);
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    batch_normalization_forward() = default;
+
+    /// Constructs a batch normalization forward propagation primitive.
+    /// @param pd Primitive descriptor for a batch normalization forward
+    ///     propagation primitive.
+    batch_normalization_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a batch normalization forward propagation primitive from
+    ///     a cache blob.
+    /// @param pd Primitive descriptor for a batch normalization forward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    batch_normalization_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Batch normalization backward propagation primitive.
+struct batch_normalization_backward : public primitive {
+    /// Descriptor for a batch normalization backward propagation primitive.
+    struct desc {
+        dnnl_batch_normalization_desc_t data;
+
+        /// Constructs a batch normalization descriptor for backward
+        /// propagation.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::backward_data and #dnnl::prop_kind::backward
+        ///     (diffs for all parameters are computed in this case).
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param epsilon Batch normalization epsilon parameter.
+        /// @param flags Batch normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &diff_data_desc,
+                const memory::desc &data_desc, float epsilon,
+                normalization_flags flags) {
+            error::wrap_c_api(dnnl_batch_normalization_backward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      &diff_data_desc.data, &data_desc.data,
+                                      epsilon, convert_to_c(flags)),
+                    "could not create a descriptor for a batch normalization "
+                    "backward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a batch normalization backward propagation
+    /// primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a batch normalization backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a batch normalization backward
+        ///     propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a batch normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const batch_normalization_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a batch normalization backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a batch normalization backward
+        ///     propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a batch normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const batch_normalization_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a batch normalization
+        /// backward propagation primitive from a C API primitive descriptor
+        /// that must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a batch normalization
+        ///     backward propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd,
+                    dnnl::primitive::kind::batch_normalization,
+                    dnnl::prop_kind::backward, dnnl::prop_kind::backward_data) {
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
+        memory::desc diff_weights_desc() const {
+            return base::diff_weights_desc(0);
+        }
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
+        memory::desc mean_desc() const { return query_md(query::src_md, 1); }
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
+        memory::desc variance_desc() const {
+            return query_md(query::src_md, 2);
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    batch_normalization_backward() = default;
+
+    /// Constructs a batch normalization backward propagation primitive.
+    /// @param pd Primitive descriptor for a batch normalization backward
+    ///     propagation primitive.
+    batch_normalization_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a batch normalization backward propagation primitive from
+    ///     a cache blob.
+    /// @param pd Primitive descriptor for a batch normalization backward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    batch_normalization_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_batch_normalization
+
+/// @addtogroup dnnl_api_layer_normalization_v2 Layer Normalization
+///
+/// A primitive to perform layer normalization. Normalization is performed
+/// within the last logical dimension of data tensor.
+///
+/// Both forward and backward propagation primitives support in-place
+/// operation; that is, src and dst can refer to the same memory for forward
+/// propagation, and diff_dst and diff_src can refer to the same memory for
+/// backward propagation.
+///
+/// The layer normalization primitives computations can be controlled by
+/// specifying different @ref dnnl::normalization_flags values. For example,
+/// layer normalization forward propagation can be configured to either
+/// compute the mean and variance or take them as arguments. It can either
+/// perform scaling and shifting using gamma and beta parameters or not.
+///
+/// @sa @ref dev_guide_layer_normalization in developer guide
+///
+/// @{
+
+/// Layer normalization forward propagation primitive.
+struct layer_normalization_forward : public primitive {
+    /// Descriptor for a layer normalization forward propagation primitive.
+    struct desc {
+        dnnl_layer_normalization_v2_desc_t data;
+
+        /// Constructs a descriptor for layer normalization forward
+        /// propagation primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param stat_desc Statistics memory descriptors.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &data_desc,
+                const memory::desc &stat_desc, float epsilon,
+                normalization_flags flags) {
+            error::wrap_c_api(
+                    dnnl_layer_normalization_v2_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind), &data_desc.data,
+                            &data_desc.data, &stat_desc.data, epsilon,
+                            convert_to_c(flags)),
+                    "could not create a descriptor for a layer normalization "
+                    "forward propagation primitive");
+        }
+
+        /// Constructs a descriptor for layer normalization forward
+        /// propagation primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &data_desc, float epsilon,
+                normalization_flags flags) {
+            error::wrap_c_api(dnnl_layer_normalization_v2_forward_desc_init(
+                                      &data, dnnl::convert_to_c(aprop_kind),
+                                      &data_desc.data, &data_desc.data, nullptr,
+                                      epsilon, convert_to_c(flags)),
+                    "could not create a descriptor for a layer normalization "
+                    "forward propagation primitive");
+        }
+
+        /// Constructs a descriptor for layer normalization forward
+        /// propagation primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param stat_desc Statistics memory descriptors.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &src_desc,
+                const memory::desc &dst_desc, const memory::desc &stat_desc,
+                float epsilon, normalization_flags flags) {
+            error::wrap_c_api(
+                    dnnl_layer_normalization_v2_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind), &src_desc.data,
+                            &dst_desc.data, &stat_desc.data, epsilon,
+                            convert_to_c(flags)),
+                    "could not create a descriptor for a layer normalization "
+                    "forward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a layer normalization forward propagation
+    /// primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a layer normalization forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a layer normalization forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a layer normalization forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a layer normalization forward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a layer normalization
+        /// forward propagation primitive from a C API primitive descriptor
+        /// that must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a layer normalization
+        ///     forward propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd,
+                    dnnl::primitive::kind::layer_normalization_v2,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
+        memory::desc mean_desc() const { return stat_desc(mean); }
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
+        memory::desc variance_desc() const { return stat_desc(var); }
+
+    private:
+        enum {
+            mean = 1,
+            var = 2,
+        };
+        memory::desc stat_desc(int kind) const {
+            dnnl_layer_normalization_desc_t *p;
+            error::wrap_c_api(
+                    dnnl_primitive_desc_query(get(),
+                            dnnl::convert_to_c(query::layer_normalization_d), 0,
+                            &p),
+                    "could not retrieve a descriptor from a primitive "
+                    "descriptor for layer normalization forward propagation "
+                    "primitive");
+            return query_md(p->flags & dnnl_use_global_stats ? query::src_md
+                                                             : query::dst_md,
+                    kind);
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    layer_normalization_forward() = default;
+
+    /// Constructs a layer normalization forward propagation primitive.
+    /// @param pd Primitive descriptor for a layer normalization forward
+    ///     propagation primitive.
+    layer_normalization_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a layer normalization forward propagation primitive from
+    ///     a cache blob.
+    /// @param pd Primitive descriptor for a layer normalization forward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    layer_normalization_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Layer normalization backward propagation primitive.
+struct layer_normalization_backward : public primitive {
+    /// Descriptor for a layer normalization backward propagation primitive.
+    struct desc {
+        dnnl_layer_normalization_v2_desc_t data;
+
+        /// Constructs a descriptor for layer normalization backward
+        /// propagation primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::backward_data and #dnnl::prop_kind::backward
+        ///     (diffs for all parameters are computed in this case).
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param stat_desc Statistics memory descriptors.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &diff_data_desc,
+                const memory::desc &data_desc, const memory::desc &stat_desc,
+                float epsilon, normalization_flags flags) {
+            error::wrap_c_api(
+                    dnnl_layer_normalization_v2_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            &diff_data_desc.data, &diff_data_desc.data,
+                            &data_desc.data, &stat_desc.data, epsilon,
+                            convert_to_c(flags)),
+                    "could not create a descriptor for a batch normalization "
+                    "backward propagation primitive");
+        }
+
+        /// Constructs a descriptor for layer normalization backward
+        /// propagation primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::backward_data and #dnnl::prop_kind::backward
+        ///     (diffs for all parameters are computed in this case).
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param data_desc Source memory descriptor.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &diff_data_desc,
+                const memory::desc &data_desc, float epsilon,
+                normalization_flags flags) {
+            error::wrap_c_api(dnnl_layer_normalization_v2_backward_desc_init(
+                                      &data, dnnl::convert_to_c(aprop_kind),
+                                      &diff_data_desc.data,
+                                      &diff_data_desc.data, &data_desc.data,
+                                      nullptr, epsilon, convert_to_c(flags)),
+                    "could not create a descriptor for a batch normalization "
+                    "backward propagation primitive");
+        }
+
+        /// Constructs a descriptor for layer normalization backward
+        /// propagation primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::backward_data and #dnnl::prop_kind::backward
+        ///     (diffs for all parameters are computed in this case).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param src_desc Source memory descriptor.
+        /// @param stat_desc Statistics memory descriptors.
+        /// @param epsilon Layer normalization epsilon parameter.
+        /// @param flags Layer normalization flags (@ref
+        ///     dnnl::normalization_flags).
+        desc(prop_kind aprop_kind, const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc, const memory::desc &src_desc,
+                const memory::desc &stat_desc, float epsilon,
+                normalization_flags flags) {
+            error::wrap_c_api(
+                    dnnl_layer_normalization_v2_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind), &diff_src_desc.data,
+                            &diff_dst_desc.data, &src_desc.data,
+                            &stat_desc.data, epsilon, convert_to_c(flags)),
+                    "could not create a descriptor for a batch normalization "
+                    "backward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a layer normalization backward propagation
+    /// primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a layer normalization backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a layer normalization backward
+        ///     propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a layer normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const layer_normalization_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a layer normalization backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a layer normalization backward
+        ///     propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a layer normalization
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const layer_normalization_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a layer normalization
+        /// backward propagation primitive from a C API primitive descriptor
+        /// that must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a layer normalization
+        ///     backward propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd,
+                    dnnl::primitive::kind::layer_normalization_v2,
+                    dnnl::prop_kind::backward, dnnl::prop_kind::backward_data) {
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
+        memory::desc diff_weights_desc() const {
+            return base::diff_weights_desc(0);
+        }
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
+        memory::desc mean_desc() const { return query_md(query::src_md, 1); }
+
+        /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
+        memory::desc variance_desc() const {
+            return query_md(query::src_md, 2);
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    layer_normalization_backward() = default;
+
+    /// Constructs a layer normalization backward propagation primitive.
+    /// @param pd Primitive descriptor for a layer normalization backward
+    ///     propagation primitive.
+    layer_normalization_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a layer normalization backward propagation primitive from
+    ///     a cache blob.
+    /// @param pd Primitive descriptor for a layer normalization backward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    layer_normalization_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_layer_normalization_v2
+
+/// @addtogroup dnnl_api_inner_product Inner Product
+///
+/// A primitive to compute an inner product.
+///
+/// @sa @ref dev_guide_inner_product in developer guide
+///
+/// @{
+
+/// Inner product forward propagation primitive.
+struct inner_product_forward : public primitive {
+    /// Descriptor for an inner product forward propagation primitive.
+    struct desc {
+        dnnl_inner_product_desc_t data;
+
+        /// Constructs a descriptor for an inner product forward propagation
+        /// primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param src_desc Memory descriptor for src.
+        /// @param weights_desc Memory descriptor for weights.
+        /// @param bias_desc Memory descriptor for bias.
+        /// @param dst_desc Memory descriptor for dst.
+        desc(prop_kind aprop_kind, const memory::desc &src_desc,
+                const memory::desc &weights_desc, const memory::desc &bias_desc,
+                const memory::desc &dst_desc) {
+            error::wrap_c_api(dnnl_inner_product_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      &src_desc.data, &weights_desc.data,
+                                      &bias_desc.data, &dst_desc.data),
+                    "could not create a descriptor for an inner product "
+                    "forward propagation primitive");
+        }
+
+        /// Constructs a descriptor for an inner product forward propagation
+        /// primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param src_desc Memory descriptor for src.
+        /// @param weights_desc Memory descriptor for weights.
+        /// @param dst_desc Memory descriptor for dst.
+        desc(prop_kind aprop_kind, const memory::desc &src_desc,
+                const memory::desc &weights_desc,
+                const memory::desc &dst_desc) {
+            error::wrap_c_api(
+                    dnnl_inner_product_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind), &src_desc.data,
+                            &weights_desc.data, nullptr, &dst_desc.data),
+                    "could not create a descriptor for an inner product "
+                    "forward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an inner product forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an inner product forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an inner product forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an inner product forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an inner product forward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an inner product forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an inner product forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::inner_product,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
+        memory::desc bias_desc() const { return base::weights_desc(1); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    inner_product_forward() = default;
+
+    /// Constructs an inner product forward propagation primitive.
+    /// @param pd Primitive descriptor for an inner product forward
+    ///     propagation primitive.
+    inner_product_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an inner product forward propagation primitive from
+    ///     a cache blob.
+    /// @param pd Primitive descriptor for an inner product forward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    inner_product_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Inner product backward propagation primitive.
+struct inner_product_backward_data : public primitive {
+    /// Descriptor for an inner product backward propagation primitive.
+    struct desc {
+        dnnl_inner_product_desc_t data;
+
+        /// Constructs a descriptor for an inner product backward propagation
+        /// primitive.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param diff_src_desc Memory descriptor for diff src.
+        /// @param weights_desc Memory descriptor for weights.
+        /// @param diff_dst_desc Memory descriptor for diff dst.
+        desc(const memory::desc &diff_src_desc,
+                const memory::desc &weights_desc,
+                const memory::desc &diff_dst_desc) {
+            error::wrap_c_api(dnnl_inner_product_backward_data_desc_init(&data,
+                                      &diff_src_desc.data, &weights_desc.data,
+                                      &diff_dst_desc.data),
+                    "could not create a descriptor for an inner product "
+                    "backward propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an inner product backward propagation
+    /// primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an inner product backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an inner product backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const inner_product_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an inner product backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an inner product backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const inner_product_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an inner product backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an inner product backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::inner_product,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const { return base::weights_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    inner_product_backward_data() = default;
+
+    /// Constructs an inner product backward propagation primitive.
+    /// @param pd Primitive descriptor for an inner product backward
+    ///     propagation primitive.
+    inner_product_backward_data(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an inner product backward propagation primitive from
+    /// a cache blob.
+    /// @param pd Primitive descriptor for an inner product backward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    inner_product_backward_data(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Inner product weights gradient primitive.
+struct inner_product_backward_weights : public primitive {
+    /// Descriptor for an inner product weights gradient primitive.
+    struct desc {
+        dnnl_inner_product_desc_t data;
+
+        /// Constructs a descriptor for an inner product descriptor weights
+        /// update primitive with bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param src_desc Memory descriptor for src.
+        /// @param diff_weights_desc Memory descriptor for diff weights.
+        /// @param diff_bias_desc Memory descriptor for diff bias.
+        /// @param diff_dst_desc Memory descriptor for diff dst.
+        desc(const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_desc) {
+            error::wrap_c_api(
+                    dnnl_inner_product_backward_weights_desc_init(&data,
+                            &src_desc.data, &diff_weights_desc.data,
+                            &diff_bias_desc.data, &diff_dst_desc.data),
+                    "could not create a descriptor for an inner product "
+                    "weights gradient primitive");
+        }
+
+        /// Constructs a descriptor for an inner product descriptor weights
+        /// update primitive without bias.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param src_desc Memory descriptor for src.
+        /// @param diff_weights_desc Memory descriptor for diff weights.
+        /// @param diff_dst_desc Memory descriptor for diff dst.
+        desc(const memory::desc &src_desc,
+                const memory::desc &diff_weights_desc,
+                const memory::desc &diff_dst_desc) {
+            error::wrap_c_api(
+                    dnnl_inner_product_backward_weights_desc_init(&data,
+                            &src_desc.data, &diff_weights_desc.data, nullptr,
+                            &diff_dst_desc.data),
+                    "could not create a descriptor for an inner product "
+                    "weights gradient primitive");
+        }
+    };
+
+    /// Primitive descriptor for an inner product weights gradient primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an inner product weights
+        /// update primitive.
+        ///
+        /// @param adesc Descriptor for an inner product weights gradient
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const inner_product_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an inner product weights
+        /// update primitive.
+        ///
+        /// @param adesc Descriptor for an inner product weights gradient
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an inner product
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const inner_product_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an inner product weights
+        /// update primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an inner product weights
+        ///     gradient primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::inner_product,
+                    dnnl::prop_kind::backward_weights) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
+        memory::desc diff_weights_desc() const {
+            return base::diff_weights_desc(0);
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// @copydoc dnnl::convolution_backward_weights::primitive_desc::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return base::diff_weights_desc(1);
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    inner_product_backward_weights() = default;
+
+    /// Constructs an inner product weights gradient primitive.
+    /// @param pd Primitive descriptor for an inner product weights gradient
+    ///     primitive.
+    inner_product_backward_weights(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an inner product weights gradient primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for an inner product weights gradient
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    inner_product_backward_weights(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_inner_product
+
+/// @addtogroup dnnl_api_rnn RNN
+///
+/// A primitive to compute recurrent neural network layers.
+///
+/// @sa @ref dev_guide_rnn in developer guide
+///
+/// @{
+
+/// Base class for primitive descriptors for RNN primitives.
+struct rnn_primitive_desc_base : public primitive_desc {
+    using primitive_desc::primitive_desc;
+
+    /// Default constructor. Produces an empty object.
+    rnn_primitive_desc_base() = default;
+
+    /// Constructs an RNN primitive descriptor base from a C API primitive
+    /// descriptor while checking that it actually describes the expected
+    /// primitive by comparing propagation and primitive kinds.
+    ///
+    /// @param pd C API primitive descriptor.
+    /// @param aprop_kind Expected propagation kind.
+    /// @param cell_kind Expected cell kind.
+    rnn_primitive_desc_base(dnnl_primitive_desc_t pd,
+            dnnl::prop_kind aprop_kind, dnnl::algorithm cell_kind)
+        : rnn_primitive_desc_base(pd, aprop_kind, aprop_kind, cell_kind) {}
+
+    /// Returns source layer memory descriptor.
+    /// @returns Source layer memory descriptor.
+    memory::desc src_layer_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_SRC_LAYER);
+    }
+
+    /// Returns AUGRU attention memory descriptor.
+    /// @returns AUGRU attention memory descriptor.
+    memory::desc augru_attention_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_AUGRU_ATTENTION);
+    }
+
+    /// Returns source iteration memory descriptor.
+    /// @returns Source iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          source iteration parameter.
+    memory::desc src_iter_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_SRC_ITER);
+    }
+
+    /// Returns source recurrent cell state memory descriptor.
+    /// @returns Source recurrent cell state memory descriptor.
+    memory::desc src_iter_c_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_SRC_ITER_C);
+    }
+
+    /// Returns weights layer memory descriptor.
+    /// @returns Weights layer memory descriptor.
+    memory::desc weights_layer_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_LAYER);
+    }
+
+    /// Returns weights iteration memory descriptor.
+    /// @returns Weights iteration memory descriptor.
+    memory::desc weights_iter_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_ITER);
+    }
+
+    /// Returns weights peephole memory descriptor.
+    /// @returns Weights peephole memory descriptor.
+    memory::desc weights_peephole_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_PEEPHOLE);
+    }
+
+    /// Returns weights projection memory descriptor.
+    /// @returns Weights projection memory descriptor.
+    memory::desc weights_projection_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_PROJECTION);
+    }
+
+    /// Returns bias memory descriptor.
+    /// @returns Bias memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          bias parameter.
+    memory::desc bias_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_BIAS);
+    }
+
+    /// Returns destination layer memory descriptor.
+    /// @returns Destination layer memory descriptor.
+    memory::desc dst_layer_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DST_LAYER);
+    }
+
+    /// Returns destination iteration memory descriptor.
+    /// @returns Destination iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          destination iteration parameter.
+    memory::desc dst_iter_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DST_ITER);
+    }
+
+    /// Returns destination recurrent cell state memory descriptor.
+    /// @returns Destination recurrent cell state memory descriptor.
+    memory::desc dst_iter_c_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DST_ITER_C);
+    }
+
+    /// Returns diff source layer memory descriptor.
+    /// @returns Diff source layer memory descriptor.
+    memory::desc diff_src_layer_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_SRC_LAYER);
+    }
+
+    /// Returns diff AUGRU attention memory descriptor.
+    /// @returns Diff AUGRU attention memory descriptor.
+    memory::desc diff_augru_attention_desc() const {
+        return base::query_md(
+                query::exec_arg_md, DNNL_ARG_DIFF_AUGRU_ATTENTION);
+    }
+
+    /// Returns diff source iteration memory descriptor.
+    /// @returns Diff source iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          diff source iteration parameter.
+    memory::desc diff_src_iter_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_SRC_ITER);
+    }
+
+    /// Returns diff source recurrent cell state memory descriptor.
+    /// @returns Diff source recurrent cell state memory descriptor.
+    memory::desc diff_src_iter_c_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_SRC_ITER_C);
+    }
+
+    /// Returns diff weights layer memory descriptor.
+    /// @returns Diff weights layer memory descriptor.
+    memory::desc diff_weights_layer_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_LAYER);
+    }
+
+    /// Returns diff weights iteration memory descriptor.
+    /// @returns Diff weights iteration memory descriptor.
+    memory::desc diff_weights_iter_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_ITER);
+    }
+
+    /// Returns diff weights peephole memory descriptor.
+    /// @returns Diff weights peephole memory descriptor.
+    memory::desc diff_weights_peephole_desc() const {
+        return base::query_md(
+                query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE);
+    }
+
+    /// Returns diff weights projection memory descriptor.
+    /// @returns Diff weights projection memory descriptor.
+    memory::desc diff_weights_projection_desc() const {
+        return base::query_md(
+                query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_PROJECTION);
+    }
+
+    /// Returns diff bias memory descriptor.
+    /// @returns Diff bias memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          diff bias parameter.
+    memory::desc diff_bias_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_BIAS);
+    }
+
+    /// Returns diff destination layer memory descriptor.
+    /// @returns Diff destination layer memory descriptor.
+    memory::desc diff_dst_layer_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_DST_LAYER);
+    }
+
+    /// Returns diff destination iteration memory descriptor.
+    /// @returns Diff destination iteration memory descriptor.
+    /// @returns A zero memory descriptor if the primitive does not have a
+    ///          diff destination iteration parameter.
+    memory::desc diff_dst_iter_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_DST_ITER);
+    }
+
+    /// Returns diff destination recurrent cell state memory descriptor.
+    /// @returns Diff destination recurrent cell state memory descriptor.
+    memory::desc diff_dst_iter_c_desc() const {
+        return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_DST_ITER_C);
+    }
+
+protected:
+    using rnn_base = rnn_primitive_desc_base;
+
+    // (Deliberately not using doxygen comments)
+    //
+    // Constructs an RNN primitive descriptor base from a C API primitive
+    // descriptor while checking that it actually describes the expected
+    // primitive by comparing propagation and primitive kinds. Caller can
+    // pass two options propagation kinds. This is typically used to check
+    // that propagation kind is inference or training forward propagation.
+    //
+    // @param pd C API primitive descriptor.
+    // @param prop_kind1 Expected propagation kind.
+    // @param prop_kind2 Expected propagation kind.
+    // @param cell_kind Expected cell kind.
+    rnn_primitive_desc_base(dnnl_primitive_desc_t pd,
+            dnnl::prop_kind prop_kind1, dnnl::prop_kind prop_kind2,
+            dnnl::algorithm cell_kind) {
+        dnnl_rnn_desc_t *rnn_d;
+        dnnl_status_t rc;
+        rc = dnnl_primitive_desc_query(pd, dnnl_query_rnn_d, 0, &rnn_d);
+        error::wrap_c_api(rc,
+                "could not retrieve a descriptor from a primitive descriptor "
+                "for an RNN primitive");
+
+        dnnl_prop_kind_t c_prop_kind1 = convert_to_c(prop_kind1);
+        dnnl_prop_kind_t c_prop_kind2 = convert_to_c(prop_kind2);
+        dnnl_alg_kind_t c_cell_kind = convert_to_c(cell_kind);
+
+        bool ok = rnn_d->primitive_kind == dnnl_rnn
+                && (rnn_d->prop_kind == c_prop_kind1
+                        || rnn_d->prop_kind == c_prop_kind2)
+                && rnn_d->cell_kind == c_cell_kind;
+
+        if (!ok)
+            DNNL_THROW_ERROR(dnnl_invalid_arguments,
+                    "mismatch between expected and provided descriptors for an "
+                    "RNN primitive");
+
+        reset_with_clone(pd);
+    }
+};
+
+/// Vanilla RNN forward propagation primitive.
+struct vanilla_rnn_forward : public primitive {
+    /// Descriptor for a vanilla RNN forward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for a vanilla RNN forward propagation
+        /// primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc.
+        ///
+        /// This would then indicate that the RNN forward propagation primitive
+        /// should not use them and should default to zero values instead.
+        ///
+        /// @note
+        ///     All memory descriptors except @p src_iter_desc can be
+        ///     initialized with an #dnnl::memory::format_tag::any value of @p
+        ///     format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param activation Activation kind. Possible values are
+        ///     #dnnl::algorithm::eltwise_relu,
+        ///     #dnnl::algorithm::eltwise_tanh, or
+        ///     #dnnl::algorithm::eltwise_logistic.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
+        /// @param alpha Negative slope if activation is
+        ///     #dnnl::algorithm::eltwise_relu.
+        /// @param beta Unused.
+        desc(prop_kind aprop_kind, algorithm activation,
+                rnn_direction direction, const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef, float alpha = 0.0f,
+                float beta = 0.0f) {
+            error::wrap_c_api(
+                    dnnl_vanilla_rnn_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(activation),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &weights_layer_desc.data,
+                            &weights_iter_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            dnnl::convert_to_c(flags), alpha, beta),
+                    "could not create a descriptor for a vanilla RNN forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a vanilla RNN forward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a vanilla RNN forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a vanilla RNN forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a vanilla RNN forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a vanilla RNN forward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a vanilla RNN forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a vanilla RNN forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference,
+                    dnnl::algorithm::vanilla_rnn) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    vanilla_rnn_forward() = default;
+
+    /// Constructs a vanilla RNN forward propagation primitive.
+    /// @param pd Primitive descriptor for a vanilla RNN forward
+    ///     propagation primitive.
+    vanilla_rnn_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a vanilla RNN forward propagation primitive from
+    ///     a cache blob.
+    /// @param pd Primitive descriptor for a vanilla RNN forward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    vanilla_rnn_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Vanilla RNN backward propagation primitive.
+struct vanilla_rnn_backward : public primitive {
+    /// Descriptor for a vanilla RNN backward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for a vanilla RNN backward propagation
+        /// primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p diff_src_iter_desc,
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+        ///
+        /// This would then indicate that the RNN backward propagation
+        /// primitive should not use the respective data and should use zero
+        /// values instead.
+        ///
+        /// @note
+        ///     All the memory descriptors may be initialized with the
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param activation Activation kind. Possible values are
+        ///     #dnnl::algorithm::eltwise_relu,
+        ///     #dnnl::algorithm::eltwise_tanh, or
+        ///     #dnnl::algorithm::eltwise_logistic.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
+        /// @param alpha Negative slope if activation is
+        ///     #dnnl::algorithm::eltwise_relu.
+        /// @param beta Unused.
+        desc(prop_kind aprop_kind, algorithm activation,
+                rnn_direction direction, const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef, float alpha = 0.0f,
+                float beta = 0.0f) {
+            error::wrap_c_api(
+                    dnnl_vanilla_rnn_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(activation),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &weights_layer_desc.data,
+                            &weights_iter_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            &diff_src_layer_desc.data, &diff_src_iter_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data, &diff_bias_desc.data,
+                            &diff_dst_layer_desc.data, &diff_dst_iter_desc.data,
+                            dnnl::convert_to_c(flags), alpha, beta),
+                    "could not create a descriptor for a vanilla RNN backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an RNN backward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a vanilla RNN backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a vanilla RNN backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a vanilla RNN
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const vanilla_rnn_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a vanilla RNN backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a vanilla RNN backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a vanilla RNN
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const vanilla_rnn_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a vanilla RNN backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a vanilla RNN backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
+                    dnnl::algorithm::vanilla_rnn) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
+        memory::desc diff_src_layer_desc() const {
+            return rnn_base::diff_src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
+        memory::desc diff_src_iter_desc() const {
+            return rnn_base::diff_src_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
+        memory::desc diff_weights_layer_desc() const {
+            return rnn_base::diff_weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
+        memory::desc diff_weights_iter_desc() const {
+            return rnn_base::diff_weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return rnn_base::diff_bias_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
+        memory::desc diff_dst_layer_desc() const {
+            return rnn_base::diff_dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
+        memory::desc diff_dst_iter_desc() const {
+            return rnn_base::diff_dst_iter_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    vanilla_rnn_backward() = default;
+
+    /// Constructs a vanilla RNN backward propagation primitive.
+    /// @param pd Primitive descriptor for a vanilla RNN backward
+    ///     propagation primitive.
+    vanilla_rnn_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a vanilla RNN backward propagation primitive from
+    ///     a cache blob.
+    /// @param pd Primitive descriptor for a vanilla RNN backward
+    ///     propagation primitive.
+    /// @param cache_blob Cache blob.
+    vanilla_rnn_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// LSTM forward propagation primitive.
+struct lstm_forward : public primitive {
+    /// Descriptor for an LSTM forward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for an LSTM (with or without peephole and
+        /// with or without projection) forward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p src_iter_c_desc,
+        /// - @p weights_peephole_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc together with @p dst_iter_c_desc.
+        ///
+        /// This would then indicate that the LSTM forward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// The @p weights_projection_desc may point to a zero memory
+        /// descriptor. This would then indicate that the LSTM doesn't have
+        /// recurrent projection layer.
+        ///
+        /// @note
+        ///     All memory descriptors can be initialized with an
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param weights_peephole_desc Memory descriptor for the weights
+        ///     applied to the cell states (according to the Peephole LSTM
+        ///     formula).
+        /// @param weights_projection_desc Memory descriptor for the weights
+        ///     applied to the hidden states to get the recurrent projection
+        ///     (according to the Projection LSTM formula).
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &src_iter_c_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &weights_peephole_desc,
+                const memory::desc &weights_projection_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &dst_iter_c_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lstm_forward_desc_init_v3(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &src_iter_c_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &weights_peephole_desc.data,
+                            &weights_projection_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            &dst_iter_c_desc.data, dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LSTM forward "
+                    "propagation primitive");
+        }
+
+        /// Constructs a descriptor for an LSTM (with or without peephole)
+        /// forward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p src_iter_c_desc,
+        /// - @p weights_peephole_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc together with @p dst_iter_c_desc.
+        ///
+        /// This would then indicate that the LSTM forward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors can be initialized with an
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param weights_peephole_desc Memory descriptor for the weights
+        ///     applied to the cell states (according to the Peephole LSTM
+        ///     formula).
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &src_iter_c_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &weights_peephole_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &dst_iter_c_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lstm_forward_desc_init_v2(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &src_iter_c_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &weights_peephole_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            &dst_iter_c_desc.data, dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LSTM forward "
+                    "propagation primitive");
+        }
+
+        /// Constructs a descriptor for an LSTM forward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p src_iter_c_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc together with @p dst_iter_c_desc.
+        ///
+        /// This would then indicate that the LSTM forward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors can be initialized with an
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &src_iter_c_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &dst_iter_c_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lstm_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &src_iter_c_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &bias_desc.data, &dst_layer_desc.data,
+                            &dst_iter_desc.data, &dst_iter_c_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LSTM forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LSTM forward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an LSTM forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an LSTM forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LSTM forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an LSTM forward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LSTM forward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an LSTM forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference,
+                    dnnl::algorithm::vanilla_lstm) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_c_desc() const {
+            return rnn_base::src_iter_c_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_peephole_desc()const
+        memory::desc weights_peephole_desc() const {
+            return rnn_base::weights_peephole_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_projection_desc()const
+        memory::desc weights_projection_desc() const {
+            return rnn_base::weights_projection_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc dst_iter_c_desc() const {
+            return rnn_base::dst_iter_c_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lstm_forward() = default;
+
+    /// Constructs an LSTM forward propagation primitive.
+    /// @param pd Primitive descriptor for an LSTM forward propagation
+    ///     primitive.
+    lstm_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LSTM forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LSTM forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lstm_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// LSTM backward propagation primitive.
+struct lstm_backward : public primitive {
+    /// Descriptor for an LSTM backward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs an LSTM (with or without peephole and with or without
+        /// projection) descriptor for backward propagation using @p prop_kind,
+        /// @p direction, and memory descriptors.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p src_iter_c_desc,
+        ///   @p diff_src_iter_desc, and @p diff_src_iter_c_desc,
+        /// - @p weights_peephole_desc together with
+        ///   @p diff_weights_peephole_desc
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p dst_iter_c_desc,
+        ///   @p diff_dst_iter_desc, and @p diff_dst_iter_c_desc.
+        ///
+        /// This would then indicate that the LSTM backward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// The @p weights_projection_desc together with @p
+        /// diff_weights_projection_desc may point to a zero memory descriptor.
+        /// This would then indicate that the LSTM doesn't have recurrent
+        /// projection layer.
+        ///
+        /// @note
+        ///     All memory descriptors can be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param weights_peephole_desc Memory descriptor for the weights
+        ///     applied to the cell states (according to the Peephole LSTM
+        ///     formula).
+        /// @param weights_projection_desc Memory descriptor for the weights
+        ///     applied to the hidden states to get the recurrent projection
+        ///     (according to the Projection LSTM formula).
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_src_iter_c_desc Memory descriptor for the diff of
+        ///     input recurrent cell state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_weights_peephole_desc Memory descriptor for the diff of
+        ///     weights applied to the cell states (according to the Peephole
+        ///     LSTM formula).
+        /// @param diff_weights_projection_desc Memory descriptor for the diff
+        ///     of weights applied to the hidden states to get the recurrent
+        ///     projection (according to the Projection LSTM formula).
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param diff_dst_iter_c_desc Memory descriptor for the diff of
+        ///     output recurrent cell state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &src_iter_c_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &weights_peephole_desc,
+                const memory::desc &weights_projection_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &dst_iter_c_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_src_iter_c_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_weights_peephole_desc,
+                const memory::desc &diff_weights_projection_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                const memory::desc &diff_dst_iter_c_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lstm_backward_desc_init_v3(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &src_iter_c_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &weights_peephole_desc.data,
+                            &weights_projection_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            &dst_iter_c_desc.data, &diff_src_layer_desc.data,
+                            &diff_src_iter_desc.data,
+                            &diff_src_iter_c_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data,
+                            &diff_weights_peephole_desc.data,
+                            &diff_weights_projection_desc.data,
+                            &diff_bias_desc.data, &diff_dst_layer_desc.data,
+                            &diff_dst_iter_desc.data,
+                            &diff_dst_iter_c_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LSTM backward "
+                    "propagation primitive");
+        }
+
+        /// Constructs an LSTM (with or without peephole) descriptor for
+        /// backward propagation using @p prop_kind, @p direction, and memory
+        /// descriptors.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p src_iter_c_desc,
+        ///   @p diff_src_iter_desc, and @p diff_src_iter_c_desc,
+        /// - @p weights_peephole_desc together with
+        ///   @p diff_weights_peephole_desc
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p dst_iter_c_desc,
+        ///   @p diff_dst_iter_desc, and @p diff_dst_iter_c_desc.
+        ///
+        /// This would then indicate that the LSTM backward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param weights_peephole_desc Memory descriptor for the weights
+        ///     applied to the cell states (according to the Peephole LSTM
+        ///     formula).
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_src_iter_c_desc Memory descriptor for the diff of
+        ///     input recurrent cell state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_weights_peephole_desc Memory descriptor for the diff of
+        ///     weights applied to the cell states (according to the Peephole
+        ///     LSTM formula).
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param diff_dst_iter_c_desc Memory descriptor for the diff of
+        ///     output recurrent cell state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &src_iter_c_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &weights_peephole_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &dst_iter_c_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_src_iter_c_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_weights_peephole_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                const memory::desc &diff_dst_iter_c_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lstm_backward_desc_init_v2(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &src_iter_c_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &weights_peephole_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            &dst_iter_c_desc.data, &diff_src_layer_desc.data,
+                            &diff_src_iter_desc.data,
+                            &diff_src_iter_c_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data,
+                            &diff_weights_peephole_desc.data,
+                            &diff_bias_desc.data, &diff_dst_layer_desc.data,
+                            &diff_dst_iter_desc.data,
+                            &diff_dst_iter_c_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LSTM backward "
+                    "propagation primitive");
+        }
+
+        /// Constructs an LSTM descriptor for backward propagation using @p
+        /// prop_kind, @p direction, and memory descriptors.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p src_iter_c_desc,
+        ///   @p diff_src_iter_desc, and @p diff_src_iter_c_desc,
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p dst_iter_c_desc,
+        ///   @p diff_dst_iter_desc, and @p diff_dst_iter_c_desc.
+        ///
+        /// This would then indicate that the LSTM backward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param src_iter_c_desc Memory descriptor for the input recurrent
+        ///     cell state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param dst_iter_c_desc Memory descriptor for the output recurrent
+        ///     cell state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_src_iter_c_desc Memory descriptor for the diff of
+        ///     input recurrent cell state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param diff_dst_iter_c_desc Memory descriptor for the diff of
+        ///     output recurrent cell state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &src_iter_c_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &dst_iter_c_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_src_iter_c_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                const memory::desc &diff_dst_iter_c_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lstm_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &src_iter_c_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &bias_desc.data, &dst_layer_desc.data,
+                            &dst_iter_desc.data, &dst_iter_c_desc.data,
+                            &diff_src_layer_desc.data, &diff_src_iter_desc.data,
+                            &diff_src_iter_c_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data, &diff_bias_desc.data,
+                            &diff_dst_layer_desc.data, &diff_dst_iter_desc.data,
+                            &diff_dst_iter_c_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LSTM backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LSTM backward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an LSTM backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for LSTM backward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LSTM
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const lstm_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LSTM backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an LSTM backward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LSTM
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const lstm_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LSTM backward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an LSTM backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
+                    dnnl::algorithm::vanilla_lstm) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_c_desc() const {
+            return rnn_base::src_iter_c_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_peephole_desc()const
+        memory::desc weights_peephole_desc() const {
+            return rnn_base::weights_peephole_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_projection_desc()const
+        memory::desc weights_projection_desc() const {
+            return rnn_base::weights_projection_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc dst_iter_c_desc() const {
+            return rnn_base::dst_iter_c_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
+        memory::desc diff_src_layer_desc() const {
+            return rnn_base::diff_src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
+        memory::desc diff_src_iter_desc() const {
+            return rnn_base::diff_src_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_c_desc()const
+        memory::desc diff_src_iter_c_desc() const {
+            return rnn_base::diff_src_iter_c_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
+        memory::desc diff_weights_layer_desc() const {
+            return rnn_base::diff_weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
+        memory::desc diff_weights_iter_desc() const {
+            return rnn_base::diff_weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_peephole_desc()const
+        memory::desc diff_weights_peephole_desc() const {
+            return rnn_base::diff_weights_peephole_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_projection_desc()const
+        memory::desc diff_weights_projection_desc() const {
+            return rnn_base::diff_weights_projection_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return rnn_base::diff_bias_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
+        memory::desc diff_dst_layer_desc() const {
+            return rnn_base::diff_dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
+        memory::desc diff_dst_iter_desc() const {
+            return rnn_base::diff_dst_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_c_desc()const
+        memory::desc diff_dst_iter_c_desc() const {
+            return rnn_base::diff_dst_iter_c_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lstm_backward() = default;
+
+    /// Constructs an LSTM backward propagation primitive.
+    /// @param pd Primitive descriptor for an LSTM backward propagation
+    ///     primitive.
+    lstm_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LSTM backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LSTM backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lstm_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// GRU forward propagation primitive.
+struct gru_forward : public primitive {
+    /// Descriptor for a GRU forward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for a GRU forward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc.
+        ///
+        /// This would then indicate that the GRU forward propagation primitive
+        /// should not use them and should default to zero values instead.
+        ///
+        /// @note
+        ///     All memory descriptors except @p src_iter_desc may be
+        ///     initialized with an #dnnl::memory::format_tag::any value of @p
+        ///     format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_gru_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &weights_layer_desc.data,
+                            &weights_iter_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for a GRU forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a GRU forward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a GRU forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for a GRU forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a GRU forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for a GRU forward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a GRU forward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a GRU forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference,
+                    dnnl::algorithm::vanilla_gru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    gru_forward() = default;
+
+    /// Constructs a GRU forward propagation primitive.
+    /// @param pd Primitive descriptor for a GRU forward propagation
+    ///     primitive.
+    gru_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a GRU forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a GRU forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    gru_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// GRU backward propagation primitive.
+struct gru_backward : public primitive {
+    /// Descriptor for a GRU backward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for a GRU backward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p diff_src_iter_desc,
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+        ///
+        /// This would then indicate that the GRU backward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_gru_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &weights_layer_desc.data,
+                            &weights_iter_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            &diff_src_layer_desc.data, &diff_src_iter_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data, &diff_bias_desc.data,
+                            &diff_dst_layer_desc.data, &diff_dst_iter_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for a GRU backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a GRU backward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a GRU backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for a GRU backward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const gru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a GRU backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for a GRU backward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const gru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a GRU backward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a GRU backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
+                    dnnl::algorithm::vanilla_gru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
+        memory::desc diff_src_layer_desc() const {
+            return rnn_base::diff_src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
+        memory::desc diff_src_iter_desc() const {
+            return rnn_base::diff_src_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
+        memory::desc diff_weights_layer_desc() const {
+            return rnn_base::diff_weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
+        memory::desc diff_weights_iter_desc() const {
+            return rnn_base::diff_weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return rnn_base::diff_bias_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
+        memory::desc diff_dst_layer_desc() const {
+            return rnn_base::diff_dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
+        memory::desc diff_dst_iter_desc() const {
+            return rnn_base::diff_dst_iter_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    gru_backward() = default;
+
+    /// Constructs a GRU backward propagation primitive.
+    /// @param pd Primitive descriptor for a GRU backward propagation
+    ///     primitive.
+    gru_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a GRU backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a GRU backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    gru_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// LBR GRU forward propagation primitive.
+struct lbr_gru_forward : public primitive {
+    /// Descriptor for an LBR GRU forward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for LBR GRU forward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc.
+        ///
+        /// This would then indicate that the LBR GRU forward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors except @p src_iter_desc may be
+        ///     initialized with an #dnnl::memory::format_tag::any value of @p
+        ///     format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lbr_gru_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &weights_layer_desc.data,
+                            &weights_iter_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LBR GRU forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LBR GRU forward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a LBR GRU forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a LBR GRU forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a LBR GRU forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a LBR GRU forward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a LBR GRU forward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a LBR GRU forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference,
+                    dnnl::algorithm::lbr_gru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lbr_gru_forward() = default;
+
+    /// Constructs an LBR GRU forward propagation primitive.
+    /// @param pd Primitive descriptor for an LBR GRU forward propagation
+    ///     primitive.
+    lbr_gru_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LBR GRU forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LBR GRU forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lbr_gru_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// LBR GRU backward propagation primitive.
+struct lbr_gru_backward : public primitive {
+    /// Descriptor for a LBR GRU backward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for LBR GRU backward propagation
+        /// primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p diff_src_iter_desc,
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+        ///
+        /// This would then indicate that the LBR GRU backward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lbr_gru_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &weights_layer_desc.data,
+                            &weights_iter_desc.data, &bias_desc.data,
+                            &dst_layer_desc.data, &dst_iter_desc.data,
+                            &diff_src_layer_desc.data, &diff_src_iter_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data, &diff_bias_desc.data,
+                            &diff_dst_layer_desc.data, &diff_dst_iter_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LBR GRU backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LBR GRU backward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an LBR GRU backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an LBR GRU backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LBR GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const lbr_gru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LBR GRU backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an LBR GRU backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LBR GRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const lbr_gru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a LBR GRU backward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a LBR GRU backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(
+                    pd, dnnl::prop_kind::backward, dnnl::algorithm::lbr_gru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
+        memory::desc diff_src_layer_desc() const {
+            return rnn_base::diff_src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
+        memory::desc diff_src_iter_desc() const {
+            return rnn_base::diff_src_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
+        memory::desc diff_weights_layer_desc() const {
+            return rnn_base::diff_weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
+        memory::desc diff_weights_iter_desc() const {
+            return rnn_base::diff_weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return rnn_base::diff_bias_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
+        memory::desc diff_dst_layer_desc() const {
+            return rnn_base::diff_dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
+        memory::desc diff_dst_iter_desc() const {
+            return rnn_base::diff_dst_iter_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lbr_gru_backward() = default;
+
+    /// Constructs an LBR GRU backward propagation primitive.
+    /// @param pd Primitive descriptor for an LBR GRU backward propagation
+    ///     primitive.
+    lbr_gru_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LBR GRU backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LBR GRU backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lbr_gru_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// AUGRU forward propagation primitive.
+struct augru_forward : public primitive {
+    /// Descriptor for an AUGRU forward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for an AUGRU forward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc.
+        ///
+        /// This would then indicate that the AUGRU forward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors except @p src_iter_desc may be
+        ///     initialized with an #dnnl::memory::format_tag::any value of @p
+        ///     format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param attention_desc Memory descriptor for the attention vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &attention_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_augru_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &attention_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &bias_desc.data, &dst_layer_desc.data,
+                            &dst_iter_desc.data, dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an AUGRU forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an AUGRU forward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an AUGRU forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an AUGRU forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an AUGRU forward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an AUGRU forward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an AUGRU forward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an AUGRU forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference,
+                    dnnl::algorithm::vanilla_augru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::attention_desc()const
+        memory::desc attention_desc() const {
+            return rnn_base::augru_attention_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    augru_forward() = default;
+
+    /// Constructs an AUGRU forward propagation primitive.
+    /// @param pd Primitive descriptor for an AUGRU forward propagation
+    ///     primitive.
+    augru_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an AUGRU forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an AUGRU forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    augru_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// AUGRU backward propagation primitive.
+struct augru_backward : public primitive {
+    /// Descriptor for an AUGRU backward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for an AUGRU backward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p diff_src_iter_desc,
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+        ///
+        /// This would then indicate that the AUGRU backward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param attention_desc Memory descriptor for the attention vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_attention_desc Memory descriptor for the diff of
+        ///     attention vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &attention_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_attention_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_augru_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &attention_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &bias_desc.data, &dst_layer_desc.data,
+                            &dst_iter_desc.data, &diff_src_layer_desc.data,
+                            &diff_src_iter_desc.data, &diff_attention_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data, &diff_bias_desc.data,
+                            &diff_dst_layer_desc.data, &diff_dst_iter_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an AUGRU backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an AUGRU backward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an AUGRU backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an AUGRU backward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an AUGRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const augru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an AUGRU backward propagation
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an AUGRU backward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an AUGRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const augru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an AUGRU backward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an AUGRU backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
+                    dnnl::algorithm::vanilla_augru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::attention_desc()const
+        memory::desc attention_desc() const {
+            return rnn_base::augru_attention_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
+        memory::desc diff_src_layer_desc() const {
+            return rnn_base::diff_src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
+        memory::desc diff_src_iter_desc() const {
+            return rnn_base::diff_src_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_attention_desc()const
+        memory::desc diff_attention_desc() const {
+            return rnn_base::diff_augru_attention_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
+        memory::desc diff_weights_layer_desc() const {
+            return rnn_base::diff_weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
+        memory::desc diff_weights_iter_desc() const {
+            return rnn_base::diff_weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return rnn_base::diff_bias_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
+        memory::desc diff_dst_layer_desc() const {
+            return rnn_base::diff_dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
+        memory::desc diff_dst_iter_desc() const {
+            return rnn_base::diff_dst_iter_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    augru_backward() = default;
+
+    /// Constructs an AUGRU backward propagation primitive.
+    /// @param pd Primitive descriptor for an AUGRU backward propagation
+    ///     primitive.
+    augru_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an AUGRU backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an AUGRU backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    augru_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// LBR AUGRU forward propagation primitive.
+struct lbr_augru_forward : public primitive {
+    /// Descriptor for an LBR AUGRU forward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for LBR AUGRU forward propagation primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc,
+        /// - @p bias_desc,
+        /// - @p dst_iter_desc.
+        ///
+        /// This would then indicate that the LBR AUGRU forward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors except @p src_iter_desc may be
+        ///     initialized with an #dnnl::memory::format_tag::any value of @p
+        ///     format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param attention_desc Memory descriptor for the attention vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &attention_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lbr_augru_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &attention_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &bias_desc.data, &dst_layer_desc.data,
+                            &dst_iter_desc.data, dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LBR AUGRU forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LBR AUGRU forward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an LBR AUGRU forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an LBR AUGRU forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LBR AUGRU forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an LBR AUGRU forward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : rnn_primitive_desc_base(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LBR AUGRU forward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an LBR AUGRU forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference,
+                    dnnl::algorithm::lbr_augru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::attention_desc()const
+        memory::desc attention_desc() const {
+            return rnn_base::augru_attention_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lbr_augru_forward() = default;
+
+    /// Constructs an LBR AUGRU forward propagation primitive.
+    /// @param pd Primitive descriptor for an LBR AUGRU forward propagation
+    ///     primitive.
+    lbr_augru_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LBR AUGRU forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LBR AUGRU forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lbr_augru_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// LBR AUGRU backward propagation primitive.
+struct lbr_augru_backward : public primitive {
+    /// Descriptor for an LBR AUGRU backward propagation primitive.
+    struct desc {
+        dnnl_rnn_desc_t data;
+
+        /// Constructs a descriptor for LBR AUGRU backward propagation
+        /// primitive.
+        ///
+        /// The following arguments may point to a zero memory descriptor:
+        /// - @p src_iter_desc together with @p diff_src_iter_desc,
+        /// - @p bias_desc together with @p diff_bias_desc,
+        /// - @p dst_iter_desc together with @p diff_dst_iter_desc.
+        ///
+        /// This would then indicate that the LBR AUGRU backward propagation
+        /// primitive should not use them and should default to zero values
+        /// instead.
+        ///
+        /// @note
+        ///     All memory descriptors may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Must be
+        ///     #dnnl::prop_kind::backward.
+        /// @param direction RNN direction. See @ref dnnl::rnn_direction for
+        ///     more info.
+        /// @param src_layer_desc Memory descriptor for the input vector.
+        /// @param src_iter_desc Memory descriptor for the input recurrent
+        ///     hidden state vector.
+        /// @param attention_desc Memory descriptor for the attention vector.
+        /// @param weights_layer_desc Memory descriptor for the weights
+        ///     applied to the layer input.
+        /// @param weights_iter_desc Memory descriptor for the weights applied
+        ///     to the recurrent input.
+        /// @param bias_desc Bias memory descriptor.
+        /// @param dst_layer_desc Memory descriptor for the output vector.
+        /// @param dst_iter_desc Memory descriptor for the output recurrent
+        ///     hidden state vector.
+        /// @param diff_src_layer_desc Memory descriptor for the diff of input
+        ///     vector.
+        /// @param diff_src_iter_desc Memory descriptor for the diff of input
+        ///     recurrent hidden state vector.
+        /// @param diff_attention_desc Memory descriptor for the diff of
+        ///     attention vector.
+        /// @param diff_weights_layer_desc Memory descriptor for the diff of
+        ///     weights applied to the layer input.
+        /// @param diff_weights_iter_desc Memory descriptor for the diff of
+        ///     weights applied to the recurrent input.
+        /// @param diff_bias_desc Diff bias memory descriptor.
+        /// @param diff_dst_layer_desc Memory descriptor for the diff of
+        ///     output vector.
+        /// @param diff_dst_iter_desc Memory descriptor for the diff of output
+        ///     recurrent hidden state vector.
+        /// @param flags Unused.
+        desc(prop_kind aprop_kind, rnn_direction direction,
+                const memory::desc &src_layer_desc,
+                const memory::desc &src_iter_desc,
+                const memory::desc &attention_desc,
+                const memory::desc &weights_layer_desc,
+                const memory::desc &weights_iter_desc,
+                const memory::desc &bias_desc,
+                const memory::desc &dst_layer_desc,
+                const memory::desc &dst_iter_desc,
+                const memory::desc &diff_src_layer_desc,
+                const memory::desc &diff_src_iter_desc,
+                const memory::desc &diff_attention_desc,
+                const memory::desc &diff_weights_layer_desc,
+                const memory::desc &diff_weights_iter_desc,
+                const memory::desc &diff_bias_desc,
+                const memory::desc &diff_dst_layer_desc,
+                const memory::desc &diff_dst_iter_desc,
+                rnn_flags flags = rnn_flags::undef) {
+            error::wrap_c_api(
+                    dnnl_lbr_augru_backward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            dnnl::convert_to_c(direction), &src_layer_desc.data,
+                            &src_iter_desc.data, &attention_desc.data,
+                            &weights_layer_desc.data, &weights_iter_desc.data,
+                            &bias_desc.data, &dst_layer_desc.data,
+                            &dst_iter_desc.data, &diff_src_layer_desc.data,
+                            &diff_src_iter_desc.data, &diff_attention_desc.data,
+                            &diff_weights_layer_desc.data,
+                            &diff_weights_iter_desc.data, &diff_bias_desc.data,
+                            &diff_dst_layer_desc.data, &diff_dst_iter_desc.data,
+                            dnnl::convert_to_c(flags)),
+                    "could not create a descriptor for an LBR AUGRU backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for an LBR AUGRU backward propagation primitive.
+    struct primitive_desc : public rnn_primitive_desc_base {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an LBR AUGRU backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an LBR AUGRU backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LBR AUGRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const lbr_augru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LBR AUGRU backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for an LBR AUGRU backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for an LBR AUGRU
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const lbr_augru_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : rnn_primitive_desc_base(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for an LBR AUGRU backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for an LBR AUGRU backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
+                    dnnl::algorithm::lbr_augru) {}
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
+        memory::desc src_layer_desc() const {
+            return rnn_base::src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
+        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::attention_desc()const
+        memory::desc attention_desc() const {
+            return rnn_base::augru_attention_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
+        memory::desc weights_layer_desc() const {
+            return rnn_base::weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
+        memory::desc weights_iter_desc() const {
+            return rnn_base::weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
+        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
+        memory::desc dst_layer_desc() const {
+            return rnn_base::dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
+        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const {
+            return rnn_base::workspace_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
+        memory::desc diff_src_layer_desc() const {
+            return rnn_base::diff_src_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
+        memory::desc diff_src_iter_desc() const {
+            return rnn_base::diff_src_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_attention_desc()const
+        memory::desc diff_attention_desc() const {
+            return rnn_base::diff_augru_attention_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
+        memory::desc diff_weights_layer_desc() const {
+            return rnn_base::diff_weights_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
+        memory::desc diff_weights_iter_desc() const {
+            return rnn_base::diff_weights_iter_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
+        memory::desc diff_bias_desc() const {
+            return rnn_base::diff_bias_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
+        memory::desc diff_dst_layer_desc() const {
+            return rnn_base::diff_dst_layer_desc();
+        }
+
+        /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
+        memory::desc diff_dst_iter_desc() const {
+            return rnn_base::diff_dst_iter_desc();
+        }
+    };
+
+    /// Default constructor. Produces an empty object.
+    lbr_augru_backward() = default;
+
+    /// Constructs an LBR AUGRU backward propagation primitive.
+    /// @param pd Primitive descriptor for an LBR AUGRU backward propagation
+    ///     primitive.
+    lbr_augru_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an LBR AUGRU backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an LBR AUGRU backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    lbr_augru_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_rnn
+
+/// @addtogroup dnnl_api_shuffle Shuffle
+///
+/// A primitive to shuffle tensor data along an axis.
+///
+/// @sa @ref dev_guide_shuffle in developer guide
+///
+/// @{
+
+/// Shuffle forward propagation primitive.
+struct shuffle_forward : public primitive {
+    /// Descriptor for a shuffle forward propagation primitive.
+    struct desc {
+        dnnl_shuffle_desc_t data;
+
+        /// Constructs a descriptor for a shuffle forward propagation
+        /// primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptor.
+        /// @param axis The axis along which the data is shuffled.
+        /// @param group_size Shuffle group size.
+        desc(prop_kind aprop_kind, const memory::desc &data_desc, int axis,
+                int group_size) {
+            error::wrap_c_api(dnnl_shuffle_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      &data_desc.data, axis, group_size),
+                    "could not create a descriptor for a shuffle forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a shuffle forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a shuffle forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a shuffle forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const primitive_attr &attr = primitive_attr(),
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a shuffle forward propagation
+        /// primitive from a C API primitive descriptor that must have a
+        /// matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a shuffle forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::shuffle,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    shuffle_forward() = default;
+
+    /// Constructs a shuffle forward propagation primitive.
+    /// @param pd Primitive descriptor for a shuffle forward propagation
+    ///     primitive.
+    shuffle_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a shuffle forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a shuffle forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    shuffle_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Shuffle backward propagation primitive.
+struct shuffle_backward : public primitive {
+    /// Descriptor for a shuffle primitive backward propagation
+    /// primitive.
+    struct desc {
+        dnnl_shuffle_desc_t data;
+
+        /// Constructs a descriptor for a shuffle backward propagation
+        /// primitive.
+        ///
+        /// @param diff_data_desc Diff source and diff destination memory
+        ///     descriptor.
+        /// @param axis The axis along which the data is shuffled.
+        /// @param group_size Shuffle group size.
+        desc(const memory::desc &diff_data_desc, int axis, int group_size) {
+            error::wrap_c_api(dnnl_shuffle_backward_desc_init(&data,
+                                      &diff_data_desc.data, axis, group_size),
+                    "could not create a descriptor for a shuffle backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a shuffle backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a shuffle backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a shuffle backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param hint_fwd_pd Primitive descriptor for a shuffle
+        ///     forward propagation primitive. It is used as a hint for
+        ///     deciding which memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const shuffle_forward::primitive_desc &hint_fwd_pd,
+                const primitive_attr &attr = primitive_attr(),
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a shuffle backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a shuffle backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::shuffle,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    shuffle_backward() = default;
+
+    /// Constructs a shuffle backward propagation primitive.
+    /// @param pd Primitive descriptor for a shuffle backward propagation
+    ///     primitive.
+    shuffle_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a shuffle backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a shuffle backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    shuffle_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_shuffle
+
+/// @addtogroup dnnl_api_binary Binary
+///
+/// A primitive to perform tensor operations over two tensors.
+///
+/// @sa @ref dev_guide_binary in developer guide
+///
+/// @{
+
+/// Elementwise binary operator primitive.
+struct binary : public primitive {
+    /// Descriptor for an elementwise binary operator primitive.
+    struct desc {
+        /// Underlying C operation descriptor.
+        dnnl_binary_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for an elementwise binary operator
+        /// primitive.
+        ///
+        /// @param aalgorithm Elementwise binary algorithm.
+        /// @param src0 Memory descriptor for source tensor #0.
+        /// @param src1 Memory descriptor for source tensor #1.
+        /// @param dst Memory descriptor for destination tensor.
+        desc(algorithm aalgorithm, const memory::desc &src0,
+                const memory::desc &src1, const memory::desc &dst) {
+            error::wrap_c_api(
+                    dnnl_binary_desc_init(&data, dnnl::convert_to_c(aalgorithm),
+                            &src0.data, &src1.data, &dst.data),
+                    "could not create a descriptor for a binary operation "
+                    "primitive");
+        }
+    };
+
+    /// Primitive descriptor for an elementwise binary operator primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for an elementwise binary operator
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an elementwise binary operator primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for an elementwise binary operator
+        /// primitive.
+        ///
+        /// @param adesc Descriptor for an elementwise binary operator primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a binary primitive from a C
+        /// API primitive descriptor that must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a binary primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::binary) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
+        memory::desc src_desc(int idx = 0) const { return base::src_desc(idx); }
+
+        /// Returns the memory descriptor for source #0.
+        memory::desc src0_desc() const { return base::src_desc(0); }
+
+        /// Returns the memory descriptor for source #1.
+        memory::desc src1_desc() const { return base::src_desc(1); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    binary() = default;
+
+    /// Constructs an elementwise binary operation primitive.
+    /// @param pd Primitive descriptor for an elementwise binary operation
+    ///     primitive.
+    binary(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs an elementwise binary operation primitive from a cache blob.
+    /// @param pd Primitive descriptor for an elementwise binary operation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    binary(const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_binary
+
+/// @addtogroup dnnl_api_matmul Matrix Multiplication
+///
+/// A primitive to perform matrix-matrix multiplication. The batched mode
+/// is supported with 3D tensors.
+///
+/// @sa @ref dev_guide_matmul in developer guide
+///
+///
+/// @{
+
+/// Matrix multiplication (matmul) primitive.
+struct matmul : public primitive {
+    /// Descriptor for a matmul primitive.
+    struct desc {
+        dnnl_matmul_desc_t data;
+
+        /// Constructs a descriptor for a matmul primitive.
+        ///
+        /// @param src_desc Memory descriptor for source (matrix A).
+        /// @param weights_desc Memory descriptor for weights (matrix B).
+        /// @param dst_desc Memory descriptor for destination (matrix C).
+        desc(const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &dst_desc) {
+            error::wrap_c_api(
+                    dnnl_matmul_desc_init(&data, &src_desc.data,
+                            &weights_desc.data, nullptr, &dst_desc.data),
+                    "could not create a descriptor for a matmul primitive");
+        }
+
+        /// Constructs a descriptor for a matmul primitive.
+        ///
+        /// @param src_desc Memory descriptor for source (matrix A).
+        /// @param weights_desc Memory descriptor for weights (matrix B).
+        /// @param dst_desc Memory descriptor for destination (matrix C).
+        /// @param bias_desc Memory descriptor for bias.
+        desc(const memory::desc &src_desc, const memory::desc &weights_desc,
+                const memory::desc &bias_desc, const memory::desc &dst_desc) {
+            error::wrap_c_api(dnnl_matmul_desc_init(&data, &src_desc.data,
+                                      &weights_desc.data, &bias_desc.data,
+                                      &dst_desc.data),
+                    "could not create a descriptor for a matmul primitive");
+        }
+    };
+
+    /// Primitive descriptor for a matmul primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a matmul primitive.
+        ///
+        /// @param adesc Descriptor for a matmul primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a matmul primitive.
+        ///
+        /// @param adesc Descriptor for a matmul primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a matmul primitive from a C
+        /// API primitive descriptor that must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a matmul primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::matmul) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return query_md(query::src_md, 0); }
+
+        /// @copydoc dnnl::primitive_desc_base::weights_desc()const
+        memory::desc weights_desc() const {
+            return query_md(query::weights_md, 0);
+        }
+
+        /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
+        memory::desc bias_desc() const {
+            return query_md(query::weights_md, 1);
+        }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return query_md(query::dst_md, 0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    matmul() = default;
+
+    /// Constructs a matmul primitive.
+    /// @param pd Primitive descriptor for a matmul primitive.
+    matmul(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a matmul primitive from a cache blob.
+    /// @param pd Primitive descriptor for a matmul primitive.
+    /// @param cache_blob Cache blob.
+    matmul(const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_matmul
+
+/// @addtogroup dnnl_api_resampling Resampling
+///
+/// A primitive to compute resampling operation on 1D, 2D or 3D data tensor
+/// using Nearest Neighbor, or Linear (Bilinear, Trilinear) interpolation
+/// method.
+///
+/// @sa @ref dev_guide_resampling in developer guide
+///
+/// @{
+
+/// Resampling forward propagation.
+struct resampling_forward : public primitive {
+    /// Descriptor for resampling forward propagation.
+    struct desc {
+        dnnl_resampling_desc_t data;
+
+        /// Constructs a descriptor for a resampling forward propagation
+        /// primitive using source and destination memory descriptors.
+        ///
+        /// @note
+        ///     Destination memory descriptor may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &dst_desc) {
+            error::wrap_c_api(dnnl_resampling_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), nullptr,
+                                      &src_desc.data, &dst_desc.data),
+                    "could not create a resampling forward descriptor");
+        }
+
+        /// Constructs a descriptor for a resampling forward propagation
+        /// primitive using source memory descriptor and factors.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param factors Vector of scaling factors for spatial dimension.
+        /// @param src_desc Source memory descriptor.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const std::vector<float> &factors,
+                const memory::desc &src_desc) {
+            memory::validate_dims(factors, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_resampling_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), &factors[0],
+                                      &src_desc.data, nullptr),
+                    "could not create a resampling forward descriptor");
+        }
+
+        /// Constructs a descriptor for a resampling forward propagation
+        /// primitive.
+        ///
+        /// @note
+        ///     The destination memory descriptor may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param factors Vector of scaling factors for spatial dimension.
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const std::vector<float> &factors, const memory::desc &src_desc,
+                const memory::desc &dst_desc) {
+            if (!factors.empty())
+                memory::validate_dims(factors, src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_resampling_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      convert_to_c(aalgorithm), factors.data(),
+                                      &src_desc.data, &dst_desc.data),
+                    "could not create a resampling forward descriptor");
+        }
+    };
+
+    /// Primitive descriptor for a resampling forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a resampling forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a resampling forward propagation
+        /// primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a resampling forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a resampling forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a resampling forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a resampling forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::resampling,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    resampling_forward() = default;
+
+    /// Constructs a resampling forward propagation primitive.
+    /// @param pd Primitive descriptor for a resampling forward propagation
+    ///     primitive.
+    resampling_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a resampling forward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a resampling forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    resampling_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Resampling backward propagation primitive.
+struct resampling_backward : public primitive {
+    /// Descriptor for a resampling backward propagation primitive.
+    struct desc {
+        dnnl_resampling_desc_t data;
+
+        /// Constructs a descriptor for a resampling backward propagation
+        /// primitive using source and destination memory descriptors.
+        ///
+        /// @param aalgorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc) {
+            error::wrap_c_api(dnnl_resampling_backward_desc_init(&data,
+                                      convert_to_c(aalgorithm), nullptr,
+                                      &diff_src_desc.data, &diff_dst_desc.data),
+                    "could not create a resampling backward data descriptor");
+        }
+
+        /// Constructs a descriptor for resampling backward propagation
+        /// primitive.
+        ///
+        /// @param aalgorithm resampling algorithm kind: either
+        ///     #dnnl::algorithm::resampling_nearest, or
+        ///     #dnnl::algorithm::resampling_linear
+        /// @param factors Vector of scaling factors for spatial dimension.
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        desc(algorithm aalgorithm, const std::vector<float> &factors,
+                const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc) {
+            if (!factors.empty())
+                memory::validate_dims(factors, diff_src_desc.data.ndims - 2);
+            error::wrap_c_api(dnnl_resampling_backward_desc_init(&data,
+                                      convert_to_c(aalgorithm), factors.data(),
+                                      &diff_src_desc.data, &diff_dst_desc.data),
+                    "could not create a resampling backward data descriptor");
+        }
+    };
+
+    /// Primitive descriptor for resampling backward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a resampling backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a resampling backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a resampling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const resampling_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a resampling backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a resampling backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a resampling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const resampling_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a resampling backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a resampling backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::resampling,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    resampling_backward() = default;
+
+    /// Constructs a resampling backward propagation primitive.
+    /// @param pd Primitive descriptor for a resampling backward propagation
+    ///     primitive.
+    resampling_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a resampling backward propagation primitive from a cache
+    ///     blob.
+    /// @param pd Primitive descriptor for a resampling backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    resampling_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_resampling
+
+/// @addtogroup dnnl_api_pooling_v2 Pooling_v2
+///
+/// A primitive to perform max or average pooling with dilation.
+///
+/// @sa @ref dev_guide_pooling in developer guide
+///
+/// @{
+
+/// Pooling v2 (dilated pooling) forward propagation primitive.
+struct pooling_v2_forward : public primitive {
+    /// Descriptor for a pooling forward propagation primitive.
+    struct desc {
+        dnnl_pooling_v2_desc_t data;
+
+        /// Constructs a descriptor for pooling v2
+        /// (dilated pooling) forward propagation primitive.
+        ///
+        /// Arrays @p strides, @p kernel, @p dilation, @p padding_l
+        /// and @p padding_r contain values for spatial dimensions only and
+        /// hence must have the same number of elements as there are spatial
+        /// dimensions. The order of values is the same as in the tensor:
+        /// depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param aalgorithm Pooling algorithm kind: either
+        ///     #dnnl::algorithm::pooling_max,
+        ///     #dnnl::algorithm::pooling_avg_include_padding,
+        ///     or #dnnl::algorithm::pooling_avg (same as
+        ///     #dnnl::algorithm::pooling_avg_exclude_padding).
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param kernel Vector of kernel spatial dimensions.
+        /// @param dilation Array of dilations for spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(prop_kind aprop_kind, algorithm aalgorithm,
+                const memory::desc &src_desc, const memory::desc &dst_desc,
+                const memory::dims &strides, const memory::dims &kernel,
+                const memory::dims &dilation, const memory::dims &padding_l,
+                const memory::dims &padding_r) {
+            memory::validate_dims(strides, src_desc.data.ndims - 2);
+            memory::validate_dims(kernel, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, src_desc.data.ndims - 2);
+            memory::validate_dims(dilation, src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_pooling_v2_forward_desc_init(&data,
+                            dnnl::convert_to_c(aprop_kind),
+                            convert_to_c(aalgorithm), &src_desc.data,
+                            &dst_desc.data, &strides[0], &kernel[0],
+                            &dilation[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a pooling forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a pooling forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a pooling v2
+        /// (dilated pooling) forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling v2
+        /// (dilated pooling) forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling forward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling v2
+        /// (dilated pooling) forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a pooling forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::pooling_v2,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    pooling_v2_forward() = default;
+
+    /// Constructs a pooling v2 (dilated pooling) forward
+    /// propagation primitive.
+    /// @param pd Primitive descriptor for a pooling v2
+    /// (dilated pooling) forward propagation primitive.
+    pooling_v2_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a pooling v2 (dilated pooling) forward
+    /// propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a pooling v2
+    /// (dilated pooling) forward propagation primitive.
+    /// @param cache_blob Cache blob.
+    pooling_v2_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// Pooling v2 (dilated pooling) backward propagation primitive.
+struct pooling_v2_backward : public primitive {
+    /// Descriptor for a pooling backward propagation primitive.
+    struct desc {
+        dnnl_pooling_v2_desc_t data;
+
+        /// Constructs a descriptor for pooling v2 (dilated pooling) backward
+        /// propagation primitive.
+        ///
+        /// Arrays @p strides, @p kernel, @p dilation, @p padding_l
+        /// and @p padding_r contain values for spatial dimensions only and
+        /// hence must have the same number of elements as there are spatial
+        /// dimensions. The order of values is the same as in the tensor:
+        /// depth (for 3D tensors), height (for 3D and 2D tensors), and width.
+        ///
+        /// @param aalgorithm Pooling algorithm kind: either
+        ///     #dnnl::algorithm::pooling_max,
+        ///     #dnnl::algorithm::pooling_avg_include_padding,
+        ///     or #dnnl::algorithm::pooling_avg (same as
+        ///     #dnnl::algorithm::pooling_avg_exclude_padding).
+        /// @param diff_src_desc Diff source memory descriptor.
+        /// @param diff_dst_desc Diff destination memory descriptor.
+        /// @param strides Vector of strides for spatial dimension.
+        /// @param kernel Vector of kernel spatial dimensions.
+        /// @param dilation Array of dilations for spatial dimension.
+        /// @param padding_l Vector of padding values for low indices for each
+        ///     spatial dimension `([[front,] top,] left)`.
+        /// @param padding_r Vector of padding values for high indices for
+        ///     each spatial dimension `([[back,] bottom,] right)`.
+        desc(algorithm aalgorithm, const memory::desc &diff_src_desc,
+                const memory::desc &diff_dst_desc, const memory::dims &strides,
+                const memory::dims &kernel, const memory::dims &dilation,
+                const memory::dims &padding_l, const memory::dims &padding_r) {
+            memory::validate_dims(strides, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(kernel, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_l, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(padding_r, diff_src_desc.data.ndims - 2);
+            memory::validate_dims(dilation, diff_src_desc.data.ndims - 2);
+            error::wrap_c_api(
+                    dnnl_pooling_v2_backward_desc_init(&data,
+                            convert_to_c(aalgorithm), &diff_src_desc.data,
+                            &diff_dst_desc.data, &strides[0], &kernel[0],
+                            &dilation[0], &padding_l[0], &padding_r[0]),
+                    "could not create a descriptor for a pooling backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a pooling v2 (dilated pooling) backward
+    /// propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a pooling v2
+        /// (dilated pooling) backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling backward propagation primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a pooling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const pooling_v2_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling v2
+        /// (dilated pooling) backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a pooling backward propagation primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a pooling forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const pooling_v2_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a pooling v2
+        /// (dilated pooling) backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a pooling backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::pooling_v2,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
+        memory::desc workspace_desc() const { return base::workspace_desc(); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    pooling_v2_backward() = default;
+
+    /// Constructs a pooling v2 (dilated pooling) backward
+    /// propagation primitive.
+    /// @param pd Primitive descriptor for a pooling backward propagation
+    ///     primitive.
+    pooling_v2_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a pooling v2 (dilated pooling) backward
+    /// propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a pooling backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    pooling_v2_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_pooling_v2
+
+/// @addtogroup dnnl_api_prelu PReLU
+///
+/// PReLU primitive
+/// A primitive to perform PReLU (leaky ReLU with trainable alpha parameter)
+///
+/// @sa @ref dev_guide_prelu in developer guide
+///
+/// @{
+
+/// PReLU forward propagation primitive.
+struct prelu_forward : public primitive {
+    /// Descriptor for a PReLU forward propagation primitive.
+    struct desc {
+        dnnl_prelu_desc_t data;
+
+        /// Constructs a descriptor for a PReLU forward propagation
+        /// primitive.
+        ///
+        /// @param aprop_kind Propagation kind. Possible values are
+        ///     #dnnl::prop_kind::forward_training, and
+        ///     #dnnl::prop_kind::forward_inference.
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param weight_desc Alpha parameters memory descriptor.
+        desc(prop_kind aprop_kind, const memory::desc &data_desc,
+                const memory::desc &weight_desc) {
+            error::wrap_c_api(dnnl_prelu_forward_desc_init(&data,
+                                      dnnl::convert_to_c(aprop_kind),
+                                      &data_desc.data, &weight_desc.data),
+                    "could not create a descriptor for a prelu forward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for a PReLU forward propagation primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a PReLU forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a PReLU forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a PReLU forward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a PReLU forward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a prelu forward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a prelu forward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::prelu,
+                    dnnl::prop_kind::forward_training,
+                    dnnl::prop_kind::forward_inference) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    prelu_forward() = default;
+
+    /// Constructs a prelu forward propagation primitive.
+    /// @param pd Primitive descriptor for a prelu forward propagation
+    ///     primitive.
+    prelu_forward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a prelu forward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a prelu forward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    prelu_forward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// PReLU backward propagation primitive.
+struct prelu_backward : public primitive {
+    /// Descriptor for a PReLU backward propagation primitive.
+    struct desc {
+        dnnl_prelu_desc_t data;
+
+        /// Constructs a descriptor for a PReLU backward propagation
+        /// primitive.
+        ///
+        /// @param data_desc Source and destination memory descriptors.
+        /// @param weight_desc Alpha parameters memory descriptor.
+        /// @param diff_data_desc Diff source and destination memory
+        ///     descriptors.
+        /// @param diff_weights_desc Diff alpha parameters memory descriptor.
+        desc(const memory::desc &data_desc, const memory::desc &weight_desc,
+                const memory::desc &diff_data_desc,
+                const memory::desc &diff_weights_desc) {
+            error::wrap_c_api(
+                    dnnl_prelu_backward_desc_init(&data, &data_desc.data,
+                            &weight_desc.data, &diff_data_desc.data,
+                            &diff_weights_desc.data),
+                    "could not create a descriptor for a prelu backward "
+                    "propagation primitive");
+        }
+    };
+
+    /// Primitive descriptor for prelu backward propagation.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a PReLU backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a PReLU backward propagation
+        ///     primitive.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a PReLU forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                const prelu_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, nullptr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a PReLU backward
+        /// propagation primitive.
+        ///
+        /// @param adesc Descriptor for a PReLU backward propagation
+        ///     primitive.
+        /// @param attr Primitive attributes to use.
+        /// @param aengine Engine to use.
+        /// @param hint_fwd_pd Primitive descriptor for a PReLU forward
+        ///     propagation primitive. It is used as a hint for deciding which
+        ///     memory format to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine,
+                const prelu_forward::primitive_desc &hint_fwd_pd,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(&adesc.data, &attr, aengine,
+                    hint_fwd_pd.get(), allow_empty) {}
+
+        /// Constructs a primitive descriptor for a prelu backward
+        /// propagation primitive from a C API primitive descriptor that must
+        /// have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a prelu backward
+        ///     propagation primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::prelu,
+                    dnnl::prop_kind::backward_data) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
+        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
+        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    prelu_backward() = default;
+
+    /// Constructs a prelu backward propagation primitive.
+    /// @param pd Primitive descriptor for a prelu backward propagation
+    ///     primitive.
+    prelu_backward(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a prelu backward propagation primitive from a cache blob.
+    /// @param pd Primitive descriptor for a prelu backward propagation
+    ///     primitive.
+    /// @param cache_blob Cache blob.
+    prelu_backward(
+            const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_prelu
+
+/// @addtogroup dnnl_api_reduction Reduction
+///
+/// A primitive to compute reduction operation on data tensor
+/// using min, max, mul, sum, mean and norm_lp operations.
+///
+/// @sa @ref dev_guide_reduction in developer guide
+///
+/// @{
+
+/// Reduction.
+struct reduction : public primitive {
+    /// Descriptor for reduction.
+    struct desc {
+        dnnl_reduction_desc_t data;
+
+        /// Default constructor. Produces an empty object.
+        desc() = default;
+
+        /// Constructs a descriptor for a reduction primitive using algorithm
+        /// specific parameters, source and destination memory descriptors.
+        ///
+        /// @note
+        ///     Destination memory descriptor may be initialized with
+        ///     #dnnl::memory::format_tag::any value of @p format_tag.
+        ///
+        /// @param aalgorithm reduction algorithm kind. Possible values:
+        ///     #dnnl_reduction_max, #dnnl_reduction_min, #dnnl_reduction_sum,
+        ///     #dnnl_reduction_mul, #dnnl_reduction_mean,
+        ///     #dnnl_reduction_norm_lp_max, #dnnl_reduction_norm_lp_sum,
+        ///     #dnnl_reduction_norm_lp_power_p_max,
+        ///     #dnnl_reduction_norm_lp_power_p_sum.
+        /// @param p algorithm specific parameter.
+        /// @param eps algorithm specific parameter.
+        /// @param src_desc Source memory descriptor.
+        /// @param dst_desc Destination memory descriptor.
+        desc(algorithm aalgorithm, const memory::desc &src_desc,
+                const memory::desc &dst_desc, float p, float eps) {
+            error::wrap_c_api(
+                    dnnl_reduction_desc_init(&data, convert_to_c(aalgorithm),
+                            &src_desc.data, &dst_desc.data, p, eps),
+                    "could not create a reduction descriptor");
+        }
+    };
+
+    /// Primitive descriptor for a reduction primitive.
+    struct primitive_desc : public dnnl::primitive_desc {
+        /// Default constructor. Produces an empty object.
+        primitive_desc() = default;
+
+        /// Constructs a primitive descriptor for a reduction primitive.
+        ///
+        /// @param adesc Descriptor for a reduction primitive.
+        /// @param aengine Engine to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const engine &aengine,
+                bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, nullptr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a reduction primitive.
+        ///
+        /// @param adesc Descriptor for a reduction primitive.
+        /// @param aengine Engine to use.
+        /// @param attr Primitive attributes to use.
+        /// @param allow_empty A flag signifying whether construction is
+        ///     allowed to fail without throwing an exception. In this case an
+        ///     empty object will be produced. This flag is optional and
+        ///     defaults to false.
+        primitive_desc(const desc &adesc, const primitive_attr &attr,
+                const engine &aengine, bool allow_empty = false)
+            : dnnl::primitive_desc(
+                    &adesc.data, &attr, aengine, nullptr, allow_empty) {}
+
+        /// Constructs a primitive descriptor for a reduction primitive from a C
+        /// API primitive descriptor that must have a matching kind.
+        ///
+        /// @param pd C API primitive descriptor for a reduction primitive.
+        primitive_desc(dnnl_primitive_desc_t pd)
+            : dnnl::primitive_desc(pd, dnnl::primitive::kind::reduction) {}
+
+        /// @copydoc dnnl::primitive_desc_base::src_desc()const
+        memory::desc src_desc() const { return base::src_desc(0); }
+
+        /// @copydoc dnnl::primitive_desc_base::dst_desc()const
+        memory::desc dst_desc() const { return base::dst_desc(0); }
+    };
+
+    /// Default constructor. Produces an empty object.
+    reduction() = default;
+
+    /// Constructs a reduction primitive.
+    /// @param pd Primitive descriptor for a reduction primitive.
+    reduction(const primitive_desc &pd) : primitive(pd) {}
+
+    /// Constructs a reduction primitive from a cache blob.
+    /// @param pd Primitive descriptor for a reduction primitive.
+    /// @param cache_blob Cache blob.
+    reduction(const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+        : primitive(pd, cache_blob) {}
+};
+
+/// @} dnnl_api_reduction
+
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_service Service
+///
+/// A set of functions that aid in oneDNN debugging and profiling.
+///
+/// @{
+
+/// @copydoc dnnl_version_t
+using version_t = dnnl_version_t;
+
+/// Status values returned by the library functions.
+enum class status {
+    /// @copydoc dnnl_success
+    success = dnnl_success,
+    /// @copydoc dnnl_out_of_memory
+    out_of_memory = dnnl_out_of_memory,
+    /// @copydoc dnnl_invalid_arguments
+    invalid_arguments = dnnl_invalid_arguments,
+    /// @copydoc dnnl_unimplemented
+    unimplemented = dnnl_unimplemented,
+    /// @copydoc dnnl_iterator_ends
+    iterator_ends = dnnl_iterator_ends,
+    /// @copydoc dnnl_runtime_error
+    runtime_error = dnnl_runtime_error,
+    /// @copydoc dnnl_not_required
+    not_required = dnnl_not_required,
+};
+
+/// @copydoc dnnl_set_verbose()
+inline status set_verbose(int level) {
+    return static_cast<status>(dnnl_set_verbose(level));
+}
+
+/// @copydoc dnnl_version()
+inline const version_t *version() {
+    return dnnl_version();
+}
+
+/// Returns the floating-point math mode that will be used by default
+/// for all subsequently created primitives.
+///
+/// @returns Output FP math mode.
+inline fpmath_mode get_default_fpmath_mode() {
+    dnnl_fpmath_mode_t mode;
+    error::wrap_c_api(dnnl_get_default_fpmath_mode(&mode),
+            "could not get a default fpmath mode");
+    return static_cast<fpmath_mode>(mode);
+}
+
+/// @copydoc dnnl_set_default_fpmath_mode()
+inline status set_default_fpmath_mode(fpmath_mode mode) {
+    return static_cast<status>(
+            dnnl_set_default_fpmath_mode(convert_to_c(mode)));
+}
+
+/// @copydoc dnnl_set_jit_dump()
+inline status set_jit_dump(int enable) {
+    return static_cast<status>(dnnl_set_jit_dump(enable));
+}
+
+/// @copydoc dnnl_set_jit_profiling_flags()
+inline status set_jit_profiling_flags(unsigned flags) {
+    return static_cast<status>(dnnl_set_jit_profiling_flags(flags));
+}
+
+/// @copydoc dnnl_set_jit_profiling_jitdumpdir()
+inline status set_jit_profiling_jitdumpdir(const std::string &dir) {
+    return static_cast<status>(dnnl_set_jit_profiling_jitdumpdir(dir.c_str()));
+}
+
+/// @copydoc dnnl_cpu_isa_t
+enum class cpu_isa {
+    /// @copydoc dnnl_cpu_isa_all
+    all = dnnl_cpu_isa_all,
+    /// @copydoc dnnl_cpu_isa_sse41
+    sse41 = dnnl_cpu_isa_sse41,
+    /// @copydoc dnnl_cpu_isa_avx
+    avx = dnnl_cpu_isa_avx,
+    /// @copydoc dnnl_cpu_isa_avx2
+    avx2 = dnnl_cpu_isa_avx2,
+    /// @copydoc dnnl_cpu_isa_avx512_mic
+    avx512_mic = dnnl_cpu_isa_avx512_mic,
+    /// @copydoc dnnl_cpu_isa_avx512_mic_4ops
+    avx512_mic_4ops = dnnl_cpu_isa_avx512_mic_4ops,
+    /// @copydoc dnnl_cpu_isa_avx512_core
+    avx512_core = dnnl_cpu_isa_avx512_core,
+    /// @copydoc dnnl_cpu_isa_avx512_core_vnni
+    avx512_core_vnni = dnnl_cpu_isa_avx512_core_vnni,
+    /// @copydoc dnnl_cpu_isa_avx512_core_bf16
+    avx512_core_bf16 = dnnl_cpu_isa_avx512_core_bf16,
+    /// @copydoc dnnl_cpu_isa_avx512_core_amx
+    avx512_core_amx = dnnl_cpu_isa_avx512_core_amx,
+    /// @copydoc dnnl_cpu_isa_avx2_vnni
+    avx2_vnni = dnnl_cpu_isa_avx2_vnni,
+    /// @copydoc dnnl_cpu_isa_avx512_core_fp16
+    avx512_core_fp16 = dnnl_cpu_isa_avx512_core_fp16,
+};
+
+/// @copydoc dnnl_set_max_cpu_isa()
+inline status set_max_cpu_isa(cpu_isa isa) {
+    return static_cast<status>(
+            dnnl_set_max_cpu_isa(static_cast<dnnl_cpu_isa_t>(isa)));
+}
+
+/// @copydoc dnnl_get_effective_cpu_isa()
+inline cpu_isa get_effective_cpu_isa() {
+    return static_cast<cpu_isa>(dnnl_get_effective_cpu_isa());
+}
+
+/// @copydoc dnnl_cpu_isa_hints_t
+enum class cpu_isa_hints {
+    /// @copydoc dnnl_cpu_isa_no_hints
+    no_hints = dnnl_cpu_isa_no_hints,
+    /// @copydoc dnnl_cpu_isa_prefer_ymm
+    prefer_ymm = dnnl_cpu_isa_prefer_ymm,
+};
+
+/// @copydoc dnnl_set_cpu_isa_hints()
+inline status set_cpu_isa_hints(cpu_isa_hints isa_hints) {
+    return static_cast<status>(dnnl_set_cpu_isa_hints(
+            static_cast<dnnl_cpu_isa_hints_t>(isa_hints)));
+}
+
+/// @copydoc dnnl_get_cpu_isa_hints()
+inline cpu_isa_hints get_cpu_isa_hints() {
+    return static_cast<cpu_isa_hints>(dnnl_get_cpu_isa_hints());
+}
+
+/// @} dnnl_api_service
+
+/// @addtogroup dnnl_api_primitive_cache Primitive Cache
+///
+/// A set of functions that provide primitive cache control.
+///
+/// @{
+
+/// Returns the number of primitives that can be held in the primitive cache
+/// at the same time.
+inline int get_primitive_cache_capacity() {
+    int result = 0;
+    error::wrap_c_api(dnnl_get_primitive_cache_capacity(&result),
+            "could not get primitive cache capacity");
+    return result;
+}
+
+/// @copydoc dnnl_set_primitive_cache_capacity(int capacity)
+inline void set_primitive_cache_capacity(int capacity) {
+    error::wrap_c_api(dnnl_set_primitive_cache_capacity(capacity),
+            "could not set primitive cache capacity");
+}
+
+/// @} dnnl_api_primitive_cache
+
+/// @addtogroup dnnl_api_blas BLAS functions
+///
+/// A subset of Basic Linear Algebra (BLAS) functions that perform
+/// matrix-matrix multiplication.
+///
+/// @{
+
+/// @copydoc dnnl_sgemm()
+inline status sgemm(char transa, char transb, dnnl_dim_t M, dnnl_dim_t N,
+        dnnl_dim_t K, float alpha, const float *A, dnnl_dim_t lda,
+        const float *B, dnnl_dim_t ldb, float beta, float *C, dnnl_dim_t ldc) {
+    return static_cast<status>(dnnl_sgemm(
+            transa, transb, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc));
+}
+
+/// @copydoc dnnl_gemm_u8s8s32()
+inline status gemm_u8s8s32(char transa, char transb, char offsetc, dnnl_dim_t M,
+        dnnl_dim_t N, dnnl_dim_t K, float alpha, const uint8_t *A,
+        dnnl_dim_t lda, uint8_t ao, const int8_t *B, dnnl_dim_t ldb, int8_t bo,
+        float beta, int32_t *C, dnnl_dim_t ldc, const int32_t *co) {
+    return static_cast<status>(dnnl_gemm_u8s8s32(transa, transb, offsetc, M, N,
+            K, alpha, A, lda, ao, B, ldb, bo, beta, C, ldc, co));
+}
+
+/// @copydoc dnnl_gemm_s8s8s32()
+inline status gemm_s8s8s32(char transa, char transb, char offsetc, dnnl_dim_t M,
+        dnnl_dim_t N, dnnl_dim_t K, float alpha, const int8_t *A,
+        dnnl_dim_t lda, int8_t ao, const int8_t *B, dnnl_dim_t ldb, int8_t bo,
+        float beta, int32_t *C, dnnl_dim_t ldc, const int32_t *co) {
+    return static_cast<status>(dnnl_gemm_s8s8s32(transa, transb, offsetc, M, N,
+            K, alpha, A, lda, ao, B, ldb, bo, beta, C, ldc, co));
+}
+
+/// @} dnnl_api_blas
+
+// implementation section
+
+/// @cond DO_NOT_DOCUMENT_THIS
+inline primitive::primitive(const_dnnl_primitive_desc_t c_pd) {
+    dnnl_primitive_t result;
+    error::wrap_c_api(dnnl_primitive_create(&result, c_pd),
+            "could not create a primitive");
+    reset(result);
+}
+
+inline primitive::primitive(const_dnnl_primitive_desc_t c_pd,
+        const std::vector<uint8_t> &cache_blob) {
+    dnnl_primitive_t result;
+    size_t size = cache_blob.size();
+    const uint8_t *cache_blob_data = cache_blob.data();
+    error::wrap_c_api(dnnl_primitive_create_from_cache_blob(
+                              &result, c_pd, size, cache_blob_data),
+            "could not create a primitive from a cache blob");
+    reset(result);
+}
+
+inline primitive::primitive(const primitive_desc &pd) : primitive(pd.get()) {}
+inline primitive::primitive(
+        const primitive_desc &pd, const std::vector<uint8_t> &cache_blob)
+    : primitive(pd.get(), cache_blob) {}
+
+inline void primitive::execute(const stream &astream,
+        const std::unordered_map<int, memory> &args) const {
+    std::vector<dnnl_exec_arg_t> c_args;
+    c_args.reserve(args.size());
+    for (const auto &a : args)
+        c_args.push_back({a.first, a.second.get(true)});
+
+    error::wrap_c_api(dnnl_primitive_execute(get(), astream.get(),
+                              (int)c_args.size(), c_args.data()),
+            "could not execute a primitive");
+}
+
+/// @endcond
+
+#undef DNNL_DEFINE_BITMASK_OPS
+
+} // namespace dnnl
+
+/// oneAPI namespace
+
+/// The oneAPI namespace.
+/// Contains the oneapi::dnnl namespace as an alias to the ::dnnl namespace.
+namespace oneapi {
+// Note: without this guard, doxygen warns of potentially recursive namespace
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/// oneDNN alias namespace
+namespace dnnl = ::dnnl;
+#endif
+} // namespace oneapi
+
+/// @} dnnl_api
+
+#endif /* ONEAPI_DNNL_DNNL_HPP */

--- a/rfcs/20220815-v3.0-API-cleanup/dnnl_types.h
+++ b/rfcs/20220815-v3.0-API-cleanup/dnnl_types.h
@@ -1,0 +1,3228 @@
+/*******************************************************************************
+* Copyright 2016-2022 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/// @file
+/// C API types definitions
+
+#ifndef ONEAPI_DNNL_DNNL_TYPES_H
+#define ONEAPI_DNNL_DNNL_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @cond DO_NOT_DOCUMENT_THIS
+#include <stddef.h>
+#include <stdint.h>
+/// @endcond
+
+/// @addtogroup dnnl_api
+/// @{
+
+/// @addtogroup dnnl_api_utils
+/// @{
+
+/// Status values returned by the library functions.
+typedef enum {
+    /// The operation was successful
+    dnnl_success = 0,
+    /// The operation failed due to an out-of-memory condition
+    dnnl_out_of_memory = 1,
+    /// The operation failed because of incorrect function arguments
+    dnnl_invalid_arguments = 2,
+    /// The operation failed because requested functionality is not implemented
+    dnnl_unimplemented = 3,
+    /// Primitive iterator passed over last primitive descriptor
+    dnnl_iterator_ends = 4,
+    /// Primitive or engine failed on execution
+    dnnl_runtime_error = 5,
+    /// Queried element is not required for given primitive
+    dnnl_not_required = 6,
+} dnnl_status_t;
+
+/// @} dnnl_api_utils
+
+/// @addtogroup dnnl_api_memory
+/// @{
+
+/// Data type specification
+typedef enum {
+    /// Undefined data type, used for empty memory descriptors.
+    dnnl_data_type_undef = 0,
+    /// 16-bit/half-precision floating point.
+    dnnl_f16 = 1,
+    /// non-standard 16-bit (bfloat16 w/ 7 bit mantissa) floating point.
+    dnnl_bf16 = 2,
+    /// 32-bit/single-precision floating point.
+    dnnl_f32 = 3,
+    /// 32-bit signed integer.
+    dnnl_s32 = 4,
+    /// 8-bit signed integer.
+    dnnl_s8 = 5,
+    /// 8-bit unsigned integer.
+    dnnl_u8 = 6,
+    /// 64-bit/double-precision floating point.
+    dnnl_f64 = 7,
+
+    /// Parameter to allow internal only data_types without undefined behavior.
+    /// This parameter is chosen to be valid for so long as sizeof(int) >= 2.
+    dnnl_data_type_max = 0x7fff,
+} dnnl_data_type_t;
+
+/// Memory format kind
+typedef enum {
+    /// Undefined memory format kind, used for empty memory descriptors.
+    dnnl_format_kind_undef = 0,
+    /// Unspecified format kind.
+    /// The primitive selects a format automatically.
+    dnnl_format_kind_any,
+    /// A tensor in a generic format described by the stride and blocking
+    /// values in each dimension. See @ref dnnl_blocking_desc_t for more
+    /// information.
+    dnnl_blocked,
+    /// Weights format used in 8bit Winograd convolution
+    dnnl_format_kind_wino,
+    /// Packed weights format used in RNN
+    dnnl_format_kind_rnn_packed,
+} dnnl_format_kind_t;
+
+/// Memory format tag specification.
+///
+/// oneDNN formats describe physical data layout. The physical layout
+/// is described as a sequence of the dimensions as they are laid out in the
+/// memory (from the outer-most to the inner-most). Note that this order
+/// doesn't affect the logical order of the dimensions that is kept in the
+/// `dims` field of the dnnl_memory_desc_t structure. The logical order of the
+/// dimensions is specified by the primitive that uses the tensor.
+///
+/// For example, CNN 5D tensor always has its logical dimensions in the order
+/// `(batch, channels, depth, height, width)`, while the physical layout might be
+/// `NCDHW` (corresponds to #dnnl_ncdhw format tag) or
+/// `NDHWC` (corresponds to #dnnl_ndhwc format tag).
+///
+/// ~~~cpp
+/// int batch = 2, channels = 16, depth = 13, height = 13, width = 13;
+///
+/// int ndims = 5; // 5D tensor
+/// dnnl_dims_t dims = {batch, channels, depth, height, width};
+/// dnnl_memory_desc_t data_in_ncdhw;
+/// dnnl_memory_desc_init_by_tag(
+///      &data_in_ncdhw, 5, dims, dnnl_f32, dnnl_ncdhw);
+///
+/// // note that in both cases dims passed are the same
+/// dnnl_memory_desc_t data_in_ndhwc;
+/// dnnl_memory_desc_init_by_tag(
+///      &data_in_ndhwc, 5, dims, dnnl_f32, dnnl_ndhwc);
+/// ~~~
+///
+/// Memory format tags can be further divided into two categories:
+///  - Domain-agnostic names, i.e. names the do not depend on the tensor usage
+///    in the specific primitive. These names use letters from `a` to `l` to
+///    denote logical dimension from 1 to 12, and form the order in which the
+///    dimensions are laid in memory. For instance, #dnnl_ab is used to denote
+///    2D tensor where the second logical dimension (aka `b`) is the innermost,
+///    i.e. has stride = 1, and the first logical dimension (`a`) laid out in
+///    memory with stride equal to the size of second dimension. On the other
+///    hand, #dnnl_ba is just transposed version of the same tensor: the
+///    first dimension (`a`) becomes the innermost one.
+///  - Domain-specific names, i.e. names that make sense only in the context of
+///    a certain domain, such as CNN. This names are just aliases to the
+///    corresponding domain-agnostic tags and used mostly for the convenience.
+///    For example, #dnnl_nc is used to denote 2D CNN activations tensor
+///    memory format, where channels are the innermost dimension and batch is an
+///    outermost one. Moreover, #dnnl_nc is just an alias to #dnnl_ab,
+///    since for oneDNN CNN primitives the logical dimensions of
+///    activations tensors come in order: batch, channels, spatial.
+///    In other words, batch corresponds to the first logical dimension (`a`),
+///    channels correspond to the second one (`b`).
+///
+/// The following domain-specific notation applies to memory format tags:
+///  - @c 'n' denotes the mini-batch dimension
+///  - @c 'c' denotes a channels dimension
+///  - When there are multiple channel dimensions (for example, in convolution
+///    weights tensor), @c 'i' and @c 'o' denote dimensions of input and output
+///    channels
+///  - @c 'd', @c 'h', and @c 'w' denote spatial depth, height, and width
+///    respectively
+///
+/// Upper-case letters indicate that the data is laid out in blocks for a
+/// particular dimension. In such cases, the format name contains both upper-
+/// and lower-case letters for that dimension with a lower-case letter preceded
+/// by the block size. For example: #dnnl_nChw8c describes a format where the
+/// outermost dimension is mini-batch, followed by the channel block number,
+/// followed by the spatial height and width, and finally followed by 8-element
+/// channel blocks.
+///
+/// @sa @ref dev_guide_understanding_memory_formats
+typedef enum {
+    /// Undefined memory format tag
+    dnnl_format_tag_undef = 0,
+    /// Undefined memory format tag.
+    /// The primitive selects a format automatically.
+    dnnl_format_tag_any,
+
+    // Semantic agnostic section
+    // The physical order of dimensions is defined by the permutation of the
+    // characters, assuming that ab..z defines the natural order.
+
+    // Plain formats
+
+    dnnl_a, ///< plain 1D tensor
+    dnnl_ab, ///< plain 2D tensor
+    dnnl_abc, ///< plain 3D tensor
+    dnnl_abcd, ///< plain 4D tensor
+    dnnl_acbd, ///< plain 4D tensor
+    dnnl_abcde, ///< plain 5D tensor
+    dnnl_abcdef, ///< plain 6D tensor
+    dnnl_abcdefg, ///< plain 7D tensor
+    dnnl_abcdefgh, ///< plain 8D tensor
+    dnnl_abcdefghi, ///< plain 9D tensor
+    dnnl_abcdefghij, ///< plain 10D tensor
+    dnnl_abcdefghijk, ///< plain 11D tensor
+    dnnl_abcdefghijkl, ///< plain 12D tensor
+
+    // Permuted plain formats
+
+    dnnl_abdc, ///< permuted 4D tensor
+    dnnl_abdec, ///< permuted 5D tensor
+    dnnl_acb, ///< permuted 3D tensor
+    dnnl_acbde, ///< permuted 5D tensor
+    dnnl_acbdef, ///< permuted 6D tensor
+    dnnl_acdb, ///< permuted 4D tensor
+    dnnl_acdeb, ///< permuted 5D tensor
+    dnnl_ba, ///< permuted 2D tensor
+    dnnl_bac, ///< permuted 3D tensor
+    dnnl_bacd, ///< permuted 4D tensor
+    dnnl_bacde, ///< permuted 5D tensor
+    dnnl_bca, ///< permuted 3D tensor
+    dnnl_bcda, ///< permuted 4D tensor
+    dnnl_bcdea, ///< permuted 5D tensor
+    dnnl_cba, ///< permuted 3D tensor
+    dnnl_cdba, ///< permuted 4D tensor
+    dnnl_dcab, ///< permuted 4D tensor
+    dnnl_cdeba, ///< permuted 5D tensor
+    dnnl_decab, ///< permuted 5D tensor
+    dnnl_defcab, ///< permuted 6D tensor
+    dnnl_abced, ///< permuted 5D tensor
+    dnnl_abcdfe, ///< permuted 6D tensor
+    dnnl_abcdegf, ///< permuted 7D tensor
+    dnnl_abcdefhg, ///< permuted 8D tensor
+    dnnl_abcdefgih, ///< permuted 9D tensor
+    dnnl_abcdefghji, ///< permuted 10D tensor
+    dnnl_abcdefghikj, ///< permuted 11D tensor
+    dnnl_abcdefghijlk, ///< permuted 12D tensor
+
+    // Opaque blocked formats
+
+    dnnl_Abc16a,
+    dnnl_ABc16a16b,
+    dnnl_ABc32a32b,
+    dnnl_ABc4a4b,
+    /// 3D tensor blocked by 2nd dimension with block size 16
+    dnnl_aBc16b,
+    dnnl_ABc16b16a,
+    dnnl_Abc4a,
+    /// 3D tensor blocked by 2nd dimension with block size 32
+    dnnl_aBc32b,
+    /// 3D tensor blocked by 2nd dimension with block size 4
+    dnnl_aBc4b,
+    dnnl_ABc4b16a4b,
+    dnnl_ABc2b8a4b,
+    dnnl_ABc16b16a4b,
+    dnnl_ABc16b16a2b,
+    dnnl_ABc4b4a,
+    dnnl_ABc8a16b2a,
+    dnnl_ABc8a8b,
+    dnnl_ABc8a4b,
+    /// 3D tensor blocked by 2nd dimension with block size 8
+    dnnl_aBc8b,
+    dnnl_ABc8b16a2b,
+    dnnl_BAc8a16b2a,
+    dnnl_ABc8b8a,
+    dnnl_Abcd16a,
+    dnnl_Abcd8a,
+    dnnl_ABcd16a16b,
+    dnnl_Abcd32a,
+    dnnl_ABcd32a32b,
+    /// 4D tensor blocked by 2nd dimension with block size 16
+    dnnl_aBcd16b,
+    dnnl_ABcd16b16a,
+    dnnl_aBCd16b16c,
+    dnnl_aBCd16c16b,
+    dnnl_Abcd4a,
+    /// 4D tensor blocked by 2nd dimension with block size 32
+    dnnl_aBcd32b,
+    /// 4D tensor blocked by 2nd dimension with block size 4
+    dnnl_aBcd4b,
+    dnnl_ABcd4b16a4b,
+    dnnl_ABcd16b16a4b,
+    dnnl_ABcd16b16a2b,
+    dnnl_ABcd4b4a,
+    dnnl_ABcd4a4b,
+    dnnl_aBCd2c4b2c,
+    dnnl_aBCd4b8c2b,
+    dnnl_aBCd4c16b4c,
+    dnnl_aBCd2c8b4c,
+    dnnl_aBCd16c16b4c,
+    dnnl_aBCd16c16b2c,
+    dnnl_aBCd4c4b,
+    dnnl_aBCd4b4c,
+    dnnl_ABcd8a16b2a,
+    dnnl_ABcd2b8a4b,
+    dnnl_ABcd8a8b,
+    dnnl_ABcd8a4b,
+    /// 4D tensor blocked by 2nd dimension with block size 8
+    dnnl_aBcd8b,
+    dnnl_aBCd4c8b2c,
+    dnnl_ABcd8b16a2b,
+    dnnl_aBCd8b16c2b,
+    dnnl_BAcd8a16b2a,
+    /// 4D tensor blocked by 1st and 2nd dimension with block size 8
+    dnnl_ABcd8b8a,
+    dnnl_aBCd8b8c,
+    dnnl_aBCd8b4c,
+    dnnl_aBCd8c16b2c,
+    dnnl_ABcde8a16b2a,
+    dnnl_aCBd8b16c2b,
+    dnnl_aBCd8c8b,
+    dnnl_Abcde16a,
+    dnnl_Abcde32a,
+    dnnl_ABcde16a16b,
+    dnnl_BAcde8a16b2a,
+    /// 4D tensor blocked by 3rd dimension with block size 4
+    dnnl_aBCd2b4c2b,
+    /// 5D tensor blocked by 1st dimension with block size 16
+    dnnl_ABcde4b16a4b,
+    /// 5D tensor blocked by 1st dimension with block size 8
+    dnnl_ABcde2b8a4b,
+    /// 5D tensor blocked by 2nd dimension with block size 16
+    dnnl_aBcde16b,
+    dnnl_ABcde16b16a,
+    dnnl_aBCde16b16c,
+    dnnl_aBCde16c16b,
+    dnnl_aBCde2c8b4c,
+    dnnl_Abcde4a,
+    /// 5D tensor blocked by 2nd dimension with block size 32
+    dnnl_aBcde32b,
+    /// 5D tensor blocked by 2nd dimension with block size 4
+    dnnl_aBcde4b,
+    dnnl_ABcde4b4a,
+    dnnl_ABcde4a4b,
+    dnnl_aBCde4b4c,
+    dnnl_aBCde2c4b2c,
+    dnnl_aBCde4b8c2b,
+    dnnl_aBCde4c16b4c,
+    dnnl_aBCde16c16b4c,
+    dnnl_aBCde16c16b2c,
+    dnnl_aBCde4c4b,
+    dnnl_Abcde8a,
+    dnnl_ABcde8a8b,
+    dnnl_ABcde8a4b,
+    dnnl_BAcde16b16a,
+    /// 5D tensor blocked by 2nd dimension with block size 8
+    dnnl_aBcde8b,
+    dnnl_ABcde8b16a2b,
+    dnnl_aBCde8b16c2b,
+    dnnl_aBCde4c8b2c,
+    dnnl_aCBde8b16c2b,
+    dnnl_ABcde8b8a,
+    dnnl_ABcde32a32b,
+    dnnl_aBCde8b8c,
+    dnnl_aBCde8b4c,
+    dnnl_ABc4a8b8a4b,
+    dnnl_ABcd4a8b8a4b,
+    dnnl_ABcde4a8b8a4b,
+    dnnl_BAc4b8a8b4a,
+    dnnl_BAcd4b8a8b4a,
+    dnnl_BAcde4b8a8b4a,
+    dnnl_ABcd2a8b8a2b,
+    dnnl_aBCd4b8c8b4c,
+    dnnl_aBCde4b8c8b4c,
+    dnnl_aBCde2b8c8b2c,
+    dnnl_aBCde8c16b2c,
+    dnnl_aBCde8c8b,
+    /// 5D tensor blocked by 3rd dimension with block size 4
+    dnnl_aBCde2b4c2b,
+    /// 6D tensor blocked by 2nd dimension with block size 16
+    dnnl_aBcdef16b,
+    dnnl_aBCdef16b16c,
+    dnnl_aBCdef16c16b,
+    dnnl_aBCdef4c16b4c,
+    /// 6D tensor blocked by 2nd dimension with block size 8
+    dnnl_aBCdef2c8b4c,
+    dnnl_aBCdef4c8b2c,
+    /// 6D tensor blocked by 3rd dimension with block size 4
+    dnnl_aBCdef2b4c2b,
+    /// 6D tensor blocked by 2nd dimension with block size 4
+    dnnl_aBcdef4b,
+    dnnl_aBCdef4c4b,
+    dnnl_aBCdef4b4c,
+    dnnl_aBCdef2c4b2c,
+    dnnl_aBCdef4b8c2b,
+    dnnl_aBCdef8b8c,
+    dnnl_aBCdef8b4c,
+    dnnl_aBCdef8c16b2c,
+    dnnl_aBCdef4b8c8b4c,
+    dnnl_aBCdef8b16c2b,
+    dnnl_aCBdef8b16c2b,
+    dnnl_aBCdef8c8b,
+    dnnl_aBdc16b,
+    dnnl_aBdC16b2c,
+    dnnl_aBdC16b4c,
+    dnnl_aBdc4b,
+    dnnl_aBdc8b,
+    dnnl_aBdec16b,
+    dnnl_aBdeC16b2c,
+    dnnl_aBdeC16b4c,
+    dnnl_aBdec32b,
+    dnnl_aBdec4b,
+    dnnl_aBdec8b,
+    dnnl_aBdefc16b,
+    dnnl_aBdefC16b2c,
+    dnnl_aCBdef16c16b,
+    dnnl_aBdefc4b,
+    dnnl_aBdefc8b,
+    dnnl_Abcdef16a,
+    dnnl_Abcdef32a,
+    dnnl_aBedc16b,
+    dnnl_Acb16a,
+    dnnl_AcB16a2b,
+    dnnl_AcB16a4b,
+    dnnl_Acb4a,
+    dnnl_Acb8a,
+    dnnl_aCBd16b16c,
+    dnnl_aCBd16c16b,
+    dnnl_aCBde16b16c,
+    dnnl_aCBde16c16b,
+    dnnl_Acdb16a,
+    dnnl_AcdB16a2b,
+    dnnl_AcdB16a4b,
+    dnnl_Acdb32a,
+    dnnl_Acdb4a,
+    dnnl_Acdb8a,
+    dnnl_Acdeb16a,
+    dnnl_AcdeB16a2b,
+    dnnl_Acdeb4a,
+    dnnl_Acdeb8a,
+    dnnl_Adcb16a,
+    dnnl_BAc16a16b,
+    dnnl_BAc16b16a,
+    dnnl_BAcd16a16b,
+    dnnl_BAcd16b16a,
+    dnnl_aCBd4c8b8c4b,
+    dnnl_aCBde4c8b8c4b,
+    dnnl_aCBdef4c8b8c4b,
+    dnnl_BAcde16a16b,
+    dnnl_aCBdef16b16c,
+    dnnl_abdfce, ///< permuted 6D tensor
+    dnnl_abdefc, ///< permuted 6D tensor
+    dnnl_ABc16b32a,
+    dnnl_ABc16b64a,
+    dnnl_ABc4b32a4b,
+    dnnl_ABc4b64a4b,
+    dnnl_ABc8b32a2b,
+    dnnl_ABc8b64a2b,
+    dnnl_AB16b16a,
+    dnnl_AB16b32a,
+    dnnl_AB16b64a,
+    dnnl_AB8b16a2b,
+    dnnl_AB8b32a2b,
+    dnnl_AB8b64a2b,
+    dnnl_AB4b16a4b,
+    dnnl_AB4b32a4b,
+    dnnl_AB4b64a4b,
+    dnnl_AB16b16a4b,
+    dnnl_ABcd16b32a,
+    dnnl_ABcd16b64a,
+    dnnl_ABcd4b32a4b,
+    dnnl_ABcd4b64a4b,
+    dnnl_ABcd8b32a2b,
+    dnnl_ABcd8b64a2b,
+    dnnl_ABcde4b32a4b,
+    dnnl_ABcde4b64a4b,
+    dnnl_ABcde16b16a4b,
+    dnnl_ABcde16b16a2b,
+    dnnl_ABcde16b32a,
+    dnnl_ABcde16b64a,
+    dnnl_ABcde8b32a2b,
+    dnnl_ABcde8b64a2b,
+    dnnl_aBCdef16c16b4c,
+    dnnl_aBCdef16c16b2c,
+    dnnl_AB32a32b8a4b,
+    dnnl_AB8a4b,
+    dnnl_AB32a32b8a2b,
+    dnnl_AB8a2b,
+    dnnl_abDc32d,
+    dnnl_abDC32d4c,
+    dnnl_abdEc32e,
+    dnnl_abdEC32e2c,
+    dnnl_abdEC32e4c,
+    dnnl_aBdefC16b4c,
+    dnnl_AcdeB16a4b,
+    dnnl_ABcd16a16b2a,
+    dnnl_ABc16a16b2a,
+    dnnl_aBCd16b16c2b,
+    dnnl_aBCde16b16c2b,
+    dnnl_Acb32a,
+    dnnl_AcB32a2b,
+    dnnl_AcB32a4b,
+    dnnl_Acb48a,
+    dnnl_AcB48a2b,
+    dnnl_AcB48a4b,
+    dnnl_Acb64a,
+    dnnl_AcB64a2b,
+    dnnl_AcB64a4b,
+    dnnl_cBa2b,
+    dnnl_cBa4b,
+    dnnl_aBdc32b,
+    dnnl_aBdC32b2c,
+    dnnl_aBdC32b4c,
+    dnnl_aBdc48b,
+    dnnl_aBdC48b2c,
+    dnnl_aBdC48b4c,
+    dnnl_aBdc64b,
+    dnnl_aBdC64b2c,
+    dnnl_aBdC64b4c,
+    dnnl_adcb,
+    dnnl_adCb2c,
+    dnnl_adCb4c,
+    dnnl_AcdB32a2b,
+    dnnl_AcdB32a4b,
+    dnnl_Acdb48a,
+    dnnl_AcdB48a2b,
+    dnnl_AcdB48a4b,
+    dnnl_Acdb64a,
+    dnnl_AcdB64a2b,
+    dnnl_AcdB64a4b,
+    dnnl_cdBa2b,
+    dnnl_cdBa4b,
+    dnnl_aBdeC32b2c,
+    dnnl_aBdeC32b4c,
+    dnnl_aBdec48b,
+    dnnl_aBdeC48b2c,
+    dnnl_aBdeC48b4c,
+    dnnl_aBdec64b,
+    dnnl_aBdeC64b2c,
+    dnnl_aBdeC64b4c,
+    dnnl_adecb,
+    dnnl_adeCb2c,
+    dnnl_adeCb4c,
+    dnnl_Acdeb32a,
+    dnnl_AcdeB32a2b,
+    dnnl_AcdeB32a4b,
+    dnnl_Acdeb48a,
+    dnnl_AcdeB48a2b,
+    dnnl_AcdeB48a4b,
+    dnnl_Acdeb64a,
+    dnnl_AcdeB64a2b,
+    dnnl_AcdeB64a4b,
+    dnnl_cdeBa2b,
+    dnnl_cdeBa4b,
+    dnnl_aBdefc32b,
+    dnnl_aBdefC32b2c,
+    dnnl_aBdefC32b4c,
+    dnnl_aBdefc48b,
+    dnnl_aBdefC48b2c,
+    dnnl_aBdefC48b4c,
+    dnnl_aBdefc64b,
+    dnnl_aBdefC64b2c,
+    dnnl_aBdefC64b4c,
+    dnnl_adefcb,
+    dnnl_adefCb2c,
+    dnnl_adefCb4c,
+    dnnl_AB16b32a4b,
+    dnnl_AB16b48a4b,
+    dnnl_AB16b64a4b,
+    dnnl_AB16b16a2b,
+    dnnl_AB16b32a2b,
+    dnnl_AB16b48a2b,
+    dnnl_AB16b64a2b,
+    dnnl_ABc16b32a4b,
+    dnnl_ABc16b48a4b,
+    dnnl_ABc16b64a4b,
+    dnnl_ABc16b32a2b,
+    dnnl_ABc16b48a2b,
+    dnnl_ABc16b64a2b,
+    dnnl_ABcd16b32a4b,
+    dnnl_ABcd16b48a4b,
+    dnnl_ABcd16b64a4b,
+    dnnl_ABcd16b32a2b,
+    dnnl_ABcd16b48a2b,
+    dnnl_ABcd16b64a2b,
+    dnnl_ABcde16b32a4b,
+    dnnl_ABcde16b48a4b,
+    dnnl_ABcde16b64a4b,
+    dnnl_ABcde16b32a2b,
+    dnnl_ABcde16b48a2b,
+    dnnl_ABcde16b64a2b,
+    dnnl_ABc32a16b,
+    dnnl_ABcd32a16b,
+    dnnl_ABcde32a16b,
+    dnnl_AB48a16b,
+    dnnl_AB48a32b,
+    dnnl_ABc40a16b,
+    dnnl_ABc40a32b,
+    dnnl_aBC48b16c,
+    dnnl_aBC48b32c,
+    dnnl_ABcd40a16b,
+    dnnl_ABcd40a32b,
+    dnnl_abCd32c,
+    dnnl_abdCe32c,
+    dnnl_abdCE32c2e,
+    dnnl_BA16a16b2a,
+    dnnl_BA16a32b2a,
+    dnnl_BA16a48b2a,
+    dnnl_BA16a64b2a,
+    dnnl_BA16a16b4a,
+    dnnl_BA16a32b4a,
+    dnnl_BA16a48b4a,
+    dnnl_BA16a64b4a,
+    dnnl_ABcd8a2b,
+    dnnl_aBdeC16c16b2c,
+    dnnl_aBdeC16c16b4c,
+    dnnl_aBdefC16c16b2c,
+    dnnl_AcB16b16a2b,
+    dnnl_AcB16b16a4b,
+    dnnl_AcdB16b16a2b,
+    dnnl_AcdB16b16a4b,
+    dnnl_AcdeB16b16a2b,
+    dnnl_aBdefC16c16b4c,
+    dnnl_AcdeB16b16a4b,
+    dnnl_AcB16b32a2b,
+    dnnl_AcB16b32a4b,
+    dnnl_AcB16b48a2b,
+    dnnl_AcB16b48a4b,
+    dnnl_AcB16b64a2b,
+    dnnl_AcB16b64a4b,
+    dnnl_aBdC16c16b2c,
+    dnnl_aBdC16c16b4c,
+    dnnl_aBdC16c32b2c,
+    dnnl_aBdC16c32b4c,
+    dnnl_aBdC16c48b2c,
+    dnnl_aBdC16c48b4c,
+    dnnl_aBdC16c64b2c,
+    dnnl_aBdC16c64b4c,
+    dnnl_AcdB16b32a2b,
+    dnnl_AcdB16b32a4b,
+    dnnl_AcdB16b48a2b,
+    dnnl_AcdB16b48a4b,
+    dnnl_AcdB16b64a2b,
+    dnnl_AcdB16b64a4b,
+    dnnl_aBdeC16c32b2c,
+    dnnl_aBdeC16c32b4c,
+    dnnl_aBdeC16c48b2c,
+    dnnl_aBdeC16c48b4c,
+    dnnl_aBdeC16c64b2c,
+    dnnl_aBdeC16c64b4c,
+    dnnl_AcdeB16b32a2b,
+    dnnl_AcdeB16b32a4b,
+    dnnl_AcdeB16b48a2b,
+    dnnl_AcdeB16b48a4b,
+    dnnl_AcdeB16b64a2b,
+    dnnl_AcdeB16b64a4b,
+    dnnl_aBdefC16c32b2c,
+    dnnl_aBdefC16c32b4c,
+    dnnl_aBdefC16c48b2c,
+    dnnl_aBdefC16c48b4c,
+    dnnl_aBdefC16c64b2c,
+    dnnl_aBdefC16c64b4c,
+    dnnl_decbA16a,
+    dnnl_ABc4a2b,
+    dnnl_ABc8a2b,
+    dnnl_aBCd8b2c,
+    dnnl_ABcde4a2b,
+    dnnl_ABcde8a2b,
+    dnnl_ABcde40a16b,
+    dnnl_ABcde40a32b,
+    dnnl_aBCde8b2c,
+    dnnl_ABcde4a8b8a2b,
+    dnnl_ABcd4a8b8a2b,
+    dnnl_ABc4a8b8a2b,
+    dnnl_aBCdef4b8c8b2c,
+    dnnl_aBCde4b8c8b2c,
+    dnnl_aBCd4b8c8b2c,
+    dnnl_BAcde4b8a8b2a,
+    dnnl_BAcd4b8a8b2a,
+    dnnl_BAc4b8a8b2a,
+    dnnl_aCBdef4c8b8c2b,
+    dnnl_aCBde4c8b8c2b,
+    dnnl_aCBd4c8b8c2b,
+    dnnl_aBCdef8b2c,
+    dnnl_AB32a16b,
+    dnnl_AB32a32b,
+    dnnl_BA4b8a8b2a,
+    dnnl_BA4b8a8b4a,
+    dnnl_aBC32b16c,
+    dnnl_aBC32b32c,
+    dnnl_aCB4c8b8c2b,
+    dnnl_aCB4c8b8c4b,
+    dnnl_ABcd4a2b,
+    dnnl_ABc2b8a16b4a,
+    dnnl_ABcd2b8a16b4a,
+    dnnl_ABcde2b8a16b4a,
+    dnnl_ABc2a8b16a4b,
+    dnnl_ABc2a8b16a2b,
+    dnnl_ABc2b32a8b,
+    dnnl_ABcd2a8b16a4b,
+    dnnl_ABcd2a8b16a2b,
+    dnnl_aCBd2c8b16c2b,
+    dnnl_ABcd2b32a8b,
+    dnnl_aBCd2c8b16c2b,
+    dnnl_ABcde2a8b16a4b,
+    dnnl_ABcde2a8b16a2b,
+    dnnl_aCBde2c8b16c2b,
+    dnnl_ABcde2b32a8b,
+    dnnl_aBC2b8c16b2c,
+    dnnl_aBCd2b8c16b2c,
+    dnnl_aBCde2b8c16b2c,
+    dnnl_aBCdef2b8c16b2c,
+    dnnl_BAcde2b8a16b4a,
+    dnnl_BAcd2b8a16b4a,
+    dnnl_BAc2b8a16b4a,
+    dnnl_BAcde2b8a16b2a,
+    dnnl_BAcd2b8a16b2a,
+    dnnl_BAc2b8a16b2a,
+    dnnl_aBCde2c8b16c2b,
+    dnnl_aBCdef2c8b16c2b,
+    dnnl_aCBdef2c8b16c2b,
+    dnnl_aBCd2b8c16b4c,
+    dnnl_aBCde2b8c16b4c,
+    dnnl_BA4b8a16b2a,
+    dnnl_BA4b8a16b4a,
+    dnnl_aCB4c8b16c2b,
+    dnnl_aCB4c8b16c4b,
+    dnnl_BA16a16b,
+    dnnl_BA16a32b,
+    dnnl_BA16a48b,
+    dnnl_BA16a64b,
+    dnnl_aCB16c2b,
+    dnnl_aCB16c4b,
+    dnnl_BA16b2a,
+    dnnl_BA16b4a,
+    dnnl_aBC16b16c,
+    dnnl_aBC16b32c,
+    dnnl_AB16a16b,
+    dnnl_AB16a32b,
+    dnnl_adbc,
+    dnnl_ABcde16a16b2a,
+    dnnl_aBCdef16b16c2b,
+    dnnl_Acedb16a,
+    dnnl_aBdfec16b,
+    dnnl_abdEC64e2c,
+    dnnl_abdEC64e4c,
+
+    /// Just a sentinel, not real memory format tag. Must be changed after new
+    /// format tag is added.
+    dnnl_format_tag_last,
+
+    // Aliases
+
+    /// 1D tensor, an alias to #dnnl_a
+    dnnl_x = dnnl_a,
+    /// 2D CNN activations tensor, an alias to #dnnl_ab
+    dnnl_nc = dnnl_ab,
+    /// 2D CNN activations tensor, an alias to #dnnl_ba
+    dnnl_cn = dnnl_ba,
+    /// 2D RNN statistics tensor, an alias to #dnnl_ab
+    dnnl_tn = dnnl_ab,
+    /// 2D RNN statistics tensor, an alias to #dnnl_ba
+    dnnl_nt = dnnl_ba,
+    /// 3D CNN activations tensor, an alias to #dnnl_abc
+    dnnl_ncw = dnnl_abc,
+    /// 3D CNN activations tensor, an alias to #dnnl_acb
+    dnnl_nwc = dnnl_acb,
+    /// 4D CNN activations tensor, an alias to #dnnl_abcd
+    dnnl_nchw = dnnl_abcd,
+    /// 4D CNN activations tensor, an alias to #dnnl_acdb
+    dnnl_nhwc = dnnl_acdb,
+    /// 4D CNN activations tensor, an alias to #dnnl_bcda
+    dnnl_chwn = dnnl_bcda,
+    /// 5D CNN activations tensor, an alias to #dnnl_abcde
+    dnnl_ncdhw = dnnl_abcde,
+    /// 5D CNN activations tensor, an alias to #dnnl_acdeb
+    dnnl_ndhwc = dnnl_acdeb,
+
+    /// 2D CNN weights tensor, an alias to #dnnl_ab
+    dnnl_oi = dnnl_ab,
+    /// 2D CNN weights tensor, an alias to #dnnl_ba
+    dnnl_io = dnnl_ba,
+    /// 3D CNN weights tensor, an alias to #dnnl_abc
+    dnnl_oiw = dnnl_abc,
+    /// 3D CNN weights tensor, an alias to #dnnl_acb
+    dnnl_owi = dnnl_acb,
+    /// 3D CNN weights tensor, an alias to #dnnl_cba
+    dnnl_wio = dnnl_cba,
+    /// 3D CNN weights tensor, an alias to #dnnl_bca
+    dnnl_iwo = dnnl_bca,
+    /// 4D CNN weights tensor, an alias to #dnnl_abcd
+    dnnl_oihw = dnnl_abcd,
+    /// 4D CNN weights tensor, an alias to #dnnl_cdba
+    dnnl_hwio = dnnl_cdba,
+    /// 4D CNN weights tensor, an alias to #dnnl_acdb
+    dnnl_ohwi = dnnl_acdb,
+    /// 4D CNN weights tensor, an alias to #dnnl_bcda
+    dnnl_ihwo = dnnl_bcda,
+    /// 4D CNN weights tensor, an alias to #dnnl_bacd
+    dnnl_iohw = dnnl_bacd,
+    /// 5D CNN weights tensor, an alias to #dnnl_abcde
+    dnnl_oidhw = dnnl_abcde,
+    /// 5D CNN weights tensor, an alias to #dnnl_bacde
+    dnnl_iodhw = dnnl_bacde,
+    /// 5D CNN weights tensor, an alias to #dnnl_cdeba
+    dnnl_dhwio = dnnl_cdeba,
+    /// 5D CNN weights tensor, an alias to #dnnl_acdeb
+    dnnl_odhwi = dnnl_acdeb,
+    /// 5D CNN weights tensor, an alias to #dnnl_bcdea
+    dnnl_idhwo = dnnl_bcdea,
+
+    /// 4D CNN weights tensor (incl. groups), an alias to #dnnl_abcd
+    dnnl_goiw = dnnl_abcd,
+    /// 4D CNN weights tensor (incl. groups), an alias to #dnnl_abdc
+    dnnl_gowi = dnnl_abdc,
+    /// 4D CNN weights tensor (incl. groups), an alias to #dnnl_dcab
+    dnnl_wigo = dnnl_dcab,
+    /// 5D CNN weights tensor (incl. groups), an alias to #dnnl_abcde
+    dnnl_goihw = dnnl_abcde,
+    /// 5D CNN weights tensor (incl. groups), an alias to #dnnl_abdec
+    dnnl_gohwi = dnnl_abdec,
+    /// 5D CNN weights tensor (incl. groups), an alias to #dnnl_decab
+    dnnl_hwigo = dnnl_decab,
+    /// 5D CNN weights tensor (incl. groups), an alias to #dnnl_acbde
+    dnnl_giohw = dnnl_acbde,
+    /// 6D CNN weights tensor (incl. groups), an alias to #dnnl_abcdef
+    dnnl_goidhw = dnnl_abcdef,
+    /// 6D CNN weights tensor (incl. groups), an alias to #dnnl_abdefc
+    dnnl_godhwi = dnnl_abdefc,
+    /// 6D CNN weights tensor (incl. groups), an alias to #dnnl_acbdef
+    dnnl_giodhw = dnnl_acbdef,
+    /// 6D CNN weights tensor (incl. groups), an alias to #dnnl_defcab
+    dnnl_dhwigo = dnnl_defcab,
+
+    /// 3D RNN data tensor in the format (seq_length, batch, input channels),
+    /// an alias to #dnnl_abc.
+    dnnl_tnc = dnnl_abc,
+    /// 3D RNN data tensor in the format (batch, seq_length, input channels),
+    /// an alias to #dnnl_bac.
+    dnnl_ntc = dnnl_bac,
+    /// 4D RNN states tensor in the format (num_layers, num_directions,
+    /// batch, state channels), an alias to #dnnl_abcd.
+    dnnl_ldnc = dnnl_abcd,
+    /// 5D RNN weights tensor in the format (num_layers, num_directions,
+    /// input_channels, num_gates, output_channels), an alias to #dnnl_abcde.
+    ///
+    ///  - For LSTM cells, the gates order is input, forget, candidate
+    ///    and output gate.
+    ///  - For GRU cells, the gates order is update, reset and output gate.
+    dnnl_ldigo = dnnl_abcde,
+    /// 5D RNN weights tensor in the format (num_layers, num_directions,
+    /// num_gates, output_channels, input_channels), an alias to #dnnl_abdec.
+    ///
+    ///  - For LSTM cells, the gates order is input, forget, candidate
+    ///    and output gate.
+    ///  - For GRU cells, the gates order is update, reset and output gate.
+    dnnl_ldgoi = dnnl_abdec,
+    /// 4D LSTM projection tensor in the format (num_layers, num_directions,
+    /// num_channels_in_hidden_state, num_channels_in_recurrent_projection),
+    /// an alias to #dnnl_abcd.
+    dnnl_ldio = dnnl_abcd,
+    /// 4D LSTM projection tensor in the format (num_layers, num_directions,
+    /// num_channels_in_recurrent_projection, num_channels_in_hidden_state),
+    /// an alias to #dnnl_abdc.
+    dnnl_ldoi = dnnl_abdc,
+    /// 4D RNN bias tensor in the format (num_layers, num_directions,
+    /// num_gates, output_channels), an alias to #dnnl_abcd.
+    ///
+    ///  - For LSTM cells, the gates order is input, forget, candidate
+    ///    and output gate.
+    ///  - For GRU cells, the gates order is update, reset and output gate.
+    dnnl_ldgo = dnnl_abcd,
+    /// 5D LSTM projection tensor
+    dnnl_ldOi32o = dnnl_abDc32d,
+    dnnl_ldOI32o4i = dnnl_abDC32d4c,
+    dnnl_ldIo32i = dnnl_abCd32c,
+    /// 6D RNN weights tensor
+    dnnl_ldgOi32o = dnnl_abdEc32e,
+    dnnl_ldgOI32o2i = dnnl_abdEC32e2c,
+    dnnl_ldgOI32o4i = dnnl_abdEC32e4c,
+    dnnl_ldgOI64o2i = dnnl_abdEC64e2c,
+    dnnl_ldgOI64o4i = dnnl_abdEC64e4c,
+    dnnl_ldgIo32i = dnnl_abdCe32c,
+    dnnl_ldgIO32i2o = dnnl_abdCE32c2e,
+
+    // Opaque data types, are not to be used explicitly
+
+    // data
+    /// 5D CNN activations tensor blocked by channels with block size 32,
+    /// an alias to #dnnl_aBcde32b
+    dnnl_nCdhw32c = dnnl_aBcde32b,
+    /// 5D CNN activations tensor blocked by channels with block size 16,
+    /// an alias to #dnnl_aBcde16b
+    dnnl_nCdhw16c = dnnl_aBcde16b,
+    /// 5D CNN activations tensor blocked by channels with block size 4,
+    /// an alias to #dnnl_aBcde4b
+    dnnl_nCdhw4c = dnnl_aBcde4b,
+    /// 5D CNN activations tensor blocked by channels with block size 8,
+    /// an alias to #dnnl_aBcde8b
+    dnnl_nCdhw8c = dnnl_aBcde8b,
+    /// 4D CNN activations tensor blocked by channels with block size 32,
+    /// an alias to #dnnl_aBcd32b
+    dnnl_nChw32c = dnnl_aBcd32b,
+    /// 4D CNN activations tensor blocked by channels with block size 16,
+    /// an alias to #dnnl_aBcd16b
+    dnnl_nChw16c = dnnl_aBcd16b,
+    /// 4D CNN activations tensor blocked by channels with block size 4,
+    /// an alias to #dnnl_aBcd4b
+    dnnl_nChw4c = dnnl_aBcd4b,
+    /// 4D CNN activations tensor blocked by channels with block size 8,
+    /// an alias to #dnnl_aBcd8b
+    dnnl_nChw8c = dnnl_aBcd8b,
+    /// 3D CNN activations tensor blocked by channels with block size 32,
+    /// an alias to #dnnl_aBc32b
+    dnnl_nCw32c = dnnl_aBc32b,
+    /// 3D CNN activations tensor blocked by channels with block size 16,
+    /// an alias to #dnnl_aBc16b
+    dnnl_nCw16c = dnnl_aBc16b,
+    /// 3D CNN activations tensor blocked by channels with block size 4,
+    /// an alias to #dnnl_aBc4b
+    dnnl_nCw4c = dnnl_aBc4b,
+    /// 3D CNN activations tensor blocked by channels with block size 8,
+    /// an alias to #dnnl_aBc8b
+    dnnl_nCw8c = dnnl_aBc8b,
+    dnnl_NCw16n16c = dnnl_ABc16a16b,
+    dnnl_NCdhw16n16c = dnnl_ABcde16a16b,
+    dnnl_NChw16n16c = dnnl_ABcd16a16b,
+    dnnl_NCw32n16c = dnnl_ABc32a16b,
+    dnnl_NChw32n16c = dnnl_ABcd32a16b,
+    dnnl_NCdhw32n16c = dnnl_ABcde32a16b,
+    dnnl_NCw32n32c = dnnl_ABc32a32b,
+    dnnl_NChw32n32c = dnnl_ABcd32a32b,
+    dnnl_NCdhw32n32c = dnnl_ABcde32a32b,
+
+    // weights, 2D
+    dnnl_OI16i16o = dnnl_AB16b16a,
+    dnnl_OI16i32o = dnnl_AB16b32a,
+    dnnl_OI16i64o = dnnl_AB16b64a,
+    dnnl_OI8i16o2i = dnnl_AB8b16a2b,
+    dnnl_OI8i32o2i = dnnl_AB8b32a2b,
+    dnnl_OI8i64o2i = dnnl_AB8b64a2b,
+    dnnl_OI4i16o4i = dnnl_AB4b16a4b,
+    dnnl_OI4i32o4i = dnnl_AB4b32a4b,
+    dnnl_OI4i64o4i = dnnl_AB4b64a4b,
+    dnnl_OI16i16o4i = dnnl_AB16b16a4b,
+    // weights, 3D
+    dnnl_IOw16o16i = dnnl_BAc16a16b,
+    dnnl_IOw16i16o = dnnl_BAc16b16a,
+    dnnl_OIw16i16o = dnnl_ABc16b16a,
+    dnnl_OIw16i32o = dnnl_ABc16b32a,
+    dnnl_OIw16i64o = dnnl_ABc16b64a,
+    dnnl_OIw16o16i = dnnl_ABc16a16b,
+    dnnl_Oiw16o = dnnl_Abc16a,
+    dnnl_OIw4i16o4i = dnnl_ABc4b16a4b,
+    dnnl_OIw4i32o4i = dnnl_ABc4b32a4b,
+    dnnl_OIw4i64o4i = dnnl_ABc4b64a4b,
+    dnnl_OIw2i8o4i = dnnl_ABc2b8a4b,
+    dnnl_OIw16i16o4i = dnnl_ABc16b16a4b,
+    dnnl_OIw16i16o2i = dnnl_ABc16b16a2b,
+    dnnl_OIw16o16i2o = dnnl_ABc16a16b2a,
+    dnnl_OIw4i4o = dnnl_ABc4b4a,
+    dnnl_OIw4o4i = dnnl_ABc4a4b,
+    dnnl_Oiw4o = dnnl_Abc4a,
+    dnnl_OIw8i16o2i = dnnl_ABc8b16a2b,
+    dnnl_OIw8i32o2i = dnnl_ABc8b32a2b,
+    dnnl_OIw8i64o2i = dnnl_ABc8b64a2b,
+    dnnl_OIw8i8o = dnnl_ABc8b8a,
+    dnnl_OIw8o16i2o = dnnl_ABc8a16b2a,
+    dnnl_IOw8o16i2o = dnnl_BAc8a16b2a,
+    dnnl_OIw8o8i = dnnl_ABc8a8b,
+    dnnl_OIw8o4i = dnnl_ABc8a4b,
+    dnnl_Owi16o = dnnl_Acb16a,
+    dnnl_OwI16o2i = dnnl_AcB16a2b,
+    dnnl_OwI16o4i = dnnl_AcB16a4b,
+    dnnl_Owi4o = dnnl_Acb4a,
+    dnnl_Owi8o = dnnl_Acb8a,
+
+    // weights, 4D
+    dnnl_IOhw16i16o = dnnl_BAcd16b16a,
+    dnnl_IOhw16o16i = dnnl_BAcd16a16b,
+    dnnl_Ohwi16o = dnnl_Acdb16a,
+    dnnl_OhwI16o2i = dnnl_AcdB16a2b,
+    dnnl_OhwI16o4i = dnnl_AcdB16a4b,
+    dnnl_Ohwi32o = dnnl_Acdb32a,
+    dnnl_Ohwi4o = dnnl_Acdb4a,
+    dnnl_Ohwi8o = dnnl_Acdb8a,
+    dnnl_OIhw16i16o = dnnl_ABcd16b16a,
+    dnnl_OIhw16i32o = dnnl_ABcd16b32a,
+    dnnl_OIhw16i64o = dnnl_ABcd16b64a,
+    dnnl_OIhw16o16i = dnnl_ABcd16a16b,
+    dnnl_Oihw16o = dnnl_Abcd16a,
+    dnnl_OIhw4i16o4i = dnnl_ABcd4b16a4b,
+    dnnl_OIhw4i32o4i = dnnl_ABcd4b32a4b,
+    dnnl_OIhw4i64o4i = dnnl_ABcd4b64a4b,
+    dnnl_OIhw16i16o4i = dnnl_ABcd16b16a4b,
+    dnnl_OIhw16i16o2i = dnnl_ABcd16b16a2b,
+    dnnl_OIhw16o16i2o = dnnl_ABcd16a16b2a,
+    dnnl_OIhw4i4o = dnnl_ABcd4b4a,
+    dnnl_OIhw4o4i = dnnl_ABcd4a4b,
+    dnnl_Oihw4o = dnnl_Abcd4a,
+    dnnl_OIhw8i16o2i = dnnl_ABcd8b16a2b,
+    dnnl_OIhw8i32o2i = dnnl_ABcd8b32a2b,
+    dnnl_OIhw8i64o2i = dnnl_ABcd8b64a2b,
+    dnnl_OIhw8i8o = dnnl_ABcd8b8a,
+    dnnl_OIhw8o16i2o = dnnl_ABcd8a16b2a,
+    dnnl_OIhw2i8o4i = dnnl_ABcd2b8a4b,
+    dnnl_IOhw8o16i2o = dnnl_BAcd8a16b2a,
+    dnnl_OIhw8o8i = dnnl_ABcd8a8b,
+    dnnl_OIhw8o4i = dnnl_ABcd8a4b,
+    dnnl_Owhi16o = dnnl_Adcb16a,
+
+    // weights, 5D
+    dnnl_Odhwi16o = dnnl_Acdeb16a,
+    dnnl_OdhwI16o2i = dnnl_AcdeB16a2b,
+    dnnl_OdhwI16o4i = dnnl_AcdeB16a4b,
+    dnnl_Odhwi4o = dnnl_Acdeb4a,
+    dnnl_Odhwi8o = dnnl_Acdeb8a,
+    dnnl_Odwhi16o = dnnl_Acedb16a,
+    dnnl_OIdhw16i16o = dnnl_ABcde16b16a,
+    dnnl_OIdhw16i32o = dnnl_ABcde16b32a,
+    dnnl_OIdhw16i64o = dnnl_ABcde16b64a,
+    dnnl_OIdhw16o16i = dnnl_ABcde16a16b,
+    dnnl_Oidhw16o = dnnl_Abcde16a,
+    dnnl_OIdhw4i4o = dnnl_ABcde4b4a,
+    dnnl_OIdhw4o4i = dnnl_ABcde4a4b,
+    dnnl_Oidhw4o = dnnl_Abcde4a,
+    dnnl_OIdhw8i16o2i = dnnl_ABcde8b16a2b,
+    dnnl_OIdhw8i32o2i = dnnl_ABcde8b32a2b,
+    dnnl_OIdhw8i64o2i = dnnl_ABcde8b64a2b,
+    dnnl_OIdhw8i8o = dnnl_ABcde8b8a,
+    dnnl_OIdhw8o16i2o = dnnl_ABcde8a16b2a,
+    dnnl_IOdhw8o16i2o = dnnl_BAcde8a16b2a,
+    dnnl_OIdhw4i16o4i = dnnl_ABcde4b16a4b,
+    dnnl_OIdhw4i32o4i = dnnl_ABcde4b32a4b,
+    dnnl_OIdhw4i64o4i = dnnl_ABcde4b64a4b,
+    dnnl_OIdhw16i16o4i = dnnl_ABcde16b16a4b,
+    dnnl_OIdhw16i16o2i = dnnl_ABcde16b16a2b,
+    dnnl_OIdhw2i8o4i = dnnl_ABcde2b8a4b,
+    dnnl_OIdhw8o8i = dnnl_ABcde8a8b,
+    dnnl_OIdhw8o4i = dnnl_ABcde8a4b,
+    dnnl_IOdhw16i16o = dnnl_BAcde16b16a,
+    dnnl_OIdhw4o8i8o4i = dnnl_ABcde4a8b8a4b,
+    dnnl_IOdhw16o16i = dnnl_BAcde16a16b,
+    dnnl_OIdhw16o16i2o = dnnl_ABcde16a16b2a,
+
+    // weights w/ groups, 3D
+    dnnl_Goiw16g = dnnl_Abcd16a,
+    dnnl_Goiw8g = dnnl_Abcd8a,
+    dnnl_Goiw4g = dnnl_Abcd4a,
+    dnnl_gIOw16o16i = dnnl_aCBd16b16c,
+    dnnl_gIOw16i16o = dnnl_aCBd16c16b,
+    dnnl_gOIw16i16o = dnnl_aBCd16c16b,
+    dnnl_gOIw16o16i = dnnl_aBCd16b16c,
+    dnnl_gOiw16o = dnnl_aBcd16b,
+    dnnl_gOIw4i16o4i = dnnl_aBCd4c16b4c,
+    dnnl_gOIw2i8o4i = dnnl_aBCd2c8b4c,
+    dnnl_gOIw16i16o4i = dnnl_aBCd16c16b4c,
+    dnnl_gOIw16i16o2i = dnnl_aBCd16c16b2c,
+    dnnl_gOIw16o16i2o = dnnl_aBCd16b16c2b,
+    dnnl_gOIw4i4o = dnnl_aBCd4c4b,
+    dnnl_gOIw4o4i = dnnl_aBCd4b4c,
+    dnnl_gOiw4o = dnnl_aBcd4b,
+    dnnl_gOIw8i16o2i = dnnl_aBCd8c16b2c,
+    dnnl_gOIw8i8o = dnnl_aBCd8c8b,
+    dnnl_gOIw8o16i2o = dnnl_aBCd8b16c2b,
+    dnnl_gIOw8o16i2o = dnnl_aCBd8b16c2b,
+    dnnl_gOIw8o8i = dnnl_aBCd8b8c,
+    dnnl_gOIw8o4i = dnnl_aBCd8b4c,
+    dnnl_gOwi16o = dnnl_aBdc16b,
+    dnnl_gOwI16o2i = dnnl_aBdC16b2c,
+    dnnl_gOwI16o4i = dnnl_aBdC16b4c,
+    dnnl_gOwi4o = dnnl_aBdc4b,
+    dnnl_gOwi8o = dnnl_aBdc8b,
+    dnnl_Goiw32g = dnnl_Abcd32a,
+    dnnl_gOIw2i4o2i = dnnl_aBCd2c4b2c,
+    dnnl_gOIw2o4i2o = dnnl_aBCd2b4c2b,
+    dnnl_gOIw4i8o2i = dnnl_aBCd4c8b2c,
+    dnnl_gOIw4o8i2o = dnnl_aBCd4b8c2b,
+
+    // weights w/ groups, 4D
+    dnnl_gIOhw16i16o = dnnl_aCBde16c16b,
+    dnnl_gIOhw16o16i = dnnl_aCBde16b16c,
+    dnnl_gOhwi16o = dnnl_aBdec16b,
+    dnnl_gOhwI16o2i = dnnl_aBdeC16b2c,
+    dnnl_gOhwI16o4i = dnnl_aBdeC16b4c,
+    dnnl_gOhwi32o = dnnl_aBdec32b,
+    dnnl_gOhwi4o = dnnl_aBdec4b,
+    dnnl_gOhwi8o = dnnl_aBdec8b,
+    dnnl_Goihw16g = dnnl_Abcde16a,
+    dnnl_gOIhw16i16o = dnnl_aBCde16c16b,
+    dnnl_gOIhw16o16i = dnnl_aBCde16b16c,
+    dnnl_gOihw16o = dnnl_aBcde16b,
+    dnnl_gOIhw2i8o4i = dnnl_aBCde2c8b4c,
+    dnnl_gOIhw4i16o4i = dnnl_aBCde4c16b4c,
+    dnnl_gOIhw16i16o4i = dnnl_aBCde16c16b4c,
+    dnnl_gOIhw16i16o2i = dnnl_aBCde16c16b2c,
+    dnnl_gOIhw16o16i2o = dnnl_aBCde16b16c2b,
+    dnnl_gOIhw4i4o = dnnl_aBCde4c4b,
+    dnnl_gOIhw4o4i = dnnl_aBCde4b4c,
+    dnnl_gOihw4o = dnnl_aBcde4b,
+    dnnl_Goihw8g = dnnl_Abcde8a,
+    dnnl_Goihw4g = dnnl_Abcde4a,
+    dnnl_gOIhw8i16o2i = dnnl_aBCde8c16b2c,
+    dnnl_gOIhw8i8o = dnnl_aBCde8c8b,
+    dnnl_gOIhw8o16i2o = dnnl_aBCde8b16c2b,
+    dnnl_gIOhw8o16i2o = dnnl_aCBde8b16c2b,
+    dnnl_gOIhw8o8i = dnnl_aBCde8b8c,
+    dnnl_gOIhw8o4i = dnnl_aBCde8b4c,
+    dnnl_Goihw32g = dnnl_Abcde32a,
+    dnnl_gOwhi16o = dnnl_aBedc16b,
+
+    dnnl_OIw4o8i8o4i = dnnl_ABc4a8b8a4b,
+    dnnl_OIhw4o8i8o4i = dnnl_ABcd4a8b8a4b,
+    dnnl_IOw4i8o8i4o = dnnl_BAc4b8a8b4a,
+    dnnl_IOhw4i8o8i4o = dnnl_BAcd4b8a8b4a,
+    dnnl_IOdhw4i8o8i4o = dnnl_BAcde4b8a8b4a,
+
+    dnnl_OIhw2o8i8o2i = dnnl_ABcd2a8b8a2b,
+    dnnl_gOIw4o8i8o4i = dnnl_aBCd4b8c8b4c,
+    dnnl_gOIhw4o8i8o4i = dnnl_aBCde4b8c8b4c,
+    dnnl_gOIdhw4o8i8o4i = dnnl_aBCdef4b8c8b4c,
+    dnnl_gIOw4i8o8i4o = dnnl_aCBd4c8b8c4b,
+    dnnl_gIOhw4i8o8i4o = dnnl_aCBde4c8b8c4b,
+    dnnl_gIOdhw4i8o8i4o = dnnl_aCBdef4c8b8c4b,
+    dnnl_gOIhw2o8i8o2i = dnnl_aBCde2b8c8b2c,
+    dnnl_gOIhw2i4o2i = dnnl_aBCde2c4b2c,
+    dnnl_gOIhw2o4i2o = dnnl_aBCde2b4c2b,
+    dnnl_gOIhw4i8o2i = dnnl_aBCde4c8b2c,
+    dnnl_gOIhw4o8i2o = dnnl_aBCde4b8c2b,
+
+    // weights w/ groups, 6D
+    dnnl_gIOdhw16i16o = dnnl_aCBdef16c16b,
+    dnnl_gIOdhw16o16i = dnnl_aCBdef16b16c,
+    dnnl_gOdhwi16o = dnnl_aBdefc16b,
+    dnnl_gOdhwI16o2i = dnnl_aBdefC16b2c,
+    dnnl_gOdhwI16o4i = dnnl_aBdefC16b4c,
+    dnnl_gOdhwi4o = dnnl_aBdefc4b,
+    dnnl_gOdhwi8o = dnnl_aBdefc8b,
+    dnnl_gOdwhi16o = dnnl_aBdfec16b,
+    dnnl_gOIdhw16i16o = dnnl_aBCdef16c16b,
+    dnnl_gOIdhw4i16o4i = dnnl_aBCdef4c16b4c,
+    dnnl_gOIdhw16i16o4i = dnnl_aBCdef16c16b4c,
+    dnnl_gOIdhw2i8o4i = dnnl_aBCdef2c8b4c,
+    dnnl_gOIdhw16i16o2i = dnnl_aBCdef16c16b2c,
+    dnnl_gOIdhw16o16i = dnnl_aBCdef16b16c,
+    dnnl_gOIdhw16o16i2o = dnnl_aBCdef16b16c2b,
+    dnnl_gOidhw16o = dnnl_aBcdef16b,
+    dnnl_gOIdhw4i4o = dnnl_aBCdef4c4b,
+    dnnl_gOIdhw4o4i = dnnl_aBCdef4b4c,
+    dnnl_gOidhw4o = dnnl_aBcdef4b,
+    dnnl_gOIdhw8i16o2i = dnnl_aBCdef8c16b2c,
+    dnnl_gOIdhw8i8o = dnnl_aBCdef8c8b,
+    dnnl_gOIdhw8o16i2o = dnnl_aBCdef8b16c2b,
+    dnnl_gIOdhw8o16i2o = dnnl_aCBdef8b16c2b,
+    dnnl_gOIdhw8o8i = dnnl_aBCdef8b8c,
+    dnnl_gOIdhw8o4i = dnnl_aBCdef8b4c,
+    dnnl_Goidhw16g = dnnl_Abcdef16a,
+    dnnl_Goidhw32g = dnnl_Abcdef32a,
+    dnnl_gOIdhw2i4o2i = dnnl_aBCdef2c4b2c,
+    dnnl_gOIdhw4i8o2i = dnnl_aBCdef4c8b2c,
+    dnnl_gOIdhw2o4i2o = dnnl_aBCdef2b4c2b,
+    dnnl_gOIdhw4o8i2o = dnnl_aBCdef4b8c2b,
+    // weights, 3D
+    dnnl_Owi32o = dnnl_Acb32a,
+    dnnl_OwI32o2i = dnnl_AcB32a2b,
+    dnnl_OwI32o4i = dnnl_AcB32a4b,
+    dnnl_Owi48o = dnnl_Acb48a,
+    dnnl_OwI48o2i = dnnl_AcB48a2b,
+    dnnl_OwI48o4i = dnnl_AcB48a4b,
+    dnnl_Owi64o = dnnl_Acb64a,
+    dnnl_OwI64o2i = dnnl_AcB64a2b,
+    dnnl_OwI64o4i = dnnl_AcB64a4b,
+    dnnl_wIo2i = dnnl_cBa2b,
+    dnnl_wIo4i = dnnl_cBa4b,
+    dnnl_gOwi32o = dnnl_aBdc32b,
+    dnnl_gOwI32o2i = dnnl_aBdC32b2c,
+    dnnl_gOwI32o4i = dnnl_aBdC32b4c,
+    dnnl_gOwi48o = dnnl_aBdc48b,
+    dnnl_gOwI48o2i = dnnl_aBdC48b2c,
+    dnnl_gOwI48o4i = dnnl_aBdC48b4c,
+    dnnl_gOwi64o = dnnl_aBdc64b,
+    dnnl_gOwI64o2i = dnnl_aBdC64b2c,
+    dnnl_gOwI64o4i = dnnl_aBdC64b4c,
+    dnnl_gwio = dnnl_adcb,
+    dnnl_gwIo2i = dnnl_adCb2c,
+    dnnl_gwIo4i = dnnl_adCb4c,
+    // weights, 4D
+    dnnl_OhwI32o = dnnl_Acdb32a,
+    dnnl_OhwI32o2i = dnnl_AcdB32a2b,
+    dnnl_OhwI32o4i = dnnl_AcdB32a4b,
+    dnnl_Ohwi48o = dnnl_Acdb48a,
+    dnnl_OhwI48o2i = dnnl_AcdB48a2b,
+    dnnl_OhwI48o4i = dnnl_AcdB48a4b,
+    dnnl_Ohwi64o = dnnl_Acdb64a,
+    dnnl_OhwI64o2i = dnnl_AcdB64a2b,
+    dnnl_OhwI64o4i = dnnl_AcdB64a4b,
+    dnnl_hwIo2i = dnnl_cdBa2b,
+    dnnl_hwIo4i = dnnl_cdBa4b,
+    dnnl_gOhwI32o = dnnl_aBdec32b,
+    dnnl_gOhwI32o2i = dnnl_aBdeC32b2c,
+    dnnl_gOhwI32o4i = dnnl_aBdeC32b4c,
+    dnnl_gOhwi48o = dnnl_aBdec48b,
+    dnnl_gOhwI48o2i = dnnl_aBdeC48b2c,
+    dnnl_gOhwI48o4i = dnnl_aBdeC48b4c,
+    dnnl_gOhwi64o = dnnl_aBdec64b,
+    dnnl_gOhwI64o2i = dnnl_aBdeC64b2c,
+    dnnl_gOhwI64o4i = dnnl_aBdeC64b4c,
+    dnnl_ghwio = dnnl_adecb,
+    dnnl_ghwIo2i = dnnl_adeCb2c,
+    dnnl_ghwIo4i = dnnl_adeCb4c,
+    // weights, 5D
+    dnnl_Odhwi32o = dnnl_Acdeb32a,
+    dnnl_OdhwI32o2i = dnnl_AcdeB32a2b,
+    dnnl_OdhwI32o4i = dnnl_AcdeB32a4b,
+    dnnl_Odhwi48o = dnnl_Acdeb48a,
+    dnnl_OdhwI48o2i = dnnl_AcdeB48a2b,
+    dnnl_OdhwI48o4i = dnnl_AcdeB48a4b,
+    dnnl_Odhwi64o = dnnl_Acdeb64a,
+    dnnl_OdhwI64o2i = dnnl_AcdeB64a2b,
+    dnnl_OdhwI64o4i = dnnl_AcdeB64a4b,
+    dnnl_dhwIo2i = dnnl_cdeBa2b,
+    dnnl_dhwIo4i = dnnl_cdeBa4b,
+    dnnl_gOdhwi32o = dnnl_aBdefc32b,
+    dnnl_gOdhwI32o2i = dnnl_aBdefC32b2c,
+    dnnl_gOdhwI32o4i = dnnl_aBdefC32b4c,
+    dnnl_gOdhwi48o = dnnl_aBdefc48b,
+    dnnl_gOdhwI48o2i = dnnl_aBdefC48b2c,
+    dnnl_gOdhwI48o4i = dnnl_aBdefC48b4c,
+    dnnl_gOdhwi64o = dnnl_aBdefc64b,
+    dnnl_gOdhwI64o2i = dnnl_aBdefC64b2c,
+    dnnl_gOdhwI64o4i = dnnl_aBdefC64b4c,
+    dnnl_gdhwio = dnnl_adefcb,
+    dnnl_gdhwIo2i = dnnl_adefCb2c,
+    dnnl_gdhwIo4i = dnnl_adefCb4c,
+    dnnl_OI16i32o4i = dnnl_AB16b32a4b,
+    dnnl_OI16i48o4i = dnnl_AB16b48a4b,
+    dnnl_OI16i64o4i = dnnl_AB16b64a4b,
+    dnnl_OI16i16o2i = dnnl_AB16b16a2b,
+    dnnl_OI16i32o2i = dnnl_AB16b32a2b,
+    dnnl_OI16i48o2i = dnnl_AB16b48a2b,
+    dnnl_OI16i64o2i = dnnl_AB16b64a2b,
+    dnnl_OIw16i32o4i = dnnl_ABc16b32a4b,
+    dnnl_OIw16i48o4i = dnnl_ABc16b48a4b,
+    dnnl_OIw16i64o4i = dnnl_ABc16b64a4b,
+    dnnl_OIw16i32o2i = dnnl_ABc16b32a2b,
+    dnnl_OIw16i48o2i = dnnl_ABc16b48a2b,
+    dnnl_OIw16i64o2i = dnnl_ABc16b64a2b,
+    dnnl_OIhw16i32o4i = dnnl_ABcd16b32a4b,
+    dnnl_OIhw16i48o4i = dnnl_ABcd16b48a4b,
+    dnnl_OIhw16i64o4i = dnnl_ABcd16b64a4b,
+    dnnl_OIhw16i32o2i = dnnl_ABcd16b32a2b,
+    dnnl_OIhw16i48o2i = dnnl_ABcd16b48a2b,
+    dnnl_OIhw16i64o2i = dnnl_ABcd16b64a2b,
+    dnnl_OIdhw16i32o4i = dnnl_ABcde16b32a4b,
+    dnnl_OIdhw16i48o4i = dnnl_ABcde16b48a4b,
+    dnnl_OIdhw16i64o4i = dnnl_ABcde16b64a4b,
+    dnnl_OIdhw16i32o2i = dnnl_ABcde16b32a2b,
+    dnnl_OIdhw16i48o2i = dnnl_ABcde16b48a2b,
+    dnnl_OIdhw16i64o2i = dnnl_ABcde16b64a2b,
+    dnnl_OwI16i16o2i = dnnl_AcB16b16a2b,
+    dnnl_OwI16i16o4i = dnnl_AcB16b16a4b,
+    dnnl_OhwI16i16o2i = dnnl_AcdB16b16a2b,
+    dnnl_OhwI16i16o4i = dnnl_AcdB16b16a4b,
+    dnnl_OdhwI16i16o2i = dnnl_AcdeB16b16a2b,
+    dnnl_OdhwI16i16o4i = dnnl_AcdeB16b16a4b,
+    dnnl_gOwI16i16o2i = dnnl_aBdC16c16b2c,
+    dnnl_gOwI16i16o4i = dnnl_aBdC16c16b4c,
+    dnnl_gOhwI16i16o2i = dnnl_aBdeC16c16b2c,
+    dnnl_gOhwI16i16o4i = dnnl_aBdeC16c16b4c,
+    dnnl_gOdhwI16i16o2i = dnnl_aBdefC16c16b2c,
+    dnnl_gOdhwI16i16o4i = dnnl_aBdefC16c16b4c,
+    dnnl_OwI16i32o2i = dnnl_AcB16b32a2b,
+    dnnl_OwI16i32o4i = dnnl_AcB16b32a4b,
+    dnnl_OwI16i48o2i = dnnl_AcB16b48a2b,
+    dnnl_OwI16i48o4i = dnnl_AcB16b48a4b,
+    dnnl_OwI16i64o2i = dnnl_AcB16b64a2b,
+    dnnl_OwI16i64o4i = dnnl_AcB16b64a4b,
+    dnnl_gOwI16i32o2i = dnnl_aBdC16c32b2c,
+    dnnl_gOwI16i32o4i = dnnl_aBdC16c32b4c,
+    dnnl_gOwI16i48o2i = dnnl_aBdC16c48b2c,
+    dnnl_gOwI16i48o4i = dnnl_aBdC16c48b4c,
+    dnnl_gOwI16i64o2i = dnnl_aBdC16c64b2c,
+    dnnl_gOwI16i64o4i = dnnl_aBdC16c64b4c,
+    dnnl_OhwI16i32o2i = dnnl_AcdB16b32a2b,
+    dnnl_OhwI16i32o4i = dnnl_AcdB16b32a4b,
+    dnnl_OhwI16i48o2i = dnnl_AcdB16b48a2b,
+    dnnl_OhwI16i48o4i = dnnl_AcdB16b48a4b,
+    dnnl_OhwI16i64o2i = dnnl_AcdB16b64a2b,
+    dnnl_OhwI16i64o4i = dnnl_AcdB16b64a4b,
+    dnnl_gOhwI16i32o2i = dnnl_aBdeC16c32b2c,
+    dnnl_gOhwI16i32o4i = dnnl_aBdeC16c32b4c,
+    dnnl_gOhwI16i48o2i = dnnl_aBdeC16c48b2c,
+    dnnl_gOhwI16i48o4i = dnnl_aBdeC16c48b4c,
+    dnnl_gOhwI16i64o2i = dnnl_aBdeC16c64b2c,
+    dnnl_gOhwI16i64o4i = dnnl_aBdeC16c64b4c,
+    dnnl_OdhwI16i32o2i = dnnl_AcdeB16b32a2b,
+    dnnl_OdhwI16i32o4i = dnnl_AcdeB16b32a4b,
+    dnnl_OdhwI16i48o2i = dnnl_AcdeB16b48a2b,
+    dnnl_OdhwI16i48o4i = dnnl_AcdeB16b48a4b,
+    dnnl_OdhwI16i64o2i = dnnl_AcdeB16b64a2b,
+    dnnl_OdhwI16i64o4i = dnnl_AcdeB16b64a4b,
+    dnnl_gOdhwI16i32o2i = dnnl_aBdefC16c32b2c,
+    dnnl_gOdhwI16i32o4i = dnnl_aBdefC16c32b4c,
+    dnnl_gOdhwI16i48o2i = dnnl_aBdefC16c48b2c,
+    dnnl_gOdhwI16i48o4i = dnnl_aBdefC16c48b4c,
+    dnnl_gOdhwI16i64o2i = dnnl_aBdefC16c64b2c,
+    dnnl_gOdhwI16i64o4i = dnnl_aBdefC16c64b4c,
+    dnnl_hwioG16g = dnnl_decbA16a,
+    dnnl_NCdhw40n16c = dnnl_ABcde40a16b,
+    dnnl_NCw40n16c = dnnl_ABc40a16b,
+    dnnl_NChw40n16c = dnnl_ABcd40a16b,
+    dnnl_NCw40n32c = dnnl_ABc40a32b,
+    dnnl_NChw40n32c = dnnl_ABcd40a32b,
+    dnnl_NCdhw40n32c = dnnl_ABcde40a32b,
+    dnnl_OIdhw4o8i8o2i = dnnl_ABcde4a8b8a2b,
+    dnnl_OIhw4o8i8o2i = dnnl_ABcd4a8b8a2b,
+    dnnl_OIw4o8i8o2i = dnnl_ABc4a8b8a2b,
+    dnnl_gOIdhw4o8i8o2i = dnnl_aBCdef4b8c8b2c,
+    dnnl_gOIhw4o8i8o2i = dnnl_aBCde4b8c8b2c,
+    dnnl_gOIw4o8i8o2i = dnnl_aBCd4b8c8b2c,
+    dnnl_IOdhw4i8o8i2o = dnnl_BAcde4b8a8b2a,
+    dnnl_IOhw4i8o8i2o = dnnl_BAcd4b8a8b2a,
+    dnnl_IOw4i8o8i2o = dnnl_BAc4b8a8b2a,
+    dnnl_gIOdhw4i8o8i2o = dnnl_aCBdef4c8b8c2b,
+    dnnl_gIOhw4i8o8i2o = dnnl_aCBde4c8b8c2b,
+    dnnl_gIOw4i8o8i2o = dnnl_aCBd4c8b8c2b,
+    dnnl_NCw2c32n8c = dnnl_ABc2b32a8b,
+    dnnl_NChw2c32n8c = dnnl_ABcd2b32a8b,
+    dnnl_NCdhw2c32n8c = dnnl_ABcde2b32a8b,
+    dnnl_OIw2i8o16i4o = dnnl_ABc2b8a16b4a,
+    dnnl_OIhw2i8o16i4o = dnnl_ABcd2b8a16b4a,
+    dnnl_OIdhw2i8o16i4o = dnnl_ABcde2b8a16b4a,
+    dnnl_OIw2o8i16o4i = dnnl_ABc2a8b16a4b,
+    dnnl_OIw2o8i16o2i = dnnl_ABc2a8b16a2b,
+    dnnl_IOw2i8o16i4o = dnnl_BAc2b8a16b4a,
+    dnnl_IOw2i8o16i2o = dnnl_BAc2b8a16b2a,
+    dnnl_OIhw2o8i16o4i = dnnl_ABcd2a8b16a4b,
+    dnnl_OIhw2o8i16o2i = dnnl_ABcd2a8b16a2b,
+    dnnl_IOhw2i8o16i4o = dnnl_BAcd2b8a16b4a,
+    dnnl_IOhw2i8o16i2o = dnnl_BAcd2b8a16b2a,
+    dnnl_OIdhw2o8i16o4i = dnnl_ABcde2a8b16a4b,
+    dnnl_OIdhw2o8i16o2i = dnnl_ABcde2a8b16a2b,
+    dnnl_IOdhw2i8o16i4o = dnnl_BAcde2b8a16b4a,
+    dnnl_IOdhw2i8o16i2o = dnnl_BAcde2b8a16b2a,
+    dnnl_gOIw2o8i16o2i = dnnl_aBCd2b8c16b2c,
+    dnnl_gIOw2i8o16i2o = dnnl_aCBd2c8b16c2b,
+    dnnl_gIOhw2i8o16i2o = dnnl_aBCde2c8b16c2b,
+    dnnl_gIOdhw2i8o16i2o = dnnl_aBCdef2c8b16c2b,
+    dnnl_gOIhw2o8i16o2i = dnnl_aBCde2b8c16b2c,
+    dnnl_gOIdhw2o8i16o2i = dnnl_aBCdef2b8c16b2c,
+    dnnl_gOIw2o8i16o4i = dnnl_aBCd2b8c16b4c,
+    dnnl_gOIhw2o8i16o4i = dnnl_aBCde2b8c16b4c,
+} dnnl_format_tag_t;
+
+/// @} dnnl_api_memory
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// Kinds of propagation.
+typedef enum {
+    // TODO: suggest renames
+    /// Undefined propagation type.
+    dnnl_prop_kind_undef = 0,
+    /// Forward data propagation (training mode). In this mode primitives
+    /// perform computations necessary for subsequent backward propagation.
+    dnnl_forward_training = 64,
+    /// Forward data propagation (inference mode). In this mode primitives
+    /// perform only computations that are necessary for inference and omit
+    /// computations that are necessary only for backward propagation.
+    dnnl_forward_inference = 96,
+    /// Forward data propagation (alias for @c dnnl_forward_inference).
+    dnnl_forward_scoring = dnnl_forward_inference,
+    /// Forward data propagation (alias for @c dnnl_forward_training).
+    dnnl_forward = dnnl_forward_training,
+    /// Backward propagation (with respect to all parameters).
+    dnnl_backward = 128,
+    /// Backward data propagation.
+    dnnl_backward_data = 160,
+    /// Backward weights propagation.
+    dnnl_backward_weights = 192,
+    /// Backward bias propagation.
+    dnnl_backward_bias = 193,
+} dnnl_prop_kind_t;
+
+/// Kinds of primitives. Used to implement a way to extend the library with new
+/// primitives without changing the ABI.
+typedef enum {
+    /// Undefined primitive
+    dnnl_undefined_primitive,
+    /// A reorder primitive.
+    dnnl_reorder,
+    /// A shuffle primitive.
+    dnnl_shuffle,
+    /// A (out-of-place) concat primitive.
+    dnnl_concat,
+    /// A sum primitive.
+    dnnl_sum,
+    /// A convolution primitive.
+    dnnl_convolution,
+    /// A deconvolution primitive.
+    dnnl_deconvolution,
+    /// An element-wise primitive.
+    dnnl_eltwise,
+    /// A softmax primitive.
+    dnnl_softmax,
+    /// A pooling primitive.
+    dnnl_pooling,
+    /// An LRN primitive.
+    dnnl_lrn,
+    /// A batch normalization primitive.
+    dnnl_batch_normalization,
+    /// A layer normalization primitive.
+    dnnl_layer_normalization,
+    /// An inner product primitive.
+    dnnl_inner_product,
+    /// A rnn primitive.
+    dnnl_rnn,
+    /// A matrix multiplication primitive (internal).
+    dnnl_gemm,
+    /// A binary primitive.
+    dnnl_binary,
+    /// A logsoftmax primitive.
+    dnnl_logsoftmax,
+    /// A matrix multiplication primitive.
+    dnnl_matmul,
+    /// A resampling primitive.
+    dnnl_resampling,
+    /// A pooling version 2 primitive (pooling with dilation support).
+    dnnl_pooling_v2,
+    /// A reduction primitive.
+    dnnl_reduction,
+    /// A PReLU primitive.
+    dnnl_prelu,
+    /// A softmax version 2 primitive (softmax with destination memory
+    /// descriptor and algorithm kind).
+    dnnl_softmax_v2,
+    /// A layer normalization version 2 primitive (layer normalization with
+    /// destination memory descriptor).
+    dnnl_layer_normalization_v2,
+
+    /// Parameter to allow internal only primitives without undefined behavior.
+    /// This parameter is chosen to be valid for so long as sizeof(int) >= 2.
+    dnnl_primitive_kind_max = 0x7fff,
+} dnnl_primitive_kind_t;
+
+/// Kinds of algorithms.
+typedef enum {
+    dnnl_alg_kind_undef,
+    /// Direct convolution
+    dnnl_convolution_direct = 0x1,
+    /// Winograd convolution
+    dnnl_convolution_winograd = 0x2,
+    /// Convolution algorithm(either direct or Winograd) is chosen just in time
+    dnnl_convolution_auto = 0x3,
+    /// Direct deconvolution
+    dnnl_deconvolution_direct = 0xa,
+    /// Winograd deconvolution
+    dnnl_deconvolution_winograd = 0xb,
+    /// Eltwise: ReLU
+    dnnl_eltwise_relu = 0x1f,
+    /// Eltwise: hyperbolic tangent non-linearity (tanh)
+    dnnl_eltwise_tanh = 0x2f,
+    /// Eltwise: exponential linear unit (elu)
+    dnnl_eltwise_elu = 0x3f,
+    /// Eltwise: square
+    dnnl_eltwise_square = 0x4f,
+    /// Eltwise: abs
+    dnnl_eltwise_abs = 0x5f,
+    /// Eltwise: square root
+    dnnl_eltwise_sqrt = 0x6f,
+    /// Eltwise: linear
+    dnnl_eltwise_linear = 0x7f,
+    /// Eltwise: bounded_relu
+    dnnl_eltwise_bounded_relu = 0x8f,
+    /// Eltwise: soft_relu
+    dnnl_eltwise_soft_relu = 0x9f,
+    /// Eltwise: soft_relu version 2
+    dnnl_eltwise_soft_relu_v2 = 0xa0,
+    /// Eltwise: hardsigmoid
+    dnnl_eltwise_hardsigmoid = 0xa1,
+    /// Eltwise: logistic
+    dnnl_eltwise_logistic = 0xaf,
+    /// Eltwise: exponent
+    dnnl_eltwise_exp = 0xbf,
+    /// Eltwise: gelu
+    ///
+    /// @note Tanh approximation formula is used to approximate
+    /// the cumulative distribution function of a Gaussian here
+    dnnl_eltwise_gelu_tanh = 0xcf,
+    /// Eltwise: tanh-based gelu (alias for dnnl_eltwise_gelu_tanh)
+    dnnl_eltwise_gelu = dnnl_eltwise_gelu_tanh,
+    /// Eltwise: swish
+    dnnl_eltwise_swish = 0xdf,
+    /// Eltwise: natural logarithm
+    dnnl_eltwise_log = 0xef,
+    /// Eltwise: clip
+    dnnl_eltwise_clip = 0xff,
+    /// Eltwise: clip version 2
+    dnnl_eltwise_clip_v2 = 0x10,
+    /// Eltwise: pow
+    dnnl_eltwise_pow = 0x20,
+    /// Eltwise: erf-based gelu
+    dnnl_eltwise_gelu_erf = 0x30,
+    /// Eltwise: round
+    dnnl_eltwise_round = 0x40,
+    /// Eltwise: logsigmoid
+    dnnl_eltwise_logsigmoid = 0x50,
+    /// Eltwise: mish
+    dnnl_eltwise_mish = 0x60,
+    /// Eltwise: hardswish
+    dnnl_eltwise_hardswish = 0x70,
+    /// Eltwise: ReLU (dst for backward)
+    dnnl_eltwise_relu_use_dst_for_bwd = 0x100,
+    /// Eltwise: hyperbolic tangent non-linearity (tanh) (dst for backward)
+    dnnl_eltwise_tanh_use_dst_for_bwd = 0x101,
+    /// Eltwise: exponential linear unit (elu) (dst for backward)
+    dnnl_eltwise_elu_use_dst_for_bwd = 0x102,
+    /// Eltwise: square root (dst for backward)
+    dnnl_eltwise_sqrt_use_dst_for_bwd = 0x103,
+    /// Eltwise: logistic (dst for backward)
+    dnnl_eltwise_logistic_use_dst_for_bwd = 0x104,
+    /// Eltwise: exp (dst for backward)
+    dnnl_eltwise_exp_use_dst_for_bwd = 0x105,
+    /// Eltwise: clip version 2 (dst for backward)
+    dnnl_eltwise_clip_v2_use_dst_for_bwd = 0x106,
+    /// Max pooling
+    dnnl_pooling_max = 0x1ff,
+    /// Average pooling include padding
+    dnnl_pooling_avg_include_padding = 0x2ff,
+    /// Average pooling exclude padding
+    dnnl_pooling_avg_exclude_padding = 0x3ff,
+    /// Average pooling (alias for #dnnl_pooling_avg_exclude_padding)
+    dnnl_pooling_avg = dnnl_pooling_avg_exclude_padding,
+    /// Local response normalization (LRN) across multiple channels
+    dnnl_lrn_across_channels = 0xaff,
+    /// LRN within a single channel
+    dnnl_lrn_within_channel = 0xbff,
+    /// RNN cell
+    dnnl_vanilla_rnn = 0x1fff,
+    /// LSTM cell
+    dnnl_vanilla_lstm = 0x2fff,
+    /// GRU cell
+    dnnl_vanilla_gru = 0x3fff,
+    /// GRU cell with linear before reset
+    ///
+    /// Modification of original GRU cell. Differs from #dnnl_vanilla_gru
+    /// in how the new memory gate is calculated:
+    /// \f[ c_t = tanh(W_c*x_t + b_{c_x} + r_t*(U_c*h_{t-1}+b_{c_h})) \f]
+    /// Primitive expects 4 biases on input:
+    /// \f$[b_{u}, b_{r}, b_{c_x}, b_{c_h}]\f$
+    dnnl_lbr_gru = 0x4fff,
+    /// AUGRU cell
+    dnnl_vanilla_augru = 0x5fff,
+    /// AUGRU cell with linear before reset
+    dnnl_lbr_augru = 0x6fff,
+    /// Binary add
+    dnnl_binary_add = 0x1fff0,
+    /// Binary mul
+    dnnl_binary_mul = 0x1fff1,
+    /// Binary max
+    dnnl_binary_max = 0x1fff2,
+    /// Binary min
+    dnnl_binary_min = 0x1fff3,
+    /// Binary div
+    dnnl_binary_div = 0x1fff4,
+    /// Binary sub
+    dnnl_binary_sub = 0x1fff5,
+    /// Binary greater or equal
+    dnnl_binary_ge = 0x1fff6,
+    /// Binary greater than
+    dnnl_binary_gt = 0x1fff7,
+    /// Binary less or equal
+    dnnl_binary_le = 0x1fff8,
+    /// Binary less than
+    dnnl_binary_lt = 0x1fff9,
+    /// Binary equal
+    dnnl_binary_eq = 0x1fffa,
+    /// Binary not equal
+    dnnl_binary_ne = 0x1fffb,
+    /// Nearest Neighbor Resampling Method
+    dnnl_resampling_nearest = 0x2fff0,
+    /// Linear Resampling Method
+    dnnl_resampling_linear = 0x2fff1,
+    /// Reduction using max
+    dnnl_reduction_max,
+    /// Reduction using min
+    dnnl_reduction_min,
+    /// Reduction using sum
+    dnnl_reduction_sum,
+    /// Reduction using mul
+    dnnl_reduction_mul,
+    /// Reduction using mean
+    dnnl_reduction_mean,
+    /// Reduction using lp norm
+    dnnl_reduction_norm_lp_max,
+    /// Reduction using lp norm
+    dnnl_reduction_norm_lp_sum,
+    /// Reduction using lp norm without final pth-root
+    dnnl_reduction_norm_lp_power_p_max,
+    /// Reduction using lp norm without final pth-root
+    dnnl_reduction_norm_lp_power_p_sum,
+    /// Softmax
+    dnnl_softmax_accurate = 0x30000,
+    /// Logsoftmax
+    dnnl_softmax_log,
+} dnnl_alg_kind_t;
+
+/// Flags for normalization primitives.
+typedef enum {
+    /// Use no normalization flags
+    ///
+    /// If specified
+    ///  - on forward training propagation mean and variance are computed and
+    ///    stored as output
+    ///  - on backward propagation compute full derivative wrt data
+    ///  - on backward propagation prop_kind == #dnnl_backward_data has the same
+    ///    behavior as prop_kind == #dnnl_backward
+    dnnl_normalization_flags_none = 0x0U,
+
+    /// Use global statistics
+    ///
+    /// If specified
+    ///  - on forward propagation use mean and variance provided by user (input)
+    ///  - on backward propagation reduces the amount of computations, since
+    ///    mean and variance are considered as constants
+    ///
+    ///  If not specified:
+    ///   - on forward propagation mean and variance are computed and stored as
+    ///     output
+    ///   - on backward propagation compute full derivative wrt data
+    dnnl_use_global_stats = 0x1U,
+
+    /// Use scale and shift parameters
+    ///
+    /// If specified:
+    ///  - on forward propagation use scale and shift (aka scale and bias) for
+    ///    the normalization results
+    ///  - on backward propagation (for prop_kind == #dnnl_backward) compute
+    ///    diff wrt scale and shift (hence one extra output used)
+    ///
+    /// If no specified:
+    ///  - on backward propagation prop_kind == #dnnl_backward_data has the
+    ///    same behavior as prop_kind == #dnnl_backward
+    dnnl_use_scaleshift = 0x2U,
+
+    /// Fuse with ReLU
+    ///
+    /// The flag implies negative slope being 0. On training this is the only
+    /// configuration supported. For inference, to use non-zero negative slope
+    /// consider using @ref dev_guide_attributes_post_ops.
+    ///
+    /// If specified:
+    ///  - on inference this option behaves the same as if the primitive were
+    ///    fused with ReLU using post ops API with zero negative slope.
+    ///  - on training primitive requires workspace (required to be able to
+    ///    perform backward pass)
+    dnnl_fuse_norm_relu = 0x4U,
+
+    /// Use scale parameter
+    ///
+    /// If specified:
+    ///  - on forward propagation use scale for the normalization results
+    ///  - on backward propagation (for prop_kind == #dnnl_backward) compute
+    ///    diff wrt scale (hence one extra output used)
+    dnnl_use_scale = 0x8U,
+
+    /// Use shift parameter
+    ///
+    /// If specified:
+    ///  - on forward propagation use shift (aka bias) for the normalization
+    ///    results
+    ///  - on backward propagation (for prop_kind == #dnnl_backward) compute
+    ///    diff wrt shift (hence one extra output used)
+    dnnl_use_shift = 0x10U,
+
+    /// Fuse with Add and then fuse with ReLU
+    ///
+    /// If specified:
+    ///
+    ///  - on forward propagation apply element-wise binary Add operation to
+    ///    to the normalization results with an additional input tensor and then
+    ///    apply ReLU with negative slope being 0.
+    ///  - on training primitive requires workspace (required to be able to
+    ///    perform backward pass).
+    ///  - on backward propagation save the result of backward ReLU operation
+    ///    with input tensor and workspace from forward pass to extra output
+    ///    tensor and then perform backward normalization.
+    dnnl_fuse_norm_add_relu = 0x20U,
+
+} dnnl_normalization_flags_t;
+
+/// @} dnnl_api_primitives_common
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_memory
+/// @{
+
+/// Maximum number of dimensions a tensor can have. Only restricts the amount
+/// of space used for the tensor description. Individual computational
+/// primitives may support only tensors of certain dimensions.
+#define DNNL_MAX_NDIMS 12
+
+/// A wildcard value for dimensions that are unknown at a primitive creation
+/// time.
+#define DNNL_RUNTIME_DIM_VAL INT64_MIN
+
+/// A `size_t` counterpart of the DNNL_RUNTIME_DIM_VAL.
+/// For instance, this value is returned by dnnl_memory_desc_get_size() if
+/// either of the dimensions or strides equal to #DNNL_RUNTIME_DIM_VAL.
+#define DNNL_RUNTIME_SIZE_VAL ((size_t)DNNL_RUNTIME_DIM_VAL)
+
+/// @cond DO_NOT_DOCUMENT_THIS
+/// Hex representation for a **special** quiet NAN (!= NAN from math.h)
+static const union {
+    unsigned u;
+    float f;
+} DNNL_RUNTIME_F32_VAL_REP = {0x7fc000d0};
+/// @endcond
+
+/// A wildcard value for floating point values that are unknown at a primitive
+/// creation time.
+#define DNNL_RUNTIME_F32_VAL (DNNL_RUNTIME_F32_VAL_REP.f)
+
+/// @cond DO_NOT_DOCUMENT_THIS
+static const int DNNL_RUNTIME_S32_VAL_REP = INT32_MIN;
+/// @endcond
+
+/// A wildcard value for int32_t values that are unknown at a primitive creation
+/// time.
+#define DNNL_RUNTIME_S32_VAL DNNL_RUNTIME_S32_VAL_REP
+
+/// A type to describe tensor dimension.
+typedef int64_t dnnl_dim_t;
+
+/// A type to describe tensor dimensions.
+typedef dnnl_dim_t dnnl_dims_t[DNNL_MAX_NDIMS];
+
+/// Generic description of blocked data layout for most memory formats.
+///
+/// @sa @ref dev_guide_understanding_memory_formats
+typedef struct {
+    /// The strides between the outermost blocks.
+    /// In case of plain (non-blocked) formats the strides between dimensions.
+    dnnl_dims_t strides;
+    // Innermost section
+    // ASSUMPTION: the innermost blocks are always dense
+    /// The number of innermost blocks, e.g. 3 in case of `OIhw_4i16o4i_`
+    int inner_nblks;
+    /// The size of the blocks, e.g. `{4, 16, 4}` in case of `OIhw_4i16o4i`
+    dnnl_dims_t inner_blks;
+    /// The logical indices of the blocks, e.g. `{1, 0, 1}` in case of
+    /// `4i16o4i`, because `i` is the 1st dim and `o` is the 0st dim
+    dnnl_dims_t inner_idxs;
+} dnnl_blocking_desc_t;
+
+/// Winograd-specific formats
+typedef enum {
+    /// Undefined memory format, used for empty memory descriptors.
+    dnnl_wino_undef = 0,
+    // Tensors of weights for 2x3 winograd convolutions.
+    dnnl_wino_wei_aaOIoi, ///< Internal weights format for 2x3 Winograd
+    dnnl_wino_wei_aaOio, ///< Internal weights format for 2x3 Winograd
+    dnnl_wino_wei_aaOBiOo, ///< Internal weights format for 2x3 Winograd
+    // Tensor of weights for 4x3 convolution.
+    dnnl_wino_wei_OBaaIBOIio ///< Internal weights format for 4x3 Winograd
+} dnnl_wino_memory_format_t;
+
+/// Description of tensor of weights for winograd 2x3 convolution.
+typedef struct {
+    dnnl_wino_memory_format_t wino_format;
+    int r;
+    int alpha;
+    int ic;
+    int oc;
+    int ic_block;
+    int oc_block;
+    int ic2_block;
+    int oc2_block;
+    float adj_scale;
+    size_t size;
+} dnnl_wino_desc_t;
+
+typedef enum {
+    dnnl_packed_format_undef = 0,
+    dnnl_ldigo_p,
+    dnnl_ldgoi_p,
+    dnnl_ldio_p
+} dnnl_rnn_packed_memory_format_t;
+
+/// Maximum number of parts of RNN weights tensor that require separate
+/// computation.
+#define DNNL_RNN_MAX_N_PARTS 4
+
+/// Description of tensor of packed weights for rnn.
+typedef struct {
+    dnnl_rnn_packed_memory_format_t format;
+    int n_parts;
+    int n;
+    int ldb;
+    int parts[DNNL_RNN_MAX_N_PARTS];
+    size_t part_pack_size[DNNL_RNN_MAX_N_PARTS];
+    unsigned pack_part[DNNL_RNN_MAX_N_PARTS];
+    size_t offset_compensation;
+    size_t size;
+    char reserved[200];
+} dnnl_rnn_packed_desc_t;
+
+/// Flags for memory special features
+typedef enum {
+    dnnl_memory_extra_flag_none = 0x0U,
+    /// Indicates the weights have an additional buffer, that depends on the
+    /// @p compensation_mask.
+    ///
+    /// For instance, in 4D case with the compensation mask equals (1 << 0)
+    /// the additional buffer would consist of OC values:
+    /// O[oc : 0,OC] =
+    ///  -128 * SUM(ic : 0,IC; kh : 0,KH; kw : 0,KW){ weights(oc, ic, kh, kw) }
+    dnnl_memory_extra_flag_compensation_conv_s8s8 = 0x1U,
+    dnnl_memory_extra_flag_scale_adjust = 0x2U,
+    dnnl_memory_extra_flag_rnn_u8s8_compensation = 0x4U,
+    dnnl_memory_extra_flag_gpu_rnn_u8s8_compensation
+    = dnnl_memory_extra_flag_rnn_u8s8_compensation,
+    dnnl_memory_extra_flag_compensation_conv_asymmetric_src = 0x8U,
+    dnnl_memory_extra_flag_rnn_s8s8_compensation = 0x16U,
+} dnnl_memory_extra_flags_t;
+
+/// Description of extra information stored in memory
+typedef struct {
+    /// The flags contain arbitrary extra information, such as compensation.
+    /// @sa dnnl_memory_extra_flags_t
+    uint64_t flags;
+    /// Compensation mask
+    int compensation_mask;
+    /// Scale applied to the data
+    float scale_adjust;
+    /// Compensation mask for asymmetric quantization
+    int asymm_compensation_mask;
+    /// For future backwards compatibility
+    char reserved[60];
+} dnnl_memory_extra_desc_t;
+
+/// Memory descriptor. The description is based on a number of dimensions,
+/// dimensions themselves, plus information about elements type and memory
+/// format. Additionally, contains format-specific descriptions of the data
+/// layout.
+typedef struct {
+    /// Number of dimensions
+    int ndims;
+    /// Dimensions in the following order:
+    /// - CNN data tensors: mini-batch, channel, spatial
+    ///   (<code>{N, C, [[D,] H,] W}</code>)
+    /// - CNN weight tensors: group (optional), output channel, input channel,
+    ///   spatial (<code>{[G,] O, I, [[D,] H,] W}</code>)
+    /// - RNN data tensors: time, mini-batch, channels (<code>{T, N, C}</code>)
+    ///   or layers, directions, states, mini-batch, channels (<code>{L, D, S, N, C}</code>)
+    /// - RNN weight tensor: layers, directions, input channel, gates, output channels
+    ///   (<code>{L, D, I, G, O}</code>).
+    ///
+    /// @note
+    ///    The order of dimensions does not depend on the memory format, so
+    ///    whether the data is laid out in #dnnl_nchw or #dnnl_nhwc
+    ///    the dims for 4D CN data tensor would be <code>{N, C, H, W}</code>.
+    dnnl_dims_t dims;
+
+    /// Data type of the tensor elements.
+    dnnl_data_type_t data_type;
+
+    /// Size of the data including padding in each dimension.
+    dnnl_dims_t padded_dims;
+
+    /// Per-dimension offset from the padding to actual data, the top-level
+    /// tensor with offsets applied must lie within the padding area.
+    dnnl_dims_t padded_offsets;
+
+    /// Offset from memory origin to the current block, non-zero only in
+    /// a description of a memory sub-block.
+    dnnl_dim_t offset0;
+
+    /// Memory format kind.
+    dnnl_format_kind_t format_kind;
+    union {
+        /// Description of the data layout for memory formats that use
+        /// blocking.
+        dnnl_blocking_desc_t blocking;
+        /// Tensor of weights for integer 8bit winograd convolution.
+        dnnl_wino_desc_t wino_desc;
+        /// Tensor of packed weights for RNN.
+        dnnl_rnn_packed_desc_t rnn_packed_desc;
+        // ... other descriptions possible
+    } format_desc;
+
+    dnnl_memory_extra_desc_t extra;
+} dnnl_memory_desc_t;
+
+/// @struct dnnl_memory
+/// An opaque structure to describe a memory.
+struct dnnl_memory;
+
+/// A memory handle.
+typedef struct dnnl_memory *dnnl_memory_t;
+
+/// A constant memory handle.
+typedef const struct dnnl_memory *const_dnnl_memory_t;
+
+/// Special pointer value that indicates that a memory object should not have
+/// an underlying buffer.
+#define DNNL_MEMORY_NONE (NULL)
+
+/// Special pointer value that indicates that the library needs to allocate an
+/// underlying buffer for a memory object.
+#define DNNL_MEMORY_ALLOCATE ((void *)(size_t)-1)
+
+/// @} dnnl_api_memory
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// A pointer to any of the operation descriptors.
+typedef void *dnnl_op_desc_t;
+/// A pointer to any of the operation descriptors (constant variant).
+typedef const void *const_dnnl_op_desc_t;
+
+/// @} dnnl_api_primitives_common
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+
+/// @addtogroup dnnl_api_convolution
+/// @{
+
+/// A descriptor of a convolution operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_convolution.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward_data,
+    /// #dnnl_backward_weights, and #dnnl_backward_bias.
+    dnnl_prop_kind_t prop_kind;
+    /// The kind of the convolution algorithm. Possible values:
+    /// #dnnl_convolution_direct.
+    dnnl_alg_kind_t alg_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Source gradient memory descriptor.
+    dnnl_memory_desc_t diff_src_desc;
+    /// Weights memory descriptor.
+    dnnl_memory_desc_t weights_desc;
+    /// Weights gradient memory descriptor.
+    dnnl_memory_desc_t diff_weights_desc;
+    /// Bias memory descriptor.
+    dnnl_memory_desc_t bias_desc;
+    /// Bias gradient memory descriptor.
+    dnnl_memory_desc_t diff_bias_desc;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_dst_desc;
+    /// Convolution strides in each spatial dimension.
+    dnnl_dims_t strides;
+    /// Convolution dilates in each spatial dimension.
+    dnnl_dims_t dilates;
+    /// Padding in each spatial dimension. padding[0] is a padding in the
+    /// beginning (@p padding_l), padding[1] is a padding in the end (@p
+    /// padding_r).
+    dnnl_dims_t padding[2];
+    /// The accumulator data type. Initialized automatically.
+    dnnl_data_type_t accum_data_type;
+} dnnl_convolution_desc_t;
+
+/// @} dnnl_api_convolution
+
+/// @addtogroup dnnl_api_deconvolution
+/// @{
+
+/// A descriptor of a deconvolution operation.
+typedef dnnl_convolution_desc_t dnnl_deconvolution_desc_t;
+
+/// @} dnnl_api_deconvolution
+
+/// @addtogroup dnnl_api_shuffle
+/// @{
+
+/// A descriptor of a shuffle operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_shuffle.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// Source and destination memory descriptor,
+    /// and source and destination gradient memory descriptor.
+    dnnl_memory_desc_t data_desc;
+    /// Axis for shuffling.
+    int axis;
+    /// Number of groups.
+    dnnl_dim_t group_size;
+} dnnl_shuffle_desc_t;
+
+/// @} dnnl_api_shuffle
+
+/// @addtogroup dnnl_api_eltwise
+/// @{
+
+/// A descriptor of a element-wise operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_eltwise.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// The kind of eltwise algorithm. Possible values: #dnnl_eltwise_relu,
+    /// #dnnl_eltwise_tanh, #dnnl_eltwise_elu, #dnnl_eltwise_square,
+    /// #dnnl_eltwise_abs, #dnnl_eltwise_sqrt, #dnnl_eltwise_linear,
+    /// #dnnl_eltwise_bounded_relu, #dnnl_eltwise_soft_relu,
+    /// #dnnl_eltwise_soft_relu_v2, #dnnl_eltwise_logistic, #dnnl_eltwise_exp,
+    /// #dnnl_eltwise_gelu_tanh, #dnnl_eltwise_swish, #dnnl_eltwise_log,
+    /// #dnnl_eltwise_clip, #dnnl_eltwise_clip_v2, #dnnl_eltwise_pow,
+    /// #dnnl_eltwise_gelu_erf, #dnnl_eltwise_round, #dnnl_eltwise_logsigmoid,
+    /// #dnnl_eltwise_mish, #dnnl_eltwise_hardswish, #dnnl_eltwise_hardsigmoid.
+    /// Possible values for passing destination memory on backward:
+    /// #dnnl_eltwise_relu_use_dst_for_bwd, #dnnl_eltwise_tanh_use_dst_for_bwd,
+    /// #dnnl_eltwise_elu_use_dst_for_bwd, #dnnl_eltwise_sqrt_use_dst_for_bwd,
+    /// #dnnl_eltwise_logistic_use_dst_for_bwd,
+    /// #dnnl_eltwise_exp_use_dst_for_bwd,
+    /// #dnnl_eltwise_clip_v2_use_dst_for_bwd.
+    dnnl_alg_kind_t alg_kind;
+    /// Source and destination memory descriptor.
+    dnnl_memory_desc_t data_desc;
+    /// Source and destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_data_desc;
+    /// Algorithm specific parameter.
+    /// Accordance table:
+    ///  - #dnnl_eltwise_relu: @p alpha -- negative slope, @p beta ignored
+    ///  - #dnnl_eltwise_tanh: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_elu: @p alpha -- negative slope, @p beta ignored
+    ///  - #dnnl_eltwise_square: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_abs: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_sqrt: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_linear: @p alpha -- scale, @p beta -- shift
+    ///  - #dnnl_eltwise_bounded_relu: @p alpha -- upper bound, @p beta ignored
+    ///  - #dnnl_eltwise_soft_relu: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_soft_relu_v2: @p alpha -- soft_relu_v2 arg scaling, @p beta ignored
+    ///  - #dnnl_eltwise_logistic: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_exp: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_gelu_tanh: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_swish: @p alpha -- sigmoid arg scaling, @p beta ignored
+    ///  - #dnnl_eltwise_log: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_clip: @p alpha -- lower bound, @p beta -- upper bound
+    ///  - #dnnl_eltwise_clip_v2: @p alpha -- lower bound, @p beta -- upper bound
+    ///  - #dnnl_eltwise_pow: @p alpha -- scale, @p beta -- exponent
+    ///  - #dnnl_eltwise_gelu_erf: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_round: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_logsigmoid: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_mish: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_hardswish: @p alpha and @p beta ignored
+    ///  - #dnnl_eltwise_hardsigmoid: @p alpha -- scale, @p beta -- shift
+    float alpha, beta;
+} dnnl_eltwise_desc_t;
+
+/// @} dnnl_api_eltwise
+
+/// @addtogroup dnnl_api_softmax
+/// @{
+
+/// A descriptor of a Softmax operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_softmax.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// Source and destination memory descriptor.
+    dnnl_memory_desc_t data_desc;
+    /// Source and Destination of gradient memory descriptor.
+    dnnl_memory_desc_t diff_desc;
+    /// The axis along which to perform the softmax.
+    int softmax_axis;
+} dnnl_softmax_desc_t;
+
+/// @} dnnl_api_softmax
+
+/// @addtogroup dnnl_api_softmax_v2
+/// @{
+
+/// A descriptor of a Softmax operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_softmax_v2.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Source gradient memory descriptor.
+    dnnl_memory_desc_t diff_src_desc;
+    /// The axis along which to perform the softmax.
+    int softmax_axis;
+    /// Softmax algorithm. Possible values: #dnnl_softmax_accurate and
+    /// #dnnl_softmax_log.
+    dnnl_alg_kind_t alg_kind;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_dst_desc;
+} dnnl_softmax_v2_desc_t;
+
+/// @} dnnl_api_softmax_v2
+
+/// @addtogroup dnnl_api_logsoftmax
+/// @{
+
+/// A descriptor of a LogSoftmax operation. An alias of Softmax structure, but
+/// primitive_kind must be #dnnl_logsoftmax.
+typedef dnnl_softmax_desc_t dnnl_logsoftmax_desc_t;
+
+/// @} dnnl_api_logsoftmax
+
+/// @addtogroup dnnl_api_pooling
+/// @{
+
+/// A descriptor of a pooling operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_pooling.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// The kind of pooling algorithm.
+    /// Possible values: #dnnl_pooling_max,
+    /// #dnnl_pooling_avg_include_padding, and
+    /// #dnnl_pooling_avg_exclude_padding.
+    dnnl_alg_kind_t alg_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Source gradient memory descriptor.
+    dnnl_memory_desc_t diff_src_desc;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_dst_desc;
+    /// Pooling kernel strides for spatial dimensions.
+    dnnl_dims_t strides;
+    /// Pooling kernel spatial dimensions.
+    dnnl_dims_t kernel;
+    /// Padding in each spatial dimension. padding[0] is a padding in the
+    /// beginning (@p padding_l), padding[1] is a padding in the end (@p
+    /// padding_r).
+    dnnl_dims_t padding[2];
+    /// The accumulator data type. Initialized automatically.
+    dnnl_data_type_t accum_data_type;
+} dnnl_pooling_desc_t;
+
+/// @} dnnl_api_pooling
+
+/// @addtogroup dnnl_api_pooling_v2
+/// @{
+
+/// A descriptor of a pooling operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_pooling_v2.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// The kind of pooling algorithm.
+    /// Possible values: #dnnl_pooling_max,
+    /// #dnnl_pooling_avg_include_padding, and
+    /// #dnnl_pooling_avg_exclude_padding.
+    dnnl_alg_kind_t alg_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Source gradient memory descriptor.
+    dnnl_memory_desc_t diff_src_desc;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_dst_desc;
+    /// Pooling kernel strides for spatial dimensions.
+    dnnl_dims_t strides;
+    /// Pooling kernel spatial dimensions.
+    dnnl_dims_t kernel;
+    /// Padding in each spatial dimension. padding[0] is a padding in the
+    /// beginning (@p padding_l), padding[1] is a padding in the end (@p
+    /// padding_r).
+    dnnl_dims_t padding[2];
+    /// The accumulator data type. Initialized automatically.
+    dnnl_data_type_t accum_data_type;
+    /// Pooling dilations for spatial dimensions.
+    dnnl_dims_t dilation;
+} dnnl_pooling_v2_desc_t;
+
+/// @} dnnl_api_pooling_v2
+
+/// @addtogroup dnnl_api_prelu
+/// @{
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_prelu.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward
+    dnnl_prop_kind_t prop_kind;
+    /// Source and destination memory descriptor.
+    dnnl_memory_desc_t data_desc;
+    /// Learnable parameter alpha memory descriptor.
+    /// Alpha describes negative slope.
+    dnnl_memory_desc_t weights_desc;
+    /// Source and destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_data_desc;
+    /// Learnable parameter alpha gradient memory descriptor.
+    dnnl_memory_desc_t diff_weights_desc;
+} dnnl_prelu_desc_t;
+
+/// @} dnnl_api_prelu
+
+/// @addtogroup dnnl_api_lrn
+/// @{
+
+/// A descriptor of a Local Response Normalization (LRN) operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_lrn.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// LRN algorithm. Possible values: #dnnl_lrn_within_channel and
+    /// #dnnl_lrn_across_channels.
+    dnnl_alg_kind_t alg_kind;
+    /// Source and destination memory descriptor.
+    dnnl_memory_desc_t data_desc;
+    /// Source and destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_data_desc;
+    /// The number of channels to sum over (for cross-channel LRN) or the side
+    /// length of the square region to sum over (for within-channel LRN).
+    dnnl_dim_t local_size;
+    /// LRN alpha parameter.
+    float lrn_alpha;
+    /// LRN beta parameter.
+    float lrn_beta;
+    /// LRN k parameter.
+    float lrn_k;
+} dnnl_lrn_desc_t;
+
+/// @} dnnl_api_lrn
+
+/// @addtogroup dnnl_api_batch_normalization
+/// @{
+
+/// A descriptor of a Batch Normalization operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_batch_normalization.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// Source and destination memory descriptor.
+    dnnl_memory_desc_t data_desc;
+    /// Source and destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_data_desc;
+    /// Scale and shift data and gradient memory descriptors.
+    ///
+    /// Scaleshift memory descriptor uses 2D #dnnl_nc format[2,Channels]. 1-st
+    /// dimension contains gamma parameter, 2-nd dimension contains beta
+    /// parameter.
+    dnnl_memory_desc_t data_scaleshift_desc;
+    dnnl_memory_desc_t diff_data_scaleshift_desc;
+    /// Statistics memory descriptor.
+    ///
+    /// Statistics (mean or variance) descriptor use 1D #dnnl_x format[Channels].
+    dnnl_memory_desc_t stat_desc;
+    /// Batch normalization epsilon parameter.
+    float batch_norm_epsilon;
+    unsigned flags;
+} dnnl_batch_normalization_desc_t;
+
+/// @} dnnl_api_batch_normalization
+
+/// @addtogroup dnnl_api_layer_normalization
+/// @{
+
+/// A descriptor of a Layer Normalization operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_layer_normalization.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// Source and destination memory descriptor.
+    dnnl_memory_desc_t data_desc;
+    /// Source and destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_data_desc;
+    /// Scale and shift data and gradient memory descriptors.
+    ///
+    /// Scaleshift memory descriptor uses 2D #dnnl_ab
+    /// format[2, normalized_dim] where 1-st dimension contains gamma parameter,
+    /// 2-nd dimension contains beta parameter. Normalized_dim is equal to the
+    /// last logical dimension of the data tensor across which normalization is
+    /// performed.
+    dnnl_memory_desc_t data_scaleshift_desc;
+    dnnl_memory_desc_t diff_data_scaleshift_desc;
+    /// Mean and variance data memory descriptors.
+    ///
+    /// Statistics (mean and variance) memory descriptor is the k-dimensional tensor
+    /// where k is equal to data_tensor_ndims - 1 and may have any plain
+    /// (stride[last_dim] == 1) user-provided format.
+    dnnl_memory_desc_t stat_desc;
+    /// Layer normalization epsilon parameter.
+    float layer_norm_epsilon;
+    unsigned flags;
+} dnnl_layer_normalization_desc_t;
+
+/// @} dnnl_api_layer_normalization
+
+/// @addtogroup dnnl_api_layer_normalization_v2
+/// @{
+
+/// A descriptor of a Layer Normalization operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_layer_normalization_v2.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
+    dnnl_prop_kind_t prop_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Source gradient memory descriptor.
+    dnnl_memory_desc_t diff_src_desc;
+    /// Scale and shift data and gradient memory descriptors.
+    ///
+    /// Scaleshift memory descriptor uses 2D #dnnl_ab
+    /// format[2, normalized_dim] where 1-st dimension contains gamma parameter,
+    /// 2-nd dimension contains beta parameter. Normalized_dim is equal to the
+    /// last logical dimension of the data tensor across which normalization is
+    /// performed.
+    dnnl_memory_desc_t data_scaleshift_desc;
+    dnnl_memory_desc_t diff_data_scaleshift_desc;
+    /// Mean and variance data memory descriptors.
+    ///
+    /// Statistics (mean and variance) memory descriptor is the k-dimensional tensor
+    /// where k is equal to data_tensor_ndims - 1 and may have any plain
+    /// (stride[last_dim] == 1) user-provided format.
+    dnnl_memory_desc_t stat_desc;
+    /// Layer normalization epsilon parameter.
+    float layer_norm_epsilon;
+    unsigned flags;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_dst_desc;
+} dnnl_layer_normalization_v2_desc_t;
+
+/// @} dnnl_api_layer_normalization_v2
+
+/// @addtogroup dnnl_api_inner_product
+/// @{
+
+/// A descriptor of an inner product operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_inner_product.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward_data,
+    /// #dnnl_backward_weights, and #dnnl_backward_bias.
+    dnnl_prop_kind_t prop_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Source gradient memory descriptor.
+    dnnl_memory_desc_t diff_src_desc;
+    /// Weights memory descriptor.
+    dnnl_memory_desc_t weights_desc;
+    /// Weights gradient memory descriptor.
+    dnnl_memory_desc_t diff_weights_desc;
+    /// Bias memory descriptor.
+    dnnl_memory_desc_t bias_desc;
+    /// Bias gradient memory descriptor.
+    dnnl_memory_desc_t diff_bias_desc;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_dst_desc;
+    /// The accumulator data type. Initialized automatically.
+    dnnl_data_type_t accum_data_type;
+} dnnl_inner_product_desc_t;
+
+/// @} dnnl_api_inner_product
+
+/// @addtogroup dnnl_api_rnn
+/// @{
+
+/// Flags for RNN cell.
+typedef enum {
+    /// Undefined RNN flags
+    dnnl_rnn_flags_undef = 0x0
+} dnnl_rnn_flags_t;
+
+/// A direction of RNN primitive execution.
+typedef enum {
+    /// Unidirectional execution of RNN primitive from left to right.
+    dnnl_unidirectional_left2right,
+    /// Unidirectional execution of RNN primitive from right to left.
+    dnnl_unidirectional_right2left,
+    /// Bidirectional execution of RNN primitive with concatenation of the
+    /// results.
+    dnnl_bidirectional_concat,
+    /// Bidirectional execution of RNN primitive with summation of the
+    /// results.
+    dnnl_bidirectional_sum,
+    /// Alias for #dnnl_unidirectional_left2right.
+    dnnl_unidirectional = dnnl_unidirectional_left2right,
+} dnnl_rnn_direction_t;
+
+/// A descriptor for an RNN operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_rnn.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, and #dnnl_backward.
+    dnnl_prop_kind_t prop_kind;
+    /// RNN cell kind. Must be one of #dnnl_vanilla_rnn,
+    /// #dnnl_vanilla_lstm, #dnnl_vanilla_gru, or #dnnl_lbr_gru.
+    dnnl_alg_kind_t cell_kind;
+    /// The direction of RNN primitive execution.
+    dnnl_rnn_direction_t direction;
+    /// Source layer memory descriptor.
+    dnnl_memory_desc_t src_layer_desc;
+    /// Source iteration memory descriptor for hidden state.
+    dnnl_memory_desc_t src_iter_desc;
+    /// Source iteration memory descriptor for cell state.
+    dnnl_memory_desc_t src_iter_c_desc;
+    /// Weights layer memory descriptor.
+    dnnl_memory_desc_t weights_layer_desc;
+    /// Weights iteration memory descriptor.
+    dnnl_memory_desc_t weights_iter_desc;
+    /// Bias memory descriptor.
+    dnnl_memory_desc_t bias_desc;
+    /// Destination layer memory descriptor.
+    dnnl_memory_desc_t dst_layer_desc;
+    /// Destination iter memory descriptor for hidden state.
+    dnnl_memory_desc_t dst_iter_desc;
+    /// Destination iter memory descriptor for cell state.
+    dnnl_memory_desc_t dst_iter_c_desc;
+    /// Weights peephole memory descriptor.
+    /// This memory descriptor is equal to zero memory descriptor in case of
+    /// non-peephole LSTMs and other non-LSTM RNNs.
+    dnnl_memory_desc_t weights_peephole_desc;
+    /// Weights projection memory descriptor.
+    /// This memory descriptor is equal to zero memory descriptor in case of
+    /// non-projection LSTMs and other non-LSTM RNNs.
+    dnnl_memory_desc_t weights_projection_desc;
+
+    /// Source gradient layer memory descriptor.
+    dnnl_memory_desc_t diff_src_layer_desc;
+    /// Source gradient iter memory descriptor for hidden state.
+    dnnl_memory_desc_t diff_src_iter_desc;
+    /// Source gradient iter memory descriptor for cell state.
+    dnnl_memory_desc_t diff_src_iter_c_desc;
+    /// Weights gradient layer memory descriptor.
+    dnnl_memory_desc_t diff_weights_layer_desc;
+    /// Weights gradient iter memory descriptor.
+    dnnl_memory_desc_t diff_weights_iter_desc;
+    /// Bias gradient memory descriptor.
+    dnnl_memory_desc_t diff_bias_desc;
+    /// Destination gradient layer memory descriptor.
+    dnnl_memory_desc_t diff_dst_layer_desc;
+    /// Destination gradient iteration memory descriptor for hidden state.
+    dnnl_memory_desc_t diff_dst_iter_desc;
+    /// Destination gradient iteration memory descriptor for cell state.
+    dnnl_memory_desc_t diff_dst_iter_c_desc;
+    /// Weights gradient peephole memory descriptor.
+    /// This memory descriptor is equal to zero memory descriptor in case of
+    /// non-peephole LSTMs and other non-LSTM RNNs.
+    dnnl_memory_desc_t diff_weights_peephole_desc;
+    /// Weights gradient projection memory descriptor.
+    /// This memory descriptor is equal to zero memory descriptor in case of
+    /// non-projection LSTMs and other non-LSTM RNNs.
+    dnnl_memory_desc_t diff_weights_projection_desc;
+
+    /// RNN cell flags
+    unsigned int flags;
+    /// Activation function used for vanilla_rnn cell kind.
+    /// Must be either #dnnl_eltwise_relu or #dnnl_eltwise_tanh.
+    dnnl_alg_kind_t activation_kind;
+    float alpha;
+    float beta;
+
+} dnnl_rnn_desc_t;
+
+/// @} dnnl_api_rnn
+
+/// @addtogroup dnnl_api_binary
+/// @{
+
+/// A descriptor of a binary operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_binary.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of the binary algorithm. Possible values:
+    /// #dnnl_binary_add, #dnnl_binary_mul, #dnnl_binary_max, #dnnl_binary_min,
+    /// #dnnl_binary_div and #dnnl_binary_sub.
+    dnnl_alg_kind_t alg_kind;
+    /// Source memory descriptors.
+    dnnl_memory_desc_t src_desc[2];
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+} dnnl_binary_desc_t;
+
+/// @} dnnl_api_binary
+
+/// @addtogroup dnnl_api_matmul
+/// @{
+
+/// A descriptor of a matrix multiplication operation.
+///
+/// 2D case:
+///     dst[m, n] = src[m, k] * weights[k, n] + bias[m, n]
+///
+/// 3D case:
+///     dst[mb, m, n] = src[mb, m, k] * weights[mb, k, n] + bias[mb, m, n]
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_matmul.
+    dnnl_primitive_kind_t primitive_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Weights memory descriptor.
+    dnnl_memory_desc_t weights_desc;
+    /// Bias memory descriptor.
+    dnnl_memory_desc_t bias_desc;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// The accumulator data type. Initialized automatically.
+    dnnl_data_type_t accum_data_type;
+} dnnl_matmul_desc_t;
+
+/// @} dnnl_api_matmul
+
+/// @addtogroup dnnl_api_resampling
+/// @{
+
+/// A descriptor of resampling operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_resampling.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of propagation. Possible values: #dnnl_forward_training,
+    /// #dnnl_forward_inference, #dnnl_backward_data,
+    dnnl_prop_kind_t prop_kind;
+    /// The kind of the resampling algorithm. Possible values:
+    /// #dnnl_resampling_nearest, #dnnl_resampling_linear.
+    dnnl_alg_kind_t alg_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Source gradient memory descriptor.
+    dnnl_memory_desc_t diff_src_desc;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Destination gradient memory descriptor.
+    dnnl_memory_desc_t diff_dst_desc;
+    /// Resampling factor in each spatial dimension.
+    float factors[DNNL_MAX_NDIMS];
+} dnnl_resampling_desc_t;
+
+/// @} dnnl_api_resampling
+
+/// @addtogroup dnnl_api_reduction
+/// @{
+
+/// A descriptor of reduction operation.
+typedef struct {
+    /// The kind of primitive. Used for self-identifying the primitive
+    /// descriptor. Must be #dnnl_reduction.
+    dnnl_primitive_kind_t primitive_kind;
+    /// The kind of reduction algorithm. Possible values:
+    /// #dnnl_reduction_max, #dnnl_reduction_min, #dnnl_reduction_sum,
+    /// #dnnl_reduction_mul, #dnnl_reduction_mean, #dnnl_reduction_norm_lp_max,
+    /// #dnnl_reduction_norm_lp_sum, #dnnl_reduction_norm_lp_power_p_max,
+    /// #dnnl_reduction_norm_lp_power_p_sum.
+    dnnl_alg_kind_t alg_kind;
+    /// Source memory descriptor.
+    dnnl_memory_desc_t src_desc;
+    /// Destination memory descriptor.
+    dnnl_memory_desc_t dst_desc;
+    /// Algorithm specific parameters.
+    /// Accordance table:
+    /// #dnnl_reduction_max: @p p and @p eps are ignored
+    /// #dnnl_reduction_min: @p p and @p eps are ignored
+    /// #dnnl_reduction_norm_lp_max: @p p -- power, @p eps -- epsilon
+    /// #dnnl_reduction_norm_lp_sum: @p p -- power, @p eps -- epsilon
+    /// #dnnl_reduction_norm_lp_power_p_max: @p p -- power, @p eps -- epsilon
+    /// #dnnl_reduction_norm_lp_power_p_sum: @p p -- power, @p eps -- epsilon
+    /// #dnnl_reduction_sum: @p p and @p eps are ignored
+    /// #dnnl_reduction_mul: @p p and @p eps are ignored
+    /// #dnnl_reduction_mean: @p p and @p eps are ignored
+    float p, eps;
+} dnnl_reduction_desc_t;
+
+/// @} dnnl_api_reduction
+
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_engine
+/// @{
+
+/// @brief Kinds of engines.
+typedef enum {
+    /// An unspecified engine.
+    dnnl_any_engine,
+    /// CPU engine.
+    dnnl_cpu,
+    /// GPU engine.
+    dnnl_gpu,
+} dnnl_engine_kind_t;
+
+/// @struct dnnl_engine
+/// @brief An opaque structure to describe an engine.
+struct dnnl_engine;
+/// @brief An engine handle.
+typedef struct dnnl_engine *dnnl_engine_t;
+#if 0
+// FIXME: looks like this never happens
+/// @brief A constant engine handle.
+typedef const struct dnnl_engine *const_dnnl_engine_t;
+#endif
+
+/// @} dnnl_api_engine
+
+/// @addtogroup dnnl_api_primitives
+/// @{
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// @struct dnnl_primitive_desc_iterator
+/// @brief An opaque structure to describe a primitive descriptor iterator.
+struct dnnl_primitive_desc_iterator;
+
+/// @brief A primitive descriptor iterator handle.
+typedef struct dnnl_primitive_desc_iterator *dnnl_primitive_desc_iterator_t;
+
+/// @brief A constant primitive descriptor iterator handle.
+typedef const struct dnnl_primitive_desc_iterator
+        *const_dnnl_primitive_desc_iterator_t;
+
+/// @struct dnnl_primitive_desc
+/// @brief An opaque structure to describe a primitive descriptor.
+struct dnnl_primitive_desc;
+
+/// @brief A primitive descriptor handle.
+typedef struct dnnl_primitive_desc *dnnl_primitive_desc_t;
+
+/// @brief A constant primitive descriptor handle.
+typedef const struct dnnl_primitive_desc *const_dnnl_primitive_desc_t;
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_attributes
+/// @{
+
+/// Floating-point math mode
+typedef enum {
+    /// Default behavior, no downconversions allowed
+    dnnl_fpmath_mode_strict,
+    /// Implicit f32->bf16 conversions allowed
+    dnnl_fpmath_mode_bf16,
+    /// Implicit f32->f16 conversions allowed
+    dnnl_fpmath_mode_f16,
+    /// Implicit f32->f16 or f32->bf16 conversions allowed
+    dnnl_fpmath_mode_any,
+    /// Implicit f32->tf32 conversions allowed
+    dnnl_fpmath_mode_tf32,
+} dnnl_fpmath_mode_t;
+
+/// Scratchpad mode
+typedef enum {
+    /// The library manages the scratchpad allocation according to the policy
+    /// specified by the `DNNL_ENABLE_CONCURRENT_EXEC`
+    /// [build option](@ref dev_guide_build_options) (default).
+    ///
+    /// When `DNNL_ENABLE_CONCURRENT_EXEC=OFF` (default), the library
+    /// scratchpad is common to all primitives to reduce the memory footprint.
+    /// This configuration comes with limited thread-safety properties, namely
+    /// primitives can be created and executed in parallel but cannot migrate
+    /// between threads (in other words, each primitive should be executed in
+    /// the same thread it was created in).
+    ///
+    /// When `DNNL_ENABLE_CONCURRENT_EXEC=ON`, the library scratchpad is
+    /// private to each primitive. The memory footprint is larger than when
+    /// using `DNNL_ENABLE_CONCURRENT_EXEC=OFF` but different primitives can be
+    /// created and run concurrently (the same primitive cannot be run
+    /// concurrently from two different threads though).
+    dnnl_scratchpad_mode_library,
+    /// The user manages the scratchpad allocation by querying and providing
+    /// the scratchpad memory to primitives. This mode is thread-safe as long
+    /// as the scratchpad buffers are not used concurrently by two primitive
+    /// executions.
+    dnnl_scratchpad_mode_user,
+} dnnl_scratchpad_mode_t;
+
+/// @struct dnnl_primitive_attr
+/// @brief An opaque structure for primitive descriptor attributes.
+///
+/// Attributes may contain:
+///  - output scales (to scale the result prior to storing it to the memory)
+struct dnnl_primitive_attr;
+
+/// @brief A primitive descriptor attributes handle that controls primitive
+/// behavior.
+typedef struct dnnl_primitive_attr *dnnl_primitive_attr_t;
+
+/// @brief A constant primitive descriptor attributes handle.
+typedef const struct dnnl_primitive_attr *const_dnnl_primitive_attr_t;
+
+/// @struct dnnl_post_ops
+/// @brief An opaque structure for a chain of post operations.
+///
+/// dnnl_post_ops can be used to perform some (trivial) operations like
+/// accumulation or eltwise after certain primitives like convolution.
+///
+/// Post operations might be combined together, making a chain of post
+/// operations. For instance one can configure convolution followed by
+/// accumulation followed by eltwise. This might be especially beneficial
+/// for residual learning blocks.
+///
+/// @warning
+///      Of course not all combinations are supported, so the user should handle
+///      errors accordingly.
+///
+/// Supported post operations:
+///  - accumulation (base primitive: convolution)
+///  - eltwise (base primitive: convolution)
+struct dnnl_post_ops;
+
+/// @brief A post operation chain handle.
+typedef struct dnnl_post_ops *dnnl_post_ops_t;
+
+/// @brief A constant post operation chain handle.
+typedef const struct dnnl_post_ops *const_dnnl_post_ops_t;
+
+/// @} dnnl_api_attributes
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// @struct dnnl_primitive
+/// An opaque structure to describe a primitive.
+struct dnnl_primitive;
+/// A primitive handle.
+typedef struct dnnl_primitive *dnnl_primitive_t;
+/// A constant primitive handle.
+typedef const struct dnnl_primitive *const_dnnl_primitive_t;
+
+/// Source argument #0.
+#define DNNL_ARG_SRC_0 1
+/// A special mnemonic for source argument for primitives that have a
+/// single source. An alias for #DNNL_ARG_SRC_0.
+#define DNNL_ARG_SRC DNNL_ARG_SRC_0
+/// A special mnemonic for RNN input vector. An alias for
+/// #DNNL_ARG_SRC_0.
+#define DNNL_ARG_SRC_LAYER DNNL_ARG_SRC_0
+/// A special mnemonic for reorder source argument. An alias for
+/// #DNNL_ARG_SRC_0.
+#define DNNL_ARG_FROM DNNL_ARG_SRC_0
+
+/// Source argument #1.
+#define DNNL_ARG_SRC_1 2
+/// A special mnemonic for RNN input recurrent hidden state vector. An alias
+/// for #DNNL_ARG_SRC_1.
+#define DNNL_ARG_SRC_ITER DNNL_ARG_SRC_1
+
+/// Source argument #2.
+#define DNNL_ARG_SRC_2 3
+/// A special mnemonic for RNN input recurrent cell state vector. An alias for
+/// #DNNL_ARG_SRC_2.
+#define DNNL_ARG_SRC_ITER_C DNNL_ARG_SRC_2
+
+/// Source argument #3.
+#define DNNL_ARG_SRC_3 4
+/// A special mnemonic for RNN input recurrent cell attention vector. An alias for
+/// #DNNL_ARG_SRC_3.
+#define DNNL_ARG_AUGRU_ATTENTION DNNL_ARG_SRC_3
+
+/// Destination argument #0.
+#define DNNL_ARG_DST_0 17
+/// A special mnemonic for destination argument for primitives that have a
+/// single destination. An alias for #DNNL_ARG_DST_0.
+#define DNNL_ARG_DST DNNL_ARG_DST_0
+/// A special mnemonic for reorder destination argument. An alias for
+/// #DNNL_ARG_DST_0.
+#define DNNL_ARG_TO DNNL_ARG_DST_0
+/// A special mnemonic for RNN output vector. An alias for #DNNL_ARG_DST_0.
+#define DNNL_ARG_DST_LAYER DNNL_ARG_DST_0
+
+/// Destination argument #1.
+#define DNNL_ARG_DST_1 18
+/// A special mnemonic for RNN input recurrent hidden state vector. An
+/// alias for #DNNL_ARG_DST_1.
+#define DNNL_ARG_DST_ITER DNNL_ARG_DST_1
+
+/// Destination argument #2.
+#define DNNL_ARG_DST_2 19
+/// A special mnemonic for LSTM output recurrent cell state vector. An
+/// alias for #DNNL_ARG_DST_2.
+#define DNNL_ARG_DST_ITER_C DNNL_ARG_DST_2
+
+/// Weights argument #0.
+#define DNNL_ARG_WEIGHTS_0 33
+/// A special mnemonic for primitives that have a single weights
+/// argument. Alias for #DNNL_ARG_WEIGHTS_0.
+#define DNNL_ARG_WEIGHTS DNNL_ARG_WEIGHTS_0
+/// A special mnemonic for scale and shift argument of normalization
+/// primitives. Alias for #DNNL_ARG_WEIGHTS_0.
+#define DNNL_ARG_SCALE_SHIFT DNNL_ARG_WEIGHTS_0
+/// A special mnemonic for RNN weights applied to the layer input. An
+/// alias for #DNNL_ARG_WEIGHTS_0.
+#define DNNL_ARG_WEIGHTS_LAYER DNNL_ARG_WEIGHTS_0
+
+/// Weights argument #1.
+#define DNNL_ARG_WEIGHTS_1 34
+/// A special mnemonic for RNN weights applied to the recurrent input.
+/// An alias for #DNNL_ARG_WEIGHTS_1.
+#define DNNL_ARG_WEIGHTS_ITER DNNL_ARG_WEIGHTS_1
+
+/// Weights argument #2.
+#define DNNL_ARG_WEIGHTS_2 35
+/// A special mnemonic for RNN weights applied to the peephole weights.
+/// An alias for #DNNL_ARG_WEIGHTS_2.
+#define DNNL_ARG_WEIGHTS_PEEPHOLE DNNL_ARG_WEIGHTS_2
+
+/// Weights argument #3.
+#define DNNL_ARG_WEIGHTS_3 36
+/// A special mnemonic for RNN weights applied to the projection weights.
+/// An alias for #DNNL_ARG_WEIGHTS_3.
+#define DNNL_ARG_WEIGHTS_PROJECTION DNNL_ARG_WEIGHTS_3
+
+/// Bias tensor argument.
+#define DNNL_ARG_BIAS 41
+
+/// Mean values tensor argument.
+#define DNNL_ARG_MEAN 49
+/// Variance values tensor argument.
+#define DNNL_ARG_VARIANCE 50
+
+/// A special mnemonic for scale argument of normalization primitives.
+#define DNNL_ARG_SCALE 51
+/// A special mnemonic for shift argument of normalization primitives.
+#define DNNL_ARG_SHIFT 52
+
+/// Workspace tensor argument. Workspace is used to pass information
+/// from forward propagation to backward propagation computations.
+#define DNNL_ARG_WORKSPACE 64
+/// Scratchpad (temporary storage) tensor argument.
+#define DNNL_ARG_SCRATCHPAD 80
+
+/// Gradient (diff) of the source argument #0.
+#define DNNL_ARG_DIFF_SRC_0 129
+/// A special mnemonic for primitives that have a single diff source argument.
+/// An alias for #DNNL_ARG_DIFF_SRC_0.
+#define DNNL_ARG_DIFF_SRC DNNL_ARG_DIFF_SRC_0
+/// A special mnemonic for gradient (diff) of RNN input vector. An alias for
+/// #DNNL_ARG_DIFF_SRC_0.
+#define DNNL_ARG_DIFF_SRC_LAYER DNNL_ARG_DIFF_SRC_0
+
+/// Gradient (diff) of the source argument #1.
+#define DNNL_ARG_DIFF_SRC_1 130
+/// A special mnemonic for gradient (diff) of RNN input recurrent hidden state
+/// vector. An alias for #DNNL_ARG_DIFF_SRC_1.
+#define DNNL_ARG_DIFF_SRC_ITER DNNL_ARG_DIFF_SRC_1
+
+/// Gradient (diff) of the source argument #2.
+#define DNNL_ARG_DIFF_SRC_2 131
+/// A special mnemonic for gradient (diff) of RNN input recurrent cell state
+/// vector. An alias for #DNNL_ARG_DIFF_SRC_1.
+#define DNNL_ARG_DIFF_SRC_ITER_C DNNL_ARG_DIFF_SRC_2
+
+/// Gradient (diff) of the source argument #3.
+#define DNNL_ARG_DIFF_SRC_3 132
+/// A special mnemonic for gradient (diff) of RNN input recurrent cell attention
+/// vector. An alias for #DNNL_ARG_DIFF_SRC_3.
+#define DNNL_ARG_DIFF_AUGRU_ATTENTION DNNL_ARG_DIFF_SRC_3
+
+/// Gradient (diff) of the destination argument #0.
+#define DNNL_ARG_DIFF_DST_0 145
+/// A special mnemonic for primitives that have a single diff destination
+/// argument. An alias for #DNNL_ARG_DIFF_DST_0.
+#define DNNL_ARG_DIFF_DST DNNL_ARG_DIFF_DST_0
+/// A special mnemonic for gradient (diff) of RNN output vector. An alias for
+/// #DNNL_ARG_DIFF_DST_0.
+#define DNNL_ARG_DIFF_DST_LAYER DNNL_ARG_DIFF_DST_0
+
+/// Gradient (diff) of the destination argument #1.
+#define DNNL_ARG_DIFF_DST_1 146
+/// A special mnemonic for gradient (diff) of RNN input recurrent hidden state
+/// vector. An alias for #DNNL_ARG_DIFF_DST_1.
+#define DNNL_ARG_DIFF_DST_ITER DNNL_ARG_DIFF_DST_1
+
+/// Gradient (diff) of the destination argument #2.
+#define DNNL_ARG_DIFF_DST_2 147
+/// A special mnemonic for gradient (diff) of RNN input recurrent cell state
+/// vector. An alias for #DNNL_ARG_DIFF_DST_2.
+#define DNNL_ARG_DIFF_DST_ITER_C DNNL_ARG_DIFF_DST_2
+
+/// Gradient (diff) of the weights argument #0.
+#define DNNL_ARG_DIFF_WEIGHTS_0 161
+/// A special mnemonic for primitives that have a single diff weights
+/// argument. Alias for #DNNL_ARG_DIFF_WEIGHTS_0.
+#define DNNL_ARG_DIFF_WEIGHTS DNNL_ARG_DIFF_WEIGHTS_0
+/// A special mnemonic for diff of scale and shift argument of normalization
+/// primitives. Alias for #DNNL_ARG_DIFF_WEIGHTS_0.
+#define DNNL_ARG_DIFF_SCALE_SHIFT DNNL_ARG_DIFF_WEIGHTS_0
+/// A special mnemonic for diff of RNN weights applied to the layer input. An
+/// alias for #DNNL_ARG_DIFF_WEIGHTS_0.
+#define DNNL_ARG_DIFF_WEIGHTS_LAYER DNNL_ARG_DIFF_WEIGHTS_0
+
+/// Gradient (diff) of the weights argument #1.
+#define DNNL_ARG_DIFF_WEIGHTS_1 162
+/// A special mnemonic for diff of RNN weights applied to the recurrent input.
+/// An alias for #DNNL_ARG_DIFF_WEIGHTS_1.
+#define DNNL_ARG_DIFF_WEIGHTS_ITER DNNL_ARG_DIFF_WEIGHTS_1
+
+/// Gradient (diff) of the weights argument #2.
+#define DNNL_ARG_DIFF_WEIGHTS_2 163
+/// A special mnemonic for diff of RNN weights applied to the peephole weights.
+/// An alias for #DNNL_ARG_DIFF_WEIGHTS_2.
+#define DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE DNNL_ARG_DIFF_WEIGHTS_2
+
+/// Gradient (diff) of the weights argument #3.
+#define DNNL_ARG_DIFF_WEIGHTS_3 164
+/// A special mnemonic for diff of RNN weights applied to the projection
+/// weights. An alias for #DNNL_ARG_DIFF_WEIGHTS_3.
+#define DNNL_ARG_DIFF_WEIGHTS_PROJECTION DNNL_ARG_DIFF_WEIGHTS_3
+
+/// Gradient (diff) of the bias tensor argument.
+#define DNNL_ARG_DIFF_BIAS 169
+
+/// A special mnemonic for scale argument of normalization primitives.
+#define DNNL_ARG_DIFF_SCALE 255
+/// A special mnemonic for shift argument of normalization primitives.
+#define DNNL_ARG_DIFF_SHIFT 256
+
+/// Output scaling factors provided at execution time.
+#define DNNL_ARG_ATTR_OUTPUT_SCALES 513
+
+/// Starting index for source arguments for primitives that take a variable
+/// number of source arguments.
+#define DNNL_ARG_MULTIPLE_SRC 1024
+/// Starting index for destination arguments for primitives that produce a
+/// variable number of destination arguments.
+#define DNNL_ARG_MULTIPLE_DST 2048
+
+/// Zero points provided at execution time.
+#define DNNL_ARG_ATTR_ZERO_POINTS 4096
+
+/// Arguments for fused depthwise convolution.
+/// See @ref dev_guide_attributes_post_ops_depthwise_fusion
+#define DNNL_ARG_ATTR_POST_OP_DW 8192
+
+/// Starting point for a binary post operation.
+#define DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE 16384
+
+/// Arguments for a binary post operation. Up to 32 arguments are supported.
+/// See @ref dev_guide_attributes_post_ops_binary_fusion
+#define DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) \
+    (DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE * ((idx) + 1))
+
+/// Input scaling factors provided at execution time.
+#define DNNL_ARG_ATTR_INPUT_SCALES 1048576
+
+/// A structure that contains an index and a memory object, and is used to pass
+/// arguments to dnnl_primitive_execute().
+typedef struct {
+    int arg; ///< An argument index, e.g. DNNL_ARG_SRC
+    dnnl_memory_t memory; ///< Input/output memory
+} dnnl_exec_arg_t;
+
+/// @} dnnl_api_primitives_common
+
+/// @addtogroup dnnl_api_primitives_common
+/// @{
+
+/// Primitive descriptor query specification
+///
+/// For generic function dnnl_primitive_desc_query(), the type of result must
+/// agree with the queried argument. The correspondence table:
+///
+/// Query kind                      | Type of query result
+/// --------------------------------|-----------------------------
+/// dnnl_query_*_engine             | #dnnl_engine_t *
+/// #dnnl_query_primitive_kind      | #dnnl_primitive_kind_t *
+/// dnnl_query_*_s32                | int *
+/// dnnl_query_*_s64                | #dnnl_dim_t * (same as int64_t *)
+/// dnnl_query_*_f64                | double *
+/// dnnl_query_*_str                | const char **
+/// #dnnl_query_op_d                | #const_dnnl_op_desc_t *
+/// dnnl_query_*_md                 | const #dnnl_memory_desc_t **
+/// dnnl_query_*_\<op\>_d           | const dnnl_\<op\>_desc_t **
+/// dnnl_query_*_pd                 | #const_dnnl_primitive_desc_t *
+/// dnnl_query_cache_blob_id        | const uint8_t **
+///
+/// @note
+///     Rule of thumb: all opaque types and structures are returned by
+///     reference. All numbers are returned by value.
+///
+/// @warning
+///     All returned references point to constant objects and are valid only
+///     during the lifetime of the queried primitive descriptor. Returned objects
+///     must not be destroyed by the user. If you need to keep the object longer
+///     than the lifetime of the queried primitive descriptor, use
+///     dnnl_primitive_desc_clone() to make a copy.
+typedef enum {
+    dnnl_query_undef = 0, ///< no query
+
+    dnnl_query_engine, ///< execution engine
+    dnnl_query_primitive_kind, ///< primitive kind
+
+    dnnl_query_num_of_inputs_s32, ///< number of inputs expected
+    dnnl_query_num_of_outputs_s32, ///< number of outputs expected
+
+    dnnl_query_time_estimate_f64, ///< runtime estimation (seconds)
+    dnnl_query_memory_consumption_s64, ///< memory consumption -- extra
+    ///  (scratch) memory, additional to
+    ///  all inputs and outputs memory
+    ///  (bytes)
+
+    dnnl_query_scratchpad_engine, ///< scratchpad engine -- engine to be used
+    ///  for creating scratchpad memory
+
+    dnnl_query_impl_info_str, ///< implementation name
+
+    dnnl_query_reorder_src_engine, ///< source engine
+    dnnl_query_reorder_dst_engine, ///< destination engine
+
+    dnnl_query_prop_kind, ///< propagation kind
+
+    dnnl_query_cache_blob_id_size_s64, ///< size of cache blob ID in bytes
+    dnnl_query_cache_blob_id, ///< cache blob  ID (pointer to array)
+
+    // memory and op descriptor section
+    dnnl_query_some_d = 64, ///< stub
+    dnnl_query_op_d, ///< op descriptor
+    dnnl_query_convolution_d, ///< convolution descriptor
+    dnnl_query_deconvolution_d, ///< deconvolution descriptor
+    dnnl_query_shuffle_d, ///< shuffle descriptor
+    dnnl_query_eltwise_d, ///< eltwise descriptor
+    dnnl_query_softmax_d, ///< softmax descriptor
+    dnnl_query_pooling_d, ///< pooling descriptor
+    dnnl_query_lrn_d, ///< lrn descriptor
+    dnnl_query_batch_normalization_d, ///< batch normalization descriptor
+    dnnl_query_layer_normalization_d, ///< layer normalization descriptor
+    dnnl_query_inner_product_d, ///< inner product descriptor
+    dnnl_query_rnn_d, ///< rnn descriptor
+    dnnl_query_gemm_d, ///< GEMM descriptor (internal)
+    dnnl_query_binary_d, ///< binary descriptor
+    dnnl_query_logsoftmax_d, ///< logsoftmax descriptor
+    dnnl_query_matmul_d, ///< matrix multiplication (matmul) descriptor
+    dnnl_query_resampling_d, ///< resampling descriptor
+    dnnl_query_pooling_v2_d, ///< pooling version 2 descriptor
+    dnnl_query_reduction_d, ///< reduction descriptor
+    dnnl_query_prelu_d, ///< prelu descriptor
+    dnnl_query_softmax_v2_d, ///< softmax version 2 descriptor
+    dnnl_query_layer_normalization_v2_d, ///< layer normalization version 2 descriptor
+
+    // memory descriptor section
+    dnnl_query_some_md = 128, ///< stub
+    dnnl_query_src_md, ///< source memory desc
+    dnnl_query_diff_src_md, ///< source gradient memory desc
+    dnnl_query_weights_md, ///< weights memory descriptor desc
+    dnnl_query_diff_weights_md, ///< weights grad. memory desc
+    dnnl_query_dst_md, ///< destination memory desc
+    dnnl_query_diff_dst_md, ///< destination grad. memory desc
+    dnnl_query_workspace_md, ///< workspace memory desc
+    dnnl_query_scratchpad_md, ///< scratchpad memory desc
+    dnnl_query_exec_arg_md = 255, ///< memory desc of an execute argument
+
+    // Max value to prevent UB for internal use only dnnl_query_t
+    dnnl_query_max = 0x7fff,
+} dnnl_query_t;
+
+/// @} dnnl_api_primitives_common
+
+/// @} dnnl_api_primitives
+
+/// @addtogroup dnnl_api_stream
+/// @{
+
+/// @brief Stream flags.
+typedef enum {
+    // In-order execution.
+    dnnl_stream_in_order = 0x1U,
+    /// Out-of-order execution.
+    dnnl_stream_out_of_order = 0x2U,
+    /// Default stream configuration.
+    dnnl_stream_default_flags = dnnl_stream_in_order,
+} dnnl_stream_flags_t;
+
+/// @struct dnnl_stream
+/// An opaque structure to describe an execution stream.
+struct dnnl_stream;
+/// An execution stream handle.
+typedef struct dnnl_stream *dnnl_stream_t;
+/// A constant execution stream handle.
+typedef const struct dnnl_stream *const_dnnl_stream_t;
+
+/// @} dnnl_api_stream
+
+/// @addtogroup dnnl_api_service
+/// @{
+
+/// No runtime (disabled)
+#define DNNL_RUNTIME_NONE 0u
+
+/// Sequential runtime (CPU only)
+#define DNNL_RUNTIME_SEQ 1u
+
+/// OpenMP runtime (CPU only)
+#define DNNL_RUNTIME_OMP 2u
+
+/// TBB runtime (CPU only)
+#define DNNL_RUNTIME_TBB 4u
+
+/// Threadpool runtime (CPU only)
+#define DNNL_RUNTIME_THREADPOOL 8u
+
+/// OpenCL runtime
+#define DNNL_RUNTIME_OCL 256u
+
+/// SYCL runtime
+#define DNNL_RUNTIME_SYCL 512u
+
+/// DPC++ runtime
+#define DNNL_RUNTIME_DPCPP DNNL_RUNTIME_SYCL
+
+/// Structure containing version information as per [Semantic
+/// Versioning](https://semver.org)
+typedef struct {
+    int major; ///< Major version
+    int minor; ///< Minor version
+    int patch; ///< Patch version
+    const char *hash; ///< Git hash of the sources (may be absent)
+    unsigned cpu_runtime; ///< CPU runtime
+    unsigned gpu_runtime; ///< GPU runtime
+} dnnl_version_t;
+
+/// Disable profiling completely
+#define DNNL_JIT_PROFILE_NONE 0u
+
+/// Enable VTune Amplifier integration
+#define DNNL_JIT_PROFILE_VTUNE 1u
+
+/// Enable Linux perf integration via perfmap files
+#define DNNL_JIT_PROFILE_LINUX_PERFMAP 2u
+
+/// Enable Linux perf integration via jitdump files
+#define DNNL_JIT_PROFILE_LINUX_JITDUMP 4u
+
+/// Instruct Linux perf integration via jitdump files to use TSC. @ref
+/// DNNL_JIT_PROFILE_LINUX_JITDUMP must be set too for this to take effect.
+#define DNNL_JIT_PROFILE_LINUX_JITDUMP_USE_TSC 8u
+
+/// Enable Linux perf integration (both jitdump and perfmap)
+#define DNNL_JIT_PROFILE_LINUX_PERF \
+    (DNNL_JIT_PROFILE_LINUX_JITDUMP | DNNL_JIT_PROFILE_LINUX_PERFMAP)
+
+/// CPU instruction set flags
+typedef enum {
+    /// Any ISA (excepting those listed as initial support)
+    dnnl_cpu_isa_all = 0x0,
+
+    /// Intel Streaming SIMD Extensions 4.1 (Intel SSE4.1)
+    dnnl_cpu_isa_sse41 = 0x1,
+
+    /// Intel Advanced Vector Extensions (Intel AVX)
+    dnnl_cpu_isa_avx = 0x3,
+
+    /// Intel Advanced Vector Extensions 2 (Intel AVX2)
+    dnnl_cpu_isa_avx2 = 0x7,
+
+    /// (deprecated) Intel Advanced Vector Extensions 512 (Intel AVX-512) subset
+    /// for Intel Xeon Phi processors x200 Series.
+    dnnl_cpu_isa_avx512_mic = 0xf,
+
+    /// (deprecated) Intel AVX-512 subset
+    /// for Intel Xeon Phi processors 7235, 7285, 7295 Series.
+    dnnl_cpu_isa_avx512_mic_4ops = 0x1f,
+
+    /// Intel AVX-512 subset for Intel Xeon Scalable processor family
+    /// and Intel Core processor family.
+    dnnl_cpu_isa_avx512_core = 0x27,
+
+    /// Intel AVX-512 and Intel Deep Learning Boost (Intel DL Boost) support
+    /// for Intel Xeon Scalable processor family
+    /// and Intel Core processor family.
+    dnnl_cpu_isa_avx512_core_vnni = 0x67,
+
+    /// Intel AVX-512, Intel DL Boost and bfloat16 support
+    /// for Intel Xeon Scalable processor family
+    /// and Intel Core processor family.
+    dnnl_cpu_isa_avx512_core_bf16 = 0xe7,
+
+    /// Intel AVX-512 with float16, Intel DL Boost and bfloat16 support
+    /// for Intel Xeon Scalable processor family
+    /// and Intel Core processor family.
+    dnnl_cpu_isa_avx512_core_fp16 = 0x1e7,
+
+    /// Intel AVX-512 with float16, Intel DL Boost and bfloat16 support and
+    /// Intel AMX with 8-bit integer and bfloat16 support
+    dnnl_cpu_isa_avx512_core_amx = 0x3e7,
+
+    /// Intel AVX2 and Intel Deep Learning Boost (Intel DL Boost) support
+    dnnl_cpu_isa_avx2_vnni = 0x407,
+
+} dnnl_cpu_isa_t;
+
+/// CPU ISA hints flags
+typedef enum {
+    /// No hints (use default features)
+    dnnl_cpu_isa_no_hints = 0x0,
+
+    /// Prefer to exclusively use Ymm registers for computations
+    dnnl_cpu_isa_prefer_ymm = 0x1,
+} dnnl_cpu_isa_hints_t;
+
+/// @} dnnl_api_service
+
+/// @} dnnl_api
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ONEAPI_DNNL_TYPES_H */


### PR DESCRIPTION
[Link to a rendered document](https://github.com/dzarukin/oneDNN/tree/dzarukin/rfcs/v3_cleanup/rfcs/20220815-v3.0-API-cleanup).

This document mentions all (or at least most) changes coming in v3.0 when it comes to names changed or removed.

P.S. Though RFC shows 20k new lines, all of them are copy-pasted public headers to keep nice links inside the document actual.