### PR TITLE
cuDNN bf16 support for Eltwise

### DIFF
--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -38,6 +38,7 @@ The following table documents the supported data types.
 | f32       | Training, Inference         |
 | f16       | Inference                   |
 | s8        | Inference (when applicable) |
+| bf16      | Training, Inference         |
 
 ## Supported Primitives and Implementation Limitations
 

--- a/src/gpu/nvidia/cudnn_pooling.cpp
+++ b/src/gpu/nvidia/cudnn_pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
 * Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,12 @@ status_t cudnn_pooling_fwd_t::execute(const exec_ctx_t &ctx) const {
                     auto val = nstl::numeric_limits<int8_t>::lowest();
                     cuMemsetD8Async(reinterpret_cast<CUdeviceptr>(dst),
                             reinterpret_cast<unsigned char &>(val),
+                            dst_wrap.nelems(),
+                            cuda_stream->get_underlying_stream());
+                } else if (dst_wrap.data_type() == data_type_t::dnnl_bf16) {
+                    bfloat16_t val = nstl::numeric_limits<bfloat16_t>::lowest();
+                    cuMemsetD32Async(reinterpret_cast<CUdeviceptr>(dst),
+                            reinterpret_cast<unsigned short &>(val),
                             dst_wrap.nelems(),
                             cuda_stream->get_underlying_stream());
                 }


### PR DESCRIPTION
### Adding support for bf16 the oneDNN Eltwise primitive.

**Supported scope:
Supported Data Types:**
Forward : bf16
Backward : bf16

**Testing scope:**
benchdnn: Passed

**Supported GPU for bf16**
NVIDIA A100

**Test output file:**
[test_eltwise_all.txt](https://github.com/oneapi-src/oneDNN/files/10857487/test_eltwise_all.txt)

**Tested Hardware:**
GPU: NVIDIA A100

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?


