### PR TITLE
Modified get_num_cores to more accurately get the information

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -198,9 +198,7 @@ unsigned get_num_cores() {
     int num_cores = x64::cpu().getNumCores(Xbyak::util::CoreLevel);
     // Sometimes getNumCores() can't detect number of cores and returns
     // 0 (e.g. in AMD Systems), so we need to read the system info
-    if (num_cores > 0) {
-        return num_cores;
-    }
+    if (num_cores > 0) { return num_cores; }
 #ifdef _WIN32
     SYSTEM_INFO sys_info;
     GetSystemInfo(&sys_info);


### PR DESCRIPTION
# Description

For some AMD Systems get_num_cores() function was returning zero, so when this happens we are reading the system information to get his the number of cores.

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [Y] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [Y] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [Y] Have you included information on how to reproduce the issue (either in a github issue or in this PR)? I mentioned the type of system where this is an issue.
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
