### PR TITLE
Added bf16 support for cuDNN inner product

### DIFF
--- a/src/gpu/nvidia/cudnn_gemm_inner_product_impl.hpp
+++ b/src/gpu/nvidia/cudnn_gemm_inner_product_impl.hpp
@@ -55,6 +55,9 @@ protected:
         switch (cudnn_dt) {
             case CUDNN_DATA_FLOAT: blas_dt = CUDA_R_32F; return status::success;
             case CUDNN_DATA_HALF: blas_dt = CUDA_R_16F; return status::success;
+            case CUDNN_DATA_BFLOAT16:
+                blas_dt = CUDA_R_16BF;
+                return status::success;
             case CUDNN_DATA_INT8: blas_dt = CUDA_R_8I; return status::success;
             case CUDNN_DATA_INT8x4: blas_dt = CUDA_R_8I; return status::success;
             default: return status::unimplemented;


### PR DESCRIPTION
### Adding support for bf16 the oneDNN InnerProduct primitive.

**Supported scope:
Supported Data Types:**
Forward : bf16 
FWD_D : bf16bf16f32 , s8s8bf16
Backward : bf16
BWD_D : f32bf16bf16 ,  bf16bf16bf16

**Non Supported Data Type:**
FWD_D : bf16bf16bf16
BWD_D : s8s8bf16

**Testing scope:**
benchdnn: Passed

**Supported GPU for bf16**
NVIDIA A100, Testla T4 

**Tested Hardware:**
GPU : NVIDIA A100
Failed Testcase are tested on GPU : Nvidia Testla T4

**Test output file on A100 GPU:**
[test_ip_all_result.txt](https://github.com/oneapi-src/oneDNN/files/10870120/test_ip_all_result.txt)
[test_ip_bfloat16_result.txt](https://github.com/oneapi-src/oneDNN/files/10870121/test_ip_bfloat16_result.txt)
[test_ip_ci_result.txt](https://github.com/oneapi-src/oneDNN/files/10870122/test_ip_ci_result.txt)

**Few Case which failed on A100 are tested on Testla T4 gpu , those were passing.**
[test_ip_on_Testla_T4.txt](https://github.com/oneapi-src/oneDNN/files/10870198/test_ip_on_Testla_T4.txt)

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

