### PR TITLE
Adding support for Reduction Primitive for CUDA backend

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -55,7 +55,6 @@ if(DNNL_SYCL_CUDA)
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/lstm.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/layer_normalization.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/prelu.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reduction.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reorder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/shuffle.cpp)
 endif()

--- a/src/gpu/nvidia/cudnn_reduction.cpp
+++ b/src/gpu/nvidia/cudnn_reduction.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/nvidia/cudnn_reduction.hpp"
+#include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
+#include "gpu/nvidia/sycl_cuda_stream.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace nvidia {
+
+status_t cudnn_reduction_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->src_md()).has_zero_dim())
+        return status::success;
+
+    nvidia::sycl_cuda_stream_t *cuda_stream
+            = utils::downcast<nvidia::sycl_cuda_stream_t *>(ctx.stream());
+
+    return cuda_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
+                    cuda_stream->engine());
+            auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = cuda_stream->get_cudnn_handle();
+
+            void *a = arg_src.get_native_pointer(ih);
+            void *c = arg_dst.get_native_pointer(ih);
+            void *scratch = arg_scratch.get_native_pointer(ih);
+            pd()->reduction_impl_->execute(handle, a, c, scratch);
+        });
+    });
+}
+
+} // namespace nvidia
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/nvidia/cudnn_reduction.hpp
+++ b/src/gpu/nvidia/cudnn_reduction.hpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_NVIDIA_CUDNN_REDUCTION_HPP
+#define GPU_NVIDIA_CUDNN_REDUCTION_HPP
+
+#include "cudnn.h"
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+#include "common/reduction_pd.hpp"
+#include "gpu/nvidia/cudnn_reduction_impl.hpp"
+#include "gpu/nvidia/sycl_cuda_engine.hpp"
+#include "gpu/nvidia/sycl_cuda_stream.hpp"
+#include "gpu/nvidia/sycl_cuda_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace nvidia {
+
+struct cudnn_reduction_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public reduction_pd_t {
+        using reduction_pd_t::reduction_pd_t;
+
+        DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_reduction_t);
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            const bool ok = (set_default_params() == status::success)
+                    && attr()->has_default_values()
+                    && utils::one_of(src_md()->data_type, data_type::f32,
+                            data_type::f16, data_type::s8)
+                    && utils::one_of(dst_md()->data_type, data_type::f32,
+                            data_type::f16, data_type::s8)
+                    && check_no_blocking() && check_format()
+                    && utils::one_of(desc()->alg_kind, alg_kind::reduction_max,
+                            alg_kind::reduction_min, alg_kind::reduction_sum,
+                            alg_kind::reduction_mul, alg_kind::reduction_mean,
+                            alg_kind::reduction_norm_lp_sum,
+                            alg_kind::reduction_norm_lp_power_p_sum)
+                    && IMPLICATION(
+                            desc()->alg_kind == alg_kind::reduction_norm_lp_sum,
+                            desc()->p == 2)
+                    && IMPLICATION(desc()->alg_kind
+                                    == alg_kind::reduction_norm_lp_power_p_sum,
+                            desc()->p == 1)
+                    && desc()->eps == 0.f;
+
+            if (!ok) return status::unimplemented;
+
+            if (check_for_zero_dims()) return status::success;
+
+            reduction_impl_.reset(new cudnn_reduction_impl_t());
+            auto status = reduction_impl_->init(this);
+
+            if (status == status::success)
+                reduction_impl_->create_and_set_workspace(this, engine);
+            return status;
+        }
+
+        bool check_for_zero_dims() const {
+            return has_zero_dims(src_md()->dims, src_md()->ndims)
+                    || has_zero_dims(dst_md()->dims, dst_md()->ndims);
+        }
+
+        bool check_no_blocking() const {
+            // Blocking is not supported by cudnnReduceTensor, return false if
+            // any blocks are present.
+            return src_md(0)->format_desc.blocking.inner_nblks
+                    + src_md(1)->format_desc.blocking.inner_nblks
+                    + dst_md()->format_desc.blocking.inner_nblks
+                    == 0;
+        }
+
+        bool check_format() const {
+            // cudnnReduceTensor produces incorrect results when src format
+            // is not nchw or its derivatives.
+            return memory_desc_wrapper(src_md()).matches_one_of_tag(
+                    format_tag::a, format_tag::ab, format_tag::abc,
+                    format_tag::abcd, format_tag::abcde);
+        }
+
+        std::shared_ptr<cudnn_reduction_impl_base_t> reduction_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace nvidia
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/nvidia/cudnn_reduction_impl.hpp
+++ b/src/gpu/nvidia/cudnn_reduction_impl.hpp
@@ -1,0 +1,174 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_NVIDIA_CUDNN_REDUCTION_IMPL_HPP
+#define GPU_NVIDIA_CUDNN_REDUCTION_IMPL_HPP
+
+#include "cudnn.h"
+
+#include "gpu/nvidia/sycl_cuda_engine.hpp"
+#include "gpu/nvidia/sycl_cuda_stream.hpp"
+#include "gpu/nvidia/sycl_cuda_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace nvidia {
+
+struct cudnn_reduction_impl_base_t {
+    enum io { src_0 = 0, dst_0, NUM_IO };
+    cudnnDataType_t data_types[NUM_IO];
+    int ndims;
+    int dims[NUM_IO][DNNL_MAX_NDIMS];
+    cudnnTensorDescriptor_t tensor_descs[NUM_IO] = {};
+    cudnnReduceTensorDescriptor_t reduce_desc_;
+    cudnnReduceTensorOp_t alg_kind;
+    cudnnNanPropagation_t Nanprop = cudnnNanPropagation_t::CUDNN_PROPAGATE_NAN;
+    cudnnReduceTensorIndices_t Indices
+            = cudnnReduceTensorIndices_t::CUDNN_REDUCE_TENSOR_NO_INDICES;
+    cudnnIndicesType_t IndicesType = cudnnIndicesType_t::CUDNN_32BIT_INDICES;
+
+    size_t workSpaceSize = 0;
+    float beta = 0.0f;
+    float alpha = 1.0f;
+
+    virtual ~cudnn_reduction_impl_base_t() {
+        if (reduce_desc_) {
+            CUDNN_EXECUTE_FUNC_V(
+                    cudnnDestroyReduceTensorDescriptor, reduce_desc_);
+        }
+        for (size_t i = 0; i < NUM_IO; i++) {
+            if (tensor_descs[i]) {
+                CUDNN_EXECUTE_FUNC_V(
+                        cudnnDestroyTensorDescriptor, tensor_descs[i]);
+            }
+        }
+    }
+
+    virtual status_t init(reduction_pd_t *pd) = 0;
+
+    virtual void create_and_set_workspace(reduction_pd_t *pd, engine_t *engine)
+            = 0;
+
+    void execute(cudnnHandle_t handle, void *a, void *c, void *scratch) {
+        CUDNN_EXECUTE_FUNC(cudnnReduceTensor, handle, reduce_desc_, nullptr, 0,
+                scratch, workSpaceSize, &alpha, tensor_descs[src_0], a, &beta,
+                tensor_descs[dst_0], c);
+    }
+
+    status_t create_and_set_reduction_descriptor(const reduction_pd_t *pd) {
+        CHECK(CUDNN_EXECUTE_FUNC_S(
+                cudnnCreateReduceTensorDescriptor, &reduce_desc_));
+
+        CHECK(CUDNN_EXECUTE_FUNC_S(cudnnSetReduceTensorDescriptor, reduce_desc_,
+                alg_kind, CUDNN_DATA_FLOAT, Nanprop, Indices, IndicesType));
+        return status::success;
+    }
+
+    status_t convert_alg_kind(
+            alg_kind_t alg_kind, cudnnReduceTensorOp_t *cudnn_alg_kind) const {
+
+        switch (alg_kind) {
+            case alg_kind::reduction_max:
+                *cudnn_alg_kind
+                        = cudnnReduceTensorOp_t::CUDNN_REDUCE_TENSOR_MAX;
+                break;
+            case alg_kind::reduction_min:
+                *cudnn_alg_kind
+                        = cudnnReduceTensorOp_t::CUDNN_REDUCE_TENSOR_MIN;
+                break;
+            case alg_kind::reduction_sum:
+                *cudnn_alg_kind
+                        = cudnnReduceTensorOp_t::CUDNN_REDUCE_TENSOR_ADD;
+                break;
+            case alg_kind::reduction_mul:
+                *cudnn_alg_kind
+                        = cudnnReduceTensorOp_t::CUDNN_REDUCE_TENSOR_MUL;
+                break;
+            case alg_kind::reduction_mean:
+                *cudnn_alg_kind
+                        = cudnnReduceTensorOp_t::CUDNN_REDUCE_TENSOR_AVG;
+                break;
+            default: return status::unimplemented;
+        }
+        return status::success;
+    }
+};
+
+struct cudnn_reduction_impl_t : public cudnn_reduction_impl_base_t {
+    int strides[NUM_IO][DNNL_MAX_NDIMS];
+
+    status_t init(reduction_pd_t *pd) override {
+        if (has_zero_dims(pd->src_md()->dims, pd->src_md()->ndims)) {
+            return status::success;
+        }
+
+        if (pd->src_md()->ndims > 5) { return status::invalid_arguments; }
+        ndims = pd->src_md()->ndims < 4 ? 4 : pd->src_md()->ndims;
+
+        convert_dims(
+                pd->src_md()->padded_dims, dims[src_0], pd->src_md()->ndims);
+        convert_dims(
+                pd->dst_md()->padded_dims, dims[dst_0], pd->src_md()->ndims);
+
+        convert_dims(pd->src_md()->format_desc.blocking.strides, strides[src_0],
+                pd->src_md()->ndims);
+        convert_dims(pd->dst_md()->format_desc.blocking.strides, strides[dst_0],
+                pd->src_md()->ndims);
+
+        alg_kind_t alg = pd->desc()->alg_kind;
+
+        auto alg_ok = convert_alg_kind(alg, &alg_kind);
+        if (alg_ok != status::success) { return status::unimplemented; }
+
+        CHECK(convert_data_type(pd->src_md(), &data_types[src_0]));
+        CHECK(convert_data_type(pd->dst_md(), &data_types[dst_0]));
+
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[src_0],
+                data_types[src_0], ndims, dims[src_0], strides[src_0]));
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[dst_0],
+                data_types[dst_0], ndims, dims[dst_0], strides[dst_0]));
+        CHECK(create_and_set_reduction_descriptor(pd));
+        return status::success;
+    }
+
+    void create_and_set_workspace(
+            reduction_pd_t *pd, engine_t *engine) override {
+        auto sycl_engine = utils::downcast<sycl_cuda_engine_t *>(engine);
+
+        stream_t *service_stream;
+        sycl_engine->get_service_stream(service_stream);
+
+        auto cuda_stream
+                = utils::downcast<sycl_cuda_stream_t *>(service_stream);
+        auto cuda_handle = cuda_stream->get_cudnn_handle();
+
+        CUDNN_EXECUTE_FUNC_S(cudnnGetReductionWorkspaceSize, cuda_handle,
+                reduce_desc_, tensor_descs[src_0], tensor_descs[dst_0],
+                &workSpaceSize);
+
+        pd->scratchpad_registry().registrar().book(
+                memory_tracking::names::key_none, workSpaceSize, size_t(1));
+    }
+};
+
+} // namespace nvidia
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -30,6 +30,7 @@
 #include "gpu/nvidia/cudnn_lrn.hpp"
 #include "gpu/nvidia/cudnn_matmul.hpp"
 #include "gpu/nvidia/cudnn_pooling.hpp"
