### PR TITLE
scripts: converter: parser: add support for old verbose naming convention

### DIFF
--- a/scripts/verbose_converter/src/dnnl_parser.py
+++ b/scripts/verbose_converter/src/dnnl_parser.py
@@ -291,7 +291,7 @@ class LogParser:
             self.__raw_data.append(line.rstrip())
             l_raw = line.split(",")
             marker = l_raw[0]
-            if marker == "onednn_verbose":
+            if marker in ["onednn_verbose","dnnl_verbose"]:
                 if l_raw[1].split('.')[0].isdigit():
                     l_raw.pop(1)
                 event = l_raw[1].split(":")[0]


### PR DESCRIPTION


# Description

Currently the verbose_converter script only supports verbose logs prior to the name change: dnnl_verbose -> onednn_verbose.

The changes enable older verbose outputs support for the converter script.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
