### PR TITLE
Nvidia Backend:Bf16, S8 datatype & output scale added  support for Softmax

### DIFF
--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -86,7 +86,7 @@ normalization.
   normalization, which is used as an input to the activation function, is saved
   in the workspace as well. This is required to compute the backward pass for
   `dnnl_fuse_norm_relu` flag.
-* Forward pass supports f32, f16 and s8 data types. Although blocking is not
+* Forward pass supports f32, f16, bf16 and s8 data types. Although blocking is not
   supported for s8.
 
 #### Backward direction
@@ -109,6 +109,7 @@ normalization.
   intermediate result of the batch normalization saved in the forward pass. This
   is used to compute the backward direction of the activation function used for
   `RELU`.
+* Backward pass supports `f32` and `bf16` data types.
 
 ### Binary
 
@@ -117,6 +118,7 @@ The `cudnnOpTensor` is equivalent of oneDNN binary primitives.
 * Only scales attribute is supported. Post-op attribute is not supported.
 * Blocking is only supported for `int8` and only in the C dimension with either
   4 or 32 block size (same as other cuDNN primitives).
+* Supported data types are f32, f16, bf16 and s8.
 
 ### Concat
 
@@ -180,9 +182,9 @@ limitations when using Nvidia backend for eltwise primitive:
 * cuDNN expects `x`, `y` and `dy` as inputs to the backward pass, hence, only
   `RELU` operation supports backward proragation kind.
   TODO: add `ELU_DST`, `TANH_DST` and `LOGISTIC_DST` support which require `dy`.
-* Forward pass supports `f32`, `f16` and `s8` data types. Although blocking is
+* Forward pass supports `f32`, `f16`, `bf16` and `s8` data types. Although blocking is
   not supported for `s8`.
-* Backward pass supports `f32` and `f16` data types.
+* Backward pass supports `f32` and `bf16` data types.
 
 ### Inner product
 
@@ -200,6 +202,8 @@ falls back to the convolution backend. `cudnnActivationForward` operation is
 used for eltwise operation and `cudnnAddTensor` is used for bias operation. The
 `beta` parameter in gemm is used for the sum scale and `alpha` parameter is used
 for the output scale.
+* Forward pass supports `f32`, `f16`, `bf16` and `s8` data types.
+* Backward pass supports `f32`and `bf16` data types.
 
 #### Using convolution
 
@@ -223,6 +227,8 @@ product has the following restrictions and performance implications:
   convolution restriction.
 * For `int8` cuDNN requires both input and output feature maps to be a multiple
   of 4.
+* Forward pass supports `f32`, `f16`, `bf16` and `s8` data types.
+* Backward pass supports `f32` and `bf16` data types.
 
 ### LRN
 
@@ -244,6 +250,7 @@ The matrix multiplication primitive in the Nvidia backend is implemented with
 * Zero points support is not provided by cuBLAS and, hence, not supported by the
   Nvidia backend.
 * Post-ops and output scale limitations are same as for Inner Product.
+* Supported data types are `f32`, `f16`, `bf16` and `s8`.
 
 ### Pooling
 
@@ -267,6 +274,8 @@ backward propagation respectively.
   workspace is always required when the Nvidia backend is used (except for the
   forward inference).
 
+* Supported data type are `f32`, `f16`, `bf16` and `s8`.
+
 ### Reorder
 
 The `cudnnTransform` function is the equivalent of oneDNN reorder function.
@@ -279,6 +288,8 @@ GPU:
   currently supports block size of 4.
 * Blocking is only supported when channel dimension is a multiple of the block
   size and the datatype is `int8`.
+* Forward pass supports `f32`, `f16`, `bf16` and `s8` data types.
+* Backward pass supports `f32` and `bf16` data types.
 
 ### Resampling
 
@@ -317,6 +328,8 @@ changed to `CUDNN_SOFTMAX_LOG`.
 * There is a bug in cuDNN softmax for 5D tensor with format `NHWC`. When the
   channel size is greater than 1, it only applies softmax for a single channel
   and leave the others untouched.
+* Forward pass supports `f32`, `f16`, `bf16` and `s8` data types.
+* Backward pass supports `f32` and `bf16` data types.
 
 ### Sum
 

--- a/src/gpu/nvidia/cudnn_softmax.hpp
+++ b/src/gpu/nvidia/cudnn_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,30 +39,58 @@ struct cudnn_softmax_fwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_softmax_fwd_t);
 
