### PR TITLE
oneDNN SYCL support for Softmax primitive

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -43,6 +43,7 @@
 #include "gpu/sycl/ref_prelu.hpp"
 #include "gpu/sycl/ref_resampling.hpp"
 #include "gpu/sycl/ref_shuffle.hpp"
+#include "gpu/sycl/ref_softmax.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -244,6 +245,8 @@ constexpr dnnl::impl::impl_list_item_t sycl_cuda_impl_list[] = {
         // Softmax
         INSTANCE(cudnn_softmax_fwd_t)
         INSTANCE(cudnn_softmax_bwd_t)
+        INSTANCE(sycl::ref_sycl_softmax_fwd_t)
+        INSTANCE(sycl::ref_sycl_softmax_bwd_t)
 
         // Binary
         INSTANCE(cudnn_binary_t)

--- a/src/gpu/sycl/batch_normalizations_kernels.hpp
+++ b/src/gpu/sycl/batch_normalizations_kernels.hpp
@@ -91,7 +91,7 @@ private:
             case 3: return mdw.off(n, c, w);
             case 4: return mdw.off(n, c, h, w);
             case 5: return mdw.off(n, c, d, h, w);
-            default: assert(!"Invalid tensor dimension in Batch");
+            default: return 0;
         }
         return 0;
     }
@@ -239,7 +239,7 @@ private:
             case 3: return mdw.off(n, c, w);
             case 4: return mdw.off(n, c, h, w);
             case 5: return mdw.off(n, c, d, h, w);
-            default: assert(!"Invalid tensor dimension in Batch");
+            default: return 0;
         }
         return 0;
     }
@@ -447,7 +447,7 @@ private:
             case 3: return mdw.off(n, c, w);
             case 4: return mdw.off(n, c, h, w);
             case 5: return mdw.off(n, c, d, h, w);
-            default: assert(!"Invalid tensor dimension in Batch");
+            default: return 0;
         }
         return 0;
     }

--- a/src/gpu/sycl/prelu_kernels.hpp
+++ b/src/gpu/sycl/prelu_kernels.hpp
@@ -129,7 +129,7 @@ private:
             case 3: return mem.off(dims[0], dims[1], dims[2]);
             case 4: return mem.off(dims[0], dims[1], dims[2], dims[3]);
             case 5: return mem.off(dims[0], dims[1], dims[2], dims[3], dims[4]);
-            default: assert(!"Unsupported ndims count");
+            default: return -1;
         }
         return -1;
     }
@@ -186,7 +186,7 @@ struct prelu_bwd_kernel_vec_t {
                         diff_weights_ptr(), diff_dst_ptr(), diff_data_ptr(),
                         ithr, item);
                 break;
-            default: assert(!"unsupported broadcast type");
+            default: return;
         }
     }
 
@@ -264,7 +264,7 @@ private:
             case 3: return mem.off(dims[0], dims[1], dims[2]);
             case 4: return mem.off(dims[0], dims[1], dims[2], dims[3]);
             case 5: return mem.off(dims[0], dims[1], dims[2], dims[3], dims[4]);
-            default: assert(!"Unsupported ndims count");
+            default: return -1;
         }
         return -1;
     }

