### PR TITLE
cpu: aarch64: binary: support blk_size = 8, 4

### DIFF
--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -136,7 +136,11 @@ conditional_register_preserve_guard_t<
                     : register_preserve_guard_t<isa> {nullptr, {}, {}}} {};
 
 template class register_preserve_guard_t<sve_512>;
+template class register_preserve_guard_t<sve_256>;
+template class register_preserve_guard_t<sve_128>;
 template class conditional_register_preserve_guard_t<sve_512>;
+template class conditional_register_preserve_guard_t<sve_256>;
+template class conditional_register_preserve_guard_t<sve_128>;
 
 } // namespace injector_utils
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1889,6 +1889,8 @@ void jit_uni_binary_injector_t<isa>::compute_vector(size_t idx,
 }
 
 template class jit_uni_binary_injector_t<sve_512>;
+template class jit_uni_binary_injector_t<sve_256>;
+template class jit_uni_binary_injector_t<sve_128>;
 
 } // namespace binary_injector
 } // namespace aarch64

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -244,6 +244,8 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
 }
 
 template class jit_uni_postops_injector_t<sve_512>;
+template class jit_uni_postops_injector_t<sve_256>;
+template class jit_uni_postops_injector_t<sve_128>;
 
 } // namespace injector
 } // namespace aarch64

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -556,6 +556,7 @@ struct jit_binary_conf_t {
     dim_t outer_dims = 1;
     int src1_stride = 1;
     int not_bcasted_sp_dims = 0;
+    cpu_isa_t isa = isa_undef;
 
     data_type_t src0_type = data_type::undef;
     data_type_t src1_type = data_type::undef;

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -74,7 +74,25 @@ static bool data_type_supported(const data_type_t dtype) {
     return utils::one_of(dtype, f32, s8, u8);
 }
 
-status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
+static cpu_isa_t get_supported_isa() {
+    if (mayiuse(sve_512)) return sve_512;
+    if (mayiuse(sve_256)) return sve_256;
+    if (mayiuse(sve_128)) return sve_128;
+
+    return isa_undef;
+}
+
+static bool data_format_supported(
+        const memory_desc_wrapper &mdw, const cpu_isa_t isa) {
+    if (mdw.is_plain()) return true;
+    const auto blk_size = mdw.blocking_desc().inner_blks[0];
+    return (is_superset(isa, sve_512) && utils::one_of(blk_size, 16, 8, 4))
+            || (is_superset(isa, sve_256) && utils::one_of(blk_size, 8, 4))
+            || (is_superset(isa, sve_128) && blk_size == 4);
+}
+
+
+  status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     using sm = primitive_attr_t::skip_mask_t;
 
     conf_.dst_type = dst_md()->data_type;
@@ -89,9 +107,12 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     const int elt_idx = po.find(primitive_kind::eltwise);
     conf_.is_i8 = utils::one_of(conf_.dst_type, s8, u8);
 
-    bool ok = mayiuse(sve_512) && data_type_supported(conf_.dst_type)
+    conf_.isa = get_supported_isa();
+
+    bool ok = data_type_supported(conf_.dst_type)
             && data_type_supported(conf_.src0_type)
             && data_type_supported(conf_.src1_type)
+      && data_format_supported(src0_md_, conf_.isa)
             && set_default_params() == status::success && !has_zero_dim_memory()
             && IMPLICATION(!conf_.is_i8, src0_md_ == dst_md_) && is_applicable()
             && attr()->has_default_values(sm::post_ops | sm::scales_runtime)
@@ -482,13 +503,30 @@ bool jit_uni_binary_t::post_ops_ok(const primitive_attr_t *attr,
 binary_kernel_t *create_binary_kernel(
         const jit_uni_binary_t::pd_t *pd, bool tail_kernel) {
     const auto &conf = pd->get_conf();
-    if (mayiuse(sve_512)) {
-        using kernel_t = jit_uni_binary_kernel_t<sve_512>;
-        return new kernel_t(pd, conf, tail_kernel && !conf.is_i8);
-    } else {
-        assert(!"unsupported isa");
-        return nullptr;
+    const memory_desc_wrapper src0_d(pd->src_md(0));
+    // No support for different blocked memory layouts
+    const auto blk_size = src0_d.blocking_desc().inner_blks[0];
+    const auto is_plain_layout = src0_d.is_plain();
+    switch (conf.isa) {
+        case sve_512:
+            if (blk_size == 16 || is_plain_layout) {
+                using kernel_t = jit_uni_binary_kernel_t<sve_512>;
+                return new kernel_t(pd, conf, tail_kernel && !conf.is_i8);
+            }
+        case sve_256:
+            if (blk_size == 8 || is_plain_layout) {
+                using kernel_t = jit_uni_binary_kernel_t<sve_256>;
+                return new kernel_t(pd, conf, tail_kernel && !conf.is_i8);
+            }
+        case sve_128:
+            if (blk_size == 4 || is_plain_layout) {
+                using kernel_t = jit_uni_binary_kernel_t<sve_128>;
+                return new kernel_t(pd, conf, tail_kernel && !conf.is_i8);
+            }
+        default: assert(!"unreachable");
     }
+    assert(!"Could not create binary kernel");
+    return nullptr;
 }
 
 jit_uni_binary_t::jit_uni_binary_t(const pd_t *apd) : primitive_t(apd) {}


### PR DESCRIPTION
# Description

This PR adds support of plane_layout and blk_size = 8, 4 to jit-ed `binary` for SVE 512/256/128.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

