### PR TITLE
SYCL kernel support for Pooling

### DIFF
--- a/src/gpu/nvidia/README.md
+++ b/src/gpu/nvidia/README.md
@@ -330,6 +330,21 @@ backward propagation respectively.
 
 * Supported data type are `f32`, `f16`, `bf16` and `s8`.
 
+#### Using SYCL Kernels
+
+The implementation supports both forward and backward directions.
+
+* Supported formats: `NCDHW`, `NDHWC`, `NCHW`, `NHWC`, `NCW`, `NWC`
+
+##### Forward Direction
+* Supported data types: `f32`, `bf16`, `f16`, `s8`, `u8` and `s32`
+* Supported post-ops: `binary`, `eltwise_linear`
+* Supported algorithms: `max`, `avg_p`, `avg_np`
+
+##### Backward Direction
+* Supported data types: `f32`, `bf16`, `f16`
+* Supported algorithms: `max`, `avg_p`, `avg_np`
+
 ### PReLU
 
 The PReLU primitive (Leaky ReLU with a trainable alpha parameter) is implemented
@@ -340,6 +355,22 @@ propagations.
 
 * Forward pass supports `f32`, `f16`, `bf16`, `s8` and `u8` data types
 * Backward pass supports `f32` and `bf16` data types
+
+### Layer Normalization
+
+The Primitive layer normalization is implemented through SYCL kernels.The implementation supports both forward and backward directions.
+
+* Supported formats: `NCDHW`, `NDHWC`, `NCHW`, `NHWC`, `NCW`, `NWC`, `NC`
+
+##### Forward direction
+* Supported data types for source and destination: `f32`, `bf16`, `f16`, `s8`, `u8`
+* Supported attributes: `Scales`
+* Supported flags: `dnnl_global_stats`, `dnnl_use_scale`, `dnnl_use_shift`
+
+##### Backward direction
+* Supported data types for source and destination: `f32`, `bf16`, `f16`
+* Supported data types for mean and variance: `f32`
+* Supported flags: `dnnl_global_stats`, `dnnl_use_scale`, `dnnl_use_shift`
 
 ### Reorder
 

--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -43,6 +43,7 @@
 #include "gpu/sycl/ref_eltwise.hpp"
 #include "gpu/sycl/ref_layer_normalizations.hpp"
 #include "gpu/sycl/ref_lrn.hpp"
+#include "gpu/sycl/ref_pooling.hpp"
 #include "gpu/sycl/ref_prelu.hpp"
 #include "gpu/sycl/ref_resampling.hpp"
 #include "gpu/sycl/ref_shuffle.hpp"
