### PR TITLE
[aarch64] rework gemm convolution and matmul operators to support caching

### DIFF
--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -27,13 +27,8 @@ template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type,
         data_type_t bia_type>
 status_t acl_gemm_convolution_fwd_t<src_type, wei_type, dst_type,
         bia_type>::execute_forward(const exec_ctx_t &ctx) const {
-    // Lock here is needed because resource_mapper does not support
-    // concurrent multithreaded access.
-    std::lock_guard<std::mutex> _lock {this->mtx};
     // Retrieve primitive resource and configured Compute Library objects
-    auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
-    acl_obj_t<arm_compute::NEGEMMConvolutionLayer> &acl_obj
-            = acl_resource->get_acl_obj();
+    acl_obj_t<arm_compute::NEGEMMConvolutionLayer> &acl_obj = get_acl_obj();
 
     return execute_forward_conv_acl<
             acl_obj_t<arm_compute::NEGEMMConvolutionLayer>, pd_t, src_data_t,

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -34,9 +34,7 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
     bool is_transB = pd()->amp_.is_transB;
     bool use_dst_acc = pd()->amp_.use_dst_acc;
 
-    std::lock_guard<std::mutex> _lock {this->mtx};
-    auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
-    acl_matmul_obj_t &acl_obj = acl_resource->get_acl_obj();
+    acl_matmul_obj_t &acl_obj = get_acl_obj();
     // Run transpose kernel
     if (is_transA && !is_transB) {
         acl_obj.src_tensor.allocator()->allocate();

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -37,24 +37,28 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
     acl_matmul_obj_t &acl_obj = get_acl_obj();
     // Run transpose kernel
     if (is_transA && !is_transB) {
-        acl_obj.src_tensor.allocator()->allocate();
+        acl_obj.src_tensor.allocator()->import_memory(
+                acl_obj.src_intermediate_tensor.allocator()->data());
         acl_obj.src_acc_tensor.allocator()->import_memory(
                 const_cast<data_t *>(src_base));
         acl_obj.transA.run();
         acl_obj.wei_tensor.allocator()->import_memory(
                 const_cast<data_t *>(wei_base));
     } else if (is_transB && !is_transA) {
-        acl_obj.wei_tensor.allocator()->allocate();
+        acl_obj.wei_tensor.allocator()->import_memory(
+                acl_obj.wei_intermediate_tensor.allocator()->data());
         acl_obj.wei_acc_tensor.allocator()->import_memory(
                 const_cast<data_t *>(wei_base));
         acl_obj.transB.run();
         acl_obj.src_tensor.allocator()->import_memory(
                 const_cast<data_t *>(src_base));
     } else if (is_transA && is_transB) {
-        acl_obj.src_tensor.allocator()->allocate();
+        acl_obj.src_tensor.allocator()->import_memory(
+                acl_obj.src_intermediate_tensor.allocator()->data());
         acl_obj.src_acc_tensor.allocator()->import_memory(
                 const_cast<data_t *>(src_base));
-        acl_obj.wei_tensor.allocator()->allocate();
+        acl_obj.wei_tensor.allocator()->import_memory(
+                acl_obj.wei_intermediate_tensor.allocator()->data());
         acl_obj.wei_acc_tensor.allocator()->import_memory(
                 const_cast<data_t *>(wei_base));
         acl_obj.transA.run();
@@ -69,7 +73,8 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
     if (use_dst_acc) {
         // Put the result in a new tensor, it will be accumalated to the dst
         // during the post ops
-        acl_obj.dst_tensor.allocator()->allocate();
+        acl_obj.dst_tensor.allocator()->import_memory(
+                acl_obj.dst_intermediate_tensor.allocator()->data());
     } else {
         auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
         acl_obj.dst_tensor.allocator()->import_memory(dst_base);

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -96,12 +96,24 @@ struct acl_matmul_t : public primitive_t {
             acl_obj_->src_acc_tensor.allocator()->init(amp.src_acc_info);
             acl_obj_->transA.configure(
                     &acl_obj_->src_acc_tensor, &acl_obj_->src_tensor);
+
+            acl_obj_->src_intermediate_tensor.allocator()->init(amp.src_info);
+            acl_obj_->src_intermediate_tensor.allocator()->allocate();
         }
         if (amp.is_transB) {
             acl_obj_->wei_acc_tensor.allocator()->init(amp.wei_acc_info);
             acl_obj_->transB.configure(
                     &acl_obj_->wei_acc_tensor, &acl_obj_->wei_tensor);
+
+            acl_obj_->wei_intermediate_tensor.allocator()->init(amp.wei_info);
+            acl_obj_->wei_intermediate_tensor.allocator()->allocate();
         }
+
+        if (amp.use_dst_acc) {
+            acl_obj_->dst_intermediate_tensor.allocator()->init(amp.dst_info);
+            acl_obj_->dst_intermediate_tensor.allocator()->allocate();
+        }
+
         // Configure GEMM
         acl_obj_->gemm.configure(&acl_obj_->src_tensor, &acl_obj_->wei_tensor,
                 nullptr, &acl_obj_->dst_tensor, amp.alpha, 0.0f, amp.gemm_info);

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -35,6 +35,9 @@ struct acl_matmul_obj_t {
     arm_compute::Tensor wei_tensor;
     arm_compute::Tensor wei_acc_tensor;
     arm_compute::Tensor dst_tensor;
+    arm_compute::Tensor dst_intermediate_tensor;
+    arm_compute::Tensor src_intermediate_tensor;
+    arm_compute::Tensor wei_intermediate_tensor;
 };
 
 struct acl_matmul_conf_t {


### PR DESCRIPTION
Rework the gemm convolution and matmul operators' state machine for acl object creation and configure to take advantage of onednn primitive caching feature.

# Description
Rework the gemm convolution and matmul operators' state machine for acl object creation and configure to take advantage of onednn primitive caching feature.

Fixes # (github issue)

# Checklist

## General

- [ x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
make test: all passed except test#79 ad test#98. they are failing on master (without this commit) as well.
- [x ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
