### PR TITLE
cpu: aarch64: Handle src!=dst in ACL bnorm

### DIFF
--- a/src/cpu/aarch64/acl_batch_normalization.hpp
+++ b/src/cpu/aarch64/acl_batch_normalization.hpp
@@ -118,6 +118,11 @@ struct acl_batch_normalization_fwd_t : public primitive_t {
             ACL_CHECK_SUPPORT(!attr()->has_default_values(smask_t::post_ops),
                     "attr must have default values");
 
+            ACL_CHECK_SUPPORT(!set_default_formats_common(),
+                    "Failed to set default formats");
+            ACL_CHECK_SUPPORT(src_d != memory_desc_wrapper(dst_md()),
+                    "Source and destination must have the same layout");
+
             // Stats must already have been calculated
             ACL_CHECK_SUPPORT(!use_global_stats(),
                     "stats must already have been computed (use global stats)");


### PR DESCRIPTION
# Description

Adds a guard to return unimplemented when src and dst layouts don't match in `acl_batch_normalization_fwd_t`. The underlying class, `arm_compute::NEBatchNormalizationLayer` does not support different src and dst layouts, and neither does the oneDNN ref implementation. This has only recently become necessary due to changes for v3.0 (#1440).

This is tested in `Test_BatchNormalization_EF`, but it doesn't currently fail on AArch64 because the test bails early (because ACL bnorm only supports global stats and the test throws an error before it gets there). There is no sensible and easy way to modify this test to fail, and I assume at some point benchdnn will be able to specify differing src and dst tags for bnorm. I think it makes sense to try to get this in as is for v3.0, but I'm open to suggestions.

The issue can be reproduced by modifying the batch normalization example to use global stats and non-matching layouts of src and dst, then building/running with ACL.

# Checklist

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

