### PR TITLE
aarch64: conv: injector, zp_compensation, dst_scale for integer conv

### DIFF
--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2018-2022 Intel Corporation
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2018-2023 Intel Corporation
+* Copyright 2020-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -181,15 +181,19 @@ static inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
     if ((cpu_isa_mask & cpu_isa) != cpu_isa) return false;
 
     switch (cpu_isa) {
-        case asimd: return cpu().has(Cpu::tADVSIMD);
+        case asimd: return cpu().has(XBYAK_AARCH64_HWCAP_ADVSIMD);
         case sve_128:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_128;
+            return cpu().has(XBYAK_AARCH64_HWCAP_SVE)
+                    && cpu().getSveLen() >= SVE_128;
         case sve_256:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_256;
+            return cpu().has(XBYAK_AARCH64_HWCAP_SVE)
+                    && cpu().getSveLen() >= SVE_256;
         case sve_384:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_384;
+            return cpu().has(XBYAK_AARCH64_HWCAP_SVE)
+                    && cpu().getSveLen() >= SVE_384;
         case sve_512:
-            return cpu().has(Cpu::tSVE) && cpu().getSveLen() >= SVE_512;
+            return cpu().has(XBYAK_AARCH64_HWCAP_SVE)
+                    && cpu().getSveLen() >= SVE_512;
         case isa_undef: return true;
         case isa_all: return false;
     }

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -178,100 +178,113 @@ static_params_t::static_params_t(const Xbyak_aarch64::XReg &param1,
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        const memory_desc_wrapper &dst_d, std::size_t tail_size,
-        bool use_exact_tail_scalar_bcast)
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, 0, dst_d, tail_size, Xbyak_aarch64::PReg(2),
-            use_exact_tail_scalar_bcast, rhs_helper_reg,
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+            Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast, rhs_helper_reg,
             false /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, dst_orig_offset, dst_d, tail_size,
-            Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast, rhs_helper_reg,
-            false /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+            tail_size, Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast,
+            rhs_helper_reg, false /*is_opmask_set*/, true /*is_dst_orig_set*/) {
+}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+            tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
+            true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
         const memory_desc_wrapper &dst_d, std::size_t tail_size,
         const Xbyak_aarch64::PReg &tail_opmask,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, 0, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, rhs_helper_reg, true /*is_opmask_set*/,
-            false /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+            tail_size, tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
+            true /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
         std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &reg_tail_size,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, dst_orig_offset, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, rhs_helper_reg, true /*is_opmask_set*/,
-            true /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+            tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
+            true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
         const memory_desc_wrapper &dst_d, std::size_t tail_size,
         const Xbyak_aarch64::PReg &tail_opmask,
         const Xbyak_aarch64::XReg &reg_tail_size,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, 0, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, reg_tail_size, true /*is_opmask_set*/,
-            false /*is_dst_orig_set*/) {}
+            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+            tail_size, tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
+            true /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
         const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
-        const Xbyak_aarch64::XReg &reg_tail_size,
-        bool use_exact_tail_scalar_bcast)
-    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, preserve_gpr_helpers, preserve_vmm_helper,
-            abi_param_offset, dst_orig_offset, dst_d, tail_size, tail_opmask,
-            use_exact_tail_scalar_bcast, reg_tail_size, true /*is_opmask_set*/,
-            true /*is_dst_orig_set*/) {}
-
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx,
-        const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        const Xbyak_aarch64::PReg &tail_opmask,
         bool use_exact_tail_scalar_bcast,
         const Xbyak_aarch64::XReg &reg_tail_size, bool is_opmask_set,
         bool is_dst_orig_set)
     : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
     , rhs_addr_reg(rhs_addr_reg)
     , rhs_helper_reg(rhs_helper_reg)
+    , rhs_addr_cache_reg(rhs_addr_cache_reg)
     , preserve_gpr_helpers(preserve_gpr_helpers)
     , preserve_vmm_helper(preserve_vmm_helper)
     , abi_param_offset(abi_param_offset)

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,6 +80,8 @@ bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
  * stored inside rhs_addr_reg.
  * @param rhs_helper_reg - gpr register used as helper for calculations during data
  * loading phase.
+ * @param rhs_addr_cache_reg - gpr register used for caching part of calculated
+ * offset, this register is always preserved.
  * @param preserve_gpr_helpers - determines whether gpr registers specified above
  * should be preserved (pushed to stack and poped back afterwords) between
  * compute_vector_range calls.
@@ -105,6 +107,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
             std::size_t tail_size = 0u,
@@ -112,6 +115,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size = 0u,
@@ -119,6 +123,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
             std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
@@ -126,6 +131,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size,
@@ -134,6 +140,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
             std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
