### PR TITLE
cpu: aarch64: conv: fix skip condition for dilated conf

### DIFF
--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -366,6 +366,9 @@ status_t jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_conf(
     bool args_ok = true && jcp.oc == jcp.ngroups && jcp.ic == jcp.ngroups
             && jcp.ngroups % simd_w == 0 && jcp.src_tag == dat_tag
             && jcp.wei_tag == wei_tag && jcp.dst_tag == dat_tag
+            && jcp.dilate_h == 0 && jcp.dilate_w == 0
+            && jcp.oh == (jcp.ihp - jcp.kh) / jcp.stride_h + 1
+            && jcp.ow == (jcp.iwp - jcp.kw) / jcp.stride_w + 1
             && jcp.ic <= diff_src_d.padded_dims()[1]
             && jcp.oc <= diff_dst_d.padded_dims()[1]
             && jcp.ngroups <= weights_d.padded_dims()[0];


### PR DESCRIPTION
# Description

This patch fixes the JIT-ed implementation of convolution for AArch64 SVE environment.
For example, the following `benchdnn` test patterns, which are included `tests/benchdnn/inputs/conv/test_conv_all`, will be passed correctly.


```
--conv --skip-impl=ref --dir=BWD_D g32ic32ih14iw14oc32oh7ow7kh3kw3sh2sw2ph1pw1dh1dw0ndilated_conv:41/dw
--conv --skip-impl=ref --dir=BWD_D g64ic64ih112iw112oc64oh56ow56kh3kw3sh2sw2ph1pw1dh1dw2ndilated_conv:42/dw
--conv --skip-impl=ref,x64:gemm --dir=BWD_D g32ic32ih14iw14oc32oh7ow7kh3kw3sh2sw2ph1pw1dh1dw0ndilated_conv:41/dw
--conv --skip-impl=ref,x64:gemm --dir=BWD_D g64ic64ih112iw112oc64oh56ow56kh3kw3sh2sw2ph1pw1dh1dw2ndilated_conv:42/dw
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?


### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
