### PR TITLE
Adding support for Pooling primitive for AMD backend

### DIFF
--- a/src/gpu/amd/miopen_pooling.cpp
+++ b/src/gpu/amd/miopen_pooling.cpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_pooling.hpp"
+#include "common/nstl.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_pooling_fwd_t::execute(const exec_ctx_t &ctx) const {
+    // If dst is empty, do nothing
+    memory_desc_wrapper dst_wrap(pd()->dst_md());
+    if (dst_wrap.size() == 0) return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    memory_desc_wrapper src_wrap(pd()->src_md());
+
+    if (src_wrap.size() == 0 && dst_wrap.size() != 0) {
+        return hip_stream->interop_task([&](::sycl::handler &cgh) {
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+
+            compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+                auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                        hip_stream->engine());
+                auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+
+                void *dst = arg_dst.get_native_pointer(ih);
+                if (dst_wrap.data_type() == data_type_t::dnnl_f32) {
+                    auto val = nstl::numeric_limits<float>::lowest();
+                    HIP_EXECUTE_FUNC(hipMemsetD16Async,
+                            reinterpret_cast<hipDeviceptr_t>(dst),
+                            reinterpret_cast<int &>(val), dst_wrap.nelems(),
+                            hip_stream->get_underlying_stream());
+                } else if (dst_wrap.data_type() == data_type_t::dnnl_f16) {
+                    float16_t val = nstl::numeric_limits<float16_t>::lowest();
+                    HIP_EXECUTE_FUNC(hipMemsetD16Async,
+                            reinterpret_cast<hipDeviceptr_t>(dst),
+                            reinterpret_cast<unsigned short &>(val),
+                            dst_wrap.nelems(),
+                            hip_stream->get_underlying_stream());
+                } else if (dst_wrap.data_type() == data_type_t::dnnl_s8) {
+                    auto val = nstl::numeric_limits<int8_t>::lowest();
+                    HIP_EXECUTE_FUNC(hipMemsetD16Async,
+                            reinterpret_cast<hipDeviceptr_t>(dst),
+                            reinterpret_cast<unsigned char &>(val),
+                            dst_wrap.nelems(),
+                            hip_stream->get_underlying_stream());
+                }
+            });
+        });
+    }
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_wkspace = CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+            void *x = arg_src.get_native_pointer(ih);
+            void *y = arg_dst.get_native_pointer(ih);
+            void *ws = arg_wkspace.get_native_pointer(ih);
+            pd()->pooling_impl_->execute(handle, x, y, ws);
+        });
+    });
+}
+
+status_t miopen_pooling_bwd_t::execute(const exec_ctx_t &ctx) const {
+    if (has_zero_dims(pd()->diff_src_md()->dims, pd()->diff_src_md()->ndims)
+            || has_zero_dims(
+                    pd()->diff_dst_md()->dims, pd()->diff_dst_md()->ndims)) {
+        return status::success;
+    }
+
+    memory_desc_wrapper wrap(pd()->diff_src_md());
+    if (wrap.size() == 0) { return status::success; }
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_wkspace = CTX_IN_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+            void *dx = arg_diff_src.get_native_pointer(ih);
+            void *dy = arg_diff_dst.get_native_pointer(ih);
+            void *ws = arg_wkspace.get_native_pointer(ih);
+
+            pd()->pooling_impl_->execute(handle, dx, dy, ws);
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_pooling.hpp
+++ b/src/gpu/amd/miopen_pooling.hpp
@@ -1,0 +1,181 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_POOLING_HPP
+#define GPU_AMD_MIOPEN_POOLING_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/pooling_pd.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+#include "gpu/amd/miopen_pooling_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_pooling_common_t {
+
+    template <typename pd_t>
+    void init_ws(const pd_t *pd, memory_desc_t &ws_md, size_t ws_size_miopen) {
+        bool is_fwd = pd->is_fwd();
+        memory_desc_wrapper src_wrap(is_fwd ? pd->src_md() : pd->diff_src_md());
+        memory_desc_wrapper dst_wrap(is_fwd ? pd->dst_md() : pd->diff_dst_md());
+
+        const auto src_size = src_wrap.size();
+        const auto dst_size = dst_wrap.size();
+
+        const size_t ws_size = src_size + dst_size + ws_size_miopen;
+        dims_t dims = {(dim_t)ws_size};
+
+        dnnl_memory_desc_init_by_tag(
+                &ws_md, ws_size ? 1 : 0, dims, data_type::u8, format_tag::a);
+    }
+};
+
+struct miopen_pooling_fwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public pooling_fwd_pd_t, public miopen_pooling_common_t {
+        using pooling_fwd_pd_t::pooling_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_pooling_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            using namespace prop_kind;
+            using namespace alg_kind;
+            using namespace format_tag;
+            assert(engine->kind() == engine_kind::gpu);
+            auto src_dt = src_md()->data_type;
+
+            bool ok = true && is_fwd()
+                    && utils::one_of(desc()->prop_kind, forward_training,
+                            forward_inference)
+                    && utils::one_of(desc()->alg_kind, pooling_max,
+                            pooling_avg_include_padding,
+                            pooling_avg_exclude_padding)
+                    && utils::one_of(src_dt, f16, f32)
+                    && src_dt == dst_md()->data_type
+                    && IMPLICATION(utils::one_of(src_dt, f16),
+                            desc()->prop_kind == forward_inference)
+                    && !is_dilated() && attr()->has_default_values()
+                    && set_default_params() == status::success
+                    && check_format();
+
+            if (!ok) return status::unimplemented;
+
+            if (has_zero_dim_memory()) return status::success;
+
+            pooling_impl_.reset(new miopen_pooling_fwd_impl_t());
+            CHECK(pooling_impl_->init(this));
+
+            if (is_training())
+                init_ws(this, ws_md_, pooling_impl_->get_ws_size_miopen());
+
+            return status::success;
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(src_md()).matches_one_of_tag(
+                            format_tag::abc, format_tag::abcd,
+                            format_tag::abcde)
+                    && memory_desc_wrapper(dst_md()).matches_one_of_tag(
+                            format_tag::abc, format_tag::abcd,
+                            format_tag::abcde));
+        }
+
+        bool is_training() const {
+            return desc_.prop_kind == prop_kind::forward_training;
+        }
+
+        std::shared_ptr<miopen_pooling_impl_base_t> pooling_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+struct miopen_pooling_bwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public pooling_bwd_pd_t, public miopen_pooling_common_t {
+        using pooling_bwd_pd_t::pooling_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_pooling_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace prop_kind;
+            using namespace alg_kind;
+            using namespace format_tag;
+            assert(engine->kind() == engine_kind::gpu);
+            bool ok = true && !is_fwd()
+                    && set_default_params() == status::success
+                    && desc()->prop_kind == backward_data
+                    && utils::one_of(desc()->alg_kind, pooling_max,
+                            pooling_avg_include_padding,
+                            pooling_avg_exclude_padding)
+                    && (utils::everyone_is(data_type::f32,
+                                diff_dst_md()->data_type,
+                                diff_src_md()->data_type)
+                            || utils::everyone_is(data_type::f16,
+                                    diff_dst_md()->data_type,
+                                    diff_src_md()->data_type))
+                    && !is_dilated() && attr()->has_default_values()
+                    && check_format();
+
+            if (!ok) return status::unimplemented;
+
+            if (has_zero_dim_memory()) { return status::success; };
+            pooling_impl_.reset(new miopen_pooling_bwd_impl_t());
+            CHECK(pooling_impl_->init(this));
+
+            init_ws(this, ws_md_, pooling_impl_->get_ws_size_miopen());
+            if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;
+            return status::success;
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(diff_src_md())
+                            .matches_one_of_tag(format_tag::abc,
+                                    format_tag::abcd, format_tag::abcde)
+                    && memory_desc_wrapper(diff_dst_md())
+                               .matches_one_of_tag(format_tag::abc,
+                                       format_tag::abcd, format_tag::abcde));
+        }
+
+        std::shared_ptr<miopen_pooling_impl_base_t> pooling_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_pooling_impl.hpp
+++ b/src/gpu/amd/miopen_pooling_impl.hpp
@@ -1,0 +1,250 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_POOLING_IMPL_HPP
+#define GPU_AMD_MIOPEN_POOLING_IMPL_HPP
+
+#include "gpu/amd/sycl_hip_utils.hpp"
+#include <miopen/miopen.h>
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_pooling_impl_base_t {
+    virtual status_t init(pooling_pd_t *pd) = 0;
+
+    virtual ~miopen_pooling_impl_base_t() {
+        for (size_t i = 0; i < NUM_IO; ++i) {
+            if (tensor_descs_[i]) {
+                MIOPEN_EXECUTE_FUNC_V(
+                        miopenDestroyTensorDescriptor, tensor_descs_[i]);
+            }
+        }
+
+        if (pool_desc_) {
+            MIOPEN_EXECUTE_FUNC_V(miopenDestroyPoolingDescriptor, pool_desc_);
+        }
+    }
+
+    virtual void execute(
+            miopenHandle_t handle, void *x, void *y, void *ws) const = 0;
+
+    size_t get_ws_size_miopen() const { return ws_size_miopen_; }
+
+protected:
+    status_t init_common(pooling_pd_t *pd) {
+        ndims_ = std::max(4, pd->ndims());
+        kernel_ndims_ = ndims_ - 2;
+
+        // Only 1D, 2D and 3D pooling is supported by MIOpen
+        if (kernel_ndims_ > 3) { return status::unimplemented; }
+
+        is_training_ = pd->desc()->prop_kind == prop_kind::forward_training;
+        bool is_fwd = pd->is_fwd();
+        auto src_md = is_fwd ? pd->src_md() : pd->diff_src_md();
+        auto dst_md = is_fwd ? pd->dst_md() : pd->diff_dst_md();
+
+        if (has_zero_dims(src_md->dims, pd->ndims())
+                || has_zero_dims(dst_md->dims, pd->ndims())) {
+            return status::success;
+        }
+
+        if (is_training_) {
+            auto src_wrap = memory_desc_wrapper(src_md);
+            x_size_bytes_ = src_wrap.size();
+        }
+
+        convert_dims(src_md->padded_dims, dims_[src], pd->ndims());
+        convert_dims(dst_md->padded_dims, dims_[dst], pd->ndims());
+
+        convert_dims(src_md->format_desc.blocking.strides, strides_[src],
+                pd->ndims());
+        convert_dims(dst_md->format_desc.blocking.strides, strides_[dst],
+                pd->ndims());
+
+        convert_dims(pd->desc()->kernel, kernel_dims_, kernel_ndims_);
+
+        // If 1D pooling
+        if (pd->ndims() == 3) {
+            // Convert to [n, c, 1, w] since the current format is
+            // [n, c, w, 1]
+            dims_[src][3] = dims_[src][2];
+            dims_[src][2] = 1;
+
+            dims_[dst][3] = dims_[dst][2];
+            dims_[dst][2] = 1;
+
+            // Set kernel dimensions to [1, kw]
+            kernel_dims_[1] = kernel_dims_[0];
+            kernel_dims_[0] = 1;
+        }
+
+        if (ndims_ == 4) {
+            kernel_padding_[0] = static_cast<int>(pd->padT());
+            kernel_padding_[1] = static_cast<int>(pd->padL());
+
+            kernel_strides_[0] = static_cast<int>(pd->KSH());
+            kernel_strides_[1] = static_cast<int>(pd->KSW());
+        } else {
+            kernel_padding_[0] = static_cast<int>(pd->padFront());
+            kernel_padding_[1] = static_cast<int>(pd->padT());
+            kernel_padding_[2] = static_cast<int>(pd->padL());
+
+            kernel_strides_[0] = static_cast<int>(pd->KSD());
+            kernel_strides_[1] = static_cast<int>(pd->KSH());
+            kernel_strides_[2] = static_cast<int>(pd->KSW());
+        }
+
+        CHECK(convert_data_type(src_md, &data_types_[src]));
+        CHECK(convert_data_type(dst_md, &data_types_[dst]));
+
+        CHECK(convert_alg_kind(pd->desc()->alg_kind, &pool_mode_));
+
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs_[src],
+                data_types_[src], ndims_, dims_[src], strides_[src]));
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs_[dst],
+                data_types_[dst], ndims_, dims_[dst], strides_[dst]));
+        CHECK(create_and_set_pooling_descriptor(pd));
+
+        return status::success;
+    }
+
+    status_t create_and_set_pooling_descriptor(const pooling_pd_t *pd) {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(
+                miopenCreatePoolingDescriptor, &pool_desc_));
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetNdPoolingDescriptor, pool_desc_,
+                pool_mode_, kernel_ndims_, kernel_dims_, kernel_padding_,
+                kernel_strides_));
+        miopenSetPoolingIndexType(pool_desc_, index_type);
+        miopenSetPoolingWorkSpaceIndexMode(pool_desc_, workspace_mode);
+
+        return status::success;
+    }
+
+    status_t convert_alg_kind(
+            alg_kind_t alg_kind, miopenPoolingMode_t *miopen_alg_kind) const {
+        switch (alg_kind) {
+            case alg_kind::pooling_max:
+                *miopen_alg_kind = miopenPoolingMax;
+                break;
+            case alg_kind::pooling_avg_include_padding:
+                *miopen_alg_kind = miopenPoolingAverageInclusive;
+                break;
+            case alg_kind::pooling_avg_exclude_padding:
+                *miopen_alg_kind = miopenPoolingAverage;
+                break;
+            default: return status::unimplemented;
+        }
+
+        return status::success;
+    }
+
+    enum io { src = 0, dst, NUM_IO };
+    miopenDataType_t data_types_[NUM_IO];
+    miopenTensorDescriptor_t tensor_descs_[NUM_IO] = {};
+    miopenPoolingDescriptor_t pool_desc_;
+
+    miopenPoolingMode_t pool_mode_ = miopenPoolingMode_t::miopenPoolingMax;
+    miopenIndexType_t index_type = miopenIndexType_t::miopenIndexUint32;
+    miopenPoolingWorkspaceIndexMode_t workspace_mode
+            = miopenPoolingWorkspaceIndexMode_t::
+                    miopenPoolingWorkspaceIndexImage;
+
+    int dims_[NUM_IO][DNNL_MAX_NDIMS];
+    int strides_[NUM_IO][DNNL_MAX_NDIMS];
+    int kernel_dims_[DNNL_MAX_NDIMS];
+    int kernel_padding_[DNNL_MAX_NDIMS];
+    int kernel_strides_[DNNL_MAX_NDIMS];
+    const float alpha_ = 1.f, beta_ = 0.f;
+    int ndims_, kernel_ndims_;
+    bool is_training_ = false;
+
+    size_t ws_size_miopen_ = 0;
+    size_t x_size_bytes_ = 0;
+};
+
+struct miopen_pooling_fwd_impl_t : public miopen_pooling_impl_base_t {
+    bool do_backward = false;
+
+    status_t init(pooling_pd_t *pd) override {
+        CHECK(init_common(pd));
+        if (is_training_) {
+            do_backward = true;
+            MIOPEN_EXECUTE_FUNC(miopenPoolingGetWorkSpaceSizeV2, pool_desc_,
+                    tensor_descs_[dst], &ws_size_miopen_);
+        }
+
+        return status::success;
+    }
+
+    void execute(
+            miopenHandle_t handle, void *x, void *y, void *ws) const override {
+        void *ws_miopen = is_training_ ? ws : nullptr;
+
+        MIOPEN_EXECUTE_FUNC(miopenPoolingForward, handle, pool_desc_, &alpha_,
+                tensor_descs_[src], x, &beta_, tensor_descs_[dst], y,
+                do_backward, ws_miopen, ws_size_miopen_);
+
+        if (is_training_) {
+            void *ws_x = (uint8_t *)ws_miopen + ws_size_miopen_;
+            void *ws_y = (uint8_t *)ws_x + x_size_bytes_;
+
+            // Copy x and y into workspace so that they can be used
+            // in the backward pass
+            int alpha2 = 0;
+            miopenTensorOp_t tensorOp = miopenTensorOpAdd;
+            miopenOpTensor(handle, tensorOp, &alpha_, tensor_descs_[src], ws_x,
+                    &alpha2, tensor_descs_[src], x, &beta_, tensor_descs_[src],
+                    ws_x);
+
+            miopenOpTensor(handle, tensorOp, &alpha_, tensor_descs_[dst], ws_y,
+                    &alpha2, tensor_descs_[dst], y, &beta_, tensor_descs_[dst],
+                    ws_y);
+        }
+    }
+};
+
+struct miopen_pooling_bwd_impl_t : public miopen_pooling_impl_base_t {
+    status_t init(pooling_pd_t *pd) override {
+        CHECK(init_common(pd));
+        MIOPEN_EXECUTE_FUNC(miopenPoolingGetWorkSpaceSizeV2, pool_desc_,
+                tensor_descs_[dst], &ws_size_miopen_);
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle, void *dx, void *dy,
+            void *ws) const override {
+        void *ws_miopen = ws;
+        void *ws_x = (uint8_t *)ws + ws_size_miopen_;
+        void *ws_y = (uint8_t *)ws_x + x_size_bytes_;
+
+        MIOPEN_EXECUTE_FUNC(miopenPoolingBackward, handle, pool_desc_, &alpha_,
+                tensor_descs_[dst], ws_y, tensor_descs_[dst], dy,
+                tensor_descs_[src], ws_x, &beta_, tensor_descs_[src], dx,
+                ws_miopen);
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -25,6 +25,7 @@
 #include "gpu/amd/miopen_binary.hpp"
 #include "gpu/amd/miopen_eltwise.hpp"
 #include "gpu/amd/miopen_lrn.hpp"
+#include "gpu/amd/miopen_pooling.hpp"
 #include "gpu/amd/miopen_softmax.hpp"
 #include "gpu/amd/sycl_hip_compat.hpp"
 #include "gpu/amd/sycl_hip_engine.hpp"
@@ -135,6 +136,9 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         // LRN
         INSTANCE(miopen_lrn_fwd_t)
         INSTANCE(miopen_lrn_bwd_t)
+        // Pooling
+        INSTANCE(miopen_pooling_fwd_t)
+        INSTANCE(miopen_pooling_bwd_t)
         nullptr,
 };
 // clang-format on

--- a/tests/gtests/test_pooling_backward.cpp
+++ b/tests/gtests/test_pooling_backward.cpp
@@ -55,6 +55,12 @@ bool cuda_check_format_tags(memory::format_tag format) {
     return format_ok;
 }
 
+bool hip_check_format_tags(memory::format_tag format) {
+    bool format_ok = format == memory::format_tag::nchw
+            || format == memory::format_tag::ncdhw;
+    return format_ok;
+}
+
 template <typename data_t>
 void check_pool_fwd(
         const pool_bwd_test_params_t &p, const memory &src, const memory &dst) {
@@ -288,6 +294,16 @@ protected:
         // This test makes assumptions on workspace content for the max
         // algorithm therefore it cannot be used for non-intel implementations.
         SKIP_IF_CUDA(p.aalgorithm == algorithm::pooling_max,
+                "Test is not designed to test non-intel implementations of max "
+                "algorithm");
+
+        SKIP_IF_HIP(!hip_check_format_tags(p.diff_src_format),
+                "Unsupported format tag");
+        SKIP_IF_HIP(!hip_check_format_tags(p.diff_dst_format),
+                "Unsupported format tag");
+        // This test makes assumptions on workspace content for the max
+        // algorithm therefore it cannot be used for non-intel implementations.
+        SKIP_IF_HIP(p.aalgorithm == algorithm::pooling_max,
                 "Test is not designed to test non-intel implementations of max "
                 "algorithm");
 


### PR DESCRIPTION
# Description

Introducing AMD backend for the oneDNN Pooling primitive.

Limitations:
MIOpen only supports NCHW layout format.
MIOpen does not support dilation for Pooling primitive.

We are also attaching output log files for benchdnn and gtests .
[benchdnn_test_pool_all.log](https://github.com/oneapi-src/oneDNN/files/9435303/benchdnn_test_pool_all.log)
[benchdnn_test_pool_ci.log](https://github.com/oneapi-src/oneDNN/files/9435304/benchdnn_test_pool_ci.log)
[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/9435305/test_api_buffer.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/9435306/test_api_sycl.log)
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/9435307/test_internals.log)
[test_pooling_backward.log](https://github.com/oneapi-src/oneDNN/files/9435308/test_pooling_backward.log)
[test_pooling_backward_buffer.log](https://github.com/oneapi-src/oneDNN/files/9435309/test_pooling_backward_buffer.log)
[test_pooling_forward.log](https://github.com/oneapi-src/oneDNN/files/9435310/test_pooling_forward.log)
[test_pooling_forward_buffer.log](https://github.com/oneapi-src/oneDNN/files/9435311/test_pooling_forward_buffer.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/9435312/test_regression.log)

Testing scope:
benchdnn: passed
gtest: API tests passed, Pooling tests passed

Supported scope:
Supported data types : f32, f16

No post-ops are supported

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?