-        status_t init(engine_t *) {
+        status_t init(engine_t *engine) {
             const memory_desc_wrapper src_d(src_md());
             const memory_desc_wrapper dst_d(dst_md());
 
+            auto sycl_dev
+                    = utils::downcast<impl::sycl::sycl_engine_base_t *>(engine)
+                              ->device();
             bool ok = is_fwd()
-                    && utils::one_of(
-                            src_d.data_type(), data_type::f32, data_type::f16)
-                    && attr()->has_default_values()
+                    && utils::one_of(src_d.data_type(), data_type::f32,
+                            data_type::f16, data_type::bf16, data_type::s8)
+                    && IMPLICATION(src_md()->data_type == data_type::bf16,
+                            has_bf16_support(sycl_dev))
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::scales_runtime)
                     && set_default_formats() == status::success
-                    && src_d.is_plain() && dst_d.is_plain() && dst_d == src_d;
+                    && src_d.is_plain() && dst_d.is_plain() && dst_d == src_d
+                    && IMPLICATION(!attr()->scales_.has_default_values(),
+                            check_scales_mask());
             if (!ok) return status::unimplemented;
 
             softmax_impl_.reset(new cudnn_softmax_fwd_impl_t());
 
             return softmax_impl_->init(this);
         }
+        bool check_scales_mask() const {
+            for (const auto &s : attr()->scales_.scales_) {
+                if (s.second.mask_ != 0) return false;
+            }
+            return true;
+        }
 
         std::shared_ptr<cudnn_softmax_impl_base_t> softmax_impl_;
     };
 
+    status_t init(engine_t *engine) override {
+        // Only single-element scale is supported
+        host_scales_ = new float[3];
+        if (!host_scales_) return status::out_of_memory;
+        host_scales_[0] = 1.0f;
+        host_scales_[1] = 1.0f;
+        host_scales_[2] = 1.0f;
+        return status::success;
+    }
+
     status_t execute(const exec_ctx_t &ctx) const override;
+
+    virtual ~cudnn_softmax_fwd_t() { delete[] host_scales_; }
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    float *host_scales_ = nullptr;
 };
 
 struct cudnn_softmax_bwd_t : public primitive_t {
@@ -73,19 +101,26 @@ struct cudnn_softmax_bwd_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("cuda:cudnn:any", cudnn_softmax_bwd_t);
 
-        status_t init(engine_t *) {
+        status_t init(engine_t *engine) {
             const memory_desc_wrapper diff_src_d(diff_src_md());
             const memory_desc_wrapper diff_dst_d(diff_dst_md());
             const memory_desc_wrapper dst_d(dst_md());
 
+            auto sycl_dev
+                    = utils::downcast<impl::sycl::sycl_engine_base_t *>(engine)
+                              ->device();
+
             bool ok = !is_fwd()
-                    && utils::one_of(
-                            dst_d.data_type(), data_type::f32, data_type::f16)
+                    && utils::one_of(dst_d.data_type(), data_type::f32,
+                            data_type::f16, data_type::bf16)
+                    && IMPLICATION(dst_md()->data_type == data_type::bf16,
+                            has_bf16_support(sycl_dev))
                     && attr()->has_default_values()
                     && set_default_formats() == status::success
                     && dst_d.is_plain() && diff_dst_d.is_plain()
                     && diff_src_d.is_plain() && diff_src_d == diff_dst_d
                     && diff_src_d == dst_d;
+
             if (!ok) return status::unimplemented;
 
             softmax_impl_.reset(new cudnn_softmax_bwd_impl_t());

--- a/src/gpu/nvidia/cudnn_softmax_impl.hpp
+++ b/src/gpu/nvidia/cudnn_softmax_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,8 +33,6 @@ struct cudnn_softmax_impl_base_t {
     cudnnSoftmaxAlgorithm_t alg_kind;
     // cuDNN only supports softmax on channel dimension
     cudnnSoftmaxMode_t mode = cudnnSoftmaxMode_t::CUDNN_SOFTMAX_MODE_CHANNEL;
-    // oneDNN softmax primitive doesn't support any post-ops or attributes,
-    // hence we can set alpha = 1 and beta = 0 for all cases
     float alpha = 1.0f;
     float beta = 0.0f;
 
@@ -183,9 +181,9 @@ struct cudnn_softmax_fwd_impl_t : public cudnn_softmax_impl_base_t {
     }
 
     void execute(cudnnHandle_t handle, void **x, int size) const override {
-        // Confirm that 2 arguments were passed, src and dst
-        assert(size == 2);
-        CUDNN_EXECUTE_FUNC(cudnnSoftmaxForward, handle, alg_kind, mode, &alpha,
+        // Confirm that 3 arguments were passed, src, dst and scale
+        assert(size == 3);
+        CUDNN_EXECUTE_FUNC(cudnnSoftmaxForward, handle, alg_kind, mode, x[2],
                 tensor_desc, x[0], &beta, tensor_desc, x[1]);
     }
 


### PR DESCRIPTION
### Adding support for bf16, s8 and output scale for oneDNN Softmax primitive.

### Supported scope:
**Supported Data Types:**
Forward : bf16, s8
Backward : bf16
**Added Output scale support for forward**

**Testing scope:**
benchdnn: Passed

**Supported GPU for bf16**
NVIDIA A100

**Test output file:**
[test_softmax_all.txt](https://github.com/oneapi-src/oneDNN/files/10908792/test_softmax_all.txt)

**Tested Hardware:**
GPU: NVIDIA A100

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

