### PR TITLE
cpu: aarch64: get fpmath mode from attr instead of just env

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -41,8 +41,8 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
     const memory_desc_wrapper dst_d(&dst_md);
     const memory_desc_wrapper bia_d(&bias_md);
 
-    auto math_mode = get_fpmath_mode();
-    acp.fast_math = one_of(math_mode, fpmath_mode::bf16, fpmath_mode::any);
+    acp.fast_math
+            = one_of(attr.fpmath_mode_, fpmath_mode::bf16, fpmath_mode::any);
 
     // Compute Library currently supports forward propagation only
     const prop_kind_t prop_kind = cd.prop_kind;

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -215,11 +215,8 @@ struct acl_inner_product_fwd_t : public primitive_t {
                 }
             }
 
-            // Fast math mode
-            auto math_mode = get_fpmath_mode();
-            bool is_fastmath_enabled = utils::one_of(
-                    math_mode, fpmath_mode::bf16, fpmath_mode::any);
-            aip.fc_info.enable_fast_math = is_fastmath_enabled;
+            aip.fc_info.enable_fast_math = utils::one_of(
+                    attr()->fpmath_mode_, fpmath_mode::bf16, fpmath_mode::any);
 
             CHECK(post_ops.init(engine, attr_.post_ops_, dst_md_,
                     aip.fc_info.activation_info));

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -86,10 +86,8 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
     amp.dst_info = arm_compute::TensorInfo(
             arm_compute::TensorShape(N, M, 1, dst_batch), 1, acl_dst_data_t);
 
-    // Fast-math mode
-    auto math_mode = get_fpmath_mode();
-    bool is_fastmath_enabled
-            = utils::one_of(math_mode, fpmath_mode::bf16, fpmath_mode::any);
+    bool is_fastmath_enabled = utils::one_of(
+            attr.fpmath_mode_, fpmath_mode::bf16, fpmath_mode::any);
     amp.gemm_info.set_fast_math(is_fastmath_enabled);
 
     // Set alpha (output scaling)


### PR DESCRIPTION
# Description

Previously, running benchdnn with `--attr-fpmath` flags set would not have any effect for primitives calling ACL kernels. Only the environment flag would change the behaviour. This patch fixes this to use the correct interface, via `attr`, which takes into account both settings.

Given that it is a bug fix, would it be possible to get this cherry picked onto the release branch please?

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests? I'm not sure this is testable, but it can be run via benchdnn

