### PR TITLE
fixup: api: aarch64: eltwise soft_relu when alpha != 1

### DIFF
--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -76,7 +76,8 @@ struct acl_eltwise_fwd_t : public primitive_t {
 
             bool ok = is_fwd() && one_of(src_d.data_type(), f32, s32, s8)
                     && !has_zero_dim_memory() && attr()->has_default_values()
-                    && src_d.is_dense();
+                    && set_default_formats_common() && src_d.is_dense()
+                    && src_d == memory_desc_wrapper(dst_md());
             if (!ok) return status::unimplemented;
 
             auto acl_data_t = acl_utils::get_acl_data_t(src_d.data_type());

--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -87,7 +87,7 @@ status_t convert_to_acl_act(alg_kind_t eltwise_alg, float alpha, float beta,
             act_info = ActivationLayerInfo(act_func::LINEAR, alpha, beta);
             break;
         case eltwise_soft_relu:
-            if (utils::one_of(alpha, 0.f, 1.f)) {
+            if (alpha == 1.f) {
                 act_info
                         = ActivationLayerInfo(act_func::SOFT_RELU, alpha, beta);
                 break;

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -265,7 +265,7 @@ template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_eltwise_bwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     using namespace alg_kind;
 
-    const memory_desc_wrapper data_d(data_md());
+    const memory_desc_wrapper data_d(src_md());
 
     bool ok = mayiuse(isa) && !is_fwd()
             && utils::everyone_is(d_type, data_md()->data_type,


### PR DESCRIPTION
# Description

ACL soft_relu does not support sharpness (alpha) parameter so we should only call into ACL from oneDNN when alpha is 1.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
Run benchdnn --eltwise --alg=soft_relu --alpha=0 1600x1600x1x1

- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?