--- a/src/gpu/sycl/ref_softmax.cpp
+++ b/src/gpu/sycl/ref_softmax.cpp
@@ -1,0 +1,136 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/sycl/ref_softmax.hpp"
+#include "gpu/sycl/softmax_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+using namespace impl::sycl;
+status_t ref_sycl_softmax_fwd_t::pd_t::init_conf() {
+    conf_ = sycl_softmax_conf_t();
+    conf_.src_md = sycl_md_t(src_md());
+    conf_.dst_md = sycl_md_t(dst_md());
+    conf_.alg_kind = desc()->alg_kind;
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+    conf_.axis = axis();
+    conf_.axis_size = axis_size(true);
+    conf_.inner_size = inner_size();
+    conf_.outer_size = outer_size();
+    conf_.channels = axis_size();
+    conf_.wk_size = inner_size() * outer_size();
+
+    return status::success;
+}
+
+status_t ref_sycl_softmax_fwd_t::init(engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<softmax_fwd_kernel_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_sycl_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto src_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+        auto dst_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+
+        float scale_val = 1.00;
+        if (!pd()->attr()->scales_.defined()) {
+            const auto scales_src
+                    = ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
+            auto src_scales = CTX_IN_SYCL_KERNEL_MEMORY(
+                    DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
+            if (src_scales.get_pointer() != NULL)
+                scale_val = load_float_value(
+                        scales_src.data_type(), src_scales.get_pointer(), 0);
+
+            const auto scales_dst
+                    = ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+            auto dst_scales = CTX_IN_SYCL_KERNEL_MEMORY(
+                    DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+            if (dst_scales.get_pointer() != NULL)
+                scale_val /= load_float_value(
+                        scales_dst.data_type(), dst_scales.get_pointer(), 0);
+        }
+
+        const auto block_size = pd()->conf_.block_size;
+        const auto wg_size = pd()->conf_.wg_size;
+        const auto t_work = pd()->conf_.wk_size;
+        const auto wg_work = wg_size * block_size;
+        const auto wg_cnt = (t_work + wg_work - 1) / wg_work;
+        auto n_thr = wg_cnt * wg_size;
+        n_thr = n_thr < 1 ? 1 : n_thr;
+
+        softmax_fwd_kernel_vec_t softmax_fwd_kernel_(
+                pd()->conf_, src_mem_arg, dst_mem_arg, scale_val);
+
+        cgh.parallel_for(
+                ::sycl::nd_range<1>(n_thr, wg_size), softmax_fwd_kernel_);
+    });
+}
+
+status_t ref_sycl_softmax_bwd_t::pd_t::init_conf() {
+    conf_ = sycl_softmax_conf_t();
+    conf_.dst_md = sycl_md_t(dst_md());
+    conf_.diff_dst_md = sycl_md_t(diff_dst_md());
+    conf_.diff_src_md = sycl_md_t(diff_src_md());
+    conf_.alg_kind = desc()->alg_kind;
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+    conf_.axis = axis();
+    conf_.axis_size = axis_size(true);
+    conf_.inner_size = inner_size();
+    conf_.outer_size = outer_size();
+    conf_.channels = axis_size();
+    conf_.wk_size = inner_size() * outer_size();
+
+    return status::success;
+}
+
+status_t ref_sycl_softmax_bwd_t::init(engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<softmax_bwd_kernel_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_sycl_softmax_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto dst = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+        auto diff_dst = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto diff_src = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
+
+        softmax_bwd_kernel_vec_t softmax_bwd_kernel(
+                pd()->conf_, dst, diff_dst, diff_src);
+
+        const auto block_size = pd()->conf_.block_size;
+        const auto wg_size = pd()->conf_.wg_size;
+        const auto t_work = pd()->conf_.wk_size;
+        const auto wg_work = wg_size * block_size;
+        const auto wg_cnt = (t_work + wg_work - 1) / wg_work;
+        auto n_thr = wg_cnt * wg_size;
+        n_thr = n_thr < 1 ? 1 : n_thr;
+
+        cgh.parallel_for(
+                ::sycl::nd_range<1>(n_thr, wg_size), softmax_bwd_kernel);
+    });
+}
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/sycl/ref_softmax.hpp
+++ b/src/gpu/sycl/ref_softmax.hpp
@@ -1,0 +1,121 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef GPU_SYCL_REF_SOFTMAX_HPP
+#define GPU_SYCL_REF_SOFTMAX_HPP
+
+#include "gpu/gpu_softmax_pd.hpp"
+#include "gpu/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct ref_sycl_softmax_fwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_softmax_fwd_pd_t {
+        using gpu_softmax_fwd_pd_t::gpu_softmax_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_softmax_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using sm = primitive_attr_t::skip_mask_t;
+
+            bool ok = is_fwd() && check_data_types(src_md()->data_type)
+                    && check_data_types(dst_md()->data_type)
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && attr()->has_default_values(sm::scales_runtime)
+                    && attr_oscale_ok()
+                    && set_default_formats() == status::success;
+
+            if (!ok) return status::unimplemented;
+            return init_conf();
+        }
+
+        sycl_softmax_conf_t conf_;
+        status_t init_conf();
+
+        bool attr_oscale_ok() const {
+            const auto &scales = attr()->scales_;
+            bool ok = true;
+            for (const auto &e : scales.scales_) {
+                ok = ok && e.second.mask_ == 0;
+            }
+            return ok;
+        }
+
+        bool check_data_types(data_type_t src) {
+            return utils::one_of(src, data_type::f32, data_type::bf16,
+                        data_type::f16, data_type::s8, data_type::u8);
+        }
+    };
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    compute::kernel_t kernel_;
+};
+
+struct ref_sycl_softmax_bwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_softmax_bwd_pd_t {
+        using gpu_softmax_bwd_pd_t::gpu_softmax_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_softmax_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            bool ok = !is_fwd()
+                    && utils::one_of(dst_md()->data_type, f32, bf16, f16)
+                    && (dst_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && dst_md()->data_type == diff_dst_md()->data_type
+                    && attr()->has_default_values()
+                    && set_default_formats() == status::success;
+
+            if (!ok) return status::unimplemented;
+            return init_conf();
+        }
+
+        sycl_softmax_conf_t conf_;
+        status_t init_conf();
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_backward(ctx);
+    }
+
+private:
+    status_t execute_backward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/resampling_kernels.hpp
+++ b/src/gpu/sycl/resampling_kernels.hpp
@@ -161,7 +161,7 @@ private:
             case 3: return mdw.off(n, c, w);
             case 4: return mdw.off(n, c, h, w);
             case 5: return mdw.off(n, c, d, h, w);
