### PR TITLE
Adding Support for Matmul Primitive - HIP Backend

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -66,7 +66,9 @@ if(DNNL_SYCL_HIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/softmax.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/lrn.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/eltwise.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reduction.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reduction.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/matmul.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/matmul_perf.cpp)
 endif()
 
 # Skip SYCL, GPU and cross-engine examples

--- a/src/gpu/amd/miopen_matmul.cpp
+++ b/src/gpu/amd/miopen_matmul.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_matmul.hpp"
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/type_helpers.hpp"
+
+#include "gpu/amd/miopen_matmul_executor.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_matmul_t::execute(const exec_ctx_t &ctx) const {
+    if (pd()->has_zero_dim_memory()) return status::success;
+    const bool with_bias = matmul_impl_->with_bias();
+    const bool has_runtime_args = matmul_impl_->has_runtime_params();
+
+    const auto src_d = ctx.memory_mdw(DNNL_ARG_SRC, pd()->src_md());
+    const auto weights_d = ctx.memory_mdw(DNNL_ARG_WEIGHTS, pd()->weights_md());
+    const auto dst_d = ctx.memory_mdw(DNNL_ARG_DST, pd()->dst_md());
+    const auto bias_d = with_bias
+            ? ctx.memory_mdw(DNNL_ARG_BIAS, pd()->weights_md(1))
+            : nullptr;
+
+    status_t status;
+    if (has_runtime_args) {
+        // Initialise all runtime parameters
+        status = matmul_impl_->init_parameters(src_d, weights_d, dst_d, bias_d);
+        if (status != status::success) return status;
+    }
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    const auto scratchpad_type = matmul_impl_->get_scratchpad_type();
+    const auto scratchpad_size = matmul_impl_->with_scratchpad()
+            ? (dst_d.nelems() * types::data_type_size(scratchpad_type))
+            : 0;
+
+    status = executor_->execute(
+            ctx, ctx.stream()->engine(), matmul_impl_, scratchpad_size);
+
+    if (has_runtime_args) {
+        auto &evts = hip_stream->get_deps();
+        for (auto e : evts) {
+            e.wait();
+        }
+
+        matmul_impl_->cleanup();
+    }
+
+    return status;
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_matmul.hpp
+++ b/src/gpu/amd/miopen_matmul.hpp
@@ -1,0 +1,182 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_MATMUL_HPP
+#define GPU_AMD_MIOPEN_MATMUL_HPP
+
+#include <assert.h>
+
+#include "common/matmul_pd.hpp"
+#include "common/primitive.hpp"
+
+#include "gpu/amd/miopen_matmul_executor.hpp"
+#include "gpu/amd/miopen_matmul_impl.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_matmul_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public matmul_pd_t {
+        using matmul_pd_t::matmul_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_matmul_t);
+
+        status_t init(engine_t *) {
+            using namespace data_type;
+            using smask_t = primitive_attr_t::skip_mask_t;
+
+            data_type_t src_dt = src_md()->data_type;
+            data_type_t dst_dt = dst_md()->data_type;
+            data_type_t wei_dt = weights_md(0)->data_type;
+            data_type_t bia_dt
+                    = with_bias() ? weights_md(1)->data_type : data_type::f32;
+
+            bool f32_case = utils::everyone_is(f32, src_dt, wei_dt, dst_dt);
+            bool f16_case = utils::everyone_is(f16, src_dt, wei_dt, dst_dt);
+            bool s8_case = utils::everyone_is(s8, src_dt, wei_dt) && (dst_dt == s32);
+
+            bool bf16_case = batched()
+                    ? utils::everyone_is(bf16, src_dt, wei_dt, dst_dt)
+                    : utils::everyone_is(bf16, src_dt, wei_dt)
+                            && utils::one_of(dst_dt, f32, bf16);
+
+            bool ok = blocking_ok()
+                    && attr()->has_default_values(smask_t::post_ops)
+                    && attr_oscale_ok() && attr_post_ops_ok(s8_case)
+                    && set_default_formats()
+                    && (f32_case || f16_case || s8_case || bf16_case)
+                    && IMPLICATION(with_bias(),
+                            (IMPLICATION(f32_case, (bia_dt == f32))
+                                    && IMPLICATION(f16_case, (bia_dt == f16))
+                                    && IMPLICATION(s8_case, (bia_dt == s32))
+                                    && IMPLICATION(bf16_case, dst_dt == f32 && bia_dt == f32)));
+
+            if (!ok) return status::unimplemented;
+
+            if (src_md()->ndims > 3) {
+                return status::unimplemented;
+            } else if (src_md()->ndims > 2) {
+                for (int i = 0; i < src_md()->ndims - 2; i++) {
+                    ok = src_md()->dims[i] == weights_md()->dims[i]
+                            && src_md()->dims[i] == dst_md()->dims[i];
+                }
+                if (!ok) return status::unimplemented;
+            }
+
+            return status::success;
+        }
+
+    private:
+        bool attr_oscale_ok() const {
+            const auto &oscale = attr()->output_scales_;
+            return oscale.mask_ == 0;
+        }
+
+        bool attr_post_ops_ok(bool s8_case) const {
+            using namespace primitive_kind;
+            const auto &p = attr()->post_ops_;
+            const int eltwise_idx = p.find(eltwise);
+            const int sum_idx = p.find(sum);
+
+            if (eltwise_idx != -1) {
+                using namespace alg_kind;
+                const bool ok = utils::one_of(p.entry_[eltwise_idx].eltwise.alg,
+                        eltwise_relu, eltwise_tanh, eltwise_elu,
+                        eltwise_logistic);
+                if (!ok) return false;
+            }
+
+            if ((sum_idx != -1) && s8_case) {
+                float sum_scale = p.entry_[sum_idx].sum.scale;
+                if (sum_scale != (int)sum_scale) return false;
+            }
+
+            switch (p.len()) {
+                case 0: return true;
+                case 1: return p.contain(sum, 0) || p.contain(eltwise, 0);
+                case 2: return p.contain(sum, 0) && p.contain(eltwise, 1);
+                default: return false;
+            }
+        }
+
+        bool blocking_ok() const {
+            std::vector<const memory_desc_t *> mds
+                    = {src_md(), dst_md(), weights_md(0)};
+            if (with_bias()) mds.push_back(weights_md(1));
+            for (const memory_desc_t *md : mds) {
+                memory_desc_wrapper mdw(md);
+                if (mdw.is_blocking_desc()) {
+                    if (mdw.blocking_desc().inner_nblks != 0) { return false; }
+                }
+            }
+            return true;
+        }
+    };
+
+    status_t init(engine_t *engine) override {
+        matmul_impl_.reset(new miopen_matmul_impl_t());
+        const auto status
+                = matmul_impl_->init((matmul_pd_t *)primitive_t::pd().get());
+
+        const bool with_bias = matmul_impl_->with_bias();
+        const bool has_runtime_args = matmul_impl_->has_runtime_params();
+        const bool with_scratchpad = matmul_impl_->with_scratchpad();
+
+        if (with_scratchpad && has_runtime_args && with_bias) {
+            executor_.reset(new miopen_matmul_scratch_runtime_args_bias_exec_t);
+        } else if (with_scratchpad && has_runtime_args) {
+            executor_.reset(new miopen_matmul_runtime_args_scratch_exec_t);
+        } else if (has_runtime_args && with_bias) {
+            executor_.reset(new miopen_matmul_runtime_args_bias_exec_t);
+        } else if (has_runtime_args) {
+            executor_.reset(new miopen_matmul_runtime_args_exec_t);
+        } else if (with_bias && with_scratchpad) {
+            executor_.reset(new miopen_matmul_bias_scratch_exec_t);
+        } else if (with_scratchpad) {
+            executor_.reset(new miopen_matmul_scratch_exec_t);
+        } else if (with_bias) {
+            executor_.reset(new miopen_matmul_bias_exec_t);
+        } else if (!with_scratchpad && !has_runtime_args && !with_bias) {
+            executor_.reset(new miopen_matmul_exec_t);
+        } else {
+            return status::unimplemented;
+        }
+
+        return status;
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+    virtual ~miopen_matmul_t() {}
+
+    std::shared_ptr<miopen_matmul_impl_t> matmul_impl_;
+    std::shared_ptr<miopen_matmul_exec_base_t> executor_;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_matmul_executor.hpp
+++ b/src/gpu/amd/miopen_matmul_executor.hpp
@@ -1,0 +1,291 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_MATMUL_EXECUTOR_HPP
+#define GPU_AMD_MIOPEN_MATMUL_EXECUTOR_HPP
+
+#include "gpu/amd/miopen_matmul.hpp"
+#include "gpu/amd/miopen_matmul_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+#include <memory>
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_matmul_exec_base_t {
+    virtual status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size)
+            = 0;
+    virtual ~miopen_matmul_exec_base_t() = default;
+
+protected:
+    template <::sycl::access::mode bias_m, ::sycl::access::mode scratch_m>
+    void interop_task(std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            engine_t *engine, ::sycl::handler &cgh,
+            amd::sycl_hip_stream_t *hip_stream,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read>
+                    arg_weights,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read> arg_src,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write> arg_dst,
+            impl::sycl::sycl_memory_arg_t<bias_m> arg_bias,
+            impl::sycl::sycl_memory_arg_t<scratch_m> arg_scratch) {
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto native_stream = hip_stream->get_underlying_stream();
+            auto rocblas_handle = hip_stream->get_rocblas_handle(native_stream);
+            auto miopen_handle = hip_stream->get_miopen_handle(native_stream);
+
+            void *scratch = arg_scratch.get_native_pointer(ih);
+            void *bias = arg_bias.get_native_pointer(ih);
+            void *weights = arg_weights.get_native_pointer(ih);
+            void *src = arg_src.get_native_pointer(ih);
+            void *dst = arg_dst.get_native_pointer(ih);
+
+            matmul_impl_->execute(rocblas_handle, miopen_handle, weights, src,
+                    dst, bias, scratch);
+        });
+    }
+};
+
+struct miopen_matmul_scratch_runtime_args_base_exec_t
+    : public miopen_matmul_exec_base_t {
+    virtual status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size)
+            = 0;
+    virtual ~miopen_matmul_scratch_runtime_args_base_exec_t() = default;
+
+protected:
+    void init_scratch_buffer(std::size_t scratch_size) {
+        if (scratch_size > 0) {
+            scratch_buff_.reset(new ::sycl::buffer<uint8_t, 1>(scratch_size));
+        }
+    }
+
+    std::shared_ptr<::sycl::buffer<uint8_t, 1>> scratch_buff_ {nullptr};
+};
+
+struct miopen_matmul_scratch_runtime_args_bias_exec_t
+    : public miopen_matmul_scratch_runtime_args_base_exec_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        init_scratch_buffer(scratchpad_size);
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_BIAS);
+            auto arg_scratch = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read_write>(*scratch_buff_, cgh);
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, arg_bias, arg_scratch);
+        });
+    }
+};
+
+struct miopen_matmul_runtime_args_scratch_exec_t
+    : public miopen_matmul_scratch_runtime_args_base_exec_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        init_scratch_buffer(scratchpad_size);
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_scratch = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read_write>(*scratch_buff_, cgh);
+            auto arg_bias = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read>();
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, /*nullptr*/ arg_bias, arg_scratch);
+        });
+    }
+};
+
+struct miopen_matmul_runtime_args_bias_exec_t
+    : public miopen_matmul_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_BIAS);
+
+            auto arg_scratch = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read_write>();
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, arg_bias, /*nullptr*/ arg_scratch);
+        });
+    }
+};
+
+struct miopen_matmul_runtime_args_exec_t : public miopen_matmul_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+
+            auto arg_bias = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read>();
+            auto arg_scratch = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read_write>();
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, /*nullptr*/ arg_bias,
+                    /*nullptr*/ arg_scratch);
+        });
+    }
+};
+
+struct miopen_matmul_bias_scratch_exec_t : public miopen_matmul_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_BIAS);
+            auto arg_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                    memory_tracking::names::key_matmul_dst_in_acc_dt);
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, arg_bias, arg_scratch);
+        });
+    }
+};
+
+struct miopen_matmul_scratch_exec_t : public miopen_matmul_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                    memory_tracking::names::key_matmul_dst_in_acc_dt);
+
+            auto arg_bias = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read>();
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, /*nullptr*/ arg_bias, arg_scratch);
+        });
+    }
+};
+
+struct miopen_matmul_bias_exec_t : public miopen_matmul_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_BIAS);
+
+            auto arg_scratch = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read_write>();
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, arg_bias, /*nullptr*/ arg_scratch);
+        });
+    }
+};
+
+struct miopen_matmul_exec_t : public miopen_matmul_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_matmul_impl_t> matmul_impl_,
+            std::size_t scratchpad_size) override {
+
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+        return hip_stream->interop_task([=](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_wt = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+
+            auto arg_bias = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read>();
+            auto arg_scratch = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::read_write>();
+
+            interop_task(matmul_impl_, engine, cgh, hip_stream, arg_wt, arg_src,
+                    arg_dst, /*nullptr*/ arg_bias,
+                    /*nullptr*/ arg_scratch);
+        });
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_matmul_impl.hpp
+++ b/src/gpu/amd/miopen_matmul_impl.hpp
@@ -1,0 +1,438 @@
+/*******************************************************************************
+* Copyright 2020-2022 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_MATMUL_IMPL_HPP
+#define GPU_AMD_MIOPEN_MATMUL_IMPL_HPP
+
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+#include "miopen/miopen.h"
+#include "rocblas.h"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_matmul_impl_t {
+    bool with_eltwise(int position, const matmul_pd_t *pd) const {
+        return pd->attr()->post_ops_.contain(primitive_kind::eltwise, position);
+    }
+
+    float eltwise_alpha(const matmul_pd_t *pd) const {
+        int eltwise_idx_ = pd->attr()->post_ops_.find(primitive_kind::eltwise);
+        return with_eltwise(0, pd) || with_eltwise(1, pd)
+                ? pd->attr()->post_ops_.entry_[eltwise_idx_].eltwise.alpha
+                : 1.0f;
+    }
+
+    alg_kind_t eltwise_algo(const matmul_pd_t *pd) const {
+        int eltwise_idx_ = pd->attr()->post_ops_.find(primitive_kind::eltwise);
+        return with_eltwise(0, pd) || with_eltwise(1, pd)
+                ? pd->attr()->post_ops_.entry_[eltwise_idx_].eltwise.alg
+                : dnnl_alg_kind_undef;
+    }
+
+    bool with_sum(const matmul_pd_t *pd) const {
+        return pd->attr()->post_ops_.contain(primitive_kind::sum, 0)
+                || pd->attr()->post_ops_.contain(primitive_kind::sum, 1);
+    }
+
+    // Returns scaling factor for post-ops=sum operation
+    float sum_scale(const matmul_pd_t *pd) const {
+        int sum_idx_ = pd->attr()->post_ops_.find(primitive_kind::sum);
+        return pd->attr()->post_ops_.entry_[sum_idx_].sum.scale;
+    }
+
+    // creates operation descriptor based on the element-wise operation specified
+    status_t create_and_set_op_descriptor(const matmul_pd_t *pd) {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(
+                miopenCreateActivationDescriptor, &act_desc_));
+
+        miopenActivationMode_t mode;
+        switch (eltwise_algo(pd)) {
+            case alg_kind::eltwise_relu:
+                mode = miopenActivationMode_t::miopenActivationLEAKYRELU;
+                break;
+            case alg_kind::eltwise_tanh:
+                mode = miopenActivationMode_t::miopenActivationTANH;
+                break;
+            case alg_kind::eltwise_elu:
+                mode = miopenActivationMode_t::miopenActivationELU;
+                break;
+            case alg_kind::eltwise_logistic:
+                mode = miopenActivationMode_t::miopenActivationLOGISTIC;
+                break;
+            default: return status::unimplemented;
+        }
+
+        //parameters for SetActivationDescriptor
+        float activAlpha;
+        float activBeta;
+        float activGamma;
+        double ceiling = eltwise_alpha(pd);
+
+        if (mode == miopenActivationMode_t::miopenActivationTANH)
+            activAlpha = activBeta = 1;
+        else if (mode == miopenActivationMode_t::miopenActivationELU)
+            activAlpha = ceiling;
+        else if (mode == miopenActivationMode_t::miopenActivationLEAKYRELU)
+            activAlpha = ceiling;
+
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetActivationDescriptor, act_desc_,
+                mode, activAlpha, activBeta, activGamma));
+
+        return status::success;
+    }
+
+    status_t init(matmul_pd_t *pd) {
+        CHECK(get_rocblas_data_type(pd->src_md()->data_type, src_type_));
+        CHECK(get_rocblas_data_type(
+                pd->weights_md()->data_type, weights_type_));
+        isbatched_ = pd->batched();
+
+        memory_desc_wrapper src_d = memory_desc_wrapper(pd->src_md());
+        memory_desc_wrapper weights_d = memory_desc_wrapper(pd->weights_md());
+        memory_desc_wrapper dst_d = memory_desc_wrapper(pd->dst_md());
+
+        with_bias_ = pd->with_bias();
+
+        CHECK(get_rocblas_data_type(pd->dst_md()->data_type, dst_type_));
+
+        if (with_eltwise(0, pd) || with_eltwise(1, pd)) {
+            with_eltwise_ = true;
+            CHECK(create_and_set_op_descriptor(pd));
+        }
+
+        // Set parameter when post-op sum is specified
+        if (with_sum(pd)) {
+            post_op_sum_ = sum_scale(pd);
+            sum_scale_s32 = post_op_sum_;
+            sum_scale_f32 = post_op_sum_;
+        }
+
+        has_runtime_params_ = src_d.has_runtime_dims_or_strides()
+                || dst_d.has_runtime_dims_or_strides()
+                || weights_d.has_runtime_dims_or_strides();
+
+        if (!has_runtime_params_) {
+            // Initialise all gemm parameters if there are no runtime parameters
+            init_parameters(src_d, weights_d, dst_d,
+                    memory_desc_wrapper(pd->weights_md(1)));
+        }
+
+        //setting compute type based on destination type
+        acc_type_ = (dst_type_ == rocblas_datatype_bf16_r
+                            || dst_type_ == rocblas_datatype_f16_r)
+                ? rocblas_datatype_f32_r
+                : dst_type_;
+
+        return status::success;
+    }
+
+    bool isbatched() { return isbatched_; }
+    bool with_bias() { return with_bias_; }
+    bool with_scratchpad() { return with_scratchpad_; }
+    bool has_runtime_params() { return has_runtime_params_; }
+
+    dnnl_data_type_t get_scratchpad_type() { return scratchpad_type_; }
+
+    void convert_dims_matmul(
+            const dnnl_dim_t *dims, int *new_dims, int n_dims) {
+        new_dims[0] = 1;
+        for (size_t i = 0; i < n_dims; i++) {
+            new_dims[i + 1] = static_cast<int>(dims[i]);
+        }
+        for (size_t i = n_dims; i < 4; i++) {
+            new_dims[i + 1] = 1;
+        }
+    }
+
+    int get_ld(const memory_desc_wrapper desc, rocblas_operation trans) {
+        const int ndims = desc.ndims();
+        const auto *strides = &desc.blocking_desc().strides[ndims - 2];
+        const int ld = strides[trans == rocblas_operation::rocblas_operation_none ? 0 : 1];
+        return ld;
+    }
+
+    int get_batch_stride(const memory_desc_wrapper desc) {
+        auto dims = desc.dims();
+        auto strides = desc.blocking_desc().strides;
+        return dims[0] == 1 ? 0 : strides[0];
+    }
+
+    status_t init_gemm_parameters(const memory_desc_wrapper src_d,
+            const memory_desc_wrapper weights_d,
+            const memory_desc_wrapper dst_d) {
+        weightBroadcastNeeded = false;
+        srcBroadcastNeeded = false;
+
+        if (isbatched_) {
+            const auto src_batch = src_d.dims()[0];
+            const auto wei_batch = weights_d.dims()[0];
+
+            if (src_batch > wei_batch)
+                weightBroadcastNeeded = true;
+            else if (wei_batch > src_batch)
+                srcBroadcastNeeded = true;
+
+            batch_count_ = dst_d.dims()[0];
+        }
+
+        const dim_t M = dst_d.dims()[isbatched_ + 1];
+        const dim_t N = dst_d.dims()[isbatched_ + 0];
+        const dim_t K = src_d.dims()[isbatched_ + 1];
+
+        M_ = (int)M;
+        N_ = (int)N;
+        K_ = (int)K;
+
+        const auto dst_strides_org = dst_d.blocking_desc().strides;
+        const auto &src_strides = &src_d.blocking_desc().strides[isbatched_];
+        const auto &weights_strides
+                = &weights_d.blocking_desc().strides[isbatched_];
+
+        // A matrix is the weights
+        transA_ = weights_strides[1] == 1
+                        && weights_d.dims()[isbatched_ + 0] > 1
+                ? rocblas_operation::rocblas_operation_none
+                : rocblas_operation::rocblas_operation_transpose;
+
+        // B matrix is the src
+        transB_ = src_strides[1] == 1 && src_d.dims()[isbatched_ + 0] > 1
+                ? rocblas_operation::rocblas_operation_none
+                : rocblas_operation::rocblas_operation_transpose;
+
+        // C matrix is the dst
+        transC_ = dst_strides_org[dst_d.ndims() - 1] != 1
+                ? rocblas_operation::rocblas_operation_transpose
+                : rocblas_operation::rocblas_operation_none;
+
+        lda_ = get_ld(weights_d, transA_);
+        ldb_ = get_ld(src_d, transB_);
+        ldc_ = get_ld(dst_d, transC_);
+
+        if (isbatched_) {
+            stride_a_ = get_batch_stride(weights_d);
+            stride_b_ = get_batch_stride(src_d);
+            stride_c_ = get_batch_stride(dst_d);
+        }
+
+        return status::success;
+    }
+
+    status_t init_parameters(const memory_desc_wrapper src_d,
+            const memory_desc_wrapper weights_d,
+            const memory_desc_wrapper dst_d, const memory_desc_wrapper bias_d) {
+        // Matmul supports runtime paramters for dimensions and scales.
+        // We need to initialize them in the execute function.
+        CHECK(init_gemm_parameters(src_d, weights_d, dst_d));
+
+        if (with_bias_ || with_eltwise_) {
+            // Initialise MIOpen descriptors
+            miopenDataType_t data_types[NUM_IO];
+            int ndims = dst_d.ndims() < 4 ? 4 : dst_d.ndims();
+            int dims[NUM_IO][DNNL_MAX_NDIMS];
+            int strides[NUM_IO][DNNL_MAX_NDIMS];
+
+            convert_dims_matmul(dst_d.dims(), dims[dst], dst_d.ndims());
+            CHECK(convert_data_type(dst_d.md_, &data_types[dst], false));
+            convert_dims_matmul(
+                    dst_d.blocking_desc().strides, strides[dst], dst_d.ndims());
+            CHECK(create_and_set_tensor_descriptor(&tensor_descs_[dst],
+                    data_types[dst], ndims, dims[dst], strides[dst]));
+
+            if (with_bias_) {
+                // Create bias and destination tensor descriptors
+                convert_dims_matmul(bias_d.dims(), dims[bias], bias_d.ndims());
+                convert_dims_matmul(bias_d.blocking_desc().strides,
+                        strides[bias], bias_d.ndims());
+                CHECK(convert_data_type(bias_d.md_, &data_types[bias], false));
+                CHECK(create_and_set_tensor_descriptor(&tensor_descs_[bias],
+                        data_types[bias], ndims, dims[bias], strides[bias]));
+            }
+        }
+        return status::success;
+    }
+
+    void execute(rocblas_handle rocblas_handle, miopenHandle_t miopen_handle,
+            void *a, void *b, void *c, void *bias, void *scratch) {
+
+        const void *alpha = get_gemm_alpha();
+        const void *beta = get_gemm_beta();
+        scratch = c;
+        temp_mem_desc_ = tensor_descs_[io::dst];
+        int solution_index = 0;
+        uint32_t flags = 0;
+
+        auto flip_op = [](rocblas_operation op) {
+            return (op == rocblas_operation::rocblas_operation_transpose)
+                    ? rocblas_operation::rocblas_operation_none
+                    : rocblas_operation::rocblas_operation_transpose;
+        };
+
+        if (isbatched_) {
+            if (weightBroadcastNeeded)
+                stride_a_ = 0;
+            else if (srcBroadcastNeeded)
+                stride_b_ = 0;
+
+            if (transC_ == rocblas_operation::rocblas_operation_transpose) {
+                ROCBLAS_EXECUTE_FUNC(rocblas_gemm_strided_batched_ex,
+                        rocblas_handle, flip_op(transB_), flip_op(transA_), N_,
+                        M_, K_, alpha, b, src_type_, ldb_, stride_b_, a,
+                        weights_type_, lda_, stride_a_, beta, scratch,
+                        dst_type_, ldc_, stride_c_, scratch, dst_type_, ldc_,
+                        stride_c_, batch_count_, acc_type_, gemm_algo_,
+                        solution_index, (uint32_t)flags);
+            } else {
+                ROCBLAS_EXECUTE_FUNC(rocblas_gemm_strided_batched_ex,
+                        rocblas_handle, transA_, transB_, M_, N_, K_, alpha, a,
+                        weights_type_, lda_, stride_a_, b, src_type_, ldb_,
+                        stride_b_, beta, scratch, dst_type_, ldc_, stride_c_,
+                        scratch, dst_type_, ldc_, stride_c_, batch_count_,
+                        acc_type_, gemm_algo_, solution_index, (uint32_t)flags);
+            }
+        } else {
+            if (transC_ == rocblas_operation::rocblas_operation_transpose) {
+                ROCBLAS_EXECUTE_FUNC(rocblas_gemm_ex, rocblas_handle,
+                        flip_op(transB_), flip_op(transA_), N_, M_, K_, alpha,
+                        b, src_type_, ldb_, a, weights_type_, lda_, beta,
+                        scratch, dst_type_, ldc_, scratch, dst_type_, ldc_,
+                        acc_type_, gemm_algo_, solution_index, (uint32_t)flags);
+            } else {
+                ROCBLAS_EXECUTE_FUNC(rocblas_gemm_ex, rocblas_handle, transA_,
+                        transB_, M_, N_, K_, alpha, a, weights_type_, lda_, b,
+                        src_type_, ldb_, beta, scratch, dst_type_, ldc_,
+                        scratch, dst_type_, ldc_, acc_type_, gemm_algo_,
+                        solution_index, (uint32_t)flags);
+            }
+        }
+        if (with_bias_) {
+            // When bias is specified call miopenOpTensor()
+            float bias_beta = 0;
+            float alpha = 1;
+            float scales = 1;
+
+            MIOPEN_EXECUTE_FUNC(miopenOpTensor, miopen_handle,
+                    miopenTensorOpAdd, &alpha, temp_mem_desc_, scratch, &scales,
+                    tensor_descs_[io::bias], bias, &bias_beta, temp_mem_desc_,
+                    scratch);
+        }
+        if (with_eltwise_) {
+            // Perform elementwise operation if specified
+            float alpha = 1;
+            float beta = 0;
+
+            MIOPEN_EXECUTE_FUNC(miopenActivationForward, miopen_handle,
+                    act_desc_, &alpha, temp_mem_desc_, scratch, &beta,
+                    temp_mem_desc_, scratch);
+        }
+    }
+
+    ~miopen_matmul_impl_t() { cleanup(); }
+
+    void cleanup() {
+        if (act_desc_) {
+            MIOPEN_EXECUTE_FUNC_V(miopenDestroyActivationDescriptor, act_desc_);
+            act_desc_ = nullptr;
+        }
+
+        for (size_t i = 0; i < NUM_IO; i++) {
+            if (tensor_descs_[i]) {
+                MIOPEN_EXECUTE_FUNC_V(
+                        miopenDestroyTensorDescriptor, tensor_descs_[i]);
+                tensor_descs_[i] = nullptr;
+            }
+        }
+    }
+
+private:
+    status_t get_rocblas_data_type(
+            dnnl_data_type_t data_type, rocblas_datatype &blas_dt) {
+        switch (data_type) {
+            case dnnl_data_type_t::dnnl_f32:
+                blas_dt = rocblas_datatype_f32_r;
+                return status::success;
+            case dnnl_data_type_t::dnnl_f16:
+                blas_dt = rocblas_datatype_f16_r;
+                return status::success;
+            case dnnl_data_type_t::dnnl_s8:
+                blas_dt = rocblas_datatype_i8_r;
+                return status::success;
+            case dnnl_data_type_t::dnnl_s32:
+                blas_dt = rocblas_datatype_i32_r;
+                return status::success;
+            case dnnl_data_type_t::dnnl_bf16:
+                blas_dt = rocblas_datatype_bf16_r;
+                return status::success;
+            default: return status::unimplemented;
+        }
+        return status::unimplemented;
+    }
+
+    const void *get_gemm_alpha() const {
+        switch (acc_type_) {
+            case rocblas_datatype::rocblas_datatype_i32_r:
+                return reinterpret_cast<const void *>(&alpha_s32);
+            case rocblas_datatype::rocblas_datatype_f32_r:
+                return reinterpret_cast<const void *>(&alpha_f32);
+            default: assert(!"unknown acc type"); return nullptr;
+        }
+    }
+
+    const void *get_gemm_beta() const {
+        switch (acc_type_) {
+            case rocblas_datatype::rocblas_datatype_i32_r:
+                return reinterpret_cast<const void *>(&sum_scale_s32);
+            case rocblas_datatype::rocblas_datatype_f32_r:
+                return reinterpret_cast<const void *>(&sum_scale_f32);
+            default: assert(!"unknown acc type"); return nullptr;
+        }
+    }
+
+    rocblas_operation transA_;
+    rocblas_operation transB_;
+    rocblas_operation transC_;
+    int M_, N_, K_;
+    int lda_, ldb_, ldc_;
+    long long int stride_a_, stride_b_, stride_c_;
+    bool weightBroadcastNeeded = false, srcBroadcastNeeded = false;
+    int alpha_s32 = 1, sum_scale_s32 = 0;
+    float alpha_f32 = 1.0f, sum_scale_f32 = 0.0f;
+    bool isbatched_ = false, with_bias_ = false;
+    bool with_eltwise_ = false;
+    bool with_scratchpad_ = false, has_runtime_params_ = false;
+    dnnl_data_type_t scratchpad_type_;
+    rocblas_datatype src_type_, weights_type_, dst_type_;
+    rocblas_datatype acc_type_;
+    rocblas_gemm_algo gemm_algo_
+            = rocblas_gemm_algo::rocblas_gemm_algo_standard;
+    int batch_count_;
+    enum io { bias = 0, dst, NUM_IO };
+    miopenTensorDescriptor_t tensor_descs_[NUM_IO] = {},
+                             temp_mem_desc_ = nullptr;
+    miopenActivationDescriptor_t act_desc_ = nullptr;
+    float post_op_sum_;
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -61,6 +61,7 @@ sycl_hip_engine_t::sycl_hip_engine_t(engine_kind_t kind,
         const ::sycl::device &dev, const ::sycl::context &ctx, size_t index)
     : base_t(kind, dev, ctx, index) {
     set_miopen_handle();
+    set_rocblas_handle();
 }
 
 sycl_hip_engine_t::sycl_hip_engine_t(
@@ -68,6 +69,24 @@ sycl_hip_engine_t::sycl_hip_engine_t(
     : sycl_hip_engine_t(engine_kind::gpu, dev, ctx, index) {
     assert(is_amd_gpu(dev));
 }
+
+status_t sycl_hip_engine_t::set_rocblas_handle() {
+    // scoped context will make sure the top of the stack context is
+    // the engine context while creating the rocblas handle.
+    hip_sycl_scoped_context_handler_t sc(*this);
+    rocblas_handle handle;
+    CHECK(ROCBLAS_EXECUTE_FUNC_S(rocblas_create_handle, &handle));
+    rocblas_handle_.set(
+            std::unique_ptr<rocblas_handle, void (*)(rocblas_handle *)>(
+                    new rocblas_handle(handle), [](rocblas_handle *h) {
+                        if (h != nullptr)
+                            ROCBLAS_EXECUTE_FUNC_V(rocblas_destroy_handle, *h);
+                        delete h;
+                    }));
+    handle = nullptr;
+    return status::success;
+}
+
 status_t sycl_hip_engine_t::set_miopen_handle() {
     // scoped context will make sure the top of the stack context is
     // the engine context while creating the miopen handle.
@@ -106,10 +125,26 @@ miopenHandle_t *sycl_hip_engine_t::get_miopen_handle() {
     return miopen_handle_.get().get();
 }
 
+rocblas_handle *sycl_hip_engine_t::get_rocblas_handle() {
+    if (!rocblas_handle_.is_set()) set_rocblas_handle();
+    return rocblas_handle_.get().get();
+}
+
 device_id_t sycl_hip_engine_t::device_id() const {
     return device_id_t(static_cast<int>(impl::sycl::backend_t::amd),
             static_cast<uint64_t>(compat::get_native<hipDevice_t>(device())),
             static_cast<uint64_t>(0));
+}
+
+void sycl_hip_engine_t::activate_stream_rocblas(HIPstream hip_stream) {
+    hip_sycl_scoped_context_handler_t sc(*this);
+    hipStream_t current_stream_id = nullptr;
+    auto rocblas_handle = get_rocblas_handle();
+    ROCBLAS_EXECUTE_FUNC(
+            rocblas_get_stream, *rocblas_handle, &current_stream_id);
+    if (current_stream_id != hip_stream) {
+        ROCBLAS_EXECUTE_FUNC(rocblas_set_stream, *rocblas_handle, hip_stream);
+    }
 }
 
 void sycl_hip_engine_t::activate_stream_miopen(HIPstream hip_stream) {

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -112,16 +112,13 @@ device_id_t sycl_hip_engine_t::device_id() const {
             static_cast<uint64_t>(0));
 }
 
-void sycl_hip_engine_t::activate_stream_miopen(stream_t *stream) {
+void sycl_hip_engine_t::activate_stream_miopen(HIPstream hip_stream) {
     hip_sycl_scoped_context_handler_t sc(*this);
-    auto hip_stream = utils::downcast<sycl_hip_stream_t *>(stream);
-    auto streamId = hip_stream->get_underlying_stream();
-    assert(context() == hip_stream->queue().get_context());
     hipStream_t current_stream_id = nullptr;
     auto miopen_handle = get_miopen_handle();
     MIOPEN_EXECUTE_FUNC_S(miopenGetStream, *miopen_handle, &current_stream_id);
-    if (current_stream_id != streamId) {
-        MIOPEN_EXECUTE_FUNC_S(miopenSetStream, *miopen_handle, streamId);
+    if (current_stream_id != hip_stream) {
+        MIOPEN_EXECUTE_FUNC_S(miopenSetStream, *miopen_handle, hip_stream);
     }
 }
 

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -25,6 +25,7 @@
 #include "gpu/amd/miopen_binary.hpp"
 #include "gpu/amd/miopen_eltwise.hpp"
 #include "gpu/amd/miopen_lrn.hpp"
+#include "gpu/amd/miopen_matmul.hpp"
 #include "gpu/amd/miopen_pooling.hpp"
 #include "gpu/amd/miopen_reduction.hpp"
 #include "gpu/amd/miopen_softmax.hpp"
@@ -178,6 +179,8 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         INSTANCE(miopen_pooling_bwd_t)
         // Reduction
         INSTANCE(miopen_reduction_t)
+        // MatMul
+        INSTANCE(miopen_matmul_t)
         nullptr,
 };
 // clang-format on

--- a/src/gpu/amd/sycl_hip_engine.hpp
+++ b/src/gpu/amd/sycl_hip_engine.hpp
@@ -80,7 +80,7 @@ public:
         return hip_sum_impl_list;
     }
 
-    void activate_stream_miopen(stream_t *stream);
+    void activate_stream_miopen(HIPstream hip_stream);
 
     const impl_list_item_t *get_implementation_list(
             const op_desc_t *) const override;

--- a/src/gpu/amd/sycl_hip_engine.hpp
+++ b/src/gpu/amd/sycl_hip_engine.hpp
@@ -18,6 +18,7 @@
 #ifndef GPU_AMD_SYCL_HIP_ENGINE_HPP
 #define GPU_AMD_SYCL_HIP_ENGINE_HPP
 
+#include <rocblas.h>
 #include <stdexcept>
 #include "common/stream.hpp"
 #include "common/thread_local_storage.hpp"
@@ -81,12 +82,14 @@ public:
     }
 
     void activate_stream_miopen(HIPstream hip_stream);
+    void activate_stream_rocblas(HIPstream hip_stream);
 
     const impl_list_item_t *get_implementation_list(
             const op_desc_t *) const override;
     hipCtx_t get_underlying_context() const;
     hipDevice_t get_underlying_device() const;
     miopenHandle_t *get_miopen_handle();
+    rocblas_handle *get_rocblas_handle();
     const bool has_primary_context() const { return primary_context_; }
     device_id_t device_id() const override;
 
@@ -95,10 +98,13 @@ protected:
 
 private:
     status_t set_miopen_handle();
+    status_t set_rocblas_handle();
     utils::thread_local_storage_t<
             std::unique_ptr<miopenHandle_t, void (*)(miopenHandle_t *)>>
             miopen_handle_;
-
+    utils::thread_local_storage_t<
+            std::unique_ptr<rocblas_handle, void (*)(rocblas_handle *)>>
+            rocblas_handle_;
     bool primary_context_;
 };
 

--- a/src/gpu/amd/sycl_hip_stream.cpp
+++ b/src/gpu/amd/sycl_hip_stream.cpp
@@ -25,6 +25,13 @@ namespace impl {
 namespace gpu {
 namespace amd {
 
+rocblas_handle &sycl_hip_stream_t::get_rocblas_handle(HIPstream hip_stream) {
+    if (!hip_stream) hip_stream = get_underlying_stream();
+    auto e = utils::downcast<sycl_hip_engine_t *>(engine());
+    assert(e->context() == queue().get_context());
+    e->activate_stream_rocblas(hip_stream);
+    return *(e->get_rocblas_handle());
+}
 miopenHandle_t &sycl_hip_stream_t::get_miopen_handle(HIPstream hip_stream) {
     auto e = utils::downcast<sycl_hip_engine_t *>(engine());
     assert(e->context() == queue().get_context());

--- a/src/gpu/amd/sycl_hip_stream.cpp
+++ b/src/gpu/amd/sycl_hip_stream.cpp
@@ -25,9 +25,11 @@ namespace impl {
 namespace gpu {
 namespace amd {
 
-miopenHandle_t &sycl_hip_stream_t::get_miopen_handle() {
+miopenHandle_t &sycl_hip_stream_t::get_miopen_handle(HIPstream hip_stream) {
     auto e = utils::downcast<sycl_hip_engine_t *>(engine());
-    e->activate_stream_miopen(this);
+    assert(e->context() == queue().get_context());
+    if (!hip_stream) hip_stream = get_underlying_stream();
+    e->activate_stream_miopen(hip_stream);
     return *(e->get_miopen_handle());
 }
 // the sycl_hip_stream_t will not own this. it is an observer pointer

--- a/src/gpu/amd/sycl_hip_stream.hpp
+++ b/src/gpu/amd/sycl_hip_stream.hpp
@@ -17,6 +17,7 @@
 
 #ifndef GPU_AMD_SYCL_HIP_STREAM_HPP
 #define GPU_AMD_SYCL_HIP_STREAM_HPP
+#include <rocblas.h>
 #include "common/engine.hpp"
 #include "sycl/sycl_stream.hpp"
 #include <hip/hip_runtime.h>
@@ -32,6 +33,7 @@ public:
     using base_t = dnnl::impl::sycl::sycl_stream_t;
 
     miopenHandle_t &get_miopen_handle(HIPstream hip_stream = nullptr);
+    rocblas_handle &get_rocblas_handle(HIPstream hip_stream = nullptr);
 
     static status_t create_stream(
             stream_t **stream, engine_t *engine, unsigned flags) {

--- a/src/gpu/amd/sycl_hip_stream.hpp
+++ b/src/gpu/amd/sycl_hip_stream.hpp
@@ -31,7 +31,7 @@ class sycl_hip_stream_t : public dnnl::impl::sycl::sycl_stream_t {
 public:
     using base_t = dnnl::impl::sycl::sycl_stream_t;
 
-    miopenHandle_t &get_miopen_handle();
+    miopenHandle_t &get_miopen_handle(HIPstream hip_stream = nullptr);
 
     static status_t create_stream(
             stream_t **stream, engine_t *engine, unsigned flags) {

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -113,8 +113,15 @@ protected:
                              || p.attr.zero_points.weights != 0),
                 "Zero points not supported for CUDA");
 
+        SKIP_IF_HIP((p.attr.zero_points.src != 0 || p.attr.zero_points.dst != 0
+                            || p.attr.zero_points.weights != 0),
+                "Zero points not supported for HIP");
+
         SKIP_IF_CUDA((p.attr.scale_flags & P::MASK_MASK) == P::PER_N,
                 "Per dimensional scaling is not supported for CUDA");
+
+        SKIP_IF_HIP((p.attr.scale_flags & P::MASK_MASK) == P::PER_N,
+                "Per dimensional scaling is not supported for HIP");
 
         catch_expected_failures(
                 [=]() { Test(); }, p.expect_to_fail, p.expected_status, false);


### PR DESCRIPTION
# Description
**Introducing AMD backend for the oneDNN Matmul primitive.**

**Supported scope:**
Supported Data Types: f32, f16, s8/s32, bf16

**Testing scope:**
benchdnn: Passed
gtest: API tests passed, Matmul tests passed

Log files for benchdnn:
[test_matmul_all.log](https://github.com/oneapi-src/oneDNN/files/10193081/test_matmul_all.log)
[test_matmul_ci.log](https://github.com/oneapi-src/oneDNN/files/10193086/test_matmul_ci.log)

Log files for gtests:
[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/10193075/test_api_buffer.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/10193076/test_api_sycl.log)
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/10193078/test_internals.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/10193087/test_regression.log)
[test_matmul.log](https://github.com/oneapi-src/oneDNN/files/10193079/test_matmul.log)
[test_matmul_buffer.log](https://github.com/oneapi-src/oneDNN/files/10193085/test_matmul_buffer.log)


**Limitations:**

This backend only supports the following combinations:
(src, weights, dst, bias) 
 -f32, f32, f32, f32
 -f16, f16, f16, f16
 -s8,  s8,  s32, s32
 -bf16, bf16, f32,(bias not supported)

**Note :** 
1) Attribute scale is not supported.
2) Currently only above four combinations supported, once reorder issue is fixed will add support for other possible combinations.
3) The bf16-bf16-bf16 combination is not yet enabled. It is having some issues (like with bias), will enable in future raising PR's.

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
