### PR TITLE
cpu: aarch64: deconv: fix invalid nb_ch and CBZ instruction

### DIFF
--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -199,7 +199,7 @@ status_t jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
     jcp.ur_w = nstl::min(jcp.ur_w, jcp.ow);
 
     jcp.ch_block = simd_w;
-    jcp.nb_ch = jcp.oc / jcp.ch_block;
+    jcp.nb_ch = div_up(jcp.oc, jcp.ch_block);
     jcp.nb_ch_blocking = isa == sve_512 ? 4 : isa == sve_256 ? 3 : 2;
     if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
 

--- a/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_impl.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_impl.h
@@ -638,7 +638,7 @@ uint32_t CodeGenerator::CompareBrEnc(uint32_t op, const RReg &rt, int64_t labelO
 }
 
 void CodeGenerator::CompareBr(uint32_t op, const RReg &rt, const Label &label) {
-  auto encFunc = [=, &op](int64_t labelOffset) { return CompareBrEnc(op, rt, labelOffset); };
+  auto encFunc = [=](int64_t labelOffset) { return CompareBrEnc(op, rt, labelOffset); };
   JmpLabel jmpL = JmpLabel(encFunc, size_);
   uint32_t code = CompareBrEnc(op, rt, genLabelOffset(label, jmpL));
   dd(code);
@@ -665,7 +665,7 @@ uint32_t CodeGenerator::TestBrEnc(uint32_t op, const RReg &rt, uint32_t imm, int
 }
 
 void CodeGenerator::TestBr(uint32_t op, const RReg &rt, uint32_t imm, const Label &label) {
-  auto encFunc = [&, op, rt, imm](int64_t labelOffset) { return TestBrEnc(op, rt, imm, labelOffset); };
+  auto encFunc = [=](int64_t labelOffset) { return TestBrEnc(op, rt, imm, labelOffset); };
   JmpLabel jmpL = JmpLabel(encFunc, size_);
   uint32_t code = TestBrEnc(op, rt, imm, genLabelOffset(label, jmpL));
   dd(code);


### PR DESCRIPTION
# Description

This PR fixes invalid nb_ch calculation and binary code of CBZ instruction of jit-ed `dwconv` for SVE.

## Example of fixed test patterns.
### nc_ch

```
build/tests/benchdnn/benchdnn --conv --stag=aBcd16b --wtag=Abcde16a --dtag=aBcd16b \
g47mb1_ic47oc47_ih20oh20kh3sh1dh0ph1_iw20ow20kw3sw1dw0pw1
```

### CBZ instruction

```
build/tests/benchdnn/ --deconv --mode=C --dir=FWD_I --cfg=u8s8f32 \
g1ic16ih5oc3oh5kh3ph1n"2d_conv:1st"
```

# Checklist

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [Not needed] Have you added relevant regression tests?

