### PR TITLE
Nvidia Backend:Bf16 datatype support added for Batch Normalization

### DIFF
--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -425,7 +425,7 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
         // On Intel GPUs mean and variance could be rounded incorrectly because
         // they are calculated using fast but potentially unstable formula.
         if (kind == MEAN) trh = 1e-7;
-        if (kind == VAR) trh = 4e-7;
+        if (kind == VAR) trh = 5e-7;
     }
     cmp.set_threshold(trh);
 


### PR DESCRIPTION
# Description 
Added bf16 datatype support for Batch Normalization

## Scope:
- Forward
- Backward
- ## General 
- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format? 
### Testing Scope:
benchdnn: Passed 
benchdnn: Failed(Known issues)
### Supported GPU for bf16
NVIDIA A100, NVIDIA H100, 
### Tested Hardware:
GPU : NVIDIA A100
### Test Output Files
Please refer below.
[Test_outputs_bnorm.zip](https://github.com/oneapi-src/oneDNN/files/10884811/Test_outputs_bnorm.zip)