### PR TITLE
src: cpu: aarch64: Fix ACL threadpool scheduler

### DIFF
--- a/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+++ b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -117,14 +117,14 @@ void ThreadpoolScheduler::run_workloads(
     if (is_async) b.init(num_threads);
     tp->parallel_for(num_threads, [&](int ithr, int nthr) {
         bool is_main = get_active_threadpool() == tp;
-        if (is_main) activate_threadpool(tp);
+        if (!is_main) activate_threadpool(tp);
         // Make ThreadInfo local to avoid race conditions
         ThreadInfo info;
         info.cpu_info = &cpu_info();
         info.num_threads = nthr;
         info.thread_id = ithr;
         process_workloads(workloads, feeder, info);
-        if (is_main) deactivate_threadpool();
+        if (!is_main) deactivate_threadpool();
         if (is_async) b.notify();
     });
     if (is_async) b.wait();


### PR DESCRIPTION
# Description

This PR fixes the threadpool scheduler implementation in oneDNN-AArch64 to make each thread maintain a local pointer to the threadpool.
Fixes the segmentation fault in https://github.com/tensorflow/tensorflow/pull/58071.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?