### PR TITLE
Adding Support for Reduction-HIP Backend

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -66,7 +66,8 @@ if(DNNL_SYCL_HIP)
     list(APPEND sources
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/softmax.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/lrn.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/eltwise.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/eltwise.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reduction.cpp)
 endif()
 
 # Skip SYCL, GPU and cross-engine examples

--- a/src/gpu/amd/miopen_reduction.cpp
+++ b/src/gpu/amd/miopen_reduction.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_reduction.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_reduction_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->src_md()).has_zero_dim())
+        return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            void *a = arg_src.get_native_pointer(ih);
+            void *c = arg_dst.get_native_pointer(ih);
+            void *scratch = arg_scratch.get_native_pointer(ih);
+            pd()->reduction_impl_->execute(handle, a, c, scratch);
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_reduction.hpp
+++ b/src/gpu/amd/miopen_reduction.hpp
@@ -1,0 +1,107 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_REDUCTION_HPP
+#define GPU_AMD_MIOPEN_REDUCTION_HPP
+
+#include <miopen/miopen.h>
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+#include "common/reduction_pd.hpp"
+#include "gpu/amd/miopen_reduction_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_reduction_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public reduction_pd_t {
+        using reduction_pd_t::reduction_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_reduction_t);
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            const bool ok = (set_default_params() == status::success)
+                    && attr()->has_default_values()
+                    && utils::one_of(
+                            src_md()->data_type, data_type::f32, data_type::f16)
+                    && utils::one_of(
+                            dst_md()->data_type, data_type::f32, data_type::f16)
+                    && check_format()
+                    && utils::one_of(desc()->alg_kind, alg_kind::reduction_max,
+                            alg_kind::reduction_min, alg_kind::reduction_sum,
+                            alg_kind::reduction_mul, alg_kind::reduction_mean,
+                            alg_kind::reduction_norm_lp_sum,
+                            alg_kind::reduction_norm_lp_power_p_sum)
+                    && IMPLICATION(
+                            desc()->alg_kind == alg_kind::reduction_norm_lp_sum,
+                            desc()->p == 2)
+                    && IMPLICATION(desc()->alg_kind
+                                    == alg_kind::reduction_norm_lp_power_p_sum,
+                            desc()->p == 1)
+                    && desc()->eps == 0.f;
+
+            if (!ok) return status::unimplemented;
+
+            if (check_for_zero_dims()) return status::success;
+
+            reduction_impl_.reset(new miopen_reduction_impl_t());
+            auto status = reduction_impl_->init(this);
+
+            if (status == status::success)
+                reduction_impl_->create_and_set_workspace(this, engine);
+            return status;
+        }
+
+        bool check_for_zero_dims() const {
+            return has_zero_dims(src_md()->dims, src_md()->ndims)
+                    || has_zero_dims(dst_md()->dims, dst_md()->ndims);
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(src_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd, format_tag::abcde)
+                    && memory_desc_wrapper(dst_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd, format_tag::abcde));
+        }
+
+        std::shared_ptr<miopen_reduction_impl_base_t> reduction_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_reduction_impl.hpp
+++ b/src/gpu/amd/miopen_reduction_impl.hpp
@@ -1,0 +1,183 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_REDUCTION_IMPL_HPP
+#define GPU_AMD_MIOPEN_REDUCTION_IMPL_HPP
+
+#include <miopen/miopen.h>
+
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_reduction_impl_base_t {
+    enum io { src_0 = 0, dst_0, NUM_IO };
+    miopenDataType_t data_types[NUM_IO];
+    int ndims;
+    int dims[NUM_IO][DNNL_MAX_NDIMS];
+    miopenTensorDescriptor_t tensor_descs[NUM_IO] = {};
+    miopenReduceTensorDescriptor_t reduce_desc_;
+    miopenReduceTensorOp_t alg_kind;
+    int strides[NUM_IO][DNNL_MAX_NDIMS];
+    miopenNanPropagation_t Nanprop
+            = miopenNanPropagation_t::MIOPEN_PROPAGATE_NAN;
+    miopenReduceTensorIndices_t Indices
+            = miopenReduceTensorIndices_t::MIOPEN_REDUCE_TENSOR_NO_INDICES;
+    miopenIndicesType_t IndicesType = miopenIndicesType_t::MIOPEN_32BIT_INDICES;
+    size_t workSpaceSize = 0;
+    float beta = 0.0f;
+    float alpha = 1.0f;
+
+    virtual ~miopen_reduction_impl_base_t() {
+        if (reduce_desc_) {
+            MIOPEN_EXECUTE_FUNC_V(
+                    miopenDestroyReduceTensorDescriptor, reduce_desc_);
+        }
+        for (size_t i = 0; i < NUM_IO; i++) {
+            if (tensor_descs[i]) {
+                MIOPEN_EXECUTE_FUNC_V(
+                        miopenDestroyTensorDescriptor, tensor_descs[i]);
+            }
+        }
+    }
+
+    virtual status_t init(reduction_pd_t *pd) = 0;
+
+    virtual void create_and_set_workspace(reduction_pd_t *pd, engine_t *engine)
+            = 0;
+
+    void execute(miopenHandle_t handle, void *a, void *c, void *scratch) {
+        MIOPEN_EXECUTE_FUNC(miopenReduceTensor, handle, reduce_desc_, nullptr,
+                0, scratch, workSpaceSize, &alpha, tensor_descs[src_0], a,
+                &beta, tensor_descs[dst_0], c);
+    }
+
+    status_t create_and_set_reduction_descriptor(const reduction_pd_t *pd) {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(
+                miopenCreateReduceTensorDescriptor, &reduce_desc_));
+
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetReduceTensorDescriptor,
+                reduce_desc_, alg_kind, miopenFloat, Nanprop, Indices,
+                IndicesType));
+        return status::success;
+    }
+
+    status_t convert_alg_kind(alg_kind_t alg_kind,
+            miopenReduceTensorOp_t *miopen_alg_kind) const {
+
+        switch (alg_kind) {
+            case alg_kind::reduction_max:
+                *miopen_alg_kind
+                        = miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_MAX;
+                break;
+            case alg_kind::reduction_min:
+                *miopen_alg_kind
+                        = miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_MIN;
+                break;
+            case alg_kind::reduction_sum:
+                *miopen_alg_kind
+                        = miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_ADD;
+                break;
+            case alg_kind::reduction_mul:
+                *miopen_alg_kind
+                        = miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_MUL;
+                break;
+            case alg_kind::reduction_mean:
+                *miopen_alg_kind
+                        = miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_AVG;
+                break;
+            case alg_kind::reduction_norm_lp_sum:
+                *miopen_alg_kind
+                        = miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_NORM2;
+                break;
+            case alg_kind::reduction_norm_lp_power_p_sum:
+                *miopen_alg_kind
+                        = miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_NORM1;
+                break;
+            default: return status::unimplemented;
+        }
+        return status::success;
+    }
+};
+
+struct miopen_reduction_impl_t : public miopen_reduction_impl_base_t {
+
+    status_t init(reduction_pd_t *pd) override {
+        if (has_zero_dims(pd->src_md()->dims, pd->src_md()->ndims)) {
+            return status::success;
+        }
+
+        if (pd->src_md()->ndims > MIOPEN_DIM_MAX) {
+            return status::invalid_arguments;
+        }
+        ndims = pd->src_md()->ndims < 4 ? 4 : pd->src_md()->ndims;
+
+        convert_dims(
+                pd->src_md()->padded_dims, dims[src_0], pd->src_md()->ndims);
+        convert_dims(
+                pd->dst_md()->padded_dims, dims[dst_0], pd->src_md()->ndims);
+
+        convert_dims(pd->src_md()->format_desc.blocking.strides, strides[src_0],
+                pd->src_md()->ndims);
+        convert_dims(pd->dst_md()->format_desc.blocking.strides, strides[dst_0],
+                pd->src_md()->ndims);
+
+        alg_kind_t alg = pd->desc()->alg_kind;
+
+        auto alg_ok = convert_alg_kind(alg, &alg_kind);
+        if (alg_ok != status::success) { return status::unimplemented; }
+
+        CHECK(convert_data_type(pd->src_md(), &data_types[src_0]));
+        CHECK(convert_data_type(pd->dst_md(), &data_types[dst_0]));
+
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[src_0],
+                data_types[src_0], ndims, dims[src_0], strides[src_0]));
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs[dst_0],
+                data_types[dst_0], ndims, dims[dst_0], strides[dst_0]));
+        CHECK(create_and_set_reduction_descriptor(pd));
+        return status::success;
+    }
+
+    void create_and_set_workspace(
+            reduction_pd_t *pd, engine_t *engine) override {
+        auto sycl_engine = utils::downcast<sycl_hip_engine_t *>(engine);
+
+        stream_t *service_stream;
+        sycl_engine->get_service_stream(service_stream);
+
+        auto hip_stream = utils::downcast<sycl_hip_stream_t *>(service_stream);
+        auto hip_handle = hip_stream->get_miopen_handle();
+
+        MIOPEN_EXECUTE_FUNC_S(miopenGetReductionWorkspaceSize, hip_handle,
+                reduce_desc_, tensor_descs[src_0], tensor_descs[dst_0],
+                &workSpaceSize);
+        pd->scratchpad_registry().registrar().book(
+                memory_tracking::names::key_none, workSpaceSize, size_t(1));
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -26,6 +26,7 @@
 #include "gpu/amd/miopen_eltwise.hpp"
 #include "gpu/amd/miopen_lrn.hpp"
 #include "gpu/amd/miopen_pooling.hpp"
+#include "gpu/amd/miopen_reduction.hpp"
 #include "gpu/amd/miopen_softmax.hpp"
 #include "gpu/amd/sycl_hip_compat.hpp"
 #include "gpu/amd/sycl_hip_engine.hpp"
@@ -139,6 +140,8 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         // Pooling
         INSTANCE(miopen_pooling_fwd_t)
         INSTANCE(miopen_pooling_bwd_t)
+        // Reduction
+        INSTANCE(miopen_reduction_t)
         nullptr,
 };
 // clang-format on

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -154,6 +154,12 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
     // TODO: consider change the filling with power-of-two values for better
     // answer precision.
     cmp.set_threshold(5 * epsilon_dt(prb->ddt));
+    if (is_amd_gpu()) {
+        // MIOpen implementation is less accurate for f16 data type therefore
+        // adjust the threshold.
+        if (prb->sdt == dnnl_f16 || prb->ddt == dnnl_f16)
+            cmp.set_threshold(1.5e-4 * 4);
+    }
 }
 
 int doit(const prb_t *prb, res_t *res) {


### PR DESCRIPTION
# Description
Introducing AMD backend for the oneDNN Reduction primitive.

Limitations:
MIOpen only supports NCHW layout format.

Supported scope:
Supported Data Types: f32, f16

This backend only supports the following algorithms:

- reduction_max
- reduction_min
- reduction_sum
- reduction_mul
- reduction_mean
- reduction_norm_lp_sum
- reduction_norm_lp_power_p_sum



## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?