### PR TITLE
fixup: api: aarch64: matmul and eltwise inits

### DIFF
--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -76,7 +76,8 @@ struct acl_eltwise_fwd_t : public primitive_t {
 
             bool ok = is_fwd() && one_of(src_d.data_type(), f32, s32, s8)
                     && !has_zero_dim_memory() && attr()->has_default_values()
-                    && src_d.is_dense();
+                    && set_default_formats_common() && src_d.is_dense()
+                    && src_d == memory_desc_wrapper(dst_md());
             if (!ok) return status::unimplemented;
 
             auto acl_data_t = acl_utils::get_acl_data_t(src_d.data_type());

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -200,16 +200,8 @@ status_t jit_uni_eltwise_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
             // refer to a comment in jit_uni_kernel why this is needed
             && IMPLICATION(!src_d.is_dense(), is_zero_preserved())
             && attr()->has_default_values() && set_default_formats_common()
-            && src_d == memory_desc_wrapper(dst_md());
-
-    ok &= utils::one_of(desc_.alg_kind, eltwise_relu_use_dst_for_bwd,
-            eltwise_relu, eltwise_elu_use_dst_for_bwd, eltwise_elu,
-            eltwise_tanh_use_dst_for_bwd, eltwise_tanh, eltwise_square,
-            eltwise_abs, eltwise_sqrt_use_dst_for_bwd, eltwise_sqrt,
-            eltwise_linear, eltwise_soft_relu, eltwise_logistic_use_dst_for_bwd,
-            eltwise_logistic, eltwise_exp_use_dst_for_bwd, eltwise_exp,
-            eltwise_gelu_tanh, eltwise_swish, eltwise_log, eltwise_clip,
-            eltwise_gelu_erf, eltwise_round);
+            && src_d == memory_desc_wrapper(dst_md())
+            && eltwise_injector::is_alg_supported(desc_.alg_kind);
 
     return ok ? status::success : status::unimplemented;
 }
@@ -277,16 +269,8 @@ status_t jit_uni_eltwise_bwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
             && data_d == memory_desc_wrapper(diff_dst_md())
             && memory_desc_wrapper(diff_src_md())
                     == memory_desc_wrapper(diff_dst_md())
-            && attr()->has_default_values();
-
-    ok &= utils::one_of(desc_.alg_kind, eltwise_relu_use_dst_for_bwd,
-            eltwise_relu, eltwise_elu_use_dst_for_bwd, eltwise_elu,
-            eltwise_tanh_use_dst_for_bwd, eltwise_tanh, eltwise_square,
-            eltwise_abs, eltwise_sqrt_use_dst_for_bwd, eltwise_sqrt,
-            eltwise_linear, eltwise_soft_relu, eltwise_logistic_use_dst_for_bwd,
-            eltwise_logistic, eltwise_exp_use_dst_for_bwd, eltwise_exp,
-            eltwise_gelu_tanh, eltwise_swish, eltwise_log, eltwise_clip,
-            eltwise_gelu_erf);
+            && attr()->has_default_values()
+            && eltwise_injector::is_alg_supported(desc_.alg_kind);
 
     return ok ? status::success : status::unimplemented;
 }

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -265,7 +265,7 @@ template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_eltwise_bwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     using namespace alg_kind;
 
-    const memory_desc_wrapper data_d(data_md());
+    const memory_desc_wrapper data_d(src_md());
 
     bool ok = mayiuse(isa) && !is_fwd()
             && utils::everyone_is(d_type, data_md()->data_type,

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -95,7 +95,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
     // Set alpha (output scaling)
     // TODO: Add runtime scales support. Creation time scales will be remove
     // in 3.0.
-    // amp.alpha = attr.output_scales_.scales_[0];
+    amp.alpha = 1.0f; // default value
     if (!attr.output_scales_.has_default_values()) return status::unimplemented;
 
     // Validate ACL transpose


### PR DESCRIPTION
# Description

This PR covers minor changes to fix issues that were encountered when running unit tests:

(1) Set default value for alpha scaling in matmul
(2) Use method is_alg_supported() from eltwise_injector when initialising primitive to decide whether algorithm is supported or not

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
Run tests cpp-tutotirals-matmul-matmul-quantization-cpp and test_benchdnn_eltwise_ci_cpu to see failures

- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?