### PR TITLE
gpu: sycl: optimize computing underlying context type

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -132,22 +132,24 @@ status_t sycl_cuda_engine_t::underlying_context_type() {
     // this is a costly function which take avarage up to 75ms
     // on titanrx. So we must run it once and store the variable
     // in primary_context_;
-    CUcontext primary,current;
+    CUcontext primary, current;
     CUcontext desired = compat::get_native<CUcontext>(context());
     CUdevice cuda_device = compat::get_native<CUdevice>(device());
     CHECK(CUDA_EXECUTE_FUNC_S(cuCtxGetCurrent, &current));
 
     unsigned int flags;
     int is_primary_active;
-    CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxGetState, cuda_device, &flags, &is_primary_active));
+    CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxGetState, cuda_device, &flags,
+            &is_primary_active));
 
     // If primary context is active, current context will be the primary context
     // So we can do the comparison without the expensive calls to CtxRetain and CtxRelease
-    if ( current == desired || is_primary_active ) {
-        primary_context_ =  (current == desired) ? (is_primary_active==1) : false;
-    }
-    else {
-        CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxRetain, &primary, cuda_device));
+    if (current == desired || is_primary_active) {
+        primary_context_
+                = (current == desired) ? (is_primary_active == 1) : false;
+    } else {
+        CHECK(CUDA_EXECUTE_FUNC_S(
+                cuDevicePrimaryCtxRetain, &primary, cuda_device));
         CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxRelease, cuda_device));
         primary_context_ = (primary == desired);
     }

--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -131,13 +131,26 @@ status_t sycl_cuda_engine_t::create_stream(
 status_t sycl_cuda_engine_t::underlying_context_type() {
     // this is a costly function which take avarage up to 75ms
     // on titanrx. So we must run it once and store the variable
-    // in  is_primary_context_;
-    CUcontext primary;
+    // in primary_context_;
+    CUcontext primary,current;
     CUcontext desired = compat::get_native<CUcontext>(context());
     CUdevice cuda_device = compat::get_native<CUdevice>(device());
-    CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxRetain, &primary, cuda_device));
-    CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxRelease, cuda_device));
-    primary_context_ = (primary == desired);
+    CHECK(CUDA_EXECUTE_FUNC_S(cuCtxGetCurrent, &current));
+
+    unsigned int flags;
+    int is_primary_active;
+    CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxGetState, cuda_device, &flags, &is_primary_active));
+
+    // If primary context is active, current context will be the primary context
+    // So we can do the comparison without the expensive calls to CtxRetain and CtxRelease
+    if ( current == desired || is_primary_active ) {
+        primary_context_ =  (current == desired) ? (is_primary_active==1) : false;
+    }
+    else {
+        CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxRetain, &primary, cuda_device));
+        CHECK(CUDA_EXECUTE_FUNC_S(cuDevicePrimaryCtxRelease, cuda_device));
+        primary_context_ = (primary == desired);
+    }
     return status::success;
 }
 


### PR DESCRIPTION
# Description

This change optimizes the computation in `underlying_context_type()`  by reducing the expensive calls to `cuDevicePrimaryCtxRetain` and  `cuDevicePrimaryCtxRelease`. It will be helpful in the case where a system has multiple devices.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

[N/A] Have you published an RFC for the new feature?
[N/A] Was the RFC approved?
[N/A] Have you added relevant tests?

### Bug fixes

[N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
[N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

[N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
[N/A] Have you added a link to the rendered document?