+#include "gpu/nvidia/cudnn_reduction.hpp"
 #include "gpu/nvidia/cudnn_resampling.hpp"
 #include "gpu/nvidia/cudnn_softmax.hpp"
 #include "gpu/nvidia/sycl_cuda_compat.hpp"
@@ -231,6 +232,9 @@ constexpr dnnl::impl::impl_list_item_t sycl_cuda_impl_list[] = {
         // Resampling
         INSTANCE(cudnn_resampling_fwd_t)
         INSTANCE(cudnn_resampling_bwd_t)
+
+        // Reduction
+        INSTANCE(cudnn_reduction_t)
         nullptr,
 };
 // clang-format on

--- a/tests/gtests/test_reduction.cpp
+++ b/tests/gtests/test_reduction.cpp
@@ -51,6 +51,16 @@ protected:
                 "Engine does not support this data type.");
         SKIP_IF(get_test_engine().get_kind() != engine::kind::cpu,
                 "Engine does not support this primitive.");
+        SKIP_IF_CUDA(p.aalgorithm != algorithm::reduction_max
+                        && p.aalgorithm != algorithm::reduction_min
+                        && p.aalgorithm != algorithm::reduction_sum
+                        && p.aalgorithm != algorithm::reduction_mul
+                        && p.aalgorithm != algorithm::reduction_mean
+                        && p.aalgorithm != algorithm::reduction_norm_lp_max
+                        && p.aalgorithm
+                                != algorithm::reduction_norm_lp_power_p_max
+                        && p.eps != 0.0f,
+                "Unsupported algorithm type for CUDA");
 
         catch_expected_failures(
                 [=]() { Test(); }, p.expect_to_fail, p.expected_status);


