### PR TITLE
Sycl Kernel Support for Shuffle Primitive

### DIFF
--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -279,7 +279,9 @@ backward propagation respectively.
 ### PReLU
 The PReLU primitive (Leaky ReLU with a trainable alpha parameter) is implemented
 using SYCL kernels. The primitive supports both forward and backward
-propagations for the data types f32, s32, bf16, f16, s8 and u8.
+propagations.
+* Forward pass supports `f32`, `f16`, `bf16`, `s8` and `u8`
+* Backward pass supports `f32`, `bf16`
 
 ### Reorder
 
@@ -340,6 +342,13 @@ changed to `CUDNN_SOFTMAX_LOG`.
 
 The sum operation uses the reorder primitive to sum tensors, so the same
 limitation as reorder applies here.
+
+### Shuffle
+
+The shuffle primitive is implemented using SYCL kernels.
+This primitive supports both forward and backward propagations.
+* Forward pass supports `f32`, `f16`, `bf16` and `s8`
+* Backward pass supports `f32`, `bf16`
 
 ### Other primitives
 

--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -37,8 +37,10 @@
 #include "gpu/nvidia/sycl_cuda_engine.hpp"
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
+
 #include "gpu/sycl/ref_binary.hpp"
 #include "gpu/sycl/ref_prelu.hpp"
+#include "gpu/sycl/ref_shuffle.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -252,6 +254,9 @@ constexpr dnnl::impl::impl_list_item_t sycl_cuda_impl_list[] = {
 
         // Reduction
         INSTANCE(cudnn_reduction_t)
+
+        // Shuffle
+        INSTANCE(sycl::ref_shuffle_t)
         nullptr,
 };
 // clang-format on

