### PR TITLE
cpu: aarch64: fix acl post ops compilation

### DIFF
--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -156,8 +156,7 @@ struct acl_post_ops_t {
             for (int idx = 1; idx < base_post_ops.len(); ++idx) {
                 // Construct empty entry then copy, so that we can check for failure
                 post_ops.entry_.emplace_back();
-                CHECK(post_ops.entry_.back().copy_from(
-                        base_post_ops.entry_[idx]));
+                post_ops.entry_.back().copy_from(base_post_ops.entry_[idx]);
             }
             return init(engine, post_ops, dst_md);
 


### PR DESCRIPTION
# Description

Remove check when copying ACL post ops, following the recent change which removes status_t return
in primitive attributes (commit a89321f).

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?


## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?