### PR TITLE
Faster packing

### DIFF
--- a/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
@@ -20,83 +20,6 @@
 namespace dnnl {
 namespace impl {
 
-static inline void memcpy_4(void *__restrict d, const void *__restrict s) {
-    int *di, *si;
-    di = (int *)(d);
-    si = (int *)(s);
-    di[0] = si[0];
-}
-
-static inline void memcpy_14(void *__restrict d, const void *__restrict s) {
-    int *di, *si;
-    di = (int *)(d);
-    si = (int *)(s);
-    di[0] = si[0];
-    di[1] = si[1];
-    di[2] = si[2];
-    *(short *)&di[3] = *(short *)&si[3];
-}
-
-static inline void memcpy_16(void *__restrict d, const void *__restrict s) {
-    int *di, *si;
-    di = (int *)(d);
-    si = (int *)(s);
-    di[0] = si[0];
-    di[1] = si[1];
-    di[2] = si[2];
-    di[3] = si[3];
-}
-
-static inline void memcpy_32(void *__restrict d, const void *__restrict s) {
-    int *di, *si;
-    di = (int *)(d);
-    si = (int *)(s);
-    di[0] = si[0];
-    di[1] = si[1];
-    di[2] = si[2];
-    di[3] = si[3];
-    di[4] = si[4];
-    di[5] = si[5];
-    di[6] = si[6];
-    di[7] = si[7];
-}
-
-static inline void memcpy_64(void *__restrict d, const void *__restrict s) {
-    int *di, *si;
-    di = (int *)(d);
-    si = (int *)(s);
-    di[0] = si[0];
-    di[1] = si[1];
-    di[2] = si[2];
-    di[3] = si[3];
-    di[4] = si[4];
-    di[5] = si[5];
-    di[6] = si[6];
-    di[7] = si[7];
-    di[8] = si[8];
-    di[9] = si[9];
-    di[10] = si[10];
-    di[11] = si[11];
-    di[12] = si[12];
-    di[13] = si[13];
-    di[14] = si[14];
-    di[15] = si[15];
-}
-
-static inline void memcpy_n(
-        void *__restrict d, const void *__restrict s, int n) {
-    int i, *di, *si;
-    int8_t *dc, *sc;
-    di = (int *)(d);
-    si = (int *)(s);
-    for (i = 0; i < (n >> 2); ++i)
-        di[i] = si[i];
-    dc = (int8_t *)&di[n >> 3];
-    sc = (int8_t *)&si[n >> 3];
-    for (i = 0; i < (n & 3); ++i)
-        dc[i] = sc[i];
-}
-
 uint64_t mker;
 
 typedef __vector signed long long vec_i64 __attribute__((aligned(8)));
@@ -105,11 +28,11 @@ typedef __vector unsigned char vec_t;
 typedef __vector signed char vec_st;
 
 int pack_N16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
-    int i, j;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+    int32_t i, j;
+    int32_t kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
             chunk4count, k8, m4, m16;
-    int m_cap = (m + 3) & ~3;
-    int k_cap = (k + 1) & ~1;
+    int32_t m_cap = (m + 3) & ~3;
+    int32_t k_cap = (k + 1) & ~1;
     krows = (k + 1) >> 1;
     mrows = (m + 3) >> 2;
     block4 = 4 * krows;
@@ -270,11 +193,11 @@ int pack_N16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
 }
 
 int pack_T16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
-    int i, j;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+    int32_t i, j;
+    int32_t kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
             chunk4count, k4, m8, m16;
-    int m_cap = (m + 3) & ~3;
-    int k_cap = (k + 1) & ~1;
+    int32_t m_cap = (m + 3) & ~3;
+    int32_t k_cap = (k + 1) & ~1;
     krows = (k + 1) >> 1;
     mrows = (m + 3) >> 2;
     block4 = 4 * krows;
@@ -434,10 +357,10 @@ int pack_T16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
 }
 
 int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
-    int i, j;
-    int kcell, cell, koff, noff, krows, k4, n8, n16;
-    int n_cap = (n + 3) & ~3;
-    int k_cap = (k + 1) & ~1;
+    int32_t i, j;
+    int32_t kcell, cell, koff, noff, krows, k4, n8, n16;
+    int32_t n_cap = (n + 3) & ~3;
+    int32_t k_cap = (k + 1) & ~1;
     krows = (k + 1) >> 1;
     k4 = (k >> 2) << 2;
     n8 = (n >> 3) << 3;
