### PR TITLE
cpu: aarch64: fix test test_iface_attr_quantization

### DIFF
--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -261,7 +262,8 @@ bool jit_uni_binary_t::pd_t::check_scales_mask() const {
     for (const auto &s : attr()->scales_.scales_) {
         if (s.second.mask_ != 0) return false;
     }
-    return true;
+    const std::vector<int> supported_args = {DNNL_ARG_SRC_0, DNNL_ARG_SRC_1};
+    return attr_scales_ok(supported_args);
 }
 
 bool jit_uni_binary_t::pd_t::is_bcast_pattern(const dims_t &bcast_dims,

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -259,9 +259,6 @@ bool jit_uni_binary_t::pd_t::alg_preserves_zero() const {
 }
 
 bool jit_uni_binary_t::pd_t::check_scales_mask() const {
-    for (const auto &s : attr()->scales_.scales_) {
-        if (s.second.mask_ != 0) return false;
-    }
     const std::vector<int> supported_args = {DNNL_ARG_SRC_0, DNNL_ARG_SRC_1};
     return attr_scales_ok(supported_args);
 }


### PR DESCRIPTION
# Description

Test test_iface_attr_quantization.TestBinary fails on Neoverse-V1 machines.

When running on Neoverse-V1, `src/cpu/aarch64/jit_uni_binary.cpp` is targeted during the test. The test checks to ensure DST cannot have a scale attribute, which fails on aarch64.
This is due to function `jit_uni_binary_t::pd_t::check_scales_mask()` missing a check on aarch64 to ensure only DNNL_ARG_SRC_0 and DNNL_ARG_SRC_1 are the allowed arguments.

This patch adds a similar check existing for x64 in `src/cpu/x64/jit_uni_binary.cpp` to the aarch64 version.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?


## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?