### PR TITLE
cpu: aarch64: bnorm: support flags for SVE 512 jit-ed

### DIFF
--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -348,12 +348,39 @@ public:
     }
 
     template <typename T>
+    void uni_fmad(const T &dst, const T &src, const T &src2) {
+        fmad(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src, src2);
+    }
+
+    void uni_fmad(const Xbyak_aarch64::VReg4S &dst,
+            const Xbyak_aarch64::VReg4S &src,
+            const Xbyak_aarch64::VReg4S &src2) {
+        fmul(dst, dst, src);
+        fadd(dst, dst, src2);
+    }
+
+    template <typename T>
     void uni_fmax(const T &dst, const T &src, const T &src2) {
         uint32_t dstIdx = dst.getIdx();
         uint32_t srcIdx = src.getIdx();
         if (dstIdx != srcIdx)
             mov(Xbyak_aarch64::ZRegD(dstIdx), Xbyak_aarch64::ZRegD(srcIdx));
         fmax(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src2);
+    }
+
+    template <typename T>
+    void uni_fmaxnm(const T &dst, const T &src, const T &src2) {
+        uint32_t dstIdx = dst.getIdx();
+        uint32_t srcIdx = src.getIdx();
+        if (dstIdx != srcIdx)
+            mov(Xbyak_aarch64::ZRegD(dstIdx), Xbyak_aarch64::ZRegD(srcIdx));
+        fmaxnm(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src2);
+    }
+
+    void uni_fmaxnm(const Xbyak_aarch64::VReg4S &dst,
+            const Xbyak_aarch64::VReg4S &src,
+            const Xbyak_aarch64::VReg4S &src2) {
+        fmaxnm(dst, src, src2);
     }
 
     template <typename T>
@@ -378,6 +405,16 @@ public:
     void uni_frinti(
             const Xbyak_aarch64::ZRegS &d, const Xbyak_aarch64::ZRegS &s) {
         frinti(d, P_ALL_ONE / Xbyak_aarch64::T_m, s);
+    }
+
+    template <typename T>
+    void uni_fsqrt(const T &dst, const T &src) {
+        fsqrt(dst, P_ALL_ONE / Xbyak_aarch64::T_m, src);
+    }
+
+    void uni_fsqrt(const Xbyak_aarch64::VReg4S &dst,
+            const Xbyak_aarch64::VReg4S &src) {
+        fsqrt(dst, src);
     }
 
     void uni_fsub(const Xbyak_aarch64::VReg4S &v1,

--- a/src/cpu/aarch64/jit_uni_batch_normalization.hpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
-* Copyright 2020 FUJITSU LIMITED
+* Copyright 2017-2022 Intel Corporation
+* Copyright 2020-2022 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,8 +25,9 @@
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
-#include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/cpu_batch_normalization_pd.hpp"
+
+#include "cpu/aarch64/cpu_isa_traits.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -50,6 +51,7 @@ struct jit_uni_batch_normalization_fwd_t : public primitive_t {
                 jit_uni_batch_normalization_fwd_t);
 
         status_t init(engine_t *engine);
+        int nthr_; // To not exceed the limit in execute used for set up.
     };
 
     jit_uni_batch_normalization_fwd_t(const pd_t *apd);
@@ -77,6 +79,7 @@ struct jit_uni_batch_normalization_bwd_t : public primitive_t {
                 jit_uni_batch_normalization_bwd_t);
 
         status_t init(engine_t *engine);
+        int nthr_; // To not exceed the limit in execute used for set up.
     };
 
     jit_uni_batch_normalization_bwd_t(const pd_t *apd);


### PR DESCRIPTION
# Description

This PR adds support of [the batch normalization flags](https://github.com/oneapi-src/oneDNN/blob/master/tests/benchdnn/doc/driver_bnorm.md) for SVE 512 jit-ed.




# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

