### PR TITLE
aarch64: conv: injector for 1x1 conv

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -178,100 +178,113 @@ static_params_t::static_params_t(const Xbyak_aarch64::XReg &param1,
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        const memory_desc_wrapper &dst_d, std::size_t tail_size,
-        bool use_exact_tail_scalar_bcast)
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, 0, dst_d, tail_size, Xbyak_aarch64::PReg(2),
-            use_exact_tail_scalar_bcast, rhs_helper_reg,
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+            Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast, rhs_helper_reg,
             false /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, dst_orig_offset, dst_d, tail_size,
-            Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast, rhs_helper_reg,
-            false /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+            tail_size, Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast,
+            rhs_helper_reg, false /*is_opmask_set*/, true /*is_dst_orig_set*/) {
+}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+            tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
+            true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
         const memory_desc_wrapper &dst_d, std::size_t tail_size,
         const Xbyak_aarch64::PReg &tail_opmask,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, 0, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, rhs_helper_reg, true /*is_opmask_set*/,
-            false /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+            tail_size, tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
+            true /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
         std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &reg_tail_size,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, dst_orig_offset, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, rhs_helper_reg, true /*is_opmask_set*/,
-            true /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+            tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
+            true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
         const memory_desc_wrapper &dst_d, std::size_t tail_size,
         const Xbyak_aarch64::PReg &tail_opmask,
         const Xbyak_aarch64::XReg &reg_tail_size,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, 0, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, reg_tail_size, true /*is_opmask_set*/,
-            false /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+            tail_size, tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
+            true /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
-        const Xbyak_aarch64::XReg &reg_tail_size,
-        bool use_exact_tail_scalar_bcast)
-    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, dst_orig_offset, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, reg_tail_size, true /*is_opmask_set*/,
-            true /*is_dst_orig_set*/) {}
-
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx,
-        const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        const Xbyak_aarch64::PReg &tail_opmask,
         bool use_exact_tail_scalar_bcast,
         const Xbyak_aarch64::XReg &reg_tail_size, bool is_opmask_set,
         bool is_dst_orig_set)
     : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
     , rhs_addr_reg(rhs_addr_reg)
     , rhs_helper_reg(rhs_helper_reg)
+    , rhs_addr_cache_reg(rhs_addr_cache_reg)
     , preserve_gpr_helpers(preserve_gpr_helpers)
     , preserve_vmm_helper(preserve_vmm_helper)
     , abi_param_offset(abi_param_offset)

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,6 +80,8 @@ bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
  * stored inside rhs_addr_reg.
  * @param rhs_helper_reg - gpr register used as helper for calculations during data
  * loading phase.
+ * @param rhs_addr_cache_reg - gpr register used for caching part of calculated
+ * offset, this register is always preserved.
  * @param preserve_gpr_helpers - determines whether gpr registers specified above
  * should be preserved (pushed to stack and poped back afterwords) between
  * compute_vector_range calls.
@@ -105,6 +107,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
             std::size_t tail_size = 0u,
@@ -112,6 +115,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size = 0u,
@@ -119,6 +123,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
             std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
@@ -126,6 +131,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size,
@@ -134,6 +140,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
             std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
