### PR TITLE
Some small memory layout fixes for ACL matmul and inner product

### DIFF
--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -141,11 +141,11 @@ struct acl_inner_product_fwd_t : public primitive_t {
 
             // Only NCHW or NHWC derivatives supported by ACL kernels
             using namespace format_tag;
-            auto src_tag = memory_desc_matches_one_of_tag(
-                    src_md_, nhwc, nchw, nc, cn);
+            auto src_tag
+                    = memory_desc_matches_one_of_tag(src_md_, nhwc, nchw, nc);
             auto wei_tag = memory_desc_matches_one_of_tag(
                     weights_md_, ohwi, oihw, oi, io);
-            auto dst_tag = memory_desc_matches_one_of_tag(dst_md_, nc, cn);
+            auto dst_tag = memory_desc_matches_one_of_tag(dst_md_, nc);
 
             ACL_CHECK_SUPPORT(
                     utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
@@ -156,8 +156,7 @@ struct acl_inner_product_fwd_t : public primitive_t {
 
             arm_compute::TensorShape src_shape, wei_shape;
             if (is_2d) {
-                src_shape = (src_tag == nc) ? arm_compute::TensorShape(ic, n)
-                                            : arm_compute::TensorShape(n, ic);
+                src_shape = arm_compute::TensorShape(ic, n);
 
                 wei_shape = (wei_tag == io) ? arm_compute::TensorShape(oc, ic)
                                             : arm_compute::TensorShape(ic, oc);

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ struct acl_matmul_t : public primitive_t {
                               weights_md()->data_type, dst_md()->data_type)
                     && platform::has_data_type_support(data_type::f16);
             bool ok = utils::one_of(true, is_fp32_ok, is_fp16_ok)
-                    && !has_zero_dim_memory()
+                    && !has_zero_dim_memory() && set_default_formats()
                     && attr()->has_default_values(
                             smask_t::oscale | smask_t::post_ops)
                     && attr_oscale_ok() && !has_runtime_dims_or_strides();

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,8 +58,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
             src_md, abcd, abdc, abc, acb, ab, ba);
     auto wei_tag = memory_desc_matches_one_of_tag(
             wei_md, abcd, abdc, abc, acb, ab, ba);
-    auto dst_tag
-            = memory_desc_matches_one_of_tag(dst_md, abcd, abc, acb, ab, ba);
+    auto dst_tag = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab, ba);
     ACL_CHECK_SUPPORT(
             utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
             "Format tag is undefined");


### PR DESCRIPTION
Three loosely related small fixes for `acl_matmul` and `acl_inner_product`

## Fix ACL matmul to cover format::any
For example, running
```
./benchdnn --matmul -v5 3x5:5x7
```
now uses ACL


## Remove ACL IP with transposed src
ACL IP does not support transposed src, but if src was square, it wasn't being detected by validation and would silently fail. This has now been removed
```
./benchdnn --ip --dir=FWD_I --stag=ba --wtag=ba --dtag=ba mb100ic100oc100
```

## Remove acb case from ACL matmul
This is not supported and produces incorrect results so it has been removed
```
./benchdnn --matmul -v5 --dtag=acb 1x3x5:1x5x7 1x3x5:11x5x7 11x3x5:1x5x7
```

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests? (testable using benchdnn)

