### PR TITLE
Nvidia Backend: bf16 datatype support added for Pooling

### DIFF
--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -38,6 +38,7 @@ The following table documents the supported data types.
 | f32       | Training, Inference         |
 | f16       | Inference                   |
 | s8        | Inference (when applicable) |
+| bf16      | Training, Inference         |
 
 ## Supported Primitives and Implementation Limitations
 

--- a/src/gpu/nvidia/cudnn_pooling.cpp
+++ b/src/gpu/nvidia/cudnn_pooling.cpp
@@ -70,6 +70,11 @@ status_t cudnn_pooling_fwd_t::execute(const exec_ctx_t &ctx) const {
                             reinterpret_cast<unsigned char &>(val),
                             dst_wrap.nelems(),
                             cuda_stream->get_underlying_stream());
+                } else if (dst_wrap.data_type() == data_type_t::dnnl_bf16) {
+                    auto val = nstl::numeric_limits<float>::lowest();
+                    cuMemsetD32Async(reinterpret_cast<CUdeviceptr>(dst),
+                            reinterpret_cast<int &>(val), dst_wrap.nelems(),
+                            cuda_stream->get_underlying_stream());
                 }
             });
         });

--- a/src/gpu/nvidia/cudnn_pooling.hpp
+++ b/src/gpu/nvidia/cudnn_pooling.hpp
@@ -81,6 +81,8 @@ struct cudnn_pooling_fwd_t : public primitive_t {
 
             assert(engine->kind() == engine_kind::gpu);
             auto src_dt = src_md()->data_type;
+            auto *sycl_engine
+                    = utils::downcast<impl::sycl::sycl_engine_base_t *>(engine);
 
             bool ok = true && is_fwd()
                     && utils::one_of(desc()->prop_kind, forward_training,
@@ -88,13 +90,17 @@ struct cudnn_pooling_fwd_t : public primitive_t {
                     && utils::one_of(desc()->alg_kind, pooling_max,
                             pooling_avg_include_padding,
                             pooling_avg_exclude_padding)
-                    && utils::one_of(src_dt, s8, f16, f32)
+                    && utils::one_of(src_dt, s8, f16, f32, bf16)
                     && src_dt == dst_md()->data_type
                     && IMPLICATION(utils::one_of(src_dt, f16),
                             desc()->prop_kind == forward_inference)
                     && IMPLICATION(src_dt == s8, desc()->accum_data_type == s32)
                     && !is_dilated() && attr()->has_default_values()
-                    && set_default_params() == status::success && blocking_ok();
+                    && set_default_params() == status::success && blocking_ok()
+                    && IMPLICATION(
+                            utils::one_of(data_type::bf16, src_md()->data_type,
+                                    dst_md()->data_type),
+                            has_bf16_support(sycl_engine->device()));
             if (!ok) return status::unimplemented;
 
             bool is_training = desc_.prop_kind == forward_training;
@@ -143,6 +149,8 @@ struct cudnn_pooling_bwd_t : public primitive_t {
             using namespace alg_kind;
             using namespace format_tag;
             assert(engine->kind() == engine_kind::gpu);
+            auto *sycl_engine
+                    = utils::downcast<impl::sycl::sycl_engine_base_t *>(engine);
 
             bool ok = true && !is_fwd()
                     && set_default_params() == status::success
@@ -155,9 +163,16 @@ struct cudnn_pooling_bwd_t : public primitive_t {
                                 diff_src_md()->data_type)
                             || utils::everyone_is(data_type::f16,
                                     diff_dst_md()->data_type,
+                                    diff_src_md()->data_type)
+                            || utils::everyone_is(data_type::bf16,
+                                    diff_dst_md()->data_type,
                                     diff_src_md()->data_type))
                     && !is_dilated() && attr()->has_default_values()
-                    && no_blocking();
+                    && no_blocking()
+                    && IMPLICATION(utils::one_of(data_type::bf16,
+                                           diff_dst_md()->data_type,
+                                           diff_src_md()->data_type),
+                            has_bf16_support(sycl_engine->device()));
             if (!ok) return status::unimplemented;
 
             init_mem_by_tag(get_tag(diff_dst_md_), diff_src_md_);

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -168,6 +168,10 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                       return args.exp == lowest_dt(args.dt)
                               && std::isinf(args.got) && std::signbit(args.got);
                   }
+                  if (is_nvidia_gpu() && args.dt == dnnl_bf16) {
+                      return args.exp == lowest_dt(args.dt)
+                              && std::isinf(args.got) && std::signbit(args.got);
+                  }
                   return false;
               };
     cmp.set_driver_check_function(pooling_add_check);
@@ -213,7 +217,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             case DNNL_ARG_WORKSPACE:
                 ref_mem_map[exec_arg]
                         = dnn_mem_t(mem.md_, dnnl_s32, tag::abx, ref_engine);
-                if (prb->dir & FLAG_FWD) SAFE(fill_ws(prb, mem, ref_mem), WARN);
+                if (prb->dir & FLAG_FWD && !is_nvidia_gpu())
+                    SAFE(fill_ws(prb, mem, ref_mem), WARN);
                 break;
             case DNNL_ARG_DST:
                 SAFE(!check_md_consistency_with_tag(mem.md_, prb->tag), WARN);


### PR DESCRIPTION
# Description

Added bf16 datatype support for pooling.


## Scope:
 - Forward
 - Backward

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Testing Scope:
benchdnn: Passed

### Supported GPU for bf16
NVIDIA A100, NVIDIA H100,

### Tested Hardware:
GPU : NVIDIA A100

### Test Output Files
Please refer below.
[pooling_bf16_test_outputs.zip](https://github.com/oneapi-src/oneDNN/files/10880009/pooling_bf16_test_outputs.zip)