@@ -238,6 +239,8 @@ constexpr dnnl::impl::impl_list_item_t sycl_cuda_impl_list[] = {
         // Pooling
         INSTANCE(cudnn_pooling_fwd_t)
         INSTANCE(cudnn_pooling_bwd_t)
+        INSTANCE(sycl::ref_pooling_fwd_t)
+        INSTANCE(sycl::ref_pooling_bwd_t)
 
         // LRN
         INSTANCE(cudnn_lrn_fwd_t)

--- a/src/gpu/sycl/pooling_kernels.hpp
+++ b/src/gpu/sycl/pooling_kernels.hpp
@@ -1,0 +1,485 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_POOLING_KERNELS_HPP
+#define GPU_SYCL_POOLING_KERNELS_HPP
+
+#include "common/dnnl_thread.hpp"
+#include "common/dnnl_traits.hpp"
+#include "common/nstl.hpp"
+#include "common/primitive_attr.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+using namespace nstl;
+struct pooling_fwd_kernel_vec_t {
+    pooling_fwd_kernel_vec_t(const sycl_pooling_conf_t &conf,
+            sycl_in_memory_arg_t &src, sycl_out_memory_arg_t &dst,
+            sycl_out_memory_arg_t &ws, sycl_in_memory_arg_t &src_1,
+            sycl_in_memory_arg_t &src_2, sycl_in_memory_arg_t &src_3,
+            sycl_in_memory_arg_t &src_4, sycl_in_memory_arg_t &src_5)
+        : conf_(conf)
+        , src_(src)
+        , dst_(dst)
+        , ws_(ws)
+        , src_1_(src_1)
+        , src_2_(src_2)
+        , src_3_(src_3)
+        , src_4_(src_4)
+        , src_5_(src_5) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        const bool is_max_pool = conf_.alg == alg_kind::pooling_max;
+        float base_res = is_max_pool ? data_conv() : 0.f;
+        dim_t MB = conf_.MB;
+        dim_t OC = conf_.OC;
+        dim_t OD = conf_.OD;
+        dim_t OH = conf_.OH;
+        dim_t OW = conf_.OW;
+        const dim_t work_amount = MB * OC * OD * OH * OW;
+        if (work_amount == 0) return;
+        dim_t start {0}, end {0};
+        balance211(work_amount, conf_.n_thr, ithr, start, end);
+        dim_t mb {0}, oc {0}, od {0}, oh {0}, ow {0};
+        utils::nd_iterator_init(start, mb, MB, oc, OC, od, OD, oh, OH, ow, OW);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            auto data_p_off = get_offset(dst_md(), mb, oc, od, oh, ow);
+            auto data_l_off = (((mb * OC + oc) * OD + od) * OH + oh) * OW + ow;
+            float res = base_res;
+
+            if (is_max_pool) {
+                ker_max(res, mb, oc, od, oh, ow);
+            } else {
+                ker_avg(res, mb, oc, od, oh, ow);
+            }
+
+            ::sycl::vec<float, 8> dst_arr;
+
+            for (int idx = 0; idx < conf_.po_len; ++idx) {
+                float r = 0.0f;
+                if (conf_.post_ops.get_post_op_kind(idx)
+                        == primitive_kind::binary) {
+                    if (idx == 0) { r = dst_Value(src_1_, idx, data_l_off); }
+                    if (idx == 1) { r = dst_Value(src_2_, idx, data_l_off); }
+                    if (idx == 2) { r = dst_Value(src_3_, idx, data_l_off); }
+                    if (idx == 3) { r = dst_Value(src_4_, idx, data_l_off); }
+                    if (idx == 4) { r = dst_Value(src_5_, idx, data_l_off); }
+                    dst_arr[idx] = r;
+                }
+            }
+            res = conf_.post_ops.apply(res, dst_arr);
+
+            store_float_value(dst_md().data_type(), res, dst_ptr(), data_p_off);
+            utils::nd_iterator_step(mb, MB, oc, OC, od, OD, oh, OH, ow, OW);
+        }
+    }
+
+private:
+    const sycl_md_t &src_md() const { return conf_.src_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const sycl_md_t &ws_md() const { return conf_.ws_md; }
+
+    void *src_ptr() const { return src_.get_pointer(); }
+    void *gen_ptr(sycl_in_memory_arg_t gen_) const {
+        return gen_.get_pointer();
+    }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+    void *ws_ptr() const { return ws_.get_pointer(); }
+
+    static dim_t get_offset(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: return 0;
+        }
+        return 0;
+    }
+    float data_conv() const {
+        switch (src_md().data_type()) {
+            case data_type::bf16:
+                return (float)std::numeric_limits<bfloat16_t>::lowest();
+            case data_type::s8:
+                return (float)numeric_limits<
+                        typename prec_traits<data_type::s8>::type>::lowest();
+            case data_type::f16:
+                return (float)numeric_limits<
+                        typename prec_traits<data_type::f16>::type>::lowest();
+            case data_type::s32:
+                return (float)numeric_limits<
+                        typename prec_traits<data_type::s32>::type>::lowest();
+            case data_type::u8:
+                return (float)numeric_limits<
+                        typename prec_traits<data_type::u8>::type>::lowest();
+            default:
+                return (float)numeric_limits<
+                        typename prec_traits<data_type::f32>::type>::lowest();
+        }
+    }
+
+    float dst_Value(sycl_in_memory_arg_t arr, int idx, int offset) const {
+        auto src1_desc = conf_.src1_md[idx];
+        dim_t src_dim[DNNL_MAX_NDIMS];
+        auto src_dim_ = src1_desc.dims();
+
+        for (int j = 0; j < src1_desc.ndims(); j++) {
+            src_dim[j] = src_dim_[j];
+        }
+        const auto off = get_binary_src1_off(
+                src1_desc, src_dim, offset, conf_.dst_dims, conf_.dst_ndims);
+        auto dst = load_float_value(src1_desc.data_type(), gen_ptr(arr), off);
+        return dst;
+    }
+
+    dim_t get_binary_src1_off(const sycl_md_t &src1_md, const dim_t *src_dim,
+            const dim_t l_offset, const dim_t *dst_dims,
+            const int dst_ndims) const {
+
+        const int mask_binary_po
+                = utils::get_dims_mask(dst_dims, src_dim, dst_ndims);
+
+        return get_po_tensor_off(
+                src1_md, l_offset, dst_dims, dst_ndims, mask_binary_po);
+    }
+
+    dim_t get_po_tensor_off(const sycl_md_t &tensor_md, const dim_t l_offset,
+            const dim_t *dst_dims, const int dst_ndims, int mask) const {
+
+        dims_t l_dims_po {};
+        get_l_dims_po(l_dims_po, l_offset, dst_dims, dst_ndims, mask);
+
+        return tensor_md.off_v(l_dims_po);
+    }
+
+    void get_l_dims_po(dims_t &l_dims_po, const dim_t l_offset,
+            const dim_t *dst_dims, const int dst_ndims, int mask) const {
+        utils::l_dims_by_l_offset(l_dims_po, l_offset, dst_dims, dst_ndims);
+        utils::apply_mask_on_dims(l_dims_po, dst_ndims, mask);
+    }
+
+    void set_ws(dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow,
+            dim_t value) const {
+        if (ws_ptr()) {
+            const auto off = get_offset(ws_md(), mb, oc, od, oh, ow);
+            const data_type_t ws_dt
+                    = ws_ptr() ? ws_md().data_type() : data_type::undef;
+            if (ws_dt == data_type::u8) {
+                store_float_value(ws_dt, value, ws_ptr(), off);
+            } else
+                store_float_value(ws_dt, value, ws_ptr(), off);
+        }
+    }
+
+    void ker_max(
+            float &d, dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow) const {
+        set_ws(mb, oc, od, oh, ow, 0);
+        for (dim_t kd = 0; kd < conf_.KD; ++kd) {
+            const dim_t id = od * conf_.SD - conf_.padF + kd * (conf_.DD + 1);
+            if (id < 0 || id >= conf_.ID) continue;
+            for (dim_t kh = 0; kh < conf_.KH; ++kh) {
+                const dim_t ih
+                        = oh * conf_.SH - conf_.padT + kh * (conf_.DH + 1);
+                if (ih < 0 || ih >= conf_.IH) continue;
+                for (dim_t kw = 0; kw < conf_.KW; ++kw) {
+                    const dim_t iw
+                            = ow * conf_.SW - conf_.padL + kw * (conf_.DW + 1);
+                    if (iw < 0 || iw >= conf_.IW) continue;
+
+                    const auto off = get_offset(src_md(), mb, oc, id, ih, iw);
+                    auto s = load_float_value(
+                            src_md().data_type(), src_ptr(), off);
+
+                    if (s > d) {
+                        d = s;
+                        set_ws(mb, oc, od, oh, ow,
+                                (kd * conf_.KH + kh) * conf_.KW + kw);
+                    }
+                }
+            }
+        }
+    }
+
+    void ker_avg(
+            float &d, dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow) const {
+        for (dim_t kd = 0; kd < conf_.KD; ++kd) {
+            const dim_t id = od * conf_.SD - conf_.padF + kd * (conf_.DD + 1);
+            if (id < 0 || id >= conf_.ID) continue;
+            for (dim_t kh = 0; kh < conf_.KH; ++kh) {
+                const dim_t ih
+                        = oh * conf_.SH - conf_.padT + kh * (conf_.DH + 1);
+                if (ih < 0 || ih >= conf_.IH) continue;
+                for (dim_t kw = 0; kw < conf_.KW; ++kw) {
+                    const dim_t iw
+                            = ow * conf_.SW - conf_.padL + kw * (conf_.DW + 1);
+                    if (iw < 0 || iw >= conf_.IW) continue;
+
+                    const auto off = get_offset(src_md(), mb, oc, id, ih, iw);
+                    float s = load_float_value(
+                            src_md().data_type(), src_ptr(), off);
+                    d += s;
+                }
+            }
+        }
+        int num_summands;
+        if (conf_.alg == alg_kind::pooling_avg_include_padding)
+            num_summands = conf_.KW * conf_.KH * conf_.KD;
+        else {
+            auto id_start = od * conf_.SD - conf_.padF;
+            auto ih_start = oh * conf_.SH - conf_.padT;
+            auto iw_start = ow * conf_.SW - conf_.padL;
+            auto id_end = od * conf_.SD - conf_.padF + (conf_.KD - 1) * conf_.DD
+                    + conf_.KD;
+            auto ih_end = oh * conf_.SH - conf_.padT + (conf_.KH - 1) * conf_.DH
+                    + conf_.KH;
+            auto iw_end = ow * conf_.SW - conf_.padL + (conf_.KW - 1) * conf_.DW
+                    + conf_.KW;
+
+            auto id_start_excluded = id_start < 0
+                    ? (0 - id_start - 1) / (conf_.DD + 1) + 1
+                    : 0;
+            auto ih_start_excluded = ih_start < 0
+                    ? (0 - ih_start - 1) / (conf_.DH + 1) + 1
+                    : 0;
+            auto iw_start_excluded = iw_start < 0
+                    ? (0 - iw_start - 1) / (conf_.DW + 1) + 1
+                    : 0;
+            auto id_end_excluded = id_end > conf_.ID
+                    ? (id_end - conf_.ID - 1) / (conf_.DD + 1) + 1
+                    : 0;
+            auto ih_end_excluded = ih_end > conf_.IH
+                    ? (ih_end - conf_.IH - 1) / (conf_.DH + 1) + 1
+                    : 0;
+            auto iw_end_excluded = iw_end > conf_.IW
+                    ? (iw_end - conf_.IW - 1) / (conf_.DW + 1) + 1
+                    : 0;
+
+            num_summands = (conf_.KD - id_start_excluded - id_end_excluded)
+                    * (conf_.KH - ih_start_excluded - ih_end_excluded)
+                    * (conf_.KW - iw_start_excluded - iw_end_excluded);
+        }
+        d /= num_summands;
+    }
+
+    sycl_pooling_conf_t conf_;
+
+    sycl_in_memory_arg_t src_;
+    sycl_out_memory_arg_t dst_;
+    sycl_out_memory_arg_t ws_;
+    sycl_in_memory_arg_t src_1_;
+    sycl_in_memory_arg_t src_2_;
+    sycl_in_memory_arg_t src_3_;
+    sycl_in_memory_arg_t src_4_;
+    sycl_in_memory_arg_t src_5_;
+};
+
+struct pooling_bwd_kernel_vec_t {
+    pooling_bwd_kernel_vec_t(const sycl_pooling_conf_t &conf,
+            sycl_in_memory_arg_t &diff_dst, sycl_out_memory_arg_t &diff_src,
+            sycl_in_memory_arg_t &ws)
+        : conf_(conf), diff_dst_(diff_dst), diff_src_(diff_src), ws_(ws) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+
+        dim_t ow_start = max(dim_t(0),
+                math::div_up(
+                        conf_.padL - ((conf_.KW - 1) * conf_.DW + conf_.KW) + 1,
+                        conf_.SW));
+        dim_t ow_end
+                = min(conf_.OW, 1 + (conf_.padL + conf_.IW - 1) / conf_.SW);
+
+        dim_t oh_start = max(dim_t(0),
+                math::div_up(
+                        conf_.padT - ((conf_.KH - 1) * conf_.DH + conf_.KH) + 1,
+                        conf_.SH));
+        dim_t oh_end
+                = min(conf_.OH, 1 + (conf_.padT + conf_.IH - 1) / conf_.SH);
+
+        dim_t od_start = max(dim_t(0),
+                math::div_up(
+                        conf_.padF - ((conf_.KD - 1) * conf_.DD + conf_.KD) + 1,
+                        conf_.SD));
+        dim_t od_end
+                = min(conf_.OD, 1 + (conf_.padF + conf_.ID - 1) / conf_.SD);
+
+        const bool is_max_pool = conf_.alg == alg_kind::pooling_max;
+        dim_t MB = conf_.MB;
+        dim_t OC = conf_.OC;
+        const dim_t work_amount = MB * OC;
+        if (work_amount == 0) return;
+        dim_t start {0}, end {0};
+        balance211(work_amount, conf_.n_thr, ithr, start, end);
+        dim_t mb {0}, oc {0};
+        utils::nd_iterator_init(start, mb, MB, oc, OC);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            ker_zero(mb, oc);
+            for_(dim_t od = od_start; od < od_end; ++od)
+            for_(dim_t oh = oh_start; oh < oh_end; ++oh)
+            for (dim_t ow = ow_start; ow < ow_end; ++ow) {
+                if (is_max_pool) {
+                    ker_max(mb, oc, od, oh, ow);
+                } else {
+                    ker_avg(mb, oc, od, oh, ow);
+                }
+            }
+            utils::nd_iterator_step(mb, MB, oc, OC);
+        }
+    }
+
+private:
+    const sycl_md_t &diff_src_md() const { return conf_.diff_src_md; }
+    const sycl_md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+    const sycl_md_t &ws_md() const { return conf_.ws_md; }
+
+    void *diff_src_ptr() const { return diff_src_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+    void *ws_ptr() const { return ws_.get_pointer(); }
+
+    static dim_t get_offset(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: return 0;
+        }
+        return 0;
+    }
+
+    void ker_zero(dim_t mb, dim_t oc) const {
+        for_(dim_t id = 0; id < conf_.ID; ++id)
+        for_(dim_t ih = 0; ih < conf_.IH; ++ih)
+        for (dim_t iw = 0; iw < conf_.IW; ++iw) {
+            const auto off = get_offset(diff_src_md(), mb, oc, id, ih, iw);
+            store_float_value(
+                    diff_src_md().data_type(), 0, diff_src_ptr(), off);
+        }
+    }
+
+    void ker_max(dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow) const {
+        const auto ws_off = get_offset(ws_md(), mb, oc, od, oh, ow);
+
+        const int index = ws_md().data_type() == data_type::u8
+                ? (int)load_float_value(ws_md().data_type(), ws_ptr(), ws_off)
+                : load_float_value(ws_md().data_type(), ws_ptr(), ws_off);
+        const dim_t kd = (index / conf_.KW) / conf_.KH;
+        const dim_t kh = (index / conf_.KW) % conf_.KH;
+        const dim_t kw = index % conf_.KW;
+        const dim_t id = od * conf_.SD - conf_.padF + kd * (conf_.DD + 1);
+        const dim_t ih = oh * conf_.SH - conf_.padT + kh * (conf_.DH + 1);
+        const dim_t iw = ow * conf_.SW - conf_.padL + kw * (conf_.DW + 1);
+        if (id < 0 || id >= conf_.ID) return;
+        if (ih < 0 || ih >= conf_.IH) return;
+        if (iw < 0 || iw >= conf_.IW) return;
+
+        const auto d_src_off = get_offset(diff_src_md(), mb, oc, id, ih, iw);
+        const auto d_dst_off = get_offset(diff_dst_md(), mb, oc, od, oh, ow);
+        float v_src = load_float_value(
+                diff_src_md().data_type(), diff_src_ptr(), d_src_off);
+        float v_dst = load_float_value(
+                diff_dst_md().data_type(), diff_dst_ptr(), d_dst_off);
+        v_src += v_dst;
+        store_float_value(
+                diff_src_md().data_type(), v_src, diff_src_ptr(), d_src_off);
+    }
+
+    void ker_avg(dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow) const {
+        int num_summands;
+        if (conf_.alg == alg_kind::pooling_avg_include_padding)
+            num_summands = conf_.KW * conf_.KH * conf_.KD;
+        else {
+            auto id_start = od * conf_.SD - conf_.padF;
+            auto ih_start = oh * conf_.SH - conf_.padT;
+            auto iw_start = ow * conf_.SW - conf_.padL;
+            auto id_end = od * conf_.SD - conf_.padF + (conf_.KD - 1) * conf_.DD
+                    + conf_.KD;
+            auto ih_end = oh * conf_.SH - conf_.padT + (conf_.KH - 1) * conf_.DH
+                    + conf_.KH;
+            auto iw_end = ow * conf_.SW - conf_.padL + (conf_.KW - 1) * conf_.DW
+                    + conf_.KW;
+
+            auto id_start_excluded = id_start < 0
+                    ? (0 - id_start - 1) / (conf_.DD + 1) + 1
+                    : 0;
+            auto ih_start_excluded = ih_start < 0
+                    ? (0 - ih_start - 1) / (conf_.DH + 1) + 1
+                    : 0;
+            auto iw_start_excluded = iw_start < 0
+                    ? (0 - iw_start - 1) / (conf_.DW + 1) + 1
+                    : 0;
+            auto id_end_excluded = id_end > conf_.ID
+                    ? (id_end - conf_.ID - 1) / (conf_.DD + 1) + 1
+                    : 0;
+            auto ih_end_excluded = ih_end > conf_.IH
+                    ? (ih_end - conf_.IH - 1) / (conf_.DH + 1) + 1
+                    : 0;
+            auto iw_end_excluded = iw_end > conf_.IW
+                    ? (iw_end - conf_.IW - 1) / (conf_.DW + 1) + 1
+                    : 0;
+
+            num_summands = (conf_.KD - id_start_excluded - id_end_excluded)
+                    * (conf_.KH - ih_start_excluded - ih_end_excluded)
+                    * (conf_.KW - iw_start_excluded - iw_end_excluded);
+        }
+        for (dim_t kd = 0; kd < conf_.KD; ++kd) {
+            const dim_t id = od * conf_.SD - conf_.padF + kd * (conf_.DD + 1);
+            if (id < 0 || id >= conf_.ID) continue;
+            for (dim_t kh = 0; kh < conf_.KH; ++kh) {
+                const dim_t ih
+                        = oh * conf_.SH - conf_.padT + kh * (conf_.DH + 1);
+                if (ih < 0 || ih >= conf_.IH) continue;
+                for (dim_t kw = 0; kw < conf_.KW; ++kw) {
+                    const dim_t iw
+                            = ow * conf_.SW - conf_.padL + kw * (conf_.DW + 1);
+                    if (iw < 0 || iw >= conf_.IW) continue;
+
+                    const auto d_src_off
+                            = get_offset(diff_src_md(), mb, oc, id, ih, iw);
+                    const auto d_dst_off
+                            = get_offset(diff_dst_md(), mb, oc, od, oh, ow);
+                    float v_src = load_float_value(diff_src_md().data_type(),
+                            diff_src_ptr(), d_src_off);
+                    float v_dst = load_float_value(diff_dst_md().data_type(),
+                            diff_dst_ptr(), d_dst_off);
+                    v_src += v_dst / num_summands;
+                    store_float_value(diff_src_md().data_type(), v_src,
+                            diff_src_ptr(), d_src_off);
+                }
+            }
+        }
+    }
+
+    sycl_pooling_conf_t conf_;
+    sycl_in_memory_arg_t diff_dst_;
+    sycl_out_memory_arg_t diff_src_;
+    sycl_in_memory_arg_t ws_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/ref_pooling.cpp
+++ b/src/gpu/sycl/ref_pooling.cpp
@@ -1,0 +1,188 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/sycl/ref_pooling.hpp"
+#include "common/c_types_map.hpp"
+#include "common/dnnl_traits.hpp"
+#include "gpu/sycl/pooling_kernels.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+using namespace impl::sycl;
+
+status_t ref_pooling_fwd_t::pd_t::init_conf() {
+    using namespace primitive_kind;
+    conf_ = sycl_pooling_conf_t();
+    conf_.ndims = ndims();
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+    conf_.src_md = sycl_md_t(src_md(0));
+    conf_.dst_md = sycl_md_t(dst_md(0));
+    conf_.ws_md = !types::is_zero_md(workspace_md())
+            ? sycl_md_t(workspace_md(0))
+            : sycl_md_t {};
+    conf_.zero_dims = has_zero_dim_memory();
+    for (int i = 0; i < DNNL_MAX_NDIMS; i++) {
+        conf_.dst_dims[i] = dst_md()->dims[i];
+    }
+    conf_.dst_ndims = dst_md()->ndims;
+    auto nelems_A = memory_desc_wrapper(src_md(0)).nelems();
+    int work_per_wg = conf_.wg_size * conf_.block_size;
+    int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+    conf_.n_thr = n_wgs * conf_.wg_size;
+    conf_.alg = desc()->alg_kind;
+    conf_.MB = MB(); //n: denotes the mini-batch dimension
+    conf_.OC = OC(); //c:outputchannel dimension
+    conf_.OD = OD(); //d: output spatial depth
+    conf_.OH = OH(); //h: ouput height
+    conf_.OW = OW(); //w: output width
+    conf_.ID = ID(); //d: input spatial depth
+    conf_.IH = IH(); //h: input height
+    conf_.IW = IW(); //w: input width
+    conf_.KD = KD(); //K: kernel D: spatial depth
+    conf_.KH = KH(); //k: kernel H: Height
+    conf_.KW = KW(); //K: kernel W:width
+    conf_.SD = KSD(); //K:kernel S:strides D:Depth
+    conf_.SH = KSH(); //K:kernel S:strides H:Height
+    conf_.SW = KSW(); //K:kernel S:strides W:Wdith
+    conf_.padF = padFront();
+    conf_.padT = padT();
+    conf_.padL = padL();
+    conf_.DD = KDD(); //K:kernel D:Dilation D:Depth
+    conf_.DH = KDH(); //K:kernel D:Dilation H:Height
+    conf_.DW = KDW(); //K:kernel D:Dilation W:Weight
+
+    const auto *att = attr();
+    const auto &attr_po = att->post_ops_;
+    conf_.po_len = attr_po.len();
+    for (auto i = 0; i < attr_po.len(); ++i) {
+        if (attr_po.contain(binary, i)) {
+            dnnl::impl::memory_desc_t mem = attr_po.entry_[i].binary.src1_desc;
+            conf_.src1_md[i] = sycl_md_t(&mem);
+        }
+    }
+    conf_.post_ops = sycl_post_ops_t(attr());
+    return status::success;
+}
+
+status_t ref_pooling_fwd_t::init(engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<pooling_fwd_kernel_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto src = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+        auto dst = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+        auto ws = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_WORKSPACE);
+        auto post_v0 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1);
+        auto post_v1 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(1) | DNNL_ARG_SRC_1);
+        auto post_v2 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(2) | DNNL_ARG_SRC_1);
+        auto post_v3 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(3) | DNNL_ARG_SRC_1);
+        auto post_v4 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(4) | DNNL_ARG_SRC_1);
+        auto nelems_A = memory_desc_wrapper(pd()->src_md(0)).nelems();
+        pooling_fwd_kernel_vec_t pooling_fwd_kernel(pd()->conf_, src, dst, ws,
+                post_v0, post_v1, post_v2, post_v3, post_v4);
+
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+
+        int work_per_wg = wg_size * block_size;
+        int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+        int n_thr = n_wgs * wg_size;
+        cgh.parallel_for(
+                ::sycl::nd_range<1>(n_thr, wg_size), pooling_fwd_kernel);
+    });
+}
+
+status_t ref_pooling_bwd_t::pd_t::init_conf() {
+    conf_ = sycl_pooling_conf_t();
+    conf_.ndims = ndims();
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+    conf_.diff_src_md = sycl_md_t(diff_src_md(0));
+    conf_.diff_dst_md = sycl_md_t(diff_dst_md(0));
+    conf_.ws_md = !types::is_zero_md(workspace_md())
+            ? sycl_md_t(workspace_md(0))
+            : sycl_md_t {};
+    conf_.zero_dims = has_zero_dim_memory();
+    auto nelems_A = memory_desc_wrapper(diff_src_md(0)).nelems();
+    int work_per_wg = conf_.wg_size * conf_.block_size;
+    int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+    conf_.n_thr = n_wgs * conf_.wg_size;
+
+    conf_.alg = desc()->alg_kind;
+    conf_.MB = MB();
+    conf_.OC = OC();
+    conf_.OD = OD();
+    conf_.OH = OH();
+    conf_.OW = OW();
+    conf_.ID = ID();
+    conf_.IH = IH();
+    conf_.IW = IW();
+    conf_.KD = KD();
+    conf_.KH = KH();
+    conf_.KW = KW();
+    conf_.SD = KSD();
+    conf_.SH = KSH();
+    conf_.SW = KSW();
+    conf_.padF = padFront();
+    conf_.padT = padT();
+    conf_.padL = padL();
+    conf_.DD = KDD();
+    conf_.DH = KDH();
+    conf_.DW = KDW();
+    return status::success;
+}
+
+status_t ref_pooling_bwd_t::init(engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<pooling_bwd_kernel_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_pooling_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto diff_dst = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto diff_src = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto ws = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_WORKSPACE);
+        auto nelems_A = memory_desc_wrapper(pd()->diff_src_md(0)).nelems();
+        pooling_bwd_kernel_vec_t pooling_bwd_kernel(
+                pd()->conf_, diff_dst, diff_src, ws);
+
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+
+        int work_per_wg = wg_size * block_size;
+        int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+        int n_thr = n_wgs * wg_size;
+        cgh.parallel_for(
+                ::sycl::nd_range<1>(n_thr, wg_size), pooling_bwd_kernel);
+    });
+}
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/sycl/ref_pooling.hpp
+++ b/src/gpu/sycl/ref_pooling.hpp
@@ -1,0 +1,147 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_REF_POOLING_HPP
+#define GPU_SYCL_REF_POOLING_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/utils.hpp"
+#include "gpu/gpu_pooling_pd.hpp"
+#include "gpu/primitive_conf.hpp"
+#include "gpu/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+#include "sycl/sycl_stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct ref_pooling_fwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_pooling_fwd_pd_t {
+        using gpu_pooling_fwd_pd_t::gpu_pooling_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_pooling_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            using namespace prop_kind;
+            using namespace alg_kind;
+            using sm = primitive_attr_t::skip_mask_t;
+            const memory_desc_wrapper src_d(src_md(0));
+            const memory_desc_wrapper dst_d(dst_md(0));
+            const memory_desc_wrapper ws_d(workspace_md(0));
+
+            const bool ok = is_fwd() && set_default_params() == status::success
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && (utils::everyone_is(
+                                s8, src_md(0)->data_type, dst_md(0)->data_type)
+                            || utils::everyone_is(u8, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(f32, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(bf16, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(f16, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(s32, src_md(0)->data_type,
+                                    dst_md(0)->data_type))
+                    && attr()->has_default_values(sm::post_ops)
+                    && attr_.set_default_formats(dst_md(0)) == status::success;
+            if (!ok) return status::unimplemented;
+            bool is_training = desc_.prop_kind == prop_kind::forward_training;
+            if (desc()->alg_kind == alg_kind::pooling_max && is_training)
+                init_default_ws();
+            return init_conf();
+        }
+
+        status_t init_conf();
+        sycl_pooling_conf_t conf_;
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+struct ref_pooling_bwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_pooling_bwd_pd_t {
+        using gpu_pooling_bwd_pd_t::gpu_pooling_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_pooling_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            const memory_desc_wrapper diff_dst_d(diff_dst_md(0));
+            const memory_desc_wrapper diff_src_d(diff_src_md(0));
+            const memory_desc_wrapper ws_d(workspace_md(0));
+
+            const bool ok = !is_fwd() && set_default_params() == status::success
+                    && (utils::everyone_is(f32, diff_src_md(0)->data_type,
+                                diff_dst_md(0)->data_type)
+                            || utils::everyone_is(bf16,
+                                    diff_src_md(0)->data_type,
+                                    diff_dst_md(0)->data_type)
+                            || utils::everyone_is(f16,
+                                    diff_src_md(0)->data_type,
+                                    diff_dst_md(0)->data_type))
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && attr()->has_default_values();
+
+            if (!ok) return status::unimplemented;
+            if (desc()->alg_kind == alg_kind::pooling_max) {
+                init_default_ws();
+                if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;
+            }
+            return init_conf();
+        }
+
+        status_t init_conf();
+        sycl_pooling_conf_t conf_;
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_backward(ctx);
+    }
+
+private:
+    status_t execute_backward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/sycl_math_utils.hpp
+++ b/src/gpu/sycl/sycl_math_utils.hpp
@@ -39,6 +39,11 @@ template <typename T>
 using rem_ref = typename utils::remove_reference<T>::type;
 
 template <typename T, typename U = rem_ref<T>>
+inline U div_up(const T a, const U b) {
+    return (a + b - 1) / b;
+}
+
+template <typename T, typename U = rem_ref<T>>
 inline U exp_fwd(T s) {
     return (U)::sycl::exp(s);
 }

--- a/src/gpu/sycl/sycl_post_ops.hpp
+++ b/src/gpu/sycl/sycl_post_ops.hpp
@@ -244,9 +244,12 @@ struct sycl_post_ops_t {
         if (n_post_ops_ == 0) return acc;
 
         int binary_idx = 0;
-
+        int eltwise_idx = 0;
         for (auto i = 0; i < n_post_ops_; ++i) {
             switch (post_op_kinds_[i]) {
+                case eltwise:
+                    acc = eltwise_post_ops_[eltwise_idx++].compute(acc);
+                    break;
                 case binary:
                     acc = binary_post_ops_[binary_idx++].compute(acc, dst[i]);
                     break;

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -289,6 +289,45 @@ struct sycl_lrn_conf_t {
     int wk_size;
 };
 
+struct sycl_pooling_conf_t {
+    sycl_md_t src_md;
+    sycl_md_t src1_md[8];
+    sycl_md_t dst_md;
+    sycl_md_t ws_md;
+    sycl_md_t diff_src_md;
+    sycl_md_t diff_dst_md;
+    int ndims;
+    int po_len;
+    bool zero_dims;
+    int block_size;
+    int wg_size;
+    size_t n_thr;
+    alg_kind_t alg;
+    dim_t MB;
+    dim_t OC;
+    dim_t OD;
+    dim_t OH;
+    dim_t OW;
+    dim_t ID;
+    dim_t IH;
+    dim_t IW;
+    dim_t KD;
+    dim_t KH;
+    dim_t KW;
+    dim_t SD;
+    dim_t SH;
+    dim_t SW;
+    dim_t padF;
+    dim_t padT;
+    dim_t padL;
+    dim_t DD;
+    dim_t DH;
+    dim_t DW;
+    dims_t dst_dims;
+    int dst_ndims;
+    sycl_post_ops_t post_ops;
+};
+
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_shuffle_conf_t);
@@ -298,6 +337,7 @@ CHECK_SYCL_KERNEL_ARG_TYPE(sycl_softmax_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_layer_normalization_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_eltwise_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_lrn_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_pooling_conf_t);
 
 } // namespace sycl
 } // namespace gpu


### PR DESCRIPTION
# Description
Introducing SYCL backend for the oneDNN Pooling primitive. This contains support for Pooling functionality in both forward and backward propagations.

# Supported scope
Supported Data Types:
- Forward : f32, s32, f16, bf16, s8, u8
- Backward: f32, f16, bf16


## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Tested Hardware
Nvidia Tesla T4

## Testing Scope
`benchdnn : passed`

Please refer the test output files
[Pooling_benchdnn_output.zip](https://github.com/oneapi-src/oneDNN/files/10948726/Pooling_benchdnn_output.zip)


