### PR TITLE
cpu: aarch64: add clip using ACL bounded relu

### DIFF
--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -97,6 +97,14 @@ status_t convert_to_acl_act(alg_kind_t eltwise_alg, float alpha, float beta,
         case eltwise_logistic:
             act_info = ActivationLayerInfo(act_func::LOGISTIC, alpha, beta);
             break;
+        case eltwise_clip:
+            // OneDNN uses alpha in CLIP as lower bound and beta as upper bound.
+            // Compute Library uses beta as lower bound and alpha as upper in
+            // the equivalent function LU_BOUNDED_RELU.
+            // Switching order of alpha and beta makes the two equivalent.
+            act_info = ActivationLayerInfo(
+                    act_func::LU_BOUNDED_RELU, beta, alpha);
+            break;
         default: act_info = ActivationLayerInfo(); return status::unimplemented;
     }
 


### PR DESCRIPTION
# Description

This PR adds support for oneDNN's clip algorithm using the Bounded Relu from Compute Library for the Arm® architecture (ACL).
Benchmarks show that performance improvements compared to ref are similar to other algs.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?


## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?