@@ -142,6 +149,7 @@ struct rhs_arg_static_params_t {
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size,
@@ -155,6 +163,7 @@ struct rhs_arg_static_params_t {
     mutable std::size_t rhs_dt_helper_vmm_idx;
     Xbyak_aarch64::XReg rhs_addr_reg;
     Xbyak_aarch64::XReg rhs_helper_reg;
+    Xbyak_aarch64::XReg rhs_addr_cache_reg;
     bool preserve_gpr_helpers;
     bool preserve_vmm_helper;
     std::size_t abi_param_offset;
@@ -170,6 +179,7 @@ private:
     rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak_aarch64::XReg &rhs_addr_reg,
             const Xbyak_aarch64::XReg &rhs_helper_reg,
+            const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
             bool preserve_gpr_helpers, bool preserve_vmm_helper,
             std::size_t abi_param_offset, std::size_t dst_orig_offset,
             const memory_desc_wrapper &dst_d, std::size_t tail_size,

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2019-2023 Intel Corporation
+* Copyright 2021-2023 FUJITSU LIMITED
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,7 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble(
         const injector_utils::vmm_index_set_t &vmm_idxs) {
     using namespace alg_kind;
     using namespace Xbyak_aarch64::util;
+    p_all = h->P_ALL_ONE;
     preserved_vecs_count = 0;
     vecs_to_preserve = aux_vecs_count();
     const auto start_idx = *(vmm_idxs.begin());
@@ -93,8 +94,6 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble(
             preserved_gpr_idxs[preserved_gprs_count++] = _idx;
     }
     assert(preserved_gprs_count == aux_gprs_count());
-
-    h->ptrue(p_all.b);
 
     if (save_state_) {
         const int reg_size = h->x0.getBit() / 8;
@@ -262,7 +261,6 @@ void jit_uni_eltwise_injector_f32<isa>::set_coef_to_regs() {
 template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_f32<isa>::compute_cmp_mask(
         const TRegS &vmm_src, const TRegS &compare_operand, int cmp_predicate) {
-
     enum {
         EQ_OQ = 0,
         LT_OS = 1,
@@ -298,7 +296,7 @@ void jit_uni_eltwise_injector_f32<isa>::compute_cmp_mask(
         TRUE_US = 31,
     };
 
-    h->mov(PRegB(IDX(p_tmp0)), h->P_ALL_ONE / T_z, h->P_ALL_ONE.b);
+    h->mov(PRegB(IDX(p_tmp0)), p_all / T_z, p_all.b);
     switch (cmp_predicate) {
         case EQ_OQ:
             h->fcmeq(

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2019-2023 Intel Corporation
+* Copyright 2021-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,14 +41,12 @@ struct static_params_t {
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
             Xbyak_aarch64::PReg p_mask = Xbyak_aarch64::PReg(1),
             Xbyak_aarch64::PReg p_tmp0 = Xbyak_aarch64::PReg(4),
-            Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(7),
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
         : save_state(save_state)
         , x_table(x_table)
         , p_mask(p_mask)
         , p_tmp0(p_tmp0)
-        , p_all(p_all)
         , is_fwd(is_fwd)
         , use_dst(use_dst)
         , preserve_vmm(preserve_vmm)
@@ -58,7 +56,6 @@ struct static_params_t {
     Xbyak_aarch64::XReg x_table;
     Xbyak_aarch64::PReg p_mask;
     Xbyak_aarch64::PReg p_tmp0;
-    Xbyak_aarch64::PReg p_all;
     bool is_fwd;
     bool use_dst;
     bool preserve_vmm;
@@ -104,7 +101,6 @@ struct jit_uni_eltwise_injector_f32 {
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
             Xbyak_aarch64::PReg p_mask = Xbyak_aarch64::PReg(1),
             Xbyak_aarch64::PReg p_tmp0 = Xbyak_aarch64::PReg(4),
-            Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(7),
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
         : alg_(alg)
@@ -116,7 +112,6 @@ struct jit_uni_eltwise_injector_f32 {
         , x_table(x_table)
         , p_mask(p_mask)
         , p_tmp0(p_tmp0)
-        , p_all(p_all)
         , is_fwd_(is_fwd)
         , use_dst_(use_dst)
         , preserve_vmm_(preserve_vmm)
@@ -132,13 +127,11 @@ struct jit_uni_eltwise_injector_f32 {
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
             Xbyak_aarch64::PReg p_mask = Xbyak_aarch64::PReg(1),
             Xbyak_aarch64::PReg p_tmp0 = Xbyak_aarch64::PReg(4),
-            Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(7),
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
         : jit_uni_eltwise_injector_f32(host, eltwise.alg, eltwise.alpha,
                 eltwise.beta, eltwise.scale, save_state, x_table, p_mask,
-                p_tmp0, p_all, is_fwd, use_dst, preserve_vmm,
-                preserve_p_table) {}
+                p_tmp0, is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
 
     void compute_vector_range(size_t start_idx, size_t end_idx);
     void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs);
@@ -156,9 +149,10 @@ private:
 
     const bool save_state_;
     const Xbyak_aarch64::XReg x_table;
+    // 99 is dummy and must be replaced meaningfull value at runtime.
+    Xbyak_aarch64::PReg p_all = Xbyak_aarch64::PReg(99);
     const Xbyak_aarch64::PReg p_mask;
     const Xbyak_aarch64::PReg p_tmp0;
-    const Xbyak_aarch64::PReg p_all;
     const bool is_fwd_;
     const bool use_dst_;
     const bool preserve_vmm_;

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -60,10 +60,11 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
     bool is_binary = false;
     bool is_eltwise = false;
 
-    for (const auto &post_op : post_ops.entry_) {
+    for (int i = 0; i < post_ops.len(); i++) {
+        const auto &post_op = post_ops.entry_[i];
         if (post_op.is_eltwise()) {
             is_eltwise = true;
-            alg_to_eltwise_injector_.emplace(post_op.eltwise.alg,
+            alg_to_eltwise_injector_.emplace(i,
                     jit_uni_eltwise_injector_f32<isa>(host_, post_op.eltwise,
                             esp.save_state, esp.x_table, esp.p_mask, esp.p_tmp0,
                             esp.is_fwd, esp.use_dst));
@@ -133,10 +134,10 @@ void jit_uni_postops_injector_t<isa>::compute_vector_range(
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
     std::size_t rhs_arg_idx = 0;
-    for (const auto &post_op : post_ops_.entry_) {
+    for (int i = 0; i < post_ops_.len(); i++) {
+        const auto &post_op = post_ops_.entry_[i];
         if (post_op.is_eltwise()) {
-            alg_to_eltwise_injector_.at(post_op.eltwise.alg)
-                    .compute_vector_range(vmm_idxs);
+            alg_to_eltwise_injector_.at(i).compute_vector_range(vmm_idxs);
         } else if (post_op.is_binary()) {
             binary_injector_->compute_vector_range(
                     vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
             alg_to_eltwise_injector_.emplace(post_op.eltwise.alg,
                     jit_uni_eltwise_injector_f32<isa>(host_, post_op.eltwise,
                             esp.save_state, esp.x_table, esp.p_mask, esp.p_tmp0,
-                            esp.p_all, esp.is_fwd, esp.use_dst));
+                            esp.is_fwd, esp.use_dst));
         } else if (post_op.is_binary()) {
             is_binary = true;
         }

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -127,8 +127,8 @@ public:
 private:
     post_ops_t post_ops_;
     jit_generator *host_;
-    std::map<dnnl::impl::alg_kind_t, jit_uni_eltwise_injector_f32<isa>>
-            alg_to_eltwise_injector_;
+    // Key is a numerical order of a post-op in attributes.
+    std::map<int, jit_uni_eltwise_injector_f32<isa>> alg_to_eltwise_injector_;
     std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa>>
             binary_injector_;
     lambda_jit_injectors_t lambda_jit_injectors_;

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2016-2023 Intel Corporation
+* Copyright 2020-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -110,6 +110,8 @@ struct jit_conv_conf_t {
     bool with_eltwise;
     bool with_binary;
 
+    data_type_t sum_dt;
+
     bool is_fused_conv;
     int dw_conv_buffer_oc;
 
@@ -188,6 +190,8 @@ struct jit_conv_conf_t {
     bool dst_zero_point;
     bool zp_src_is_common; // common, otherwise (TODO) per-channel
 
+    bool dst_scale;
+
     bool uses_permw_transposition;
     bool transpose_src;
     bool transpose_dst;
@@ -234,6 +238,7 @@ struct jit_conv_call_s {
     const int32_t *dst_zero_point;
     const void *tile_cfg;
     const void *tile_cfg_tail;
+    const void *dst_scale;
 
     // ptr to table of void * elements that are pointers to
     // post_op binary src1 tensors

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
+#include "cpu/aarch64/injectors/injector_utils.hpp"
+#include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
+#include "cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp"
 
 #define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_call_s, field))
@@ -42,9 +45,50 @@ void pick_loop_order(jit_conv_conf_t &jcp, int nthr) {
         jcp.loop_order = loop_ngcw;
         if (jcp.mb < nthr)
             jcp.loop_order = jcp.ndims == 3 ? loop_nwcg : loop_nhwcg;
+    } else if (jcp.mb >= nthr && jcp.ic_without_padding <= 16) {
+        jcp.loop_order = loop_ngcw;
     }
 }
 } // namespace
+
+jit_sve_512_x8s8s32x_fwd_kernel::jit_sve_512_x8s8s32x_fwd_kernel(
+        const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
+        const memory_desc_t &dst_md)
+    : jcp(ajcp), attr_(attr) {
+    int ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+    switch (ch_block) {
+        case 16: sve_len_ = 64; break;
+        case 8: sve_len_ = 32; break;
+        case 4: sve_len_ = 16; break;
+        default: assert(!"unreachable"); break;
+    }
+    if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
+        using namespace binary_injector;
+        static constexpr bool preserve_gpr = true;
+        static constexpr bool preserve_vmm = false;
+        static constexpr size_t helper_vmm_idx = 31;
+        const size_t oc_block_tail = jcp.oc_block % isa_simd_width_;
+        const size_t tail_size = oc_block_tail
+                ? oc_block_tail
+                : jcp.oc_without_padding % isa_simd_width_;
+        static constexpr bool use_exact_tail_scalar_bcast = false;
+
+        const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,
+                x14, x15, x13, preserve_gpr, preserve_vmm,
+                GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
+                memory_desc_wrapper(dst_md), tail_size, postops_mask,
+                use_exact_tail_scalar_bcast};
+        const static_params_t static_params {
+                this->param1, rhs_arg_static_params};
+
+        const eltwise_injector::static_params_t eltwise_params {
+                true, x14, mask_tmp, mask_tmp2};
+
+        postops_injector_ = utils::make_unique<
+                injector::jit_uni_postops_injector_t<sve_512>>(
+                this, jcp.post_ops, static_params, eltwise_params);
+    }
+}
 
 void jit_sve_512_x8s8s32x_fwd_kernel::prepare_output(int ur_w) {
     int nb_oc_block
@@ -115,6 +159,106 @@ void jit_sve_512_x8s8s32x_fwd_kernel::cvt2ps(data_type_t type_in,
     if (type_in != data_type::f32) scvtf(vmm_in.s, mask_all_one, vmm_in.s);
 }
 
+template <typename F>
+static void iterate(const int nb_oc_block, const int ur_w,
+        const bool last_oc_block_flag, const bool force_masking, const F &f) {
+    for (int k = 0; k < nb_oc_block; k++) {
+        const bool mask_flag
+                = force_masking || (last_oc_block_flag && k + 1 == nb_oc_block);
+        for (int j = 0; j < ur_w; j++)
+            f(mask_flag, k, j);
+    }
+}
+template <typename F>
+static void iterate(const int nb_oc_block, const int ur_w,
+        const bool last_oc_block_flag, const F &f) {
+    iterate(nb_oc_block, ur_w, last_oc_block_flag, false, f);
+}
+template <typename F>
+static void iterate(const int nb_oc_block, const int ur_w, const F &f) {
+    iterate(nb_oc_block, ur_w, false, false, f);
+}
+
+void jit_sve_512_x8s8s32x_fwd_kernel::apply_sum(int ur_w,
+        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
+        const float *p_sum_scale, const int32_t *p_sum_zp) {
+    if (jcp.with_sum) {
+        const float sum_scale = *p_sum_scale;
+        const int32_t sum_zp = *p_sum_zp;
+        const auto sum_injector_lam = [this, oc_block, sum_scale, sum_zp](
+                                              const bool mask_flag, const int k,
+                                              const int j) {
+            int aux_output_offset = jcp.typesize_out
+                    * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
+            auto vmm = vmm_out(j, k);
+            cvt2ps(jcp.sum_dt, vmm_prev_dst, reg_out, aux_output_offset,
+                    mask_flag);
+            if (sum_zp != 0) {
+                fsub(vmm_prev_dst.s, vmm_prev_dst.s, vmm_sum_zp.s);
+            }
+            if (sum_scale == 1.f) {
+                fadd(vmm.s, vmm.s, vmm_prev_dst.s);
+            } else {
+                ld1rw(vmm_tmp.s, mask_all_one / T_z, ptr(reg_ptr_sum_scale));
+                fmla(vmm.s, mask_all_one / T_m, vmm_prev_dst.s, vmm_tmp.s);
+            }
+        };
+        const auto sum_injector = [=]() {
+            iterate(nb_oc_block, ur_w, last_oc_block_flag, sum_injector_lam);
+        };
+        if (sum_scale != 1.f) {
+            mov_imm(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
+        }
+        if (sum_zp != 0) {
+            mov_imm(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
+            ld1rb(vmm_tmp.s, mask_all_one / T_m, ptr(reg_ptr_sum_zp));
+            scvtf(vmm_sum_zp.s, mask_all_one / T_m, vmm_tmp.s);
+        }
+        postops_injector_->set_lambda_injector(
+                primitive_kind::sum, sum_injector);
+    }
+}
+
+void jit_sve_512_x8s8s32x_fwd_kernel::apply_postops(int ur_w,
+        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
+        const float *p_sum_scale, const int32_t *p_sum_zp) {
+    if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
+        apply_sum(ur_w, last_oc_block_flag, nb_oc_block, oc_block, p_sum_scale,
+                p_sum_zp);
+
+        injector_utils::vmm_index_set_t vmm_idxs;
+        if (jcp.with_binary) {
+            binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
+            const bool oc_blk_is_smaller_than_vmm = oc_block < isa_simd_width_;
+            iterate(nb_oc_block, ur_w, last_oc_block_flag,
+                    oc_blk_is_smaller_than_vmm,
+                    [&](const bool mask_flag, const int k, const int j) {
+                        const size_t aux_output_l_off = jcp.typesize_out
+                                * (k * oc_block
+                                        + j * jcp.oc_without_padding
+                                                * jcp.ngroups);
+                        const auto vmm_idx = vmm_out_idx(j, k);
+                        vmm_idxs.emplace(vmm_idx);
+
+                        rhs_arg_params.vmm_idx_to_out_reg.emplace(
+                                vmm_idx, reg_out);
+                        rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
+                                vmm_idx, aux_output_l_off);
+                        if (mask_flag)
+                            rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
+                    });
+
+            postops_injector_->compute_vector_range(vmm_idxs, rhs_arg_params);
+        } else {
+            iterate(nb_oc_block, ur_w,
+                    [&](const bool, const int k, const int j) {
+                        vmm_idxs.emplace(vmm_out_idx(j, k));
+                    });
+            postops_injector_->compute_vector_range(vmm_idxs);
+        }
+    }
+}
+
 void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
         int ur_w, bool last_oc_block_flag) {
     int nb_oc_block
@@ -126,16 +270,20 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
     if (!jcp.signed_input)
         ldr(reg_compensation, ptr(reg_param1, GET_OFF(compensation)));
 
+    if (jcp.src_zero_point) {
+        ldr(reg_zp_compensation, ptr(reg_param1, GET_OFF(zp_compensation)));
+        ldr(reg_src_zero_point, ptr(reg_param1, GET_OFF(src_zero_point)));
+    }
+
     const auto &p = attr_.post_ops_;
     const int sum_idx = p.find(primitive_kind::sum);
     const float *p_sum_scale = nullptr;
+    const int32_t *p_sum_zp = nullptr;
     if (sum_idx != -1) {
         const auto &p_entry = p.entry_[sum_idx];
         p_sum_scale = &p_entry.sum.scale;
+        p_sum_zp = &p_entry.sum.zero_point;
     }
-
-    if (p_sum_scale && *p_sum_scale != 1.f)
-        mov_imm(reg_ptr_sum_scale, (size_t)p_sum_scale);
 
     for (int k = 0; k < nb_oc_block; k++) {
         const bool mask_flag
@@ -150,11 +298,23 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
         if (!jcp.signed_input) {
             int comp_offset = sizeof(int32_t) * k * oc_block;
 
-            cvt2ps(data_type::s32, vmm_comp, reg_compensation, comp_offset,
-                    mask_flag);
+            auto reg_addr = get_comp_addr_reg(reg_compensation, comp_offset);
+            ld1w(vmm_comp.s, mask / T_z, ptr(reg_addr));
+        }
+        if (jcp.src_zero_point) {
+            // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
+            int zp_offset = sizeof(int32_t) * k * oc_block;
+            auto reg_addr = get_comp_addr_reg(reg_zp_compensation, zp_offset);
+            ld1w(vmm_zp.s, mask / T_z, ptr(reg_addr));
+            auto reg_addr2 = get_comp_addr_reg(reg_src_zero_point, 0);
+            st1w(vmm_tmp.s, mask_all_one / T_z, ptr(reg_stack, -1, MUL_VL));
+            vmm_load_zero_point(vmm_tmp, reg_addr2, mask, jcp.zp_src_is_common);
+            mul(vmm_zp.s, mask / T_m, vmm_tmp.s);
+            ld1w(vmm_tmp.s, mask_all_one / T_z, ptr(reg_stack, -1, MUL_VL));
         }
         /* optimization under specific conditions: preload scale_offset data */
-        if (!jcp.is_fast_depthwise && jcp.signed_input) {
+        if ((!jcp.is_fast_depthwise && jcp.signed_input
+                    && !jcp.src_zero_point)) {
             auto reg_addr = get_comp_addr_reg(reg_ptr_scales, scale_offset);
             ld1w(vmm_pre_load.s, mask / T_z, ptr(reg_addr));
         }
@@ -187,11 +347,14 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
                 ldr(zmm_tmp1, ptr(reg_stack));
                 add(reg_stack, reg_stack, 64);
             }
+            /* add comp in s32 to avoid loss of precision
+               when convert s32 to f32 in integer(2^24)
+               TODO: do the same to bias */
+            if (!jcp.signed_input) sub(vmm.s, vmm.s, vmm_comp.s);
+            if (jcp.src_zero_point) add(vmm.s, vmm.s, vmm_zp.s);
             scvtf(vmm.s, mask_all_one, vmm.s);
-            if (!jcp.signed_input) fsub(vmm.s, vmm.s, vmm_comp.s);
-            if (jcp.with_bias) fadd(vmm.s, vmm.s, vmm_bias.s);
-
-            if (!jcp.is_fast_depthwise && jcp.signed_input) {
+            if ((!jcp.is_fast_depthwise && jcp.signed_input
+                        && !jcp.src_zero_point)) {
                 /* optimization under specific conditions: optimize using preloaded scale_offset data */
                 fmul(vmm.s, vmm.s, vmm_pre_load.s);
             } else {
@@ -201,32 +364,40 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
                 fmul(vmm.s, vmm.s, vmm_tmp.s);
                 ld1w(vmm_tmp.s, mask_all_one / T_z, ptr(reg_stack, -1, MUL_VL));
             }
+            if (jcp.with_bias) fadd(vmm.s, vmm.s, vmm_bias.s);
         }
     }
 
-    /* Do post-ops */
-    if (p_sum_scale) { // post_op: sum
+    apply_postops(ur_w, last_oc_block_flag, nb_oc_block, oc_block, p_sum_scale,
+            p_sum_zp);
+
+    if (jcp.dst_scale) {
+        ldr(reg_dst_scale, ptr(reg_param1, GET_OFF(dst_scale)));
+        auto reg_addr = get_comp_addr_reg(reg_dst_scale, 0);
+        ld1w(vmm_dst_scale.s, mask_all_one, ptr(reg_addr));
+
+        /* Apply dst scale to accumulator */
         for (int k = 0; k < nb_oc_block; k++) {
-            const bool mask_flag
-                    = last_oc_block_flag && k == nb_oc_block - 1 && mask_gflag;
+            const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
             for (int j = 0; j < ur_w; j++) {
-                int aux_output_offset = jcp.typesize_out
-                        * (k * oc_block
-                                + j * jcp.oc_without_padding * jcp.ngroups);
-                auto vmm = vmm_out(j, k);
-                cvt2ps(jcp.dst_dt, vmm_prev_dst, reg_out, aux_output_offset,
-                        mask_flag);
-                if (*p_sum_scale == 1.f) {
-                    fadd(vmm.s, vmm.s, vmm_prev_dst.s);
-                } else {
-                    sub(reg_stack, reg_stack, 64);
-                    str(vmm_tmp, ptr(reg_stack));
-                    ld1rw(vmm_tmp.s, mask_all_one / T_z,
-                            ptr(reg_ptr_sum_scale));
-                    fmla(vmm.s, mask_all_one / T_m, vmm_prev_dst.s, vmm_tmp.s);
-                    ldr(vmm_tmp, ptr(reg_stack));
-                    add(reg_stack, reg_stack, 64);
-                }
+                ZReg vmm = vmm_out(j, k);
+                fmul(vmm.s, vmm.s, vmm_dst_scale.s);
+                if (mask_flag) mov(vmm.s, ktail_mask / T_m, vmm.s);
+            }
+        }
+    }
+
+    if (jcp.dst_zero_point) {
+        ldr(reg_dst_zero_point, ptr(reg_param1, GET_OFF(dst_zero_point)));
+        auto reg_addr = get_comp_addr_reg(reg_dst_zero_point, 0);
+        vmm_load_zero_point(vmm_zp, reg_addr, mask_all_one, true);
+        scvtf(vmm_zp.s, mask_all_one / T_m, vmm_zp.s);
+
+        /* Add dst zero_point to accumulator */
+        for (int k = 0; k < nb_oc_block; k++) {
+            for (int j = 0; j < ur_w; j++) {
+                ZReg vmm = vmm_out(j, k);
+                fadd(vmm.s, vmm.s, vmm_zp.s);
             }
         }
     }
@@ -271,11 +442,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
                     : ((j % 4) == 1)          ? reg_tmp1_adr
                     : ((j % 4) == 2)          ? reg_tmp2_adr
                                               : reg_tmp3_adr;
-            auto reg_tmp_imm = ((j % 4) == 0) ? reg_tmp0_imm
-                    : ((j % 4) == 1)          ? reg_tmp1_imm
-                    : ((j % 4) == 2)          ? reg_tmp2_imm
-                                              : reg_tmp3_imm;
-            add_imm(reg_tmp_adr, base, re, reg_tmp_imm);
+            add_imm(reg_tmp_adr, base, re, reg_tmp0_imm);
 
             auto vmm = vmm_out(j, k);
 
@@ -306,6 +473,15 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker_dw(int ur_w, int pad_l,
     if (sve_len_ != 64)
         assert(!"invalid group blocking for depthwise convolution");
 
+    const bool compute_kernel = IMPLICATION(h_padded, !jcp.signed_input);
+
+    if (jcp.src_zero_point) {
+        sub(reg_stack, reg_stack, 8);
+        str(aux_reg_ker_d, ptr(reg_stack));
+        auto reg_addr = get_comp_addr_reg(reg_param1, GET_OFF(src_zero_point));
+        ldr(reg_src_zero_point, ptr(reg_addr));
+    }
+
     auto input_spatial_index = [=](int oi, int ki) {
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
@@ -327,6 +503,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker_dw(int ur_w, int pad_l,
     };
 
     auto compute = [=](ZReg vreg_acc, ZReg vreg_wei, ZReg vreg_src) {
+        // okay for depthwise since src is zero-extended
         sdot(vreg_acc.s, vreg_src.b, vreg_wei.b);
     };
 
@@ -363,13 +540,19 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker_dw(int ur_w, int pad_l,
                 auto zmm_inp_msk = zmm_inp_tmp;
                 if (jcp.is_fast_depthwise) {
                     assert(!mask_flag);
-                    auto reg_addr
-                            = get_comp_addr_reg(aux_reg_inp, aux_input_offset);
-                    ldr(QReg(zmm_inp_msk.getIdx()), ptr(reg_addr));
-                    ptrue(mask_tmp.d, VL2);
-                    splice(zmm_inp_msk.d, mask_tmp.d, zmm_inp_msk.d);
-                    ptrue(mask_tmp.d, VL4);
-                    splice(zmm_inp_msk.d, mask_tmp.d, zmm_inp_msk.d);
+                    if (ii == ii_start)
+                        not_(mask_tmp.b, mask_all_one, ktail_mask.b);
+                    if (aux_input_offset % 16 == 0
+                            && aux_input_offset <= 65520) {
+                        ldr(QReg(zmm_inp_tmp.getIdx()),
+                                ptr(aux_reg_inp, aux_input_offset));
+                    } else {
+                        auto reg_addr = get_comp_addr_reg(
+                                aux_reg_inp, aux_input_offset);
+                        ldr(QReg(zmm_inp_tmp.getIdx()), ptr(reg_addr));
+                    }
+                    dup(zmm_inp_tmp.q, zmm_inp_tmp.q[0]);
+                    sel(zmm_inp_tmp.s, mask_tmp, zmm_inp_tmp.s, vmm_zero.s);
                 } else {
                     auto reg_addr
                             = get_comp_addr_reg(aux_reg_inp, aux_input_offset);
@@ -402,96 +585,163 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker_dw(int ur_w, int pad_l,
         }
         for (int ki = 0; ki < jcp.kw; ki++) {
             int aux_kernel_offset = kernel_offset(ci, ki);
-            if (jcp.is_fast_depthwise) {
-                auto reg_addr
-                        = get_comp_addr_reg(aux_reg_ker, aux_kernel_offset);
-                ldr(QReg(zmm_wei.getIdx()), ptr(reg_addr));
-                ptrue(mask_tmp.d, VL2);
-                splice(zmm_wei.d, mask_tmp.d, zmm_wei.d);
-                ptrue(mask_tmp.d, VL4);
-                splice(zmm_wei.d, mask_tmp.d, zmm_wei.d);
-                not_(mask_tmp.b, mask_all_one, kblend_mask.b);
-                mov(zmm_wei.b, kblend_mask / T_m, zmm_wei.b);
-                mov(zmm_wei.b, mask_tmp / T_m, 0);
-            } else {
-                auto reg_addr
-                        = get_comp_addr_reg(aux_reg_ker, aux_kernel_offset);
-                auto zmm_tmp = ZReg(30);
-                sub(reg_stack, reg_stack, 64);
-                str(zmm_tmp, ptr(reg_stack));
-                ldr(QReg(zmm_tmp.getIdx()), ptr(reg_addr));
-                zip1(zmm_tmp.b, zmm_tmp.b, zmm_tmp.b);
-                zip1(zmm_tmp.h, zmm_tmp.h, zmm_tmp.h);
-                sxtb(zmm_wei.s, mask_all_one / T_m, zmm_tmp.s);
-                ldr(zmm_tmp, ptr(reg_stack));
-                add(reg_stack, reg_stack, 64);
-            }
-            if (h_padded) {
-                assert(!jcp.signed_input);
-                for (int oi = 0; oi < ur_w; oi++)
-                    compute(zmm_out(oi, ci), zmm_wei, zmm_shifted_zero);
-            } else {
-                auto r_zmm_src = zmm_src;
-                int oi_start = get_ow_start(ki, pad_l);
-                int oi_end = get_ow_end(ur_w, ki, pad_r);
-                int start_ = !jcp.signed_input ? 0 : oi_start;
-                int end_ = !jcp.signed_input ? ur_w : oi_end;
-                for (int oi = start_; oi < end_; oi++) {
-                    if (oi >= oi_start && oi < oi_end) {
-                        if (jcp.is_resrc_depthwise) {
-                            int ii = input_spatial_index(oi, ki);
-                            zmm_src = zmm_inp(ii, jcp.nb_ch_blocking);
-                        } else {
-                            int aux_input_offset = input_offset3(oi, ci, ki);
-                            if (jcp.is_fast_depthwise) {
-                                assert(!mask_flag);
-                                auto reg_addr = get_comp_addr_reg(
-                                        aux_reg_inp, aux_input_offset);
-                                ldr(QReg(r_zmm_src.getIdx()), ptr(reg_addr));
-                                ptrue(mask_tmp.d, VL2);
-                                splice(r_zmm_src.d, mask_tmp.d, r_zmm_src.d);
-                                ptrue(mask_tmp.d, VL4);
-                                splice(r_zmm_src.d, mask_tmp.d, r_zmm_src.d);
-                            } else {
-                                auto reg_addr = get_comp_addr_reg(
-                                        aux_reg_inp, aux_input_offset);
-                                auto zmm_tmp = ZReg(31);
-                                sub(reg_stack, reg_stack, 64);
-                                str(zmm_tmp, ptr(reg_stack));
-                                if (mask_flag) {
-                                    eor(mask_tmp.b, mask_all_one, mask_tmp.b,
-                                            mask_tmp.b);
-                                    eor(mask_tmp2.b, mask_all_one, mask_tmp2.b,
-                                            mask_tmp2.b);
-                                    uzp1(mask_tmp.h, ktail_mask.h, mask_tmp.h);
-                                    uzp1(mask_tmp.b, mask_tmp.b, mask_tmp2.b);
-                                } else {
-                                    ptrue(mask_tmp.b, VL16);
-                                }
-                                ld1b(zmm_tmp.b, mask_tmp, ptr(reg_addr));
-                                zip1(zmm_tmp.b, zmm_tmp.b, zmm_tmp.b);
-                                zip1(zmm_tmp.h, zmm_tmp.h, zmm_tmp.h);
-                                uxtb(r_zmm_src.s, mask_all_one / T_m,
-                                        zmm_tmp.s);
-                                if (mask_flag) {
-                                    not_(mask_tmp.b, mask_all_one.b,
-                                            ktail_mask.b);
-                                    mov(r_zmm_src.s, mask_tmp / T_m, 0);
-                                }
-                                ldr(zmm_tmp, ptr(reg_stack));
-                                add(reg_stack, reg_stack, 64);
-                            }
-                            if (!jcp.signed_input)
-                                sub(zmm_src.b, zmm_src.b, vmm_shift.b);
-                        }
-                        compute(zmm_out(oi, ci), zmm_wei, zmm_src);
-                    } else {
-                        assert(!jcp.signed_input);
+            const int oi_start = get_ow_start(ki, pad_l);
+            const int oi_end = get_ow_end(ur_w, ki, pad_r);
+            if (compute_kernel) {
+                if (jcp.is_fast_depthwise) {
+                    auto reg_addr
+                            = get_comp_addr_reg(aux_reg_ker, aux_kernel_offset);
+                    ldr(QReg(zmm_wei.getIdx()), ptr(reg_addr));
+                    ptrue(mask_tmp.d, VL2);
+                    splice(zmm_wei.d, mask_tmp.d, zmm_wei.d);
+                    ptrue(mask_tmp.d, VL4);
+                    splice(zmm_wei.d, mask_tmp.d, zmm_wei.d);
+                    not_(mask_tmp.b, mask_all_one, kblend_mask.b);
+                    mov(zmm_wei.b, kblend_mask / T_m, zmm_wei.b);
+                    mov(zmm_wei.b, mask_tmp / T_m, 0);
+                } else {
+                    auto reg_addr
+                            = get_comp_addr_reg(aux_reg_ker, aux_kernel_offset);
+                    auto zmm_tmp = ZReg(30);
+                    sub(reg_stack, reg_stack, 64);
+                    str(zmm_tmp, ptr(reg_stack));
+                    ldr(QReg(zmm_tmp.getIdx()), ptr(reg_addr));
+                    zip1(zmm_tmp.b, zmm_tmp.b, zmm_tmp.b);
+                    zip1(zmm_tmp.h, zmm_tmp.h, zmm_tmp.h);
+                    sxtb(zmm_wei.s, mask_all_one / T_m, zmm_tmp.s);
+                    ldr(zmm_tmp, ptr(reg_stack));
+                    add(reg_stack, reg_stack, 64);
+                }
+                if (h_padded) {
+                    assert(!jcp.signed_input);
+                    for (int oi = 0; oi < ur_w; oi++)
                         compute(zmm_out(oi, ci), zmm_wei, zmm_shifted_zero);
+                } else {
+                    auto r_zmm_src = zmm_src;
+                    int oi_start = get_ow_start(ki, pad_l);
+                    int oi_end = get_ow_end(ur_w, ki, pad_r);
+                    int start_ = !jcp.signed_input ? 0 : oi_start;
+                    int end_ = !jcp.signed_input ? ur_w : oi_end;
+                    for (int oi = start_; oi < end_; oi++) {
+                        if (oi >= oi_start && oi < oi_end) {
+                            if (jcp.is_resrc_depthwise) {
+                                int ii = input_spatial_index(oi, ki);
+                                zmm_src = zmm_inp(ii, jcp.nb_ch_blocking);
+                            } else {
+                                int aux_input_offset
+                                        = input_offset3(oi, ci, ki);
+                                if (jcp.is_fast_depthwise) {
+                                    assert(!mask_flag);
+                                    auto reg_addr = get_comp_addr_reg(
+                                            aux_reg_inp, aux_input_offset);
+                                    ldr(QReg(r_zmm_src.getIdx()),
+                                            ptr(reg_addr));
+                                    ptrue(mask_tmp.d, VL2);
+                                    splice(r_zmm_src.d, mask_tmp.d,
+                                            r_zmm_src.d);
+                                    ptrue(mask_tmp.d, VL4);
+                                    splice(r_zmm_src.d, mask_tmp.d,
+                                            r_zmm_src.d);
+                                } else {
+                                    auto reg_addr = get_comp_addr_reg(
+                                            aux_reg_inp, aux_input_offset);
+                                    auto zmm_tmp = ZReg(31);
+                                    sub(reg_stack, reg_stack, 64);
+                                    str(zmm_tmp, ptr(reg_stack));
+                                    if (mask_flag) {
+                                        eor(mask_tmp.b, mask_all_one,
+                                                mask_tmp.b, mask_tmp.b);
+                                        eor(mask_tmp2.b, mask_all_one,
+                                                mask_tmp2.b, mask_tmp2.b);
+                                        uzp1(mask_tmp.h, ktail_mask.h,
+                                                mask_tmp.h);
+                                        uzp1(mask_tmp.b, mask_tmp.b,
+                                                mask_tmp2.b);
+                                    } else {
+                                        ptrue(mask_tmp.b, VL16);
+                                    }
+                                    ld1b(zmm_tmp.b, mask_tmp, ptr(reg_addr));
+                                    zip1(zmm_tmp.b, zmm_tmp.b, zmm_tmp.b);
+                                    zip1(zmm_tmp.h, zmm_tmp.h, zmm_tmp.h);
+                                    uxtb(r_zmm_src.s, mask_all_one / T_m,
+                                            zmm_tmp.s);
+                                    if (mask_flag) {
+                                        not_(mask_tmp.b, mask_all_one.b,
+                                                ktail_mask.b);
+                                        mov(r_zmm_src.s, mask_tmp / T_m, 0);
+                                    }
+                                    ldr(zmm_tmp, ptr(reg_stack));
+                                    add(reg_stack, reg_stack, 64);
+                                }
+                                if (!jcp.signed_input)
+                                    sub(zmm_src.b, zmm_src.b, vmm_shift.b);
+                            }
+                            compute(zmm_out(oi, ci), zmm_wei, zmm_src);
+                        } else {
+                            assert(!jcp.signed_input);
+                            compute(zmm_out(oi, ci), zmm_wei, zmm_shifted_zero);
+                        }
+                    }
+                }
+            }
+            if (jcp.src_zero_point) {
+                /* calculate src_zero_point padding as:
+                *      (is_padding ?
+                *           src_zero_point_s32 * conv(1, wei_s32) : 0) */
+                if (jcp.is_fast_depthwise || !compute_kernel) {
+                    auto reg_addr
+                            = get_comp_addr_reg(aux_reg_ker, aux_kernel_offset);
+                    sub(reg_stack, reg_stack, 64);
+                    str(vmm_tmp, ptr(reg_stack));
+                    vmm_load_src(vmm_tmp, reg_addr, false);
+                    zip1(vmm_tmp.b, vmm_tmp.b, vmm_tmp.b);
+                    zip1(vmm_tmp.h, vmm_tmp.h, vmm_tmp.h);
+                    sxtb(zmm_wei.s, mask_all_one / T_m, vmm_tmp.s);
+                    ldr(vmm_tmp, ptr(reg_stack));
+                    add(reg_stack, reg_stack, 64);
+                    if (jcp.is_fast_depthwise) {
+                        auto zmm_tmp1 = ZReg(28);
+                        auto zmm_tmp2 = ZReg(30);
+                        auto zmm_tmp3 = ZReg(29);
+                        sub(reg_stack, reg_stack, 64);
+                        str(zmm_tmp1, ptr(reg_stack));
+                        sub(reg_stack, reg_stack, 64);
+                        str(zmm_tmp2, ptr(reg_stack));
+                        sub(reg_stack, reg_stack, 64);
+                        str(zmm_tmp3, ptr(reg_stack));
+                        mov(zmm_tmp1.s, 15);
+                        and_(zmm_tmp1.b, mask_all_one, zmm_permute.b);
+                        for (int i = 0; i < 16; i++) {
+                            cmpeq(mask_tmp.s, mask_all_one, zmm_tmp1.s, i);
+                            dup(zmm_tmp2.s, zmm_wei.s[i]);
+                            mov(zmm_tmp3.s, mask_tmp / T_m, zmm_tmp2.s);
+                        }
+                        mov(zmm_wei.d, zmm_tmp3.d);
+                        ldr(zmm_tmp3, ptr(reg_stack));
+                        add(reg_stack, reg_stack, 64);
+                        ldr(zmm_tmp2, ptr(reg_stack));
+                        add(reg_stack, reg_stack, 64);
+                        ldr(zmm_tmp1, ptr(reg_stack));
+                        add(reg_stack, reg_stack, 64);
+                    }
+                } // else: already loaded weights from previous block
+                int zp_offset = 0;
+                for (int oi = 0; oi < ur_w; oi++) {
+                    if (oi < oi_start || oi >= oi_end || h_padded) {
+                        auto reg_addr = get_comp_addr_reg(
+                                reg_src_zero_point, zp_offset);
+                        vmm_load_zero_point(vmm_zp_tmp, reg_addr, mask_all_one,
+                                jcp.zp_src_is_common);
+                        mla(zmm_out(oi, ci).s, mask_all_one / T_m, zmm_wei.s,
+                                vmm_zp_tmp.s);
                     }
                 }
             }
         }
+    }
+    if (jcp.src_zero_point) {
+        ldr(aux_reg_ker_d, ptr(reg_stack));
+        add(reg_stack, reg_stack, 8);
     }
 }
 
@@ -499,6 +749,16 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker(int ur_w, int pad_l,
         int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
+
+    const bool compute_kernel = IMPLICATION(h_padded, !jcp.signed_input);
+
+    assert(IMPLICATION(h_padded, jcp.src_zero_point || !jcp.signed_input));
+
+    if (jcp.src_zero_point) {
+        sub(reg_stack, reg_stack, 8);
+        str(aux_reg_ker_d, ptr(reg_stack));
+        ldr(reg_src_zero_point, ptr(param1, GET_OFF(src_zero_point)));
+    }
 
     int kw = jcp.kw;
     int stride_w = jcp.stride_w;
@@ -535,102 +795,118 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker(int ur_w, int pad_l,
         int icb = (last_ic_block_flag != no_last_block)
                 ? div_up((jcp.ic_without_padding % ic_block), 4)
                 : ic_block / 4;
-        for (int ic = 0; ic < icb; ic++) {
-            if (h_padded) {
-                /* fill padded area with shifted values */
-                auto inp = vmm_inp(0, nb_oc_block);
-                eor(inp.d, inp.d, inp.d);
-                sub(inp.b, inp.b, vmm_shift.b);
-            } else {
-                for (int jj = _start; jj < _end; jj++) {
-                    int aux_input_offset = input_offset(jj, ic, ki);
-                    if (jj >= jj_start && jj < jj_end) {
-                        if (last_ic_block_flag == last_sp_block
-                                && ic_tail_size != 0 && ic == icb - 1) {
-                            auto xmm_tmp = VReg16B(
-                                    vmm_inp(jj, nb_oc_block).getIdx());
-                            for (int r = 0; r < ic_tail_size; ++r) {
-                                add_imm(reg_tmp0_adr, aux_reg_inp,
-                                        (aux_input_offset + r), reg_tmp0_imm);
-                                ldrb(WReg(reg_tmp1_imm.getIdx()),
-                                        ptr(reg_tmp0_adr));
-                                ins(VReg16B(xmm_tmp.getIdx())[r],
-                                        WReg(reg_tmp1_imm.getIdx()));
-                            }
-                            dup(vmm_inp(jj, nb_oc_block).s,
-                                    ZRegS(xmm_tmp.getIdx())[0]);
-                        } else {
-                            auto base = aux_reg_inp;
-                            auto re = get_offset(aux_input_offset);
+        if (compute_kernel) {
+            for (int ic = 0; ic < icb; ic++) {
+                if (h_padded) {
+                    /* fill padded area with shifted values */
+                    if (ic == 0) {
+                        auto inp = vmm_inp(0, nb_oc_block);
+                        eor(inp.d, inp.d, inp.d);
+                        sub(inp.b, inp.b, vmm_shift.b);
+                    }
+                } else {
+                    for (int jj = _start; jj < _end; jj++) {
+                        int aux_input_offset = input_offset(jj, ic, ki);
+                        if (jj >= jj_start && jj < jj_end) {
+                            if (last_ic_block_flag == last_sp_block
+                                    && ic_tail_size != 0 && ic == icb - 1) {
+                                auto xmm_tmp = VReg16B(
+                                        vmm_inp(jj, nb_oc_block).getIdx());
+                                for (int r = 0; r < ic_tail_size; ++r) {
+                                    add_imm(reg_tmp0_adr, aux_reg_inp,
+                                            (aux_input_offset + r),
+                                            reg_tmp0_imm);
+                                    ldrb(WReg(reg_tmp1_imm.getIdx()),
+                                            ptr(reg_tmp0_adr));
+                                    ins(VReg16B(xmm_tmp.getIdx())[r],
+                                            WReg(reg_tmp1_imm.getIdx()));
+                                }
+                                dup(vmm_inp(jj, nb_oc_block).s,
+                                        ZRegS(xmm_tmp.getIdx())[0]);
+                            } else {
+                                auto base = aux_reg_inp;
+                                auto re = get_offset(aux_input_offset);
 
-                            if ((-0x40 <= re) && (re < 0x40) && ((re % 4) == 0))
-                                ld1rw(vmm_inp(jj, nb_oc_block).s, mask_all_one,
-                                        ptr(base, static_cast<int32_t>(re)));
-                            else {
-                                auto reg_tmp_adr = ((jj % 4) == 0)
-                                        ? reg_tmp0_adr
-                                        : ((jj % 4) == 1) ? reg_tmp1_adr
-                                        : ((jj % 4) == 2) ? reg_tmp2_adr
-                                                          : reg_tmp3_adr;
-                                auto reg_tmp_imm = ((jj % 4) == 0)
-                                        ? reg_tmp0_imm
-                                        : ((jj % 4) == 1) ? reg_tmp1_imm
-                                        : ((jj % 4) == 2) ? reg_tmp2_imm
-                                                          : reg_tmp3_imm;
-                                add_imm(reg_tmp_adr, base, re, reg_tmp_imm);
-                                ld1rw(vmm_inp(jj, nb_oc_block).s, mask_all_one,
-                                        ptr(reg_tmp_adr));
+                                if ((-0x40 <= re) && (re < 0x40)
+                                        && ((re % 4) == 0))
+                                    ld1rw(vmm_inp(jj, nb_oc_block).s,
+                                            mask_all_one,
+                                            ptr(base,
+                                                    static_cast<int32_t>(re)));
+                                else {
+                                    auto reg_tmp_adr = ((jj % 4) == 0)
+                                            ? reg_tmp0_adr
+                                            : ((jj % 4) == 1) ? reg_tmp1_adr
+                                            : ((jj % 4) == 2) ? reg_tmp2_adr
+                                                              : reg_tmp3_adr;
+                                    auto reg_tmp_imm = ((jj % 4) == 0)
+                                            ? reg_tmp0_imm
+                                            : ((jj % 4) == 1) ? reg_tmp1_imm
+                                            : ((jj % 4) == 2) ? reg_tmp2_imm
+                                                              : reg_tmp3_imm;
+                                    add_imm(reg_tmp_adr, base, re, reg_tmp_imm);
+                                    ld1rw(vmm_inp(jj, nb_oc_block).s,
+                                            mask_all_one, ptr(reg_tmp_adr));
+                                }
                             }
-                        }
-                        if (!jcp.signed_input)
-                            sub(vmm_inp(jj, nb_oc_block).b,
-                                    vmm_inp(jj, nb_oc_block).b, vmm_shift.b);
-                    } else {
-                        /* fill padded area with shifted values */
-                        if (!jcp.signed_input) {
-                            auto inp = vmm_inp(jj, nb_oc_block);
-                            eor(inp.d, inp.d, inp.d);
-                            sub(inp.b, inp.b, vmm_shift.b);
+                            if (!jcp.signed_input)
+                                sub(vmm_inp(jj, nb_oc_block).b,
+                                        vmm_inp(jj, nb_oc_block).b,
+                                        vmm_shift.b);
+                        } else {
+                            // fill padded area with shifted value in
+                            // first iteration
+                            if (!jcp.signed_input && ic == 0) {
+                                auto inp = vmm_inp(jj, nb_oc_block);
+                                eor(inp.d, inp.d, inp.d);
+                                sub(inp.b, inp.b, vmm_shift.b);
+                            }
                         }
                     }
                 }
-            }
-            for (int ii = 0; ii < nb_oc_block; ii++) {
-                if (!jcp.signed_input) {
+                for (int ii = 0; ii < nb_oc_block; ii++) {
                     int aux_kernel_offset = kernel_offset(ii, ic, ki);
                     auto reg_addr
                             = get_comp_addr_reg(aux_reg_ker, aux_kernel_offset);
                     ld1w(vmm_wei.s, mask_all_one, ptr(reg_addr));
                     for (int jj = _start; jj < _end; jj++) {
-                        auto inp = (h_padded == true)
-                                ? vmm_inp(0, nb_oc_block)
-                                : vmm_inp(jj, nb_oc_block);
+                        auto inp = h_padded ? vmm_inp(0, nb_oc_block)
+                                            : vmm_inp(jj, nb_oc_block);
                         compute(vmm_out(jj, ii), vmm_wei, inp);
-                    }
-                } else {
-                    if (ii == 0) {
-                        int aux_kernel_offset = kernel_offset(ii, ic, ki);
-                        auto reg_addr = get_comp_addr_reg(
-                                aux_reg_ker, aux_kernel_offset);
-                        ld1w(vmm_wei.s, mask_all_one, ptr(reg_addr));
-                    }
-                    if ((ii + 1) < nb_oc_block) {
-                        int aux_kernel_offset = kernel_offset((ii + 1), ic, ki);
-                        auto _vmm_wei = ((ii % 2) == 0) ? vmm_comp : vmm_wei;
-                        auto reg_addr = get_comp_addr_reg(
-                                aux_reg_ker, aux_kernel_offset);
-                        ld1w(_vmm_wei.s, mask_all_one, ptr(reg_addr));
-                    }
-                    for (int jj = _start; jj < _end; jj++) {
-                        auto _vmm_wei = ((ii % 2) == 0) ? vmm_wei : vmm_comp;
-                        auto inp = (h_padded == true)
-                                ? vmm_inp(0, nb_oc_block)
-                                : vmm_inp(jj, nb_oc_block);
-                        compute(vmm_out(jj, ii), _vmm_wei, inp);
                     }
                 }
             }
         }
+        if (jcp.src_zero_point) {
+            /* calculate src_zero_point padding as:
+             *      (is_padding ? src_zero_point_s32 * conv(1, wei_s8) : 0) */
+            ZReg vmm_tmp = vmm_inp(0, nb_oc_block);
+            for (int jj = 0; jj < ur_w; jj++) {
+                if (jj < jj_start || jj >= jj_end || h_padded) {
+                    for (int ii = 0; ii < nb_oc_block; ii++) {
+                        eor(vmm_zp_tmp.d, vmm_zp_tmp.d, vmm_zp_tmp.d);
+                        for (int ic = 0; ic < icb; ic++) {
+                            int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                            auto reg_addr = get_comp_addr_reg(
+                                    aux_reg_ker, aux_kernel_offset);
+                            ld1w(vmm_tmp.s, mask_all_one, ptr(reg_addr));
+                            sdot(vmm_zp_tmp.s, vmm_zp_one.b, vmm_tmp.b);
+                        }
+                        int zp_offset = 0;
+                        auto reg_addr = get_comp_addr_reg(
+                                reg_src_zero_point, zp_offset);
+                        vmm_load_zero_point(vmm_tmp, reg_addr, mask_all_one,
+                                jcp.zp_src_is_common);
+                        mla(vmm_out(jj, ii).s, mask_all_one / T_m, vmm_tmp.s,
+                                vmm_zp_tmp.s);
+                    }
+                }
+            }
+        }
+    }
+    if (jcp.src_zero_point) {
+        ldr(aux_reg_ker_d, ptr(reg_stack));
+        add(reg_stack, reg_stack, 8);
     }
 }
 
@@ -650,7 +926,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
     if (jcp.ndims == 5) {
         mov(aux_reg_ker_d, reg_ker);
         mov(aux_reg_inp_d, reg_inp);
-        if (!jcp.signed_input) {
+        if (!jcp.signed_input || jcp.src_zero_point) {
             //TODO: May be avoided when f_pad=0 and dd0
             //TODO: Potential optimization by precomputing, when kd <<< od?
             ldr(reg_ki, ptr(reg_param1, GET_OFF(f_overflow)));
@@ -677,8 +953,9 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
         }
 
         ldr(reg_ki, ptr(reg_param1, GET_OFF(kd_padding)));
-        if ((!jcp.signed_input) || (jcp.dilate_d >= jcp.id)
-                || (jcp.signed_input
+        if ((!jcp.signed_input || jcp.src_zero_point)
+                || (jcp.dilate_d >= jcp.id)
+                || (!(!jcp.signed_input || jcp.src_zero_point)
                         && (jcp.kd - 1) * (jcp.dilate_d + 1)
                                 < nstl::max(jcp.f_pad, jcp.back_pad))) {
             cmp(reg_ki, 0);
@@ -696,7 +973,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
         mov(aux_reg_ker, reg_ker);
     }
 
-    if (!jcp.signed_input && jcp.ndims > 3) {
+    if ((!jcp.signed_input || jcp.src_zero_point) && jcp.ndims > 3) {
         ldr(reg_overflow, ptr(reg_param1, GET_OFF(t_overflow)));
         cmp(reg_overflow, 0);
         b(EQ, no_t_overflow_label);
@@ -712,8 +989,8 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
         L(no_t_overflow_label);
     }
     ldr(reg_kj, ptr(reg_param1, GET_OFF(kh_padding)));
-    if ((!jcp.signed_input) || (jcp.dilate_h >= jcp.ih)
-            || (jcp.signed_input
+    if ((!jcp.signed_input || jcp.src_zero_point) || (jcp.dilate_h >= jcp.ih)
+            || (!(!jcp.signed_input || jcp.src_zero_point)
                     && (jcp.kh - 1) * (jcp.dilate_h + 1)
                             < nstl::max(jcp.t_pad, jcp.b_pad))) {
         cmp(reg_kj, 0);
@@ -740,7 +1017,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
         b(GT, kh_label);
     }
     L(skip_kh_loop);
-    if (!jcp.signed_input && jcp.ndims > 3) {
+    if ((!jcp.signed_input || jcp.src_zero_point) && jcp.ndims > 3) {
         ldr(reg_overflow, ptr(reg_param1, GET_OFF(b_overflow)));
         cmp(reg_overflow, 0);
         b(EQ, no_b_overflow_label);
@@ -765,7 +1042,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
         b(NE, kd_label);
 
         L(skip_kd_loop);
-        if (!jcp.signed_input) {
+        if (!jcp.signed_input || jcp.src_zero_point) {
             ldr(reg_ki, ptr(reg_param1, GET_OFF(back_overflow)));
             cmp(reg_ki, 0);
             b(EQ, no_back_overflow_label);
@@ -793,46 +1070,58 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
 
 void jit_sve_512_x8s8s32x_fwd_kernel::icb_loop(
         int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
+
+    if (jcp.src_zero_point && !jcp.is_depthwise) {
+        eor(reg_scratch, reg_scratch, reg_scratch);
+        dup(vmm_zp_one.b, 0x1);
+    }
+
     prepare_output(ur_w);
 
     // IC loop
     Label icb_label;
     mov_imm(reg_icb, jcp.nb_ic);
     L(icb_label);
+    const bool do_icb_loop
+            = jcp.is_depthwise ? jcp.nb_ch > jcp.nb_ch_blocking : jcp.nb_ic > 1;
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.ic_without_padding != jcp.ic) {
         Label common_ker, end_ker;
-
-        if (jcp.is_depthwise)
-            cmp(reg_oc_blocks, jcp.nb_ch - jcp.nb_ch_blocking);
-        else
-            cmp(reg_icb, 1); // The last IC block
-        b(NE, common_ker);
-
+        if (do_icb_loop) {
+            if (jcp.is_depthwise)
+                cmp(reg_oc_blocks, jcp.nb_ch - jcp.nb_ch_blocking);
+            else
+                cmp(reg_icb, 1); // The last IC block
+            b(NE, common_ker);
+        }
         kh_loop(ur_w, pad_l, pad_r,
                 is_last_sp_block ? last_sp_block : last_ic_block);
-        b(end_ker);
+        if (do_icb_loop) {
+            b(end_ker);
 
-        L(common_ker);
-        kh_loop(ur_w, pad_l, pad_r, no_last_block);
+            L(common_ker);
+            kh_loop(ur_w, pad_l, pad_r, no_last_block);
 
-        L(end_ker);
+            L(end_ker);
+        }
     } else {
         kh_loop(ur_w, pad_l, pad_r, no_last_block);
     }
     // End of IC Loop
-    int inp_step = jcp.ic_block;
-    int ker_step = jcp.kd * jcp.kh * jcp.kw * jcp.oc_block * jcp.ic_block;
-    adds_imm(reg_inp, reg_inp, jcp.typesize_in * inp_step, reg_tmp0_imm);
-    adds_imm(reg_ker, reg_ker, jcp.typesize_in * ker_step, reg_tmp0_imm);
+    if (do_icb_loop) {
+        int inp_step = jcp.ic_block;
+        int ker_step = jcp.kd * jcp.kh * jcp.kw * jcp.oc_block * jcp.ic_block;
+        adds_imm(reg_inp, reg_inp, jcp.typesize_in * inp_step, reg_tmp0_imm);
+        adds_imm(reg_ker, reg_ker, jcp.typesize_in * ker_step, reg_tmp0_imm);
 
-    subs(reg_icb, reg_icb, 1);
-    cmp(reg_icb, 0);
-    b(GT, icb_label);
+        subs(reg_icb, reg_icb, 1);
+        cmp(reg_icb, 0);
+        b(GT, icb_label);
 
-    subs_imm(reg_inp, reg_inp, jcp.typesize_in * inp_step * jcp.nb_ic,
-            reg_tmp0_imm);
-    subs_imm(reg_ker, reg_ker, jcp.typesize_in * ker_step * jcp.nb_ic,
-            reg_tmp0_imm);
+        subs_imm(reg_inp, reg_inp, jcp.typesize_in * inp_step * jcp.nb_ic,
+                reg_tmp0_imm);
+        subs_imm(reg_ker, reg_ker, jcp.typesize_in * ker_step * jcp.nb_ic,
+                reg_tmp0_imm);
+    }
 
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.oc_without_padding != jcp.oc) {
         Label common_store, end_store;
@@ -891,14 +1180,24 @@ void jit_sve_512_x8s8s32x_fwd_kernel::vmm_load_src(
     ld1b(src.b, mask_tmp, ptr(reg_addr));
 }
 
+void jit_sve_512_x8s8s32x_fwd_kernel::vmm_load_zero_point(
+        ZReg src, XReg reg_addr, PReg mask, bool bcast) {
+    if (bcast)
+        ld1rw(src.s, mask, ptr(reg_addr));
+    else
+        ld1w(src.s, mask, ptr(reg_addr));
+}
+
 void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
     Label permute_index_table;
     int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
                                         : jcp.ic_without_padding * jcp.ngroups;
-    int inp_shift_pad = jcp.typesize_in * (jcp.ur_w * jcp.stride_w - jcp.l_pad)
-            * in_ic_shift;
-    int inp_shift_pad_second_block
-            = -1 * jcp.typesize_in * jcp.l_pad * in_ic_shift;
+    const int urw_inp_stride = jcp.ur_w * jcp.stride_w;
+    const int n_urw_l_pad
+            = nstl::min(div_up(jcp.l_pad, urw_inp_stride), jcp.ow / jcp.ur_w);
+    const int inp_shift_pad = nstl::max(0,
+            jcp.typesize_in * (n_urw_l_pad * urw_inp_stride - jcp.l_pad)
+                    * in_ic_shift);
     int inp_shift = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
     int out_shift = jcp.typesize_out
             * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups);
@@ -907,14 +1206,19 @@ void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
     vmm_mask_all_one();
 
     if (jcp.is_depthwise) {
-        int idx = jcp.max_regs_ur - 1;
+        bool is_zero_point = jcp.src_zero_point || jcp.dst_zero_point;
+        // dst zero point and dst scale reuse the same register
+        int idx = jcp.max_regs_ur - 1
+                + nstl::max(2 * is_zero_point, static_cast<int>(jcp.dst_scale));
         if (!jcp.is_resrc_depthwise) zmm_src = ZReg(++idx);
         if (jcp.is_fast_depthwise) zmm_permute = ZReg(++idx);
         if (!jcp.signed_input) zmm_shifted_zero = ZReg(++idx);
         // due to extra register used for shifts and compensations
         // and/or saturation, we increment by one more
         if (!jcp.signed_input || jcp.need_saturation) ++idx;
-        assert(idx == ker_dw_reg_base_idx);
+        assert(IMPLICATION(!jcp.dst_scale && !is_zero_point
+                /*&& jcp.dst_dt != data_type::bf16*/,
+                idx == ker_dw_reg_base_idx));
     }
 
     if (jcp.is_fused_conv) {
@@ -922,6 +1226,16 @@ void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
         /* In case of fused depthwise convolution, `param.src` is not a pointer
         to input, instead it points to a buffer containing pointers to
         consecutive rows of input in format wc with c=jcp.dw_conv_buffer_oc.
+        Example: [ptr_to_inp_row0, ptr_to_inp_row1, ptr_to_inp_row2].
+        Traverse the data as
+            mov(reg_data, ptr[reg_input_buffer_ptr])
+            ... process row0 ...
+            add(reg_input_buffer_ptr, sizeof(void*))
+            mov(reg_data, ptr[reg_input_buffer_ptr])
+            ... process row1 ...
+            add(reg_input_buffer_ptr, sizeof(void*))
+            mov(reg_data, ptr[reg_input_buffer_ptr])
+            ... process row2 ...
         */
         mov_imm(reg_inp, 0);
     } else {
@@ -946,7 +1260,21 @@ void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
         dup(vmm_tmp1.s, WReg(regw_tmp.getIdx()));
         and_(vmm_tmp1.d, vmm_tmp1.d, vmm_tmp2.d);
         cmpne(ktail_mask.s, mask_all_one, vmm_tmp1.s, 0);
-    }
+        cmpne(postops_mask.s, mask_all_one, vmm_tmp1.s, 0);
+    } else if (jcp.with_binary)
+        if (jcp.oc_block != isa_simd_width_) {
+            const int mask = (1 << jcp.oc_block) - 1;
+            auto regw_tmp = reg_oi;
+            mov(regw_tmp, mask);
+            auto vmm_tmp1 = ZReg(31);
+            auto vmm_tmp2 = ZReg(30);
+            index(vmm_tmp1.s, 0, 1);
+            mov(vmm_tmp2.s, 1);
+            lsl(vmm_tmp2.s, mask_all_one / T_m, vmm_tmp1.s);
+            dup(vmm_tmp1.s, WReg(regw_tmp.getIdx()));
+            and_(vmm_tmp1.d, vmm_tmp1.d, vmm_tmp2.d);
+            cmpne(postops_mask.s, mask_all_one, vmm_tmp1.s, 0);
+        }
     if (jcp.is_fast_depthwise) {
         // prepare mask register for blending weights
         movk(reg_scratch, uint16_t(0x1111), 0);
@@ -962,176 +1290,302 @@ void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
         ld1w(zmm_permute.s, mask_all_one, ptr(reg_scratch));
     }
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = jcp.ow / jcp.ur_w;
-    int r_pad1 = calculate_end_padding(jcp.l_pad, jcp.ur_w * n_oi, jcp.iw,
-            jcp.stride_w, calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
+    const int extended_filter_size
+            = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int r_pad = nstl::max(0, jcp.r_pad);
+    const int ow_with_no_rpad = 1
+            + (jcp.iw + jcp.l_pad + nstl::min(0, jcp.r_pad)
+                      - extended_filter_size)
+                    / jcp.stride_w;
+    const int n_urw_per_ow_block = jcp.ow_block / jcp.ur_w;
+    const int max_safe_iw = nstl::max(
+            0, jcp.iw - div_up(ic_sub_step, jcp.ic_without_padding));
+    const int max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
+            ? jcp.ow
+            : (max_safe_iw + jcp.l_pad - extended_filter_size) / jcp.stride_w;
+    Label middle_block_label, done_compute;
+    std::vector<Label> ow_block_jmp_table;
 
-    if (jcp.nb_ow == 1) {
-        if (r_pad1 > 0 || jcp.ur_w_tail == 0) n_oi--;
+    // r_pad_fall_through is a special ow_block, where the block overlaps
+    // both middle_block and r_pad/ur_w_tail region when it exists.
+    // The number of ur_w's to compute in middle_block before executing
+    // r_pad region is stored in r_pad_fall_through_n_urw and the ow_block
+    // number is stored in r_pad_fall_through_ow_block.
+    int r_pad_fall_through_ow_block = 0;
+    int r_pad_fall_through_n_urw = 0;
 
-        eor(reg_oi, reg_oi, reg_oi);
-        if (jcp.ow == jcp.ur_w) {
-            icb_loop(jcp.ur_w, jcp.l_pad, r_pad, true);
-        } else {
-            if (n_oi == 0) {
-                icb_loop(jcp.ur_w, jcp.l_pad, r_pad1, jcp.ur_w_tail == 0);
-                adds_imm(reg_inp, reg_inp, inp_shift_pad, reg_tmp0_imm);
-                adds_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
-                if (jcp.ur_w_tail != 0) {
-                    icb_loop(jcp.ur_w_tail, 0, r_pad, true);
-                }
+    if (jcp.nb_ow > 1) {
+        // Only one ow block is processed, per jit call.
+        // Number of this ow block is passed as parameter owb,
+        // and padding processing depends on this number.
+        //
+        // The compute block to run is determined by using a jmp-table.
+        // jmp-table Layout:
+        //  idx -> addr
+        //  0   -> [...l_pad_region label[0]...]
+        //         : : : : : : : : : : : : : : :
+        //  L ->   [...l_pad_region label[L]...]
+        //  L+1 -> [...r_pad_region label[0]...]
+        //         : : : : : : : : : : : : : : :
+        //  L+R -> [...r_pad_region label[R]...]
+        //
+        // Note: Label for middle_block is not stored in the jmp-table.
+        //
+        // During jit call, the jump address is calculated as below:
+        // if (owb < L) {
+        //   jmp([jmp_table + owb*sizeof(void*)]);
+        // } else if (owb < X) {
+        //   // X is the number of ow_blocks before r_pad region (see below).
+        //   jmp(middle_block);
+        // } else {
+        //   sub(owb, X);
+        //   jmp([jmp_table + owb*sizeof(void*) + L*sizeof(void)]);
+        // }
+        //
+        // To configure the jmp-table, we need to determine some constants
+        // (namely, r_pad_fall_through_n_urw, r_pad_fall_through_ow_block,
+        // n_l_pad_labels, n_labels) ahead of writing the compute assembly. So,
+        // we simulate the filter path without writing the assembly initially.
+        // This makes the math for calculating the constants become simple and
+        // self explanatory.
+
+        // Begin simulation without writing assembly
+        int n_l_pad_labels = 0;
+        int n_labels = 0;
+        int cur_ow = 0;
+
+        // l_pad region:
+        n_l_pad_labels = div_up(n_urw_l_pad, n_urw_per_ow_block);
+        n_labels = n_l_pad_labels;
+        cur_ow += n_urw_l_pad * jcp.ur_w;
+
+        // middle_region:
+        int n_urw_middle_block_loop = 0;
+        int cur_r_pad = nstl::max(0,
+                calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
+                        jcp.stride_w, extended_filter_size));
+        if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
+            n_urw_middle_block_loop
+                    = nstl::max(0,
+                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    / jcp.ur_w;
+            cur_ow += n_urw_middle_block_loop * jcp.ur_w;
+        }
+        r_pad_fall_through_n_urw = (cur_ow / jcp.ur_w) % n_urw_per_ow_block;
+        r_pad_fall_through_ow_block = cur_ow / (n_urw_per_ow_block * jcp.ur_w);
+
+        // r_pad or last_sp_block
+        if (cur_ow + jcp.ur_w <= jcp.ow) {
+            if (r_pad_fall_through_n_urw == 0) ++n_labels;
+            const int n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
+            n_labels += nstl::max(0,
+                    div_up(r_pad_fall_through_n_urw + n_urw_r_pad_region,
+                            n_urw_per_ow_block)
+                            - 1);
+        }
+
+        if (jcp.ur_w_tail != 0) {
+            if (jcp.ow % jcp.ow_block == jcp.ur_w_tail) ++n_labels;
+        }
+        // End of simulation
+
+        ow_block_jmp_table.resize(n_labels);
+
+        // Begin jump-table logic
+        Label ow_block_jmp_table_label;
+        if (!ow_block_jmp_table.empty()) {
+            adr(reg_jmp_tbl_base, ow_block_jmp_table_label);
+        }
+        mov_imm(reg_oi, n_urw_per_ow_block);
+        ldr(reg_owb, ptr(reg_param1, GET_OFF(owb)));
+        if (jcp.l_pad > 0) {
+            Label middle_or_rpad_check;
+            cmp_imm(reg_owb, n_l_pad_labels, reg_tmp0_imm);
+            b(GE, middle_or_rpad_check);
+            mov_imm(reg_tmp0_imm, sizeof(void *));
+            madd(reg_tmp0_adr, reg_owb, reg_tmp0_imm, reg_jmp_tbl_base);
+            br(reg_tmp0_adr);
+            L(middle_or_rpad_check);
+            // harness passes shifted src pointer that does not take
+            // left-padding into account. So, we must re-shift here.
+            const int inp_shift_pad_middle_block = -1 * jcp.typesize_in
+                    * nstl::min(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
+                    * in_ic_shift;
+            add_imm(reg_inp, reg_inp, inp_shift_pad_middle_block, reg_tmp0_imm);
+        }
+        if (r_pad_fall_through_n_urw != 0) {
+            Label reg_scratch_end_label;
+            mov_imm(reg_scratch, r_pad_fall_through_n_urw);
+            cmp_imm(reg_owb, r_pad_fall_through_ow_block, reg_tmp1_imm);
+            b(NE, reg_scratch_end_label);
+            add(reg_oi, reg_scratch, 0);
+            L(reg_scratch_end_label);
+            if (n_urw_middle_block_loop > 0) {
+                subs_imm(reg_owb, reg_owb, r_pad_fall_through_ow_block,
+                        reg_tmp0_imm);
+                // simple middle_block
+                b(LE, middle_block_label);
+                sub(reg_owb, reg_owb, 1);
             } else {
-                if (jcp.l_pad > 0) {
-                    icb_loop(jcp.ur_w, jcp.l_pad, 0, false);
-                    adds_imm(reg_inp, reg_inp, inp_shift_pad, reg_tmp0_imm);
-                    adds_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
+                sub_imm(reg_owb, reg_owb, r_pad_fall_through_ow_block + 1,
+                        reg_tmp0_imm);
+            }
+        } else {
+            subs_imm(reg_owb, reg_owb, r_pad_fall_through_ow_block,
+                    reg_tmp0_imm);
+            // simple middle_block
+            if (n_urw_middle_block_loop) b(LT, middle_block_label);
+        }
+        // r_pad-only region
+        if (!ow_block_jmp_table.empty()) {
+            mov_imm(reg_tmp0_imm, sizeof(void *));
+            mul(reg_tmp1_imm, reg_owb, reg_tmp0_imm);
+            add_imm(reg_tmp0_adr, reg_tmp1_imm, n_l_pad_labels * sizeof(void *),
+                    reg_tmp2_imm);
+            add(reg_tmp1_adr, reg_jmp_tbl_base, reg_tmp0_adr);
+            br(reg_tmp1_adr);
+        }
 
-                    adds(reg_oi, reg_oi, 1);
-                }
-                if ((jcp.l_pad <= 0 && n_oi > 0)
-                        || (jcp.l_pad > 0 && n_oi > 1)) {
-                    Label ow_loop_label;
-                    L(ow_loop_label);
-                    {
-                        icb_loop(jcp.ur_w, 0, 0, false);
-                        adds_imm(reg_inp, reg_inp, inp_shift, reg_tmp0_imm);
-                        adds_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
-
-                        adds(reg_oi, reg_oi, 1);
-                        mov_imm(reg_tmp0_imm, n_oi);
-                        cmp(reg_oi, reg_tmp0_imm);
-                        b(LT, ow_loop_label);
-                    }
-                }
-                if (r_pad1 > 0 || jcp.ur_w_tail == 0) {
-                    icb_loop(jcp.ur_w, 0, r_pad1, jcp.ur_w_tail == 0);
-                    adds_imm(reg_inp, reg_inp, inp_shift, reg_tmp0_imm);
-                    adds_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
-                }
-                if (jcp.ur_w_tail != 0) {
-                    icb_loop(jcp.ur_w_tail, 0, r_pad, true);
+        if (!ow_block_jmp_table.empty()) {
+            //align(8);
+            L(ow_block_jmp_table_label);
+            {
+                for (size_t i = 0; i < ow_block_jmp_table.size(); ++i) {
+                    adr(reg_tmp0_adr, ow_block_jmp_table[i]);
+                    br(reg_tmp0_adr);
                 }
             }
         }
-    } else {
-        // ow block is only processed.
-        // Number of block is passed as parameter owb,
-        // and padding processing depends on this number.
-        Label end_label, last_oi_label, middle_ow_blocks_label, tail_label,
-                oi_loop_label, oi_loop_end_label;
-
-        assert(jcp.ow_block % jcp.ur_w == 0);
-        int n_oi_not_last_ow_block = jcp.ow_block / jcp.ur_w;
-        // to simplify code (and general regs usage),
-        // size of ow block must be >= 2 * ur_w
-        assert(n_oi_not_last_ow_block > 1);
-        int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
-        int n_oi_first_ow_block = n_oi_not_last_ow_block;
-        int n_oi_last_ow_block
-                = (jcp.ow - jcp.ow_block * (jcp.nb_ow - 1)) / jcp.ur_w;
-        // prepare right padding
-        bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
-        bool first_ow_block_padded
-                = next_last_ow_block_padded && jcp.nb_ow == 2;
-        bool last_ow_block_padded
-                = (r_pad1 > 0 || jcp.ur_w_tail == 0) && n_oi_last_ow_block > 0;
-
-        if (last_ow_block_padded)
-            n_oi_last_ow_block--;
-        else if (first_ow_block_padded)
-            n_oi_first_ow_block--;
-        else if (next_last_ow_block_padded)
-            n_oi_next_last_ow_block--;
-
-        ldr(reg_owb, ptr(reg_param1, GET_OFF(owb)));
-        cmp(reg_owb, 0); // is that the first ow-block ?
-        b(GT, middle_ow_blocks_label);
-
-        // the first ow block, compute left padding
-        mov_imm(reg_oi, n_oi_first_ow_block);
-        if (jcp.l_pad > 0) {
-            icb_loop(jcp.ur_w, jcp.l_pad, 0, false);
-            adds_imm(reg_inp, reg_inp, inp_shift_pad, reg_tmp0_imm);
-            adds_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
-
-            subs(reg_oi, reg_oi, 1);
-        }
-        b(oi_loop_label);
-
-        // middle or last ow block entry
-        L(middle_ow_blocks_label);
-
-        if (jcp.l_pad > 0) {
-            // just to consider left padding, not compute
-            adds_imm(
-                    reg_inp, reg_inp, inp_shift_pad_second_block, reg_tmp0_imm);
-        }
-
-        // set number of iteration for oi-loop
-        if (n_oi_last_ow_block != n_oi_not_last_ow_block) {
-            cmp(reg_owb, jcp.nb_ow - 1); // last ow-block ?
-            mov_imm(reg_oi, n_oi_last_ow_block);
-            b(EQ, oi_loop_label);
-        }
-
-        if (n_oi_next_last_ow_block != n_oi_not_last_ow_block) {
-            cmp(reg_owb, jcp.nb_ow - 2); // next to last ow-block ?
-
-            mov_imm(reg_oi, n_oi_next_last_ow_block);
-            b(EQ, oi_loop_label);
-        }
-        mov_imm(reg_oi, n_oi_not_last_ow_block); // other middle ow-blocks
-
-        // oi loop w/o padding
-        L(oi_loop_label);
-        {
-            cmp(reg_oi, 0);
-            b(LE, oi_loop_end_label);
-
-            icb_loop(jcp.ur_w, 0, 0, false);
-
-            adds_imm(reg_inp, reg_inp, inp_shift, reg_tmp0_imm);
-            adds_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
-            subs(reg_oi, reg_oi, 1);
-
-            b(oi_loop_label);
-        }
-        L(oi_loop_end_label);
-
-        ldr(reg_owb, ptr(reg_param1, GET_OFF(owb)));
-        cmp(reg_owb, 0); // first ow-block ?
-        if (first_ow_block_padded)
-            b(EQ, last_oi_label);
-        else
-            b(EQ, end_label);
-
-        cmp(reg_owb, jcp.nb_ow - 2); // next to last ow-block ?
-        b(LT, end_label);
-        if (next_last_ow_block_padded)
-            b(EQ, last_oi_label);
-        else
-            b(EQ, end_label);
-
-        // that is last block
-        if (!last_ow_block_padded) b(tail_label);
-
-        // last oi block with right padding
-        L(last_oi_label);
-        icb_loop(jcp.ur_w, 0, r_pad1, jcp.ur_w_tail == 0);
-        adds_imm(reg_inp, reg_inp, inp_shift, reg_tmp0_imm);
-        adds_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
-
-        ldr(reg_owb, ptr(reg_param1, GET_OFF(owb)));
-        cmp(reg_owb, jcp.nb_ow - 1); // last ow_block?
-        b(LT, end_label);
-
-        // ur_w tail
-        L(tail_label);
-        if (jcp.ur_w_tail != 0) { icb_loop(jcp.ur_w_tail, 0, r_pad, true); }
-        L(end_label);
+        // End of jump-table logic
     }
+
+    // Begin kernel
+    int cur_ow = 0;
+    int cur_n_oi = 0; // used only for jcp.nb_ow > 1 scenario
+    int label_cntr = 0;
+    int cur_l_pad = 0;
+    if (jcp.l_pad > 0) {
+        for (cur_l_pad = jcp.l_pad;
+                cur_l_pad > 0 && cur_ow + jcp.ur_w <= jcp.ow;
+                cur_l_pad -= urw_inp_stride) {
+            if (jcp.nb_ow > 1 && cur_n_oi == 0) {
+                // cur_n_oi == 0 signifies beginning of new ow_block
+                // (or end of previous block)
+                const dim_t inp_lpad_region_shift = -label_cntr * jcp.ow_block
+                        * jcp.stride_w * in_ic_shift;
+                L(ow_block_jmp_table[label_cntr++]);
+                // harness passes shifted src pointer that does not take
+                // left-padding into account. So, we must re-shift here.
+                add_imm(reg_inp, reg_inp, inp_lpad_region_shift, reg_tmp0_imm);
+            }
+
+            cur_ow += jcp.ur_w;
+            int cur_r_pad = nstl::max(0,
+                    calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
+                            jcp.stride_w, extended_filter_size));
+            icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
+            add_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
+            sub(reg_oi, reg_oi, 1);
+
+            if (jcp.nb_ow > 1 && ++cur_n_oi == n_urw_per_ow_block) {
+                // We compute one owb per jit call. So, insert an
+                // unconditional jmp, after computing one owb.
+                b(done_compute);
+                cur_n_oi = 0;
+            }
+        }
+        if (jcp.nb_ow == 1 || cur_n_oi != 0) {
+            // Let it "fall-through" middle_block_label
+            add_imm(reg_inp, reg_inp, inp_shift_pad, reg_tmp0_imm);
+        }
+    }
+
+    // middle_block
+    {
+        int cur_r_pad = nstl::max(0,
+                calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
+                        jcp.stride_w, extended_filter_size));
+        if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
+            int n_oi_middle_block_loop
+                    = nstl::max(0,
+                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    / jcp.ur_w;
+            if (jcp.nb_ow == 1 && n_oi_middle_block_loop > 1)
+                mov_imm(reg_oi, n_oi_middle_block_loop);
+            L(middle_block_label);
+            if (n_oi_middle_block_loop > 0) {
+                icb_loop(jcp.ur_w, 0, 0, false);
+                add_imm(reg_inp, reg_inp, inp_shift, reg_tmp0_imm);
+                add_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
+                if (n_oi_middle_block_loop > 1) {
+                    subs(reg_oi, reg_oi, 1);
+                    b(GT, middle_block_label);
+                }
+            }
+            cur_ow += n_oi_middle_block_loop * jcp.ur_w;
+            cur_n_oi = (cur_n_oi + n_oi_middle_block_loop) % n_urw_per_ow_block;
+        }
+    }
+
+    // r_pad region or last_sp_block
+    if (cur_ow + jcp.ur_w <= jcp.ow) {
+        if (jcp.nb_ow > 1) {
+            if (cur_n_oi == 0) {
+                b(done_compute);
+            } else {
+                // r_pad fall-through
+                ldr(reg_owb, ptr(reg_param1, GET_OFF(owb)));
+                cmp(reg_owb, r_pad_fall_through_ow_block);
+                b(NE, done_compute);
+            }
+        }
+
+        while (cur_ow + jcp.ur_w <= jcp.ow) {
+            if (jcp.nb_ow > 1 && cur_n_oi == 0) {
+                L(ow_block_jmp_table[label_cntr++]);
+            }
+            cur_ow += jcp.ur_w;
+            int cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
+                    jcp.stride_w, extended_filter_size);
+            assert(cur_r_pad > 0 || cur_ow > max_safe_ow); // else, why be here?
+            icb_loop(jcp.ur_w, 0, cur_r_pad, cur_ow > max_safe_ow);
+            add_imm(reg_inp, reg_inp, inp_shift, reg_tmp0_imm);
+            add_imm(reg_out, reg_out, out_shift, reg_tmp0_imm);
+
+            if (jcp.nb_ow > 1 && ++cur_n_oi == n_urw_per_ow_block) {
+                // We compute one owb per jit call. So, insert an
+                // unconditional jmp, after computing one owb.
+                b(done_compute);
+                cur_n_oi = 0;
+            }
+        }
+        // Let it fall-through ur_w_tail
+    }
+
+    // ur_w_tail
+    if (jcp.ur_w_tail != 0) {
+        if (jcp.nb_ow > 1) {
+            if (cur_n_oi == 0) {
+                b(done_compute);
+                L(ow_block_jmp_table[label_cntr++]);
+            } else {
+                // In case, when there is no r_pad region, then there exists an
+                // ambiguity btw middle_blocks and r_pad_fall_through_ow_block.
+                // If not properly distinguished, there can be a race condition
+                // as middle_blocks and r_pad_fall_through_ow_block both try to
+                // compute ur_w_tail work at the end.
+                ldr(reg_owb, ptr(reg_param1, GET_OFF(owb)));
+                cmp(reg_owb, jcp.nb_ow - 1); // last ow_block?
+                b(NE, done_compute);
+            }
+        }
+        icb_loop(jcp.ur_w_tail, nstl::max(0, cur_l_pad), r_pad, true);
+    }
+    L(done_compute);
+    assert(ow_block_jmp_table.size() == static_cast<size_t>(label_cntr));
     postamble();
+
+    if (jcp.with_eltwise) postops_injector_->prepare_table();
 
     if (jcp.is_fast_depthwise) {
         align(64);
@@ -1143,19 +1597,10 @@ void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
     }
 }
 
-bool jit_sve_512_x8s8s32x_fwd_kernel::post_ops_ok(
-        jit_conv_conf_t &jcp, const primitive_attr_t &attr) {
-    using namespace primitive_kind;
-    const auto &p = attr.post_ops_;
-
-    /* At this time, post_op is not supported. */
-    return 0 == p.len();
-}
-
 status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
-        memory_desc_t &bias_md, const primitive_attr_t &attr, int nthreads) {
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
     using namespace prop_kind;
 
     const memory_desc_wrapper src_d(&src_md);
@@ -1204,6 +1649,7 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
     jcp.stride_w = cd.strides[ndims - 3];
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
+    jcp.ur_h = 1; /* no code-unrolling by h so far */
     jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
@@ -1256,7 +1702,30 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
             return status::unimplemented;
     }
 
-    if (!post_ops_ok(jcp, attr)) return status::unimplemented;
+    jcp.simd_w = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+
+    const auto zp = attr.zero_points_;
+    jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
+    jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
+    jcp.zp_src_is_common
+            = zp.common(DNNL_ARG_SRC); // otherwise, it's per-channel
+    assert(IMPLICATION(jcp.src_zero_point, jcp.zp_src_is_common));
+
+    if ((jcp.dst_zero_point || jcp.src_zero_point) && jcp.is_fused_conv)
+        return status::unimplemented;
+
+    const auto &src_scales = attr.scales_.get(DNNL_ARG_SRC);
+    const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
+    const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
+    const int wei_mask_per_oc = 1 << (int)with_groups;
+    jcp.is_oc_scale = wei_scales.mask_ == wei_mask_per_oc;
+    jcp.dst_scale = !dst_scales.has_default_values();
+
+    // only common src & dst scales are supported
+    // only common and per-oc-channel weight scales are supported
+    const bool scales_ok = one_of(wei_scales.mask_, 0, wei_mask_per_oc)
+            && everyone_is(src_scales.mask_, dst_scales.mask_, 0);
+    if (!scales_ok) return status::unimplemented;
 
     jcp.is_fast_depthwise = true && jcp.is_depthwise
             && jcp.ngroups % jcp.ch_block == 0; /* groups not multiple of
@@ -1266,14 +1735,21 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
             && jcp.kw < 4 && jcp.dilate_w == 0;
     if (jcp.is_depthwise) {
         jcp.max_regs_ur = 31 - jcp.is_fast_depthwise - !jcp.is_resrc_depthwise
-                - !jcp.signed_input
+                - (!jcp.signed_input)
                 - (!jcp.signed_input || jcp.need_saturation); // both alias
     } else {
         jcp.max_regs_ur = 31;
     }
 
+    // TODO: re-implement so that the JIT Kernel uses the least amount of
+    // registers. Currently, there are issues because of compile and run time
+    // definitions.
+    if (jcp.dst_scale) jcp.max_regs_ur = 26;
+    if (jcp.src_zero_point || jcp.dst_zero_point) jcp.max_regs_ur = 25;
+
     auto set_or_check_wei_format = [&]() {
         using namespace format_tag;
+        using namespace memory_extra_flags;
         format_tag_t wei_tag;
         if (jcp.ic_block == 16 || jcp.ch_block == 16) {
             if (is_3d) {
@@ -1298,12 +1774,15 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
         memory_desc_t want_wei_md = weights_md;
         memory_desc_init_by_tag(want_wei_md, wei_tag);
         if (!jcp.signed_input) {
-            want_wei_md.extra.flags = 0
-                    | memory_extra_flags::compensation_conv_s8s8
-                    | memory_extra_flags::scale_adjust;
+            want_wei_md.extra.flags = 0 | compensation_conv_s8s8 | scale_adjust;
             want_wei_md.extra.compensation_mask = (1 << 0)
                     + (with_groups && !jcp.is_depthwise ? (1 << 1) : 0);
             want_wei_md.extra.scale_adjust = 1.f;
+        }
+        if (jcp.src_zero_point) {
+            want_wei_md.extra.flags |= compensation_conv_asymmetric_src;
+            want_wei_md.extra.asymm_compensation_mask = (1 << 0)
+                    + (with_groups && !jcp.is_depthwise ? (1 << 1) : 0);
         }
 
         if (weights_md.format_kind == format_kind::any) {
@@ -1342,6 +1821,30 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
 
     jcp.bia_dt = jcp.with_bias ? cd.bias_desc.data_type : data_type::undef;
     jcp.dst_dt = cd.dst_desc.data_type;
+
+    CHECK(attr.set_default_formats(&dst_md));
+
+    const auto &post_ops = attr.post_ops_;
+    const int eltwise_ind = post_ops.find(primitive_kind::eltwise);
+    jcp.with_eltwise = eltwise_ind != -1;
+
+    const int binary_ind = post_ops.find(primitive_kind::binary);
+    jcp.with_binary = binary_ind != -1;
+
+    const int sum_ind = post_ops.find(primitive_kind::sum);
+    jcp.with_sum = sum_ind != -1;
+    jcp.sum_dt = post_ops.get_sum_dt(jcp.dst_dt);
+
+    jcp.post_ops = post_ops;
+
+    using namespace injector;
+    static constexpr bool sum_at_pos_0_only = false;
+    static constexpr bool sum_requires_scale_one = false;
+    static constexpr bool sum_requires_zp_zero = false;
+    const bool post_ops_ok_ = post_ops_ok({sve_512, {eltwise, binary, sum},
+            jcp.post_ops, &dst_d, sum_at_pos_0_only, sum_requires_scale_one,
+            sum_requires_zp_zero});
+    if (!post_ops_ok_) return status::unimplemented;
 
     jcp.typesize_in = types::data_type_size(src_d.data_type());
     jcp.typesize_out = types::data_type_size(dst_d.data_type());
@@ -1387,69 +1890,43 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
                 / (jcp.is_depthwise ? jcp.nb_ch_blocking
                                     : jcp.nb_oc_blocking + 1);
     if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
-    if (!jcp.is_depthwise && jcp.ur_w < jcp.ow) {
-        // tune ur_w such that penultimate ur_w block (including ur_w_tail)
-        // does not read past the end of src
-        const int broadcast_size = 4;
-        if (jcp.ic_without_padding % broadcast_size != 0) {
-            while (jcp.ur_w > 0) {
-                int last_block_size = (jcp.ow % jcp.ur_w == 0)
-                        ? jcp.ur_w
-                        : jcp.ow % jcp.ur_w;
-                int penultimate_iw_index
-                        = (jcp.ow - 1 - last_block_size) * jcp.stride_w
-                        + (jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad;
-                int penultimate_iw_leeway = (jcp.iw - 1 - penultimate_iw_index)
-                                * jcp.ic_without_padding
-                        + jcp.ic_without_padding % broadcast_size;
-                if (penultimate_iw_leeway >= broadcast_size) break;
-                --jcp.ur_w;
-            }
-            if (jcp.ur_w == 0) // no satisfactory ur_w could be found
-                return status::unimplemented;
-        }
-    }
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
-    jcp.ow_block = jcp.ow;
-    int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
-            * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
-    float best_thr_eff
-            = (float)base_work_amount / rnd_up(base_work_amount, jcp.nthr);
-    int max_nb_ow = div_up(jcp.ow, 2 * jcp.ur_w);
-    for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-        int ow_block
-                = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), jcp.ur_w), jcp.ow);
-        if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
-                && best_thr_eff > 0.8f)
-            break;
-        if (div_up(jcp.ow, ow_block) != nb_ow) continue;
+    auto get_thr_eff = [=](int nb_ow, int nthr) {
+        int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
+                * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
         auto work_amount = base_work_amount * nb_ow;
-        float thr_eff = (float)work_amount / rnd_up(work_amount, jcp.nthr);
-        if (ow_block >= 2 * jcp.ur_w && thr_eff > 1.1f * best_thr_eff) {
-            jcp.ow_block = ow_block;
-            best_thr_eff = thr_eff;
+        return float(work_amount) / rnd_up(work_amount, nthr);
+    };
+
+    auto get_ow_block = [=](int ur_w, int nthr) {
+        int res_ow_block = jcp.ow;
+        float best_thr_eff = get_thr_eff(1, nthr);
+        float thr_eff;
+        int max_nb_ow = div_up(jcp.ow, ur_w);
+        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            int ow_block
+                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+            if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
+                    && best_thr_eff > 0.8f)
+                break;
+            if (div_up(jcp.ow, ow_block) != nb_ow) continue;
+            thr_eff = get_thr_eff(nb_ow, nthr);
+            if (ow_block >= ur_w && thr_eff > 1.1f * best_thr_eff) {
+                res_ow_block = ow_block;
+                best_thr_eff = thr_eff;
+            }
+            if (best_thr_eff > 0.9f) break;
         }
-        if (best_thr_eff > 0.9f) break;
-    }
+        return res_ow_block;
+    };
+
+    jcp.ow_block = get_ow_block(jcp.ur_w, jcp.nthr);
     jcp.nb_ow = div_up(jcp.ow, jcp.ow_block);
 
-    bool args_ok = true && jcp.oc % jcp.oc_block == 0 && jcp.l_pad <= jcp.ur_w;
-    if (!args_ok) return status::unimplemented;
-
-    int r_pad_no_tail = nstl::max(0,
-            calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
-    if (r_pad_no_tail > jcp.ur_w) return status::unimplemented;
+    if (jcp.oc % jcp.oc_block != 0) return status::unimplemented;
 
     pick_loop_order(jcp, jcp.nthr);
-
-    const auto &oscales = attr.output_scales_;
-    jcp.is_oc_scale = oscales.mask_ == 1 << 1;
-
-    // only common and per-oc-channel scales are supported
-    const bool oscales_ok = one_of(oscales.mask_, 0, 1 << 1);
-    if (!oscales_ok) return status::unimplemented;
 
     jcp.wei_adj_scale
             = (weights_d.extra().flags & memory_extra_flags::scale_adjust)
@@ -1461,7 +1938,12 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
 
 void jit_sve_512_x8s8s32x_fwd_kernel::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
-        const primitive_attr_t &attr) {}
+        const primitive_attr_t &attr) {
+    const int wei_mask = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const dim_t scales_count = wei_mask == 0 ? 1 : jcp.oc * jcp.ngroups;
+    dim_t count = wei_mask == 0 ? (dim_t)16 : scales_count;
+    scratchpad.book<float>(key_conv_adjusted_scales, count);
+}
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 
 #include "cpu/cpu_convolution_pd.hpp"
 
+#include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp"
 
 namespace dnnl {
@@ -44,23 +45,29 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
                 jit_sve_512_x8s8s32x_convolution_fwd_t);
 
         status_t init(engine_t *engine) {
+            using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
-            bool ok = true && is_fwd()
+            bool ok = is_fwd()
                     && set_default_alg_kind(alg_kind::convolution_direct)
-                    && expect_data_types(src_type, data_type::s8,
-                            data_type::undef, dst_type, data_type::s32)
+                    && utils::one_of(src_md(0)->data_type, s8, u8)
+                    && weights_md(0)->data_type == s8
                     && IMPLICATION(with_bias(),
-                            utils::one_of(bias_md_.data_type, data_type::f32,
-                                    data_type::s32, data_type::s8,
-                                    data_type::u8))
-                    && attr()->has_default_values(
-                            smask_t::oscale_runtime | smask_t::post_ops,
-                            dst_type)
-                    && !has_zero_dim_memory();
+                            utils::one_of(
+                                    weights_md(1)->data_type, f32, s32, s8, u8))
+                    && utils::one_of(
+                            dst_md(0)->data_type, f32, s32, s8, u8 /*, bf16*/)
+                    && desc()->accum_data_type == s32
+                    && attr()->has_default_values(smask_t::scales_runtime
+                                    | smask_t::zero_points_runtime
+                                    | smask_t::post_ops | smask_t::sum_dt,
+                            dst_md(0)->data_type)
+                    && attr()->post_ops_.check_sum_consistent_dt(
+                            dst_md(0)->data_type)
+                    && !has_zero_dim_memory() && zero_points_ok();
             if (!ok) return status::unimplemented;
 
             status_t status = jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jcp_,
-                    *desc(), src_md_, weights_md_, dst_md_, bias_md_, *attr(),
+                    *desc(), src_md_, weights_md_, dst_md_, bias_md_, attr_,
                     dnnl_get_max_threads());
             if (status != status::success) return status;
 
@@ -72,6 +79,16 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
         }
 
         jit_conv_conf_t jcp_;
+
+    protected:
+        bool zero_points_ok() const {
+            // Only common zero points are supported -> mask should only be 0
+            int mask_src = 0, mask_dst = 0;
+            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
+            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
+            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
+                    && mask_src == 0 && mask_dst == 0;
+        }
     };
 
     jit_sve_512_x8s8s32x_convolution_fwd_t(const pd_t *apd)
@@ -84,7 +101,7 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
                 new jit_sve_512_x8s8s32x_fwd_kernel(
-                        pd()->jcp_, *pd()->attr())));
+                        pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         return kernel_->create_kernel();
     }
 
@@ -108,6 +125,8 @@ private:
     status_t execute_forward_2d_dw(const exec_ctx_t &ctx) const;
     status_t execute_forward_3d(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    const float *adjust_oscales(const memory_tracking::grantor_t &scratchpad,
+            const float *src_scales, const float *wei_scales) const;
 
     std::unique_ptr<jit_sve_512_x8s8s32x_fwd_kernel> kernel_;
 };

--- a/src/cpu/aarch64/jit_uni_binary.hpp
+++ b/src/cpu/aarch64/jit_uni_binary.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2019-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,8 +20,9 @@
 
 #include "common/primitive.hpp"
 
-#include "cpu/aarch64/jit_uni_binary_kernel.hpp"
 #include "cpu/cpu_eltwise_pd.hpp"
+
+#include "cpu/aarch64/jit_uni_binary_kernel.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -127,9 +127,10 @@ void jit_uni_binary_kernel_t<isa>::init_post_ops_injector() {
             reg_elt_inj_table_, elt_inj_opmask_, elt_inj_p_tmp0_,
             true /*is_fwd*/, false /*use_dst*/);
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
-            reg_elt_inj_table_, true /*preserve gpr*/, true /*preserve vmm*/,
-            PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig), dst_d,
-            tail_size_, tail_opmask_, false /*use_exact_tail_scalar_bcast*/};
+            reg_elt_inj_table_, x13, true /*preserve gpr*/,
+            true /*preserve vmm*/, PARAM_OFF(post_ops_binary_rhs_arg_vec),
+            PARAM_OFF(dst_orig), dst_d, tail_size_, tail_opmask_,
+            false /*use_exact_tail_scalar_bcast*/};
     const binary_injector::static_params_t bsp(this->param1,
             get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -125,7 +125,7 @@ void jit_uni_binary_kernel_t<isa>::init_post_ops_injector() {
 
     const eltwise_injector::static_params_t esp(true /*save_state*/,
             reg_elt_inj_table_, elt_inj_opmask_, elt_inj_p_tmp0_,
-            elt_inj_p_all_, true /*is_fwd*/, false /*use_dst*/);
+            true /*is_fwd*/, false /*use_dst*/);
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
             reg_elt_inj_table_, true /*preserve gpr*/, true /*preserve vmm*/,
             PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig), dst_d,

--- a/src/cpu/aarch64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,7 +109,6 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     const Vmm vmm_gathered_src_ = Vmm(31);
 
     const size_t unroll_regs_ = 8;
-
     const size_t offt_src0_;
     const size_t offt_src1_;
 
@@ -134,6 +133,8 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     void prepare_isa_kernel();
     void compute_bcast(bool tail);
     void load_src1(const Vmm &vreg_src1, const int offt, bool tail);
+    void store(int unroll, bool tail);
+    void compute_dst_body(int unroll, bool tail);
     void compute_dst(int unroll, bool tail);
     void forward();
     void forward_over_outer_dims();
@@ -151,7 +152,6 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
             bool tail_kernel = false);
     ~jit_uni_binary_kernel_t() override = default;
 
-    jit_generator *host_;
     std::map<data_type_t, io::io_saturation_conf_t>
     create_saturation_vmm_map() const;
 };

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2022 Intel Corporation
-* Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2021-2023 FUJITSU LIMITED
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,8 +73,8 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
         const bool save_state = is_fwd ? false : true;
         eltwise_injector_.reset(new jit_uni_eltwise_injector_f32<isa>(this,
                 desc.alg_kind, desc.alpha, desc.beta, 1.f, save_state,
-                reg_injector_table, injector_mask, injector_p_tmp0,
-                injector_p_all, is_fwd, pd_->use_dst()));
+                reg_injector_table, injector_mask, injector_p_tmp0, is_fwd,
+                pd_->use_dst()));
     }
 
     void generate() override {

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
-* Copyright 2017-2022 Intel Corporation
+* Copyright 2017-2023 Intel Corporation
 * Copyright 2018 YANDEX LLC
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2020-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
                 static_cast<std::size_t>(this->v4.getIdx()), this->x14,
-                this->x15, preserve_gpr, preserve_vmm,
+                this->x15, this->x13, preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(jpp.tag_kind == jit_memory_tag_kind_t::ncsp
                                 ? jpp.tmp_md

--- a/src/cpu/aarch64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder_utils.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2018-2022 Intel Corporation
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2018-2023 Intel Corporation
+* Copyright 2020-2023 FUJITSU LIMITED
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -206,7 +206,7 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
             && !im_d.has_runtime_dims_or_strides() && !im_d.has_zero_dim()
             && !om_d.has_runtime_dims_or_strides() && !om_d.has_zero_dim()
             && attr->has_default_values(
-                    primitive_attr_t::skip_mask_t::oscale_runtime
+                    primitive_attr_t::skip_mask_t::scales_runtime
                     | primitive_attr_t::skip_mask_t::zero_points_runtime
                     | primitive_attr_t::skip_mask_t::post_ops)
             && check_post_ops(attr);
@@ -273,10 +273,28 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
     p.is_tail_present = is_tail_present;
     p.req_src_zp = !attr->zero_points_.has_default_values(DNNL_ARG_SRC);
     p.req_dst_zp = !attr->zero_points_.has_default_values(DNNL_ARG_DST);
-    p.scale_type = attr->output_scales_.has_default_values()
-            ? scale_type_t::NONE
-            : (attr->output_scales_.mask_ == 0 ? scale_type_t::COMMON
-                                               : scale_type_t::MANY);
+
+    p.src_scale_type = scale_type_t::NONE;
+    int src_mask = 0;
+    bool is_src_set = false;
+    CHECK(attr->scales_.get(DNNL_ARG_SRC, &src_mask, &is_src_set));
+    if (is_src_set) {
+        p.src_scale_type
+                = src_mask == 0 ? scale_type_t::COMMON : scale_type_t::MANY;
+    }
+
+    p.dst_scale_type = scale_type_t::NONE;
+    int dst_mask = 0;
+    bool is_dst_set = false;
+    CHECK(attr->scales_.get(DNNL_ARG_DST, &dst_mask, &is_dst_set));
+    if (is_dst_set) {
+        p.dst_scale_type
+                = dst_mask == 0 ? scale_type_t::COMMON : scale_type_t::MANY;
+    }
+
+    if (is_src_set && is_dst_set && src_mask != dst_mask)
+        return status::unimplemented;
+
     p.scale_adjust = (om_d.extra().flags & memory_extra_flags::scale_adjust)
             ? om_d.extra().scale_adjust
             : 1.f;
@@ -297,8 +315,9 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
         return status::unimplemented;
 
     ptrdiff_t ss[max_ndims] = {0}; // scales strides
-    if (p.scale_type == scale_type_t::MANY) {
-        const int mask = attr->output_scales_.mask_;
+    if (p.src_scale_type == scale_type_t::MANY
+            || p.dst_scale_type == scale_type_t::MANY) {
+        const int mask = nstl::max(src_mask, dst_mask);
         ptrdiff_t dense_stride = 1;
         ptrdiff_t last_stride = 1;
         for (int d = old.ndims - 1; d >= 0; --d) {

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2019-2023 Intel Corporation
+* Copyright 2020-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -342,13 +342,11 @@ struct jit_softmax_base_t : public jit_generator {
         if (pd_->is_fwd() || is_logsoftmax_)
             exp_injector_.reset(new jit_uni_eltwise_injector_f32<isa>(this,
                     alg_kind::eltwise_exp, 0.0f, 0.0f, 1.0f, true,
-                    reg_exp_injector_table, injector_mask, injector_tmp,
-                    P_ALL_ONE));
+                    reg_exp_injector_table, injector_mask, injector_tmp));
         if (pd_->is_fwd() && is_logsoftmax_) {
             log_injector_.reset(new jit_uni_eltwise_injector_f32<isa>(this,
                     alg_kind::eltwise_log, 0.0f, 0.0f, 1.0f, true,
-                    reg_log_injector_table, injector_mask, injector_tmp,
-                    P_ALL_ONE));
+                    reg_log_injector_table, injector_mask, injector_tmp));
         }
 
         compute_predefined_variables();

--- a/src/cpu/aarch64/xbyak_aarch64/src/err_impl.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/err_impl.h
@@ -1,0 +1,59 @@
+#pragma once
+/*******************************************************************************
+ * Copyright 2018-2023 Intel Corporation
+ * Copyright 2020-2023 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+Error::Error(int err) : err_(err), msg_("") {
+  if (err_ <= 0)
+    return;
+  fprintf(stderr, "bad err=%d in Xbyak::Error\n", err_);
+  static const char *tbl[32] = {
+      "none",
+      "code is too big",
+      "label is redefined",
+      "label is too far",
+      "label is not found",
+      "bad parameter",
+      "can't protect",
+      "offset is too big",
+      "can't alloc",
+      "label is not set by L()",
+      "label is already set by L()",
+      "internal error",
+      "illegal register index (can not encoding register index)",
+      "illegal register element index (can not encoding element index)",
+      "illegal predicate register type",
+      "illegal immediate parameter (range error)",
+      "illegal immediate parameter (unavailable value error)",
+      "illegal immediate parameter (condition error)",
+      "illegal shift-mode paramater",
+      "illegal extend-mode parameter",
+      "illegal condition parameter",
+      "illegal barrier option",
+      "illegal const parameter (range error)",
+      "illegal const parameter (unavailable error)",
+      "illegal const parameter (condition error)",
+      "illegal type",
+      "bad align",
+      "bad addressing",
+      "bad scale",
+  };
+  if ((size_t)err_ >= sizeof(tbl) / sizeof(tbl[0])) {
+    msg_ = "bad err num";
+  } else {
+    msg_ = tbl[err_];
+  }
+}

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl.cpp
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2022 FUJITSU LIMITED
+ * Copyright 2020-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,263 +13,189 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_util.h"
+
+#include "util_impl.h"
+
+#if defined(__linux__)
+#include "util_impl_linux.h"
+#elif defined(__APPLE__)
+#include "util_impl_mac.h"
+#elif defined(_M_ARM64)
+#include "util_impl_windows.h"
+#else
+#error "Unsupported OS"
+#endif
 
 namespace Xbyak_aarch64 {
 namespace util {
+void CpuInfo::dumpCacheInfo() const {
+  printf("numCores=%d\n", numCores_[/* Phisical cores */ 1]);
+  for (size_t i = 0; i < maxCacheLevel; i++) {
+    auto cache = &cacheInfo_.levelCache[i];
+    printf("L%zd, %d, %d, %d, %d, %d, %d, %d\n", i + 1, cache->type, cache->size[0], cache->size[1], cache->size[2], cache->sharingCores[0], cache->sharingCores[1], cache->sharingCores[2]);
+  }
+}
 
-void Cpu::setCacheHierarchy() {
-  /* Cache size of AArch64 CPUs are described in the system registers,
-     which can't be read from user-space applications.
-     Linux provides `sysconf` API and `/sys/devices/system/cpu/`
-     device files to get cache size, but they dosen't always return
-     correct values. It may depend on Linux kernel version and
-     support status of CPUs. To avoid this situation, cahche size is
-     firstly read from `cacheInfoDict`, secondly get by `sysconf`.
-
-     `sysconf` example
-     #include <unistd.h>
-     int main() {
-       reutrn sysconf(_SC_LEVEL1_DCACHE_SIZE);
-     }
-   */
-  const cacheInfo_t *c = nullptr;
-
-  for (size_t j = 0; j < sizeof(cacheInfoDict) / sizeof(cacheInfo_t); j++) {
-    if (cacheInfoDict[j].midr_el1 == midr_el1_) {
-      c = cacheInfoDict + j;
+int CpuInfo::getCacheSize(cacheType_t type, uint32_t level) const {
+  if (level <= maxCacheLevel) {
+    auto cache = &cacheInfo_.levelCache[level - 1];
+    switch (type) {
+    case ICache:
+      return cache->size[0];
+      break;
+    case DCache:
+      return cache->size[1];
+      break;
+    case UCache:
+      return cache->size[2];
+      break;
+    default:
+      throw Error(ERR_BAD_PARAMETER);
       break;
     }
-  }
-
-  if (c != nullptr) {
-    dataCacheLevel_ = c->dataCacheLevel;
-    for (uint32_t i = 0; i < maxNumberCacheLevel; i++) {
-      if (i < c->highestInnerCacheLevel)
-        dataCacheSize_[i] = c->dataCacheSize[i];
-      else
-        dataCacheSize_[i] = c->dataCacheSize[i] / coresSharingDataCache_[i];
-    }
   } else {
-    /**
-     * @ToDo Get cache information by `sysconf`
-     * for the case thd dictionary is unavailable.
-     */
-
-// _SC_LEVEL<L>_DCACHE_SIZE macros are not defined on macOS.
-#if defined(__APPLE__)
-#define GET_CACHE_SIZE(ID) 0
-#else
-#define GET_CACHE_SIZE(ID) sysconf(ID)
-#endif
-
-#define XBYAK_AARCH64_CACHE_SIZE(LEVEL, SIZE, ID, CORES, VAL)                                                                                                                                                                                                                                              \
-  cache_size = GET_CACHE_SIZE(ID);                                                                                                                                                                                                                                                                         \
-  VAL[LEVEL] = cache_size ? (cache_size / (CORES)) : ((SIZE) / (CORES));
-
-    uint32_t cache_size;
-
-    /* If `sysconf` returns zero as cache sizes, 32KiB, 1MiB, 0 and 0 is set as
-       1st, 2nd, 3rd and 4th level cache sizes. 2nd cache is assumed as sharing cache. */
-    XBYAK_AARCH64_CACHE_SIZE(0, 1024 * 32, _SC_LEVEL1_DCACHE_SIZE, 1, coresSharingDataCache_);
-    XBYAK_AARCH64_CACHE_SIZE(1, 1024 * 1024, _SC_LEVEL2_CACHE_SIZE, 1, coresSharingDataCache_);
-    XBYAK_AARCH64_CACHE_SIZE(2, 0, _SC_LEVEL3_CACHE_SIZE, 1, coresSharingDataCache_);
-    XBYAK_AARCH64_CACHE_SIZE(3, 0, _SC_LEVEL4_CACHE_SIZE, 1, coresSharingDataCache_);
-
-    XBYAK_AARCH64_CACHE_SIZE(0, 1024 * 32, _SC_LEVEL1_DCACHE_SIZE, 1, dataCacheSize_);
-    XBYAK_AARCH64_CACHE_SIZE(1, 1024 * 1024, _SC_LEVEL2_CACHE_SIZE, 8, dataCacheSize_);
-    XBYAK_AARCH64_CACHE_SIZE(2, 0, _SC_LEVEL3_CACHE_SIZE, 1, dataCacheSize_);
-    XBYAK_AARCH64_CACHE_SIZE(3, 0, _SC_LEVEL4_CACHE_SIZE, 1, dataCacheSize_);
-#undef XBYAK_AARCH64_CACHE_SIZE
-  }
-}
-
-void Cpu::setNumCores() {
-#ifdef __linux__
-  /**
-   * @ToDo There are some methods to get # of cores.
-   Considering various kernel versions and CPUs, a combination of
-   multiple methods may be required.
-   1) sysconf(_SC_NPROCESSORS_ONLN)
-   2) /sys/devices/system/cpu/online
-   3) std::thread::hardware_concurrency()
-  */
-  numCores_[0] = numCores_[1] = sysconf(_SC_NPROCESSORS_ONLN);
-  coresSharingDataCache_[0] = 1;
-
-  /* # of numa nodes: /sys/devices/system/node/node[0-9]+
-     # of cores for each numa node: /sys/devices/system/node/node[0-9]+/cpu[0-9]+
-     It is assumed L2 cache is shared by each numa node. */
-  const int nodes = getFilePathMaxTailNumPlus1(XBYAK_AARCH64_PATH_NODES);
-  int cores = 1;
-
-  if (nodes > 0) {
-    cores = getFilePathMaxTailNumPlus1(XBYAK_AARCH64_PATH_CORES);
-    coresSharingDataCache_[1] = (cores > 0) ? cores : 1;
-  } else {
-    coresSharingDataCache_[1] = 1;
-  }
-#else
-  numCores_[0] = numCores_[1] = 1;
-  for (unsigned int i = 0; i < maxNumberCacheLevel; i++)
-    coresSharingDataCache_[i] = 1;
-
-  coresSharingDataCache_[1] = 8; // Set possible value.
-#endif
-}
-
-void Cpu::setSysRegVal() {
-#ifdef __linux__
-  XBYAK_AARCH64_READ_SYSREG(midr_el1_, MIDR_EL1);
-#endif
-}
-
-/**
- * Return directory path
- * @param[in] path ex. /sys/devices/system/node/node
- * @param[out] buf ex. /sys/devices/system/node
- */
-int Cpu::getRegEx(char *buf, const char *path, const char *regex) {
-  regex_t regexBuf;
-  regmatch_t match[1];
-
-  if (regcomp(&regexBuf, regex, REG_EXTENDED) != 0)
-    throw ERR_INTERNAL;
-
-  const int retVal = regexec(&regexBuf, path, 1, match, 0);
-  regfree(&regexBuf);
-
-  if (retVal != 0)
-    return -1;
-
-  const int startIdx = match[0].rm_so;
-  const int endIdx = match[0].rm_eo;
-
-  /* Something wrong (multiple match or not match) */
-  if (startIdx == -1 || endIdx == -1 || (endIdx - startIdx - 1) < 1)
-    return -1;
-
-  strncpy(buf, path + startIdx, endIdx - startIdx);
-  buf[endIdx - startIdx] = '\0';
-
-  return 0;
-}
-
-int Cpu::getFilePathMaxTailNumPlus1(const char *path) {
-#ifdef __linux__
-  char dir_path[max_path_len];
-  char file_pattern[max_path_len];
-  int retVal = 0;
-
-  getRegEx(dir_path, path, "/([^/]+/)+");
-  /* Remove last '/'. */
-  dir_path[strlen(dir_path) - 1] = '\0';
-  getRegEx(file_pattern, path, "[^/]+$");
-  strncat(file_pattern, "[0-9]+", 16);
-
-  fflush(stdout);
-
-  DIR *dir = opendir(dir_path);
-  struct dirent *dp;
-
-  dp = readdir(dir);
-  while (dp != NULL) {
-    if (getRegEx(dir_path, dp->d_name, file_pattern) == 0)
-      retVal++;
-    dp = readdir(dir);
-  }
-
-  if (dir != NULL)
-    closedir(dir);
-
-  return retVal;
-#else
-  return 0;
-#endif
-}
-
-Cpu::Cpu() : type_(tNONE), sveLen_(SVE_NONE) {
-#ifdef __linux__
-  unsigned long hwcap = getauxval(AT_HWCAP);
-  if (hwcap & HWCAP_ATOMICS) {
-    type_ |= tATOMIC;
-  }
-
-  if (hwcap & HWCAP_FP) {
-    type_ |= tFP;
-  }
-  if (hwcap & HWCAP_ASIMD) {
-    type_ |= tADVSIMD;
-  }
-#ifdef HWCAP_SVE
-  /* Some old <sys/auxv.h> may not define HWCAP_SVE.
-     In that case, SVE is treated as if it were not supported. */
-  if (hwcap & HWCAP_SVE) {
-    type_ |= tSVE;
-    // svcntb(); if arm_sve.h is available
-    sveLen_ = (sveLen_t)prctl(51); // PR_SVE_GET_VL
-  }
-#endif
-#elif defined(__APPLE__)
-  size_t val = 0;
-  size_t len = sizeof(val);
-
-  if (sysctlbyname(hw_opt_atomics, &val, &len, NULL, 0) != 0)
-    throw Error(ERR_INTERNAL);
-  else
-    type_ |= (val == 1) ? tATOMIC : 0;
-
-  if (sysctlbyname(hw_opt_fp, &val, &len, NULL, 0) != 0)
-    throw Error(ERR_INTERNAL);
-  else
-    type_ |= (val == 1) ? tFP : 0;
-
-  if (sysctlbyname(hw_opt_neon, &val, &len, NULL, 0) != 0)
-    throw Error(ERR_INTERNAL);
-  else
-    type_ |= (val == 1) ? tADVSIMD : 0;
-#endif
-
-  setSysRegVal();
-  setNumCores();
-  setCacheHierarchy();
-}
-
-Type Cpu::getType() const { return type_; }
-bool Cpu::has(Type type) const { return (type & type_) != 0; }
-uint64_t Cpu::getSveLen() const { return sveLen_; }
-bool Cpu::isAtomicSupported() const { return type_ & tATOMIC; }
-const char *Cpu::getImplementer() const {
-  uint64_t implementer = (midr_el1_ >> 24) & 0xff;
-
-  for (size_t i = 0; i < sizeof(implementers) / sizeof(implementer_t); i++) {
-    if (implementers[i].id == implementer)
-      return implementers[i].implementer;
-  }
-
-  return nullptr;
-}
-
-uint32_t Cpu::getCoresSharingDataCache(uint32_t i) const {
-  if (i >= dataCacheLevel_)
     throw Error(ERR_BAD_PARAMETER);
-  return coresSharingDataCache_[i];
+  }
 }
 
-uint32_t Cpu::getDataCacheLevels() const { return dataCacheLevel_; }
+Arm64CacheType CpuInfo::getCacheType(int level) const { return cacheInfo_.levelCache[level - 1].type; }
+int CpuInfo::getCodeCacheSize(int level) const { return cacheInfo_.levelCache[level - 1].size[0]; }
 
-uint32_t Cpu::getDataCacheSize(uint32_t i) const {
-  if (i >= dataCacheLevel_)
-    throw Error(ERR_BAD_PARAMETER);
-  return dataCacheSize_[i];
-}
-uint32_t Cpu::getNumCores(Arm64CpuTopologyLevel level) const {
-  switch (level) {
-  case CoreLevel:
-    return numCores_[level - 1];
+int CpuInfo::getCoresSharingDataCache(int level) const {
+  auto cache = &cacheInfo_.levelCache[level - 1];
+  int cores;
+
+  switch (cache->type) {
+  case DataCacheOnly:
+  case SeparateCache:
+    cores = cache->sharingCores[1];
+    break;
+  case UnifiedCache:
+    cores = cache->sharingCores[2];
+    break;
   default:
-    throw Error(ERR_BAD_PARAMETER);
+    cores = 0;
+    break;
+  }
+
+  return cores;
+}
+
+int CpuInfo::getDataCacheSize(int level) const { return cacheInfo_.levelCache[level - 1].size[1]; }
+
+const char *CpuInfo::getImplementer() const { return implementer_; }
+int CpuInfo::getLastDataCacheLevel() const { return lastDataCacheLevel_; }
+
+int CpuInfo::getNumCores(Arm64CpuTopologyLevel level) const {
+  switch (level) {
+  case SmtLevel:
+    return numCores_[0];
+    break;
+  case CoreLevel:
+    return numCores_[1];
+    break;
+  default:
+    return 0;
   }
 }
+
+uint64_t CpuInfo::getSveLen() const { return sveLen_; }
+Type CpuInfo::getType() const { return type_; }
+int CpuInfo::getUnifiedCacheSize(int level) const { return cacheInfo_.levelCache[level - 1].size[2]; }
+
+void CpuInfo::init() {
+  for (size_t i = 0; i < maxCacheLevel; i++) {
+    auto cache = &cacheInfo_.levelCache[i];
+    cache->type = NoCache;
+    cache->size[0] = cache->size[1] = cache->size[2] = 0;
+    cache->sharingCores[0] = cache->sharingCores[1] = cache->sharingCores[2] = 0;
+  }
+}
+
+void CpuInfo::put() const {
+  printf("numCores=%d\n", numCores_[0]);
+  for (int level = 1; level <= 3; level++) {
+    printf("L%d unified size = %d\n", level, getUnifiedCacheSize(level));
+    printf("L%d code size = %d\n", level, getCodeCacheSize(level));
+    printf("L%d data size = %d\n", level, getDataCacheSize(level));
+  }
+}
+
+void CpuInfo::setImplementer() {
+  const uint32_t id = (cacheInfo_.midr_el1 >> 24) & 0xff;
+  const int lastId = sizeof(implementers) / sizeof(implementer_t);
+
+  for (int i = 0; i < lastId; i++) {
+    if (implementers[i].id == id) {
+      implementer_ = implementers[i].implementer;
+      return;
+    }
+  }
+  implementer_ = (char *)implementers[lastId - 1].implementer;
+}
+
+void CpuInfo::setLastDataCacheLevel() {
+  for (uint32_t i = 0; i < maxCacheLevel; i++) {
+    const Arm64CacheType type = cacheInfo_.levelCache[i].type;
+    if (type == DataCacheOnly || type == SeparateCache || type == UnifiedCache)
+      lastDataCacheLevel_ = i + 1;
+  }
+}
+
+Cpu::Cpu() {
+#if defined(__linux__)
+  info = new CpuInfoLinux();
+#elif defined(__APPLE__)
+  info = new CpuInfoMac();
+#elif defined(_M_ARM64)
+  info = new CpuInfoWindows();
+#endif
+}
+
+void Cpu::dumpCacheInfo() const { return info->dumpCacheInfo(); }
+
+/* 2023.02.11 To be removed. */
+#if defined(__GNUC__) || defined(__clang_version__)
+uint32_t Cpu::getDataCacheLevels() const { return getLastDataCacheLevel(); }
+#endif
+
+Arm64CacheType Cpu::getCacheType(const Arm64CacheLevel i) const { return info->getCacheType(i); }
+
+uint32_t Cpu::getCoresSharingDataCache(const Arm64CacheLevel i) const { return info->getCoresSharingDataCache(i); }
+
+uint32_t Cpu::getDataCacheSize(const Arm64CacheLevel i) const {
+  uint32_t size;
+  switch (info->getCacheType(i)) {
+  case DataCacheOnly:
+  case SeparateCache:
+    size = info->getDataCacheSize(i);
+    break;
+  case UnifiedCache:
+    size = info->getUnifiedCacheSize(i);
+    break;
+  default:
+    size = 0;
+    break;
+  }
+
+  return size;
+}
+
+const char *Cpu::getImplementer() const { return info->getImplementer(); }
+
+uint32_t Cpu::getLastDataCacheLevel() const { return info->getLastDataCacheLevel(); }
+uint32_t Cpu::getNumCores(Arm64CpuTopologyLevel level) const { return info->getNumCores(level); }
+uint64_t Cpu::getSveLen() const { return info->getSveLen(); }
+Type Cpu::getType() const { return info->getType(); }
+bool Cpu::has(Type type) const { return (type & info->getType()) != 0; }
+bool Cpu::isAtomicSupported() const { return info->getType() & (Type)XBYAK_AARCH64_HWCAP_ATOMIC; }
+
 } // namespace util
 } // namespace Xbyak_aarch64

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl.h
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright 2020-2023 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+namespace Xbyak_aarch64 {
+namespace util {
+
+struct levelCacheInfo_t {
+  Arm64CacheType type;
+  /* I cache size, D cache size and Unified cache size.
+     Example1: some cache level of a CPU core has separate caches of
+     32KB I$ and 64KB D$, size[] = {1024 * 32, 1024 * 64, 0},
+     sharingCores[] = 1, 1, 0}.
+     Example2: some cache level of CPU cores has a 1MB unified cache,
+     and it is shared by 12 CPU cores,
+     size[] = {0, 0, 1024 * 1024}, sharingCores[] = {0, 0, 12}.
+   */
+  uint32_t size[3];         // I cache, D cache, Unified cache
+  uint32_t sharingCores[3]; // I cache, D cache, Unified cache
+};
+
+struct cacheInfo_v2_t {
+  uint64_t midr_el1; // used as table index
+  levelCacheInfo_t levelCache[maxCacheLevel];
+};
+
+const struct implementer_t implementers[] = {
+    {0x00, "Reserved for software use"},
+    {0xC0, "Ampere Computing"},
+    {0x41, "Arm Limited"},
+    {0x42, "Broadcom Corporation"},
+    {0x43, "Cavium Inc."},
+    {0x44, "Digital Equipment Corporation"},
+    {0x46, "Fujitsu Ltd."},
+    {0x49, "Infineon Technologies AG"},
+    {0x4D, "Motorola or Freescale Semiconductor Inc."},
+    {0x4E, "NVIDIA Corporation"},
+    {0x50, "Applied Micro Circuits Corporation"},
+    {0x51, "Qualcomm Inc."},
+    {0x56, "Marvell International Ltd."},
+    {0x69, "Intel Corporation"},
+    {0xFE, "Apple Inc."}, // Xbyak_aarch64 original definition
+    {0xFF, "Cannot identified"},
+};
+
+class CpuInfo {
+protected:
+  int numCores_[2] = {}; // [0]:SmtLevel, [1], CoreLevel
+  cacheInfo_v2_t cacheInfo_;
+  uint32_t lastDataCacheLevel_;
+  Type type_ = 0;
+  uint64_t sveLen_ = 0;
+  const char *implementer_ = nullptr;
+
+  void init();
+  void setImplementer();
+  void setLastDataCacheLevel();
+
+public:
+  CpuInfo() {}
+  void dumpCacheInfo() const;
+  int getCacheSize(cacheType_t type, uint32_t level) const;
+  Arm64CacheType getCacheType(int level) const;
+  int getCodeCacheSize(int level) const;
+  int getCoresSharingDataCache(int level) const;
+  int getDataCacheSize(int level) const;
+  const char *getImplementer() const;
+  int getLastDataCacheLevel() const;
+  int getNumCores(Arm64CpuTopologyLevel level = CoreLevel) const;
+  uint64_t getSveLen() const;
+  Type getType() const;
+  int getUnifiedCacheSize(int level) const;
+  void put() const;
+};
+} // namespace util
+} // namespace Xbyak_aarch64

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
@@ -1,0 +1,426 @@
+/*******************************************************************************
+ * Copyright 2020-2023 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+#ifndef __linux__
+#error "Something wrong"
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <dirent.h>
+#include <regex.h>
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+
+#include "xbyak_aarch64_err.h"
+#include "xbyak_aarch64_util.h"
+
+/* In old Linux such as Ubuntu 16.04, HWCAP_ATOMICS, HWCAP_FP, HWCAP_ASIMD
+   can not be found in <bits/hwcap.h> which is included from <sys/auxv.h>.
+   Xbyak_aarch64 uses <asm/hwcap.h> as an alternative.
+ */
+#ifndef HWCAP_FP
+#include <asm/hwcap.h>
+#endif
+
+namespace Xbyak_aarch64 {
+namespace util {
+#define XBYAK_AARCH64_ERROR_ fprintf(stderr, "%s, %d, Error occurrs during read cache infomation.\n", __FILE__, __LINE__);
+#define XBYAK_AARCH64_PATH_NODES "/sys/devices/system/node/node"
+#define XBYAK_AARCH64_PATH_CORES "/sys/devices/system/node/node0/cpu"
+#define XBYAK_AARCH64_PATH_CACHE_DIR "/sys/devices/system/cpu/cpu0/cache"
+#define XBYAK_AARCH64_PATH_CACHE_LEVEL "/sys/devices/system/cpu/cpu0/cache/index0/level"
+#define XBYAK_AARCH64_PATH_CACHE_SIZE "/sys/devices/system/cpu/cpu0/cache/index0/size"
+#define XBYAK_AARCH64_PATH_CACHE_TYPE "/sys/devices/system/cpu/cpu0/cache/index0/type"
+#define XBYAK_AARCH64_PATH_CACHE_LIST "/sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list"
+#define XBYAK_AARCH64_MIDR_EL1(I, V, A, P, R) ((I << 24) | (V << 20) | (A << 16) | (P << 4) | (R << 0))
+#define XBYAK_AARCH64_READ_SYSREG(var, ID) asm("mrs %0, " #ID : "=r"(var));
+
+class CpuInfoLinux : public CpuInfo {
+public:
+  CpuInfoLinux() {
+    init();
+    setSysRegVal(); // Read MIDR_EL1 before setCacheHierarchy().
+    setNumCores();
+    setHwCap();
+    setCacheHierarchy();
+    setImplementer();
+  }
+
+private:
+  static constexpr int max_path_len = 1024;
+  static constexpr int buf_size = 1024;
+  const struct cacheInfo_v2_t cacheInfoDict[2] = {{/* A64FX */ XBYAK_AARCH64_MIDR_EL1(0x46, 0x1, 0xf, 0x1, 0x0),
+                                                   {{/* L1 */ SeparateCache, {1024 * 64, 1024 * 64, 0}, {1, 1, 0}},
+                                                    {/* L2 */ UnifiedCache, {0, 0, 1024 * 1024 * 8}, {0, 0, 12}},
+                                                    {/* L3 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L4 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L5 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L6 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L7 */ NoCache, {0, 0, 0}, {0, 0, 0}}}},
+                                                  {/* A64FX */ XBYAK_AARCH64_MIDR_EL1(0x46, 0x2, 0xf, 0x1, 0x0),
+                                                   {{/* L1 */ SeparateCache, {1024 * 64, 1024 * 64, 0}, {1, 1, 0}},
+                                                    {/* L2 */ UnifiedCache, {0, 0, 1024 * 1024 * 8}, {0, 0, 12}},
+                                                    {/* L3 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L4 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L5 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L6 */ NoCache, {0, 0, 0}, {0, 0, 0}},
+                                                    {/* L7 */ NoCache, {0, 0, 0}, {0, 0, 0}}}}};
+
+  int getFilePathMaxTailNumPlus1(const char *path) {
+    char dir_path[max_path_len];
+    char file_pattern[max_path_len];
+    int retVal = 0;
+
+    getRegEx(dir_path, path, "/([^/]+/)+");
+    /* Remove last '/'. */
+    dir_path[strlen(dir_path) - 1] = '\0';
+    getRegEx(file_pattern, path, "[^/]+$");
+    strncat(file_pattern, "[0-9]+", 16);
+
+    DIR *dir = opendir(dir_path);
+    struct dirent *dp;
+
+    dp = readdir(dir);
+    while (dp != NULL) {
+      if (getRegEx(dir_path, dp->d_name, file_pattern) == 0)
+        retVal++;
+      dp = readdir(dir);
+    }
+
+    if (dir != NULL)
+      closedir(dir);
+
+    return retVal;
+  }
+
+  void getLineInFile(char *buf, const char *path, const int num) {
+    auto chomp = [](char *ptr, const int num) {
+      for (int i = 0; i < num; i++) {
+        if ('\n' == *(ptr + i))
+          *(ptr + i) = '\0';
+        else if ('\0' == *(ptr + i))
+          break;
+      }
+    };
+
+    FILE *fp = fopen(path, "r");
+    if (!(fp && fread(buf, sizeof(char), num, fp)))
+      buf[0] = '\0';
+
+    chomp(buf, buf_size);
+  }
+
+  /**
+   * Return directory path
+   * @param[in] path ex. /sys/devices/system/node/node
+   * @param[out] buf ex. /sys/devices/system/node
+   */
+  int getRegEx(char *buf, const char *path, const char *regex) {
+    regex_t regexBuf;
+    regmatch_t match[1];
+
+    if (regcomp(&regexBuf, regex, REG_EXTENDED) != 0)
+      throw ERR_INTERNAL;
+
+    const int retVal = regexec(&regexBuf, path, 1, match, 0);
+    regfree(&regexBuf);
+
+    if (retVal != 0)
+      return -1;
+
+    const int startIdx = match[0].rm_so;
+    const int endIdx = match[0].rm_eo;
+
+    /* Something wrong (multiple match or not match) */
+    if (startIdx == -1 || endIdx == -1 || (endIdx - startIdx - 1) < 1)
+      return -1;
+
+    strncpy(buf, path + startIdx, endIdx - startIdx);
+    buf[endIdx - startIdx] = '\0';
+
+    return 0;
+  }
+
+  /* Read the following files and set cacheInfo_.
+     If an error occurs, halfway result are cleared and return false.
+     /sys/devices/system/cpu/cpu0/cache/index[0-9]+/level "1", "2", ...
+     /sys/devices/system/cpu/cpu0/cache/index[0-9]+/size  "32K", "1M"
+     /sys/devices/system/cpu/cpu0/cache/index[0-9]+/type  "Instruction", "Data", "Unified"
+     /sys/devices/system/cpu/cpu0/cache/index[0-9]+/shared_cpu_list "0", "0-1"
+  */
+  bool readCacheInfoFromSysDevice() {
+    char buf0[buf_size];
+    char buf1[buf_size];
+    char buf2[buf_size];
+    struct dirent *dp;
+    DIR *dir = opendir(XBYAK_AARCH64_PATH_CACHE_DIR);
+    if (dir == NULL)
+      goto init_and_return_false;
+
+    dp = readdir(dir);
+    while (dp != NULL) {
+      regex_t regexBuf;
+      regmatch_t match[2];
+
+      if (regcomp(&regexBuf, "index[0-9]*$", REG_EXTENDED) != 0)
+        throw ERR_INTERNAL;
+
+      if (regexec(&regexBuf, dp->d_name, 1, match, 0) == 0) { // Found index[1-9][0-9]. directory
+        char *dir_name = buf0;
+        char *file_name = buf1;
+        char *buf = buf2;
+        char *end_ptr;
+        strncpy(dir_name, XBYAK_AARCH64_PATH_CACHE_DIR, buf_size);
+        strncat(dir_name, "/", 2);
+        strncat(dir_name, dp->d_name + match[0].rm_so, match[0].rm_eo - match[0].rm_so);
+        strncat(dir_name, "/", 2);
+
+        // Get cache level
+        strncpy(file_name, dir_name, buf_size);
+        strncat(file_name, "level", buf_size);
+        getLineInFile(buf, file_name, buf_size);
+        const long int level = strtol(buf, &end_ptr, 10);
+        if ('\0' != *end_ptr) { // Non-numeric characters exist.
+          XBYAK_AARCH64_ERROR_;
+          goto init_and_return_false;
+        }
+
+        // Get cache size
+        strncpy(file_name, dir_name, buf_size);
+        strncat(file_name, "size", buf_size);
+        getLineInFile(buf, file_name, buf_size);
+        long int size = strtol(buf, &end_ptr, 10);
+        if ('\0' != *end_ptr) {
+          if (strncmp(end_ptr, "K", 2) == 0) {
+            size = size * 1024;
+          } else if (strncmp(end_ptr, "M", 2) == 0) {
+            size = size * 1024 * 1024;
+          } else {
+            XBYAK_AARCH64_ERROR_;
+            goto init_and_return_false;
+          }
+        }
+
+        // Get cache type
+        Arm64CacheType type;
+        strncpy(file_name, dir_name, buf_size);
+        strncat(file_name, "type", buf_size);
+        getLineInFile(buf, file_name, buf_size);
+        if (strncmp(buf, "Instruction", buf_size) == 0) {
+          type = InstCacheOnly;
+        } else if (strncmp(buf, "Data", buf_size) == 0) {
+          type = DataCacheOnly;
+        } else if (strncmp(buf, "Unified", buf_size) == 0) {
+          type = UnifiedCache;
+        } else { // Unconsidered text exists.
+          XBYAK_AARCH64_ERROR_;
+          goto init_and_return_false;
+        }
+
+        /* Get cache-sharing cpu list
+           Example0: "0"
+           Example1: "0-7"
+           Example2: "0,64"
+           Example3: "0-31,64-95" */
+        long int start, end;
+        int sharing_cores = 0;
+        strncpy(file_name, dir_name, buf_size);
+        strncat(file_name, "shared_cpu_list", buf_size);
+        getLineInFile(buf, file_name, buf_size);
+        /* Debug:
+           strncpy(buf, "0", buf_size);
+           strncpy(buf, "4-8", buf_size);
+           strncpy(buf, "2,34,111", buf_size);
+           strncpy(buf, "12-23,48-60", buf_size);
+        */
+        end_ptr = buf;
+        while ('\0' != *buf) {
+          printf("%s\n", buf);
+          start = strtol(buf, &end_ptr, 10);
+          if ('\0' == *end_ptr) {
+            sharing_cores += 1;
+            // No more core exists.
+            break;
+          } else if ('-' == *end_ptr) {
+            buf = end_ptr + 1;
+            end = strtol(buf, &end_ptr, 10);
+            sharing_cores += end - start + 1;
+            buf = end_ptr;
+            while (',' == *buf || ' ' == *buf)
+              buf++;
+          } else if (',' == *end_ptr) {
+            buf = end_ptr + 1;
+            sharing_cores += 1;
+          } else {
+            XBYAK_AARCH64_ERROR_;
+            goto init_and_return_false;
+          }
+        }
+
+        auto cache = &cacheInfo_.levelCache[level - 1];
+
+        switch (type) {
+        case UnifiedCache:
+          cache->type = UnifiedCache;
+          cache->size[2] = size;
+          cache->sharingCores[2] = sharing_cores;
+          break;
+        case InstCacheOnly:
+          cache->type = cache->type == DataCacheOnly ? SeparateCache : InstCacheOnly;
+          cache->size[0] = size;
+          cache->sharingCores[0] = sharing_cores;
+          break;
+        case DataCacheOnly:
+          cache->type = cache->type == InstCacheOnly ? SeparateCache : DataCacheOnly;
+          cache->size[1] = size;
+          cache->sharingCores[1] = sharing_cores;
+          break;
+        default:
+          XBYAK_AARCH64_ERROR_;
+          goto init_and_return_false;
+        }
+      }
+
+      regfree(&regexBuf);
+      dp = readdir(dir); // Try next
+    }
+
+    if (dir != NULL)
+      closedir(dir);
+
+    setLastDataCacheLevel();
+    return true;
+
+  init_and_return_false:
+    init(); // Clear halfway result
+    return false;
+  }
+
+  void setCacheHierarchy() {
+    /* Cache size of AArch64 CPUs are described in the system registers,
+       which can't be read from user-space applications.
+       Linux provides `sysconf` API and `/sys/devices/system/cpu/`
+       device files to get cache size, but they dosen't always return
+       correct values. It may depend on Linux kernel version and
+       support status of CPUs. To avoid this situation, cahche size is
+       firstly read from `cacheInfoDict`, secondly get by `sysconf`.
+
+       `sysconf` example
+       #include <unistd.h>
+       int main() {
+         reutrn sysconf(_SC_LEVEL1_DCACHE_SIZE);
+       }
+     */
+    const cacheInfo_v2_t *c = nullptr;
+    const uint64_t midr_el1 = cacheInfo_.midr_el1;
+
+    for (size_t j = 0; j < sizeof(cacheInfoDict) / sizeof(cacheInfo_v2_t); j++) {
+      if (cacheInfoDict[j].midr_el1 == midr_el1) {
+        c = cacheInfoDict + j;
+        break;
+      }
+    }
+
+    if (c != nullptr) {
+      for (size_t i = 0; i < maxCacheLevel; i++) {
+        auto dict = &c->levelCache[i];
+        auto cache = &cacheInfo_.levelCache[i];
+        cache->type = dict->type;
+
+        switch (dict->type) {
+        case InstCacheOnly:
+          cache->size[0] = dict->size[0];
+          cache->sharingCores[0] = dict->sharingCores[0];
+          break;
+        case DataCacheOnly:
+          cache->size[1] = dict->size[1];
+          cache->sharingCores[1] = dict->sharingCores[1];
+          break;
+        case SeparateCache:
+          cache->size[0] = dict->size[0];
+          cache->size[1] = dict->size[1];
+          cache->sharingCores[0] = dict->sharingCores[0];
+          cache->sharingCores[1] = dict->sharingCores[1];
+          break;
+        case UnifiedCache:
+          cache->size[2] = dict->size[2];
+          cache->sharingCores[2] = dict->sharingCores[2];
+          break;
+        default:
+          // Do nothing
+          break;
+        }
+        lastDataCacheLevel_ = (dict->size[1] || dict->size[2]) ? i + 1 : lastDataCacheLevel_;
+      }
+    } else if (!readCacheInfoFromSysDevice()) {
+      /**
+       * @ToDo Get chache information by `sysconf`
+       * for the case thd dictionary is unavailable.
+       */
+      lastDataCacheLevel_ = 2; // It is assumed L1 and L2 cache exist.
+
+      cacheInfo_.levelCache[0].size[0] = sysconf(_SC_LEVEL1_ICACHE_SIZE); // L1, ICache
+      cacheInfo_.levelCache[0].size[1] = sysconf(_SC_LEVEL1_DCACHE_SIZE); // L1, DCache
+      cacheInfo_.levelCache[1].size[2] = sysconf(_SC_LEVEL2_CACHE_SIZE);  // L2, UCache
+      cacheInfo_.levelCache[2].size[2] = sysconf(_SC_LEVEL3_CACHE_SIZE);  // L3, UCache
+    }
+  }
+
+  void setHwCap() {
+    unsigned long hwcap = getauxval(AT_HWCAP);
+    if (hwcap & HWCAP_ATOMICS) {
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_ATOMIC;
+    }
+
+    if (hwcap & HWCAP_FP) {
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_FP;
+    }
+    if (hwcap & HWCAP_ASIMD) {
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
+    }
+#ifdef HWCAP_SVE
+    /* Some old <sys/auxv.h> may not define HWCAP_SVE.
+       In that case, SVE is treated as if it were not supported. */
+    if (hwcap & HWCAP_SVE) {
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_SVE;
+      // svcntb(); if arm_sve.h is available
+      sveLen_ = (sveLen_t)prctl(51); // PR_SVE_GET_VL
+    }
+#endif
+  }
+
+  void setNumCores() {
+    /**
+     * @ToDo There are some methods to get # of cores.
+     Considering various kernel versions and CPUs, a combination of
+     multiple methods may be required.
+     1) sysconf(_SC_NPROCESSORS_ONLN)
+     2) /sys/devices/system/cpu/online
+     3) std::thread::hardware_concurrency()
+    */
+    numCores_[0] = numCores_[1] = sysconf(_SC_NPROCESSORS_ONLN);
+  }
+
+  void setSysRegVal() { XBYAK_AARCH64_READ_SYSREG(cacheInfo_.midr_el1, MIDR_EL1); }
+};
+
+#undef XBYAK_AARCH64_ERROR_
+} // namespace util
+} // namespace Xbyak_aarch64

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_mac.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_mac.h
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright 2020-2023 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+#ifndef __APPLE__
+#error "Something wrong"
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/sysctl.h>
+
+#include "xbyak_aarch64_err.h"
+#include "xbyak_aarch64_util.h"
+
+namespace Xbyak_aarch64 {
+namespace util {
+constexpr char hw_cacheconfig[] = "hw.cacheconfig";
+constexpr char hw_l1icachesize[] = "hw.l1icachesize";
+constexpr char hw_l1dcachesize[] = "hw.l1dcachesize";
+constexpr char hw_l2cachesize[] = "hw.l2cachesize";
+constexpr char hw_l3cachesize[] = "hw.l3cachesize";
+constexpr char hw_ncpu[] = "hw.ncpu";
+constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
+constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
+constexpr char hw_opt_neon[] = "hw.optional.neon";
+constexpr char hw_perflevel1_logicalcpu[] = "hw.perflevel1.logicalcpu";
+
+class CpuInfoMac : public CpuInfo {
+public:
+  CpuInfoMac() {
+    init();
+    cacheInfo_.midr_el1 = 0xFE << 24;
+    setNumCores();
+    setHwCap();
+    setCacheHierarchy();
+    setImplementer();
+  }
+
+private:
+  uint8_t sysInfoBuf_[128];
+
+  int getSysInfo(char const *name, const size_t len) {
+    size_t len_ = len;
+    int retVal;
+
+    if ((retVal = sysctlbyname(name, sysInfoBuf_, &len_, NULL, 0)) != 0)
+      memset(sysInfoBuf_, 0, sizeof(sysInfoBuf_));
+
+    return retVal;
+  }
+
+  void setCacheHierarchy() {
+    // L1 cache
+    cacheInfo_.levelCache[0].type = SeparateCache;
+    getSysInfo(hw_l1icachesize, sizeof(sysInfoBuf_));
+    cacheInfo_.levelCache[0].size[0] = ((int64_t *)sysInfoBuf_)[0];
+    getSysInfo(hw_l1dcachesize, sizeof(sysInfoBuf_));
+    cacheInfo_.levelCache[0].size[1] = ((int64_t *)sysInfoBuf_)[0];
+
+    // L2 cache
+    cacheInfo_.levelCache[1].type = UnifiedCache;
+    getSysInfo(hw_l2cachesize, sizeof(sysInfoBuf_));
+    cacheInfo_.levelCache[1].size[2] = ((int64_t *)sysInfoBuf_)[0];
+
+    // L3 cache
+    cacheInfo_.levelCache[2].type = UnifiedCache;
+    getSysInfo(hw_l3cachesize, sizeof(sysInfoBuf_));
+    cacheInfo_.levelCache[2].size[2] = ((int64_t *)sysInfoBuf_)[0];
+
+    for (size_t i = 0; i < maxCacheLevel; i++) {
+      const auto cache = &cacheInfo_.levelCache[i];
+      if (cache->size[1] || cache->size[2])
+        lastDataCacheLevel_ = i + 1;
+    }
+
+    getSysInfo(hw_cacheconfig, sizeof(sysInfoBuf_));
+    // L1
+    cacheInfo_.levelCache[0].sharingCores[0] = ((uint64_t *)sysInfoBuf_)[1];
+    cacheInfo_.levelCache[0].sharingCores[1] = ((uint64_t *)sysInfoBuf_)[1];
+    // L2
+    cacheInfo_.levelCache[1].sharingCores[2] = ((uint64_t *)sysInfoBuf_)[2];
+    // L3
+    cacheInfo_.levelCache[2].sharingCores[2] = ((uint64_t *)sysInfoBuf_)[3];
+  }
+
+  void setHwCap() {
+    size_t val = 0;
+    size_t len = sizeof(val);
+
+    if (sysctlbyname(hw_opt_atomics, &val, &len, NULL, 0) != 0)
+      throw Error(ERR_INTERNAL);
+    else
+      type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_ATOMIC : 0;
+
+    if (sysctlbyname(hw_opt_fp, &val, &len, NULL, 0) != 0)
+      throw Error(ERR_INTERNAL);
+    else
+      type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_FP : 0;
+
+    if (sysctlbyname(hw_opt_neon, &val, &len, NULL, 0) != 0)
+      throw Error(ERR_INTERNAL);
+    else
+      type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_ADVSIMD : 0;
+  }
+
+  void setNumCores() {
+    // ToDo: Distinguish physical and logical cores
+    getSysInfo(hw_ncpu, sizeof(int32_t));
+    numCores_[0] = numCores_[1] = ((int32_t *)sysInfoBuf_)[0];
+  }
+};
+
+} // namespace util
+} // namespace Xbyak_aarch64

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_windows.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_windows.h
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright 2022-2023 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+#ifndef _M_ARM64
+#error "Something wrong"
+#endif
+
+#include "xbyak_aarch64_err.h"
+#include "xbyak_aarch64_util.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <malloc.h>
+#include <windows.h>
+
+namespace Xbyak_aarch64 {
+namespace util {
+
+class CpuInfoWindows : public CpuInfo {
+public:
+  CpuInfoWindows() {
+    init();
+    setCacheHierarchy();
+    setImplementer();
+  }
+
+private:
+  void setCacheHierarchy() {
+    DWORD bufSize = 0;
+    GetLogicalProcessorInformation(NULL, &bufSize);
+    auto *ptr = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)_alloca(bufSize);
+    if (GetLogicalProcessorInformation(ptr, &bufSize) == FALSE)
+      return;
+
+    DWORD offset = 0;
+    while (offset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) <= bufSize) {
+      switch (ptr->Relationship) {
+      case RelationProcessorCore:
+        numCores_[1]++;
+        break;
+
+      case RelationCache: {
+        const auto cache = &ptr->Cache;
+        auto levelCache = &cacheInfo_.levelCache[cache->Level - 1];
+        ULONG_PTR mask = ptr->ProcessorMask;
+        int count = 0;
+        while (mask) {
+          count += (mask & 0x1) ? 1 : 0;
+          mask = mask >> 1;
+        }
+
+        switch (cache->Type) {
+        case CacheUnified:
+          levelCache->type = UnifiedCache;
+          levelCache->size[2] = cache->Size;
+          levelCache->sharingCores[2] = count;
+          break;
+        case CacheInstruction:
+          levelCache->type = levelCache->type == DataCacheOnly ? SeparateCache : InstCacheOnly;
+          levelCache->size[0] = cache->Size;
+          levelCache->sharingCores[0] = count;
+          break;
+        case CacheData:
+          levelCache->type = levelCache->type == InstCacheOnly ? SeparateCache : DataCacheOnly;
+          levelCache->size[1] = cache->Size;
+          levelCache->sharingCores[1] = count;
+          break;
+        default:
+          break;
+        }
+      }
+      }
+      offset += sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+      ptr++;
+    }
+    numCores_[0] = numCores_[1];
+
+    setLastDataCacheLevel();
+  }
+};
+
+} // namespace util
+} // namespace Xbyak_aarch64

--- a/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_impl.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_impl.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2022 FUJITSU LIMITED
+ * Copyright 2020-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4259,4 +4259,14 @@ void CodeGenerator::SveStorePredVec(const _ZReg &zt, const AdrScImm &adr) {
 void CodeGenerator::SveStorePredVec(const _ZReg &zt, const AdrNoOfs &adr) {
   uint32_t code = concat({F(0x72, 25), F(3, 23), F(0, 16), F(2, 13), F(0, 10), F(adr.getXn().getIdx(), 5), F(zt.getIdx(), 0)});
   dd(code);
+}
+
+void CodeGenerator::clearCache(void *begin, void *end) {
+#ifdef _WIN32
+  FlushInstructionCache(GetCurrentProcess(), begin, ((char *)end) - ((char *)begin));
+#elif defined(__APPLE__)
+  sys_icache_invalidate(begin, ((char *)end) - ((char *)begin));
+#else
+  __builtin___clear_cache((char *)begin, (char *)end);
+#endif
 }

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
@@ -1,6 +1,6 @@
 #pragma once
 /*******************************************************************************
- * Copyright 2019-2021 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #undef mvn
 #endif
@@ -51,6 +53,7 @@
 #include <unistd.h>
 #endif
 
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 
@@ -65,6 +68,8 @@
 #define MAP_JIT 0x800
 #endif
 #endif
+
+#include "xbyak_aarch64_err.h"
 
 namespace Xbyak_aarch64 {
 const uint64_t SP_IDX = 31;

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h
@@ -1,6 +1,6 @@
 #pragma once
 /*******************************************************************************
- * Copyright 2019-2022 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_reg.h"
 
 enum ShMod { LSL = 0, LSR = 1, ASR = 2, ROR = 3, MSL = 4, NONE = 5 };

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -1,6 +1,6 @@
 #pragma once
 /*******************************************************************************
- * Copyright 2019-2021 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * limitations under the License.
  *******************************************************************************/
 
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_inner.h"
 
 static const size_t CSIZE = sizeof(uint32_t);

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_err.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_err.h
@@ -1,6 +1,6 @@
 #pragma once
 /*******************************************************************************
- * Copyright 2019-2021 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  * limitations under the License.
  *******************************************************************************/
 #include <exception>
+
+namespace Xbyak_aarch64 {
 
 enum {
   ERR_NONE = 0,
@@ -54,49 +56,11 @@ class Error : public std::exception {
   const char *msg_;
 
 public:
-  explicit Error(int err) : err_(err), msg_("") {
-    if (err_ <= 0)
-      return;
-    fprintf(stderr, "bad err=%d in Xbyak::Error\n", err_);
-    static const char *tbl[32] = {
-        "none",
-        "code is too big",
-        "label is redefined",
-        "label is too far",
-        "label is not found",
-        "bad parameter",
-        "can't protect",
-        "offset is too big",
-        "can't alloc",
-        "label is not set by L()",
-        "label is already set by L()",
-        "internal error",
-        "illegal register index (can not encoding register index)",
-        "illegal register element index (can not encoding element index)",
-        "illegal predicate register type",
-        "illegal immediate parameter (range error)",
-        "illegal immediate parameter (unavailable value error)",
-        "illegal immediate parameter (condition error)",
-        "illegal shift-mode paramater",
-        "illegal extend-mode parameter",
-        "illegal condition parameter",
-        "illegal barrier option",
-        "illegal const parameter (range error)",
-        "illegal const parameter (unavailable error)",
-        "illegal const parameter (condition error)",
-        "illegal type",
-        "bad align",
-        "bad addressing",
-        "bad scale",
-    };
-    if ((size_t)err_ >= sizeof(tbl) / sizeof(tbl[0])) {
-      msg_ = "bad err num";
-    } else {
-      msg_ = tbl[err_];
-    }
-  }
+  explicit Error(int err);
   operator int() const { return err_; }
   const char *what() const throw() { return msg_; }
 };
 
 inline const char *ConvertErrorToString(const Error &err) { return err.what(); }
+
+} // namespace Xbyak_aarch64

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -1,6 +1,6 @@
 #pragma once
 /*******************************************************************************
- * Copyright 2019-2022 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 
 #include "xbyak_aarch64_adr.h"
 #include "xbyak_aarch64_code_array.h"
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_label.h"
 #include "xbyak_aarch64_reg.h"
 
@@ -740,8 +739,6 @@ public:
     labelMgr_.set(this);
   }
 
-  unsigned int getVersion() const { return VERSION; }
-
   void L(Label &label) { labelMgr_.defineClabel(label); }
   Label L() {
     Label label;
@@ -771,16 +768,7 @@ public:
     labelMgr_.set(this);
   }
   bool hasUndefinedLabel() const { return labelMgr_.hasUndefClabel(); }
-  void clearCache(void *begin, void *end) {
-#ifdef _WIN32
-    (void)begin;
-    (void)end;
-#elif defined(__APPLE__)
-    sys_icache_invalidate(begin, ((char *)end) - ((char *)begin));
-#else
-    __builtin___clear_cache((char *)begin, (char *)end);
-#endif
-  }
+  void clearCache(void *begin, void *end);
   /*
           MUST call ready() to complete generating code if you use AutoGrow
      mode.
@@ -842,6 +830,7 @@ public:
 
 #include "xbyak_aarch64_meta_mnemonic.h"
 #include "xbyak_aarch64_mnemonic_def.h"
+#include "xbyak_aarch64_version.h"
 
   void align(size_t x) {
     if (x == 4)

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
@@ -1,6 +1,6 @@
 #pragma once
 /*******************************************************************************
- * Copyright 2019-2021 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  * limitations under the License.
  *******************************************************************************/
 
-enum {
-  DEFAULT_MAX_CODE_SIZE = 4096,
-  VERSION = 0x5800 /* 0xABCD = A.BC(D) */
-};
+enum { DEFAULT_MAX_CODE_SIZE = 4096 };
 
 namespace inner {
 

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_label.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019-2021 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #define _XBYAK_AARCH64_LABEL_
 
 #include "xbyak_aarch64_code_array.h"
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_inner.h"
 
 struct JmpLabel {

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
@@ -1,6 +1,6 @@
 #pragma once
 /*******************************************************************************
- * Copyright 2020-2022 FUJITSU LIMITED
+ * Copyright 2020-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,46 +17,24 @@
 #ifndef XBYAK_AARCH64_UTIL_H_
 #define XBYAK_AARCH64_UTIL_H_
 
-#include <dirent.h>
-#include <regex.h>
+#if !(defined(__linux__) || defined(__APPLE__) || defined(_M_ARM64))
+#error "Unsupported OS"
+#endif
+
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#ifdef __linux__
-#include <sys/auxv.h>
-#include <sys/prctl.h>
-#include <unistd.h>
-
-/* In old Linux such as Ubuntu 16.04, HWCAP_ATOMICS, HWCAP_FP, HWCAP_ASIMD
-   can not be found in <bits/hwcap.h> which is included from <sys/auxv.h>.
-   Xbyak_aarch64 uses <asm/hwcap.h> as an alternative.
- */
-#ifndef HWCAP_FP
-#include <asm/hwcap.h>
-#endif
-
-#elif defined(__APPLE__)
-#include <sys/sysctl.h>
-#endif
-
-#include "xbyak_aarch64_err.h"
-
-#define XBYAK_AARCH64_MIDR_EL1(I, V, A, P, R) ((I << 24) | (V << 20) | (A << 16) | (P << 4) | (R << 0))
-#define XBYAK_AARCH64_PATH_NODES "/sys/devices/system/node/node"
-#define XBYAK_AARCH64_PATH_CORES "/sys/devices/system/node/node0/cpu"
-#define XBYAK_AARCH64_READ_SYSREG(var, ID) asm("mrs %0, " #ID : "=r"(var));
 
 namespace Xbyak_aarch64 {
 namespace util {
 typedef uint64_t Type;
 
-constexpr uint32_t maxNumberCacheLevel = 4;
+constexpr uint32_t maxCacheLevel = 7; // Specification of Armv9
 constexpr uint32_t maxTopologyLevel = 2;
 constexpr uint32_t max_path_len = 1024;
 
 enum Arm64CpuTopologyLevel { SmtLevel = 1, CoreLevel = 2 };
+enum Arm64CacheType { NoCache = 0, InstCacheOnly = 1, DataCacheOnly = 2, SeparateCache = 3, UnifiedCache = 4, OtherCache = 5 };
+enum Arm64CacheLevel { L1 = 1, L2, L3, L4, L5, L6, L7 };
+enum cacheType_t { ICache = 0, DCache = 1, UCache = 2 };
 
 enum sveLen_t {
   SVE_NONE = 0,
@@ -78,82 +56,58 @@ enum sveLen_t {
   SVE_2048 = 16 * 16,
 };
 
+enum hwCap_t {
+  XBYAK_AARCH64_HWCAP_NONE = 0,
+  XBYAK_AARCH64_HWCAP_ADVSIMD = 1 << 1,
+  XBYAK_AARCH64_HWCAP_FP = 1 << 2,
+  XBYAK_AARCH64_HWCAP_SVE = 1 << 3,
+  XBYAK_AARCH64_HWCAP_ATOMIC = 1 << 4,
+};
+
 struct implementer_t {
   uint32_t id;
   const char *implementer;
 };
 
-struct cacheInfo_t {
+/* 2023.02.11
+   cacheInfo_t does not need to be disclosed. */
+#if defined(__GNUC__) || defined(__clang_version__)
+struct __attribute__((deprecated)) cacheInfo_t {
+#elif defined(_MSC_VER)
+struct __declspec(deprecated) cacheInfo_t {
+#endif
   uint64_t midr_el1;
   uint32_t dataCacheLevel;
   uint32_t highestInnerCacheLevel;
-  uint32_t dataCacheSize[maxNumberCacheLevel];
+  uint32_t dataCacheSize[maxCacheLevel];
 };
-
-#ifdef __APPLE__
-constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
-constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
-constexpr char hw_opt_neon[] = "hw.optional.neon";
-#endif
-
-const struct implementer_t implementers[] = {{0x00, "Reserved for software use"},
-                                             {0xC0, "Ampere Computing"},
-                                             {0x41, "Arm Limited"},
-                                             {0x42, "Broadcom Corporation"},
-                                             {0x43, "Cavium Inc."},
-                                             {0x44, "Digital Equipment Corporation"},
-                                             {0x46, "Fujitsu Ltd."},
-                                             {0x49, "Infineon Technologies AG"},
-                                             {0x4D, "Motorola or Freescale Semiconductor Inc."},
-                                             {0x4E, "NVIDIA Corporation"},
-                                             {0x50, "Applied Micro Circuits Corporation"},
-                                             {0x51, "Qualcomm Inc."},
-                                             {0x56, "Marvell International Ltd."},
-                                             {0x69, "Intel Corporation"}};
 
 /**
    CPU detection class
 */
+class CpuInfo;
 class Cpu {
-  uint64_t type_;
-  sveLen_t sveLen_;
-
 private:
-  const struct cacheInfo_t cacheInfoDict[2] = {
-      {/* A64FX */ XBYAK_AARCH64_MIDR_EL1(0x46, 0x1, 0xf, 0x1, 0x0), 2, 1, {1024 * 64, 1024 * 1024 * 8 * 4, 0, 0}},
-      {/* A64FX */ XBYAK_AARCH64_MIDR_EL1(0x46, 0x2, 0xf, 0x1, 0x0), 2, 1, {1024 * 64, 1024 * 1024 * 8 * 4, 0, 0}},
-  };
-
-  uint32_t coresSharingDataCache_[maxNumberCacheLevel];
-  uint32_t dataCacheSize_[maxNumberCacheLevel];
-  uint32_t dataCacheLevel_;
-  uint64_t midr_el1_;
-  uint32_t numCores_[maxTopologyLevel];
-
-  void setCacheHierarchy();
-  void setNumCores();
-  void setSysRegVal();
-  int getRegEx(char *buf, const char *path, const char *regex);
-  int getFilePathMaxTailNumPlus1(const char *path);
+  CpuInfo *info;
 
 public:
-  static const Type tNONE = 0;
-  static const Type tADVSIMD = 1 << 1;
-  static const Type tFP = 1 << 2;
-  static const Type tSVE = 1 << 3;
-  static const Type tATOMIC = 1 << 4;
-
   Cpu();
 
-  Type getType() const;
-  bool has(Type type) const;
-  uint64_t getSveLen() const;
-  bool isAtomicSupported() const;
+  void dumpCacheInfo() const;
+  Arm64CacheType getCacheType(const Arm64CacheLevel i) const;
+  uint32_t getCoresSharingDataCache(const Arm64CacheLevel i) const;
+  /* 2023.02.11 */
+#if defined(__GNUC__) || defined(__clang_version__)
+  uint32_t __attribute__((deprecated("Please use getLastDataCacheLevel()"))) getDataCacheLevels() const;
+#endif
+  uint32_t getDataCacheSize(const Arm64CacheLevel i) const;
   const char *getImplementer() const;
-  uint32_t getCoresSharingDataCache(uint32_t i) const;
-  uint32_t getDataCacheLevels() const;
-  uint32_t getDataCacheSize(uint32_t i) const;
+  uint32_t getLastDataCacheLevel() const;
   uint32_t getNumCores(Arm64CpuTopologyLevel level) const;
+  Type getType() const;
+  uint64_t getSveLen() const;
+  bool has(Type type) const;
+  bool isAtomicSupported() const;
 };
 
 } // namespace util

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_version.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_version.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2023 FUJITSU LIMITED
+ * Copyright 2022-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-#define XBYAK_AARCH64_MAKE_INSTANCE
-#include "xbyak_aarch64.h"
-#include <memory.h>
-#include <stdio.h>
-#ifdef _WIN32
-#include <intrin.h>
-#include <processthreadsapi.h> // FlushInstructionCache
-#endif
-
-namespace Xbyak_aarch64 {
-
-#include "err_impl.h"
-#include "xbyak_aarch64_impl.h"
-#include "xbyak_aarch64_mnemonic.h"
-
-} // namespace Xbyak_aarch64
+static const int majorVersion = 1;
+static const int minorVersion = 0;
+static const int patchVersion = 0;
+static int getVersion() { return (majorVersion << 16) + (minorVersion << 8) + patchVersion; }
+static const char *getVersionString() { return "1.0.0"; }

--- a/src/cpu/reorder/cpu_reorder_comp_f32_s8.cpp
+++ b/src/cpu/reorder/cpu_reorder_comp_f32_s8.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,6 +28,7 @@ const impl_list_map_t &comp_f32_s8_impl_list_map() {
         // f32 -> s8
         {{f32, s8, 2}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(f32, oi, s8, OI4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, io, s8, OI4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, oi, s8, OI4i32o4i, fmt_order::keep, spec::conv_req_comp))
@@ -46,6 +48,7 @@ const impl_list_map_t &comp_f32_s8_impl_list_map() {
         // f32 -> s8
         {{f32, s8, 3}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(f32, any, s8, wio, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, iwo, s8, OIw4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, iwo, s8, OIw4i32o4i, fmt_order::keep, spec::conv_req_comp))
@@ -83,6 +86,7 @@ const impl_list_map_t &comp_f32_s8_impl_list_map() {
         }},
         {{f32, s8, 4}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(f32, any, s8, hwio, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, any, s8, wigo, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, goiw, s8, gOIw4i16o4i, fmt_order::keep, spec::conv_req_comp))
@@ -131,6 +135,7 @@ const impl_list_map_t &comp_f32_s8_impl_list_map() {
         }},
         {{f32, s8, 5}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
 
             DNNL_NON_X64_ONLY(REG_SR(f32, any, s8, hwigo, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, any, s8, dhwio, fmt_order::keep, spec::conv_req_comp))
@@ -177,6 +182,7 @@ const impl_list_map_t &comp_f32_s8_impl_list_map() {
         }},
         {{f32, s8, 6}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(f32, any, s8, dhwigo, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, goidhw, s8, gOIdhw4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(f32, goidhw, s8, gOIdhw2i8o4i, fmt_order::keep, spec::conv_req_comp))

--- a/src/cpu/reorder/cpu_reorder_comp_s8_s8.cpp
+++ b/src/cpu/reorder/cpu_reorder_comp_s8_s8.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,6 +29,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
         {{s8, s8, 2}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_matrix_B_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, oi, s8, OI4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, io, s8, OI4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, oi, s8, OI4i32o4i, fmt_order::keep, spec::conv_req_comp))
@@ -49,6 +51,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
         {{s8, s8, 3}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_matrix_B_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, wio, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, iwo, s8, OIw4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, iwo, s8, OIw4i32o4i, fmt_order::keep, spec::conv_req_comp))
@@ -86,6 +89,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
         }},
         {{s8, s8, 4}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, hwio, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, wigo, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, goiw, s8, gOIw4i16o4i, fmt_order::keep, spec::conv_req_comp))
@@ -134,6 +138,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
         }},
         {{s8, s8, 5}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, hwigo, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, dhwio, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, goihw, s8, gOIhw4i16o4i, fmt_order::keep, spec::conv_req_comp))
@@ -179,6 +184,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
         }},
         {{s8, s8, 6}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, dhwigo, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, goidhw, s8, gOIdhw4i16o4i, fmt_order::keep, spec::conv_req_comp))
             DNNL_NON_X64_ONLY(REG_SR(s8, goidhw, s8, gOIdhw2i8o4i, fmt_order::keep, spec::conv_req_comp))


### PR DESCRIPTION
# Description

This PR supports injectors, zp_compensation, dst_scale for integer convolution. 
The following PRs may be required before merge this PR.
- https://github.com/oneapi-src/oneDNN/pull/1556 
- https://github.com/oneapi-src/oneDNN/pull/1557 
- https://github.com/oneapi-src/oneDNN/pull/1558 
- https://github.com/oneapi-src/oneDNN/pull/1559
- https://github.com/oneapi-src/oneDNN/pull/1561

Thank you.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

`./test_iface_attr_quantization --gtest_filter="attr_quantization_test_t.TestConvGroup"` failed. I'm fixing it.