@@ -483,7 +406,7 @@ int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
             *(vec_t *)&dst2367[24] = D7;
         }
         for (j = n16; j < n8; j += 8) {
-            int columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
             short *dst = &bp[8 * (columns_done * krows + (i & (~1)))];
             vec_t V0, V1, V2, V3;
             vec_t D0, D1, D2, D3;
@@ -513,10 +436,10 @@ int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
         for (j = n8; j < n_cap; ++j) {
             kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 1;
             noff = j & 3;
@@ -532,10 +455,10 @@ int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
         for (j = 0; j < n8; ++j) {
             kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 1;
             noff = j & 3;
@@ -551,10 +474,10 @@ int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
         for (j = n8; j < n_cap; ++j) {
             kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 1;
             noff = j & 3;
@@ -568,10 +491,10 @@ int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
 }
 
 int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
-    int i, j;
-    int kcell, cell, koff, noff, krows, k8, k16, n4, n8;
-    int n_cap = (n + 3) & ~3;
-    int k_cap = (k + 1) & ~1;
+    int32_t i, j;
+    int32_t kcell, cell, koff, noff, krows, k8, k16, n4, n8;
+    int32_t n_cap = (n + 3) & ~3;
+    int32_t k_cap = (k + 1) & ~1;
     krows = (k + 1) >> 1;
     k8 = (k >> 3) << 3;
     k16 = (k >> 4) << 4;
@@ -582,8 +505,8 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
     for (j = 0; j < n8; j += 4) {
         for (i = 0; i < k16; i += 16) {
             kcell = i >> 1; // 0, 1, 2, 3
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             koff = i & 1;
             noff = j & 3;
             short *dst = &bp[8 * (columns_done * krows + kcell * 2 + j_hiflag)];
@@ -637,8 +560,8 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
         }
         for (i = k16; i < k8; i += 8) {
             kcell = i >> 1; // 0, 1, 2, 3
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             koff = i & 1;
             noff = j & 3;
             short *dst = &bp[8 * (columns_done * krows + kcell * 2 + j_hiflag)];
@@ -679,10 +602,10 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
     for (j = n8; j < n4; ++j) {
         for (i = 0; i < k8; ++i) {
             kcell = i >> 1;
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 1;
             noff = j & 3;
@@ -695,10 +618,10 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
         for (i = 0; i < k8; ++i) {
             kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 1;
             noff = j & 3;
@@ -714,10 +637,10 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
         for (i = k8; i < k_cap; ++i) {
             kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 1;
             noff = j & 3;
@@ -733,10 +656,10 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
         for (i = k8; i < k_cap; ++i) {
             kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 1;
             noff = j & 3;
@@ -750,10 +673,10 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
 }
 
 int pack_T16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
-    int i, j;
-    int m_cap = (m + 3) & ~3;
-    int k_cap = (k + 3) & ~3;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+    int32_t i, j;
+    int32_t m_cap = (m + 3) & ~3;
+    int32_t k_cap = (k + 3) & ~3;
+    int32_t kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
             chunk4count, m16, k4;
     m16 = (m >> 4) << 4;
     k4 = (k >> 2) << 2;
@@ -889,10 +812,10 @@ int pack_T16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
 }
 
 int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
-    int i, j;
-    int kcell, cell, koff, noff, krows, k8, n8;
-    int n_cap = (n + 3) & ~3;
-    int k_cap = (k + 3) & ~3;
+    int32_t i, j;
+    int32_t kcell, cell, koff, noff, krows, k8, n8;
+    int32_t n_cap = (n + 3) & ~3;
+    int32_t k_cap = (k + 3) & ~3;
     krows = (k + 3) >> 2;
     k8 = k >> 3;
     n8 = n >> 3;
@@ -935,10 +858,10 @@ int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
         for (i = 0; i < (k8 << 3); ++i) {
             kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 3;
             noff = j & 3;
@@ -954,10 +877,10 @@ int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
         for (i = (k8 << 3); i < k_cap; ++i) {
             kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 3;
             noff = j & 3;
@@ -973,10 +896,10 @@ int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
         for (i = (k8 << 3); i < k_cap; ++i) {
             kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 3;
             noff = j & 3;
@@ -991,10 +914,10 @@ int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
 }
 
 int pack_N16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
-    int i, j;
-    int m_cap = (m + 3) & ~3;
-    int k_cap = (k + 3) & ~3;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+    int32_t i, j;
+    int32_t m_cap = (m + 3) & ~3;
+    int32_t k_cap = (k + 3) & ~3;
+    int32_t kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
             chunk4count, m16, k4, k16;
     m16 = (m >> 4) << 4;
     k4 = (k >> 2) << 2;
@@ -1210,10 +1133,10 @@ int pack_N16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
 }
 
 int pack_T8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
-    int i, j;
-    int kcell, cell, koff, noff, krows, k8, n8;
-    int n_cap = (n + 3) & ~3;
-    int k_cap = (k + 3) & ~3;
+    int32_t i, j;
+    int32_t kcell, cell, koff, noff, krows, k8, n8;
+    int32_t n_cap = (n + 3) & ~3;
+    int32_t k_cap = (k + 3) & ~3;
     krows = (k + 3) >> 2;
     k8 = (k >> 3) << 3;
     n8 = (n >> 3) << 3;
@@ -1274,10 +1197,10 @@ int pack_T8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
         for (j = n8; j < n_cap; ++j) {
             kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 3;
             noff = j & 3;
@@ -1293,10 +1216,10 @@ int pack_T8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
         for (j = 0; j < n8; ++j) {
             kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 3;
             noff = j & 3;
@@ -1312,10 +1235,10 @@ int pack_T8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
         for (j = n8; j < n_cap; ++j) {
             kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
-            int maingroup = (j & (~7)) < (n & (~7));
-            int columns_done = ((j & (~7)) >> 3) << 1;
-            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
-            int j_hiflag = (j & 4) >> 2;
+            int32_t maingroup = (j & (~7)) < (n & (~7));
+            int32_t columns_done = ((j & (~7)) >> 3) << 1;
+            int32_t groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int32_t j_hiflag = (j & 4) >> 2;
             cell = columns_done * krows + kcell * groupwidth + j_hiflag;
             koff = i & 3;
             noff = j & 3;
@@ -1329,7 +1252,7 @@ int pack_T8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
     return 0;
 }
 
-typedef __vector signed int v4si_t __attribute__((aligned(4)));
+typedef __vector int32_t v4si_t __attribute__((aligned(4)));
 
 #define SWIZZLE_4x4 \
     { \
@@ -1481,14 +1404,14 @@ typedef __vector signed int v4si_t __attribute__((aligned(4)));
 #define MMA __builtin_mma_xvi16ger2pp
 
 void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
-        short *B, int *C, float beta, dim_t ldc) {
-    int i;
-    int m_cap = (m + 3) & ~3;
-    int n_cap = (n + 3) & ~3;
-    int k_cap = (k + 1) & ~1;
-    int m_skip;
-    int n_skip = (n & 8) != (n_cap & 8);
-    int fastpath;
+        short *B, int32_t *C, float beta, dim_t ldc) {
+    int32_t i;
+    int32_t m_cap = (m + 3) & ~3;
+    int32_t n_cap = (n + 3) & ~3;
+    int32_t k_cap = (k + 1) & ~1;
+    int32_t m_skip;
+    int32_t n_skip = (n & 8) != (n_cap & 8);
+    int32_t fastpath;
     v4si_t result[4], result_i[4], result_t[4];
     vec_t swizA = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23};
     vec_t swizB
@@ -1501,8 +1424,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
     /* Loop for multiples of 8 */
     i = n_cap >> 3;
     while (i) {
-        int j;
-        int *CO;
+        int32_t j;
+        int32_t *CO;
         short *AO;
         CO = C;
         C += ldc << 3;
@@ -1517,7 +1440,7 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             v4si_t *rowC;
             __vector_quad acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
             SET_ACC_ZERO8();
-            int l;
+            int32_t l;
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
             for (l = 0; l < k_cap / 2; l++) {
@@ -1557,8 +1480,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                 CO += 4;
                 if (((j == 1) && m_skip) || ((i == 1) && n_skip)) {
                     if ((j == 1) && m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc6);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -1617,8 +1540,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                 CO += 4;
                 if (((j == 1) && m_skip) || ((i == 1) && n_skip)) {
                     if ((j == 1) && m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc6);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -1679,7 +1602,7 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             SET_ACC_ZERO4();
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 2; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[0], rowB[1]);
@@ -1699,8 +1622,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                 CO += 4;
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc2);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -1745,8 +1668,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                 CO += 4;
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc2);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -1807,7 +1730,7 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             __builtin_mma_xxsetaccz(&acc1);
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l = 0;
+            int32_t l = 0;
             for (l = 0; l < k_cap / 2; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[0], rowB[1]);
@@ -1818,8 +1741,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             if (fastpath) {
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc0);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -1863,8 +1786,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             } else {
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc0);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -1928,13 +1851,13 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
     }
 
     if (n_cap & 4) {
-        int j;
-        int *CO;
+        int32_t j;
+        int32_t *CO;
         short *AO;
         CO = C;
         C += ldc << 2;
         AO = A;
-        int n_skip = (n != n_cap);
+        int32_t n_skip = (n != n_cap);
         /* Loop for m >= 32. */
         m_skip = (m >> 5) != (m_cap >> 5);
         for (j = 0; j < (m_cap >> 5); j++) {
@@ -1946,7 +1869,7 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowA1 = (vec_t *)A1;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 2; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[1], rowB[0]);
@@ -1971,8 +1894,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                     SAVE_ACC_COND_ABSC(&acc5, 20);
                     SAVE_ACC_COND_ABSC(&acc6, 24);
                     if ((j == (m_cap >> 5) - 1) && m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc7);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 28 + ii]
@@ -2014,8 +1937,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                     SAVE_ACC_COND(&acc5, 20);
                     SAVE_ACC_COND(&acc6, 24);
                     if ((j == (m_cap >> 5) - 1) && m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc7);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 28 + ii]
@@ -2070,7 +1993,7 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             SET_ACC_ZERO4();
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 2; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[1], rowB[0]);
@@ -2087,8 +2010,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                     SAVE_ACC_COND_ABSC(&acc2, 8);
                     if (m_skip) {
                         __builtin_mma_disassemble_acc((void *)result, &acc3);
-                        SWIZZLE_4x4 int count = 4 - (m_cap - m);
-                        int ii;
+                        SWIZZLE_4x4 int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         for (ii = 0; ii < count; ++ii)
                             CO[0 * ldc + 12 + ii] = result_t[0][ii];
                         if ((n_cap - n) < 3)
@@ -2119,8 +2042,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                     SAVE_ACC_COND(&acc2, 8);
                     if (m_skip) {
                         __builtin_mma_disassemble_acc((void *)result, &acc3);
-                        SWIZZLE_4x4 int count = 4 - (m_cap - m);
-                        int ii;
+                        SWIZZLE_4x4 int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         for (ii = 0; ii < count; ++ii)
                             CO[0 * ldc + 12 + ii] = beta * CO[0 * ldc + 12 + ii]
                                     + alpha * result_t[0][ii];
@@ -2168,7 +2091,7 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             __builtin_mma_xxsetaccz(&acc1);
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 2; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[1], rowB[0]);
@@ -2180,8 +2103,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                 if (m_skip || n_skip) {
                     SAVE_ACC_COND_ABSC(&acc0, 0);
                     if (m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc1);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 4 + ii]
@@ -2206,8 +2129,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                 if (m_skip || n_skip) {
                     SAVE_ACC_COND(&acc0, 0);
                     if (m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc1);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 4 + ii]
@@ -2250,7 +2173,7 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
             v4si_t *rowC;
             __vector_quad acc0;
             __builtin_mma_xxsetaccz(&acc0);
-            int l;
+            int32_t l;
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
             for (l = 0; l < k_cap / 2; l++) {
@@ -2261,8 +2184,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
 
             if (fastpath) {
                 if (m_skip || n_skip) {
-                    int count = 4 - (m_cap - m);
-                    int ii;
+                    int32_t count = 4 - (m_cap - m);
+                    int32_t ii;
                     __builtin_mma_disassemble_acc((void *)result, &acc0);
                     SWIZZLE_4x4 for (ii = 0; ii < count; ++ii) CO[0 * ldc + ii]
                             = result_t[0][ii];
@@ -2280,8 +2203,8 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
                 }
             } else {
                 if (m_skip || n_skip) {
-                    int count = 4 - (m_cap - m);
-                    int ii;
+                    int32_t count = 4 - (m_cap - m);
+                    int32_t ii;
                     __builtin_mma_disassemble_acc((void *)result, &acc0);
                     SWIZZLE_4x4 for (ii = 0; ii < count; ++ii) CO[0 * ldc + ii]
                             = beta * CO[0 * ldc + ii] + alpha * result_t[0][ii];
@@ -2316,14 +2239,14 @@ void gemm_kernel_16bit(dim_t m, dim_t n, dim_t k, float alpha, short *A,
 #define MMA __builtin_mma_xvi8ger4pp
 
 void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
-        uint8_t *B, int *C, float beta, dim_t ldc) {
-    int i;
-    int m_cap = (m + 3) & ~3;
-    int n_cap = (n + 3) & ~3;
-    int k_cap = (k + 3) & ~3;
-    int m_skip;
-    int n_skip = (n & 8) != (n_cap & 8);
-    int fastpath;
+        uint8_t *B, int32_t *C, float beta, dim_t ldc) {
+    int32_t i;
+    int32_t m_cap = (m + 3) & ~3;
+    int32_t n_cap = (n + 3) & ~3;
+    int32_t k_cap = (k + 3) & ~3;
+    int32_t m_skip;
+    int32_t n_skip = (n & 8) != (n_cap & 8);
+    int32_t fastpath;
     v4si_t result[4], result_i[4], result_t[4];
     vec_t swizA = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23};
     vec_t swizB
@@ -2336,8 +2259,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
     /* Loop for multiples of 8 */
     i = n_cap >> 3;
     while (i) {
-        int j;
-        int *CO;
+        int32_t j;
+        int32_t *CO;
         int8_t *AO;
         CO = C;
         C += ldc << 3;
@@ -2352,7 +2275,7 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             v4si_t *rowC;
             __vector_quad acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
             SET_ACC_ZERO8();
-            int l;
+            int32_t l;
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
             for (l = 0; l < k_cap / 4; l++) {
@@ -2392,8 +2315,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                 CO += 4;
                 if (((j == 1) && m_skip) || ((i == 1) && n_skip)) {
                     if ((j == 1) && m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc6);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -2452,8 +2375,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                 CO += 4;
                 if (((j == 1) && m_skip) || ((i == 1) && n_skip)) {
                     if ((j == 1) && m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc6);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -2514,7 +2437,7 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             SET_ACC_ZERO4();
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 4; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[0], rowB[1]);
@@ -2534,8 +2457,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                 CO += 4;
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc2);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -2580,8 +2503,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                 CO += 4;
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc2);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -2642,7 +2565,7 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             __builtin_mma_xxsetaccz(&acc1);
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l = 0;
+            int32_t l = 0;
             for (l = 0; l < k_cap / 4; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[0], rowB[1]);
@@ -2653,8 +2576,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             if (fastpath) {
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc0);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -2698,8 +2621,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             } else {
                 if (m_skip || ((i == 1) & n_skip)) {
                     if (m_skip) {
-                        int count = 4 - (m_cap - m);
-                        int ii;
+                        int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         __builtin_mma_disassemble_acc((void *)result, &acc0);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + ii]
@@ -2763,13 +2686,13 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
     }
 
     if (n_cap & 4) {
-        int j;
-        int *CO;
+        int32_t j;
+        int32_t *CO;
         int8_t *AO;
         CO = C;
         C += ldc << 2;
         AO = A;
-        int n_skip = (n != n_cap);
+        int32_t n_skip = (n != n_cap);
         /* Loop for m >= 32. */
         m_skip = (m >> 5) != (m_cap >> 5);
         for (j = 0; j < (m_cap >> 5); j++) {
@@ -2781,7 +2704,7 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowA1 = (vec_t *)A1;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 4; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[1], rowB[0]);
@@ -2806,8 +2729,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                     SAVE_ACC_COND_ABSC(&acc5, 20);
                     SAVE_ACC_COND_ABSC(&acc6, 24);
                     if ((j == (m_cap >> 5) - 1) && m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc7);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 28 + ii]
@@ -2849,8 +2772,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                     SAVE_ACC_COND(&acc5, 20);
                     SAVE_ACC_COND(&acc6, 24);
                     if ((j == (m_cap >> 5) - 1) && m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc7);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 28 + ii]
@@ -2905,7 +2828,7 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             SET_ACC_ZERO4();
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 4; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[1], rowB[0]);
@@ -2922,8 +2845,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                     SAVE_ACC_COND_ABSC(&acc2, 8);
                     if (m_skip) {
                         __builtin_mma_disassemble_acc((void *)result, &acc3);
-                        SWIZZLE_4x4 int count = 4 - (m_cap - m);
-                        int ii;
+                        SWIZZLE_4x4 int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         for (ii = 0; ii < count; ++ii)
                             CO[0 * ldc + 12 + ii] = result_t[0][ii];
                         if ((n_cap - n) < 3)
@@ -2954,8 +2877,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                     SAVE_ACC_COND(&acc2, 8);
                     if (m_skip) {
                         __builtin_mma_disassemble_acc((void *)result, &acc3);
-                        SWIZZLE_4x4 int count = 4 - (m_cap - m);
-                        int ii;
+                        SWIZZLE_4x4 int32_t count = 4 - (m_cap - m);
+                        int32_t ii;
                         for (ii = 0; ii < count; ++ii)
                             CO[0 * ldc + 12 + ii] = beta * CO[0 * ldc + 12 + ii]
                                     + alpha * result_t[0][ii];
@@ -3003,7 +2926,7 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             __builtin_mma_xxsetaccz(&acc1);
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
-            int l;
+            int32_t l;
             for (l = 0; l < k_cap / 4; l++) {
                 MMA(&acc0, rowA[0], rowB[0]);
                 MMA(&acc1, rowA[1], rowB[0]);
@@ -3015,8 +2938,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                 if (m_skip || n_skip) {
                     SAVE_ACC_COND_ABSC(&acc0, 0);
                     if (m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc1);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 4 + ii]
@@ -3041,8 +2964,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                 if (m_skip || n_skip) {
                     SAVE_ACC_COND(&acc0, 0);
                     if (m_skip) {
-                        int ii;
-                        int count = 4 - (m_cap - m);
+                        int32_t ii;
+                        int32_t count = 4 - (m_cap - m);
                         __builtin_mma_disassemble_acc((void *)result, &acc1);
                         SWIZZLE_4x4 for (ii = 0; ii < count; ++ii)
                                 CO[0 * ldc + 4 + ii]
@@ -3085,7 +3008,7 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
             v4si_t *rowC;
             __vector_quad acc0;
             __builtin_mma_xxsetaccz(&acc0);
-            int l;
+            int32_t l;
             vec_t *rowA = (vec_t *)AO;
             vec_t *rowB = (vec_t *)BO;
             for (l = 0; l < k_cap / 4; l++) {
@@ -3096,8 +3019,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
 
             if (fastpath) {
                 if (m_skip || n_skip) {
-                    int count = 4 - (m_cap - m);
-                    int ii;
+                    int32_t count = 4 - (m_cap - m);
+                    int32_t ii;
                     __builtin_mma_disassemble_acc((void *)result, &acc0);
                     SWIZZLE_4x4 for (ii = 0; ii < count; ++ii) CO[0 * ldc + ii]
                             = result_t[0][ii];
@@ -3115,8 +3038,8 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
                 }
             } else {
                 if (m_skip || n_skip) {
-                    int count = 4 - (m_cap - m);
-                    int ii;
+                    int32_t count = 4 - (m_cap - m);
+                    int32_t ii;
                     __builtin_mma_disassemble_acc((void *)result, &acc0);
                     SWIZZLE_4x4 for (ii = 0; ii < count; ++ii) CO[0 * ldc + ii]
                             = beta * CO[0 * ldc + ii] + alpha * result_t[0][ii];

--- a/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
@@ -20,385 +20,247 @@
 namespace dnnl {
 namespace impl {
 
-typedef int int_A1 __attribute__((aligned(1)));
-#define memcpy_4(_d, _s) *((int_A1 *)(_d)) = *((int_A1 *)(_s));
+static inline void memcpy_4(void * __restrict d, const void * __restrict s) {
+        int *di, *si;
+        di = (int *)(d);
+        si = (int *)(s);
+        di[0] = si[0];
+}
 
-#define memcpy_14(_d, _s) \
-    { \
-        int_A1 *_di, *_si; \
-        _di = (int *)(_d); \
-        _si = (int *)(_s); \
-        *_di++ = *_si++; \
-        *_di++ = *_si++; \
-        *_di++ = *_si++; \
-        *((short *)(_di)) = *((short *)(_si)); \
-    }
+static inline void memcpy_14(void * __restrict d, const void * __restrict s) {
+        int *di, *si;
+        di = (int *)(d);
+        si = (int *)(s);
+        di[0] = si[0];
+        di[1] = si[1];
+        di[2] = si[2];
+        *(short *) &di[3] = *(short *) &si[3];
+}
 
-#define memcpy_16(_d, _s) \
-    { \
-        int_A1 *_di, *_si; \
-        _di = (int *)(_d); \
-        _si = (int *)(_s); \
-        _di[0] = _si[0]; \
-        _di[1] = _si[1]; \
-        _di[2] = _si[2]; \
-        _di[3] = _si[3]; \
-    }
+static inline void memcpy_16(void * __restrict d, const void * __restrict s) {
+        int *di, *si;
+        di = (int *)(d);
+        si = (int *)(s);
+        di[0] = si[0];
+        di[1] = si[1];
+        di[2] = si[2];
+        di[3] = si[3];
+}
 
-#define memcpy_32(_d, _s) \
-    { \
-        int_A1 *_di, *_si; \
-        _di = (int *)(_d); \
-        _si = (int *)(_s); \
-        _di[0] = _si[0]; \
-        _di[1] = _si[1]; \
-        _di[2] = _si[2]; \
-        _di[3] = _si[3]; \
-        _di[4] = _si[4]; \
-        _di[5] = _si[5]; \
-        _di[6] = _si[6]; \
-        _di[7] = _si[7]; \
-    }
+static inline void memcpy_32(void * __restrict d, const void * __restrict s) {
+        int *di, *si;
+        di = (int *)(d);
+        si = (int *)(s);
+        di[0] = si[0];
+        di[1] = si[1];
+        di[2] = si[2];
+        di[3] = si[3];
+        di[4] = si[4];
+        di[5] = si[5];
+        di[6] = si[6];
+        di[7] = si[7];
+}
 
-#define memcpy_32S(_d, _s) \
-    { \
-        _d[0] = _s[0]; \
-        _d[1] = _s[1]; \
-        _d[2] = _s[2]; \
-        _d[3] = _s[3]; \
-        _d[4] = _s[4]; \
-        _d[5] = _s[5]; \
-        _d[6] = _s[6]; \
-        _d[7] = _s[7]; \
-        _d[8] = _s[8]; \
-        _d[9] = _s[9]; \
-        _d[10] = _s[10]; \
-        _d[11] = _s[11]; \
-        _d[12] = _s[12]; \
-        _d[13] = _s[13]; \
-        _d[14] = _s[14]; \
-        _d[15] = _s[15]; \
-    }
+static inline void memcpy_64(void * __restrict d, const void * __restrict s) {
+        int *di, *si;
+        di = (int *)(d);
+        si = (int *)(s);
+        di[0] = si[0];
+        di[1] = si[1];
+        di[2] = si[2];
+        di[3] = si[3];
+        di[4] = si[4];
+        di[5] = si[5];
+        di[6] = si[6];
+        di[7] = si[7];
+        di[8] = si[8];
+        di[9] = si[9];
+        di[10] = si[10];
+        di[11] = si[11];
+        di[12] = si[12];
+        di[13] = si[13];
+        di[14] = si[14];
+        di[15] = si[15];
+}
 
-#define memcpy_64(_d, _s) \
-    { \
-        int_A1 *_di, *_si; \
-        _di = (int *)(_d); \
-        _si = (int *)(_s); \
-        _di[0] = _si[0]; \
-        _di[1] = _si[1]; \
-        _di[2] = _si[2]; \
-        _di[3] = _si[3]; \
-        _di[4] = _si[4]; \
-        _di[5] = _si[5]; \
-        _di[6] = _si[6]; \
-        _di[7] = _si[7]; \
-        _di[8] = _si[8]; \
-        _di[9] = _si[9]; \
-        _di[10] = _si[10]; \
-        _di[11] = _si[11]; \
-        _di[12] = _si[12]; \
-        _di[13] = _si[13]; \
-        _di[14] = _si[14]; \
-        _di[15] = _si[15]; \
-    }
-
-#define memcpy_n(_d, _s, _n) \
-    { \
-        int8_t *_di, *_si; \
-        int _i; \
-        _di = (int8_t *)(_d); \
-        _si = (int8_t *)(_s); \
-        for (_i = 0; _i < _n; ++_i) \
-            *_di++ = *_si++; \
-    }
+static inline void memcpy_n(void * __restrict d, const void * __restrict s, int n) {
+	int i, *di, *si;
+	int8_t *dc, *sc;
+        di = (int *)(d);
+        si = (int *)(s);
+	for (i=0; i<(n>>2); ++i) di[i] = si[i];
+	dc = (int8_t *) &di[n>>3];
+	sc = (int8_t *) &si[n>>3];
+	for (i=0; i<(n&3); ++i) dc[i] = sc[i];
+}
 
 uint64_t mker;
 
+typedef __vector signed long long vec_i64 __attribute__((aligned(8)));
 typedef __vector short vec_i16 __attribute__((aligned(2)));
 typedef __vector unsigned char vec_t;
 typedef __vector signed char vec_st;
 
 int pack_N16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
     int i, j;
-    int fastpath;
-    short *a_offset;
-    short *a_offset1, *a_offset2, *a_offset3, *a_offset4;
-    short *a_offset5, *a_offset6, *a_offset7, *a_offset8;
-    short *a_offset9, *a_offset10, *a_offset11, *a_offset12;
-    short *a_offset13, *a_offset14, *a_offset15, *a_offset16;
-    short *ap_offset;
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, k8, m4, m16;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 1) & ~1;
-    a_offset = a;
-    ap_offset = ap;
-    fastpath = (((k & 1) == 0) && (m & 3) == 0);
+    krows = (k+1) >> 1;
+    mrows = (m+3) >> 2;
+    block4 = 4 * krows;
+    block2 = 2 * krows;
+    k8 = (k>>3)<<3;
+    m4 = (m>>2)<<2;
+    m16 = (m>>4)<<4;
 
-    j = (m_cap >> 4);
-    int m_skip = (j != (m >> 4));
-    while (j) {
-        a_offset1 = a_offset;
-        a_offset2 = a_offset1 + lda;
-        a_offset3 = a_offset2 + lda;
-        a_offset4 = a_offset3 + lda;
-        a_offset5 = a_offset4 + lda;
-        a_offset6 = a_offset5 + lda;
-        a_offset7 = a_offset6 + lda;
-        a_offset8 = a_offset7 + lda;
-        a_offset9 = a_offset8 + lda;
-        a_offset10 = a_offset9 + lda;
-        a_offset11 = a_offset10 + lda;
-        a_offset12 = a_offset11 + lda;
-        a_offset13 = a_offset12 + lda;
-        a_offset14 = a_offset13 + lda;
-        a_offset15 = a_offset14 + lda;
-        a_offset16 = a_offset15 + lda;
-        a_offset += 16 * lda;
+    // MAIN BLOCK
+    for (j=0; j<m16; j+=4) {
+        for (i=0; i<k8; i+=8) {
+            kcell = i>>1; // 0, 1, 2, 3
+            mcell = j>>2;
+            short *dest = &ap[32 * ((mcell>>2) * krows + kcell) + 8*(mcell & 3)];
 
-        i = (k >> 1);
-        while (i) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            *(ap_offset + 1) = *(a_offset1 + 1);
-            *(ap_offset + 2) = *(a_offset2 + 0);
-            *(ap_offset + 3) = *(a_offset2 + 1);
-            *(ap_offset + 4) = *(a_offset3 + 0);
-            *(ap_offset + 5) = *(a_offset3 + 1);
-            *(ap_offset + 6) = *(a_offset4 + 0);
-            *(ap_offset + 7) = *(a_offset4 + 1);
+	    vec_t V0, V1, V2, V3;
+            vec_t D01A, D01B, D23A, D23B;
+            vec_t D0, D1, D2, D3;
+            vec_t swizA = { 0,  1,  2,  3, 16, 17, 18, 19,  4,  5,  6,  7, 20, 21, 22, 23};
+            vec_t swizB = { 8,  9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
+            vec_t swizL = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizR = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
 
-            *(ap_offset + 8) = *(a_offset5 + 0);
-            *(ap_offset + 9) = *(a_offset5 + 1);
-            *(ap_offset + 10) = *(a_offset6 + 0);
-            *(ap_offset + 11) = *(a_offset6 + 1);
-            *(ap_offset + 12) = *(a_offset7 + 0);
-            *(ap_offset + 13) = *(a_offset7 + 1);
-            *(ap_offset + 14) = *(a_offset8 + 0);
-            *(ap_offset + 15) = *(a_offset8 + 1);
+            V0 = *(vec_t *) &a[lda*(j+0) + i];
+            V1 = *(vec_t *) &a[lda*(j+1) + i];
+            V2 = *(vec_t *) &a[lda*(j+2) + i];
+            V3 = *(vec_t *) &a[lda*(j+3) + i];
 
-            *(ap_offset + 16) = *(a_offset9 + 0);
-            *(ap_offset + 17) = *(a_offset9 + 1);
-            *(ap_offset + 18) = *(a_offset10 + 0);
-            *(ap_offset + 19) = *(a_offset10 + 1);
-            *(ap_offset + 20) = *(a_offset11 + 0);
-            *(ap_offset + 21) = *(a_offset11 + 1);
-            *(ap_offset + 22) = *(a_offset12 + 0);
-            *(ap_offset + 23) = *(a_offset12 + 1);
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
 
-            *(ap_offset + 24) = *(a_offset13 + 0);
-            *(ap_offset + 25) = *(a_offset13 + 1);
-            if (fastpath) {
-                *(ap_offset + 26) = *(a_offset14 + 0);
-                *(ap_offset + 27) = *(a_offset14 + 1);
-                *(ap_offset + 28) = *(a_offset15 + 0);
-                *(ap_offset + 29) = *(a_offset15 + 1);
-                *(ap_offset + 30) = *(a_offset16 + 0);
-                *(ap_offset + 31) = *(a_offset16 + 1);
-            } else {
-                if ((j != 1) || (!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 26) = *(a_offset14 + 0);
-                if ((j != 1) || (!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 27) = *(a_offset14 + 1);
-                if ((j != 1) || (!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 28) = *(a_offset15 + 0);
-                if ((j != 1) || (!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 29) = *(a_offset15 + 1);
-                if ((j != 1) || (!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 30) = *(a_offset16 + 0);
-                if ((j != 1) || (!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 31) = *(a_offset16 + 1);
-            }
-
-            a_offset1 += 2;
-            a_offset2 += 2;
-            a_offset3 += 2;
-            a_offset4 += 2;
-            a_offset5 += 2;
-            a_offset6 += 2;
-            a_offset7 += 2;
-            a_offset8 += 2;
-
-            a_offset9 += 2;
-            a_offset10 += 2;
-            a_offset11 += 2;
-            a_offset12 += 2;
-            a_offset13 += 2;
-            a_offset14 += 2;
-            a_offset15 += 2;
-            a_offset16 += 2;
-            ap_offset += 32;
-
-            i--;
-        } // end of while (i)
-
-        if (k < k_cap) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            *(ap_offset + 2) = *(a_offset2 + 0);
-            *(ap_offset + 4) = *(a_offset3 + 0);
-            *(ap_offset + 6) = *(a_offset4 + 0);
-
-            *(ap_offset + 8) = *(a_offset5 + 0);
-            *(ap_offset + 10) = *(a_offset6 + 0);
-            *(ap_offset + 12) = *(a_offset7 + 0);
-            *(ap_offset + 14) = *(a_offset8 + 0);
-
-            *(ap_offset + 16) = *(a_offset9 + 0);
-            *(ap_offset + 18) = *(a_offset10 + 0);
-            *(ap_offset + 20) = *(a_offset11 + 0);
-            *(ap_offset + 22) = *(a_offset12 + 0);
-
-            *(ap_offset + 24) = *(a_offset13 + 0);
-            if ((j != 1) || (!m_skip) || (m_cap - m < 3))
-                *(ap_offset + 26) = *(a_offset14 + 0);
-            if ((j != 1) || (!m_skip) || (m_cap - m < 2))
-                *(ap_offset + 28) = *(a_offset15 + 0);
-            if ((j != 1) || (!m_skip) || (m_cap - m < 1))
-                *(ap_offset + 30) = *(a_offset16 + 0);
-
-            for (int ii = 1; ii < 32; ii += 2)
-                *(ap_offset + ii) = 0;
-
-            ap_offset += 32;
-        }
-        j--;
-    } // end of while(j)
-
-    if (m_cap & 8) {
-        m_skip = (m & 8) != (m_cap & 8);
-        a_offset1 = a_offset;
-        a_offset2 = a_offset1 + lda;
-        a_offset3 = a_offset2 + lda;
-        a_offset4 = a_offset3 + lda;
-        a_offset5 = a_offset4 + lda;
-        a_offset6 = a_offset5 + lda;
-        a_offset7 = a_offset6 + lda;
-        a_offset8 = a_offset7 + lda;
-        a_offset += 8 * lda;
-
-        i = (k >> 1);
-        while (i) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            *(ap_offset + 1) = *(a_offset1 + 1);
-            *(ap_offset + 2) = *(a_offset2 + 0);
-            *(ap_offset + 3) = *(a_offset2 + 1);
-            *(ap_offset + 4) = *(a_offset3 + 0);
-            *(ap_offset + 5) = *(a_offset3 + 1);
-            *(ap_offset + 6) = *(a_offset4 + 0);
-            *(ap_offset + 7) = *(a_offset4 + 1);
-
-            *(ap_offset + 8) = *(a_offset5 + 0);
-            *(ap_offset + 9) = *(a_offset5 + 1);
-            if (fastpath) {
-                *(ap_offset + 10) = *(a_offset6 + 0);
-                *(ap_offset + 11) = *(a_offset6 + 1);
-                *(ap_offset + 12) = *(a_offset7 + 0);
-                *(ap_offset + 13) = *(a_offset7 + 1);
-                *(ap_offset + 14) = *(a_offset8 + 0);
-                *(ap_offset + 15) = *(a_offset8 + 1);
-            } else {
-                if ((!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 10) = *(a_offset6 + 0);
-                if ((!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 11) = *(a_offset6 + 1);
-                if ((!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 12) = *(a_offset7 + 0);
-                if ((!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 13) = *(a_offset7 + 1);
-                if ((!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 14) = *(a_offset8 + 0);
-                if ((!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 15) = *(a_offset8 + 1);
-            }
-
-            a_offset1 += 2;
-            a_offset2 += 2;
-            a_offset3 += 2;
-            a_offset4 += 2;
-            a_offset5 += 2;
-            a_offset6 += 2;
-            a_offset7 += 2;
-            a_offset8 += 2;
-            ap_offset += 16;
-
-            i--;
-        } // end of while (i)
-
-        if (k < k_cap) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            *(ap_offset + 2) = *(a_offset2 + 0);
-            *(ap_offset + 4) = *(a_offset3 + 0);
-            *(ap_offset + 6) = *(a_offset4 + 0);
-
-            *(ap_offset + 8) = *(a_offset5 + 0);
-            if ((!m_skip) || (m_cap - m < 3))
-                *(ap_offset + 10) = *(a_offset6 + 0);
-            if ((!m_skip) || (m_cap - m < 2))
-                *(ap_offset + 12) = *(a_offset7 + 0);
-            if ((!m_skip) || (m_cap - m < 1))
-                *(ap_offset + 14) = *(a_offset8 + 0);
-
-            for (int ii = 1; ii < 16; ii += 2)
-                *(ap_offset + ii) = 0;
-
-            ap_offset += 16;
+            *(vec_t *) &dest[ 0] = D0;
+            *(vec_t *) &dest[32] = D1;
+            *(vec_t *) &dest[64] = D2;
+            *(vec_t *) &dest[96] = D3;
         }
     }
 
-    if (m_cap & 4) {
-        m_skip = (m & 4) != (m_cap & 4);
-        a_offset1 = a_offset;
-        a_offset2 = a_offset1 + lda;
-        a_offset3 = a_offset2 + lda;
-        a_offset4 = a_offset3 + lda;
-        a_offset += 4 * lda;
-
-        i = (k >> 1);
-        while (i) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            *(ap_offset + 1) = *(a_offset1 + 1);
-            if (fastpath) {
-                *(ap_offset + 2) = *(a_offset2 + 0);
-                *(ap_offset + 3) = *(a_offset2 + 1);
-                *(ap_offset + 4) = *(a_offset3 + 0);
-                *(ap_offset + 5) = *(a_offset3 + 1);
-                *(ap_offset + 6) = *(a_offset4 + 0);
-                *(ap_offset + 7) = *(a_offset4 + 1);
-            } else {
-                if ((!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 2) = *(a_offset2 + 0);
-                if ((!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 3) = *(a_offset2 + 1);
-                if ((!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 4) = *(a_offset3 + 0);
-                if ((!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 5) = *(a_offset3 + 1);
-                if ((!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 6) = *(a_offset4 + 0);
-                if ((!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 7) = *(a_offset4 + 1);
+    for (j=m16; j<m4; ++j) {
+        for (i=0; i<k8; ++i) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = (chunk4count * block4);
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
             }
+            koff = i&1;
+            moff = j&3;
+            ap[8*cell + 2*moff+koff] = a[lda*j+i];
+        }
+    }
 
-            a_offset1 += 2;
-            a_offset2 += 2;
-            a_offset3 += 2;
-            a_offset4 += 2;
-            ap_offset += 8;
+    // HIGH EDGE IN M DIRECTION
+    for (j=m4; j<m_cap; ++j) {
+        for (i=0; i<k8; ++i) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = (chunk4count * block4);
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&1;
+            moff = j&3;
+	    if (j < m) ap[8*cell + 2*moff+koff] = a[lda*j+i];
+	    else       ap[8*cell + 2*moff+koff] = 0;
+        }
+    }
 
-            i--;
-        } // end of while (i)
+    // HIGH EDGE IN K DIRECTION
+    for (j=0; j<m4; ++j) {
+        for (i=k8; i<k_cap; ++i) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = (chunk4count * block4);
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&1;
+            moff = j&3;
+            if (i < k) ap[8*cell + 2*moff+koff] = a[lda*j+i];
+	    else       ap[8*cell + 2*moff+koff] = 0;
+        }
+    }
 
-        if (k < k_cap) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            if ((!m_skip) || (m_cap - m < 3))
-                *(ap_offset + 2) = *(a_offset2 + 0);
-            if ((!m_skip) || (m_cap - m < 2))
-                *(ap_offset + 4) = *(a_offset3 + 0);
-            if ((!m_skip) || (m_cap - m < 1))
-                *(ap_offset + 6) = *(a_offset4 + 0);
-
-            for (int ii = 1; ii < 8; ii += 2)
-                *(ap_offset + ii) = 0;
-
-            ap_offset += 8;
+    // UPPER CORNER (HIGH M, HIGH K)
+    for (j=m4; j<m_cap; ++j) {
+        for (i=k8; i<k_cap; ++i) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = (chunk4count * block4);
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&1;
+            moff = j&3;
+            if (j < m && i < k) ap[8*cell + 2*moff+koff] = a[lda*j+i];
+	    else                ap[8*cell + 2*moff+koff] = 0;           
         }
     }
     return 0;
@@ -406,186 +268,166 @@ int pack_N16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
 
 int pack_T16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
     int i, j;
-    int fastpath;
-    short *a_offset;
-    short *a_offset1, *a_offset2;
-    short *ap_offset;
-    vec_i16 vtemp01, vtemp02, vtemp03, vtemp04;
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, k4, m8, m16;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 1) & ~1;
-    a_offset = a;
-    ap_offset = ap;
-    fastpath = (((k & 1) == 0) && (m & 3) == 0);
+    krows = (k+1) >> 1;
+    mrows = (m+3) >> 2;
+    block4 = 4 * krows;
+    block2 = 2 * krows;
+    k4 = (k>>2)<<2;
+    m16 = (m>>4)<<4;
+    m8 = (m>>3)<<3;
 
-    j = (m_cap >> 4);
-    int m_skip = (j != (m >> 4));
-    while (j) {
-        a_offset1 = a_offset;
-        a_offset2 = a_offset + lda;
-        a_offset += 16;
+    // MAIN BLOCK
+    for (i=0; i<k4; i+=4) {
+        for (j=0; j<m16; j+=16) {
+	    short *src = &a[lda*i + j];
+	    short *dst = &ap[2 * j * krows + 16 * i];
+            vec_t V0, V1, V2, V3, V4, V5, V6, V7;
+            vec_t D0, D1, D2, D3, D4, D5, D6, D7;
+            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
+            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
 
-        i = (k >> 1);
-        while (i > 1) {
-            vtemp01 = *(vec_i16 *)(a_offset1);
-            vtemp02 = *(vec_i16 *)(a_offset1 + 8);
-            vtemp03 = *(vec_i16 *)(a_offset2);
-            vtemp04 = *(vec_i16 *)(a_offset2 + 8);
-            *(vec_i16 *)(ap_offset + 0) = vec_mergeh(vtemp01, vtemp03);
-            *(vec_i16 *)(ap_offset + 8) = vec_mergel(vtemp01, vtemp03);
-            *(vec_i16 *)(ap_offset + 16) = vec_mergeh(vtemp02, vtemp04);
-            *(vec_i16 *)(ap_offset + 24) = vec_mergel(vtemp02, vtemp04);
-            a_offset1 += 2 * lda;
-            a_offset2 += 2 * lda;
-            ap_offset += 32;
+            V0 = *(vec_t *) &src[0];
+            V1 = *(vec_t *) &src[lda];
+            V2 = *(vec_t *) &src[8];
+            V3 = *(vec_t *) &src[lda + 8];
+            V4 = *(vec_t *) &src[2*lda];
+            V5 = *(vec_t *) &src[3*lda];
+            V6 = *(vec_t *) &src[2*lda + 8];
+            V7 = *(vec_t *) &src[3*lda + 8];
+            D0 = vec_perm(V0, V1, swizL);
+            D1 = vec_perm(V0, V1, swizR);
+            D2 = vec_perm(V2, V3, swizL);
+            D3 = vec_perm(V2, V3, swizR);
+            D4 = vec_perm(V4, V5, swizL);
+            D5 = vec_perm(V4, V5, swizR);
+            D6 = vec_perm(V6, V7, swizL);
+            D7 = vec_perm(V6, V7, swizR);
 
-            i--;
-        } // end of while (i)
-        if (i == 1) {
-            if ((j > 1) || (!m_skip)) {
-                vtemp01 = *(vec_i16 *)(a_offset1);
-                vtemp02 = *(vec_i16 *)(a_offset1 + 8);
-                vtemp03 = *(vec_i16 *)(a_offset2);
-                vtemp04 = *(vec_i16 *)(a_offset2 + 8);
-                *(vec_i16 *)(ap_offset + 0) = vec_mergeh(vtemp01, vtemp03);
-                *(vec_i16 *)(ap_offset + 8) = vec_mergel(vtemp01, vtemp03);
-                *(vec_i16 *)(ap_offset + 16) = vec_mergeh(vtemp02, vtemp04);
-                *(vec_i16 *)(ap_offset + 24) = vec_mergel(vtemp02, vtemp04);
-            } else {
-                for (int i16 = 0; i16 < 13; ++i16) {
-                    *(ap_offset + 2 * i16 + 0) = *(a_offset1 + i16);
-                    *(ap_offset + 2 * i16 + 1) = *(a_offset2 + i16);
-                }
-                if (m_cap - m < 3) {
-                    *(ap_offset + 26) = *(a_offset1 + 13);
-                    *(ap_offset + 27) = *(a_offset2 + 13);
-                } else {
-                    *(ap_offset + 26) = 0;
-                    *(ap_offset + 27) = 0;
-                }
-                if (m_cap - m < 2) {
-                    *(ap_offset + 28) = *(a_offset1 + 14);
-                    *(ap_offset + 29) = *(a_offset2 + 14);
-                } else {
-                    *(ap_offset + 28) = 0;
-                    *(ap_offset + 29) = 0;
-                }
-                if (m_cap - m < 1) {
-                    *(ap_offset + 30) = *(a_offset1 + 15);
-                    *(ap_offset + 31) = *(a_offset2 + 15);
-                } else {
-                    *(ap_offset + 30) = 0;
-                    *(ap_offset + 31) = 0;
-                }
-            }
-            a_offset1 += 2 * lda;
-            a_offset2 += 2 * lda;
-            ap_offset += 32;
-        }
-
-        if (k < k_cap) {
-            vtemp01 = *(vec_i16 *)(a_offset1);
-            vtemp02 = *(vec_i16 *)(a_offset1 + 8);
-            vtemp03 = *(vec_i16 *)(a_offset1); // garbage, never read
-            vtemp04 = *(vec_i16 *)(a_offset1 + 8); // garbage, never read
-            *(vec_i16 *)(ap_offset + 0) = vec_mergeh(vtemp01, vtemp03);
-            *(vec_i16 *)(ap_offset + 8) = vec_mergel(vtemp01, vtemp03);
-            *(vec_i16 *)(ap_offset + 16) = vec_mergeh(vtemp02, vtemp04);
-            *(vec_i16 *)(ap_offset + 24) = vec_mergel(vtemp02, vtemp04);
-
-            for (int ii = 1; ii < 32; ii += 2)
-                *(ap_offset + ii) = 0;
-
-            ap_offset += 32;
-        }
-
-        j--;
-    } // end of while (j)
-
-    if (m_cap & 8) {
-        m_skip = (m & 8) != (m_cap & 8);
-        a_offset1 = a_offset;
-        a_offset2 = a_offset + lda;
-        a_offset += 8;
-
-        i = (k >> 1);
-        while (i) {
-            vtemp01 = *(vec_i16 *)(a_offset1);
-            vtemp03 = *(vec_i16 *)(a_offset2);
-            *(vec_i16 *)(ap_offset + 0) = vec_mergeh(vtemp01, vtemp03);
-            *(vec_i16 *)(ap_offset + 8) = vec_mergel(vtemp01, vtemp03);
-
-            a_offset1 += 2 * lda;
-            a_offset2 += 2 * lda;
-            ap_offset += 16;
-
-            i--;
-        } // end of while (i)
-
-        if (k < k_cap) {
-            vtemp01 = *(vec_i16 *)(a_offset1);
-            vtemp03 = *(vec_i16 *)(a_offset1); // garbage, never read
-            *(vec_i16 *)(ap_offset + 0) = vec_mergeh(vtemp01, vtemp03);
-            *(vec_i16 *)(ap_offset + 8) = vec_mergel(vtemp01, vtemp03);
-
-            for (int ii = 1; ii < 16; ii += 2)
-                *(ap_offset + ii) = 0;
-
-            ap_offset += 16;
+	    *(vec_t *) &dst[ 0] = D0;
+	    *(vec_t *) &dst[ 8] = D1;
+	    *(vec_t *) &dst[16] = D2;
+	    *(vec_t *) &dst[24] = D3;
+	    *(vec_t *) &dst[32] = D4;
+	    *(vec_t *) &dst[40] = D5;
+	    *(vec_t *) &dst[48] = D6;
+	    *(vec_t *) &dst[56] = D7;
         }
     }
 
-    if (m_cap & 4) {
-        m_skip = (m & 4) != (m_cap & 4);
-        a_offset1 = a_offset;
-        a_offset2 = a_offset + lda;
-        a_offset += 4;
-
-        i = (k >> 1);
-        while (i) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            *(ap_offset + 1) = *(a_offset2 + 0);
-            if (fastpath) {
-                *(ap_offset + 2) = *(a_offset1 + 1);
-                *(ap_offset + 3) = *(a_offset2 + 1);
-                *(ap_offset + 4) = *(a_offset1 + 2);
-                *(ap_offset + 5) = *(a_offset2 + 2);
-                *(ap_offset + 6) = *(a_offset1 + 3);
-                *(ap_offset + 7) = *(a_offset2 + 3);
-            } else {
-                if ((!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 2) = *(a_offset1 + 1);
-                if ((!m_skip) || (m_cap - m < 3))
-                    *(ap_offset + 3) = *(a_offset2 + 1);
-                if ((!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 4) = *(a_offset1 + 2);
-                if ((!m_skip) || (m_cap - m < 2))
-                    *(ap_offset + 5) = *(a_offset2 + 2);
-                if ((!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 6) = *(a_offset1 + 3);
-                if ((!m_skip) || (m_cap - m < 1))
-                    *(ap_offset + 7) = *(a_offset2 + 3);
+    for (i=0; i<k4; ++i) {
+        for (j=m16; j<m8; ++j) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = chunk4count * block4;
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
             }
+            koff = i&1;
+            moff = j&3;
+            ap[8*cell + 2*moff+koff] = a[lda*i+j];
+        }
+    }
 
-            a_offset1 += 2 * lda;
-            a_offset2 += 2 * lda;
-            ap_offset += 8;
+    // HIGH EDGE IN M DIRECTION
+    for (i=0; i<k4; ++i) {
+        for (j=m8; j<m_cap; ++j) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = chunk4count * block4;
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&1;
+            moff = j&3;
+            if (j < m) ap[8*cell + 2*moff+koff] = a[lda*i+j];
+	    else       ap[8*cell + 2*moff+koff] = 0;
+        }
+    }
 
-            i--;
-        } // end of while (i)
+    // HIGH EDGE IN K DIRECTION
+    for (i=k4; i<k_cap; ++i) {
+        for (j=0; j<m8; ++j) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = chunk4count * block4;
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&1;
+            moff = j&3;
+            if (i < k) ap[8*cell + 2*moff+koff] = a[lda*i+j];
+	    else       ap[8*cell + 2*moff+koff] = 0;          
+        }
+    }
 
-        if (k < k_cap) {
-            *(ap_offset + 0) = *(a_offset1 + 0);
-            if ((!m_skip) || (m_cap - m < 3))
-                *(ap_offset + 2) = *(a_offset1 + 1);
-            if ((!m_skip) || (m_cap - m < 2))
-                *(ap_offset + 4) = *(a_offset1 + 2);
-            if ((!m_skip) || (m_cap - m < 1))
-                *(ap_offset + 6) = *(a_offset1 + 3);
-
-            for (int ii = 1; ii < 8; ii += 2)
-                *(ap_offset + ii) = 0;
-
-            ap_offset += 8;
+    // UPPER CORNER (HIGH M, HIGH K)
+    for (i=k4; i<k_cap; ++i) {
+        for (j=m8; j<m_cap; ++j) {
+            kcell = i>>1;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = chunk4count * block4;
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&1;
+            moff = j&3;
+            if (i < k && j < m) ap[8*cell + 2*moff+koff] = a[lda*i+j];
+	    else                ap[8*cell + 2*moff+koff] = 0;           
         }
     }
     return 0;
@@ -593,1135 +435,521 @@ int pack_T16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
 
 int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
     int i, j;
-    int fastpath;
-    short *b_offset, *b_offset1, *b_offset2, *b_offset3, *b_offset4, *b_offset5,
-            *b_offset6, *b_offset7, *b_offset8;
-    short *bp_offset, *bp_offset1, *bp_offset2;
-    vec_i16 vtemp01, vtemp02, vtemp03, vtemp04;
-    vec_i16 vtemp05, vtemp06, vtemp07, vtemp08;
-    int n_cap = (n + 3) & (~3);
-    int k_cap = (k + 1) & (~1);
-    fastpath = (((k & 1) == 0) && (n & 3) == 0);
+    int kcell, cell, koff, noff, krows, k4, n8, n16;
+    int n_cap = (n + 3) & ~3;
+    int k_cap = (k + 1) & ~1;
+    krows = (k+1) >> 1;
+    k4 = (k>>2)<<2;
+    n8 = (n>>3)<<3;
+    n16 = (n>>4)<<4;
 
-    b_offset = b;
-    bp_offset = bp;
-    bp_offset2 = bp + k_cap * (n_cap & ~7);
+    // MAIN BLOCK
+    for (i=0; i<k4; i+=4) {
+        for (j=0; j<n16; j+=16) {
+            short *src = &b[ldb * i + j];
+	    short *dst0145 = &bp[2 * j * krows + 8 * i];
+	    short *dst2367 = &bp[2 * (j+8) * krows + 8 * i];
+            vec_t V0, V1, V2, V3, V4, V5, V6, V7;
+            vec_t D0, D1, D2, D3, D4, D5, D6, D7;
+            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
+            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
 
-    j = (k_cap >> 3);
-    int k_skip = ((k >> 3) != j);
-    while (j) {
-        b_offset1 = b_offset;
-        b_offset2 = b_offset1 + ldb;
-        b_offset3 = b_offset2 + ldb;
-        b_offset4 = b_offset3 + ldb;
-        b_offset5 = b_offset4 + ldb;
-        b_offset6 = b_offset5 + ldb;
-        b_offset7 = b_offset6 + ldb;
-        b_offset8 = b_offset7 + ldb;
-        b_offset += 8 * ldb;
+            V0 = *(vec_t *) &src[0];
+            V1 = *(vec_t *) &src[ldb];
+            V2 = *(vec_t *) &src[8];
+            V3 = *(vec_t *) &src[ldb + 8];
+            V4 = *(vec_t *) &src[2*ldb];
+            V5 = *(vec_t *) &src[3*ldb];
+            V6 = *(vec_t *) &src[2*ldb + 8];
+            V7 = *(vec_t *) &src[3*ldb + 8];
+            D0 = vec_perm(V0, V1, swizL);
+            D1 = vec_perm(V0, V1, swizR);
+            D2 = vec_perm(V2, V3, swizL);
+            D3 = vec_perm(V2, V3, swizR);
+            D4 = vec_perm(V4, V5, swizL);
+            D5 = vec_perm(V4, V5, swizR);
+            D6 = vec_perm(V6, V7, swizL);
+            D7 = vec_perm(V6, V7, swizR);
 
-        bp_offset1 = bp_offset;
-        bp_offset += 64;
-
-        i = (n_cap >> 3);
-        // we need to be careful about not going past the end of the B array if n is less than n_cap.
-        // fortunately, we can only go out-of-bounds by accessing elements of b_offset8, so the others
-        // can just load garbage in the not_used elements of the vtemp vectors.
-        while (i) {
-            vtemp01 = *(vec_i16 *)(b_offset1);
-            vtemp02 = *(vec_i16 *)(b_offset2);
-            vtemp03 = *(vec_i16 *)(b_offset3);
-            vtemp04 = *(vec_i16 *)(b_offset4);
-            vtemp05 = *(vec_i16 *)(b_offset5);
-            vtemp06 = *(vec_i16 *)(b_offset6);
-            vtemp07 = *(vec_i16 *)(b_offset7);
-            if ((j == 1) && k_skip) {
-                short temp[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-                vtemp08 = *(vec_i16 *)(temp);
-            } else {
-                if ((i == 1) && (!(n_cap & 4))) {
-                    memcpy_16(&vtemp08, b_offset8);
-                } else {
-                    vtemp08 = *(vec_i16 *)(b_offset8);
-                }
-            }
-            b_offset1 += 8;
-            b_offset2 += 8;
-            b_offset3 += 8;
-            b_offset4 += 8;
-            b_offset5 += 8;
-            b_offset6 += 8;
-            b_offset7 += 8;
-            b_offset8 += 8;
-
-            *(vec_i16 *)(bp_offset1 + 0) = vec_mergeh(vtemp01, vtemp02);
-            *(vec_i16 *)(bp_offset1 + 8) = vec_mergel(vtemp01, vtemp02);
-            *(vec_i16 *)(bp_offset1 + 16) = vec_mergeh(vtemp03, vtemp04);
-            *(vec_i16 *)(bp_offset1 + 24) = vec_mergel(vtemp03, vtemp04);
-            *(vec_i16 *)(bp_offset1 + 32) = vec_mergeh(vtemp05, vtemp06);
-            *(vec_i16 *)(bp_offset1 + 40) = vec_mergel(vtemp05, vtemp06);
-            *(vec_i16 *)(bp_offset1 + 48) = vec_mergeh(vtemp07, vtemp08);
-            *(vec_i16 *)(bp_offset1 + 56) = vec_mergel(vtemp07, vtemp08);
-
-            bp_offset1 += k_cap * 8;
-            i--;
-        } // end of while (i)
-
-        if (n_cap & 4) {
-            *(bp_offset2 + 0) = *(b_offset1 + 0);
-            *(bp_offset2 + 1) = *(b_offset2 + 0);
-            *(bp_offset2 + 2) = *(b_offset1 + 1);
-            *(bp_offset2 + 3) = *(b_offset2 + 1);
-            *(bp_offset2 + 4) = *(b_offset1 + 2);
-            *(bp_offset2 + 5) = *(b_offset2 + 2);
-            *(bp_offset2 + 6) = *(b_offset1 + 3);
-            *(bp_offset2 + 7) = *(b_offset2 + 3);
-
-            *(bp_offset2 + 8) = *(b_offset3 + 0);
-            *(bp_offset2 + 9) = *(b_offset4 + 0);
-            *(bp_offset2 + 10) = *(b_offset3 + 1);
-            *(bp_offset2 + 11) = *(b_offset4 + 1);
-            *(bp_offset2 + 12) = *(b_offset3 + 2);
-            *(bp_offset2 + 13) = *(b_offset4 + 2);
-            *(bp_offset2 + 14) = *(b_offset3 + 3);
-            *(bp_offset2 + 15) = *(b_offset4 + 3);
-
-            // same story here, if n is less than n_cap, we have to be careful with accessing b_offset8
-            *(bp_offset2 + 16) = *(b_offset5 + 0);
-            if (fastpath) {
-                *(bp_offset2 + 17) = *(b_offset6 + 0);
-                *(bp_offset2 + 18) = *(b_offset5 + 1);
-                *(bp_offset2 + 19) = *(b_offset6 + 1);
-                *(bp_offset2 + 20) = *(b_offset5 + 2);
-                *(bp_offset2 + 21) = *(b_offset6 + 2);
-                *(bp_offset2 + 22) = *(b_offset5 + 3);
-                *(bp_offset2 + 23) = *(b_offset6 + 3);
-            } else {
-                *(bp_offset2 + 17) = *(b_offset6 + 0);
-                *(bp_offset2 + 18) = *(b_offset5 + 1);
-                *(bp_offset2 + 19) = *(b_offset6 + 1);
-                *(bp_offset2 + 20) = *(b_offset5 + 2);
-                *(bp_offset2 + 21) = *(b_offset6 + 2);
-                *(bp_offset2 + 22) = *(b_offset5 + 3);
-                if (!k_skip || j > 1)
-                    *(bp_offset2 + 23)
-                            = *(b_offset6 + ((n_cap - n < 3) ? 3 : 0));
-            }
-            *(bp_offset2 + 24) = *(b_offset7 + 0);
-            if (fastpath) {
-                *(bp_offset2 + 25) = *(b_offset8 + 0);
-                *(bp_offset2 + 26) = *(b_offset7 + 1);
-                *(bp_offset2 + 27) = *(b_offset8 + 1);
-                *(bp_offset2 + 28) = *(b_offset7 + 2);
-                *(bp_offset2 + 29) = *(b_offset8 + 2);
-                *(bp_offset2 + 30) = *(b_offset7 + 3);
-                *(bp_offset2 + 31) = *(b_offset8 + 3);
-            } else {
-                if (!k_skip || j > 1) *(bp_offset2 + 25) = *(b_offset8 + 0);
-                *(bp_offset2 + 26) = *(b_offset7 + 1);
-                if (!k_skip || j > 1)
-                    *(bp_offset2 + 27)
-                            = *(b_offset8 + ((n_cap - n < 3) ? 1 : 0));
-
-                if (!k_skip || j > 1)
-                    *(bp_offset2 + 28)
-                            = *(b_offset7 + ((n_cap - n < 3) ? 2 : 0));
-
-                if (!k_skip || j > 1)
-                    *(bp_offset2 + 29)
-                            = *(b_offset8 + ((n_cap - n < 2) ? 2 : 0));
-
-                if (!k_skip || j > 1)
-                    *(bp_offset2 + 30)
-                            = *(b_offset7 + ((n_cap - n < 2) ? 3 : 0));
-
-                if (!k_skip || j > 1)
-                    *(bp_offset2 + 31)
-                            = *(b_offset8 + ((n_cap - n < 1) ? 3 : 0));
-            }
-
-            b_offset1 += 4;
-            b_offset2 += 4;
-            b_offset3 += 4;
-            b_offset4 += 4;
-            b_offset5 += 4;
-            b_offset6 += 4;
-            b_offset7 += 4;
-            b_offset8 += 4;
-            bp_offset2 += 32;
+	    *(vec_t *) &dst0145[0] = D0;
+	    *(vec_t *) &dst0145[8] = D1;
+	    *(vec_t *) &dst2367[0] = D2;
+	    *(vec_t *) &dst2367[8] = D3;
+	    *(vec_t *) &dst0145[16] = D4;
+	    *(vec_t *) &dst0145[24] = D5;
+	    *(vec_t *) &dst2367[16] = D6;
+	    *(vec_t *) &dst2367[24] = D7;
         }
+        for (j=n16; j<n8; j+=8) {
+            int columns_done = ((j & (~7)) >> 3) << 1;
+	    short *dst = &bp[8*(columns_done*krows + (i & (~1)))];
+            vec_t V0, V1, V2, V3;
+            vec_t D0, D1, D2, D3;
+            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
+            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
 
-        j--;
-    } // end of while (j)
+            V0 = *(vec_t *) &b[ldb*(i+0) + j];
+            V1 = *(vec_t *) &b[ldb*(i+1) + j];
+            V2 = *(vec_t *) &b[ldb*(i+2) + j];
+            V3 = *(vec_t *) &b[ldb*(i+3) + j];
+            D0 = vec_perm(V0, V1, swizL);
+            D1 = vec_perm(V0, V1, swizR);
+            D2 = vec_perm(V2, V3, swizL);
+            D3 = vec_perm(V2, V3, swizR);
 
-    if (k_cap & 4) {
-        k_skip = (k & 4) != (k_cap & 4);
-
-        b_offset1 = b_offset;
-        b_offset2 = b_offset1 + ldb;
-        b_offset3 = b_offset2 + ldb;
-        b_offset4 = b_offset3 + ldb;
-        b_offset += 4 * ldb;
-
-        bp_offset1 = bp_offset;
-        bp_offset += 32;
-
-        i = (n_cap >> 3);
-        // we need to be careful about not going past the end of the B array if n is less than n_cap.
-        // fortunately, we can only go out-of-bounds by accessing elements of b_offset4, so the others
-        // can just load garbage in the not_used elements of the vtemp vectors.
-        while (i) {
-            if (fastpath) {
-                vtemp01 = *(vec_i16 *)(b_offset1);
-                vtemp02 = *(vec_i16 *)(b_offset2);
-                vtemp03 = *(vec_i16 *)(b_offset3);
-                vtemp04 = *(vec_i16 *)(b_offset4);
-                *(vec_i16 *)(bp_offset1 + 0) = vec_mergeh(vtemp01, vtemp02);
-                *(vec_i16 *)(bp_offset1 + 8) = vec_mergel(vtemp01, vtemp02);
-                *(vec_i16 *)(bp_offset1 + 16) = vec_mergeh(vtemp03, vtemp04);
-                *(vec_i16 *)(bp_offset1 + 24) = vec_mergel(vtemp03, vtemp04);
-            } else {
-                *(bp_offset1 + 0) = *(b_offset1 + 0);
-                *(bp_offset1 + 1) = *(b_offset2 + 0);
-                *(bp_offset1 + 2) = *(b_offset1 + 1);
-                *(bp_offset1 + 3) = *(b_offset2 + 1);
-                *(bp_offset1 + 4) = *(b_offset1 + 2);
-                *(bp_offset1 + 5) = *(b_offset2 + 2);
-                *(bp_offset1 + 6) = *(b_offset1 + 3);
-                *(bp_offset1 + 7) = *(b_offset2 + 3);
-
-                *(bp_offset1 + 8) = *(b_offset1 + 4);
-                *(bp_offset1 + 9) = *(b_offset2 + 4);
-                *(bp_offset1 + 10) = *(b_offset1 + 5);
-                *(bp_offset1 + 11) = *(b_offset2 + 5);
-                *(bp_offset1 + 12) = *(b_offset1 + 6);
-                *(bp_offset1 + 13) = *(b_offset2 + 6);
-                *(bp_offset1 + 14) = *(b_offset1 + 7);
-                *(bp_offset1 + 15) = *(b_offset2 + 7);
-
-                *(bp_offset1 + 16) = *(b_offset3 + 0);
-                if (!k_skip) *(bp_offset1 + 17) = *(b_offset4 + 0);
-                *(bp_offset1 + 18) = *(b_offset3 + 1);
-                if (!k_skip) *(bp_offset1 + 19) = *(b_offset4 + 1);
-                *(bp_offset1 + 20) = *(b_offset3 + 2);
-                if (!k_skip) *(bp_offset1 + 21) = *(b_offset4 + 2);
-                *(bp_offset1 + 22) = *(b_offset3 + 3);
-                if (!k_skip) *(bp_offset1 + 23) = *(b_offset4 + 3);
-
-                *(bp_offset1 + 24) = *(b_offset3 + 4);
-                if (!k_skip) *(bp_offset1 + 25) = *(b_offset4 + 4);
-                *(bp_offset1 + 26) = *(b_offset3 + 5);
-                if (!k_skip)
-                    *(bp_offset1 + 27) = *(b_offset4
-                            + (((i > 1) || (n_cap & 4) || (n_cap - n < 3))
-                                            ? 5
-                                            : 0));
-                *(bp_offset1 + 28) = *(b_offset3 + 6);
-                if (!k_skip)
-                    *(bp_offset1 + 29) = *(b_offset4
-                            + (((i > 1) || (n_cap & 4) || (n_cap - n < 2))
-                                            ? 6
-                                            : 0));
-                *(bp_offset1 + 30) = *(b_offset3 + 7);
-                if (!k_skip)
-                    *(bp_offset1 + 31) = *(b_offset4
-                            + (((i > 1) || (n_cap & 4) || (n_cap - n < 1))
-                                            ? 7
-                                            : 0));
-            }
-
-            b_offset1 += 8;
-            b_offset2 += 8;
-            b_offset3 += 8;
-            b_offset4 += 8;
-            bp_offset1 += 8 * k_cap;
-            i--;
-        } // end of while (i)
-
-        if (n_cap & 4) {
-            *(bp_offset2 + 0) = *(b_offset1 + 0);
-            *(bp_offset2 + 1) = *(b_offset2 + 0);
-            *(bp_offset2 + 2) = *(b_offset1 + 1);
-            *(bp_offset2 + 3) = *(b_offset2 + 1);
-            *(bp_offset2 + 4) = *(b_offset1 + 2);
-            *(bp_offset2 + 5) = *(b_offset2 + 2);
-            *(bp_offset2 + 6) = *(b_offset1 + 3);
-            *(bp_offset2 + 7) = *(b_offset2 + 3);
-
-            if (fastpath) {
-                *(bp_offset2 + 8) = *(b_offset3 + 0);
-                *(bp_offset2 + 9) = *(b_offset4 + 0);
-                *(bp_offset2 + 10) = *(b_offset3 + 1);
-                *(bp_offset2 + 11) = *(b_offset4 + 1);
-                *(bp_offset2 + 12) = *(b_offset3 + 2);
-                *(bp_offset2 + 13) = *(b_offset4 + 2);
-                *(bp_offset2 + 14) = *(b_offset3 + 3);
-                *(bp_offset2 + 15) = *(b_offset4 + 3);
-            } else {
-                *(bp_offset2 + 8) = *(b_offset3 + 0);
-                if (!k_skip) *(bp_offset2 + 9) = *(b_offset4 + 0);
-                *(bp_offset2 + 10) = *(b_offset3 + 1);
-                if (!k_skip)
-                    *(bp_offset2 + 11)
-                            = *(b_offset4 + ((n_cap - n < 3) ? 1 : 0));
-                *(bp_offset2 + 12) = *(b_offset3 + 2);
-                if (!k_skip)
-                    *(bp_offset2 + 13)
-                            = *(b_offset4 + ((n_cap - n < 2) ? 2 : 0));
-                *(bp_offset2 + 14) = *(b_offset3 + 3);
-                if (!k_skip)
-                    *(bp_offset2 + 15)
-                            = *(b_offset4 + ((n_cap - n < 1) ? 3 : 0));
-            }
-            b_offset1 += 4;
-            b_offset2 += 4;
-            b_offset3 += 4;
-            b_offset4 += 4;
-            bp_offset2 += 16;
+	    *(vec_t *) &dst[0] = D0;
+	    *(vec_t *) &dst[8] = D1;
+	    *(vec_t *) &dst[16] = D2;
+	    *(vec_t *) &dst[24] = D3;
         }
     }
 
-    if (k_cap & 2) {
-        k_skip = (k & 2) != (k_cap & 2);
-
-        b_offset1 = b_offset;
-        b_offset2 = b_offset1 + ldb;
-        b_offset += 2 * ldb;
-
-        bp_offset1 = bp_offset;
-        bp_offset += 16;
-
-        i = (n_cap >> 3);
-        if (fastpath) {
-            while (i) {
-                vtemp01 = *(vec_i16 *)(b_offset1);
-                vtemp02 = *(vec_i16 *)(b_offset2);
-                *(vec_i16 *)(bp_offset1 + 0) = vec_mergeh(vtemp01, vtemp02);
-                *(vec_i16 *)(bp_offset1 + 8) = vec_mergel(vtemp01, vtemp02);
-
-                b_offset1 += 8;
-                b_offset2 += 8;
-                bp_offset1 += 8 * k_cap;
-                i--;
-            } // end of while (i)
-
-            if (n_cap & 4) {
-                *(bp_offset2 + 0) = *(b_offset1 + 0);
-                *(bp_offset2 + 1) = *(b_offset2 + 0);
-                *(bp_offset2 + 2) = *(b_offset1 + 1);
-                *(bp_offset2 + 3) = *(b_offset2 + 1);
-                *(bp_offset2 + 4) = *(b_offset1 + 2);
-                *(bp_offset2 + 5) = *(b_offset2 + 2);
-                *(bp_offset2 + 6) = *(b_offset1 + 3);
-                *(bp_offset2 + 7) = *(b_offset2 + 3);
-                b_offset1 += 4;
-                b_offset2 += 4;
-                bp_offset2 += 8;
-            }
-        } else {
-            // we need to be careful about not going past the end of the B array if n is less than n_cap.
-            // fortunately, we can only go out-of-bounds by accessing elements of b_offset2, so the others
-            // can just load garbage in the not_used elements of the vtemp vectors.
-            while (i) {
-                *(bp_offset1 + 0) = *(b_offset1 + 0);
-                if (!k_skip) *(bp_offset1 + 1) = *(b_offset2 + 0);
-                *(bp_offset1 + 2) = *(b_offset1 + 1);
-                if (!k_skip) *(bp_offset1 + 3) = *(b_offset2 + 1);
-                *(bp_offset1 + 4) = *(b_offset1 + 2);
-                if (!k_skip) *(bp_offset1 + 5) = *(b_offset2 + 2);
-                *(bp_offset1 + 6) = *(b_offset1 + 3);
-                if (!k_skip) *(bp_offset1 + 7) = *(b_offset2 + 3);
-
-                *(bp_offset1 + 8) = *(b_offset1 + 4);
-                if (!k_skip) *(bp_offset1 + 9) = *(b_offset2 + 4);
-                *(bp_offset1 + 10) = *(b_offset1 + 5);
-                if (!k_skip)
-                    *(bp_offset1 + 11) = *(b_offset2
-                            + ((i > 1) || (n_cap & 4) || ((n_cap - n < 3))
-                                            ? 5
-                                            : 0));
-                *(bp_offset1 + 12) = *(b_offset1 + 6);
-                if (!k_skip)
-                    *(bp_offset1 + 13) = *(b_offset2
-                            + ((i > 1) || (n_cap & 4) || ((n_cap - n < 2))
-                                            ? 6
-                                            : 0));
-                *(bp_offset1 + 14) = *(b_offset1 + 7);
-                if (!k_skip)
-                    *(bp_offset1 + 15) = *(b_offset2
-                            + ((i > 1) || (n_cap & 4) || ((n_cap - n < 1))
-                                            ? 7
-                                            : 0));
-
-                b_offset1 += 8;
-                b_offset2 += 8;
-                bp_offset1 += 8 * k_cap;
-                i--;
-            } // end of while (i)
-
-            if (n_cap & 4) {
-                *(bp_offset2 + 0) = *(b_offset1 + 0);
-                if (!k_skip) *(bp_offset2 + 1) = *(b_offset2 + 0);
-
-                *(bp_offset2 + 2) = *(b_offset1 + ((n_cap - n < 3) ? 1 : 0));
-                if (!k_skip)
-                    *(bp_offset2 + 3)
-                            = *(b_offset2 + ((n_cap - n < 3) ? 1 : 0));
-
-                *(bp_offset2 + 4) = *(b_offset1 + ((n_cap - n < 2) ? 2 : 0));
-                if (!k_skip)
-                    *(bp_offset2 + 5)
-                            = *(b_offset2 + ((n_cap - n < 2) ? 2 : 0));
-
-                *(bp_offset2 + 6) = *(b_offset1 + ((n_cap - n < 1) ? 3 : 0));
-                if (!k_skip)
-                    *(bp_offset2 + 7)
-                            = *(b_offset2 + ((n_cap - n < 1) ? 3 : 0));
-
-                b_offset1 += 4;
-                b_offset2 += 4;
-                bp_offset2 += 8;
-            }
+    // HIGH EDGE IN N DIRECTION
+    for (i=0; i<k4; ++i) {
+        for (j=n8; j<n_cap; ++j) {
+            kcell = i>>1;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&1;
+            noff = j&3;
+            if (j < n) bp[8*cell + 2*noff+koff] = b[ldb*i+j];
+	    else       bp[8*cell + 2*noff+koff] = 0;
         }
     }
 
+    // HIGH EDGE IN K DIRECTION
+    for (i=k4; i<k_cap; ++i) {
+        for (j=0; j<n8; ++j) {
+            kcell = i>>1;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&1;
+            noff = j&3;
+            if (i < k) bp[8*cell + 2*noff+koff] = b[ldb*i+j];
+	    else       bp[8*cell + 2*noff+koff] = 0;
+        }
+    }
+
+    // UPPER CORNER (HIGH N, HIGH K)
+    for (i=k4; i<k_cap; ++i) {
+        for (j=n8; j<n_cap; ++j) {
+            kcell = i>>1;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&1;
+            noff = j&3;
+            if (i < k && j < n) bp[8*cell + 2*noff+koff] = b[ldb*i+j];
+	    else                bp[8*cell + 2*noff+koff] = 0;
+        }
+    }
     return 0;
 }
 
 int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
-    int i, j, k_skip;
-    int fastpath;
-    short *b_offset;
-    short *b_offset1, *b_offset2, *b_offset3, *b_offset4;
-    short *b_offset5, *b_offset6, *b_offset7, *b_offset8;
-    short *bp_offset;
+    int i, j;
+    int kcell, cell, koff, noff, krows, k8, k16, n4, n8;
     int n_cap = (n + 3) & ~3;
     int k_cap = (k + 1) & ~1;
-    vec_i16 vtemp01, vtemp02, vtemp03, vtemp04;
-    vec_i16 vtemp05, vtemp06, vtemp07, vtemp08;
-    vec_i16 vtemp09, vtemp10, vtemp11, vtemp12;
-    vec_t mask = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23};
-    vec_t mask1
-            = {8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
-    fastpath = (((k & 1) == 0) && (n & 3) == 0);
+    krows = (k+1) >> 1;
+    k8 = (k>>3)<<3;
+    k16 = (k>>4)<<4;
+    n4 = (n>>2)<<2;
+    n8 = (n>>3)<<3;
 
-    b_offset = b;
-    bp_offset = bp;
+    // MAIN BLOCK
+    for (j=0; j<n8; j+=4) {
+        for (i=0; i<k16; i+=16) {
+            kcell = i>>1; // 0, 1, 2, 3
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int j_hiflag = (j & 4) >> 2;
+            koff = i&1;
+            noff = j&3;
+	    short *dst = &bp[8*(columns_done*krows + kcell*2 + j_hiflag)];
 
-    j = (n_cap >> 3);
-    while (j) {
-        b_offset1 = b_offset;
-        b_offset2 = b_offset1 + ldb;
-        b_offset3 = b_offset2 + ldb;
-        b_offset4 = b_offset3 + ldb;
-        b_offset5 = b_offset4 + ldb;
-        b_offset6 = b_offset5 + ldb;
-        b_offset7 = b_offset6 + ldb;
-        b_offset8 = b_offset7 + ldb;
-        b_offset += 8 * ldb;
+	    vec_t V0, V1, V2, V3, V4, V5, V6, V7;
+            vec_t D01A, D01B, D23A, D23B, D45A, D45B, D67A, D67B;
+            vec_t D0, D1, D2, D3, D4, D5, D6, D7;
+            vec_t swizA = { 0,  1,  2,  3, 16, 17, 18, 19,  4,  5,  6,  7, 20, 21, 22, 23};
+            vec_t swizB = { 8,  9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
+            vec_t swizL = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizR = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
 
-        i = (k_cap >> 3);
-        k_skip = ((k >> 3) != i);
-        int copy6 = (j != 1) || (n_cap & 4) || (n_cap - n < 3);
-        int copy7 = (j != 1) || (n_cap & 4) || (n_cap - n < 2);
-        int copy8 = (j != 1) || (n_cap & 4) || (n_cap - n < 1);
-        while (i) {
-            if (i == 1 && k_skip) {
-                short temp1[8], temp2[8], temp3[8], temp4[8], temp5[8],
-                        temp6[8], temp7[8], temp8[8];
-                memcpy_14(temp1, b_offset1);
-                memcpy_14(temp2, b_offset2);
-                memcpy_14(temp3, b_offset3);
-                memcpy_14(temp4, b_offset4);
-                memcpy_14(temp5, b_offset5);
-                short *s6, *s7, *s8;
-                s6 = copy6 ? b_offset6 : b_offset5;
-                s7 = copy7 ? b_offset7 : b_offset5;
-                s8 = copy8 ? b_offset8 : b_offset5;
-                memcpy_14(temp6, s6);
-                memcpy_14(temp7, s7);
-                memcpy_14(temp8, s8);
-                vtemp01 = *(vec_i16 *)(temp1);
-                vtemp02 = *(vec_i16 *)(temp2);
-                vtemp03 = *(vec_i16 *)(temp3);
-                vtemp04 = *(vec_i16 *)(temp4);
-                vtemp05 = *(vec_i16 *)(temp5);
-                vtemp06 = *(vec_i16 *)(temp6);
-                vtemp07 = *(vec_i16 *)(temp7);
-                vtemp08 = *(vec_i16 *)(temp8);
-            } else {
-                vtemp01 = *(vec_i16 *)(b_offset1);
-                vtemp02 = *(vec_i16 *)(b_offset2);
-                vtemp03 = *(vec_i16 *)(b_offset3);
-                vtemp04 = *(vec_i16 *)(b_offset4);
-                vtemp05 = *(vec_i16 *)(b_offset5);
-                if (fastpath) {
-                    vtemp06 = *(vec_i16 *)(b_offset6);
-                    vtemp07 = *(vec_i16 *)(b_offset7);
-                    vtemp08 = *(vec_i16 *)(b_offset8);
-                } else {
-                    vtemp06 = *(vec_i16 *)(copy6 ? b_offset6 : b_offset5);
-                    vtemp07 = *(vec_i16 *)(copy7 ? b_offset7 : b_offset5);
-                    vtemp08 = *(vec_i16 *)(copy8 ? b_offset8 : b_offset5);
-                }
-            }
+            V0 = *(vec_t *) &b[ldb*(j+0) + i];
+            V1 = *(vec_t *) &b[ldb*(j+1) + i];
+            V2 = *(vec_t *) &b[ldb*(j+2) + i];
+            V3 = *(vec_t *) &b[ldb*(j+3) + i];
+            V4 = *(vec_t *) &b[ldb*(j+0) + i + 8];
+            V5 = *(vec_t *) &b[ldb*(j+1) + i + 8];
+            V6 = *(vec_t *) &b[ldb*(j+2) + i + 8];
+            V7 = *(vec_t *) &b[ldb*(j+3) + i + 8];
 
-            vtemp09 = vec_perm(vtemp01, vtemp02, mask);
-            vtemp10 = vec_perm(vtemp03, vtemp04, mask);
-            vtemp11 = vec_perm(vtemp05, vtemp06, mask);
-            vtemp12 = vec_perm(vtemp07, vtemp08, mask);
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D45A = vec_perm(V4, V5, swizA);
+            D45B = vec_perm(V4, V5, swizB);
+            D67A = vec_perm(V6, V7, swizA);
+            D67B = vec_perm(V6, V7, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
+            D4 = vec_perm(D45A, D67A, swizL);
+            D5 = vec_perm(D45A, D67A, swizR);
+            D6 = vec_perm(D45B, D67B, swizL);
+            D7 = vec_perm(D45B, D67B, swizR);
 
-            *(vec_i16 *)(bp_offset + 0) = vec_xxpermdi(vtemp09, vtemp10, 0);
-            *(vec_i16 *)(bp_offset + 8) = vec_xxpermdi(vtemp11, vtemp12, 0);
-            *(vec_i16 *)(bp_offset + 16) = vec_xxpermdi(vtemp09, vtemp10, 3);
-            *(vec_i16 *)(bp_offset + 24) = vec_xxpermdi(vtemp11, vtemp12, 3);
-
-            vtemp09 = vec_perm(vtemp01, vtemp02, mask1);
-            vtemp10 = vec_perm(vtemp03, vtemp04, mask1);
-            vtemp11 = vec_perm(vtemp05, vtemp06, mask1);
-            vtemp12 = vec_perm(vtemp07, vtemp08, mask1);
-
-            *(vec_i16 *)(bp_offset + 32) = vec_xxpermdi(vtemp09, vtemp10, 0);
-            *(vec_i16 *)(bp_offset + 40) = vec_xxpermdi(vtemp11, vtemp12, 0);
-            *(vec_i16 *)(bp_offset + 48) = vec_xxpermdi(vtemp09, vtemp10, 3);
-            *(vec_i16 *)(bp_offset + 56) = vec_xxpermdi(vtemp11, vtemp12, 3);
-
-            if (i == 1 && k_skip) {
-                b_offset1 += 7;
-                b_offset2 += 7;
-                b_offset3 += 7;
-                b_offset4 += 7;
-                b_offset5 += 7;
-                b_offset6 += 7;
-                b_offset7 += 7;
-                b_offset8 += 7;
-            } else {
-                b_offset1 += 8;
-                b_offset2 += 8;
-                b_offset3 += 8;
-                b_offset4 += 8;
-                b_offset5 += 8;
-                b_offset6 += 8;
-                b_offset7 += 8;
-                b_offset8 += 8;
-            }
-            bp_offset += 64;
-            i--;
-        } // end of while (i)
-
-        if (k_skip) goto endloop;
-
-        i = (k & 7);
-        while (i > 1) {
-            *(bp_offset + 0) = *(b_offset1 + 0);
-            *(bp_offset + 1) = *(b_offset1 + 1);
-            *(bp_offset + 2) = *(b_offset2 + 0);
-            *(bp_offset + 3) = *(b_offset2 + 1);
-            *(bp_offset + 4) = *(b_offset3 + 0);
-            *(bp_offset + 5) = *(b_offset3 + 1);
-            *(bp_offset + 6) = *(b_offset4 + 0);
-            *(bp_offset + 7) = *(b_offset4 + 1);
-
-            *(bp_offset + 8) = *(b_offset5 + 0);
-            *(bp_offset + 9) = *(b_offset5 + 1);
-            if (fastpath) {
-                *(bp_offset + 10) = *(b_offset6 + 0);
-                *(bp_offset + 11) = *(b_offset6 + 1);
-                *(bp_offset + 12) = *(b_offset7 + 0);
-                *(bp_offset + 13) = *(b_offset7 + 1);
-                *(bp_offset + 14) = *(b_offset8 + 0);
-                *(bp_offset + 15) = *(b_offset8 + 1);
-            } else {
-                *(bp_offset + 10) = *((copy6 ? b_offset6 : b_offset5) + 0);
-                *(bp_offset + 11) = *((copy6 ? b_offset6 : b_offset5) + 1);
-                *(bp_offset + 12) = *((copy7 ? b_offset7 : b_offset5) + 0);
-                *(bp_offset + 13) = *((copy7 ? b_offset7 : b_offset5) + 1);
-                *(bp_offset + 14) = *((copy8 ? b_offset8 : b_offset5) + 0);
-                *(bp_offset + 15) = *((copy8 ? b_offset8 : b_offset5) + 1);
-            }
-
-            b_offset1 += 2;
-            b_offset2 += 2;
-            b_offset3 += 2;
-            b_offset4 += 2;
-            b_offset5 += 2;
-            b_offset6 += 2;
-            b_offset7 += 2;
-            b_offset8 += 2;
-            bp_offset += 16;
-            i -= 2;
-        } // end of while (i)
-        if (k < k_cap) {
-            *(bp_offset + 0) = *(b_offset1 + 0);
-            *(bp_offset + 2) = *(b_offset2 + 0);
-            *(bp_offset + 4) = *(b_offset3 + 0);
-            *(bp_offset + 6) = *(b_offset4 + 0);
-            *(bp_offset + 8) = *(b_offset5 + 0);
-            *(bp_offset + 10) = *((copy6 ? b_offset6 : b_offset5) + 0);
-            *(bp_offset + 12) = *((copy7 ? b_offset7 : b_offset5) + 0);
-            *(bp_offset + 14) = *((copy8 ? b_offset8 : b_offset5) + 0);
-
-            b_offset1++;
-            b_offset2++;
-            b_offset3++;
-            b_offset4++;
-            b_offset5++;
-            b_offset6++;
-            b_offset7++;
-            b_offset8++;
-            bp_offset += 16;
+            *(vec_t *) &dst[ 0] = D0;
+            *(vec_t *) &dst[16] = D1;
+            *(vec_t *) &dst[32] = D2;
+            *(vec_t *) &dst[48] = D3;
+            *(vec_t *) &dst[64] = D4;
+            *(vec_t *) &dst[80] = D5;
+            *(vec_t *) &dst[96] = D6;
+            *(vec_t *) &dst[112] = D7;
         }
+        for (i=k16; i<k8; i+=8) {
+            kcell = i>>1; // 0, 1, 2, 3
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int j_hiflag = (j & 4) >> 2;
+            koff = i&1;
+            noff = j&3;
+	    short *dst = &bp[8*(columns_done*krows + kcell*2 + j_hiflag)];
 
-    endloop:
-        j--;
-    } // end of while (j)
+	    vec_t V0, V1, V2, V3;
+            vec_t D01A, D01B, D23A, D23B;
+            vec_t D0, D1, D2, D3;
+            vec_t swizA = { 0,  1,  2,  3, 16, 17, 18, 19,  4,  5,  6,  7, 20, 21, 22, 23};
+            vec_t swizB = { 8,  9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
+            vec_t swizL = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizR = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
 
-    if (n_cap & 4) {
-        b_offset1 = b_offset;
-        b_offset2 = b_offset1 + ldb;
-        b_offset3 = b_offset2 + ldb;
-        b_offset4 = b_offset3 + ldb;
-        b_offset += 4 * ldb;
+            V0 = *(vec_t *) &b[ldb*(j+0) + i];
+            V1 = *(vec_t *) &b[ldb*(j+1) + i];
+            V2 = *(vec_t *) &b[ldb*(j+2) + i];
+            V3 = *(vec_t *) &b[ldb*(j+3) + i];
 
-        i = (k_cap >> 2);
-        k_skip = ((k >> 2) != i);
-        int copy2 = (n_cap - n < 3);
-        int copy3 = (n_cap - n < 2);
-        int copy4 = (n_cap - n < 1);
-        while (i) {
-            *(bp_offset + 0) = *(b_offset1 + 0);
-            *(bp_offset + 1) = *(b_offset1 + 1);
-            if (fastpath) {
-                *(bp_offset + 2) = *(b_offset2 + 0);
-                *(bp_offset + 3) = *(b_offset2 + 1);
-                *(bp_offset + 4) = *(b_offset3 + 0);
-                *(bp_offset + 5) = *(b_offset3 + 1);
-                *(bp_offset + 6) = *(b_offset4 + 0);
-                *(bp_offset + 7) = *(b_offset4 + 1);
-                *(bp_offset + 8) = *(b_offset1 + 2);
-                *(bp_offset + 9) = *(b_offset1 + 3);
-                *(bp_offset + 10) = *(b_offset2 + 2);
-                *(bp_offset + 11) = *(b_offset2 + 3);
-                *(bp_offset + 12) = *(b_offset3 + 2);
-                *(bp_offset + 13) = *(b_offset3 + 3);
-                *(bp_offset + 14) = *(b_offset4 + 2);
-                *(bp_offset + 15) = *(b_offset4 + 3);
-            } else {
-                *(bp_offset + 2) = *((copy2 ? b_offset2 : b_offset1) + 0);
-                *(bp_offset + 3) = *((copy2 ? b_offset2 : b_offset1) + 1);
-                *(bp_offset + 4) = *((copy3 ? b_offset3 : b_offset1) + 0);
-                *(bp_offset + 5) = *((copy3 ? b_offset3 : b_offset1) + 1);
-                *(bp_offset + 6) = *((copy4 ? b_offset4 : b_offset1) + 0);
-                *(bp_offset + 7) = *((copy4 ? b_offset4 : b_offset1) + 1);
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
 
-                *(bp_offset + 8) = *(b_offset1 + 2);
-                if ((i > 1) || (!k_skip)) *(bp_offset + 9) = *(b_offset1 + 3);
-                *(bp_offset + 10) = *((copy2 ? b_offset2 : b_offset1) + 2);
-                if ((i > 1) || (!k_skip))
-                    *(bp_offset + 11) = *((copy2 ? b_offset2 : b_offset1) + 3);
-                *(bp_offset + 12) = *((copy3 ? b_offset3 : b_offset1) + 2);
-                if ((i > 1) || (!k_skip))
-                    *(bp_offset + 13) = *((copy3 ? b_offset3 : b_offset1) + 3);
-                *(bp_offset + 14) = *((copy4 ? b_offset4 : b_offset1) + 2);
-                if ((i > 1) || (!k_skip))
-                    *(bp_offset + 15) = *((copy4 ? b_offset4 : b_offset1) + 3);
-            }
-
-            b_offset1 += 4;
-            b_offset2 += 4;
-            b_offset3 += 4;
-            b_offset4 += 4;
-            bp_offset += 16;
-            i--;
-        } // end of while (i)
-
-        if (k_skip) goto exit;
-
-        if (k & 2) {
-            *(bp_offset + 0) = *(b_offset1 + 0);
-            *(bp_offset + 1) = *(b_offset1 + 1);
-            if (fastpath) {
-                *(bp_offset + 2) = *(b_offset2 + 0);
-                *(bp_offset + 3) = *(b_offset2 + 1);
-                *(bp_offset + 4) = *(b_offset3 + 0);
-                *(bp_offset + 5) = *(b_offset3 + 1);
-                *(bp_offset + 6) = *(b_offset4 + 0);
-                *(bp_offset + 7) = *(b_offset4 + 1);
-            } else {
-                *(bp_offset + 2) = *((copy2 ? b_offset2 : b_offset1) + 0);
-                *(bp_offset + 3) = *((copy2 ? b_offset2 : b_offset1) + 1);
-                *(bp_offset + 4) = *((copy3 ? b_offset3 : b_offset1) + 0);
-                *(bp_offset + 5) = *((copy3 ? b_offset3 : b_offset1) + 1);
-                *(bp_offset + 6) = *((copy4 ? b_offset4 : b_offset1) + 0);
-                *(bp_offset + 7) = *((copy4 ? b_offset4 : b_offset1) + 1);
-            }
-
-            b_offset1 += 2;
-            b_offset2 += 2;
-            b_offset3 += 2;
-            b_offset4 += 2;
-            bp_offset += 8;
-        }
-
-        if (k & 1) {
-            *(bp_offset + 0) = *(b_offset1 + 0);
-            *(bp_offset + 2) = *((copy2 ? b_offset2 : b_offset1) + 0);
-            *(bp_offset + 4) = *((copy3 ? b_offset3 : b_offset1) + 0);
-            *(bp_offset + 6) = *((copy4 ? b_offset4 : b_offset1) + 0);
-            b_offset1++;
-            b_offset2++;
-            b_offset3++;
-            b_offset4++;
-            bp_offset += 8;
+            *(vec_t *) &dst[ 0] = D0;
+            *(vec_t *) &dst[16] = D1;
+            *(vec_t *) &dst[32] = D2;
+            *(vec_t *) &dst[48] = D3;
         }
     }
 
-exit:
+    for (j=n8; j<n4; ++j) {
+        for (i=0; i<k8; ++i) {
+            kcell = i>>1;
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&1;
+            noff = j&3;
+            bp[8*cell + 2*noff+koff] = b[ldb*j+i];
+        }
+    }
+
+    // HIGH EDGE IN N DIRECTION
+    for (j=n4; j<n_cap; ++j) {
+        for (i=0; i<k8; ++i) {
+            kcell = i>>1;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&1;
+            noff = j&3;
+            if (j < n) bp[8*cell + 2*noff+koff] = b[ldb*j+i];
+	    else       bp[8*cell + 2*noff+koff] = 0;
+        }
+    }
+
+    // HIGH EDGE IN K DIRECTION
+    for (j=0; j<n4; ++j) {
+        for (i=k8; i<k_cap; ++i) {
+            kcell = i>>1;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&1;
+            noff = j&3;
+            if (i < k) bp[8*cell + 2*noff+koff] = b[ldb*j+i];
+	    else       bp[8*cell + 2*noff+koff] = 0;
+        }
+    }
+
+    // UPPER CORNER (HIGH N, HIGH K)
+    for (j=n4; j<n_cap; ++j) {
+        for (i=k8; i<k_cap; ++i) {
+            kcell = i>>1;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&1;
+            noff = j&3;
+            if (j < n && i < k) bp[8*cell + 2*noff+koff] = b[ldb*j+i];
+	    else                bp[8*cell + 2*noff+koff] = 0;
+        }
+    }
     return 0;
 }
 
 int pack_T16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
     int i, j;
-    int fastpath;
-    const int8_t *a_offset;
-    const int8_t *a_off[4];
-    int8_t *ap_offset;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    vec_st vw0, vw1, vw2, vw3, vap[4];
-    vec_t swiz = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
-    a_offset = a;
-    ap_offset = ap;
-    fastpath = (((k & 3) == 0) && (m & 3) == 0);
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, m16, k4;
+    m16 = (m>>4)<<4;
+    k4 = (k>>2)<<2;
+    krows = (k+3) >> 2;
+    mrows = (m+3) >> 2;
+    block4 = 4 * krows;
+    block2 = 2 * krows;
 
-    j = (m_cap >> 4);
-    int m_skip = (j != (m >> 4));
-    while (j) {
-        a_off[0] = a_offset;
-        a_off[1] = a_off[0] + lda;
-        a_off[2] = a_off[1] + lda;
-        a_off[3] = a_off[2] + lda;
-        a_offset += 16;
+    // MAIN BLOCK
+    for (i=0; i<k4; i+=4) {
+        for (j=0; j<m16; j+=16) {
+            vec_t V0, V1, V2, V3;
+            vec_t D01A, D01B, D23A, D23B;
+            vec_t D0, D1, D2, D3;
+            vec_t swizA = { 0, 16,  1, 17,  2, 18,  3, 19,  4, 20,  5, 21,  6, 22,  7, 23};
+            vec_t swizB = { 8, 24,  9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31};
+            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
+            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
+	    int8_t *dest;
 
-        i = (k >> 2);
-        while (i) {
-            vw0 = vec_splat_s8((int8_t)0);
-            vw1 = vec_splat_s8((int8_t)0);
-            vw2 = vec_splat_s8((int8_t)0);
-            vw3 = vec_splat_s8((int8_t)0);
-            int *temp0, *temp1, *temp2, *temp3;
-            temp0 = (int *)&vw0;
-            temp1 = (int *)&vw1;
-            temp2 = (int *)&vw2;
-            temp3 = (int *)&vw3;
-            memcpy_4(&temp0[0], &a_off[0][0]);
-            memcpy_4(&temp0[1], &a_off[1][0]);
-            memcpy_4(&temp0[2], &a_off[2][0]);
-            memcpy_4(&temp0[3], &a_off[3][0]);
-            memcpy_4(&temp1[0], &a_off[0][4]);
-            memcpy_4(&temp1[1], &a_off[1][4]);
-            memcpy_4(&temp1[2], &a_off[2][4]);
-            memcpy_4(&temp1[3], &a_off[3][4]);
-            memcpy_4(&temp2[0], &a_off[0][8]);
-            memcpy_4(&temp2[1], &a_off[1][8]);
-            memcpy_4(&temp2[2], &a_off[2][8]);
-            memcpy_4(&temp2[3], &a_off[3][8]);
-            if (fastpath) {
-                memcpy_4(&temp3[0], &a_off[0][12]);
-                memcpy_4(&temp3[1], &a_off[1][12]);
-                memcpy_4(&temp3[2], &a_off[2][12]);
-                memcpy_4(&temp3[3], &a_off[3][12]);
-            } else {
-                int nbytes = ((j > 1) || (!m_skip)) ? 4 : 4 - (m_cap - m);
-                memcpy_n(&temp3[0], &a_off[0][12], nbytes);
-                memcpy_n(&temp3[1], &a_off[1][12], nbytes);
-                memcpy_n(&temp3[2], &a_off[2][12], nbytes);
-                memcpy_n(&temp3[3], &a_off[3][12], nbytes);
-            }
-            vap[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            vap[1] = vec_perm(vw1, vw1, swiz); // 4x4 transpose
-            vap[2] = vec_perm(vw2, vw2, swiz); // 4x4 transpose
-            vap[3] = vec_perm(vw3, vw3, swiz); // 4x4 transpose
-            memcpy_64(ap_offset, vap);
-            a_off[0] += 4 * lda;
-            a_off[1] += 4 * lda;
-            a_off[2] += 4 * lda;
-            a_off[3] += 4 * lda;
-            ap_offset += 64;
+	    V0 = *(vec_t *) &a[lda*(i+0) + j];
+	    V1 = *(vec_t *) &a[lda*(i+1) + j];
+	    V2 = *(vec_t *) &a[lda*(i+2) + j];
+	    V3 = *(vec_t *) &a[lda*(i+3) + j];
 
-            i--;
-        } // end of while (i)
+	    D01A = vec_perm(V0, V1, swizA);
+	    D01B = vec_perm(V0, V1, swizB);
+	    D23A = vec_perm(V2, V3, swizA);
+	    D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL); 
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
 
-        if (k < k_cap) {
-            int delk = k_cap - k;
-            int nbytes = ((j > 1) || (!m_skip)) ? 4 : 4 - (m_cap - m);
-            vw0 = vec_splat_s8((int8_t)0);
-            vw1 = vec_splat_s8((int8_t)0);
-            vw2 = vec_splat_s8((int8_t)0);
-            vw3 = vec_splat_s8((int8_t)0);
-            int *temp0, *temp1, *temp2, *temp3;
-            temp0 = (int *)&vw0;
-            temp1 = (int *)&vw1;
-            temp2 = (int *)&vw2;
-            temp3 = (int *)&vw3;
-            memcpy_4(&temp0[0], &a_off[0][0]);
-            memcpy_4(&temp1[0], &a_off[0][4]);
-            memcpy_4(&temp2[0], &a_off[0][8]);
-            memcpy_n(&temp3[0], &a_off[0][12], nbytes);
-            if (delk < 3) {
-                memcpy_4(&temp0[1], &a_off[1][0]);
-                memcpy_4(&temp1[1], &a_off[1][4]);
-                memcpy_4(&temp2[1], &a_off[1][8]);
-                memcpy_n(&temp3[1], &a_off[1][12], nbytes);
-            }
-            if (delk < 2) {
-                memcpy_4(&temp0[2], &a_off[2][0]);
-                memcpy_4(&temp1[2], &a_off[2][4]);
-                memcpy_4(&temp2[2], &a_off[2][8]);
-                memcpy_n(&temp3[2], &a_off[2][12], nbytes);
-            }
-            if (delk < 1) {
-                memcpy_4(&temp0[3], &a_off[3][0]);
-                memcpy_4(&temp1[3], &a_off[3][4]);
-                memcpy_4(&temp2[3], &a_off[3][8]);
-                memcpy_n(&temp3[3], &a_off[3][12], nbytes);
-            }
-            vap[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            vap[1] = vec_perm(vw1, vw1, swiz); // 4x4 transpose
-            vap[2] = vec_perm(vw2, vw2, swiz); // 4x4 transpose
-            vap[3] = vec_perm(vw3, vw3, swiz); // 4x4 transpose
-            memcpy_64(ap_offset, vap);
-            a_off[0] += 4 * lda;
-            a_off[1] += 4 * lda;
-            a_off[2] += 4 * lda;
-            a_off[3] += 4 * lda;
-            ap_offset += 64;
-        }
+            dest = &ap[16 * (((j>>4) * block4) + i)];
 
-        j--;
-    } // end of while (j)
-
-    if (m_cap & 8) {
-        m_skip = (m & 8) != (m_cap & 8);
-        a_off[0] = a_offset;
-        a_off[1] = a_off[0] + lda;
-        a_off[2] = a_off[1] + lda;
-        a_off[3] = a_off[2] + lda;
-        a_offset += 8;
-
-        i = (k >> 2);
-        while (i) {
-            vw0 = vec_splat_s8((int8_t)0);
-            vw1 = vec_splat_s8((int8_t)0);
-            int *temp0, *temp1;
-            temp0 = (int *)&vw0;
-            temp1 = (int *)&vw1;
-            memcpy_4(&temp0[0], &a_off[0][0]);
-            memcpy_4(&temp0[1], &a_off[1][0]);
-            memcpy_4(&temp0[2], &a_off[2][0]);
-            memcpy_4(&temp0[3], &a_off[3][0]);
-            if (fastpath) {
-                memcpy_4(&temp1[0], &a_off[0][4]);
-                memcpy_4(&temp1[1], &a_off[1][4]);
-                memcpy_4(&temp1[2], &a_off[2][4]);
-                memcpy_4(&temp1[3], &a_off[3][4]);
-            } else {
-                int nbytes = (!m_skip) ? 4 : 4 - (m_cap - m);
-                memcpy_n(&temp1[0], &a_off[0][4], nbytes);
-                memcpy_n(&temp1[1], &a_off[1][4], nbytes);
-                memcpy_n(&temp1[2], &a_off[2][4], nbytes);
-                memcpy_n(&temp1[3], &a_off[3][4], nbytes);
-            }
-            vap[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            vap[1] = vec_perm(vw1, vw1, swiz); // 4x4 transpose
-            memcpy_32(ap_offset, vap);
-            a_off[0] += 4 * lda;
-            a_off[1] += 4 * lda;
-            a_off[2] += 4 * lda;
-            a_off[3] += 4 * lda;
-            ap_offset += 32;
-            i--;
-        } // end of while (i)
-
-        if (k < k_cap) {
-            int delk = k_cap - k;
-            int nbytes = (!m_skip) ? 4 : 4 - (m_cap - m);
-            vw0 = vec_splat_s8((int8_t)0);
-            vw1 = vec_splat_s8((int8_t)0);
-            int *temp0, *temp1;
-            temp0 = (int *)&vw0;
-            temp1 = (int *)&vw1;
-            memcpy_4(&temp0[0], &a_off[0][0]);
-            memcpy_n(&temp1[0], &a_off[0][4], nbytes);
-            if (delk < 3) {
-                memcpy_4(&temp0[1], &a_off[1][0]);
-                memcpy_n(&temp1[1], &a_off[1][4], nbytes);
-            }
-            if (delk < 2) {
-                memcpy_4(&temp0[2], &a_off[2][0]);
-                memcpy_n(&temp1[2], &a_off[2][4], nbytes);
-            }
-            if (delk < 1) {
-                memcpy_4(&temp0[3], &a_off[3][0]);
-                memcpy_n(&temp1[3], &a_off[3][4], nbytes);
-            }
-            vap[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            vap[1] = vec_perm(vw1, vw1, swiz); // 4x4 transpose
-            memcpy_32(ap_offset, vap);
-            a_off[0] += 4 * lda;
-            a_off[1] += 4 * lda;
-            a_off[2] += 4 * lda;
-            a_off[3] += 4 * lda;
-            ap_offset += 32;
+	    *(vec_t *) &dest[ 0] = D0;
+	    *(vec_t *) &dest[16] = D1;
+	    *(vec_t *) &dest[32] = D2;
+	    *(vec_t *) &dest[48] = D3;
         }
     }
 
-    if (m_cap & 4) {
-        m_skip = (m & 4) != (m_cap & 4);
-        a_off[0] = a_offset;
-        a_off[1] = a_off[0] + lda;
-        a_off[2] = a_off[1] + lda;
-        a_off[3] = a_off[2] + lda;
-        a_offset += 4;
-
-        i = (k >> 2);
-        while (i) {
-            vw0 = vec_splat_s8((int8_t)0);
-            int *temp0;
-            temp0 = (int *)&vw0;
-            if (fastpath) {
-                memcpy_4(&temp0[0], &a_off[0][0]);
-                memcpy_4(&temp0[1], &a_off[1][0]);
-                memcpy_4(&temp0[2], &a_off[2][0]);
-                memcpy_4(&temp0[3], &a_off[3][0]);
-            } else {
-                int nbytes = (!m_skip) ? 4 : 4 - (m_cap - m);
-                memcpy_n(&temp0[0], &a_off[0][0], nbytes);
-                memcpy_n(&temp0[1], &a_off[1][0], nbytes);
-                memcpy_n(&temp0[2], &a_off[2][0], nbytes);
-                memcpy_n(&temp0[3], &a_off[3][0], nbytes);
+    // HIGH EDGE IN M DIRECTION
+    for (i=0; i<k4; ++i) {
+        for (j=m16; j<m_cap; ++j) {
+            kcell = i>>2;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = chunk4count * block4;
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
             }
-            vap[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            memcpy_16(ap_offset, vap);
-            a_off[0] += 4 * lda;
-            a_off[1] += 4 * lda;
-            a_off[2] += 4 * lda;
-            a_off[3] += 4 * lda;
-            ap_offset += 16;
-
-            i--;
-        } // end of while (i)
-
-        if (k < k_cap) {
-            int delk = k_cap - k;
-            int nbytes = (!m_skip) ? 4 : 4 - (m_cap - m);
-            vw0 = vec_splat_s8((int8_t)0);
-            int *temp0;
-            temp0 = (int *)&vw0;
-            memcpy_n(&temp0[0], &a_off[0][0], nbytes);
-            if (delk < 3) memcpy_n(&temp0[1], &a_off[1][0], nbytes);
-            if (delk < 2) memcpy_n(&temp0[2], &a_off[2][0], nbytes);
-            if (delk < 1) memcpy_n(&temp0[3], &a_off[3][0], nbytes);
-            vap[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            memcpy_16(ap_offset, vap);
-            a_off[0] += 4 * lda;
-            a_off[1] += 4 * lda;
-            a_off[2] += 4 * lda;
-            a_off[3] += 4 * lda;
-            ap_offset += 16;
+            koff = i&3;
+            moff = j&3;
+            if (j < m) ap[16*cell + 4*moff+koff] = a[lda*i+j];
+	    else       ap[16*cell + 4*moff+koff] = 0;
         }
     }
+
+    // HIGH EDGE IN K DIRECTION
+    for (i=k4; i<k_cap; ++i) {
+        for (j=0; j<m16; ++j) {
+            kcell = i>>2;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = chunk4count * block4;
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&3;
+            moff = j&3;
+            if (i < k) ap[16*cell + 4*moff+koff] = a[lda*i+j];
+	    else       ap[16*cell + 4*moff+koff] = 0;
+        }
+    }
+
+    // UPPER CORNER (HIGH M, HIGH K)
+    for (i=k4; i<k_cap; ++i) {
+        for (j=m16; j<m_cap; ++j) {
+            kcell = i>>2;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = chunk4count * block4;
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&3;
+            moff = j&3;
+            if (i < k && j < m) ap[16*cell + 4*moff+koff] = a[lda*i+j];
+	    else                ap[16*cell + 4*moff+koff] = 0;
+        }
+    }
+
     return 0;
 }
 
 int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
     int i, j;
-    int fastpath;
-    const uint8_t *b_offset;
-    const uint8_t *b_off[8];
-    uint8_t *bp_offset;
+    int kcell, cell, koff, noff, krows, k8, n8;
     int n_cap = (n + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    fastpath = (((k & 3) == 0) && (n & 3) == 0);
+    krows = (k+3) >> 2;
+    k8 = k>>3;
+    n8 = n>>3;
 
-    b_offset = b;
-    bp_offset = bp;
+    // MAIN BLOCK
+    for (j=0; j<(n8<<3); j+=8) {
+        for (i=0; i<(k8<<3); i+=8) {
+            vec_t V0, V1, V2, V3;
+            vec_t D0, D1, D2, D3;
+            vec_t swizA = {  0,  1,  2,  3,  8,  9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27};
+            vec_t swizB = {  4,  5,  6,  7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31};
+	    const uint8_t *src = &b[ldb*j+i];
+	    uint8_t *dest = &bp[16 * (krows * (j >> 2) + (i >> 1))];
 
-    j = (n_cap >> 3);
-    int n_skip = (j != (n >> 3));
-    while (j) {
-        b_off[0] = b_offset;
-        b_off[1] = b_off[0] + ldb;
-        b_off[2] = b_off[1] + ldb;
-        b_off[3] = b_off[2] + ldb;
-        b_off[4] = b_off[3] + ldb;
-        b_off[5] = b_off[4] + ldb;
-        b_off[6] = b_off[5] + ldb;
-        b_off[7] = b_off[6] + ldb;
-        b_offset += 8 * ldb;
+	    *(signed long long *) &V0[0] = *(signed long long *) &src[ldb*0];
+	    *(signed long long *) &V0[8] = *(signed long long *) &src[ldb*1];
+	    *(signed long long *) &V1[0] = *(signed long long *) &src[ldb*2];
+	    *(signed long long *) &V1[8] = *(signed long long *) &src[ldb*3];
+	    *(signed long long *) &V2[0] = *(signed long long *) &src[ldb*4];
+	    *(signed long long *) &V2[8] = *(signed long long *) &src[ldb*5];
+	    *(signed long long *) &V3[0] = *(signed long long *) &src[ldb*6];
+	    *(signed long long *) &V3[8] = *(signed long long *) &src[ldb*7];
 
-        i = (k >> 2);
-        while (i) {
-            int *temp = (int *)bp_offset;
-            temp[5] = temp[6] = temp[7] = 0;
-            memcpy_4(&bp_offset[0], b_off[0]);
-            memcpy_4(&bp_offset[4], b_off[1]);
-            memcpy_4(&bp_offset[8], b_off[2]);
-            memcpy_4(&bp_offset[12], b_off[3]);
-            memcpy_4(&bp_offset[16], b_off[4]);
-            if (fastpath) {
-                memcpy_4(&bp_offset[20], b_off[5]);
-                memcpy_4(&bp_offset[24], b_off[6]);
-                memcpy_4(&bp_offset[28], b_off[7]);
-            } else {
-                if ((j > 1) || (!n_skip) || (n_cap - n < 3))
-                    memcpy_4(&bp_offset[20], b_off[5]);
-                if ((j > 1) || (!n_skip) || (n_cap - n < 2))
-                    memcpy_4(&bp_offset[24], b_off[6]);
-                if ((j > 1) || (!n_skip) || (n_cap - n < 1))
-                    memcpy_4(&bp_offset[28], b_off[7]);
-            }
-            b_off[0] += 4;
-            b_off[1] += 4;
-            b_off[2] += 4;
-            b_off[3] += 4;
-            b_off[4] += 4;
-            b_off[5] += 4;
-            b_off[6] += 4;
-            b_off[7] += 4;
-            bp_offset += 32;
-            i--;
-        } // end of while (i)
+            D0 = vec_perm(V0, V1, swizA); 
+            D1 = vec_perm(V2, V3, swizA);
+            D2 = vec_perm(V0, V1, swizB);
+            D3 = vec_perm(V2, V3, swizB);
 
-        if (k < k_cap) {
-            int delk, ii;
-            delk = 4 - (k_cap - k);
-            for (ii = 0; ii < delk; ++ii)
-                *(bp_offset + 0 + ii) = *(b_off[0] + ii);
-            for (ii = 0; ii < delk; ++ii)
-                *(bp_offset + 4 + ii) = *(b_off[1] + ii);
-            for (ii = 0; ii < delk; ++ii)
-                *(bp_offset + 8 + ii) = *(b_off[2] + ii);
-            for (ii = 0; ii < delk; ++ii)
-                *(bp_offset + 12 + ii) = *(b_off[3] + ii);
-            for (ii = 0; ii < delk; ++ii)
-                *(bp_offset + 16 + ii) = *(b_off[4] + ii);
-            if ((j > 1) || (!n_skip) || (n_cap - n < 3))
-                for (ii = 0; ii < delk; ++ii)
-                    *(bp_offset + 20 + ii) = *(b_off[5] + ii);
-            if ((j > 1) || (!n_skip) || (n_cap - n < 2))
-                for (ii = 0; ii < delk; ++ii)
-                    *(bp_offset + 24 + ii) = *(b_off[6] + ii);
-            if ((j > 1) || (!n_skip) || (n_cap - n < 1))
-                for (ii = 0; ii < delk; ++ii)
-                    *(bp_offset + 28 + ii) = *(b_off[7] + ii);
-
-            for (ii = delk; ii < 4; ++ii)
-                *(bp_offset + 0 + ii) = 0;
-            for (ii = delk; ii < 4; ++ii)
-                *(bp_offset + 4 + ii) = 0;
-            for (ii = delk; ii < 4; ++ii)
-                *(bp_offset + 8 + ii) = 0;
-            for (ii = delk; ii < 4; ++ii)
-                *(bp_offset + 12 + ii) = 0;
-            for (ii = delk; ii < 4; ++ii)
-                *(bp_offset + 16 + ii) = 0;
-            if ((j > 1) || (!n_skip) || (n_cap - n < 3))
-                for (ii = delk; ii < 4; ++ii)
-                    *(bp_offset + 20 + ii) = 0;
-            if ((j > 1) || (!n_skip) || (n_cap - n < 2))
-                for (ii = delk; ii < 4; ++ii)
-                    *(bp_offset + 24 + ii) = 0;
-            if ((j > 1) || (!n_skip) || (n_cap - n < 1))
-                for (ii = delk; ii < 4; ++ii)
-                    *(bp_offset + 28 + ii) = 0;
-            bp_offset += 32;
+	    *(vec_t *) &dest[ 0] = D0;
+	    *(vec_t *) &dest[16] = D1;
+	    *(vec_t *) &dest[32] = D2;
+	    *(vec_t *) &dest[48] = D3;
         }
+    }
 
-        j--;
-    } // end of while (j)
+    // HIGH EDGE IN N DIRECTION
+    for (j=(n8<<3); j<n_cap; ++j) {
+        for (i=0; i<(k8<<3); ++i) {
+            kcell = i>>2;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&3;
+            noff = j&3;
+            if (j < n) bp[16*cell + 4*noff+koff] = b[ldb*j+i];
+	    else       bp[16*cell + 4*noff+koff] = 0;
+        }
+    }
 
-    if (n_cap & 4) {
-        b_off[0] = b_offset;
-        b_off[1] = b_off[0] + ldb;
-        b_off[2] = b_off[1] + ldb;
-        b_off[3] = b_off[2] + ldb;
+    // HIGH EDGE IN K DIRECTION
+    for (j=0; j<(n8<<3); ++j) {
+        for (i=(k8<<3); i<k_cap; ++i) {
+            kcell = i>>2;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&3;
+            noff = j&3;
+            if (i < k) bp[16*cell + 4*noff+koff] = b[ldb*j+i];
+	    else       bp[16*cell + 4*noff+koff] = 0;
+        }
+    }
 
-        i = (k_cap >> 2);
-        if (fastpath) {
-            while (i) {
-                *(bp_offset + 0) = *(b_off[0] + 0);
-                *(bp_offset + 1) = *(b_off[0] + 1);
-                *(bp_offset + 2) = *(b_off[0] + 2);
-                *(bp_offset + 3) = *(b_off[0] + 3);
-                *(bp_offset + 4) = *(b_off[1] + 0);
-                *(bp_offset + 5) = *(b_off[1] + 1);
-                *(bp_offset + 6) = *(b_off[1] + 2);
-                *(bp_offset + 7) = *(b_off[1] + 3);
-                *(bp_offset + 8) = *(b_off[2] + 0);
-                *(bp_offset + 9) = *(b_off[2] + 1);
-                *(bp_offset + 10) = *(b_off[2] + 2);
-                *(bp_offset + 11) = *(b_off[2] + 3);
-                *(bp_offset + 12) = *(b_off[3] + 0);
-                *(bp_offset + 13) = *(b_off[3] + 1);
-                *(bp_offset + 14) = *(b_off[3] + 2);
-                *(bp_offset + 15) = *(b_off[3] + 3);
-                b_off[0] += 4;
-                b_off[1] += 4;
-                b_off[2] += 4;
-                b_off[3] += 4;
-                bp_offset += 16;
-                i--;
-            } // end of while (i)
-        } else {
-            int ncopy1 = (n_cap - n < 3);
-            int ncopy2 = (n_cap - n < 2);
-            int ncopy3 = (n_cap - n < 1);
-            while (i > 1) {
-                *(bp_offset + 0) = *(b_off[0] + 0);
-                *(bp_offset + 1) = *(b_off[0] + 1);
-                *(bp_offset + 2) = *(b_off[0] + 2);
-                *(bp_offset + 3) = *(b_off[0] + 3);
-                *(bp_offset + 4) = ncopy1 ? *(b_off[1] + 0) : 0;
-                *(bp_offset + 5) = ncopy1 ? *(b_off[1] + 1) : 0;
-                *(bp_offset + 6) = ncopy1 ? *(b_off[1] + 2) : 0;
-                *(bp_offset + 7) = ncopy1 ? *(b_off[1] + 3) : 0;
-                *(bp_offset + 8) = ncopy2 ? *(b_off[2] + 0) : 0;
-                *(bp_offset + 9) = ncopy2 ? *(b_off[2] + 1) : 0;
-                *(bp_offset + 10) = ncopy2 ? *(b_off[2] + 2) : 0;
-                *(bp_offset + 11) = ncopy2 ? *(b_off[2] + 3) : 0;
-                *(bp_offset + 12) = ncopy3 ? *(b_off[3] + 0) : 0;
-                *(bp_offset + 13) = ncopy3 ? *(b_off[3] + 1) : 0;
-                *(bp_offset + 14) = ncopy3 ? *(b_off[3] + 2) : 0;
-                *(bp_offset + 15) = ncopy3 ? *(b_off[3] + 3) : 0;
-                b_off[0] += 4;
-                b_off[1] += 4;
-                b_off[2] += 4;
-                b_off[3] += 4;
-                bp_offset += 16;
-                i--;
-            } // end of while (i>1)
-
-            int kcopy1 = (k_cap - k < 3);
-            int kcopy2 = (k_cap - k < 2);
-            int kcopy3 = (k_cap - k < 1);
-
-            *(bp_offset + 0) = *(b_off[0] + 0);
-            *(bp_offset + 1) = (kcopy1) ? *(b_off[0] + 1) : 0;
-            *(bp_offset + 2) = (kcopy2) ? *(b_off[0] + 2) : 0;
-            *(bp_offset + 3) = (kcopy3) ? *(b_off[0] + 3) : 0;
-            *(bp_offset + 4) = (ncopy1) ? *(b_off[1] + 0) : 0;
-            *(bp_offset + 5) = (kcopy1 && ncopy1) ? *(b_off[1] + 1) : 0;
-            *(bp_offset + 6) = (kcopy2 && ncopy1) ? *(b_off[1] + 2) : 0;
-            *(bp_offset + 7) = (kcopy3 && ncopy1) ? *(b_off[1] + 3) : 0;
-            *(bp_offset + 8) = (ncopy2) ? *(b_off[2] + 0) : 0;
-            *(bp_offset + 9) = (kcopy1 && ncopy2) ? *(b_off[2] + 1) : 0;
-            *(bp_offset + 10) = (kcopy2 && ncopy2) ? *(b_off[2] + 2) : 0;
-            *(bp_offset + 11) = (kcopy3 && ncopy2) ? *(b_off[2] + 3) : 0;
-            *(bp_offset + 12) = (ncopy3) ? *(b_off[3] + 0) : 0;
-            *(bp_offset + 13) = (kcopy1 && ncopy3) ? *(b_off[3] + 1) : 0;
-            *(bp_offset + 14) = (kcopy2 && ncopy3) ? *(b_off[3] + 2) : 0;
-            *(bp_offset + 15) = (kcopy3 && ncopy3) ? *(b_off[3] + 3) : 0;
+    // UPPER CORNER (HIGH N, HIGH K)
+    for (j=(n8<<3); j<n_cap; ++j) {
+        for (i=(k8<<3); i<k_cap; ++i) {
+            kcell = i>>2;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&3;
+            noff = j&3;
+            if (j < n && i < k) bp[16*cell + 4*noff+koff] = b[ldb*j+i];
+	    else                bp[16*cell + 4*noff+koff] = 0;
         }
     }
 
@@ -1729,399 +957,318 @@ int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
 }
 
 int pack_N16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
-    int i, j, ii;
-    int fastpath;
-    const int8_t *a_offset, *a_off[16];
-    int8_t *ap_offset;
+    int i, j;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    a_offset = a;
-    ap_offset = ap;
-    fastpath = (((k & 3) == 0) && (m & 3) == 0);
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, m16, k4, k16;
+    m16 = (m>>4)<<4;
+    k4 = (k>>2)<<2;
+    k16 = (k>>4)<<4;
+    krows = (k+3) >> 2;
+    mrows = (m+3) >> 2;
+    block4 = 4 * krows;
+    block2 = 2 * krows;
 
-    j = (m_cap >> 4);
-    int m_skip = (j != (m >> 4));
-    while (j) {
-        for (ii = 0; ii < 16; ++ii)
-            a_off[ii] = a_offset + ii * lda;
-        a_offset += 16 * lda;
-        i = (k >> 2);
-        while (i) {
-            int *temp = (int *)ap_offset;
-            temp[13] = temp[14] = temp[15] = 0;
-            memcpy_4(&ap_offset[0], a_off[0]);
-            memcpy_4(&ap_offset[4], a_off[1]);
-            memcpy_4(&ap_offset[8], a_off[2]);
-            memcpy_4(&ap_offset[12], a_off[3]);
-            memcpy_4(&ap_offset[16], a_off[4]);
-            memcpy_4(&ap_offset[20], a_off[5]);
-            memcpy_4(&ap_offset[24], a_off[6]);
-            memcpy_4(&ap_offset[28], a_off[7]);
-            memcpy_4(&ap_offset[32], a_off[8]);
-            memcpy_4(&ap_offset[36], a_off[9]);
-            memcpy_4(&ap_offset[40], a_off[10]);
-            memcpy_4(&ap_offset[44], a_off[11]);
-            memcpy_4(&ap_offset[48], a_off[12]);
-            if (fastpath) {
-                memcpy_4(&ap_offset[52], a_off[13]);
-                memcpy_4(&ap_offset[56], a_off[14]);
-                memcpy_4(&ap_offset[60], a_off[15]);
-            } else {
-                if ((j > 1) || (!m_skip) || (m_cap - m < 3))
-                    memcpy_4(&ap_offset[52], a_off[13]);
-                if ((j > 1) || (!m_skip) || (m_cap - m < 2))
-                    memcpy_4(&ap_offset[56], a_off[14]);
-                if ((j > 1) || (!m_skip) || (m_cap - m < 1))
-                    memcpy_4(&ap_offset[60], a_off[15]);
-            }
-            for (ii = 0; ii < 16; ++ii)
-                a_off[ii] += 4;
-            ap_offset += 64;
-            i--;
-        } // end of while (i)
+    // MAIN BLOCK
+    for (j=0; j<m16; j+=16) {
+        for (i=0; i<k16; i+=16) {
+            vec_t V0, V1, V2, V3;
+            vec_t D01A, D01B, D23A, D23B;
+            vec_t D0, D1, D2, D3;
+            vec_t swizA = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizB = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
+            vec_t swizL = { 0,  1,  2,  3,  8,  9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27};
+            vec_t swizR = { 4,  5,  6,  7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31};
 
-        if (k < k_cap) {
-            int *temp = (int *)ap_offset;
-            for (int ii = 0; ii < 16; ++ii)
-                temp[ii] = 0;
-            int delk = 4 - (k_cap - k);
-            memcpy_n(&ap_offset[0], a_off[0], delk);
-            memcpy_n(&ap_offset[4], a_off[1], delk);
-            memcpy_n(&ap_offset[8], a_off[2], delk);
-            memcpy_n(&ap_offset[12], a_off[3], delk);
-            memcpy_n(&ap_offset[16], a_off[4], delk);
-            memcpy_n(&ap_offset[20], a_off[5], delk);
-            memcpy_n(&ap_offset[24], a_off[6], delk);
-            memcpy_n(&ap_offset[28], a_off[7], delk);
-            memcpy_n(&ap_offset[32], a_off[8], delk);
-            memcpy_n(&ap_offset[36], a_off[9], delk);
-            memcpy_n(&ap_offset[40], a_off[10], delk);
-            memcpy_n(&ap_offset[44], a_off[11], delk);
-            memcpy_n(&ap_offset[48], a_off[12], delk);
-            if ((j != 1) || (!m_skip) || (m_cap - m < 3))
-                memcpy_n(&ap_offset[52], a_off[13], delk);
-            if ((j != 1) || (!m_skip) || (m_cap - m < 2))
-                memcpy_n(&ap_offset[56], a_off[14], delk);
-            if ((j != 1) || (!m_skip) || (m_cap - m < 1))
-                memcpy_n(&ap_offset[60], a_off[15], delk);
-            ap_offset += 64;
+	    const int8_t *src = &a[lda*j+i];
+	    int8_t *dest = &ap[j * (krows << 2) + (i << 4)];
+
+            V0 = *(vec_t *) &src[0 * lda];
+            V1 = *(vec_t *) &src[1 * lda];
+            V2 = *(vec_t *) &src[2 * lda];
+            V3 = *(vec_t *) &src[3 * lda];
+	    D01A = vec_perm(V0, V1, swizA);
+	    D01B = vec_perm(V0, V1, swizB);
+	    D23A = vec_perm(V2, V3, swizA);
+	    D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL); 
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
+            *(vec_t *) &dest[  0] = D0;
+            *(vec_t *) &dest[ 64] = D1;
+            *(vec_t *) &dest[128] = D2;
+            *(vec_t *) &dest[192] = D3;
+
+            V0 = *(vec_t *) &src[4 * lda];
+            V1 = *(vec_t *) &src[5 * lda];
+            V2 = *(vec_t *) &src[6 * lda];
+            V3 = *(vec_t *) &src[7 * lda];
+	    D01A = vec_perm(V0, V1, swizA);
+	    D01B = vec_perm(V0, V1, swizB);
+	    D23A = vec_perm(V2, V3, swizA);
+	    D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL); 
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
+            *(vec_t *) &dest[ 16] = D0;
+            *(vec_t *) &dest[ 80] = D1;
+            *(vec_t *) &dest[144] = D2;
+            *(vec_t *) &dest[208] = D3;
+
+            V0 = *(vec_t *) &src[ 8 * lda];
+            V1 = *(vec_t *) &src[ 9 * lda];
+            V2 = *(vec_t *) &src[10 * lda];
+            V3 = *(vec_t *) &src[11 * lda];
+	    D01A = vec_perm(V0, V1, swizA);
+	    D01B = vec_perm(V0, V1, swizB);
+	    D23A = vec_perm(V2, V3, swizA);
+	    D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL); 
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
+            *(vec_t *) &dest[ 32] = D0;
+            *(vec_t *) &dest[ 96] = D1;
+            *(vec_t *) &dest[160] = D2;
+            *(vec_t *) &dest[224] = D3;
+
+            V0 = *(vec_t *) &src[12 * lda];
+            V1 = *(vec_t *) &src[13 * lda];
+            V2 = *(vec_t *) &src[14 * lda];
+            V3 = *(vec_t *) &src[15 * lda];
+	    D01A = vec_perm(V0, V1, swizA);
+	    D01B = vec_perm(V0, V1, swizB);
+	    D23A = vec_perm(V2, V3, swizA);
+	    D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL); 
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
+            *(vec_t *) &dest[ 48] = D0;
+            *(vec_t *) &dest[112] = D1;
+            *(vec_t *) &dest[176] = D2;
+            *(vec_t *) &dest[240] = D3;
         }
-        j--;
-    } // end of while(j)
+        for (i=k16; i<k4; i+=4) {
+            vec_t D0, D1, D2, D3;
+	    const int8_t *src = &a[lda*j+i];
+	    int8_t *dest = &ap[j * (krows << 2) + (i << 4)];
 
-    if (m_cap & 8) {
-        m_skip = (m & 8) != (m_cap & 8);
-        for (ii = 0; ii < 8; ++ii)
-            a_off[ii] = a_offset + ii * lda;
-        a_offset += 8 * lda;
-        i = (k >> 2);
-        while (i) {
-            int *temp = (int *)ap_offset;
-            temp[5] = temp[6] = temp[7] = 0;
-            memcpy_4(&ap_offset[0], a_off[0]);
-            memcpy_4(&ap_offset[4], a_off[1]);
-            memcpy_4(&ap_offset[8], a_off[2]);
-            memcpy_4(&ap_offset[12], a_off[3]);
-            memcpy_4(&ap_offset[16], a_off[4]);
-            if (fastpath) {
-                memcpy_4(&ap_offset[20], a_off[5]);
-                memcpy_4(&ap_offset[24], a_off[6]);
-                memcpy_4(&ap_offset[28], a_off[7]);
-            } else {
-                if ((!m_skip) || (m_cap - m < 3))
-                    memcpy_4(&ap_offset[20], a_off[5]);
-                if ((!m_skip) || (m_cap - m < 2))
-                    memcpy_4(&ap_offset[24], a_off[6]);
-                if ((!m_skip) || (m_cap - m < 1))
-                    memcpy_4(&ap_offset[28], a_off[7]);
-            }
-            for (ii = 0; ii < 8; ++ii)
-                a_off[ii] += 4;
-            ap_offset += 32;
-            i--;
-        } // end of while (i)
+            *(int *) &D0[ 0] = *(int *) &src[ 0 * lda];
+            *(int *) &D0[ 4] = *(int *) &src[ 1 * lda];
+            *(int *) &D0[ 8] = *(int *) &src[ 2 * lda];
+            *(int *) &D0[12] = *(int *) &src[ 3 * lda];
+            *(int *) &D1[ 0] = *(int *) &src[ 4 * lda];
+            *(int *) &D1[ 4] = *(int *) &src[ 5 * lda];
+            *(int *) &D1[ 8] = *(int *) &src[ 6 * lda];
+            *(int *) &D1[12] = *(int *) &src[ 7 * lda];
+            *(int *) &D2[ 0] = *(int *) &src[ 8 * lda];
+            *(int *) &D2[ 4] = *(int *) &src[ 9 * lda];
+            *(int *) &D2[ 8] = *(int *) &src[10 * lda];
+            *(int *) &D2[12] = *(int *) &src[11 * lda];
+            *(int *) &D3[ 0] = *(int *) &src[12 * lda];
+            *(int *) &D3[ 4] = *(int *) &src[13 * lda];
+            *(int *) &D3[ 8] = *(int *) &src[14 * lda];
+            *(int *) &D3[12] = *(int *) &src[15 * lda];
 
-        if (k < k_cap) {
-            int *temp = (int *)ap_offset;
-            for (int ii = 0; ii < 8; ++ii)
-                temp[ii] = 0;
-            int delk = 4 - (k_cap - k);
-            memcpy_n(&ap_offset[0], a_off[0], delk);
-            memcpy_n(&ap_offset[4], a_off[1], delk);
-            memcpy_n(&ap_offset[8], a_off[2], delk);
-            memcpy_n(&ap_offset[12], a_off[3], delk);
-            memcpy_n(&ap_offset[16], a_off[4], delk);
-            if ((!m_skip) || (m_cap - m < 3))
-                memcpy_n(&ap_offset[20], a_off[5], delk);
-            if ((!m_skip) || (m_cap - m < 2))
-                memcpy_n(&ap_offset[24], a_off[6], delk);
-            if ((!m_skip) || (m_cap - m < 1))
-                memcpy_n(&ap_offset[28], a_off[7], delk);
-            ap_offset += 32;
+            *(vec_t *) &dest[ 0] = D0;
+            *(vec_t *) &dest[16] = D1;
+            *(vec_t *) &dest[32] = D2;
+            *(vec_t *) &dest[48] = D3;
         }
     }
 
-    if (m_cap & 4) {
-        m_skip = (m & 4) != (m_cap & 4);
-        for (ii = 0; ii < 4; ++ii)
-            a_off[ii] = a_offset + ii * lda;
-        a_offset += 4 * lda;
-        i = (k >> 2);
-        while (i) {
-            int *temp = (int *)ap_offset;
-            temp[1] = temp[2] = temp[3] = 0;
-            memcpy_4(&ap_offset[0], a_off[0]);
-            if (fastpath) {
-                memcpy_4(&ap_offset[4], a_off[1]);
-                memcpy_4(&ap_offset[8], a_off[2]);
-                memcpy_4(&ap_offset[12], a_off[3]);
-            } else {
-                if ((!m_skip) || (m_cap - m < 3))
-                    memcpy_4(&ap_offset[4], a_off[1]);
-                if ((!m_skip) || (m_cap - m < 2))
-                    memcpy_4(&ap_offset[8], a_off[2]);
-                if ((!m_skip) || (m_cap - m < 1))
-                    memcpy_4(&ap_offset[12], a_off[3]);
+    // HIGH EDGE IN M DIRECTION
+    for (j=m16; j<m_cap; ++j) {
+        for (i=0; i<k4; ++i) {
+            kcell = i>>2;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+    
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = (chunk4count * block4);
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
             }
-            for (ii = 0; ii < 4; ++ii)
-                a_off[ii] += 4;
-            ap_offset += 16;
-
-            i--;
-        } // end of while (i)
-
-        if (k < k_cap) {
-            int *temp = (int *)ap_offset;
-            for (int ii = 0; ii < 4; ++ii)
-                temp[ii] = 0;
-            int delk = 4 - (k_cap - k);
-            memcpy_n(&ap_offset[0], a_off[0], delk);
-            if ((!m_skip) || (m_cap - m < 3))
-                memcpy_n(&ap_offset[4], a_off[1], delk);
-            if ((!m_skip) || (m_cap - m < 2))
-                memcpy_n(&ap_offset[8], a_off[2], delk);
-            if ((!m_skip) || (m_cap - m < 1))
-                memcpy_n(&ap_offset[12], a_off[3], delk);
-            ap_offset += 16;
+            koff = i&3;
+            moff = j&3;
+            if (j < m) ap[16*cell + 4*moff+koff] = a[lda*j+i];
+	    else       ap[16*cell + 4*moff+koff] = 0;
         }
     }
+
+    // HIGH EDGE IN K DIRECTION
+    for (j=0; j<m16; ++j) {
+        for (i=k4; i<k_cap; ++i) {
+            kcell = i>>2;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+    
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = (chunk4count * block4);
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&3;
+            moff = j&3;
+            if (i < k) ap[16*cell + 4*moff+koff] = a[lda*j+i];
+	    else       ap[16*cell + 4*moff+koff] = 0;
+        }
+    }
+
+    // UPPER CORNER (HIGH M, HIGH K)
+    for (j=m16; j<m_cap; ++j) {
+        for (i=k4; i<k_cap; ++i) {
+            kcell = i>>2;
+            mcell = j>>2;
+            chunk4count = mcell >> 2;
+    
+            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            else {
+                cell = (chunk4count * block4);
+                if (m_cap & 8) {
+                    switch (mcell & 3) {
+                    case 0:
+                    case 1:
+                        cell += 2 * kcell + (mcell & 1);
+                        break;
+                    case 2:
+                        cell += block2 + kcell;
+                        break;
+                    }
+                }
+                else if (m_cap & 4) cell += kcell;
+            }
+            koff = i&3;
+            moff = j&3;
+            if (j < m && i < k) ap[16*cell + 4*moff+koff] = a[lda*j+i];
+	    else                ap[16*cell + 4*moff+koff] = 0;
+        }
+    }
+
     return 0;
 }
 
 int pack_T8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
-    int i, j, ii;
-    int fastpath;
-    const uint8_t *b_offset;
-    const uint8_t *b_off[8];
-    uint8_t *bp_offset, *bp_offset1, *bp_offset2;
+    int i, j;
+    int kcell, cell, koff, noff, krows, k8, n8;
     int n_cap = (n + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    int delk = k_cap - k;
-    vec_t vw0, vw1, vw2, vw3, vbp[4];
-    vec_t swiz = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
-    b_offset = b;
-    bp_offset = bp;
-    bp_offset2 = bp + k_cap * (n_cap & ~7);
-    fastpath = (((k & 3) == 0) && (n & 3) == 0);
+    krows = (k+3) >> 2;
+    k8 = (k>>3)<<3;
+    n8 = (n>>3)<<3;
 
-    j = (k_cap >> 3);
-    int k_skip = (j != (k >> 3));
-    while (j) {
-        for (ii = 0; ii < 8; ++ii)
-            b_off[ii] = b_offset + ii * ldb;
-        b_offset += 8 * ldb;
-        bp_offset1 = bp_offset;
-        bp_offset += 64;
+    // MAIN BLOCK
+    for (i=0; i<k8; i+=8) { 
+        for (j=0; j<n8; j+=8) {
+            vec_t V0, V1, V2, V3;
+            vec_t D01A, D01B, D23A, D23B;
+            vec_t D0, D1, D2, D3;
+            vec_t swizA = { 0, 16,  1, 17,  2, 18,  3, 19,  4, 20,  5, 21,  6, 22,  7, 23};
+            vec_t swizB = { 8, 24,  9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31};
+            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
+            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
+	    uint8_t *dest;
 
-        i = (n_cap >> 3);
-        // we need to be careful about not going past the end of the B array if n is less than n_cap.
-        // fortunately, we can only go out-of-bounds by accessing elements of b_off[5/6/7], so the others
-        // can just load garbage in the not_used elements of the vtemp vectors.
-        int n_skip = (i != (n >> 3));
-        while (i) {
-            vw0 = vec_splat_u8((uint8_t)0);
-            vw1 = vec_splat_u8((uint8_t)0);
-            vw2 = vec_splat_u8((uint8_t)0);
-            vw3 = vec_splat_u8((uint8_t)0);
-            int *temp0, *temp1, *temp2, *temp3;
-            int zerodata = 0;
-            temp0 = (int *)&vw0;
-            temp1 = (int *)&vw1;
-            temp2 = (int *)&vw2;
-            temp3 = (int *)&vw3;
-            memcpy_4(&temp0[0], &b_off[0][0]);
-            memcpy_4(&temp0[1], &b_off[1][0]);
-            memcpy_4(&temp0[2], &b_off[2][0]);
-            memcpy_4(&temp0[3], &b_off[3][0]);
-            memcpy_4(&temp2[0], &b_off[4][0]);
-            if (j > 1) {
-                memcpy_4(&temp2[1], &b_off[5][0]);
-                memcpy_4(&temp2[2], &b_off[6][0]);
-                memcpy_4(&temp2[3], &b_off[7][0]);
-            } else {
-                memcpy_4(&temp2[1], (const uint8_t *)&zerodata);
-                memcpy_4(&temp2[2], (const uint8_t *)&zerodata);
-                memcpy_4(&temp2[3], (const uint8_t *)&zerodata);
-                if ((!(k_skip)) || (delk < 3))
-                    memcpy_4(&temp2[1], &b_off[5][0]);
-                if ((!(k_skip)) || (delk < 2))
-                    memcpy_4(&temp2[2], &b_off[6][0]);
-                if ((!(k_skip)) || (delk < 1))
-                    memcpy_4(&temp2[3], &b_off[7][0]);
-            }
-            if (fastpath) {
-                memcpy_4(&temp1[0], &b_off[0][4]);
-                memcpy_4(&temp1[1], &b_off[1][4]);
-                memcpy_4(&temp1[2], &b_off[2][4]);
-                memcpy_4(&temp1[3], &b_off[3][4]);
-                memcpy_4(&temp3[0], &b_off[4][4]);
-                if (j > 1) {
-                    memcpy_4(&temp3[1], &b_off[5][4]);
-                    memcpy_4(&temp3[2], &b_off[6][4]);
-                    memcpy_4(&temp3[3], &b_off[7][4]);
-                } else {
-                    memcpy_4(&temp3[1], (const uint8_t *)&zerodata);
-                    memcpy_4(&temp3[2], (const uint8_t *)&zerodata);
-                    memcpy_4(&temp3[3], (const uint8_t *)&zerodata);
-                    if (delk < 3) memcpy_4(&temp3[1], &b_off[5][4]);
-                    if (delk < 2) memcpy_4(&temp3[2], &b_off[6][4]);
-                    if (delk < 1) memcpy_4(&temp3[3], &b_off[7][4]);
-                }
-            } else {
-                int nbytes = ((i > 1) || (!(n_skip))) ? 4 : 4 - (n_cap - n);
-                memcpy_n(&temp1[0], &b_off[0][4], nbytes);
-                memcpy_n(&temp1[1], &b_off[1][4], nbytes);
-                memcpy_n(&temp1[2], &b_off[2][4], nbytes);
-                memcpy_n(&temp1[3], &b_off[3][4], nbytes);
-                memcpy_n(&temp3[0], &b_off[4][4], nbytes);
-                if (j > 1) {
-                    memcpy_n(&temp3[1], &b_off[5][4], nbytes);
-                    memcpy_n(&temp3[2], &b_off[6][4], nbytes);
-                    memcpy_n(&temp3[3], &b_off[7][4], nbytes);
-                } else {
-                    memcpy_n(&temp3[1], (const uint8_t *)&zerodata, nbytes);
-                    memcpy_n(&temp3[2], (const uint8_t *)&zerodata, nbytes);
-                    memcpy_n(&temp3[3], (const uint8_t *)&zerodata, nbytes);
-                    if ((!(k_skip)) || (delk < 3))
-                        memcpy_n(&temp3[1], &b_off[5][4], nbytes);
-                    if ((!(k_skip)) || (delk < 2))
-                        memcpy_n(&temp3[2], &b_off[6][4], nbytes);
-                    if ((!(k_skip)) || (delk < 1))
-                        memcpy_n(&temp3[3], &b_off[7][4], nbytes);
-                }
-            }
-            vbp[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            vbp[1] = vec_perm(vw1, vw1, swiz); // 4x4 transpose
-            vbp[2] = vec_perm(vw2, vw2, swiz); // 4x4 transpose
-            vbp[3] = vec_perm(vw3, vw3, swiz); // 4x4 transpose
-            memcpy_64(bp_offset1, vbp);
-            for (ii = 0; ii < 8; ++ii)
-                b_off[ii] += 8;
-            bp_offset1 += k_cap * 8;
-            i--;
-        } // end of while (i)
+	    *(signed long long *) &V0[0] = *(signed long long *) &b[ldb*(i+0) + j];
+	    *(signed long long *) &V1[0] = *(signed long long *) &b[ldb*(i+1) + j];
+	    *(signed long long *) &V2[0] = *(signed long long *) &b[ldb*(i+2) + j];
+	    *(signed long long *) &V3[0] = *(signed long long *) &b[ldb*(i+3) + j];
+	    *(signed long long *) &V0[8] = *(signed long long *) &b[ldb*(i+4) + j];
+	    *(signed long long *) &V1[8] = *(signed long long *) &b[ldb*(i+5) + j];
+	    *(signed long long *) &V2[8] = *(signed long long *) &b[ldb*(i+6) + j];
+	    *(signed long long *) &V3[8] = *(signed long long *) &b[ldb*(i+7) + j];
 
-        if (n_cap & 4) {
-            vw0 = vec_splat_u8((uint8_t)0);
-            vw1 = vec_splat_u8((uint8_t)0);
-            int *temp0, *temp1;
-            temp0 = (int *)&vw0;
-            temp1 = (int *)&vw1;
-            if (fastpath) {
-                memcpy_4(&temp0[0], b_off[0]);
-                memcpy_4(&temp0[1], b_off[1]);
-                memcpy_4(&temp0[2], b_off[2]);
-                memcpy_4(&temp0[3], b_off[3]);
-                memcpy_4(&temp1[0], b_off[4]);
-                memcpy_4(&temp1[1], b_off[5]);
-                memcpy_4(&temp1[2], b_off[6]);
-                memcpy_4(&temp1[3], b_off[7]);
-            } else {
-                int nbytes = 4 - (n_cap - n);
-                memcpy_n(&temp0[0], b_off[0], nbytes);
-                memcpy_n(&temp0[1], b_off[1], nbytes);
-                memcpy_n(&temp0[2], b_off[2], nbytes);
-                memcpy_n(&temp0[3], b_off[3], nbytes);
-                memcpy_n(&temp1[0], b_off[4], nbytes);
-                if (j > 1 || (!k_skip) || delk < 3)
-                    memcpy_n(&temp1[1], b_off[5], nbytes);
-                if (j > 1 || (!k_skip) || delk < 2)
-                    memcpy_n(&temp1[2], b_off[6], nbytes);
-                if (j > 1 || (!k_skip) || delk < 1)
-                    memcpy_n(&temp1[3], b_off[7], nbytes);
-            }
-            vbp[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            vbp[1] = vec_perm(vw1, vw1, swiz); // 4x4 transpose
-            memcpy_32(bp_offset2, vbp);
-            for (ii = 0; ii < 8; ++ii)
-                b_off[ii] += 4;
-            bp_offset2 += 32;
+	    D01A = vec_perm(V0, V1, swizA);
+	    D01B = vec_perm(V0, V1, swizB);
+	    D23A = vec_perm(V2, V3, swizA);
+	    D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL); 
+            D1 = vec_perm(D01A, D23A, swizR);
+            D2 = vec_perm(D01B, D23B, swizL);
+            D3 = vec_perm(D01B, D23B, swizR);
+
+            dest = &bp[16 * ((j >> 2) * krows + (i >> 1))];
+
+	    *(vec_t *) &dest[ 0] = D0;
+	    *(vec_t *) &dest[16] = D1;
+	    *(vec_t *) &dest[32] = D2;
+	    *(vec_t *) &dest[48] = D3;
         }
+    }
 
-        j--;
-    } // end of while (j)
+    // HIGH EDGE IN N DIRECTION
+    for (i=0; i<k8; ++i) {
+        for (j=n8; j<n_cap; ++j) {
+            kcell = i>>2;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+                int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&3;
+            noff = j&3;
+            if (j < n) bp[16*cell + 4*noff+koff] = b[ldb*i+j];
+	    else       bp[16*cell + 4*noff+koff] = 0;
+        }
+    }
 
-    if (k_cap & 4) {
-        for (ii = 0; ii < 4; ++ii)
-            b_off[ii] = b_offset + ii * ldb;
-        b_offset += 4 * ldb;
-        bp_offset1 = bp_offset;
-        bp_offset += 32;
+    // HIGH EDGE IN K DIRECTION
+    for (i=k8; i<k_cap; ++i) {
+        for (j=0; j<n8; ++j) {
+            kcell = i>>2;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&3;
+            noff = j&3;
+            if (i < k) bp[16*cell + 4*noff+koff] = b[ldb*i+j];
+	    else       bp[16*cell + 4*noff+koff] = 0;
+        }
+    }
 
-        i = (n_cap >> 3);
-        int n_skip = (i != (n >> 3));
-        while (i) {
-            vw0 = vec_splat_u8((uint8_t)0);
-            vw1 = vec_splat_u8((uint8_t)0);
-            int *temp0, *temp1;
-            temp0 = (int *)&vw0;
-            temp1 = (int *)&vw1;
-            memcpy_4(&temp0[0], &b_off[0][0]);
-            if (fastpath) {
-                memcpy_4(&temp0[1], &b_off[1][0]);
-                memcpy_4(&temp0[2], &b_off[2][0]);
-                memcpy_4(&temp0[3], &b_off[3][0]);
-                memcpy_4(&temp1[0], &b_off[0][4]);
-                memcpy_4(&temp1[1], &b_off[1][4]);
-                memcpy_4(&temp1[2], &b_off[2][4]);
-                memcpy_4(&temp1[3], &b_off[3][4]);
-            } else {
-                int nbytes = ((i > 1) || (!(n_skip))) ? 4 : 4 - (n_cap - n);
-                if (delk < 3) memcpy_4(&temp0[1], &b_off[1][0]);
-                if (delk < 2) memcpy_4(&temp0[2], &b_off[2][0]);
-                if (delk < 1) memcpy_4(&temp0[3], &b_off[3][0]);
-                memcpy_n(&temp1[0], &b_off[0][4], nbytes);
-                if (delk < 3) memcpy_n(&temp1[1], &b_off[1][4], nbytes);
-                if (delk < 2) memcpy_n(&temp1[2], &b_off[2][4], nbytes);
-                if (delk < 1) memcpy_n(&temp1[3], &b_off[3][4], nbytes);
-            }
-            vbp[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            vbp[1] = vec_perm(vw1, vw1, swiz); // 4x4 transpose
-            memcpy_32(bp_offset1, vbp);
-            for (ii = 0; ii < 4; ++ii)
-                b_off[ii] += 8;
-            bp_offset1 += k_cap * 8;
-            i--;
-        } // end of while (i)
-
-        if (n_cap & 4) {
-            int nbytes = 4 - (n_cap - n);
-            vw0 = vec_splat_u8((uint8_t)0);
-            int *temp0;
-            temp0 = (int *)&vw0;
-            if (fastpath) {
-                memcpy_4(&temp0[0], b_off[0]);
-                memcpy_4(&temp0[1], b_off[1]);
-                memcpy_4(&temp0[2], b_off[2]);
-                memcpy_4(&temp0[3], b_off[3]);
-            } else {
-                memcpy_n(&temp0[0], b_off[0], nbytes);
-                if (delk < 3) memcpy_n(&temp0[1], b_off[1], nbytes);
-                if (delk < 2) memcpy_n(&temp0[2], b_off[2], nbytes);
-                if (delk < 1) memcpy_n(&temp0[3], b_off[3], nbytes);
-            }
-            vbp[0] = vec_perm(vw0, vw0, swiz); // 4x4 transpose
-            memcpy_16(bp_offset2, vbp);
+    // UPPER CORNER (HIGH N, HIGH K)
+    for (i=k8; i<k_cap; ++i) {
+        for (j=n8; j<n_cap; ++j) {
+            kcell = i>>2;
+            // special handling if j is in a PARTIAL last "group of 8"
+            int maingroup = (j & (~7)) < (n & (~7));
+            int columns_done = ((j & (~7)) >> 3) << 1;
+            int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
+            int j_hiflag = (j & 4) >> 2;
+            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
+            koff = i&3;
+            noff = j&3;
+            if (i < k && j < n) bp[16*cell + 4*noff+koff] = b[ldb*i+j];
+	    else                bp[16*cell + 4*noff+koff] = 0;
         }
     }
 

--- a/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
@@ -20,78 +20,81 @@
 namespace dnnl {
 namespace impl {
 
-static inline void memcpy_4(void * __restrict d, const void * __restrict s) {
-        int *di, *si;
-        di = (int *)(d);
-        si = (int *)(s);
-        di[0] = si[0];
+static inline void memcpy_4(void *__restrict d, const void *__restrict s) {
+    int *di, *si;
+    di = (int *)(d);
+    si = (int *)(s);
+    di[0] = si[0];
 }
 
-static inline void memcpy_14(void * __restrict d, const void * __restrict s) {
-        int *di, *si;
-        di = (int *)(d);
-        si = (int *)(s);
-        di[0] = si[0];
-        di[1] = si[1];
-        di[2] = si[2];
-        *(short *) &di[3] = *(short *) &si[3];
+static inline void memcpy_14(void *__restrict d, const void *__restrict s) {
+    int *di, *si;
+    di = (int *)(d);
+    si = (int *)(s);
+    di[0] = si[0];
+    di[1] = si[1];
+    di[2] = si[2];
+    *(short *)&di[3] = *(short *)&si[3];
 }
 
-static inline void memcpy_16(void * __restrict d, const void * __restrict s) {
-        int *di, *si;
-        di = (int *)(d);
-        si = (int *)(s);
-        di[0] = si[0];
-        di[1] = si[1];
-        di[2] = si[2];
-        di[3] = si[3];
+static inline void memcpy_16(void *__restrict d, const void *__restrict s) {
+    int *di, *si;
+    di = (int *)(d);
+    si = (int *)(s);
+    di[0] = si[0];
+    di[1] = si[1];
+    di[2] = si[2];
+    di[3] = si[3];
 }
 
-static inline void memcpy_32(void * __restrict d, const void * __restrict s) {
-        int *di, *si;
-        di = (int *)(d);
-        si = (int *)(s);
-        di[0] = si[0];
-        di[1] = si[1];
-        di[2] = si[2];
-        di[3] = si[3];
-        di[4] = si[4];
-        di[5] = si[5];
-        di[6] = si[6];
-        di[7] = si[7];
+static inline void memcpy_32(void *__restrict d, const void *__restrict s) {
+    int *di, *si;
+    di = (int *)(d);
+    si = (int *)(s);
+    di[0] = si[0];
+    di[1] = si[1];
+    di[2] = si[2];
+    di[3] = si[3];
+    di[4] = si[4];
+    di[5] = si[5];
+    di[6] = si[6];
+    di[7] = si[7];
 }
 
-static inline void memcpy_64(void * __restrict d, const void * __restrict s) {
-        int *di, *si;
-        di = (int *)(d);
-        si = (int *)(s);
-        di[0] = si[0];
-        di[1] = si[1];
-        di[2] = si[2];
-        di[3] = si[3];
-        di[4] = si[4];
-        di[5] = si[5];
-        di[6] = si[6];
-        di[7] = si[7];
-        di[8] = si[8];
-        di[9] = si[9];
-        di[10] = si[10];
-        di[11] = si[11];
-        di[12] = si[12];
-        di[13] = si[13];
-        di[14] = si[14];
-        di[15] = si[15];
+static inline void memcpy_64(void *__restrict d, const void *__restrict s) {
+    int *di, *si;
+    di = (int *)(d);
+    si = (int *)(s);
+    di[0] = si[0];
+    di[1] = si[1];
+    di[2] = si[2];
+    di[3] = si[3];
+    di[4] = si[4];
+    di[5] = si[5];
+    di[6] = si[6];
+    di[7] = si[7];
+    di[8] = si[8];
+    di[9] = si[9];
+    di[10] = si[10];
+    di[11] = si[11];
+    di[12] = si[12];
+    di[13] = si[13];
+    di[14] = si[14];
+    di[15] = si[15];
 }
 
-static inline void memcpy_n(void * __restrict d, const void * __restrict s, int n) {
-	int i, *di, *si;
-	int8_t *dc, *sc;
-        di = (int *)(d);
-        si = (int *)(s);
-	for (i=0; i<(n>>2); ++i) di[i] = si[i];
-	dc = (int8_t *) &di[n>>3];
-	sc = (int8_t *) &si[n>>3];
-	for (i=0; i<(n&3); ++i) dc[i] = sc[i];
+static inline void memcpy_n(
+        void *__restrict d, const void *__restrict s, int n) {
+    int i, *di, *si;
+    int8_t *dc, *sc;
+    di = (int *)(d);
+    si = (int *)(s);
+    for (i = 0; i < (n >> 2); ++i)
+        di[i] = si[i];
+    dc = (int8_t *)&di[n >> 3];
+    sc = (int8_t *)&si[n >> 3];
+    for (i = 0; i < (n & 3); ++i)
+        dc[i] = sc[i];
 }
 
 uint64_t mker;
@@ -103,36 +106,42 @@ typedef __vector signed char vec_st;
 
 int pack_N16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
     int i, j;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, k8, m4, m16;
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+            chunk4count, k8, m4, m16;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 1) & ~1;
-    krows = (k+1) >> 1;
-    mrows = (m+3) >> 2;
+    krows = (k + 1) >> 1;
+    mrows = (m + 3) >> 2;
     block4 = 4 * krows;
     block2 = 2 * krows;
-    k8 = (k>>3)<<3;
-    m4 = (m>>2)<<2;
-    m16 = (m>>4)<<4;
+    k8 = (k >> 3) << 3;
+    m4 = (m >> 2) << 2;
+    m16 = (m >> 4) << 4;
 
     // MAIN BLOCK
-    for (j=0; j<m16; j+=4) {
-        for (i=0; i<k8; i+=8) {
-            kcell = i>>1; // 0, 1, 2, 3
-            mcell = j>>2;
-            short *dest = &ap[32 * ((mcell>>2) * krows + kcell) + 8*(mcell & 3)];
+    for (j = 0; j < m16; j += 4) {
+        for (i = 0; i < k8; i += 8) {
+            kcell = i >> 1; // 0, 1, 2, 3
+            mcell = j >> 2;
+            short *dest = &ap[32 * ((mcell >> 2) * krows + kcell)
+                    + 8 * (mcell & 3)];
 
-	    vec_t V0, V1, V2, V3;
+            vec_t V0, V1, V2, V3;
             vec_t D01A, D01B, D23A, D23B;
             vec_t D0, D1, D2, D3;
-            vec_t swizA = { 0,  1,  2,  3, 16, 17, 18, 19,  4,  5,  6,  7, 20, 21, 22, 23};
-            vec_t swizB = { 8,  9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
-            vec_t swizL = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
-            vec_t swizR = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
+            vec_t swizA
+                    = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23};
+            vec_t swizB = {8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29,
+                    30, 31};
+            vec_t swizL
+                    = {0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizR = {8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29,
+                    30, 31};
 
-            V0 = *(vec_t *) &a[lda*(j+0) + i];
-            V1 = *(vec_t *) &a[lda*(j+1) + i];
-            V2 = *(vec_t *) &a[lda*(j+2) + i];
-            V3 = *(vec_t *) &a[lda*(j+3) + i];
+            V0 = *(vec_t *)&a[lda * (j + 0) + i];
+            V1 = *(vec_t *)&a[lda * (j + 1) + i];
+            V2 = *(vec_t *)&a[lda * (j + 2) + i];
+            V3 = *(vec_t *)&a[lda * (j + 3) + i];
 
             D01A = vec_perm(V0, V1, swizA);
             D01B = vec_perm(V0, V1, swizB);
@@ -143,124 +152,118 @@ int pack_N16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
 
-            *(vec_t *) &dest[ 0] = D0;
-            *(vec_t *) &dest[32] = D1;
-            *(vec_t *) &dest[64] = D2;
-            *(vec_t *) &dest[96] = D3;
+            *(vec_t *)&dest[0] = D0;
+            *(vec_t *)&dest[32] = D1;
+            *(vec_t *)&dest[64] = D2;
+            *(vec_t *)&dest[96] = D3;
         }
     }
 
-    for (j=m16; j<m4; ++j) {
-        for (i=0; i<k8; ++i) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (j = m16; j < m4; ++j) {
+        for (i = 0; i < k8; ++i) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = (chunk4count * block4);
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-            ap[8*cell + 2*moff+koff] = a[lda*j+i];
+            koff = i & 1;
+            moff = j & 3;
+            ap[8 * cell + 2 * moff + koff] = a[lda * j + i];
         }
     }
 
     // HIGH EDGE IN M DIRECTION
-    for (j=m4; j<m_cap; ++j) {
-        for (i=0; i<k8; ++i) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (j = m4; j < m_cap; ++j) {
+        for (i = 0; i < k8; ++i) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = (chunk4count * block4);
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-	    if (j < m) ap[8*cell + 2*moff+koff] = a[lda*j+i];
-	    else       ap[8*cell + 2*moff+koff] = 0;
+            koff = i & 1;
+            moff = j & 3;
+            if (j < m)
+                ap[8 * cell + 2 * moff + koff] = a[lda * j + i];
+            else
+                ap[8 * cell + 2 * moff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (j=0; j<m4; ++j) {
-        for (i=k8; i<k_cap; ++i) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (j = 0; j < m4; ++j) {
+        for (i = k8; i < k_cap; ++i) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = (chunk4count * block4);
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-            if (i < k) ap[8*cell + 2*moff+koff] = a[lda*j+i];
-	    else       ap[8*cell + 2*moff+koff] = 0;
+            koff = i & 1;
+            moff = j & 3;
+            if (i < k)
+                ap[8 * cell + 2 * moff + koff] = a[lda * j + i];
+            else
+                ap[8 * cell + 2 * moff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH M, HIGH K)
-    for (j=m4; j<m_cap; ++j) {
-        for (i=k8; i<k_cap; ++i) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (j = m4; j < m_cap; ++j) {
+        for (i = k8; i < k_cap; ++i) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = (chunk4count * block4);
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-            if (j < m && i < k) ap[8*cell + 2*moff+koff] = a[lda*j+i];
-	    else                ap[8*cell + 2*moff+koff] = 0;           
+            koff = i & 1;
+            moff = j & 3;
+            if (j < m && i < k)
+                ap[8 * cell + 2 * moff + koff] = a[lda * j + i];
+            else
+                ap[8 * cell + 2 * moff + koff] = 0;
         }
     }
     return 0;
@@ -268,35 +271,38 @@ int pack_N16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
 
 int pack_T16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
     int i, j;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, k4, m8, m16;
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+            chunk4count, k4, m8, m16;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 1) & ~1;
-    krows = (k+1) >> 1;
-    mrows = (m+3) >> 2;
+    krows = (k + 1) >> 1;
+    mrows = (m + 3) >> 2;
     block4 = 4 * krows;
     block2 = 2 * krows;
-    k4 = (k>>2)<<2;
-    m16 = (m>>4)<<4;
-    m8 = (m>>3)<<3;
+    k4 = (k >> 2) << 2;
+    m16 = (m >> 4) << 4;
+    m8 = (m >> 3) << 3;
 
     // MAIN BLOCK
-    for (i=0; i<k4; i+=4) {
-        for (j=0; j<m16; j+=16) {
-	    short *src = &a[lda*i + j];
-	    short *dst = &ap[2 * j * krows + 16 * i];
+    for (i = 0; i < k4; i += 4) {
+        for (j = 0; j < m16; j += 16) {
+            short *src = &a[lda * i + j];
+            short *dst = &ap[2 * j * krows + 16 * i];
             vec_t V0, V1, V2, V3, V4, V5, V6, V7;
             vec_t D0, D1, D2, D3, D4, D5, D6, D7;
-            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
-            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
+            vec_t swizL
+                    = {0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23};
+            vec_t swizR = {8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15,
+                    30, 31};
 
-            V0 = *(vec_t *) &src[0];
-            V1 = *(vec_t *) &src[lda];
-            V2 = *(vec_t *) &src[8];
-            V3 = *(vec_t *) &src[lda + 8];
-            V4 = *(vec_t *) &src[2*lda];
-            V5 = *(vec_t *) &src[3*lda];
-            V6 = *(vec_t *) &src[2*lda + 8];
-            V7 = *(vec_t *) &src[3*lda + 8];
+            V0 = *(vec_t *)&src[0];
+            V1 = *(vec_t *)&src[lda];
+            V2 = *(vec_t *)&src[8];
+            V3 = *(vec_t *)&src[lda + 8];
+            V4 = *(vec_t *)&src[2 * lda];
+            V5 = *(vec_t *)&src[3 * lda];
+            V6 = *(vec_t *)&src[2 * lda + 8];
+            V7 = *(vec_t *)&src[3 * lda + 8];
             D0 = vec_perm(V0, V1, swizL);
             D1 = vec_perm(V0, V1, swizR);
             D2 = vec_perm(V2, V3, swizL);
@@ -306,128 +312,122 @@ int pack_T16_16bit(dim_t k, dim_t m, short *a, dim_t lda, short *ap) {
             D6 = vec_perm(V6, V7, swizL);
             D7 = vec_perm(V6, V7, swizR);
 
-	    *(vec_t *) &dst[ 0] = D0;
-	    *(vec_t *) &dst[ 8] = D1;
-	    *(vec_t *) &dst[16] = D2;
-	    *(vec_t *) &dst[24] = D3;
-	    *(vec_t *) &dst[32] = D4;
-	    *(vec_t *) &dst[40] = D5;
-	    *(vec_t *) &dst[48] = D6;
-	    *(vec_t *) &dst[56] = D7;
+            *(vec_t *)&dst[0] = D0;
+            *(vec_t *)&dst[8] = D1;
+            *(vec_t *)&dst[16] = D2;
+            *(vec_t *)&dst[24] = D3;
+            *(vec_t *)&dst[32] = D4;
+            *(vec_t *)&dst[40] = D5;
+            *(vec_t *)&dst[48] = D6;
+            *(vec_t *)&dst[56] = D7;
         }
     }
 
-    for (i=0; i<k4; ++i) {
-        for (j=m16; j<m8; ++j) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (i = 0; i < k4; ++i) {
+        for (j = m16; j < m8; ++j) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = chunk4count * block4;
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-            ap[8*cell + 2*moff+koff] = a[lda*i+j];
+            koff = i & 1;
+            moff = j & 3;
+            ap[8 * cell + 2 * moff + koff] = a[lda * i + j];
         }
     }
 
     // HIGH EDGE IN M DIRECTION
-    for (i=0; i<k4; ++i) {
-        for (j=m8; j<m_cap; ++j) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (i = 0; i < k4; ++i) {
+        for (j = m8; j < m_cap; ++j) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = chunk4count * block4;
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-            if (j < m) ap[8*cell + 2*moff+koff] = a[lda*i+j];
-	    else       ap[8*cell + 2*moff+koff] = 0;
+            koff = i & 1;
+            moff = j & 3;
+            if (j < m)
+                ap[8 * cell + 2 * moff + koff] = a[lda * i + j];
+            else
+                ap[8 * cell + 2 * moff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (i=k4; i<k_cap; ++i) {
-        for (j=0; j<m8; ++j) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (i = k4; i < k_cap; ++i) {
+        for (j = 0; j < m8; ++j) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = chunk4count * block4;
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-            if (i < k) ap[8*cell + 2*moff+koff] = a[lda*i+j];
-	    else       ap[8*cell + 2*moff+koff] = 0;          
+            koff = i & 1;
+            moff = j & 3;
+            if (i < k)
+                ap[8 * cell + 2 * moff + koff] = a[lda * i + j];
+            else
+                ap[8 * cell + 2 * moff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH M, HIGH K)
-    for (i=k4; i<k_cap; ++i) {
-        for (j=m8; j<m_cap; ++j) {
-            kcell = i>>1;
-            mcell = j>>2;
+    for (i = k4; i < k_cap; ++i) {
+        for (j = m8; j < m_cap; ++j) {
+            kcell = i >> 1;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = chunk4count * block4;
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&1;
-            moff = j&3;
-            if (i < k && j < m) ap[8*cell + 2*moff+koff] = a[lda*i+j];
-	    else                ap[8*cell + 2*moff+koff] = 0;           
+            koff = i & 1;
+            moff = j & 3;
+            if (i < k && j < m)
+                ap[8 * cell + 2 * moff + koff] = a[lda * i + j];
+            else
+                ap[8 * cell + 2 * moff + koff] = 0;
         }
     }
     return 0;
@@ -438,30 +438,32 @@ int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
     int kcell, cell, koff, noff, krows, k4, n8, n16;
     int n_cap = (n + 3) & ~3;
     int k_cap = (k + 1) & ~1;
-    krows = (k+1) >> 1;
-    k4 = (k>>2)<<2;
-    n8 = (n>>3)<<3;
-    n16 = (n>>4)<<4;
+    krows = (k + 1) >> 1;
+    k4 = (k >> 2) << 2;
+    n8 = (n >> 3) << 3;
+    n16 = (n >> 4) << 4;
 
     // MAIN BLOCK
-    for (i=0; i<k4; i+=4) {
-        for (j=0; j<n16; j+=16) {
+    for (i = 0; i < k4; i += 4) {
+        for (j = 0; j < n16; j += 16) {
             short *src = &b[ldb * i + j];
-	    short *dst0145 = &bp[2 * j * krows + 8 * i];
-	    short *dst2367 = &bp[2 * (j+8) * krows + 8 * i];
+            short *dst0145 = &bp[2 * j * krows + 8 * i];
+            short *dst2367 = &bp[2 * (j + 8) * krows + 8 * i];
             vec_t V0, V1, V2, V3, V4, V5, V6, V7;
             vec_t D0, D1, D2, D3, D4, D5, D6, D7;
-            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
-            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
+            vec_t swizL
+                    = {0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23};
+            vec_t swizR = {8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15,
+                    30, 31};
 
-            V0 = *(vec_t *) &src[0];
-            V1 = *(vec_t *) &src[ldb];
-            V2 = *(vec_t *) &src[8];
-            V3 = *(vec_t *) &src[ldb + 8];
-            V4 = *(vec_t *) &src[2*ldb];
-            V5 = *(vec_t *) &src[3*ldb];
-            V6 = *(vec_t *) &src[2*ldb + 8];
-            V7 = *(vec_t *) &src[3*ldb + 8];
+            V0 = *(vec_t *)&src[0];
+            V1 = *(vec_t *)&src[ldb];
+            V2 = *(vec_t *)&src[8];
+            V3 = *(vec_t *)&src[ldb + 8];
+            V4 = *(vec_t *)&src[2 * ldb];
+            V5 = *(vec_t *)&src[3 * ldb];
+            V6 = *(vec_t *)&src[2 * ldb + 8];
+            V7 = *(vec_t *)&src[3 * ldb + 8];
             D0 = vec_perm(V0, V1, swizL);
             D1 = vec_perm(V0, V1, swizR);
             D2 = vec_perm(V2, V3, swizL);
@@ -471,87 +473,95 @@ int pack_T8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
             D6 = vec_perm(V6, V7, swizL);
             D7 = vec_perm(V6, V7, swizR);
 
-	    *(vec_t *) &dst0145[0] = D0;
-	    *(vec_t *) &dst0145[8] = D1;
-	    *(vec_t *) &dst2367[0] = D2;
-	    *(vec_t *) &dst2367[8] = D3;
-	    *(vec_t *) &dst0145[16] = D4;
-	    *(vec_t *) &dst0145[24] = D5;
-	    *(vec_t *) &dst2367[16] = D6;
-	    *(vec_t *) &dst2367[24] = D7;
+            *(vec_t *)&dst0145[0] = D0;
+            *(vec_t *)&dst0145[8] = D1;
+            *(vec_t *)&dst2367[0] = D2;
+            *(vec_t *)&dst2367[8] = D3;
+            *(vec_t *)&dst0145[16] = D4;
+            *(vec_t *)&dst0145[24] = D5;
+            *(vec_t *)&dst2367[16] = D6;
+            *(vec_t *)&dst2367[24] = D7;
         }
-        for (j=n16; j<n8; j+=8) {
+        for (j = n16; j < n8; j += 8) {
             int columns_done = ((j & (~7)) >> 3) << 1;
-	    short *dst = &bp[8*(columns_done*krows + (i & (~1)))];
+            short *dst = &bp[8 * (columns_done * krows + (i & (~1)))];
             vec_t V0, V1, V2, V3;
             vec_t D0, D1, D2, D3;
-            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
-            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
+            vec_t swizL
+                    = {0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23};
+            vec_t swizR = {8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15,
+                    30, 31};
 
-            V0 = *(vec_t *) &b[ldb*(i+0) + j];
-            V1 = *(vec_t *) &b[ldb*(i+1) + j];
-            V2 = *(vec_t *) &b[ldb*(i+2) + j];
-            V3 = *(vec_t *) &b[ldb*(i+3) + j];
+            V0 = *(vec_t *)&b[ldb * (i + 0) + j];
+            V1 = *(vec_t *)&b[ldb * (i + 1) + j];
+            V2 = *(vec_t *)&b[ldb * (i + 2) + j];
+            V3 = *(vec_t *)&b[ldb * (i + 3) + j];
             D0 = vec_perm(V0, V1, swizL);
             D1 = vec_perm(V0, V1, swizR);
             D2 = vec_perm(V2, V3, swizL);
             D3 = vec_perm(V2, V3, swizR);
 
-	    *(vec_t *) &dst[0] = D0;
-	    *(vec_t *) &dst[8] = D1;
-	    *(vec_t *) &dst[16] = D2;
-	    *(vec_t *) &dst[24] = D3;
+            *(vec_t *)&dst[0] = D0;
+            *(vec_t *)&dst[8] = D1;
+            *(vec_t *)&dst[16] = D2;
+            *(vec_t *)&dst[24] = D3;
         }
     }
 
     // HIGH EDGE IN N DIRECTION
-    for (i=0; i<k4; ++i) {
-        for (j=n8; j<n_cap; ++j) {
-            kcell = i>>1;
+    for (i = 0; i < k4; ++i) {
+        for (j = n8; j < n_cap; ++j) {
+            kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&1;
-            noff = j&3;
-            if (j < n) bp[8*cell + 2*noff+koff] = b[ldb*i+j];
-	    else       bp[8*cell + 2*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 1;
+            noff = j & 3;
+            if (j < n)
+                bp[8 * cell + 2 * noff + koff] = b[ldb * i + j];
+            else
+                bp[8 * cell + 2 * noff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (i=k4; i<k_cap; ++i) {
-        for (j=0; j<n8; ++j) {
-            kcell = i>>1;
+    for (i = k4; i < k_cap; ++i) {
+        for (j = 0; j < n8; ++j) {
+            kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&1;
-            noff = j&3;
-            if (i < k) bp[8*cell + 2*noff+koff] = b[ldb*i+j];
-	    else       bp[8*cell + 2*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 1;
+            noff = j & 3;
+            if (i < k)
+                bp[8 * cell + 2 * noff + koff] = b[ldb * i + j];
+            else
+                bp[8 * cell + 2 * noff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH N, HIGH K)
-    for (i=k4; i<k_cap; ++i) {
-        for (j=n8; j<n_cap; ++j) {
-            kcell = i>>1;
+    for (i = k4; i < k_cap; ++i) {
+        for (j = n8; j < n_cap; ++j) {
+            kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&1;
-            noff = j&3;
-            if (i < k && j < n) bp[8*cell + 2*noff+koff] = b[ldb*i+j];
-	    else                bp[8*cell + 2*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 1;
+            noff = j & 3;
+            if (i < k && j < n)
+                bp[8 * cell + 2 * noff + koff] = b[ldb * i + j];
+            else
+                bp[8 * cell + 2 * noff + koff] = 0;
         }
     }
     return 0;
@@ -562,38 +572,42 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
     int kcell, cell, koff, noff, krows, k8, k16, n4, n8;
     int n_cap = (n + 3) & ~3;
     int k_cap = (k + 1) & ~1;
-    krows = (k+1) >> 1;
-    k8 = (k>>3)<<3;
-    k16 = (k>>4)<<4;
-    n4 = (n>>2)<<2;
-    n8 = (n>>3)<<3;
+    krows = (k + 1) >> 1;
+    k8 = (k >> 3) << 3;
+    k16 = (k >> 4) << 4;
+    n4 = (n >> 2) << 2;
+    n8 = (n >> 3) << 3;
 
     // MAIN BLOCK
-    for (j=0; j<n8; j+=4) {
-        for (i=0; i<k16; i+=16) {
-            kcell = i>>1; // 0, 1, 2, 3
+    for (j = 0; j < n8; j += 4) {
+        for (i = 0; i < k16; i += 16) {
+            kcell = i >> 1; // 0, 1, 2, 3
             int columns_done = ((j & (~7)) >> 3) << 1;
             int j_hiflag = (j & 4) >> 2;
-            koff = i&1;
-            noff = j&3;
-	    short *dst = &bp[8*(columns_done*krows + kcell*2 + j_hiflag)];
+            koff = i & 1;
+            noff = j & 3;
+            short *dst = &bp[8 * (columns_done * krows + kcell * 2 + j_hiflag)];
 
-	    vec_t V0, V1, V2, V3, V4, V5, V6, V7;
+            vec_t V0, V1, V2, V3, V4, V5, V6, V7;
             vec_t D01A, D01B, D23A, D23B, D45A, D45B, D67A, D67B;
             vec_t D0, D1, D2, D3, D4, D5, D6, D7;
-            vec_t swizA = { 0,  1,  2,  3, 16, 17, 18, 19,  4,  5,  6,  7, 20, 21, 22, 23};
-            vec_t swizB = { 8,  9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
-            vec_t swizL = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
-            vec_t swizR = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
+            vec_t swizA
+                    = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23};
+            vec_t swizB = {8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29,
+                    30, 31};
+            vec_t swizL
+                    = {0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizR = {8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29,
+                    30, 31};
 
-            V0 = *(vec_t *) &b[ldb*(j+0) + i];
-            V1 = *(vec_t *) &b[ldb*(j+1) + i];
-            V2 = *(vec_t *) &b[ldb*(j+2) + i];
-            V3 = *(vec_t *) &b[ldb*(j+3) + i];
-            V4 = *(vec_t *) &b[ldb*(j+0) + i + 8];
-            V5 = *(vec_t *) &b[ldb*(j+1) + i + 8];
-            V6 = *(vec_t *) &b[ldb*(j+2) + i + 8];
-            V7 = *(vec_t *) &b[ldb*(j+3) + i + 8];
+            V0 = *(vec_t *)&b[ldb * (j + 0) + i];
+            V1 = *(vec_t *)&b[ldb * (j + 1) + i];
+            V2 = *(vec_t *)&b[ldb * (j + 2) + i];
+            V3 = *(vec_t *)&b[ldb * (j + 3) + i];
+            V4 = *(vec_t *)&b[ldb * (j + 0) + i + 8];
+            V5 = *(vec_t *)&b[ldb * (j + 1) + i + 8];
+            V6 = *(vec_t *)&b[ldb * (j + 2) + i + 8];
+            V7 = *(vec_t *)&b[ldb * (j + 3) + i + 8];
 
             D01A = vec_perm(V0, V1, swizA);
             D01B = vec_perm(V0, V1, swizB);
@@ -612,35 +626,39 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
             D6 = vec_perm(D45B, D67B, swizL);
             D7 = vec_perm(D45B, D67B, swizR);
 
-            *(vec_t *) &dst[ 0] = D0;
-            *(vec_t *) &dst[16] = D1;
-            *(vec_t *) &dst[32] = D2;
-            *(vec_t *) &dst[48] = D3;
-            *(vec_t *) &dst[64] = D4;
-            *(vec_t *) &dst[80] = D5;
-            *(vec_t *) &dst[96] = D6;
-            *(vec_t *) &dst[112] = D7;
+            *(vec_t *)&dst[0] = D0;
+            *(vec_t *)&dst[16] = D1;
+            *(vec_t *)&dst[32] = D2;
+            *(vec_t *)&dst[48] = D3;
+            *(vec_t *)&dst[64] = D4;
+            *(vec_t *)&dst[80] = D5;
+            *(vec_t *)&dst[96] = D6;
+            *(vec_t *)&dst[112] = D7;
         }
-        for (i=k16; i<k8; i+=8) {
-            kcell = i>>1; // 0, 1, 2, 3
+        for (i = k16; i < k8; i += 8) {
+            kcell = i >> 1; // 0, 1, 2, 3
             int columns_done = ((j & (~7)) >> 3) << 1;
             int j_hiflag = (j & 4) >> 2;
-            koff = i&1;
-            noff = j&3;
-	    short *dst = &bp[8*(columns_done*krows + kcell*2 + j_hiflag)];
+            koff = i & 1;
+            noff = j & 3;
+            short *dst = &bp[8 * (columns_done * krows + kcell * 2 + j_hiflag)];
 
-	    vec_t V0, V1, V2, V3;
+            vec_t V0, V1, V2, V3;
             vec_t D01A, D01B, D23A, D23B;
             vec_t D0, D1, D2, D3;
-            vec_t swizA = { 0,  1,  2,  3, 16, 17, 18, 19,  4,  5,  6,  7, 20, 21, 22, 23};
-            vec_t swizB = { 8,  9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
-            vec_t swizL = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
-            vec_t swizR = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
+            vec_t swizA
+                    = {0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23};
+            vec_t swizB = {8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29,
+                    30, 31};
+            vec_t swizL
+                    = {0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizR = {8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29,
+                    30, 31};
 
-            V0 = *(vec_t *) &b[ldb*(j+0) + i];
-            V1 = *(vec_t *) &b[ldb*(j+1) + i];
-            V2 = *(vec_t *) &b[ldb*(j+2) + i];
-            V3 = *(vec_t *) &b[ldb*(j+3) + i];
+            V0 = *(vec_t *)&b[ldb * (j + 0) + i];
+            V1 = *(vec_t *)&b[ldb * (j + 1) + i];
+            V2 = *(vec_t *)&b[ldb * (j + 2) + i];
+            V3 = *(vec_t *)&b[ldb * (j + 3) + i];
 
             D01A = vec_perm(V0, V1, swizA);
             D01B = vec_perm(V0, V1, swizB);
@@ -651,75 +669,81 @@ int pack_N8_16bit(dim_t k, dim_t n, short *b, dim_t ldb, short *bp) {
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
 
-            *(vec_t *) &dst[ 0] = D0;
-            *(vec_t *) &dst[16] = D1;
-            *(vec_t *) &dst[32] = D2;
-            *(vec_t *) &dst[48] = D3;
+            *(vec_t *)&dst[0] = D0;
+            *(vec_t *)&dst[16] = D1;
+            *(vec_t *)&dst[32] = D2;
+            *(vec_t *)&dst[48] = D3;
         }
     }
 
-    for (j=n8; j<n4; ++j) {
-        for (i=0; i<k8; ++i) {
-            kcell = i>>1;
+    for (j = n8; j < n4; ++j) {
+        for (i = 0; i < k8; ++i) {
+            kcell = i >> 1;
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&1;
-            noff = j&3;
-            bp[8*cell + 2*noff+koff] = b[ldb*j+i];
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 1;
+            noff = j & 3;
+            bp[8 * cell + 2 * noff + koff] = b[ldb * j + i];
         }
     }
 
     // HIGH EDGE IN N DIRECTION
-    for (j=n4; j<n_cap; ++j) {
-        for (i=0; i<k8; ++i) {
-            kcell = i>>1;
+    for (j = n4; j < n_cap; ++j) {
+        for (i = 0; i < k8; ++i) {
+            kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&1;
-            noff = j&3;
-            if (j < n) bp[8*cell + 2*noff+koff] = b[ldb*j+i];
-	    else       bp[8*cell + 2*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 1;
+            noff = j & 3;
+            if (j < n)
+                bp[8 * cell + 2 * noff + koff] = b[ldb * j + i];
+            else
+                bp[8 * cell + 2 * noff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (j=0; j<n4; ++j) {
-        for (i=k8; i<k_cap; ++i) {
-            kcell = i>>1;
+    for (j = 0; j < n4; ++j) {
+        for (i = k8; i < k_cap; ++i) {
+            kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&1;
-            noff = j&3;
-            if (i < k) bp[8*cell + 2*noff+koff] = b[ldb*j+i];
-	    else       bp[8*cell + 2*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 1;
+            noff = j & 3;
+            if (i < k)
+                bp[8 * cell + 2 * noff + koff] = b[ldb * j + i];
+            else
+                bp[8 * cell + 2 * noff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH N, HIGH K)
-    for (j=n4; j<n_cap; ++j) {
-        for (i=k8; i<k_cap; ++i) {
-            kcell = i>>1;
+    for (j = n4; j < n_cap; ++j) {
+        for (i = k8; i < k_cap; ++i) {
+            kcell = i >> 1;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&1;
-            noff = j&3;
-            if (j < n && i < k) bp[8*cell + 2*noff+koff] = b[ldb*j+i];
-	    else                bp[8*cell + 2*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 1;
+            noff = j & 3;
+            if (j < n && i < k)
+                bp[8 * cell + 2 * noff + koff] = b[ldb * j + i];
+            else
+                bp[8 * cell + 2 * noff + koff] = 0;
         }
     }
     return 0;
@@ -729,133 +753,135 @@ int pack_T16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
     int i, j;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, m16, k4;
-    m16 = (m>>4)<<4;
-    k4 = (k>>2)<<2;
-    krows = (k+3) >> 2;
-    mrows = (m+3) >> 2;
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+            chunk4count, m16, k4;
+    m16 = (m >> 4) << 4;
+    k4 = (k >> 2) << 2;
+    krows = (k + 3) >> 2;
+    mrows = (m + 3) >> 2;
     block4 = 4 * krows;
     block2 = 2 * krows;
 
     // MAIN BLOCK
-    for (i=0; i<k4; i+=4) {
-        for (j=0; j<m16; j+=16) {
+    for (i = 0; i < k4; i += 4) {
+        for (j = 0; j < m16; j += 16) {
             vec_t V0, V1, V2, V3;
             vec_t D01A, D01B, D23A, D23B;
             vec_t D0, D1, D2, D3;
-            vec_t swizA = { 0, 16,  1, 17,  2, 18,  3, 19,  4, 20,  5, 21,  6, 22,  7, 23};
-            vec_t swizB = { 8, 24,  9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31};
-            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
-            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
-	    int8_t *dest;
+            vec_t swizA
+                    = {0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23};
+            vec_t swizB = {8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30,
+                    15, 31};
+            vec_t swizL
+                    = {0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23};
+            vec_t swizR = {8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15,
+                    30, 31};
+            int8_t *dest;
 
-	    V0 = *(vec_t *) &a[lda*(i+0) + j];
-	    V1 = *(vec_t *) &a[lda*(i+1) + j];
-	    V2 = *(vec_t *) &a[lda*(i+2) + j];
-	    V3 = *(vec_t *) &a[lda*(i+3) + j];
+            V0 = *(vec_t *)&a[lda * (i + 0) + j];
+            V1 = *(vec_t *)&a[lda * (i + 1) + j];
+            V2 = *(vec_t *)&a[lda * (i + 2) + j];
+            V3 = *(vec_t *)&a[lda * (i + 3) + j];
 
-	    D01A = vec_perm(V0, V1, swizA);
-	    D01B = vec_perm(V0, V1, swizB);
-	    D23A = vec_perm(V2, V3, swizA);
-	    D23B = vec_perm(V2, V3, swizB);
-            D0 = vec_perm(D01A, D23A, swizL); 
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
             D1 = vec_perm(D01A, D23A, swizR);
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
 
-            dest = &ap[16 * (((j>>4) * block4) + i)];
+            dest = &ap[16 * (((j >> 4) * block4) + i)];
 
-	    *(vec_t *) &dest[ 0] = D0;
-	    *(vec_t *) &dest[16] = D1;
-	    *(vec_t *) &dest[32] = D2;
-	    *(vec_t *) &dest[48] = D3;
+            *(vec_t *)&dest[0] = D0;
+            *(vec_t *)&dest[16] = D1;
+            *(vec_t *)&dest[32] = D2;
+            *(vec_t *)&dest[48] = D3;
         }
     }
 
     // HIGH EDGE IN M DIRECTION
-    for (i=0; i<k4; ++i) {
-        for (j=m16; j<m_cap; ++j) {
-            kcell = i>>2;
-            mcell = j>>2;
+    for (i = 0; i < k4; ++i) {
+        for (j = m16; j < m_cap; ++j) {
+            kcell = i >> 2;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = chunk4count * block4;
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&3;
-            moff = j&3;
-            if (j < m) ap[16*cell + 4*moff+koff] = a[lda*i+j];
-	    else       ap[16*cell + 4*moff+koff] = 0;
+            koff = i & 3;
+            moff = j & 3;
+            if (j < m)
+                ap[16 * cell + 4 * moff + koff] = a[lda * i + j];
+            else
+                ap[16 * cell + 4 * moff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (i=k4; i<k_cap; ++i) {
-        for (j=0; j<m16; ++j) {
-            kcell = i>>2;
-            mcell = j>>2;
+    for (i = k4; i < k_cap; ++i) {
+        for (j = 0; j < m16; ++j) {
+            kcell = i >> 2;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = chunk4count * block4;
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&3;
-            moff = j&3;
-            if (i < k) ap[16*cell + 4*moff+koff] = a[lda*i+j];
-	    else       ap[16*cell + 4*moff+koff] = 0;
+            koff = i & 3;
+            moff = j & 3;
+            if (i < k)
+                ap[16 * cell + 4 * moff + koff] = a[lda * i + j];
+            else
+                ap[16 * cell + 4 * moff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH M, HIGH K)
-    for (i=k4; i<k_cap; ++i) {
-        for (j=m16; j<m_cap; ++j) {
-            kcell = i>>2;
-            mcell = j>>2;
+    for (i = k4; i < k_cap; ++i) {
+        for (j = m16; j < m_cap; ++j) {
+            kcell = i >> 2;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = chunk4count * block4;
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&3;
-            moff = j&3;
-            if (i < k && j < m) ap[16*cell + 4*moff+koff] = a[lda*i+j];
-	    else                ap[16*cell + 4*moff+koff] = 0;
+            koff = i & 3;
+            moff = j & 3;
+            if (i < k && j < m)
+                ap[16 * cell + 4 * moff + koff] = a[lda * i + j];
+            else
+                ap[16 * cell + 4 * moff + koff] = 0;
         }
     }
 
@@ -867,89 +893,97 @@ int pack_N8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
     int kcell, cell, koff, noff, krows, k8, n8;
     int n_cap = (n + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    krows = (k+3) >> 2;
-    k8 = k>>3;
-    n8 = n>>3;
+    krows = (k + 3) >> 2;
+    k8 = k >> 3;
+    n8 = n >> 3;
 
     // MAIN BLOCK
-    for (j=0; j<(n8<<3); j+=8) {
-        for (i=0; i<(k8<<3); i+=8) {
+    for (j = 0; j < (n8 << 3); j += 8) {
+        for (i = 0; i < (k8 << 3); i += 8) {
             vec_t V0, V1, V2, V3;
             vec_t D0, D1, D2, D3;
-            vec_t swizA = {  0,  1,  2,  3,  8,  9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27};
-            vec_t swizB = {  4,  5,  6,  7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31};
-	    const uint8_t *src = &b[ldb*j+i];
-	    uint8_t *dest = &bp[16 * (krows * (j >> 2) + (i >> 1))];
+            vec_t swizA = {
+                    0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27};
+            vec_t swizB = {
+                    4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31};
+            const uint8_t *src = &b[ldb * j + i];
+            uint8_t *dest = &bp[16 * (krows * (j >> 2) + (i >> 1))];
 
-	    *(signed long long *) &V0[0] = *(signed long long *) &src[ldb*0];
-	    *(signed long long *) &V0[8] = *(signed long long *) &src[ldb*1];
-	    *(signed long long *) &V1[0] = *(signed long long *) &src[ldb*2];
-	    *(signed long long *) &V1[8] = *(signed long long *) &src[ldb*3];
-	    *(signed long long *) &V2[0] = *(signed long long *) &src[ldb*4];
-	    *(signed long long *) &V2[8] = *(signed long long *) &src[ldb*5];
-	    *(signed long long *) &V3[0] = *(signed long long *) &src[ldb*6];
-	    *(signed long long *) &V3[8] = *(signed long long *) &src[ldb*7];
+            *(signed long long *)&V0[0] = *(signed long long *)&src[ldb * 0];
+            *(signed long long *)&V0[8] = *(signed long long *)&src[ldb * 1];
+            *(signed long long *)&V1[0] = *(signed long long *)&src[ldb * 2];
+            *(signed long long *)&V1[8] = *(signed long long *)&src[ldb * 3];
+            *(signed long long *)&V2[0] = *(signed long long *)&src[ldb * 4];
+            *(signed long long *)&V2[8] = *(signed long long *)&src[ldb * 5];
+            *(signed long long *)&V3[0] = *(signed long long *)&src[ldb * 6];
+            *(signed long long *)&V3[8] = *(signed long long *)&src[ldb * 7];
 
-            D0 = vec_perm(V0, V1, swizA); 
+            D0 = vec_perm(V0, V1, swizA);
             D1 = vec_perm(V2, V3, swizA);
             D2 = vec_perm(V0, V1, swizB);
             D3 = vec_perm(V2, V3, swizB);
 
-	    *(vec_t *) &dest[ 0] = D0;
-	    *(vec_t *) &dest[16] = D1;
-	    *(vec_t *) &dest[32] = D2;
-	    *(vec_t *) &dest[48] = D3;
+            *(vec_t *)&dest[0] = D0;
+            *(vec_t *)&dest[16] = D1;
+            *(vec_t *)&dest[32] = D2;
+            *(vec_t *)&dest[48] = D3;
         }
     }
 
     // HIGH EDGE IN N DIRECTION
-    for (j=(n8<<3); j<n_cap; ++j) {
-        for (i=0; i<(k8<<3); ++i) {
-            kcell = i>>2;
+    for (j = (n8 << 3); j < n_cap; ++j) {
+        for (i = 0; i < (k8 << 3); ++i) {
+            kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&3;
-            noff = j&3;
-            if (j < n) bp[16*cell + 4*noff+koff] = b[ldb*j+i];
-	    else       bp[16*cell + 4*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 3;
+            noff = j & 3;
+            if (j < n)
+                bp[16 * cell + 4 * noff + koff] = b[ldb * j + i];
+            else
+                bp[16 * cell + 4 * noff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (j=0; j<(n8<<3); ++j) {
-        for (i=(k8<<3); i<k_cap; ++i) {
-            kcell = i>>2;
+    for (j = 0; j < (n8 << 3); ++j) {
+        for (i = (k8 << 3); i < k_cap; ++i) {
+            kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&3;
-            noff = j&3;
-            if (i < k) bp[16*cell + 4*noff+koff] = b[ldb*j+i];
-	    else       bp[16*cell + 4*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 3;
+            noff = j & 3;
+            if (i < k)
+                bp[16 * cell + 4 * noff + koff] = b[ldb * j + i];
+            else
+                bp[16 * cell + 4 * noff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH N, HIGH K)
-    for (j=(n8<<3); j<n_cap; ++j) {
-        for (i=(k8<<3); i<k_cap; ++i) {
-            kcell = i>>2;
+    for (j = (n8 << 3); j < n_cap; ++j) {
+        for (i = (k8 << 3); i < k_cap; ++i) {
+            kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&3;
-            noff = j&3;
-            if (j < n && i < k) bp[16*cell + 4*noff+koff] = b[ldb*j+i];
-	    else                bp[16*cell + 4*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 3;
+            noff = j & 3;
+            if (j < n && i < k)
+                bp[16 * cell + 4 * noff + koff] = b[ldb * j + i];
+            else
+                bp[16 * cell + 4 * noff + koff] = 0;
         }
     }
 
@@ -960,213 +994,215 @@ int pack_N16_8bit(dim_t k, dim_t m, const int8_t *a, dim_t lda, int8_t *ap) {
     int i, j;
     int m_cap = (m + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell, chunk4count, m16, k4, k16;
-    m16 = (m>>4)<<4;
-    k4 = (k>>2)<<2;
-    k16 = (k>>4)<<4;
-    krows = (k+3) >> 2;
-    mrows = (m+3) >> 2;
+    int kcell, cell, koff, moff, krows, mrows, block4, block2, mcell,
+            chunk4count, m16, k4, k16;
+    m16 = (m >> 4) << 4;
+    k4 = (k >> 2) << 2;
+    k16 = (k >> 4) << 4;
+    krows = (k + 3) >> 2;
+    mrows = (m + 3) >> 2;
     block4 = 4 * krows;
     block2 = 2 * krows;
 
     // MAIN BLOCK
-    for (j=0; j<m16; j+=16) {
-        for (i=0; i<k16; i+=16) {
+    for (j = 0; j < m16; j += 16) {
+        for (i = 0; i < k16; i += 16) {
             vec_t V0, V1, V2, V3;
             vec_t D01A, D01B, D23A, D23B;
             vec_t D0, D1, D2, D3;
-            vec_t swizA = { 0,  1,  2,  3,  4,  5,  6,  7, 16, 17, 18, 19, 20, 21, 22, 23};
-            vec_t swizB = { 8,  9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31};
-            vec_t swizL = { 0,  1,  2,  3,  8,  9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27};
-            vec_t swizR = { 4,  5,  6,  7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31};
+            vec_t swizA
+                    = {0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23};
+            vec_t swizB = {8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29,
+                    30, 31};
+            vec_t swizL = {
+                    0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27};
+            vec_t swizR = {
+                    4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31};
 
-	    const int8_t *src = &a[lda*j+i];
-	    int8_t *dest = &ap[j * (krows << 2) + (i << 4)];
+            const int8_t *src = &a[lda * j + i];
+            int8_t *dest = &ap[j * (krows << 2) + (i << 4)];
 
-            V0 = *(vec_t *) &src[0 * lda];
-            V1 = *(vec_t *) &src[1 * lda];
-            V2 = *(vec_t *) &src[2 * lda];
-            V3 = *(vec_t *) &src[3 * lda];
-	    D01A = vec_perm(V0, V1, swizA);
-	    D01B = vec_perm(V0, V1, swizB);
-	    D23A = vec_perm(V2, V3, swizA);
-	    D23B = vec_perm(V2, V3, swizB);
-            D0 = vec_perm(D01A, D23A, swizL); 
+            V0 = *(vec_t *)&src[0 * lda];
+            V1 = *(vec_t *)&src[1 * lda];
+            V2 = *(vec_t *)&src[2 * lda];
+            V3 = *(vec_t *)&src[3 * lda];
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
             D1 = vec_perm(D01A, D23A, swizR);
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
-            *(vec_t *) &dest[  0] = D0;
-            *(vec_t *) &dest[ 64] = D1;
-            *(vec_t *) &dest[128] = D2;
-            *(vec_t *) &dest[192] = D3;
+            *(vec_t *)&dest[0] = D0;
+            *(vec_t *)&dest[64] = D1;
+            *(vec_t *)&dest[128] = D2;
+            *(vec_t *)&dest[192] = D3;
 
-            V0 = *(vec_t *) &src[4 * lda];
-            V1 = *(vec_t *) &src[5 * lda];
-            V2 = *(vec_t *) &src[6 * lda];
-            V3 = *(vec_t *) &src[7 * lda];
-	    D01A = vec_perm(V0, V1, swizA);
-	    D01B = vec_perm(V0, V1, swizB);
-	    D23A = vec_perm(V2, V3, swizA);
-	    D23B = vec_perm(V2, V3, swizB);
-            D0 = vec_perm(D01A, D23A, swizL); 
+            V0 = *(vec_t *)&src[4 * lda];
+            V1 = *(vec_t *)&src[5 * lda];
+            V2 = *(vec_t *)&src[6 * lda];
+            V3 = *(vec_t *)&src[7 * lda];
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
             D1 = vec_perm(D01A, D23A, swizR);
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
-            *(vec_t *) &dest[ 16] = D0;
-            *(vec_t *) &dest[ 80] = D1;
-            *(vec_t *) &dest[144] = D2;
-            *(vec_t *) &dest[208] = D3;
+            *(vec_t *)&dest[16] = D0;
+            *(vec_t *)&dest[80] = D1;
+            *(vec_t *)&dest[144] = D2;
+            *(vec_t *)&dest[208] = D3;
 
-            V0 = *(vec_t *) &src[ 8 * lda];
-            V1 = *(vec_t *) &src[ 9 * lda];
-            V2 = *(vec_t *) &src[10 * lda];
-            V3 = *(vec_t *) &src[11 * lda];
-	    D01A = vec_perm(V0, V1, swizA);
-	    D01B = vec_perm(V0, V1, swizB);
-	    D23A = vec_perm(V2, V3, swizA);
-	    D23B = vec_perm(V2, V3, swizB);
-            D0 = vec_perm(D01A, D23A, swizL); 
+            V0 = *(vec_t *)&src[8 * lda];
+            V1 = *(vec_t *)&src[9 * lda];
+            V2 = *(vec_t *)&src[10 * lda];
+            V3 = *(vec_t *)&src[11 * lda];
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
             D1 = vec_perm(D01A, D23A, swizR);
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
-            *(vec_t *) &dest[ 32] = D0;
-            *(vec_t *) &dest[ 96] = D1;
-            *(vec_t *) &dest[160] = D2;
-            *(vec_t *) &dest[224] = D3;
+            *(vec_t *)&dest[32] = D0;
+            *(vec_t *)&dest[96] = D1;
+            *(vec_t *)&dest[160] = D2;
+            *(vec_t *)&dest[224] = D3;
 
-            V0 = *(vec_t *) &src[12 * lda];
-            V1 = *(vec_t *) &src[13 * lda];
-            V2 = *(vec_t *) &src[14 * lda];
-            V3 = *(vec_t *) &src[15 * lda];
-	    D01A = vec_perm(V0, V1, swizA);
-	    D01B = vec_perm(V0, V1, swizB);
-	    D23A = vec_perm(V2, V3, swizA);
-	    D23B = vec_perm(V2, V3, swizB);
-            D0 = vec_perm(D01A, D23A, swizL); 
+            V0 = *(vec_t *)&src[12 * lda];
+            V1 = *(vec_t *)&src[13 * lda];
+            V2 = *(vec_t *)&src[14 * lda];
+            V3 = *(vec_t *)&src[15 * lda];
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
             D1 = vec_perm(D01A, D23A, swizR);
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
-            *(vec_t *) &dest[ 48] = D0;
-            *(vec_t *) &dest[112] = D1;
-            *(vec_t *) &dest[176] = D2;
-            *(vec_t *) &dest[240] = D3;
+            *(vec_t *)&dest[48] = D0;
+            *(vec_t *)&dest[112] = D1;
+            *(vec_t *)&dest[176] = D2;
+            *(vec_t *)&dest[240] = D3;
         }
-        for (i=k16; i<k4; i+=4) {
+        for (i = k16; i < k4; i += 4) {
             vec_t D0, D1, D2, D3;
-	    const int8_t *src = &a[lda*j+i];
-	    int8_t *dest = &ap[j * (krows << 2) + (i << 4)];
+            const int8_t *src = &a[lda * j + i];
+            int8_t *dest = &ap[j * (krows << 2) + (i << 4)];
 
-            *(int *) &D0[ 0] = *(int *) &src[ 0 * lda];
-            *(int *) &D0[ 4] = *(int *) &src[ 1 * lda];
-            *(int *) &D0[ 8] = *(int *) &src[ 2 * lda];
-            *(int *) &D0[12] = *(int *) &src[ 3 * lda];
-            *(int *) &D1[ 0] = *(int *) &src[ 4 * lda];
-            *(int *) &D1[ 4] = *(int *) &src[ 5 * lda];
-            *(int *) &D1[ 8] = *(int *) &src[ 6 * lda];
-            *(int *) &D1[12] = *(int *) &src[ 7 * lda];
-            *(int *) &D2[ 0] = *(int *) &src[ 8 * lda];
-            *(int *) &D2[ 4] = *(int *) &src[ 9 * lda];
-            *(int *) &D2[ 8] = *(int *) &src[10 * lda];
-            *(int *) &D2[12] = *(int *) &src[11 * lda];
-            *(int *) &D3[ 0] = *(int *) &src[12 * lda];
-            *(int *) &D3[ 4] = *(int *) &src[13 * lda];
-            *(int *) &D3[ 8] = *(int *) &src[14 * lda];
-            *(int *) &D3[12] = *(int *) &src[15 * lda];
+            *(int *)&D0[0] = *(int *)&src[0 * lda];
+            *(int *)&D0[4] = *(int *)&src[1 * lda];
+            *(int *)&D0[8] = *(int *)&src[2 * lda];
+            *(int *)&D0[12] = *(int *)&src[3 * lda];
+            *(int *)&D1[0] = *(int *)&src[4 * lda];
+            *(int *)&D1[4] = *(int *)&src[5 * lda];
+            *(int *)&D1[8] = *(int *)&src[6 * lda];
+            *(int *)&D1[12] = *(int *)&src[7 * lda];
+            *(int *)&D2[0] = *(int *)&src[8 * lda];
+            *(int *)&D2[4] = *(int *)&src[9 * lda];
+            *(int *)&D2[8] = *(int *)&src[10 * lda];
+            *(int *)&D2[12] = *(int *)&src[11 * lda];
+            *(int *)&D3[0] = *(int *)&src[12 * lda];
+            *(int *)&D3[4] = *(int *)&src[13 * lda];
+            *(int *)&D3[8] = *(int *)&src[14 * lda];
+            *(int *)&D3[12] = *(int *)&src[15 * lda];
 
-            *(vec_t *) &dest[ 0] = D0;
-            *(vec_t *) &dest[16] = D1;
-            *(vec_t *) &dest[32] = D2;
-            *(vec_t *) &dest[48] = D3;
+            *(vec_t *)&dest[0] = D0;
+            *(vec_t *)&dest[16] = D1;
+            *(vec_t *)&dest[32] = D2;
+            *(vec_t *)&dest[48] = D3;
         }
     }
 
     // HIGH EDGE IN M DIRECTION
-    for (j=m16; j<m_cap; ++j) {
-        for (i=0; i<k4; ++i) {
-            kcell = i>>2;
-            mcell = j>>2;
+    for (j = m16; j < m_cap; ++j) {
+        for (i = 0; i < k4; ++i) {
+            kcell = i >> 2;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-    
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = (chunk4count * block4);
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&3;
-            moff = j&3;
-            if (j < m) ap[16*cell + 4*moff+koff] = a[lda*j+i];
-	    else       ap[16*cell + 4*moff+koff] = 0;
+            koff = i & 3;
+            moff = j & 3;
+            if (j < m)
+                ap[16 * cell + 4 * moff + koff] = a[lda * j + i];
+            else
+                ap[16 * cell + 4 * moff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (j=0; j<m16; ++j) {
-        for (i=k4; i<k_cap; ++i) {
-            kcell = i>>2;
-            mcell = j>>2;
+    for (j = 0; j < m16; ++j) {
+        for (i = k4; i < k_cap; ++i) {
+            kcell = i >> 2;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-    
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = (chunk4count * block4);
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&3;
-            moff = j&3;
-            if (i < k) ap[16*cell + 4*moff+koff] = a[lda*j+i];
-	    else       ap[16*cell + 4*moff+koff] = 0;
+            koff = i & 3;
+            moff = j & 3;
+            if (i < k)
+                ap[16 * cell + 4 * moff + koff] = a[lda * j + i];
+            else
+                ap[16 * cell + 4 * moff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH M, HIGH K)
-    for (j=m16; j<m_cap; ++j) {
-        for (i=k4; i<k_cap; ++i) {
-            kcell = i>>2;
-            mcell = j>>2;
+    for (j = m16; j < m_cap; ++j) {
+        for (i = k4; i < k_cap; ++i) {
+            kcell = i >> 2;
+            mcell = j >> 2;
             chunk4count = mcell >> 2;
-    
-            if (mcell < (mrows & ~3)) cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
+
+            if (mcell < (mrows & ~3))
+                cell = (chunk4count * block4) + (4 * kcell) + (mcell & 3);
             else {
                 cell = (chunk4count * block4);
                 if (m_cap & 8) {
                     switch (mcell & 3) {
-                    case 0:
-                    case 1:
-                        cell += 2 * kcell + (mcell & 1);
-                        break;
-                    case 2:
-                        cell += block2 + kcell;
-                        break;
+                        case 0:
+                        case 1: cell += 2 * kcell + (mcell & 1); break;
+                        case 2: cell += block2 + kcell; break;
                     }
-                }
-                else if (m_cap & 4) cell += kcell;
+                } else if (m_cap & 4)
+                    cell += kcell;
             }
-            koff = i&3;
-            moff = j&3;
-            if (j < m && i < k) ap[16*cell + 4*moff+koff] = a[lda*j+i];
-	    else                ap[16*cell + 4*moff+koff] = 0;
+            koff = i & 3;
+            moff = j & 3;
+            if (j < m && i < k)
+                ap[16 * cell + 4 * moff + koff] = a[lda * j + i];
+            else
+                ap[16 * cell + 4 * moff + koff] = 0;
         }
     }
 
@@ -1178,97 +1214,115 @@ int pack_T8_8bit(dim_t k, dim_t n, const uint8_t *b, dim_t ldb, uint8_t *bp) {
     int kcell, cell, koff, noff, krows, k8, n8;
     int n_cap = (n + 3) & ~3;
     int k_cap = (k + 3) & ~3;
-    krows = (k+3) >> 2;
-    k8 = (k>>3)<<3;
-    n8 = (n>>3)<<3;
+    krows = (k + 3) >> 2;
+    k8 = (k >> 3) << 3;
+    n8 = (n >> 3) << 3;
 
     // MAIN BLOCK
-    for (i=0; i<k8; i+=8) { 
-        for (j=0; j<n8; j+=8) {
+    for (i = 0; i < k8; i += 8) {
+        for (j = 0; j < n8; j += 8) {
             vec_t V0, V1, V2, V3;
             vec_t D01A, D01B, D23A, D23B;
             vec_t D0, D1, D2, D3;
-            vec_t swizA = { 0, 16,  1, 17,  2, 18,  3, 19,  4, 20,  5, 21,  6, 22,  7, 23};
-            vec_t swizB = { 8, 24,  9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31};
-            vec_t swizL = { 0,  1, 16, 17,  2,  3, 18, 19,  4,  5, 20, 21,  6,  7, 22, 23};
-            vec_t swizR = { 8,  9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31};
-	    uint8_t *dest;
+            vec_t swizA
+                    = {0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23};
+            vec_t swizB = {8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30,
+                    15, 31};
+            vec_t swizL
+                    = {0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23};
+            vec_t swizR = {8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15,
+                    30, 31};
+            uint8_t *dest;
 
-	    *(signed long long *) &V0[0] = *(signed long long *) &b[ldb*(i+0) + j];
-	    *(signed long long *) &V1[0] = *(signed long long *) &b[ldb*(i+1) + j];
-	    *(signed long long *) &V2[0] = *(signed long long *) &b[ldb*(i+2) + j];
-	    *(signed long long *) &V3[0] = *(signed long long *) &b[ldb*(i+3) + j];
-	    *(signed long long *) &V0[8] = *(signed long long *) &b[ldb*(i+4) + j];
-	    *(signed long long *) &V1[8] = *(signed long long *) &b[ldb*(i+5) + j];
-	    *(signed long long *) &V2[8] = *(signed long long *) &b[ldb*(i+6) + j];
-	    *(signed long long *) &V3[8] = *(signed long long *) &b[ldb*(i+7) + j];
+            *(signed long long *)&V0[0]
+                    = *(signed long long *)&b[ldb * (i + 0) + j];
+            *(signed long long *)&V1[0]
+                    = *(signed long long *)&b[ldb * (i + 1) + j];
+            *(signed long long *)&V2[0]
+                    = *(signed long long *)&b[ldb * (i + 2) + j];
+            *(signed long long *)&V3[0]
+                    = *(signed long long *)&b[ldb * (i + 3) + j];
+            *(signed long long *)&V0[8]
+                    = *(signed long long *)&b[ldb * (i + 4) + j];
+            *(signed long long *)&V1[8]
+                    = *(signed long long *)&b[ldb * (i + 5) + j];
+            *(signed long long *)&V2[8]
+                    = *(signed long long *)&b[ldb * (i + 6) + j];
+            *(signed long long *)&V3[8]
+                    = *(signed long long *)&b[ldb * (i + 7) + j];
 
-	    D01A = vec_perm(V0, V1, swizA);
-	    D01B = vec_perm(V0, V1, swizB);
-	    D23A = vec_perm(V2, V3, swizA);
-	    D23B = vec_perm(V2, V3, swizB);
-            D0 = vec_perm(D01A, D23A, swizL); 
+            D01A = vec_perm(V0, V1, swizA);
+            D01B = vec_perm(V0, V1, swizB);
+            D23A = vec_perm(V2, V3, swizA);
+            D23B = vec_perm(V2, V3, swizB);
+            D0 = vec_perm(D01A, D23A, swizL);
             D1 = vec_perm(D01A, D23A, swizR);
             D2 = vec_perm(D01B, D23B, swizL);
             D3 = vec_perm(D01B, D23B, swizR);
 
             dest = &bp[16 * ((j >> 2) * krows + (i >> 1))];
 
-	    *(vec_t *) &dest[ 0] = D0;
-	    *(vec_t *) &dest[16] = D1;
-	    *(vec_t *) &dest[32] = D2;
-	    *(vec_t *) &dest[48] = D3;
+            *(vec_t *)&dest[0] = D0;
+            *(vec_t *)&dest[16] = D1;
+            *(vec_t *)&dest[32] = D2;
+            *(vec_t *)&dest[48] = D3;
         }
     }
 
     // HIGH EDGE IN N DIRECTION
-    for (i=0; i<k8; ++i) {
-        for (j=n8; j<n_cap; ++j) {
-            kcell = i>>2;
+    for (i = 0; i < k8; ++i) {
+        for (j = n8; j < n_cap; ++j) {
+            kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
-                int columns_done = ((j & (~7)) >> 3) << 1;
+            int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&3;
-            noff = j&3;
-            if (j < n) bp[16*cell + 4*noff+koff] = b[ldb*i+j];
-	    else       bp[16*cell + 4*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 3;
+            noff = j & 3;
+            if (j < n)
+                bp[16 * cell + 4 * noff + koff] = b[ldb * i + j];
+            else
+                bp[16 * cell + 4 * noff + koff] = 0;
         }
     }
 
     // HIGH EDGE IN K DIRECTION
-    for (i=k8; i<k_cap; ++i) {
-        for (j=0; j<n8; ++j) {
-            kcell = i>>2;
+    for (i = k8; i < k_cap; ++i) {
+        for (j = 0; j < n8; ++j) {
+            kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&3;
-            noff = j&3;
-            if (i < k) bp[16*cell + 4*noff+koff] = b[ldb*i+j];
-	    else       bp[16*cell + 4*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 3;
+            noff = j & 3;
+            if (i < k)
+                bp[16 * cell + 4 * noff + koff] = b[ldb * i + j];
+            else
+                bp[16 * cell + 4 * noff + koff] = 0;
         }
     }
 
     // UPPER CORNER (HIGH N, HIGH K)
-    for (i=k8; i<k_cap; ++i) {
-        for (j=n8; j<n_cap; ++j) {
-            kcell = i>>2;
+    for (i = k8; i < k_cap; ++i) {
+        for (j = n8; j < n_cap; ++j) {
+            kcell = i >> 2;
             // special handling if j is in a PARTIAL last "group of 8"
             int maingroup = (j & (~7)) < (n & (~7));
             int columns_done = ((j & (~7)) >> 3) << 1;
             int groupwidth = (maingroup || ((n & 7) > 4)) ? 2 : 1;
             int j_hiflag = (j & 4) >> 2;
-            cell = columns_done*krows+kcell*groupwidth+j_hiflag;
-            koff = i&3;
-            noff = j&3;
-            if (i < k && j < n) bp[16*cell + 4*noff+koff] = b[ldb*i+j];
-	    else                bp[16*cell + 4*noff+koff] = 0;
+            cell = columns_done * krows + kcell * groupwidth + j_hiflag;
+            koff = i & 3;
+            noff = j & 3;
+            if (i < k && j < n)
+                bp[16 * cell + 4 * noff + koff] = b[ldb * i + j];
+            else
+                bp[16 * cell + 4 * noff + koff] = 0;
         }
     }
 


### PR DESCRIPTION
# Description

After some review, I realized that the eight packing routines in my code for Power-optimized 8-bit matrix multiplication were slow (and also fairly hard to read and understand).  
I've replaced them with new routines.
The four 8-bit packing routines now run 4x faster than before.
The four 16-bit "fallback" packing routines run 2x faster than previously.
The code size for these eight routines is roughly half of what it was before.

Fixes # (github issue)

# Checklist

## General

- [ YES] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ YES] Have you formatted the code using clang-format?

## Performance improvements

- [ See answer] Have you submitted performance data that demonstrates performance improvements?
   I will attach a spreadsheet in a comment below that summarizes the improvements I saw.

### New features

- [ n/a] Have you published an RFC for the new feature?
- [ n/a] Was the RFC approved?
- [ n/a] Have you added relevant tests?

### Bug fixes

- [ n/a] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ n/a] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ n/a] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ n/a] Have you added a link to the rendered document?