### PR DESCRIPTION
# Description
Introducing CUDA backend for the oneDNN Reduction primitive.

Limitations:
cudnnReduceTensor supports only five modes of reduction operations via enumerators which are as follows.  
    - `CUDNN_REDUCE_TENSOR_MAX` 
    - `CUDNN_REDUCE_TENSOR_MIN` 
    - `CUDNN_REDUCE_TENSOR_MUL`
    - `CUDNN_REDUCE_TENSOR_ADD` 
    - `CUDNN_REDUCE_TENSOR_AVG` 

We are also attaching output log files for benchdnn and gtests .
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/9572342/test_regression.log)
[test_reduction_buffer.log](https://github.com/oneapi-src/oneDNN/files/9572343/test_reduction_buffer.log)
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/9572344/test_internals.log)
[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/9572345/test_api_buffer.log)
[benchdnn_test_reduction_ci.log](https://github.com/oneapi-src/oneDNN/files/9572346/benchdnn_test_reduction_ci.log)
[test_reduction.log](https://github.com/oneapi-src/oneDNN/files/9572348/test_reduction.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/9572349/test_api_sycl.log)
[benchdnn_test_reduction_all.log](https://github.com/oneapi-src/oneDNN/files/9572350/benchdnn_test_reduction_all.log)

Testing scope:
benchdnn: passed
gtest: API tests passed, Reduction tests passed

Supported scope:
Supported Data Types:  f32, s8

## General
- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