--- a/src/gpu/sycl/ref_shuffle.cpp
+++ b/src/gpu/sycl/ref_shuffle.cpp
@@ -1,0 +1,156 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/sycl/ref_shuffle.hpp"
+#include "gpu/sycl/shuffle_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+using namespace impl::sycl;
+using namespace impl::format_tag;
+using namespace impl::utils;
+
+status_t ref_shuffle_t::pd_t::init_conf() {
+    conf_ = sycl_shuffle_conf_t();
+    const memory_desc_wrapper data_d(src_md(0));
+
+    conf_.axis = axis();
+    conf_.axis_size = axis_size();
+    conf_.ndims = ndims();
+    auto dim = desc()->dst_desc.dims;
+    conf_.ndims_d = desc()->dst_desc.ndims;
+    conf_.outer_size = utils::array_product(dim, conf_.axis);
+    conf_.inner_size = utils::array_product(
+            dim + conf_.axis + 1, conf_.ndims_d - conf_.axis - 1);
+    conf_.group_size = group_size();
+    conf_.wg_size = 32;
+    conf_.MB = MB();
+    conf_.C = C();
+
+    const bool has_spatial = utils::one_of(data_d.ndims(), 3, 4, 5);
+    if (has_spatial) {
+        conf_.H = H();
+        conf_.W = W();
+        conf_.D = D();
+        conf_.HW = conf_.H * conf_.W;
+        conf_.SP = conf_.D * conf_.HW;
+    }
+    conf_.stat_md = sycl_md_t(src_md(0));
+    conf_.work_amount = memory_desc_wrapper(src_md()).nelems();
+    conf_.src_md = sycl_md_t(src_md(0));
+    conf_.dst_md = sycl_md_t(dst_md(0));
+
+    if (ndims() == 5) {
+        const auto tag
+                = memory_desc_matches_one_of_tag(*data_d.md_, ncdhw, ndhwc);
+        if (!tag) return status::unimplemented;
+        conf_.tag = tag;
+    } else if (ndims() == 4) {
+        const auto tag
+                = memory_desc_matches_one_of_tag(*data_d.md_, nchw, nhwc);
+        if (!tag) return status::unimplemented;
+        conf_.tag = tag;
+    } else
+        conf_.tag = any;
+
+    conf_.stride_m = data_d.blocking_desc().strides[0];
+    conf_.block_size = data_d.blocking_desc().strides[conf_.ndims - 1];
+
+    conf_.transpose_row
+            = is_fwd() ? conf_.group_size : conf_.axis_size / conf_.group_size;
+    conf_.transpose_col
+            = is_fwd() ? conf_.axis_size / conf_.group_size : conf_.group_size;
+
+    int d2 = (conf_.block_size > conf_.C) ? 1 : conf_.block_size;
+
+    const int t_work = (conf_.MB) * ((conf_.C / d2)) * conf_.SP;
+    const int wg_work = conf_.wg_size * conf_.block_size;
+    const int wg_cnt = (t_work + wg_work - 1) / wg_work;
+    conf_.nthr = wg_cnt * conf_.wg_size;
+
+    if (memory_desc_wrapper(src_md()).nelems() % conf_.block_size != 0)
+        return status::unimplemented;
+
+    return status::success;
+}
+
+status_t ref_shuffle_t::init(engine_t *engine) {
+    if (pd()->conf_.axis == 1 && one_of(pd()->conf_.tag, nchw, ncdhw)) {
+        const auto kid = ::sycl::get_kernel_id<shuffle_kernel_vec1_t>();
+        CHECK(create_kernel(engine, kid, &kernel_));
+    } else if (pd()->conf_.axis == 1 && one_of(pd()->conf_.tag, nhwc, ndhwc)) {
+        const auto kid = ::sycl::get_kernel_id<shuffle_kernel_vec2_t>();
+        CHECK(create_kernel(engine, kid, &kernel_));
+    } else {
+        const auto kid = ::sycl::get_kernel_id<shuffle_kernel_vec3_t>();
+        CHECK(create_kernel(engine, kid, &kernel_));
+    }
+    return status::success;
+}
+
+status_t ref_shuffle_t::execute(const exec_ctx_t &ctx) const {
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto src_mem_arg = pd()->is_fwd()
+                ? CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC)
+                : CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+
+        auto dst_mem_arg = pd()->is_fwd()
+                ? CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST)
+                : CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
+        int axis = pd()->axis();
+
+        shuffle_kernel_vec1_t shuffle_kernel1(
+                pd()->conf_, src_mem_arg, dst_mem_arg);
+
+        shuffle_kernel_vec2_t shuffle_kernel2(
+                pd()->conf_, src_mem_arg, dst_mem_arg);
+
+        shuffle_kernel_vec3_t shuffle_kernel3(
+                pd()->conf_, src_mem_arg, dst_mem_arg);
+
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+
+        int d2 = (block_size > pd()->conf_.C) ? 1 : block_size;
+
+        const int t_work
+                = (pd()->conf_.MB) * ((pd()->conf_.C / d2)) * pd()->conf_.SP;
+
+        std::cout << std::endl;
+        const int wg_work = wg_size * block_size;
+        const int wg_cnt = (t_work + wg_work - 1) / wg_work;
+        const int n_thr = wg_cnt * wg_size;
+
+        if (axis == 1 && one_of(pd()->conf_.tag, nchw, ncdhw)) {
+            cgh.parallel_for(
+                    ::sycl::nd_range<1>(n_thr, wg_size), shuffle_kernel1);
+        } else if (axis == 1 && one_of(pd()->conf_.tag, nhwc, ndhwc)) {
+            cgh.parallel_for(
+                    ::sycl::nd_range<1>(n_thr, wg_size), shuffle_kernel2);
+        } else {
+            cgh.parallel_for(
+                    ::sycl::nd_range<1>(n_thr, wg_size), shuffle_kernel3);
+        }
+    });
+}
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/sycl/ref_shuffle.hpp
+++ b/src/gpu/sycl/ref_shuffle.hpp
@@ -1,0 +1,78 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_REF_SHUFFLE_HPP
+#define GPU_SYCL_REF_SHUFFLE_HPP
+
+#include "gpu/gpu_shuffle_pd.hpp"
+#include "gpu/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+#include "sycl/sycl_stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct ref_shuffle_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_shuffle_pd_t {
+        using gpu_shuffle_pd_t::gpu_shuffle_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_shuffle_t);
+
+        status_t init(engine_t *engine) {
+            using namespace format_tag;
+            using namespace data_type;
+            const memory_desc_wrapper data_d(src_md(0));
+            const memory_desc_wrapper dst_d(dst_md(0));
+
+            const bool ok = src_md()->data_type == dst_md()->data_type
+                    && (src_md()->data_type == bf16 || src_md()->data_type == s8
+                            || src_md()->data_type == f16
+                            || src_md()->data_type == f32)
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && attr()->has_default_values()
+                    && set_default_formats_common()
+
+                    && IMPLICATION(!is_fwd(), set_default_formats_common());
+            if (!ok) return status::unimplemented;
+            return init_conf();
+        }
+
+        status_t init_conf();
+        sycl_shuffle_conf_t conf_;
+    };
+
+    status_t init(engine_t *engine) override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t execute(const exec_ctx_t &ctx) const override;
+    compute::kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/shuffle_kernels.hpp
+++ b/src/gpu/sycl/shuffle_kernels.hpp
@@ -1,0 +1,169 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_SHUFFLE_KERNELS_HPP
+#define GPU_SYCL_SHUFFLE_KERNELS_HPP
+
+#include "common/dnnl_thread.hpp"
+#include "common/dnnl_traits.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct shuffle_kernel_vec1_t {
+    shuffle_kernel_vec1_t(const sycl_shuffle_conf_t &conf,
+            sycl_in_memory_arg_t &data, sycl_out_memory_arg_t &dst)
+        : conf_(conf), data_(data), dst_(dst) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        auto sg = item.get_sub_group();
+        dim_t blk_size = conf_.block_size;
+        const dim_t stride_mb = conf_.stride_m;
+        size_t base = ((item.get_group(0) * conf_.wg_size
+                               + sg.get_group_id()[0] * sg.get_local_range()[0])
+                        * blk_size
+                + sg.get_local_id() * blk_size);
+
+        size_t xaxis = (base / 1) % conf_.MB;
+        dim_t yaxis = (base / conf_.MB) % conf_.C;
+
+        int j = yaxis / conf_.transpose_col;
+        int i = yaxis % conf_.transpose_col;
+
+        const dim_t output_off = xaxis * stride_mb + yaxis * conf_.SP;
+        const dim_t input_off
+                = xaxis * stride_mb + (i * conf_.transpose_row + j) * conf_.SP;
+
+        for (dim_t sp = 0; sp < conf_.SP; ++sp) {
+            float dst = load_float_value(
+                    data_md().data_type(), data_ptr(), input_off + sp);
+            store_float_value(
+                    data_md().data_type(), dst, dst_ptr(), output_off + sp);
+        }
+    }
+
+private:
+    const sycl_md_t &data_md() const { return conf_.src_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const sycl_md_t &stat_md() const { return conf_.stat_md; }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+
+    sycl_shuffle_conf_t conf_;
+    sycl_in_memory_arg_t data_;
+    sycl_out_memory_arg_t dst_;
+};
+
+struct shuffle_kernel_vec2_t {
+    shuffle_kernel_vec2_t(const sycl_shuffle_conf_t &conf,
+            sycl_in_memory_arg_t &data, sycl_out_memory_arg_t &dst)
+        : conf_(conf), data_(data), dst_(dst) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        const dim_t stride_mb = conf_.stride_m;
+
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        dim_t sp_start {0}, sp_end {0};
+        balance211(conf_.SP, conf_.nthr, ithr, sp_start, sp_end);
+
+        for (size_t mb = 0; mb < conf_.MB; mb++) {
+            for (size_t sp = sp_start; sp < sp_end; sp++) {
+                const dim_t off = mb * stride_mb + sp * conf_.C;
+                for (dim_t c = 0; c < conf_.C; ++c) {
+                    dim_t i = c % conf_.transpose_col;
+                    dim_t j = c / conf_.transpose_col;
+                    float dst = load_float_value(data_md().data_type(),
+                            data_ptr(), (off + (i * conf_.transpose_row + j)));
+                    store_float_value(
+                            data_md().data_type(), dst, dst_ptr(), off + c);
+                }
+            }
+        }
+    }
+
+private:
+    const sycl_md_t &data_md() const { return conf_.src_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const sycl_md_t &stat_md() const { return conf_.stat_md; }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+
+    sycl_shuffle_conf_t conf_;
+    sycl_in_memory_arg_t data_;
+    sycl_out_memory_arg_t dst_;
+};
+
+struct shuffle_kernel_vec3_t {
+    shuffle_kernel_vec3_t(const sycl_shuffle_conf_t &conf,
+            sycl_in_memory_arg_t &data, sycl_out_memory_arg_t &dst)
+        : conf_(conf), data_(data), dst_(dst) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        const dim_t outer_size = conf_.outer_size;
+        const dim_t inner_size = conf_.inner_size;
+        const dim_t dim = conf_.axis_size * inner_size;
+
+        dim_t axis_size = conf_.axis_size;
+        dim_t ax_start {0}, ax_end {0};
+        balance211(axis_size, conf_.nthr, ithr, ax_start, ax_end);
+
+        for (dim_t ou = 0; ou < outer_size; ou++) {
+            for (dim_t iwork = ax_start; iwork < ax_end; ++iwork) {
+                int j = iwork / conf_.transpose_col;
+                int i = iwork % conf_.transpose_col;
+                for (dim_t in = 0; in < inner_size; in++) {
+                    const dim_t off = ou * dim + in;
+                    float dst = load_float_value(data_md().data_type(),
+                            data_ptr(),
+                            data_md().off_l(off
+                                    + (i * conf_.transpose_row + j)
+                                            * inner_size));
+                    store_float_value(data_md().data_type(), dst, dst_ptr(),
+                            data_md().off_l(off + iwork * inner_size));
+                }
+            }
+        }
+    }
+
+private:
+    const sycl_md_t &data_md() const { return conf_.src_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const sycl_md_t &stat_md() const { return conf_.stat_md; }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+
+    sycl_shuffle_conf_t conf_;
+    sycl_in_memory_arg_t data_;
+    sycl_out_memory_arg_t dst_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -67,8 +67,42 @@ struct sycl_prelu_conf_t {
     size_t i_thr;
 };
 
-CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
+struct sycl_shuffle_conf_t {
+    sycl_md_t src_md;
+    sycl_md_t dst_md;
+    sycl_md_t stat_md;
+    sycl_md_t axis_md;
+    dim_t transpose_col;
+    dim_t transpose_row;
+    dim_t group_size;
+
+    dim_t outer_size;
+    dim_t inner_size;
+    dim_t stride_m;
+    dim_t blksize;
+    format_tag_t tag;
+    int axis;
+    int axis_size;
+    dim_t MB;
+    dim_t C;
+    dim_t H;
+    dim_t W;
+    dim_t D;
+    dim_t HW;
+    dim_t SP;
+
+    int ndims;
+    int ndims_d;
+    dim_t dims;
+    size_t nthr;
+    int block_size;
+    int wg_size;
+    dim_t work_amount;
+};
+
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_shuffle_conf_t);
 
 } // namespace sycl
 } // namespace gpu


### PR DESCRIPTION
# Description

Introducing SYCL backend for oneDNN Shuffle primitive. This contains support for Shuffle functionality.

# **Supported scope**
Supported Data Types: f32, bf16, f16

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

# **Testing Scope**
         benchdnn: Passed

Please refer the attached test output files.
[test_shuffle.zip](https://github.com/oneapi-src/oneDNN/files/10879962/test_shuffle.zip)