-            default: assert(!"Invalid tensor dimension in pooling");
+            default: return 0;
         }
         return 0;
     }
@@ -286,7 +286,7 @@ private:
             case 3: return mdw.off(n, c, w);
             case 4: return mdw.off(n, c, h, w);
             case 5: return mdw.off(n, c, d, h, w);
-            default: assert(!"Invalid tensor dimension in pooling");
+            default: return 0;
         }
         return 0;
     }
@@ -363,7 +363,7 @@ private:
             case 3: return mdw.off(n, c, w);
             case 4: return mdw.off(n, c, h, w);
             case 5: return mdw.off(n, c, d, h, w);
-            default: assert(!"Invalid tensor dimension in pooling");
+            default: return 0;
         }
         return 0;
     }

--- a/src/gpu/sycl/softmax_kernels.hpp
+++ b/src/gpu/sycl/softmax_kernels.hpp
@@ -1,0 +1,197 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_SOFTMAX_KERNELS_HPP
+#define GPU_SYCL_SOFTMAX_KERNELS_HPP
+
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct softmax_fwd_kernel_vec_t {
+    softmax_fwd_kernel_vec_t(const sycl_softmax_conf_t &conf,
+            sycl_in_memory_arg_t &src, sycl_out_memory_arg_t &dst, float scale)
+        : conf_(conf), src_(src), dst_(dst), scale_(scale) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        auto sg = item.get_sub_group();
+        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
+        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
+        size_t wi_offset_t = sg.get_local_id();
+        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
+        size_t base_idx = offset_t * conf_.block_size;
+
+        auto operation = [=](dim_t &ou, dim_t &in) {
+            float space_denom = 0;
+            float space_max = -FLT_MAX;
+            dim_t ou_in_offset = ou * conf_.channels * conf_.inner_size + in;
+
+            for (dim_t c = 0; c < conf_.channels; c++) {
+                size_t off
+                        = src_md().off_l(ou_in_offset + c * conf_.inner_size);
+                float s = load_float_value(
+                        src_md().data_type(), src_ptr(), off);
+                space_max = nstl::max(space_max, s);
+            }
+            for (dim_t c = 0; c < conf_.channels; c++) {
+                size_t src_off
+                        = src_md().off_l(ou_in_offset + c * conf_.inner_size);
+                float s = load_float_value(
+                        src_md().data_type(), src_ptr(), src_off);
+                float d = s - space_max;
+                space_denom += ::sycl::exp((float)d);
+            }
+            if (conf_.alg_kind == alg_kind::softmax_log) {
+                space_denom = ::sycl::log((float)space_denom);
+            }
+            for (dim_t c = 0; c < conf_.channels; c++) {
+                size_t src_off
+                        = src_md().off_l(ou_in_offset + c * conf_.inner_size);
+                float s = load_float_value(
+                        src_md().data_type(), src_ptr(), src_off);
+                float d = s - space_max;
+                if (conf_.alg_kind == alg_kind::softmax_accurate) {
+                    d = ::sycl::exp((float)d);
+                }
+                float sd = space_denom;
+                if (conf_.alg_kind == alg_kind::softmax_accurate) {
+                    d /= sd;
+                } else if (conf_.alg_kind == alg_kind::softmax_log) {
+                    d -= sd;
+                }
+                d = (d * scale_);
+                size_t dst_off
+                        = dst_md().off_l(ou_in_offset + c * conf_.inner_size);
+                store_float_value(dst_md().data_type(), d, dst_ptr(), dst_off);
+            }
+        };
+
+        for (dim_t blk_idx = 0; blk_idx < conf_.block_size; blk_idx++) {
+            dim_t idx = base_idx + blk_idx;
+
+            if (idx < conf_.wk_size) {
+                dim_t in = (idx / (1)) % conf_.inner_size;
+                dim_t ou = (idx / (conf_.inner_size)) % conf_.outer_size;
+                operation(ou, in);
+            }
+        }
+    }
+
+private:
+    const sycl_md_t &src_md() const { return conf_.src_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+
+    void *src_ptr() const { return src_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+
+    sycl_softmax_conf_t conf_;
+    sycl_in_memory_arg_t src_;
+    sycl_out_memory_arg_t dst_;
+    float scale_;
+};
+
+struct softmax_bwd_kernel_vec_t {
+    softmax_bwd_kernel_vec_t(const sycl_softmax_conf_t &conf,
+            sycl_in_memory_arg_t &dst, sycl_in_memory_arg_t &diff_dst,
+            sycl_out_memory_arg_t &diff_src)
+        : conf_(conf), dst_(dst), diff_dst_(diff_dst), diff_src_(diff_src) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        auto sg = item.get_sub_group();
+        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
+        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
+        size_t wi_offset_t = sg.get_local_id();
+        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
+        size_t base_idx = offset_t * conf_.block_size;
+
+        auto operation = [=](dim_t &ou, dim_t &in) {
+            dim_t ou_in_offset = ou * conf_.channels * conf_.inner_size + in;
+            float sbr = 0;
+            for (dim_t c = 0; c < conf_.channels; ++c) {
+                auto diff_dst_off = diff_dst_md().off_l(
+                        ou_in_offset + c * conf_.inner_size);
+                float dd = load_float_value(diff_dst_md().data_type(),
+                        diff_dst_ptr(), diff_dst_off);
+                if (conf_.alg_kind == alg_kind::softmax_accurate) {
+                    auto dst_off = dst_md().off_l(
+                            ou_in_offset + c * conf_.inner_size);
+                    float d = load_float_value(
+                            dst_md().data_type(), dst_ptr(), dst_off);
+                    sbr += dd * d;
+                } else if (conf_.alg_kind == alg_kind::softmax_log) {
+                    sbr += dd;
+                }
+            }
+
+            for (dim_t c = 0; c < conf_.channels; ++c) {
+                auto diff_dst_off = diff_dst_md().off_l(
+                        ou_in_offset + c * conf_.inner_size);
+                auto dst_off
+                        = dst_md().off_l(ou_in_offset + c * conf_.inner_size);
+
+                float d = load_float_value(
+                        dst_md().data_type(), dst_ptr(), dst_off);
+                float dd = load_float_value(diff_dst_md().data_type(),
+                        diff_dst_ptr(), diff_dst_off);
+
+                float val = 0;
+                if (conf_.alg_kind == alg_kind::softmax_accurate) {
+                    val = d * (dd - sbr);
+                } else if (conf_.alg_kind == alg_kind::softmax_log) {
+                    val = dd - ::sycl::exp(d) * sbr;
+                }
+
+                auto diff_src_off = diff_src_md().off_l(
+                        ou_in_offset + c * conf_.inner_size);
+                store_float_value(diff_src_md().data_type(), val,
+                        diff_src_ptr(), diff_src_off);
+            }
+        };
+
+        for (dim_t i = 0; i < conf_.block_size; i++) {
+            dim_t idx = base_idx + i;
+            if (idx < conf_.wk_size) {
+                dim_t in = (idx / 1) % conf_.inner_size;
+                dim_t ou = (idx / conf_.inner_size) % conf_.outer_size;
+                operation(ou, in);
+            }
+        }
+    }
+
+private:
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const sycl_md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+    const sycl_md_t &diff_src_md() const { return conf_.diff_src_md; }
+
+    void *dst_ptr() const { return dst_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+    void *diff_src_ptr() const { return diff_src_.get_pointer(); }
+
+    sycl_softmax_conf_t conf_;
+    sycl_in_memory_arg_t dst_;
+    sycl_in_memory_arg_t diff_dst_;
+    sycl_out_memory_arg_t diff_src_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+#endif

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -177,11 +177,32 @@ struct sycl_batch_normalization_conf_t {
     bool with_relu;
 };
 
+struct sycl_softmax_conf_t {
+    prop_kind_t prop_kind;
+    sycl_md_t src_md;
+    sycl_md_t dst_md;
+
+    sycl_md_t diff_md;
+    sycl_md_t diff_src_md;
+    sycl_md_t diff_dst_md;
+    alg_kind_t alg_kind;
+    dim_t block_size;
+    dim_t wg_size;
+    dim_t wk_size;
+
+    dim_t axis;
+    dim_t axis_size;
+    dim_t inner_size;
+    dim_t outer_size;
+    dim_t channels;
+};
+
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_shuffle_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_resampling_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_batch_normalization_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_softmax_conf_t);
 
 } // namespace sycl
 } // namespace gpu


### PR DESCRIPTION
### Description
Introducing SYCL backend for the oneDNN Softmax primitive. This contains support for Softmax functionality in both forward and backward propagations.

**Supported scope**
Supported Data Types:
Forward : f32, bf16, f16, u8, s8
Backward : f32, bf16, f16

**Attribute**
Forward : Scales

**Tested Hardware**
Nvidia Tesla T4

**General**
- [x] Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

**Testing Scope**
benchdnn : passed

**Test Output Files**
[file_ci.txt](https://github.com/oneapi-src/oneDNN/files/10942893/file_ci.txt)
[file_gpu.txt](https://github.com/oneapi-src/oneDNN/files/10942894/file_gpu.txt)
[file_all.txt](https://github.com/oneapi-src/oneDNN/files/10942895/file_all.txt)
