### PR TITLE
Added bf16 support for matmul in cuDNN

### DIFF
--- a/src/gpu/nvidia/cudnn_matmul_impl.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_impl.hpp
@@ -431,6 +431,9 @@ private:
             case dnnl_data_type_t::dnnl_f16:
                 blas_dt = CUDA_R_16F;
                 return status::success;
+            case dnnl_data_type_t::dnnl_bf16:
+                blas_dt = CUDA_R_16BF;
+                return status::success;
             case dnnl_data_type_t::dnnl_s8:
                 blas_dt = CUDA_R_8I;
                 return status::success;


### PR DESCRIPTION
### Adding support for bf16 in oneDNN for Matmul primitive CuDNN side.

**Supported scope:**
Supported Data Types: bf16

**Testing scope:**
benchdnn: Passed

**Supported GPU for bf16:**
NVIDIA A100

**Test output file:**
[test_matmul_ci_result.txt](https://github.com/oneapi-src/oneDNN/files/10881427/test_matmul_ci_result.txt)
[test_matmul_bfloat16_result.txt](https://github.com/oneapi-src/oneDNN/files/10881429/test_matmul_bfloat16_result.txt)

**Tested Hardware:**
GPU: NVIDIA A100

**Tested Hardware:**
GPU: NVIDIA A100

**Comment:**
In the existing code few cases was failing for other data type. Similarly, for bf16 as well same cases do failed.
 
## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
