### PR TITLE
Adding Support for Innerproduct Primitive - HIP Backend

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -71,7 +71,8 @@ if(DNNL_SYCL_HIP)
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/eltwise.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reduction.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/matmul.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/matmul_perf.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/matmul_perf.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/inner_product.cpp)
 endif()
 
 # Skip SYCL, GPU and cross-engine examples

--- a/src/gpu/amd/miopen_gemm_inner_product.hpp
+++ b/src/gpu/amd/miopen_gemm_inner_product.hpp
@@ -1,0 +1,363 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_GEMM_INNER_PRODUCT_HPP
+#define GPU_AMD_MIOPEN_GEMM_INNER_PRODUCT_HPP
+
+#include <miopen/miopen.h>
+
+#include "common/c_types_map.hpp"
+#include "common/inner_product_pd.hpp"
+#include "common/primitive.hpp"
+#include "gpu/amd/miopen_gemm_inner_product_impl.hpp"
+#include "gpu/amd/miopen_inner_product.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+namespace {
+
+inline bool gemm_consitency_check(const memory_desc_wrapper &src_d,
+        const memory_desc_wrapper &wei_d, const memory_desc_wrapper &dst_d) {
+    using namespace utils;
+
+    auto strides_compatible = [&]() {
+        bool ok = true;
+        auto w_str = wei_d.blocking_desc().strides;
+        auto d_str = src_d.blocking_desc().strides;
+        for (int i = 1; i < src_d.ndims() - 1; i++) {
+            ok = ok && w_str[i] / d_str[i] == w_str[i + 1] / d_str[i + 1];
+        }
+        return ok && one_of(w_str[1] / d_str[1], 1, wei_d.padded_dims()[0]);
+    };
+
+    auto inner_blk_compatible = [&]() {
+        auto d_inner_blks = src_d.blocking_desc().inner_blks;
+        auto w_inner_blks = wei_d.blocking_desc().inner_blks;
+        auto d_inner_idxs = src_d.blocking_desc().inner_idxs;
+        auto w_inner_idxs = wei_d.blocking_desc().inner_idxs;
+
+        int d_inner_nblks = src_d.blocking_desc().inner_nblks;
+        int w_inner_nblks = wei_d.blocking_desc().inner_nblks;
+
+        bool ok = true;
+
+        if ((wei_d.blocking_desc().strides[0] == 1) && (w_inner_nblks > 0)) {
+            ok = ok && wei_d.dims()[0] / w_inner_blks[w_inner_nblks - 1] == 1
+                    && w_inner_idxs[w_inner_nblks - 1] == 0;
+            w_inner_nblks--;
+        }
+
+        ok = ok && d_inner_nblks == w_inner_nblks;
+        bool supported_block_size = (d_inner_nblks == 0
+                || (d_inner_nblks == 1 && d_inner_idxs[0] == w_inner_idxs[0]
+                        && w_inner_idxs[0] == 1
+                        && d_inner_blks[0] == w_inner_blks[0]
+                        && d_inner_blks[0] == 4
+                        && src_d.data_type() == data_type::s8));
+        ok = ok && supported_block_size;
+        for (int d = 1; d < w_inner_nblks; d++)
+            ok = ok && (d_inner_blks[d] == w_inner_blks[d] == 0)
+                    && (d_inner_idxs[d] == w_inner_idxs[d] == 0);
+        return ok;
+    };
+
+    return true && src_d.is_blocking_desc() && wei_d.is_blocking_desc()
+            && src_d.ndims() == wei_d.ndims() && inner_blk_compatible()
+            && strides_compatible() && dst_d.matches_tag(format_tag::nc)
+            && src_d.only_padded_dim(1) && wei_d.only_padded_dim(1)
+            && src_d.padded_dims()[1] == wei_d.padded_dims()[1];
+}
+
+inline bool reorder_check(const memory_desc_wrapper &src_d,
+        const memory_desc_wrapper &wei_d, const memory_desc_wrapper &dst_d) {
+    using namespace format_tag;
+    using namespace utils;
+
+    return true
+            && ((src_d.matches_tag(nwc)
+                        && (wei_d.matches_one_of_tag(oiw, iwo) != undef))
+                    || (src_d.matches_tag(ncw)
+                            && (wei_d.matches_one_of_tag(wio, owi) != undef))
+                    || (src_d.matches_tag(nhwc),
+                            (wei_d.matches_one_of_tag(oihw, ihwo) != undef))
+                    || (src_d.matches_tag(nchw)
+                            && (wei_d.matches_one_of_tag(ohwi, hwio) != undef))
+                    || (src_d.matches_tag(ndhwc)
+                            && (wei_d.matches_one_of_tag(oidhw, idhwo)
+                                    != undef))
+                    || (src_d.matches_tag(ncdhw)
+                            && (wei_d.matches_one_of_tag(odhwi, dhwio)
+                                    != undef)))
+            && dst_d.matches_tag(nc);
+}
+
+inline bool dense_check(const memory_desc_wrapper &src_d,
+        const memory_desc_wrapper &wei_d, const memory_desc_wrapper &dst_d) {
+    return true && src_d.is_dense(true) && dst_d.is_dense()
+            && wei_d.is_dense(true);
+}
+
+status_t template_set_default_params(memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t *bias_md, int ndims) {
+    using namespace format_tag;
+
+    auto init_md = [&](memory_desc_t &out_md, const memory_desc_t &in_md) {
+        format_tag_t md_tag;
+        if (memory_desc_matches_one_of_tag(in_md, ab, abc, abcd, abcde))
+            md_tag = utils::pick(ndims - 2, ab, abc, abcd, abcde);
+        else if (memory_desc_matches_one_of_tag(in_md, acb, acdb, acdeb))
+            md_tag = utils::pick(ndims - 3, cba, cdba, cdeba);
+        else if (memory_desc_matches_one_of_tag(in_md, ba, cba, cdba, cdeba))
+            md_tag = utils::pick(ndims - 2, ab, acb, acdb, acdeb);
+        else {
+            memory_desc_wrapper md_desc_wrapper(in_md);
+            return memory_desc_init_by_blocking_desc(
+                    out_md, md_desc_wrapper.blocking_desc());
+        }
+        return memory_desc_init_by_tag(out_md, md_tag);
+    };
+    if (src_md.format_kind == format_kind::any
+            && weights_md.format_kind == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(
+                src_md, utils::pick(ndims - 2, nc, ncw, nchw, ncdhw)));
+        CHECK(memory_desc_init_by_tag(
+                weights_md, utils::pick(ndims - 2, oi, oiw, oihw, oidhw)));
+    } else if (src_md.format_kind == format_kind::any) {
+        CHECK(init_md(src_md, weights_md));
+    } else if (weights_md.format_kind == format_kind::any) {
+        CHECK(init_md(weights_md, src_md));
+    }
+    if (dst_md.format_kind == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(dst_md, nc));
+    }
+    if (bias_md->format_kind == format_kind::any) {
+        CHECK(memory_desc_init_by_tag(*bias_md, x));
+    }
+    return status::success;
+}
+
+} // namespace
+
+struct miopen_gemm_inner_product_fwd_t : public miopen_inner_product_fwd_t {
+    using miopen_inner_product_fwd_t::miopen_inner_product_fwd_t;
+    using parrent_pd_t = miopen_inner_product_fwd_t::pd_t;
+
+    struct pd_t : public parrent_pd_t {
+        using parrent_pd_t::parrent_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:gemm", miopen_gemm_inner_product_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            using namespace prop_kind;
+            using namespace data_type;
+
+            bool ok = is_fwd() && (set_default_params() == status::success);
+            if (!ok) return status::unimplemented;
+            if (has_zero_dim_memory()) return status::success;
+            bool gemm_compatible
+                    = gemm_consitency_check(src_md(), weights_md(), dst_md());
+            bool need_reorder = gemm_compatible
+                    ? false
+                    : reorder_check(src_md(), weights_md(), dst_md());
+
+            using sm_t = primitive_attr_t::skip_mask_t;
+            const auto attr_skip_mask = sm_t::oscale_runtime | sm_t::post_ops;
+
+            bool with_eltwise
+                    = attr()->post_ops_.find(primitive_kind::eltwise) != -1;
+            bool with_sum = attr()->post_ops_.find(primitive_kind::sum) != -1;
+
+            data_type_t src_dt = src_md()->data_type;
+            data_type_t dst_dt = dst_md()->data_type;
+            data_type_t wei_dt = weights_md(0)->data_type;
+
+            data_type_t bia_dt = data_type::undef;
+            if (with_bias()) bia_dt = weights_md(1)->data_type;
+
+            bool f32_case = utils::everyone_is(f32, src_dt, wei_dt, dst_dt);
+            bool f16_case = utils::everyone_is(f16, src_dt, wei_dt, dst_dt);
+            bool s8_case
+                    = utils::everyone_is(s8, src_dt, wei_dt) && (dst_dt == s32);
+            bool bf16_case = utils::everyone_is(bf16, src_dt, wei_dt)
+                    && (utils::one_of(dst_dt, bf16, f32));
+
+            ok = (f32_case || f16_case || bf16_case || s8_case)
+                    && IMPLICATION(with_bias(),
+                            (IMPLICATION(f32_case, (bia_dt == f32))
+                                    && IMPLICATION(f16_case, (bia_dt == f16))
+                                    && IMPLICATION(s8_case, (bia_dt == s32))
+                                    && IMPLICATION(
+                                            bf16_case, (bia_dt == f32))));
+            ok = ok && memory_format_ok(src_md())
+                    && memory_format_ok(weights_md(0))
+                    && memory_format_ok(dst_md())
+                    && IMPLICATION(!attr()->output_scales_.has_default_values(),
+                            utils::one_of(src_md_.data_type, s8)
+                                    && attr()->output_scales_.mask_ == 0)
+                    && attr()->has_default_values(attr_skip_mask)
+                    && attr_post_ops_ok(attr(), s8_case)
+                    && dense_check(src_md(), weights_md(), dst_md())
+                    && (gemm_compatible || need_reorder);
+            if (!ok) return status::unimplemented;
+
+            inner_product_impl_.reset(
+                    new miopen_gemm_inner_product_fwd_impl_t());
+
+            return inner_product_impl_->init(engine, this, with_eltwise,
+                    with_eltwise, with_sum, need_reorder);
+        }
+
+        status_t set_default_params() {
+            return template_set_default_params(
+                    src_md_, weights_md_, dst_md_, &bias_md_, ndims());
+        }
+    };
+
+    const pd_t *pd() const override {
+        return (const pd_t *)primitive_t::pd().get();
+    }
+};
+
+struct miopen_gemm_inner_product_bwd_data_t
+    : public miopen_inner_product_bwd_data_t {
+    using miopen_inner_product_bwd_data_t::miopen_inner_product_bwd_data_t;
+    using parent_pd_t = miopen_inner_product_bwd_data_t::pd_t;
+
+    struct pd_t : public parent_pd_t {
+        using parent_pd_t::parent_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                "hip:miopen:gemm", miopen_gemm_inner_product_bwd_data_t);
+
+        status_t init(engine_t *engine) {
+            using namespace prop_kind;
+            using namespace data_type;
+            assert(engine->kind() == engine_kind::gpu);
+            bool ok = true && this->desc()->prop_kind == backward_data
+                    && set_default_params() == status::success;
+            if (!ok) return status::unimplemented;
+            if (has_zero_dim_memory()) return status::success;
+            bool gemm_compatible = gemm_consitency_check(
+                    diff_src_md(), weights_md(), diff_dst_md());
+            bool need_reorder = gemm_compatible
+                    ? false
+                    : reorder_check(diff_src_md(), weights_md(), diff_dst_md());
+
+            data_type_t diff_src_dt = diff_src_md()->data_type;
+            data_type_t diff_dst_dt = diff_dst_md()->data_type;
+            data_type_t wei_dt = weights_md(0)->data_type;
+
+            bool f32_case
+                    = utils::everyone_is(f32, diff_src_dt, wei_dt, diff_dst_dt);
+            bool bf16_case = utils::everyone_is(bf16, diff_dst_dt, wei_dt)
+                    && (utils::one_of(diff_src_dt, bf16, f32));
+
+            ok = ok && (f32_case || bf16_case) && attr()->has_default_values()
+                    && dense_check(diff_src_md(), weights_md(), diff_dst_md())
+                    && (gemm_compatible || need_reorder);
+            if (!ok) return status::unimplemented;
+
+            inner_product_impl_.reset(
+                    new miopen_gemm_inner_product_bwd_data_impl_t());
+
+            return inner_product_impl_->init(
+                    engine, this, false, false, false, need_reorder);
+        }
+
+        status_t set_default_params() {
+            return template_set_default_params(diff_src_md_, weights_md_,
+                    diff_dst_md_, &glob_zero_md, ndims());
+        }
+    };
+
+    const pd_t *pd() const override {
+        return (const pd_t *)primitive_t::pd().get();
+    }
+};
+
+struct miopen_gemm_inner_product_bwd_weights_t
+    : public miopen_inner_product_bwd_weights_t {
+    using miopen_inner_product_bwd_weights_t::
+            miopen_inner_product_bwd_weights_t;
+    using parent_pd_t = miopen_inner_product_bwd_weights_t::pd_t;
+
+    struct pd_t : public parent_pd_t {
+        using parent_pd_t::parent_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                "hip:miopen:gemm", miopen_gemm_inner_product_bwd_weights_t);
+
+        status_t init(engine_t *engine) {
+            using namespace prop_kind;
+            using namespace data_type;
+            assert(engine->kind() == engine_kind::gpu);
+            bool ok = true && this->desc()->prop_kind == backward_weights
+                    && set_default_params() == status::success;
+            if (!ok) return status::unimplemented;
+            if (has_zero_dim_memory()) return status::success;
+            bool gemm_compatible = gemm_consitency_check(
+                    src_md(), diff_weights_md(), diff_dst_md());
+            bool need_reorder = gemm_compatible
+                    ? false
+                    : reorder_check(src_md(), diff_weights_md(), diff_dst_md());
+
+            data_type_t src_dt = src_md()->data_type;
+            data_type_t diff_dst_dt = diff_dst_md()->data_type;
+            data_type_t diff_wei_dt = diff_weights_md(0)->data_type;
+
+            bool f32_case
+                    = utils::everyone_is(f32, src_dt, diff_dst_dt, diff_wei_dt);
+            bool bf16_case = utils::everyone_is(bf16, src_dt, diff_dst_dt)
+                    && (utils::one_of(diff_wei_dt, bf16, f32));
+
+            ok = ok && (f32_case || bf16_case) && attr()->has_default_values()
+                    && dense_check(src_md(), diff_weights_md(), diff_dst_md())
+                    && (gemm_compatible || need_reorder);
+
+            if (bf16_case) ok = ok && (!with_bias());
+
+            if (!ok) return status::unimplemented;
+            inner_product_impl_.reset(
+                    new miopen_gemm_inner_product_bwd_weights_impl_t());
+            return inner_product_impl_->init(
+                    engine, this, false, false, false, need_reorder);
+        }
+
+        status_t set_default_params() {
+            return template_set_default_params(src_md_, diff_weights_md_,
+                    diff_dst_md_, &diff_bias_md_, ndims());
+        }
+    };
+
+    const pd_t *pd() const override {
+        return (const pd_t *)primitive_t::pd().get();
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
+++ b/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
@@ -1,0 +1,626 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_GEMM_INNER_PRODUCT_IMPL_HPP
+#define GPU_AMD_MIOPEN_GEMM_INNER_PRODUCT_IMPL_HPP
+
+#include <rocblas.h>
+#include <miopen/miopen.h>
+
+#include "common/type_helpers.hpp"
+#include "gpu/amd/miopen_inner_product_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_gemm_inner_product_base_t {
+protected:
+    int m_, n_, k_, lda_, ldb_, ldc_;
+    rocblas_operation trans_a_, trans_b_, trans_c_;
+    rocblas_datatype a_type_, b_type_, c_type_,
+            compute_type_ = rocblas_datatype_f32_r;
+    rocblas_gemm_algo algo_ = rocblas_gemm_algo_standard;
+
+    int32_t solution_index = 0;
+    uint32_t flags = 0;
+    float filter_alpha_ = 1, filter_beta_ = 0;
+
+    miopenTensorDescriptor_t current_filter_desc_, transform_filter_desc_;
+
+    status_t get_rocblas_data_type(const miopenDataType_t &miopen_dt,
+            rocblas_datatype &blas_dt) const {
+        switch (miopen_dt) {
+            case miopenFloat:
+                blas_dt = rocblas_datatype_f32_r;
+                return status::success;
+            case miopenHalf:
+                blas_dt = rocblas_datatype_f16_r;
+                return status::success;
+            case miopenInt8:
+                blas_dt = rocblas_datatype_i8_r;
+                return status::success;
+            case miopenInt8x4:
+                blas_dt = rocblas_datatype_i8_r;
+                return status::success;
+            case miopenInt32:
+                blas_dt = rocblas_datatype_i32_r;
+                return status::success;
+            case miopenBFloat16:
+                blas_dt = rocblas_datatype_bf16_r;
+                return status::success;
+            default: return status::unimplemented;
+        }
+        return status::unimplemented;
+    }
+
+    void propagate_strides(int *strides, const int *dims,
+            std::initializer_list<int> perm) const {
+        int prev_p = -1;
+        for (auto p : perm) {
+            strides[p] = prev_p == -1 ? 1 : strides[prev_p] * dims[prev_p];
+            prev_p = p;
+        }
+    }
+
+    virtual status_t init_filter_transformation(
+            miopenDataType_t filter_data_types, int filter_ndims,
+            int *filter_dims, int *current_filter_strides,
+            int *transform_filter_strides) {
+        // Set a descriptor for the current filter.
+        CHECK(create_and_set_tensor_descriptor(&current_filter_desc_,
+                filter_data_types, filter_ndims, filter_dims,
+                current_filter_strides));
+
+        // Set a descriptor for the transform filter.
+        CHECK(create_and_set_tensor_descriptor(&transform_filter_desc_,
+                filter_data_types, filter_ndims, filter_dims,
+                transform_filter_strides));
+        return status::success;
+    }
+
+    virtual void set_filter_nchw(
+            int filter_ndims, int *transform_filter_strides, int *filter_dims) {
+        switch (filter_ndims) {
+            case 4:
+                return propagate_strides(
+                        transform_filter_strides, filter_dims, {3, 2, 1, 0});
+            case 5:
+                return propagate_strides(
+                        transform_filter_strides, filter_dims, {4, 3, 2, 1, 0});
+            case 6:
+                return propagate_strides(transform_filter_strides, filter_dims,
+                        {5, 4, 3, 2, 1, 0});
+        }
+    }
+
+    virtual void set_filter_nhwc(
+            int filter_ndims, int *transform_filter_strides, int *filter_dims) {
+        switch (filter_ndims) {
+            case 4:
+                return propagate_strides(
+                        transform_filter_strides, filter_dims, {1, 3, 2, 0});
+            case 5:
+                return propagate_strides(
+                        transform_filter_strides, filter_dims, {1, 4, 3, 2, 0});
+            case 6:
+                return propagate_strides(transform_filter_strides, filter_dims,
+                        {1, 5, 4, 3, 2, 0});
+        }
+    }
+
+    void set_filter_format(int filter_ndims, int *filter_dims,
+            int *transform_filter_strides, miopenTensorLayout_t format) {
+        if (format == miopenTensorNCHW) {
+            set_filter_nchw(
+                    filter_ndims, transform_filter_strides, filter_dims);
+        } else {
+            set_filter_nhwc(
+                    filter_ndims, transform_filter_strides, filter_dims);
+        }
+    }
+    void transform_filter(miopenHandle_t handle, void *current_filter,
+            void *transform_filter) const {
+        MIOPEN_EXECUTE_FUNC(miopenTransformTensor, handle, &filter_alpha_,
+                current_filter_desc_, current_filter, &filter_beta_,
+                transform_filter_desc_, transform_filter);
+    }
+    void undo_transform_filter(miopenHandle_t handle, void *transform_filter,
+            void *current_filter) const {
+        MIOPEN_EXECUTE_FUNC(miopenTransformTensor, handle, &filter_alpha_,
+                transform_filter_desc_, transform_filter, &filter_beta_,
+                current_filter_desc_, current_filter);
+    }
+
+    virtual ~miopen_gemm_inner_product_base_t() {
+        if (current_filter_desc_) {
+            MIOPEN_EXECUTE_FUNC_V(
+                    miopenDestroyTensorDescriptor, current_filter_desc_);
+        }
+        if (transform_filter_desc_) {
+            MIOPEN_EXECUTE_FUNC_V(
+                    miopenDestroyTensorDescriptor, transform_filter_desc_);
+        }
+    }
+};
+
+struct miopen_gemm_inner_product_fwd_impl_t
+    : public miopen_inner_product_fwd_base_t,
+      public miopen_gemm_inner_product_base_t {
+    miopenActivationDescriptor_t act_desc_;
+    bool use_acc_dst_;
+    miopenTensorDescriptor_t y_acc_desc_;
+    bool need_reorder_;
+
+    int alpha_s32 = 1, beta_s32 = 0;
+    float alpha_f32 = 1.0f, beta_f32 = 0.0f;
+
+    const void *get_gemm_alpha() const {
+        switch (compute_type_) {
+            case rocblas_datatype::rocblas_datatype_i32_r:
+                return reinterpret_cast<const void *>(&alpha_s32);
+            case rocblas_datatype::rocblas_datatype_f32_r:
+                return reinterpret_cast<const void *>(&alpha_f32);
+            default: assert(!"unknown compute type"); return nullptr;
+        }
+    }
+
+    const void *get_gemm_beta() const {
+        switch (compute_type_) {
+            case rocblas_datatype::rocblas_datatype_i32_r:
+                return reinterpret_cast<const void *>(&beta_s32);
+            case rocblas_datatype::rocblas_datatype_f32_r:
+                return reinterpret_cast<const void *>(&beta_f32);
+            default: assert(!"unknown compute type"); return nullptr;
+        }
+    }
+
+    bool ip_using_scratchpad() const override { return (use_acc_dst_ > 0); }
+    virtual bool need_to_transform_filter() const override {
+        return need_reorder_;
+    }
+
+    virtual status_t init(engine_t *, inner_product_pd_t *pd, bool with_relu,
+            bool with_eltwise, bool with_sum, bool need_reorder) override {
+        need_reorder_ = need_reorder;
+
+        int ic = pd->IC_total_padded();
+        int oc = pd->OC();
+        int mb = pd->MB();
+
+        bool wie_tr = (pd->weights_md()->format_desc.blocking.strides[0] != 1);
+        bool src_tr = (pd->src_md()->format_desc.blocking.strides[0] == 1)
+                && (ic > 1);
+
+        CHECK(convert_data_type(pd->src_md(), &data_types_[io::src]));
+        CHECK(convert_data_type(pd->weights_md(0), &data_types_[io::wei]));
+        if (need_reorder) {
+            miopenTensorLayout_t source_format;
+            CHECK(get_format(pd->src_md(), source_format));
+            ndims_ = pd->ndims() < 4 ? 4 : pd->ndims();
+            get_4d_tensor_descriptor(
+                    pd->weights_md(0), dims_[io::wei], strides_[io::wei]);
+            set_filter_format(ndims_, dims_[io::wei], strides_[io::NUM_IO],
+                    source_format);
+            CHECK(init_filter_transformation(data_types_[io::wei], ndims_,
+                    dims_[io::wei], strides_[io::wei], strides_[io::NUM_IO]));
+
+            pd->scratchpad_registry().registrar().book(
+                    memory_tracking::names::key_none,
+                    memory_desc_wrapper(pd->weights_md(0)).size(), size_t(1));
+            wie_tr = strides_[io::NUM_IO][0] != 1;
+        }
+
+        trans_a_
+                = wie_tr ? rocblas_operation_transpose : rocblas_operation_none;
+        trans_b_
+                = src_tr ? rocblas_operation_transpose : rocblas_operation_none;
+
+        n_ = mb;
+        k_ = ic;
+        m_ = oc;
+
+        lda_ = wie_tr ? k_ : m_;
+        ldb_ = src_tr ? n_ : k_;
+        ldc_ = m_;
+
+        with_bias_ = pd->with_bias();
+        with_eltwise_ = with_eltwise || with_relu;
+        with_relu_ = with_eltwise;
+
+        output_scales_ = 1.0f;
+        alpha_s32 = output_scales_;
+        alpha_f32 = output_scales_;
+
+        with_sum_ = with_sum;
+        sum_scale_ = sum_scale(pd);
+        beta_s32 = sum_scale_;
+        beta_f32 = sum_scale_;
+
+        ndims_ = 4;
+        bool input_is_blocked
+                = pd->src_md()->format_desc.blocking.inner_blks[0] == 4
+                && pd->weights_md(0)->format_desc.blocking.inner_blks[0] == 4;
+        if (input_is_blocked) {
+            data_types_[io::src] = miopenInt8;
+            data_types_[io::wei] = miopenInt8;
+            data_types_[io::dst] = miopenInt8;
+        } else {
+            CHECK(convert_data_type(pd->dst_md(), &data_types_[io::dst]));
+        }
+        CHECK(get_rocblas_data_type(data_types_[io::wei], a_type_));
+        CHECK(get_rocblas_data_type(data_types_[io::src], b_type_));
+
+        get_4d_tensor_descriptor(
+                pd->dst_md(), dims_[io::dst], strides_[io::dst]);
+
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs_[io::dst],
+                data_types_[io::dst], ndims_, dims_[io::dst],
+                strides_[io::dst]));
+
+        if (with_bias_) {
+            CHECK(convert_data_type(pd->weights_md(1), &data_types_[io::bia]));
+            set_bias_dims(miopenTensorNCHW, ndims_, pd->OC());
+            CHECK(create_and_set_tensor_descriptor(&tensor_descs_[io::bia],
+                    data_types_[io::bia], ndims_, dims_[io::bia],
+                    strides_[io::bia]));
+        }
+
+        y_acc_desc_ = tensor_descs_[io::dst];
+
+        if (with_eltwise_) { CHECK(create_and_set_op_descriptor(pd)); }
+
+        CHECK(convert_data_type(pd->dst_md(), &data_types_[io::dst]));
+        CHECK(get_rocblas_data_type(data_types_[io::dst], c_type_));
+        compute_type_ = (c_type_ == rocblas_datatype_bf16_r
+                                || c_type_ == rocblas_datatype_f16_r)
+                ? rocblas_datatype_f32_r
+                : c_type_;
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t miopen_handle, rocblas_handle blas_handle,
+            const std::vector<void *> &args) const override {
+        assert(args.size() == 8);
+        auto x = args[0], w = args[1], b = args[2], y = args[3];
+
+        auto y_dst = y;
+        auto w_arg = w;
+        const void *alpha = get_gemm_alpha();
+        const void *beta = get_gemm_beta();
+        float alpha2 = 0;
+
+        if (need_reorder_) {
+            void *transformed_w = args[5];
+            transform_filter(miopen_handle, w, transformed_w);
+            w_arg = transformed_w;
+        }
+
+        ROCBLAS_EXECUTE_FUNC(rocblas_gemm_ex, blas_handle, trans_a_, trans_b_,
+                m_, n_, k_, alpha, w_arg, a_type_, lda_, x, b_type_, ldb_, beta,
+                y_dst, c_type_, ldc_, y_dst, c_type_, ldc_, compute_type_,
+                algo_, solution_index, flags);
+
+        if (with_bias_) {
+            MIOPEN_EXECUTE_FUNC(miopenOpTensor, miopen_handle,
+                    miopenTensorOpAdd, &alpha_, y_acc_desc_, y_dst,
+                    &output_scales_, tensor_descs_[io::bia], b, &alpha2,
+                    y_acc_desc_, y_dst);
+        }
+
+        if (with_eltwise_) {
+            MIOPEN_EXECUTE_FUNC(miopenActivationForward, miopen_handle,
+                    act_desc_, &alpha_, tensor_descs_[io::dst], y, &beta_,
+                    tensor_descs_[io::dst], y);
+        }
+    }
+
+    status_t create_and_set_op_descriptor(const inner_product_pd_t *pd) {
+
+        CHECK(MIOPEN_EXECUTE_FUNC_S(
+                miopenCreateActivationDescriptor, &act_desc_));
+
+        miopenActivationMode_t act_mode;
+        switch (eltwise_algorithm_kind(pd)) {
+            case alg_kind::eltwise_tanh: act_mode = miopenActivationTANH; break;
+            case alg_kind::eltwise_elu: act_mode = miopenActivationELU; break;
+            case alg_kind::eltwise_relu:
+                act_mode = miopenActivationLEAKYRELU;
+                break;
+            case alg_kind::eltwise_logistic:
+                act_mode = miopenActivationLOGISTIC;
+                break;
+            default: return status::unimplemented;
+        }
+
+        float activeAlpha;
+        float activeBeta;
+        float activeGamma;
+
+        double ceiling = eltwise_alpha(pd);
+
+        if (act_mode == miopenActivationMode_t::miopenActivationTANH)
+            activeAlpha = activeBeta = 1;
+        else if (act_mode == miopenActivationMode_t::miopenActivationELU)
+            activeAlpha = ceiling;
+        else if (act_mode == miopenActivationMode_t::miopenActivationLEAKYRELU)
+            activeAlpha = ceiling;
+
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetActivationDescriptor, act_desc_,
+                act_mode, activeAlpha, activeBeta, activeGamma));
+        return status::success;
+    }
+};
+
+struct miopen_gemm_inner_product_bwd_data_impl_t
+    : public miopen_inner_product_impl_base_t,
+      public miopen_gemm_inner_product_base_t {
+    bool need_reorder_;
+
+    virtual bool need_to_transform_filter() const override {
+        return need_reorder_;
+    }
+
+    virtual status_t init(engine_t *, inner_product_pd_t *pd,
+            bool /*with_relu*/, bool /*with_eltwise*/, bool /*with_sum */,
+            bool need_reorder) override {
+        need_reorder_ = need_reorder;
+
+        int ic = pd->IC_total_padded();
+        int oc = pd->OC();
+        int mb = pd->MB();
+
+        bool wie_tr = (pd->weights_md(0)->format_desc.blocking.strides[0] == 1);
+        bool diff_src_tr
+                = (pd->diff_src_md()->format_desc.blocking.strides[0] == 1)
+                && (ic > 1);
+
+        CHECK(convert_data_type(pd->diff_src_md(), &data_types_[io::src]));
+        CHECK(convert_data_type(pd->weights_md(0), &data_types_[io::wei]));
+        CHECK(convert_data_type(pd->diff_dst_md(), &data_types_[io::dst]));
+        if (need_reorder) {
+            miopenTensorLayout_t diff_source_format_;
+            CHECK(get_format(pd->diff_src_md(), diff_source_format_));
+            ndims_ = pd->ndims() < 4 ? 4 : pd->ndims();
+            get_4d_tensor_descriptor(
+                    pd->weights_md(0), dims_[io::wei], strides_[io::wei]);
+            set_filter_format(ndims_, dims_[io::wei], strides_[NUM_IO],
+                    diff_source_format_);
+            CHECK(init_filter_transformation(data_types_[io::wei], ndims_,
+                    dims_[io::wei], strides_[io::wei], strides_[NUM_IO]));
+
+            pd->scratchpad_registry().registrar().book(
+                    memory_tracking::names::key_none,
+                    memory_desc_wrapper(pd->weights_md(0)).size(), size_t(1));
+            wie_tr = strides_[NUM_IO][0] == 1;
+        }
+
+        trans_a_
+                = wie_tr ? rocblas_operation_transpose : rocblas_operation_none;
+        trans_b_ = rocblas_operation_none;
+        trans_c_ = diff_src_tr ? rocblas_operation_transpose
+                               : rocblas_operation_none;
+
+        n_ = mb;
+        k_ = oc;
+        m_ = ic;
+
+        lda_ = wie_tr ? k_ : m_;
+        ldb_ = k_;
+        ldc_ = m_;
+
+        CHECK(get_rocblas_data_type(data_types_[io::wei], a_type_));
+        CHECK(get_rocblas_data_type(data_types_[io::dst], b_type_));
+        CHECK(get_rocblas_data_type(data_types_[io::src], c_type_));
+        return status::success;
+    }
+    void execute(miopenHandle_t miopen_handle, rocblas_handle blas_handle,
+            const std::vector<void *> &args) const override {
+        assert(args.size() == 5);
+        auto dx = args[0], w = args[1], dy = args[2];
+        auto w_arg = w;
+
+        if (need_reorder_) {
+            void *transformed_w = args[4];
+            transform_filter(miopen_handle, w, transformed_w);
+            w_arg = transformed_w;
+        }
+
+        auto flip_op = [](rocblas_operation op) {
+            return (op == rocblas_operation::rocblas_operation_transpose)
+                    ? rocblas_operation::rocblas_operation_none
+                    : rocblas_operation::rocblas_operation_transpose;
+        };
+
+        if (trans_c_ == rocblas_operation_transpose) {
+            ROCBLAS_EXECUTE_FUNC(rocblas_gemm_ex, blas_handle,
+                    flip_op(trans_b_), flip_op(trans_a_), n_, m_, k_, &alpha_,
+                    dy, b_type_, ldb_, w_arg, a_type_, lda_, &beta_, dx,
+                    c_type_, ldc_, dx, c_type_, ldc_, compute_type_, algo_,
+                    solution_index, flags);
+        } else {
+            ROCBLAS_EXECUTE_FUNC(rocblas_gemm_ex, blas_handle, trans_a_,
+                    trans_b_, m_, n_, k_, &alpha_, w_arg, a_type_, lda_, dy,
+                    b_type_, ldb_, &beta_, dx, c_type_, ldc_, dx, c_type_, ldc_,
+                    compute_type_, algo_, solution_index, flags);
+        }
+    }
+};
+
+struct miopen_gemm_inner_product_bwd_weights_impl_t
+    : public miopen_inner_product_impl_base_t,
+      public miopen_gemm_inner_product_base_t {
+    miopenReduceTensorDescriptor_t reduceTensorDesc_ = nullptr;
+    bool wie_tr_;
+    bool need_reorder_;
+
+    virtual bool need_to_transform_filter() const override {
+        return need_reorder_;
+    }
+
+    virtual ~miopen_gemm_inner_product_bwd_weights_impl_t() {
+        if (reduceTensorDesc_) {
+            MIOPEN_EXECUTE_FUNC_V(
+                    miopenDestroyReduceTensorDescriptor, reduceTensorDesc_);
+        }
+    }
+    status_t create_and_set_reduce_descriptor() {
+        MIOPEN_EXECUTE_FUNC_S(
+                miopenCreateReduceTensorDescriptor, &reduceTensorDesc_);
+        MIOPEN_EXECUTE_FUNC_S(miopenSetReduceTensorDescriptor,
+                reduceTensorDesc_, MIOPEN_REDUCE_TENSOR_ADD, miopenFloat,
+                MIOPEN_PROPAGATE_NAN, MIOPEN_REDUCE_TENSOR_NO_INDICES,
+                MIOPEN_32BIT_INDICES);
+        return status::success;
+    }
+    virtual status_t init(engine_t *engine, inner_product_pd_t *pd,
+            bool /*with_relu*/, bool /*with_eltwise*/, bool /*with_sum */,
+            bool need_reorder) override {
+        need_reorder_ = need_reorder;
+        with_bias_ = pd->with_bias();
+
+        int ic = pd->IC_total_padded();
+        int oc = pd->OC();
+        int mb = pd->MB();
+
+        wie_tr_ = (pd->diff_weights_md(0)->format_desc.blocking.strides[0]
+                == 1);
+        bool src_tr_ = (pd->src_md()->format_desc.blocking.strides[0] == 1)
+                && (ic > 1);
+        bool dst_tr_
+                = (pd->diff_dst_md(0)->format_desc.blocking.strides[0] == 1)
+                && (oc > 1);
+
+        CHECK(convert_data_type(pd->src_md(), &data_types_[io::src]));
+        CHECK(convert_data_type(pd->diff_weights_md(0), &data_types_[io::wei]));
+        CHECK(convert_data_type(pd->diff_dst_md(), &data_types_[io::dst]));
+        if (need_reorder_) {
+            miopenTensorLayout_t source_format;
+            CHECK(get_format(pd->src_md(), source_format));
+            ndims_ = pd->ndims() < 4 ? 4 : pd->ndims();
+            get_4d_tensor_descriptor(
+                    pd->diff_weights_md(0), dims_[io::wei], strides_[io::wei]);
+            set_filter_format(
+                    ndims_, dims_[io::wei], strides_[NUM_IO], source_format);
+            CHECK(init_filter_transformation(data_types_[io::wei], ndims_,
+                    dims_[io::wei], strides_[NUM_IO], strides_[io::wei]));
+            pd->scratchpad_registry().registrar().book(
+                    memory_tracking::names::key_none,
+                    memory_desc_wrapper(pd->diff_weights_md(0)).size(),
+                    size_t(1));
+            wie_tr_ = (strides_[NUM_IO][0] == 1);
+        }
+
+        trans_a_ = src_tr_ ? rocblas_operation_transpose
+                           : rocblas_operation_none;
+        trans_b_ = dst_tr_ ? rocblas_operation_none
+                           : rocblas_operation_transpose;
+        trans_c_ = wie_tr_ ? rocblas_operation_transpose
+                           : rocblas_operation_none;
+
+        n_ = wie_tr_ ? ic : oc;
+        k_ = mb;
+        m_ = wie_tr_ ? oc : ic;
+
+        lda_ = m_;
+        ldb_ = n_;
+        ldc_ = m_;
+
+        CHECK(get_rocblas_data_type(data_types_[io::src], a_type_));
+        CHECK(get_rocblas_data_type(data_types_[io::dst], b_type_));
+        CHECK(get_rocblas_data_type(data_types_[io::wei], c_type_));
+
+        if (with_bias_) {
+            ndims_ = 4;
+            get_4d_tensor_descriptor(
+                    pd->diff_dst_md(), dims_[io::dst], strides_[io::dst]);
+            CHECK(convert_data_type(pd->diff_dst_md(), &data_types_[io::dst]));
+            set_bias_dims(miopenTensorNCHW, ndims_, pd->OC());
+            CHECK(convert_data_type(
+                    pd->diff_weights_md(1), &data_types_[io::bia]));
+            CHECK(create_and_set_tensor_descriptor(&tensor_descs_[io::dst],
+                    data_types_[io::dst], ndims_, dims_[io::dst],
+                    strides_[io::dst]));
+            CHECK(create_and_set_tensor_descriptor(&tensor_descs_[io::bia],
+                    data_types_[io::bia], ndims_, dims_[io::bia],
+                    strides_[io::bia]));
+            CHECK(create_and_set_reduce_descriptor());
+
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(engine);
+            stream_t *service_stream;
+            CHECK(sycl_engine.get_service_stream(service_stream));
+
+            auto hip_stream
+                    = utils::downcast<sycl_hip_stream_t *>(service_stream);
+            auto handle = hip_stream->get_miopen_handle();
+
+            // get the required workspace size
+            MIOPEN_EXECUTE_FUNC_S(miopenGetReductionWorkspaceSize, handle,
+                    reduceTensorDesc_, tensor_descs_[io::dst],
+                    tensor_descs_[io::bia], &workspace_size_);
+        }
+
+        if (workspace_size_ > 0) {
+            pd->scratchpad_registry().registrar().book(
+                    memory_tracking::names::key_iprod_int_dat_in_acc_dt,
+                    workspace_size_, size_t(1));
+        }
+
+        return status::success;
+    }
+    void execute(miopenHandle_t miopen_handle, rocblas_handle blas_handle,
+            const std::vector<void *> &args) const override {
+        assert(args.size() == 6);
+        auto x = args[0], dy = args[1], dw = args[2], db = args[3],
+             workspace = args[4];
+        auto dw_arg = need_reorder_ ? args[5] : dw;
+
+        auto flip_op = [](rocblas_operation op) {
+            return (op == rocblas_operation::rocblas_operation_transpose)
+                    ? rocblas_operation::rocblas_operation_none
+                    : rocblas_operation::rocblas_operation_transpose;
+        };
+
+        ROCBLAS_EXECUTE_FUNC(rocblas_gemm_ex, blas_handle,
+                wie_tr_ ? flip_op(trans_b_) : trans_a_,
+                wie_tr_ ? flip_op(trans_a_) : trans_b_, m_, n_, k_, &alpha_,
+                (wie_tr_ ? dy : x), a_type_, lda_, (wie_tr_ ? x : dy), b_type_,
+                ldb_, &beta_, dw_arg, c_type_, ldc_, dw_arg, c_type_, ldc_,
+                compute_type_, algo_, solution_index, flags);
+
+        if (need_reorder_) { transform_filter(miopen_handle, dw_arg, dw); }
+        if (with_bias_) {
+            MIOPEN_EXECUTE_FUNC(miopenReduceTensor, miopen_handle,
+                    reduceTensorDesc_, nullptr, 0, workspace, workspace_size_,
+                    &alpha_, tensor_descs_[io::dst], dy, &beta_,
+                    tensor_descs_[io::bia], db);
+        }
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_inner_product.cpp
+++ b/src/gpu/amd/miopen_inner_product.cpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_inner_product.hpp"
+#include "gpu/amd/miopen_gemm_inner_product.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "sycl/sycl_buffer_memory_storage.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_inner_product_fwd_t::execute(const exec_ctx_t &ctx) const {
+    if (pd()->has_zero_dim_memory()) return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_wei = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+        auto arg_bias = CTX_IN_SYCL_MEMORY(DNNL_ARG_BIAS);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_oscale = CTX_IN_SYCL_MEMORY(DNNL_ARG_ATTR_OUTPUT_SCALES);
+        auto arg_ip_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_iprod_int_dat_in_acc_dt);
+        auto arg_spacial_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+        auto arg_scaled_bias_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_conv_adjusted_scales);
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto native_stream = hip_stream->get_underlying_stream();
+            auto miopen_handle = hip_stream->get_miopen_handle(native_stream);
+            auto rocblas_handle = hip_stream->get_rocblas_handle(native_stream);
+
+            std::vector<void *> args;
+
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_wei.get_native_pointer(ih));
+            args.push_back(arg_bias.get_native_pointer(ih));
+            args.push_back(arg_dst.get_native_pointer(ih));
+            args.push_back(arg_ip_scratch.get_native_pointer(ih));
+            args.push_back(arg_spacial_scratch.get_native_pointer(ih));
+            args.push_back(arg_scaled_bias_scratch.get_native_pointer(ih));
+            args.push_back(arg_oscale.get_native_pointer(ih));
+
+            pd()->inner_product_impl_->execute(
+                    miopen_handle, rocblas_handle, args);
+        });
+    });
+}
+
+status_t miopen_inner_product_bwd_data_t::execute(const exec_ctx_t &ctx) const {
+    if (pd()->has_zero_dim_memory()) return status::success;
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_wei = CTX_IN_SYCL_MEMORY(DNNL_ARG_WEIGHTS);
+        auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto arg_ip_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_iprod_int_dat_in_acc_dt);
+        auto arg_spacial_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto native_stream = hip_stream->get_underlying_stream();
+            auto miopen_handle = hip_stream->get_miopen_handle(native_stream);
+            auto rocblas_handle = hip_stream->get_rocblas_handle(native_stream);
+
+            std::vector<void *> args;
+
+            args.push_back(arg_diff_src.get_native_pointer(ih));
+            args.push_back(arg_wei.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+            args.push_back(arg_ip_scratch.get_native_pointer(ih));
+            args.push_back(arg_spacial_scratch.get_native_pointer(ih));
+
+            pd()->inner_product_impl_->execute(
+                    miopen_handle, rocblas_handle, args);
+        });
+    });
+}
+
+status_t miopen_inner_product_bwd_weights_t::execute(
+        const exec_ctx_t &ctx) const {
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    if (pd()->has_zero_dim_memory()) {
+        auto wei_sz = memory_desc_wrapper(pd()->diff_weights_md(0)).size();
+        size_t bias_sz = (pd()->with_bias()
+                        ? memory_desc_wrapper(pd()->diff_weights_md(1)).size()
+                        : 0);
+
+        if (wei_sz != 0) {
+            auto status = hip_stream->fill(
+                    CTX_OUT_STORAGE(DNNL_ARG_DIFF_WEIGHTS), 0, wei_sz,
+                    hip_stream->ctx().get_deps(), hip_stream->ctx().get_deps());
+            if (status != status::success) return status;
+        }
+        if (bias_sz != 0) {
+            auto status = hip_stream->fill(CTX_OUT_STORAGE(DNNL_ARG_DIFF_BIAS),
+                    0, bias_sz, hip_stream->ctx().get_deps(),
+                    hip_stream->ctx().get_deps());
+            if (status != status::success) return status;
+        }
+        return status::success;
+    }
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto arg_diff_wei = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_WEIGHTS);
+        auto arg_bias = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_BIAS);
+        auto arg_ip_scratch = CTX_SCRATCH_SYCL_MEMORY(
+                memory_tracking::names::key_iprod_int_dat_in_acc_dt);
+        auto arg_spacial_scratch
+                = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto native_stream = hip_stream->get_underlying_stream();
+            auto miopen_handle = hip_stream->get_miopen_handle(native_stream);
+            auto rocblas_handle = hip_stream->get_rocblas_handle(native_stream);
+            std::vector<void *> args;
+
+            args.push_back(arg_src.get_native_pointer(ih));
+            args.push_back(arg_diff_dst.get_native_pointer(ih));
+            args.push_back(arg_diff_wei.get_native_pointer(ih));
+            args.push_back(arg_bias.get_native_pointer(ih));
+            args.push_back(arg_ip_scratch.get_native_pointer(ih));
+            args.push_back(arg_spacial_scratch.get_native_pointer(ih));
+
+            pd()->inner_product_impl_->execute(
+                    miopen_handle, rocblas_handle, args);
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_inner_product.hpp
+++ b/src/gpu/amd/miopen_inner_product.hpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_INNER_PRODUCT_HPP
+#define GPU_AMD_MIOPEN_INNER_PRODUCT_HPP
+
+#include <miopen/miopen.h>
+
+#include "common/c_types_map.hpp"
+#include "common/inner_product_pd.hpp"
+#include "common/primitive.hpp"
+#include "gpu/amd/miopen_inner_product_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_inner_product_fwd_t : public primitive_t {
+public:
+    using primitive_t::primitive_t;
+
+    struct pd_t : public inner_product_fwd_pd_t {
+        using inner_product_fwd_pd_t::inner_product_fwd_pd_t;
+
+        std::shared_ptr<miopen_inner_product_impl_base_t> inner_product_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+    virtual const pd_t *pd() const {
+        return (const pd_t *)primitive_t::pd().get();
+    }
+};
+
+struct miopen_inner_product_bwd_data_t : public primitive_t {
+public:
+    using primitive_t::primitive_t;
+
+    struct pd_t : public inner_product_bwd_data_pd_t {
+        using inner_product_bwd_data_pd_t::inner_product_bwd_data_pd_t;
+
+        std::shared_ptr<miopen_inner_product_impl_base_t> inner_product_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+    virtual const pd_t *pd() const {
+        return (const pd_t *)primitive_t::pd().get();
+    }
+};
+
+struct miopen_inner_product_bwd_weights_t : public primitive_t {
+public:
+    using primitive_t::primitive_t;
+    struct pd_t : public inner_product_bwd_weights_pd_t {
+        using inner_product_bwd_weights_pd_t::inner_product_bwd_weights_pd_t;
+
+        std::shared_ptr<miopen_inner_product_impl_base_t> inner_product_impl_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+    virtual const pd_t *pd() const {
+        return (const pd_t *)primitive_t::pd().get();
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_inner_product_impl.hpp
+++ b/src/gpu/amd/miopen_inner_product_impl.hpp
@@ -1,0 +1,186 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_INNER_PRODUCT_IMPL_HPP
+#define GPU_AMD_MIOPEN_INNER_PRODUCT_IMPL_HPP
+
+#include "rocblas.h"
+#include <miopen/miopen.h>
+
+#include "common/type_helpers.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+namespace {
+inline void get_4d_tensor_descriptor(
+        const memory_desc_t *mem_desc1, int *dims, int *strides) {
+    memory_desc_t mem_desc = *mem_desc1;
+
+    // Forcing tensors dims less than 4 to be 4 {n c h w};
+    using namespace format_tag;
+    auto set_dim = [&]() {
+        if (mem_desc.ndims == 3) {
+            mem_desc.ndims = 4;
+            mem_desc.dims[3] = mem_desc.dims[2];
+            mem_desc.dims[2] = 1;
+            mem_desc.padded_dims[3] = mem_desc.padded_dims[2];
+            mem_desc.padded_dims[2] = 1;
+        } else if (mem_desc.ndims == 2) {
+            mem_desc.ndims = 4;
+            mem_desc.dims[3] = 1;
+            mem_desc.dims[2] = 1;
+            mem_desc.padded_dims[3] = 1;
+            mem_desc.padded_dims[2] = 1;
+        }
+    };
+    // Forcing strides < 4 to be 4
+    if (memory_desc_matches_tag(mem_desc, nwc)) {
+        set_dim();
+        //  promoting nwc(owi) to NHWC = {wc 1 c} to {wc 1 wc c}
+        mem_desc.format_desc.blocking.strides[3]
+                = mem_desc.format_desc.blocking.strides[2];
+        mem_desc.format_desc.blocking.strides[2]
+                = mem_desc.format_desc.blocking.strides[0];
+        assert(memory_desc_matches_tag(mem_desc, nhwc)
+                && "Tag is not set to NHWC");
+    } else if (memory_desc_matches_tag(mem_desc, ncw)) {
+        set_dim();
+        // promoting ncw(oiw) to NCHW = {wc w 1} to {wc w w 1}
+        mem_desc.format_desc.blocking.strides[3]
+                = mem_desc.format_desc.blocking.strides[2];
+        mem_desc.format_desc.blocking.strides[2]
+                = mem_desc.format_desc.blocking.strides[1];
+        assert(memory_desc_matches_tag(mem_desc, nchw)
+                && "Tag is not set to NCHW");
+    } else if (memory_desc_matches_tag(mem_desc, wio)) {
+        set_dim();
+        // promoting wcn(wio) to HWCN = {1 n nc} to {1 n ncw nc}
+        mem_desc.format_desc.blocking.strides[3]
+                = mem_desc.format_desc.blocking.strides[2];
+        mem_desc.format_desc.blocking.strides[2] *= mem_desc.dims[3];
+        assert(memory_desc_matches_tag(mem_desc, hwio)
+                && " Tag is not set to HWIO");
+    } else if (memory_desc_matches_tag(mem_desc, nc)) {
+        set_dim();
+        // fixing strides
+        // promoting nc(oi) to NCHW = {c 1} to {c 1 1 1}
+        mem_desc.format_desc.blocking.strides[2]
+                = mem_desc.format_desc.blocking.strides[1];
+        mem_desc.format_desc.blocking.strides[3]
+                = mem_desc.format_desc.blocking.strides[1];
+        assert(memory_desc_matches_tag(mem_desc, nchw)
+                && " Tag is not set to NCHW");
+    } else if (memory_desc_matches_tag(mem_desc, cn)) {
+        set_dim();
+        // fixing strides cn(oi) to HWCN = {1 n} to {1 n nc nc}.
+        // Note that CHWN exists as well, but for inner product
+        // we convert it to HWCN. Other primitives may need
+        // different conversion.
+        mem_desc.format_desc.blocking.strides[2]
+                = mem_desc.format_desc.blocking.strides[1]
+                * mem_desc.padded_dims[1];
+        mem_desc.format_desc.blocking.strides[3]
+                = mem_desc.format_desc.blocking.strides[2];
+        assert(memory_desc_matches_tag(mem_desc, hwio)
+                && " Tag is not set to NCHW");
+    }
+    convert_dnnl_dims_array(mem_desc.dims, dims, mem_desc.ndims);
+    convert_dnnl_dims_array(
+            mem_desc.format_desc.blocking.strides, strides, mem_desc.ndims);
+}
+} // namespace
+struct miopen_inner_product_impl_base_t {
+    // The io enum requires the weights be the last parameter to ensure
+    // tensor_descs is contiguous.
+    enum io { src = 0, bia, dst, wei, NUM_IO };
+    miopenDataType_t data_types_[NUM_IO + 1]; // +1 data-type for accumulation
+    int ndims_;
+    int dims_[NUM_IO][DNNL_MAX_NDIMS];
+    // one extra stride added for transform filter
+    int strides_[NUM_IO + 1][DNNL_MAX_NDIMS];
+
+    miopenTensorDescriptor_t tensor_descs_[NUM_IO - 1] = {};
+
+    size_t workspace_size_ = 0;
+    float alpha_ = 1, beta_ = 0;
+    bool with_bias_;
+    bool scale_bias_ = false;
+    bool with_relu_ = false, with_eltwise_ = false, with_sum_ = false;
+    bool filter_using_spatial_format_ = false;
+
+    virtual bool need_to_transform_filter() const {
+        return filter_using_spatial_format_;
+    }
+
+    virtual bool ip_using_scratchpad() const { return (workspace_size_ > 0); }
+    bool conv_using_scale_scratchpad() const { return scale_bias_; }
+
+    void set_bias_dims(miopenTensorLayout_t format, int ndims, int bias_dim) {
+        for (size_t i = 0; i < ndims; ++i) {
+            dims_[io::bia][i] = 1;
+            strides_[io::bia][i] = (format != miopenTensorNHWC ? 1 : bias_dim);
+        }
+        dims_[io::bia][1] = bias_dim;
+        strides_[io::bia][1] = 1;
+        strides_[io::bia][0] = bias_dim;
+    }
+    virtual status_t init(engine_t * /*engine*/, inner_product_pd_t * /*pd*/,
+            bool /*with_relu*/, bool /*with_eltwise*/, bool /*with_sum */,
+            bool /*using_fused_path_for_blocking*/)
+            = 0;
+
+    virtual void execute(miopenHandle_t /*handle*/,
+            rocblas_handle /*rocblas_handle*/,
+            const std::vector<void *> & /*args*/) const = 0;
+};
+
+struct miopen_inner_product_fwd_base_t
+    : public miopen_inner_product_impl_base_t {
+    float output_scales_; // alpha in gemm
+    bool do_scaling_ {false}, runtime_scaling_ {false};
+    float sum_scale_; // beta in gemm
+    float eltwise_alpha(const inner_product_pd_t *pd) const {
+        const int eltwise_idx
+                = pd->attr()->post_ops_.find(primitive_kind::eltwise);
+        return with_eltwise_
+                ? pd->attr()->post_ops_.entry_[eltwise_idx].eltwise.alpha
+                : 0.0f;
+    }
+    float sum_scale(const inner_product_pd_t *pd) const {
+        const int sum_idx = pd->attr()->post_ops_.find(primitive_kind::sum);
+        return with_sum_ ? pd->attr()->post_ops_.entry_[sum_idx].sum.scale
+                         : 0.0f;
+    }
+
+    dnnl::impl::alg_kind_t eltwise_algorithm_kind(
+            const inner_product_pd_t *pd) const {
+        const int eltwise_idx
+                = pd->attr()->post_ops_.find(primitive_kind::eltwise);
+        return pd->attr()->post_ops_.entry_[eltwise_idx].eltwise.alg;
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
 
 #include "gpu/amd/miopen_binary.hpp"
 #include "gpu/amd/miopen_eltwise.hpp"
+#include "gpu/amd/miopen_gemm_inner_product.hpp"
 #include "gpu/amd/miopen_lrn.hpp"
 #include "gpu/amd/miopen_matmul.hpp"
 #include "gpu/amd/miopen_pooling.hpp"
@@ -181,6 +182,10 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         INSTANCE(miopen_reduction_t)
         // MatMul
         INSTANCE(miopen_matmul_t)
+        // Inner Product
+        INSTANCE(miopen_gemm_inner_product_fwd_t)
+        INSTANCE(miopen_gemm_inner_product_bwd_data_t)
+        INSTANCE(miopen_gemm_inner_product_bwd_weights_t)
         nullptr,
 };
 // clang-format on

--- a/src/gpu/amd/sycl_hip_engine.hpp
+++ b/src/gpu/amd/sycl_hip_engine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,9 +36,25 @@ namespace amd {
 class hip_gpu_engine_impl_list_t {
 public:
     static const impl_list_item_t *get_reorder_implementation_list(
-            const memory_desc_t *src_md, const memory_desc_t *dst_md);
-    static const dnnl::impl::impl_list_item_t *get_concat_implementation_list();
-    static const dnnl::impl::impl_list_item_t *get_sum_implementation_list();
+            const memory_desc_t *src_md, const memory_desc_t *dst_md) {
+        static impl_list_item_t hip_reorder_impl_list[] = {
+                nullptr,
+        };
+        return hip_reorder_impl_list;
+    }
+    static const dnnl::impl::impl_list_item_t *
+    get_concat_implementation_list() {
+        static impl_list_item_t hip_concat_impl_list[] = {
+                nullptr,
+        };
+        return hip_concat_impl_list;
+    }
+    static const dnnl::impl::impl_list_item_t *get_sum_implementation_list() {
+        static impl_list_item_t hip_sum_impl_list[] = {
+                nullptr,
+        };
+        return hip_sum_impl_list;
+    }
 };
 
 class sycl_hip_engine_t : public dnnl::impl::sycl::sycl_engine_base_t {
@@ -56,29 +72,18 @@ public:
     const dnnl::impl::impl_list_item_t *get_reorder_implementation_list(
             const memory_desc_t *src_md,
             const memory_desc_t *dst_md) const override {
-        static impl_list_item_t hip_reorder_impl_list[] = {
-
-                nullptr,
-        };
-        return hip_reorder_impl_list;
+        return hip_gpu_engine_impl_list_t::get_reorder_implementation_list(
+                src_md, dst_md);
     }
 
     const dnnl::impl::impl_list_item_t *
     get_concat_implementation_list() const override {
-        static impl_list_item_t hip_concat_impl_list[] = {
-
-                nullptr,
-        };
-        return hip_concat_impl_list;
+        return hip_gpu_engine_impl_list_t::get_concat_implementation_list();
     }
 
     const dnnl::impl::impl_list_item_t *
     get_sum_implementation_list() const override {
-        static impl_list_item_t hip_sum_impl_list[] = {
-
-                nullptr,
-        };
-        return hip_sum_impl_list;
+        return hip_gpu_engine_impl_list_t::get_sum_implementation_list();
     }
 
     void activate_stream_miopen(HIPstream hip_stream);


### PR DESCRIPTION
# Description
Introducing AMD backend for the oneDNN Innerproduct primitive.

**Supported scope:**
Supported Data Types: 
Forward : f32, f16, s8/s32, bf16
Backward data : f32, bf16
Backward weight : f32, bf16

**Testing scope:**
benchdnn: Passed
gtest: API tests passed, Innerproduct tests passed

**Log files for benchdnn:**
[test_ip_all.log](https://github.com/oneapi-src/oneDNN/files/10471606/test_ip_all.log)
[test_ip_ci.log](https://github.com/oneapi-src/oneDNN/files/10471607/test_ip_ci.log)

**Log files for gtests:**
[test_inner_product_forward.log](https://github.com/oneapi-src/oneDNN/files/10471610/test_inner_product_forward.log)
[test_inner_product_forward_buffer.log](https://github.com/oneapi-src/oneDNN/files/10471611/test_inner_product_forward_buffer.log)
[test_inner_product_backward_data.log](https://github.com/oneapi-src/oneDNN/files/10471612/test_inner_product_backward_data.log)
[test_inner_product_backward_data_buffer.log](https://github.com/oneapi-src/oneDNN/files/10471613/test_inner_product_backward_data_buffer.log)
[test_inner_product_backward_weights.log](https://github.com/oneapi-src/oneDNN/files/10471615/test_inner_product_backward_weights.log)
[test_inner_product_backward_weights_buffer.log](https://github.com/oneapi-src/oneDNN/files/10471617/test_inner_product_backward_weights_buffer.log)

[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/10471618/test_api_buffer.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/10471619/test_api_sycl.log)
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/10471620/test_internals.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/10471621/test_regression.log)

**Limitations:**
This backend only supports the following combinations:
(src, weights, dst, bias)
FWD
-f32, f32, f32, f32
-f16, f16, f16, f16
-s8, s8, s32, s32
-bf16, bf16, bf16, (bias not supported)
-bf16, bf16, f32, f32
BWD Data
-f32, f32, f32, bias not Applicable
-bf16, bf16, bf16, bias not Applicable
BWD Weights
-f32, f32, f32, f32
-bf16, bf16, bf16, (bias not supported)

**Note :**

- Currently only above combinations are supported, once reorder issue is fixed will add support for other possible combinations.
- Gemm based implementation was done, convolution based implementation was not done for now.

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?