### PR TITLE
tests: benchdnn: aarch64: set error in conv tests to eps of fp16

### DIFF
--- a/tests/benchdnn/conv/cfg.cpp
+++ b/tests/benchdnn/conv/cfg.cpp
@@ -45,7 +45,7 @@ const _dt_conf_t conf_f16 = {
         {dnnl_f16, -int_max_exact_half, int_max_exact_half, -6, 6, 0, 1, 1.0,
                 0.},
         {dnnl_f16, -int_max_exact_half, int_max_exact_half, -4, 4, 0, 1, .25,
-                0.},
+                1e-3},
         {dnnl_f32},
 };
 


### PR DESCRIPTION
# Description

The previous value for relative error (for conv) was zero, which caused conv with relu to fail after adding support for fp16 on aarch64. The reason for the failure is that the reference implementation does the calculations in fp32 and then casts to fp16, instead of doing the calculations in fp16.
Note that eps for fp16 = 0.000977 ~ 0.001

# Checklist

## General

- [ yes] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ yes] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A ] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
can be reproduced by running benchdnn conv + relu in fp16 mode with ACL
`./tests/benchdnn/benchdnn --conv --skip-impl=ref --allow-enum-tags-only=false --cfg=f16 --attr-post-ops=relu:0.1 mb1ic128ih52oc256oh52kh3ph1n"yolo.inf.fp16.ov.mb1*3"`

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
