### PR TITLE
added bf16 support for cuDNN reorder

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_utils.cpp
+++ b/src/gpu/nvidia/sycl_cuda_utils.cpp
@@ -58,6 +58,15 @@ bool attr_post_ops_ok(const primitive_attr_t *attr) {
     }
 }
 
+bool has_bf16_support(const ::sycl::device &dev) {
+    // This function checks compute capabilities of the given device.
+    // BF16 is supported starting with compute capabilities 8.0.
+    auto cuda_dev = compat::get_native<CUdevice>(dev);
+    cudaDeviceProp prop {};
+    cudaGetDeviceProperties(&prop, cuda_dev);
+    return prop.major >= 8;
+}
+
 } // namespace nvidia
 } // namespace gpu
 } // namespace impl

--- a/src/gpu/nvidia/sycl_cuda_utils.hpp
+++ b/src/gpu/nvidia/sycl_cuda_utils.hpp
@@ -58,6 +58,7 @@ namespace nvidia {
             .get_access<::sycl::access::mode::read_write>(cgh)
 
 bool compare_cuda_devices(const ::sycl::device &lhs, const ::sycl::device &rhs);
+bool has_bf16_support(const ::sycl::device &dev);
 
 // Check if the device type matches the passed engine kind
 inline status_t check_device(dnnl::impl::engine_kind_t eng_kind) {
@@ -162,6 +163,9 @@ static status_t convert_data_type(const memory_desc_t *mem_desc,
     switch (mem_desc->data_type) {
         case dnnl_data_type_t::dnnl_f16:
             *cudnn_data_type = cudnnDataType_t::CUDNN_DATA_HALF;
+            break;
+        case dnnl_data_type_t::dnnl_bf16:
+            *cudnn_data_type = cudnnDataType_t::CUDNN_DATA_BFLOAT16;
             break;
         case dnnl_data_type_t::dnnl_f32:
             *cudnn_data_type = cudnnDataType_t::CUDNN_DATA_FLOAT;


### PR DESCRIPTION
### Adding support for bf16 the oneDNN Reorder primitive.

**Supported scope:**
**Supported Data Types:** bf16

sdt=bf16 and ddt=bf16, f32, s8
sdt=bf16, f32, s8 and ddt=bf16

**Non Supported Data Types:** 

sdt=bf16 and ddt=f16
sdt=f16 and ddt=bf16

**Testing scope:**
benchdnn: Passed

**Supported GPU for bf16:**
NVIDIA A100

**Test output file:**
[test_reorder_all_result.txt](https://github.com/oneapi-src/oneDNN/files/10868643/test_reorder_all_result.txt)
[test_reorder_ci_result.txt](https://github.com/oneapi-src/oneDNN/files/10868645/test_reorder_ci_result.txt)

**Tested Hardware:**
GPU: NVIDIA A100

**General**
- [x] Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally for each commit?
- [x] Have you formatted the code using clang-format?