### PR TITLE
cpu: aarch64: eltwise: fix invalid preserved Z register size and indices

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -109,7 +109,6 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble(
             for (size_t i = 0; i < preserved_vecs_count; ++i)
                 h->str(ZReg(preserved_vec_idxs[i]), ptr(h->X_SP, i, MUL_VL));
         }
-
         load_table_addr();
     }
 
@@ -138,7 +137,8 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble_tail(
 
     if (save_state_ && preserve_vmm_) {
         for (size_t i = 0; i < tail_vecs_to_preserve; ++i)
-            h->str(ZReg(idx_off + i), ptr(h->X_SP, i, MUL_VL));
+            h->str(ZReg(preserved_vec_idxs[idx_off + i]),
+                    ptr(h->X_SP, i, MUL_VL));
 
         if (idx_off) h->sub_imm(h->X_SP, h->X_SP, idx_off * vlen, h->X_TMP_0);
     }
@@ -1597,8 +1597,6 @@ void jit_uni_eltwise_injector_f32<isa>::prepare_table(bool gen_table) {
     for (auto it = entry_map_.begin(); it != entry_map_.end(); it++) {
         const auto &te = (*it).second; // get map entry for a given key
         const auto len = te.bcast ? vlen : sizeof(table_entry_val_t);
-        /*        for (size_t d = 0; d < len; d += sizeof(table_entry_val_t))
-            h->dd(te.val);*/
         for (size_t d = 0; d < len; d += sizeof(table_entry_val_t))
             h->dd(te.val);
 

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -177,7 +177,7 @@ private:
         _op_mxcsr = jit_generator::_op_mxcsr
     };
 
-    static constexpr size_t vlen = cpu_isa_traits<isa>::vlen;
+    const size_t vlen = get_sve_length();
     static constexpr size_t preserved_vecs_max = 9;
     static constexpr size_t preserved_gprs_max = 4;
     static constexpr size_t vecs_count = cpu_isa_traits<isa>::n_vregs;


### PR DESCRIPTION
# Description

This PR fixes invalid preserved Z register size and indices of jit-ed `eltwise` for SVE.


## Example of fixed test patterns.

### register size

```
tests/gtests/test_convolution_eltwise_forward_f32 \
--gtest_filter="Convolution_SimpleSmall_Blocked16_Tail_eltwise_CPU/\
convolution_test.TestConvolutionEltwise/0"
```

### register indices

```
tests/benchdnn/benchdnn --conv --dir=FWD_I --stag=axb --dtag=axb \
--attr-post-ops=relu+dw_k3s2p1+tanh --attr-scratchpad=user \
ic32ih112oc64oh112kh1ph0n"MobileNet_v1_fused_stride_2"
```

# Checklist

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