@@ -142,6 +149,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size,
@@ -155,6 +163,7 @@ struct rhs_arg_static_params_t {
     mutable std::size_t rhs_dt_helper_vmm_idx;
     Xbyak_aarch64::XReg rhs_addr_reg;
     Xbyak_aarch64::XReg rhs_helper_reg;
+    Xbyak_aarch64::XReg rhs_addr_cache_reg;
     bool preserve_gpr_helpers;
     bool preserve_vmm_helper;
     std::size_t abi_param_offset;
@@ -170,6 +179,7 @@ private:
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size,

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2019-2023 Intel Corporation
+* Copyright 2021-2023 FUJITSU LIMITED
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,7 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble(
         const injector_utils::vmm_index_set_t &vmm_idxs) {
     using namespace alg_kind;
     using namespace Xbyak_aarch64::util;
+    p_all = h->P_ALL_ONE;
     preserved_vecs_count = 0;
     vecs_to_preserve = aux_vecs_count();
     const auto start_idx = *(vmm_idxs.begin());
@@ -93,8 +94,6 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble(
             preserved_gpr_idxs[preserved_gprs_count++] = _idx;
     }
     assert(preserved_gprs_count == aux_gprs_count());
-
-    h->ptrue(p_all.b);
 
     if (save_state_) {
         const int reg_size = h->x0.getBit() / 8;
@@ -262,7 +261,6 @@ void jit_uni_eltwise_injector_f32<isa>::set_coef_to_regs() {
 template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_f32<isa>::compute_cmp_mask(
         const TRegS &vmm_src, const TRegS &compare_operand, int cmp_predicate) {
-
     enum {
         EQ_OQ = 0,
         LT_OS = 1,
@@ -298,7 +296,7 @@ void jit_uni_eltwise_injector_f32<isa>::compute_cmp_mask(
         TRUE_US = 31,
     };
 
-    h->mov(PRegB(IDX(p_tmp0)), h->P_ALL_ONE / T_z, h->P_ALL_ONE.b);
+    h->mov(PRegB(IDX(p_tmp0)), p_all / T_z, p_all.b);
     switch (cmp_predicate) {
         case EQ_OQ:
             h->fcmeq(

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2019-2023 Intel Corporation
+* Copyright 2021-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,14 +41,12 @@ struct static_params_t {
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
             Xbyak_aarch64::PReg p_mask = Xbyak_aarch64::PReg(1),
             Xbyak_aarch64::PReg p_tmp0 = Xbyak_aarch64::PReg(4),
-            Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(7),
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
         : save_state(save_state)
         , x_table(x_table)
         , p_mask(p_mask)
         , p_tmp0(p_tmp0)
-        , p_all(p_all)
         , is_fwd(is_fwd)
         , use_dst(use_dst)
         , preserve_vmm(preserve_vmm)
@@ -58,7 +56,6 @@ struct static_params_t {
     Xbyak_aarch64::XReg x_table;
     Xbyak_aarch64::PReg p_mask;
     Xbyak_aarch64::PReg p_tmp0;
-    Xbyak_aarch64::PReg p_all;
     bool is_fwd;
     bool use_dst;
     bool preserve_vmm;
@@ -104,7 +101,6 @@ struct jit_uni_eltwise_injector_f32 {
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
             Xbyak_aarch64::PReg p_mask = Xbyak_aarch64::PReg(1),
             Xbyak_aarch64::PReg p_tmp0 = Xbyak_aarch64::PReg(4),
-            Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(7),
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
         : alg_(alg)
@@ -116,7 +112,6 @@ struct jit_uni_eltwise_injector_f32 {
         , x_table(x_table)
         , p_mask(p_mask)
         , p_tmp0(p_tmp0)
-        , p_all(p_all)
         , is_fwd_(is_fwd)
         , use_dst_(use_dst)
         , preserve_vmm_(preserve_vmm)
@@ -132,13 +127,11 @@ struct jit_uni_eltwise_injector_f32 {
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
             Xbyak_aarch64::PReg p_mask = Xbyak_aarch64::PReg(1),
             Xbyak_aarch64::PReg p_tmp0 = Xbyak_aarch64::PReg(4),
-            Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(7),
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
         : jit_uni_eltwise_injector_f32(host, eltwise.alg, eltwise.alpha,
                 eltwise.beta, eltwise.scale, save_state, x_table, p_mask,
-                p_tmp0, p_all, is_fwd, use_dst, preserve_vmm,
-                preserve_p_table) {}
+                p_tmp0, is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
 
     void compute_vector_range(size_t start_idx, size_t end_idx);
     void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs);
@@ -156,9 +149,10 @@ private:
 
     const bool save_state_;
     const Xbyak_aarch64::XReg x_table;
+    // 99 is dummy and must be replaced meaningfull value at runtime.
+    Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(99);
     const Xbyak_aarch64::PReg p_mask;
     const Xbyak_aarch64::PReg p_tmp0;
-    const Xbyak_aarch64::PReg p_all;
     const bool is_fwd_;
     const bool use_dst_;
     const bool preserve_vmm_;

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -60,10 +60,11 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
     bool is_binary = false;
     bool is_eltwise = false;
 
-    for (const auto &post_op : post_ops.entry_) {
+    for (int i = 0; i < post_ops.len(); i++) {
+        const auto &post_op = post_ops.entry_[i];
         if (post_op.is_eltwise()) {
             is_eltwise = true;
-            alg_to_eltwise_injector_.emplace(post_op.eltwise.alg,
+            alg_to_eltwise_injector_.emplace(i,
                     jit_uni_eltwise_injector_f32<isa>(host_, post_op.eltwise,
                             esp.save_state, esp.x_table, esp.p_mask, esp.p_tmp0,
                             esp.is_fwd, esp.use_dst));
@@ -133,10 +134,10 @@ void jit_uni_postops_injector_t<isa>::compute_vector_range(
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
     std::size_t rhs_arg_idx = 0;
-    for (const auto &post_op : post_ops_.entry_) {
+    for (int i = 0; i < post_ops_.len(); i++) {
+        const auto &post_op = post_ops_.entry_[i];
         if (post_op.is_eltwise()) {
-            alg_to_eltwise_injector_.at(post_op.eltwise.alg)
-                    .compute_vector_range(vmm_idxs);
+            alg_to_eltwise_injector_.at(i).compute_vector_range(vmm_idxs);
         } else if (post_op.is_binary()) {
             binary_injector_->compute_vector_range(
                     vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
             alg_to_eltwise_injector_.emplace(post_op.eltwise.alg,
                     jit_uni_eltwise_injector_f32<isa>(host_, post_op.eltwise,
                             esp.save_state, esp.x_table, esp.p_mask, esp.p_tmp0,
-                            esp.p_all, esp.is_fwd, esp.use_dst));
+                            esp.is_fwd, esp.use_dst));
         } else if (post_op.is_binary()) {
             is_binary = true;
         }

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -127,8 +127,8 @@ public:
 private:
     post_ops_t post_ops_;
     jit_generator *host_;
-    std::map<dnnl::impl::alg_kind_t, jit_uni_eltwise_injector_f32<isa>>
-            alg_to_eltwise_injector_;
+    // Key is a numerical order of a post-op in attributes.
+    std::map<int, jit_uni_eltwise_injector_f32<isa>> alg_to_eltwise_injector_;
     std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa>>
             binary_injector_;
     lambda_jit_injectors_t lambda_jit_injectors_;

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,14 +21,10 @@
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
+#include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
 #include "cpu/aarch64/jit_op_imm_check.hpp"
 #include "cpu/aarch64/jit_primitive_conf.hpp"
-
-#define DISABLE_ELTWISE
-#ifndef DISABLE_ELTWISE
-#include "cpu/aarch64/jit_uni_eltwise_injector.hpp"
-#endif
 
 using namespace Xbyak_aarch64;
 
@@ -41,32 +37,10 @@ namespace aarch64 {
 #define VL64_OFS(ofs) ((ofs) >> 6)
 
 struct jit_sve_512_1x1_conv_kernel : public jit_generator {
-    jit_sve_512_1x1_conv_kernel(
-            const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr)
-        : jcp(ajcp)
-        , attr_(attr)
-#ifndef DISABLE_ELTWISE
-        , eltwise_injector_(nullptr)
-#endif
-    {
-        if (jcp.with_eltwise) {
-#ifndef DISABLE_ELTWISE
-            eltwise_injector_ = new jit_uni_eltwise_injector_f32<sve_512>(
-                    this, jcp.eltwise);
-#endif
-        }
-    }
-
-    ~jit_sve_512_1x1_conv_kernel() {
-#ifndef DISABLE_ELTWISE
-        delete eltwise_injector_;
-#endif
-    }
+    jit_sve_512_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
+            const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_512_1x1_conv_kernel)
-
-    static bool post_ops_ok(
-            jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr);
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
@@ -112,6 +86,41 @@ private:
     /* Temporay registers */
     reg64_t reg_tmp_imm = x18; // tmp for add_imm
     reg64_t reg_tmp_ofs = x19; // tmp reg to calc bwd wei offset in out_load
+
+    reg64_t reg_load_dim_tail_mask = aux_reg_load_data;
+
+    std::unique_ptr<injector::jit_uni_postops_injector_t<sve_512>>
+            postops_injector_;
+
+    constexpr static int isa_simd_width_
+            = cpu_isa_traits<sve_512>::vlen / sizeof(float);
+
+    ZReg vreg_bcast = ZReg(31);
+    PReg k_load_dim_mask = p2;
+    PReg k_load_dim_tail_mask = p3;
+    ZReg zreg_tmp = ZReg(31);
+    ZReg zreg_tmp1 = ZReg(30);
+
+    constexpr static int reg64_size_ = sizeof(int64_t);
+    constexpr static int reg_bcast_loop_work_offt = 0;
+    constexpr static int reg_binary_post_op_acc_off = 1 * reg64_size_;
+    constexpr static int reg_abi_param1_backup = 2 * reg64_size_;
+    constexpr static int stack_space_needed = 3 * reg64_size_;
+
+    template <typename T>
+    Xbyak_aarch64::XReg EVEX_compress_addr(const Xbyak_aarch64::XReg &addr,
+            const Xbyak_aarch64::XReg &x_tmp, Xbyak_aarch64::XReg base,
+            T raw_offt, bool bcast = false) {
+
+        assert(raw_offt <= INT_MAX);
+        auto offt = static_cast<int>(raw_offt);
+
+        add_imm(addr, base, offt, x_tmp);
+        if (bcast) {
+            // addr is the same as addr when bcast is false.
+        }
+        return addr;
+    }
 
     void prefetch(
             const std::string prfop, int level, reg64_t in, long long int ofs) {
@@ -165,14 +174,26 @@ private:
         }
     }
 
-#ifndef DISABLE_ELTWISE
-    jit_uni_eltwise_injector_f32<sve_512> *eltwise_injector_;
-#endif
     void bcast_loop(int load_loop_blk);
     void reduce_loop(int load_loop_blk, int ur, int substep, bool wraparound);
 
     void generate() override;
     static void balance(jit_1x1_conv_conf_t &jcp);
+
+    inline size_t get_output_offset(
+            const bool is_out_layout_nxc, const int i_load, const int i_ur) {
+        const size_t i_load_shift = is_out_layout_nxc
+                ? jcp.load_block
+                : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
+        const size_t i_ur_shift
+                = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
+        return jcp.typesize_out * (i_load * i_load_shift + i_ur * i_ur_shift);
+    }
+
+    Xbyak_aarch64::XReg output_ptr(const bool out_layout_nxc, const int i_load,
+            const int i_ur, Xbyak_aarch64::XReg addr);
+    void apply_postops(const bool is_out_layout_nxc, const int load_loop_blk,
+            const int ur);
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -127,9 +127,10 @@ void jit_uni_binary_kernel_t<isa>::init_post_ops_injector() {
             reg_elt_inj_table_, elt_inj_opmask_, elt_inj_p_tmp0_,
             true /*is_fwd*/, false /*use_dst*/);
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
-            reg_elt_inj_table_, true /*preserve gpr*/, true /*preserve vmm*/,
-            PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig), dst_d,
-            tail_size_, tail_opmask_, false /*use_exact_tail_scalar_bcast*/};
+            reg_elt_inj_table_, x13, true /*preserve gpr*/,
+            true /*preserve vmm*/, PARAM_OFF(post_ops_binary_rhs_arg_vec),
+            PARAM_OFF(dst_orig), dst_d, tail_size_, tail_opmask_,
+            false /*use_exact_tail_scalar_bcast*/};
     const binary_injector::static_params_t bsp(this->param1,
             get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -125,7 +125,7 @@ void jit_uni_binary_kernel_t<isa>::init_post_ops_injector() {
 
     const eltwise_injector::static_params_t esp(true /*save_state*/,
             reg_elt_inj_table_, elt_inj_opmask_, elt_inj_p_tmp0_,
-            elt_inj_p_all_, true /*is_fwd*/, false /*use_dst*/);
+            true /*is_fwd*/, false /*use_dst*/);
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
             reg_elt_inj_table_, true /*preserve gpr*/, true /*preserve vmm*/,
             PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig), dst_d,

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2021-2023 FUJITSU LIMITED
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,8 +73,8 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
         const bool save_state = is_fwd ? false : true;
         eltwise_injector_.reset(new jit_uni_eltwise_injector_f32<isa>(this,
                 desc.alg_kind, desc.alpha, desc.beta, 1.f, save_state,
-                reg_injector_table, injector_mask, injector_p_tmp0,
-                injector_p_all, is_fwd, pd_->use_dst()));
+                reg_injector_table, injector_mask, injector_p_tmp0, is_fwd,
+                pd_->use_dst()));
     }
 
     void generate() override {

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
-* Copyright 2017-2022 Intel Corporation
+* Copyright 2017-2023 Intel Corporation
 * Copyright 2018 YANDEX LLC
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2020-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
                 static_cast<std::size_t>(this->v4.getIdx()), this->x14,
-                this->x15, preserve_gpr, preserve_vmm,
+                this->x15, this->x13, preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(jpp.tag_kind == jit_memory_tag_kind_t::ncsp
                                 ? jpp.tmp_md

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2019-2023 Intel Corporation
+* Copyright 2020-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -342,13 +342,11 @@ struct jit_softmax_base_t : public jit_generator {
         if (pd_->is_fwd() || is_logsoftmax_)
             exp_injector_.reset(new jit_uni_eltwise_injector_f32<isa>(this,
                     alg_kind::eltwise_exp, 0.0f, 0.0f, 1.0f, true,
-                    reg_exp_injector_table, injector_mask, injector_tmp,
-                    P_ALL_ONE));
+                    reg_exp_injector_table, injector_mask, injector_tmp));
         if (pd_->is_fwd() && is_logsoftmax_) {
             log_injector_.reset(new jit_uni_eltwise_injector_f32<isa>(this,
                     alg_kind::eltwise_log, 0.0f, 0.0f, 1.0f, true,
-                    reg_log_injector_table, injector_mask, injector_tmp,
-                    P_ALL_ONE));
+                    reg_log_injector_table, injector_mask, injector_tmp));
         }
 
         compute_predefined_variables();


### PR DESCRIPTION
# Description

This PR supports injectors for 1x1 convolution. 
The following PRs may be required before merge this PR.
- https://github.com/oneapi-src/oneDNN/pull/1556 
- https://github.com/oneapi-src/oneDNN/pull/1557 
- https://github.com/oneapi-src/oneDNN/pull/1558 
- https://github.com/oneapi-src/oneDNN/pull/1559

Thank you.


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
