### PR TITLE
fixup: api: eltwise: aarch64: correct initialisation

### DIFF
--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -76,7 +76,8 @@ struct acl_eltwise_fwd_t : public primitive_t {
 
             bool ok = is_fwd() && one_of(src_d.data_type(), f32, s32, s8)
                     && !has_zero_dim_memory() && attr()->has_default_values()
-                    && src_d.is_dense();
+                    && set_default_formats_common() && src_d.is_dense()
+                    && src_d == memory_desc_wrapper(dst_md());
             if (!ok) return status::unimplemented;
 
             auto acl_data_t = acl_utils::get_acl_data_t(src_d.data_type());

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -265,7 +265,7 @@ template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_eltwise_bwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     using namespace alg_kind;
 
-    const memory_desc_wrapper data_d(data_md());
+    const memory_desc_wrapper data_d(src_md());
 
     bool ok = mayiuse(isa) && !is_fwd()
             && utils::everyone_is(d_type, data_md()->data_type,


### PR DESCRIPTION
# Description

This PR covers minor changes to fix issues that were encountered when running test_eltwise on AArch64.

(1) When initialising eltwise primitive for calling to ACL operation add check that source and destination have the same memory format
(2) When initialising JIT eltwise for backward pass initialise data with correct memory descriptor.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
Run test_eltwise and see failures.

- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document
