### PR TITLE
cpu: aarch64: fp16 postops: disable ACL post ops for fp16

### DIFF
--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -34,6 +34,12 @@ struct acl_post_ops_t {
     status_t init(engine_t *engine, post_ops_t &post_ops,
             const memory_desc_t &dst_md) {
 
+        // Disable ACL post ops when in f16 mode. This is because the oneDNN reference runs
+        // the post op in f32 and then casts down to f16 while ACL runs the post op in f16
+        // leading to a loss of accuracy compared to ref.
+        ACL_CHECK_SUPPORT(
+                post_ops.len() >= 1 && dst_md.data_type == data_type::f16,
+                "post ops cannot be executed in fp16");
         CHECK(post_ops.set_default_formats(&dst_md));
 
         // Reset properties derived from post_ops
@@ -129,6 +135,12 @@ struct acl_post_ops_t {
             const memory_desc_t &dst_md,
             arm_compute::ActivationLayerInfo &act_info_to_fuse) {
 
+        // Disable ACL post ops when in f16 mode. This is because the oneDNN reference runs
+        // the post op in f32 and then casts down to f16 while ACL runs the post op in f16
+        // leading to a loss of accuracy compared to ref.
+        ACL_CHECK_SUPPORT(
+                base_post_ops.len() >= 1 && dst_md.data_type == data_type::f16,
+                "post ops cannot be executed in fp16");
         CHECK(base_post_ops.set_default_formats(&dst_md));
 
         // If the first entry is eltwise, we fuse it


### PR DESCRIPTION
# Description

The oneDNN API specifies that post ops need to (always) be executed in fp32, but ACL executes them in f16 (when running in fp16 mode) which caused a lot of conv+relu benchdnn tests to fail.

Fixes # (#1499)

# Checklist

## General

- [ YES ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ YES ] Have you formatted the code using clang-format?

## Performance improvements

- [ N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ N/A] Have you published an RFC for the new feature?
- [ N/A] Was the RFC approved?
- [ N/A] Have you added relevant tests?

### Bug fixes

- [ YES] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ N/A] Have you added relevant regression tests?

