### PR TITLE
Do not let altivec.h redefine bool

### DIFF
--- a/include/oneapi/dnnl/dnnl_ocl.h
+++ b/include/oneapi/dnnl/dnnl_ocl.h
@@ -28,6 +28,9 @@
 #endif
 
 #include <CL/cl.h>
+#if defined( __VEC__ ) && defined(bool)
+#undef bool
+#endif
 /// @endcond
 
 #ifdef __cplusplus

--- a/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
@@ -15,6 +15,9 @@
 *******************************************************************************/
 
 #include <altivec.h>
+#ifdef bool
+#undef bool
+#endif
 #include "cpu/simple_q10n.hpp"
 
 namespace dnnl {


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?


On ppc64le without this the build fails with
```
In file included from /home/conda/feedstock_root/build_artifacts/onednn-split_1668974280014/work/examples/cnn_inference_f32.c:50:
/home/conda/feedstock_root/build_artifacts/onednn-split_1668974280014/work/examples/example_utils.h: In function 'read_from_dnnl_memory':
/home/conda/feedstock_root/build_artifacts/onednn-split_1668974280014/work/examples/example_utils.h:108:15: error: incompatible types when initializing type '__vector __bool int' {aka '__vector(4) __bool int'} using type 'int'
  108 |             = (DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL && eng_kind == dnnl_cpu);
      |               ^
/home/conda/feedstock_root/build_artifacts/onednn-split_1668974280014/work/examples/example_utils.h:110:30: error: invalid operands to binary || (have 'int' and '__vector __bool int' {aka '__vector(4) __bool int'})
  110 |     if (eng_kind == dnnl_gpu || is_cpu_sycl) {
      |         ~~~~~~~~~~~~~~~~~~~~ ^~
      |                  |
      |                  int
```
See the bug report at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58241
