### PR TITLE
fixup: avoid avx-sse transition penalty for jit_uni_pool

### DIFF
--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -373,7 +373,7 @@ inline void jit_uni_pool_kernel<isa>::put_one_in_vmm() {
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel<isa>::uni_broadcast_reg_val(
         const int reg_idx, const int vmm_idx) {
-    movq(Xmm(vmm_idx), reg64_t(reg_idx));
+    uni_vmovq(Xmm(vmm_idx), reg64_t(reg_idx));
     uni_vpbroadcastd(Vmm(vmm_idx), Xmm(vmm_idx));
 }
 
@@ -604,7 +604,7 @@ inline void jit_uni_pool_kernel<isa>::maybe_recalculate_divisor(
 
         if (non_zero_kw != prev_kw) {
             mov(tmp_gpr, float2int((float)non_zero_kw));
-            movq(xmm_tmp, tmp_gpr);
+            uni_vmovq(xmm_tmp, tmp_gpr);
             uni_vbroadcastss(vmm_tmp, xmm_tmp);
             if (with_c_tail_proccessing && (isa == avx || isa == avx2)) {
                 push_vmm_val(vmm_c_tail_mask.getIdx());
@@ -795,7 +795,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
     };
 
     mov(tmp_gpr, float2int(nstl::numeric_limits<float>::lowest()));
-    movq(xmm_tmp, tmp_gpr);
+    uni_vmovq(xmm_tmp, tmp_gpr);
     uni_vbroadcastss(vmm_tmp, xmm_tmp);
 
     for_(int jj = 0; jj < ur_w; jj++)
@@ -808,7 +808,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
         }
     }
     if (jpp.is_training) {
-        movq(xmm_tmp, reg_k_shift);
+        uni_vmovq(xmm_tmp, reg_k_shift);
         uni_vpbroadcastd(vmm_k_offset, xmm_tmp);
     }
     if (jpp.ndims == 5) {
@@ -884,7 +884,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
         add(aux_reg_input_d, jpp.dt_size * jpp.ih * iw * c_off);
         if (jpp.is_training) {
             mov(tmp_gpr, ptr[reg_param + GET_OFF(kd_padding_shift)]);
-            movq(xmm_tmp, tmp_gpr);
+            uni_vmovq(xmm_tmp, tmp_gpr);
             uni_vpbroadcastd(vmm_tmp, xmm_tmp);
             if (isa == avx && !mayiuse(avx2)) {
                 Xmm t(vmm_mask.getIdx());
@@ -1098,7 +1098,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
                     is_tail_processing(bci));
         }
     }
-    movq(xmm_tmp, reg_k_shift);
+    uni_vmovq(xmm_tmp, reg_k_shift);
     uni_vpbroadcastd(vmm_k_offset, xmm_tmp);
 
     if (jpp.simple_alg && jpp.ndims == 5) {
@@ -1212,7 +1212,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
         add(aux_reg_input_d, jpp.dt_size * jpp.ih * iw * c_off);
 
         mov(tmp_gpr, reg_kd_pad_shift);
-        movq(xmm_tmp, tmp_gpr);
+        uni_vmovq(xmm_tmp, tmp_gpr);
         uni_vpbroadcastd(vmm_tmp, xmm_tmp);
         if (isa == avx && !mayiuse(avx2)) {
             Xmm t(vmm_mask.getIdx());
@@ -1416,7 +1416,7 @@ void jit_uni_pool_kernel<isa>::generate() {
 
         if (jpp.alg == pooling_avg_include_padding) {
             mov(tmp_gpr, float2int((float)(kw * kh * jpp.kd)));
-            movq(xmm_tmp, tmp_gpr);
+            uni_vmovq(xmm_tmp, tmp_gpr);
             uni_vpbroadcastd(vmm_tmp, xmm_tmp);
         }
 


### PR DESCRIPTION
# Description

A lot of avx-sse transitions are observed in jit_uni_pook kernel and avx-sse transition slows down the CPU for about tens of cycles.
This patch cleaned the avx-sse transitions that observed. And got a remarkable performance speedup (~10%) with my workload.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

This could be observed by emon with the following command:
```shell
:~/openvino/build# emon -C 'ASSISTS.SSE_AVX_MIX' -t1 -l 10000
Version Info: V11.33  (Mar 15 2022 at 22:11:59) Intel(R) microarchitecture code named Alderlake-S M:151 S:2
ASSISTS.SSE_AVX_MIX     2,112,264,872   0       2,162,328       0       0       0       0       0       0       0       0       0       0       0       0       0       0       N/A     N/A     N/A     N/A
==========
ASSISTS.SSE_AVX_MIX     2,112,316,661   0       2,138,112       0       0       0       0       0       0       0       0       0       0       0       0       0       0       N/A     N/A     N/A     N/A
==========
```
