### PR TITLE
src: aarch64: fix ACL add with non-matching strides

### DIFF
--- a/src/cpu/aarch64/acl_binary.hpp
+++ b/src/cpu/aarch64/acl_binary.hpp
@@ -170,6 +170,17 @@ struct acl_binary_t : public primitive_t {
             CHECK(tensor_info(asp_.src1_info, src_d1_permed));
             CHECK(tensor_info(asp_.dst_info, dst_d_permed));
 
+            // In this case ACL tries to treat src0 and src1 as a 1D array, but
+            // fails because the strides aren't equal. TODO: remove when fixed
+            // in ACL
+            if (asp_.alg == alg_kind::binary_add
+                    && asp_.src0_info.tensor_shape()
+                            == asp_.src1_info.tensor_shape()
+                    && asp_.src0_info.strides_in_bytes()
+                            != asp_.src1_info.strides_in_bytes()) {
+                return status::unimplemented;
+            }
+
             // This forces ACL not to parallelise with small workloads, this is
             // a temporary fix and should be removed in future versions (TODO)
             memory_desc_wrapper dst_d(dst_md());


### PR DESCRIPTION
# Description

When built with Compute Library for Arm (ACL) version 22.08, binary addition fails when there is no broadcasting and the strides don't match. This causes `test_binary_all` to fail. This patch adds a guard to return unimplemented in this case.
A patch is also underway for ACL which will fix the next release, and allow us to remove this guard.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests? (`test_binary_all` already tests this)

