### PR TITLE
SYCL Kernel support for Batch Normalization

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -38,6 +38,7 @@
 #include "gpu/nvidia/sycl_cuda_scoped_context.hpp"
 #include "gpu/nvidia/sycl_cuda_stream.hpp"
 
+#include "gpu/sycl/ref_batch_normalization.hpp"
 #include "gpu/sycl/ref_binary.hpp"
 #include "gpu/sycl/ref_prelu.hpp"
 #include "gpu/sycl/ref_resampling.hpp"
@@ -217,6 +218,8 @@ constexpr dnnl::impl::impl_list_item_t sycl_cuda_impl_list[] = {
         // Batch Normalization
         INSTANCE(cudnn_batch_normalization_fwd_t)
         INSTANCE(cudnn_batch_normalization_bwd_t)
+        INSTANCE(sycl::ref_batch_normalization_fwd_t)
+        INSTANCE(sycl::ref_batch_normalization_bwd_t)
 
         // PReLU
         INSTANCE(sycl::ref_prelu_fwd_t)

--- a/src/gpu/sycl/batch_normalizations_kernels.hpp
+++ b/src/gpu/sycl/batch_normalizations_kernels.hpp
@@ -1,0 +1,594 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_BATCH_NORMALIZATION_KERNELS_HPP
+#define GPU_SYCL_BATCH_NORMALIZATION_KERNELS_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/dnnl_traits.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+namespace {
+
+using acc_data_t = float;
+
+template <typename T>
+inline float maybe_up_convert(T x) {
+    return x;
+}
+
+template <>
+inline float maybe_up_convert<bfloat16_t>(bfloat16_t x) {
+    return (float)x;
+}
+
+} // namespace
+
+struct batch_normalization_fwd_kernel_vec_t {
+    batch_normalization_fwd_kernel_vec_t(
+            const sycl_batch_normalization_conf_t &conf,
+            sycl_in_memory_arg_t &data, sycl_in_memory_arg_t &scale,
+            sycl_in_memory_arg_t &shift, sycl_in_memory_arg_t &stat,
+            sycl_in_memory_arg_t &var, sycl_out_memory_arg_t &dst,
+            sycl_out_memory_arg_t &ws, sycl_in_memory_arg_t &src1)
+        : conf_(conf)
+        , data_(data)
+        , scale_(scale)
+        , shift_(shift)
+        , stat_(stat)
+        , var_(var)
+        , dst_(dst)
+        , ws_(ws)
+        , src1_(src1) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        dim_t start_c, end_c;
+        balance211(conf_.C, conf_.n_thr, ithr, start_c, end_c);
+        compute_fwd(start_c, end_c);
+    }
+
+private:
+    const sycl_md_t &data_md() const { return conf_.data_md; }
+    const sycl_md_t &src1_md() const { return conf_.src1_md; }
+    const sycl_md_t &ws_md() const { return conf_.ws_md; }
+    const sycl_md_t &data_scaleshift_md() const {
+        return conf_.data_scaleshift_md;
+    }
+    const sycl_md_t &var_md() const { return conf_.var_md; }
+    const sycl_md_t &stat_d() const { return conf_.stat_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const float epsilon() const { return conf_.batch_norm_epsilon; }
+
+    inline static dim_t DATA_OFF(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 1: return mdw.off(n);
+            case 2: return mdw.off(n, c);
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: assert(!"Invalid tensor dimension in Batch");
+        }
+        return 0;
+    }
+
+    void compute_fwd(dim_t start_c, dim_t end_c) const {
+        const bool with_relu = conf_.with_relu;
+        auto maybe_post_op = [&](float res) {
+            if (with_relu) { return math::relu_fwd(res, conf_.alpha); }
+            return res;
+        };
+
+        for (dim_t c = start_c; c < end_c; c++) {
+            float v_mean
+                    = load_float_value(stat_d().data_type(), stat_ptr(), c);
+            float v_variance
+                    = load_float_value(var_md().data_type(), var_ptr(), c);
+            float sqrt_variance = sqrtf(v_variance + conf_.batch_norm_epsilon);
+            float sm = (conf_.use_scale ? load_float_value(
+                                data_scaleshift_md().data_type(), scale_ptr(),
+                                data_scaleshift_md().off(c))
+                                        : 1.0f)
+                    / sqrt_variance;
+            float sv = conf_.use_shift
+                    ? load_float_value(data_scaleshift_md().data_type(),
+                            shift_ptr(), data_scaleshift_md().off(c))
+                    : 0;
+
+            for_(dim_t n = 0; n < conf_.N; ++n)
+            for_(dim_t d = 0; d < conf_.D; ++d)
+            for_(dim_t h = 0; h < conf_.H; ++h)
+            for (dim_t w = 0; w < conf_.W; ++w) {
+                auto d_off = DATA_OFF(data_md(), n, c, d, h, w);
+                float bn_res = (sm
+                                       * (maybe_up_convert(load_float_value(
+                                                  data_md().data_type(),
+                                                  data_ptr(), d_off))
+                                               - v_mean))
+                        + sv;
+                if (conf_.fuse_norm_relu) {
+                    if (bn_res <= 0) {
+                        bn_res = 0;
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                    } else {
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                    }
+                }
+
+                if (conf_.fuse_norm_add_relu) {
+                    float v = load_float_value(
+                            src1_md().data_type(), src1_ptr(), d_off);
+                    bn_res = bn_res + v;
+                    if (bn_res <= 0) {
+                        bn_res = 0;
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                    } else {
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                    }
+                }
+
+                if (data_md().data_type() == data_type::s8) {
+                    bn_res = ::dnnl::impl::sycl::qz_a1b0<float,
+                            sycl_prec_traits<data_type::s8>::type>()(
+                            maybe_post_op(bn_res));
+                    store_float_value(
+                            dst_md().data_type(), bn_res, dst_ptr(), d_off);
+                } else {
+                    bn_res = maybe_post_op(bn_res);
+                    store_float_value(
+                            dst_md().data_type(), bn_res, dst_ptr(), d_off);
+                }
+            }
+        }
+    }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *src1_ptr() const { return src1_.get_pointer(); }
+    void *scale_ptr() const { return scale_.get_pointer(); }
+    void *shift_ptr() const { return shift_.get_pointer(); }
+    void *stat_ptr() const { return stat_.get_pointer(); }
+    void *var_ptr() const { return var_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+    void *ws_ptr() const { return ws_.get_pointer(); }
+
+    sycl_batch_normalization_conf_t conf_;
+
+    sycl_in_memory_arg_t data_;
+    sycl_in_memory_arg_t scale_;
+    sycl_in_memory_arg_t shift_;
+    sycl_in_memory_arg_t stat_;
+    sycl_in_memory_arg_t var_;
+    sycl_out_memory_arg_t dst_;
+    sycl_out_memory_arg_t ws_;
+    sycl_in_memory_arg_t src1_;
+};
+
+struct batch_normalization_fwd_kernel_vec_t1 {
+    batch_normalization_fwd_kernel_vec_t1(
+            const sycl_batch_normalization_conf_t &conf,
+            sycl_in_memory_arg_t &data, sycl_in_memory_arg_t &scale,
+            sycl_in_memory_arg_t &shift, sycl_out_memory_arg_t &dst,
+            sycl_out_memory_arg_t &mean_out, sycl_out_memory_arg_t &var_out,
+            sycl_out_memory_arg_t &ws, sycl_in_memory_arg_t &src1)
+        : conf_(conf)
+        , data_(data)
+        , scale_(scale)
+        , shift_(shift)
+        , dst_(dst)
+        , mean_out_(mean_out)
+        , var_out_(var_out)
+        , ws_(ws)
+        , src1_(src1) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        dim_t start_c, end_c;
+        balance211(conf_.C, conf_.n_thr, ithr, start_c, end_c);
+        compute_fwd(start_c, end_c);
+    }
+
+private:
+    const sycl_md_t &data_md() const { return conf_.data_md; }
+    const sycl_md_t &src1_md() const { return conf_.src1_md; }
+    const sycl_md_t &ws_md() const { return conf_.ws_md; }
+    const sycl_md_t &data_scaleshift_md() const {
+        return conf_.data_scaleshift_md;
+    }
+    const sycl_md_t &var_md() const { return conf_.var_md; }
+    const sycl_md_t &stat_d() const { return conf_.stat_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const float epsilon() const { return conf_.batch_norm_epsilon; }
+
+    inline static dim_t DATA_OFF(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 1: return mdw.off(n);
+            case 2: return mdw.off(n, c);
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: assert(!"Invalid tensor dimension in Batch");
+        }
+        return 0;
+    }
+
+    void compute_fwd(dim_t start_c, dim_t end_c) const {
+
+        if (conf_.zero_dims && conf_.calculate_stats && conf_.save_stats) {
+            for (dim_t i = 0; i < conf_.C; i++) {
+                store_float_value(stat_d().data_type(), 0, stat_out_ptr(), i);
+                store_float_value(var_md().data_type(), 0, var_out_ptr(), i);
+            }
+        }
+
+        const bool with_relu = conf_.with_relu;
+        auto maybe_post_op = [&](float res) {
+            if (with_relu) { return math::relu_fwd(res, conf_.alpha); }
+            return res;
+        };
+
+        for (dim_t c = start_c; c < end_c; c++) {
+
+            float v_mean = 0;
+            float v_variance = 0;
+            for_(dim_t n = 0; n < conf_.N; ++n)
+            for_(dim_t d = 0; d < conf_.D; ++d)
+            for_(dim_t h = 0; h < conf_.H; ++h)
+            for (dim_t w = 0; w < conf_.W; ++w) {
+                auto data_off = DATA_OFF(data_md(), n, c, d, h, w);
+                v_mean += maybe_up_convert(load_float_value(
+                        data_md().data_type(), data_ptr(), data_off));
+            }
+            v_mean /= (conf_.W * conf_.N * conf_.H * conf_.D);
+
+            for_(dim_t n = 0; n < conf_.N; ++n)
+            for_(dim_t d = 0; d < conf_.D; ++d)
+            for_(dim_t h = 0; h < conf_.H; ++h)
+            for (dim_t w = 0; w < conf_.W; ++w) {
+                auto data_off = DATA_OFF(data_md(), n, c, d, h, w);
+                auto m = load_float_value(
+                                 data_md().data_type(), data_ptr(), data_off)
+                        - v_mean;
+                v_variance += m * m;
+            }
+            v_variance /= (conf_.W * conf_.H * conf_.N * conf_.D);
+
+            float sqrt_variance = sqrtf(v_variance + conf_.batch_norm_epsilon);
+            float sm = (conf_.use_scale ? load_float_value(
+                                data_scaleshift_md().data_type(), scale_ptr(),
+                                data_scaleshift_md().off(c))
+                                        : 1.0f)
+                    / sqrt_variance;
+            float sv = conf_.use_shift
+                    ? load_float_value(data_scaleshift_md().data_type(),
+                            shift_ptr(), data_scaleshift_md().off(c))
+                    : 0;
+
+            for_(dim_t n = 0; n < conf_.N; ++n)
+            for_(dim_t d = 0; d < conf_.D; ++d)
+            for_(dim_t h = 0; h < conf_.H; ++h)
+            for (dim_t w = 0; w < conf_.W; ++w) {
+                auto d_off = DATA_OFF(data_md(), n, c, d, h, w);
+                float bn_res = (sm
+                                       * (maybe_up_convert(load_float_value(
+                                                  data_md().data_type(),
+                                                  data_ptr(), d_off))
+                                               - v_mean))
+                        + sv;
+                if (conf_.fuse_norm_relu) {
+                    if (bn_res <= 0) {
+                        bn_res = 0;
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                    } else {
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                    }
+                }
+
+                if (conf_.fuse_norm_add_relu) {
+                    float v = load_float_value(
+                            src1_md().data_type(), src1_ptr(), d_off);
+                    bn_res = bn_res + v;
+                    if (bn_res <= 0) {
+                        bn_res = 0;
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                    } else {
+                        if (conf_.is_training)
+                            store_float_value(
+                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                    }
+                }
+
+                if (data_md().data_type() == data_type::s8) {
+                    bn_res = ::dnnl::impl::sycl::qz_a1b0<float,
+                            sycl_prec_traits<data_type::s8>::type>()(
+                            maybe_post_op(bn_res));
+                    store_float_value(
+                            dst_md().data_type(), bn_res, dst_ptr(), d_off);
+                } else {
+                    bn_res = maybe_post_op(bn_res);
+                    store_float_value(
+                            dst_md().data_type(), bn_res, dst_ptr(), d_off);
+                }
+            }
+            if (conf_.calculate_stats) {
+                if (conf_.save_stats) {
+                    store_float_value(
+                            stat_d().data_type(), v_mean, stat_out_ptr(), c);
+                    store_float_value(
+                            var_md().data_type(), v_variance, var_out_ptr(), c);
+                }
+            }
+        }
+    }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *src1_ptr() const { return src1_.get_pointer(); }
+    void *scale_ptr() const { return scale_.get_pointer(); }
+    void *shift_ptr() const { return shift_.get_pointer(); }
+    void *stat_out_ptr() const { return mean_out_.get_pointer(); }
+    void *var_out_ptr() const { return var_out_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+    void *ws_ptr() const { return ws_.get_pointer(); }
+
+    sycl_batch_normalization_conf_t conf_;
+
+    sycl_in_memory_arg_t data_;
+    sycl_in_memory_arg_t scale_;
+    sycl_in_memory_arg_t shift_;
+    sycl_out_memory_arg_t dst_;
+    sycl_out_memory_arg_t mean_out_;
+    sycl_out_memory_arg_t var_out_;
+    sycl_out_memory_arg_t ws_;
+    sycl_in_memory_arg_t src1_;
+};
+
+struct batch_normalization_bwd_kernel_vec_t {
+    batch_normalization_bwd_kernel_vec_t(
+            const sycl_batch_normalization_conf_t &conf,
+            sycl_in_memory_arg_t &data, sycl_out_memory_arg_t &diff_data,
+            sycl_in_memory_arg_t &scale, sycl_out_memory_arg_t &diff_scale,
+            sycl_out_memory_arg_t &diff_shift, sycl_in_memory_arg_t &stat,
+            sycl_in_memory_arg_t &var, sycl_in_memory_arg_t &diff_dst,
+            sycl_in_memory_arg_t &dst, sycl_in_memory_arg_t &ws,
+            sycl_in_memory_arg_t &diff_src1)
+        : conf_(conf)
+        , data_(data)
+        , diff_data_(diff_data)
+        , scale_(scale)
+        , diff_scale_(diff_scale)
+        , diff_shift_(diff_shift)
+        , stat_(stat)
+        , var_(var)
+        , diff_dst_(diff_dst)
+        , dst_(dst)
+        , ws_(ws)
+        , diff_src1_(diff_src1) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        dim_t start_c, end_c;
+        balance211(conf_.C, conf_.n_thr, ithr, start_c, end_c);
+        compute_bwd(start_c, end_c);
+    }
+
+private:
+    const sycl_md_t &data_md() const { return conf_.data_md; }
+    const sycl_md_t &diff_data_md() const { return conf_.diff_data_md; }
+    const sycl_md_t &diff_src1_md() const { return conf_.diff_src1_md; }
+    const sycl_md_t &stat_d() const { return conf_.stat_md; }
+    const sycl_md_t &ws_md() const { return conf_.ws_md; }
+    const sycl_md_t &data_scaleshift_md() const {
+        return conf_.data_scaleshift_md;
+    }
+    const sycl_md_t &diff_data_scaleshift_md() const {
+        return conf_.diff_data_scaleshift_md;
+    }
+    const sycl_md_t &var_md() const { return conf_.var_md; }
+    const sycl_md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+    const unsigned flags() const { return conf_.flags; }
+    const float epsilon() const { return conf_.batch_norm_epsilon; }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *scale_ptr() const { return scale_.get_pointer(); }
+    void *diff_data_ptr() const { return diff_data_.get_pointer(); }
+    void *diff_src1_ptr() const { return diff_src1_.get_pointer(); }
+    void *diff_scale_ptr() const { return diff_scale_.get_pointer(); }
+    void *diff_shift_ptr() const { return diff_shift_.get_pointer(); }
+    void *stat_ptr() const { return stat_.get_pointer(); }
+    void *var_ptr() const { return var_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+    void *ws_ptr() const { return ws_.get_pointer(); }
+
+    static dim_t DATA_OFF(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 1: return mdw.off(n);
+            case 2: return mdw.off(n, c);
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: assert(!"Invalid tensor dimension in Batch");
+        }
+        return 0;
+    }
+
+    void compute_bwd(dim_t start_c, dim_t end_c) const {
+        if (conf_.zero_dims) {
+            if (conf_.use_scale) {
+                for (dim_t c = 0; c < conf_.C; ++c) {
+                    store_float_value(diff_data_scaleshift_md().data_type(),
+                            0.0f, diff_scale_ptr(),
+                            diff_data_scaleshift_md().off(c));
+                }
+            }
+            if (conf_.use_shift) {
+                for (dim_t c = 0; c < conf_.C; ++c) {
+                    store_float_value(diff_data_scaleshift_md().data_type(),
+                            0.0f, diff_shift_ptr(),
+                            diff_data_scaleshift_md().off(c));
+                }
+            }
+        }
+
+        for (dim_t c = start_c; c < end_c; c++) {
+
+            float v_mean
+                    = load_float_value(stat_d().data_type(), stat_ptr(), c);
+            float v_variance
+                    = load_float_value(var_md().data_type(), var_ptr(), c);
+            float sqrt_variance = static_cast<float>(
+                    1.0f / sqrtf(v_variance + conf_.batch_norm_epsilon));
+            float gamma = conf_.use_scale
+                    ? load_float_value(data_scaleshift_md().data_type(),
+                            scale_ptr(), data_scaleshift_md().off(c))
+                    : 1.0f;
+            float diff_gamma = 0;
+            float diff_beta = 0;
+
+            for_(dim_t n = 0; n < conf_.N; ++n)
+            for_(dim_t d = 0; d < conf_.D; ++d)
+            for_(dim_t h = 0; h < conf_.H; ++h)
+            for (dim_t w = 0; w < conf_.W; ++w) {
+                const size_t s_off = DATA_OFF(data_md(), n, c, d, h, w);
+
+                float dd = maybe_up_convert(load_float_value(
+                        diff_dst_md().data_type(), diff_dst_ptr(),
+                        DATA_OFF(diff_data_md(), n, c, d, h, w)));
+                if (conf_.fuse_norm_relu
+                        && !load_float_value(
+                                ws_md().data_type(), ws_ptr(), s_off))
+                    dd = 0;
+
+                if (conf_.fuse_norm_add_relu) {
+                    dd = ::dnnl::impl::math::relu_bwd(dd,
+                            load_float_value(
+                                    ws_md().data_type(), ws_ptr(), s_off),
+                            conf_.alpha);
+                    store_float_value(diff_src1_md().data_type(), dd,
+                            diff_src1_ptr(), s_off);
+                }
+
+                diff_gamma
+                        += (maybe_up_convert(load_float_value(
+                                    data_md().data_type(), data_ptr(), s_off))
+                                   - v_mean)
+                        * dd;
+                diff_beta += dd;
+            }
+            diff_gamma *= sqrt_variance;
+
+            if (conf_.use_scale) {
+                store_float_value(diff_data_scaleshift_md().data_type(),
+                        diff_gamma, diff_scale_ptr(),
+                        diff_data_scaleshift_md().off(c));
+            }
+
+            if (conf_.use_shift) {
+                store_float_value(diff_data_scaleshift_md().data_type(),
+                        diff_beta, diff_shift_ptr(),
+                        diff_data_scaleshift_md().off(c));
+            }
+
+            for_(dim_t n = 0; n < conf_.N; ++n)
+            for_(dim_t d = 0; d < conf_.D; ++d)
+            for_(dim_t h = 0; h < conf_.H; ++h)
+            for (dim_t w = 0; w < conf_.W; ++w) {
+                const size_t s_off = DATA_OFF(data_md(), n, c, d, h, w);
+                const size_t dd_off = DATA_OFF(diff_data_md(), n, c, d, h, w);
+                float dd = maybe_up_convert(load_float_value(
+                        diff_dst_md().data_type(), diff_dst_ptr(), dd_off));
+
+                if (conf_.fuse_norm_relu
+                        && !load_float_value(
+                                ws_md().data_type(), ws_ptr(), s_off))
+                    dd = 0;
+
+                if (conf_.fuse_norm_add_relu) {
+                    dd = ::dnnl::impl::math::relu_bwd(dd,
+                            load_float_value(
+                                    ws_md().data_type(), ws_ptr(), s_off),
+                            conf_.alpha);
+                    store_float_value(diff_src1_md().data_type(), dd,
+                            diff_src1_ptr(), s_off);
+                }
+
+                float v_diff_src = dd;
+                if (conf_.calculate_diff_stats) {
+                    v_diff_src -= diff_beta
+                                    / (conf_.D * conf_.W * conf_.H * conf_.N)
+                            + (maybe_up_convert(
+                                       load_float_value(data_md().data_type(),
+                                               data_ptr(), s_off))
+                                      - v_mean)
+                                    * diff_gamma * sqrt_variance
+                                    / (conf_.D * conf_.W * conf_.H * conf_.N);
+                }
+                v_diff_src *= gamma * sqrt_variance;
+                store_float_value(diff_data_md().data_type(), v_diff_src,
+                        diff_data_ptr(), dd_off);
+            }
+        } //end of main loop
+
+    } //end of compute
+
+    sycl_batch_normalization_conf_t conf_;
+
+    sycl_in_memory_arg_t data_;
+    sycl_out_memory_arg_t diff_data_;
+    sycl_in_memory_arg_t scale_;
+    sycl_out_memory_arg_t diff_scale_;
+    sycl_out_memory_arg_t diff_shift_;
+    sycl_in_memory_arg_t stat_;
+    sycl_in_memory_arg_t var_;
+    sycl_in_memory_arg_t diff_dst_;
+    sycl_in_memory_arg_t dst_;
+    sycl_in_memory_arg_t ws_;
+    sycl_in_memory_arg_t diff_src1_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/ref_batch_normalization.cpp
+++ b/src/gpu/sycl/ref_batch_normalization.cpp
@@ -1,0 +1,208 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_traits.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+#include "gpu/sycl/batch_normalizations_kernels.hpp"
+#include "gpu/sycl/ref_batch_normalization.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+using namespace impl::sycl;
+
+status_t ref_batch_normalization_fwd_t::pd_t::init_conf() {
+    conf_ = sycl_batch_normalization_conf_t();
+
+    conf_.ndims = ndims();
+    conf_.flags = desc()->flags;
+    conf_.wk_size = memory_desc_wrapper(src_md(0)).nelems();
+    conf_.src1_md = sycl_md_t(dst_md(3));
+    conf_.dst1_md = sycl_md_t(dst_md(0));
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+    conf_.dir = !is_fwd();
+    conf_.use_scale = use_scale();
+    conf_.use_shift = use_shift();
+    conf_.data_md = sycl_md_t(src_md(0));
+    conf_.data_scaleshift_md = sycl_md_t(weights_md(0));
+    conf_.stat_md
+            = stats_is_src() ? sycl_md_t(src_md(1)) : sycl_md_t(dst_md(1));
+    conf_.dst_md = sycl_md_t(dst_md(0));
+    conf_.var_md = stats_is_src() ? sycl_md_t(src_md(2)) : sycl_md_t(dst_md(2));
+    conf_.ws_md = sycl_md_t(workspace_md(0));
+    int work_per_wg = conf_.wg_size * conf_.block_size;
+    int n_wgs = (C() + work_per_wg - 1) / work_per_wg;
+    conf_.n_thr = n_wgs * conf_.wg_size;
+    conf_.N = MB();
+    conf_.C = C();
+    conf_.D = D();
+    conf_.H = H();
+    conf_.W = W();
+    conf_.batch_norm_epsilon = desc()->batch_norm_epsilon;
+    conf_.save_stats = is_training();
+    conf_.calculate_stats = !stats_is_src();
+    conf_.fuse_norm_relu = fuse_norm_relu();
+    conf_.fuse_norm_add_relu = fuse_norm_add_relu();
+    conf_.zero_dims = has_zero_dim_memory();
+    conf_.is_training = is_training();
+    conf_.with_relu = with_relu_post_op(is_training());
+    conf_.alpha = alpha();
+
+    return status::success;
+}
+
+status_t ref_batch_normalization_fwd_t::init(engine_t *engine) {
+    if (pd()->stats_is_src()) {
+        const auto kid
+                = ::sycl::get_kernel_id<batch_normalization_fwd_kernel_vec_t>();
+        CHECK(create_kernel(engine, kid, &kernel_));
+    } else {
+        const auto kid = ::sycl::get_kernel_id<
+                batch_normalization_fwd_kernel_vec_t1>();
+        CHECK(create_kernel(engine, kid, &kernel_));
+    }
+    return status::success;
+}
+
+status_t ref_batch_normalization_fwd_t::execute_forward(
+        const exec_ctx_t &ctx) const {
+
+    if (pd()->stats_is_src())
+        return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+            auto data = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+            auto scale = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SCALE); //added
+            auto src1 = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC_1);
+            auto shift = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SHIFT);
+            auto mean = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MEAN);
+            auto var = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_VARIANCE);
+            auto dst = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+            auto ws = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_WORKSPACE);
+            batch_normalization_fwd_kernel_vec_t batch_normalization_fwd_kernel(
+                    pd()->conf_, data, scale, shift, mean, var, dst, ws, src1);
+            const int block_size = pd()->conf_.block_size;
+            const int wg_size = pd()->conf_.wg_size;
+            int work_per_wg = wg_size * block_size;
+            int n_wgs = (pd()->C() + work_per_wg - 1) / work_per_wg;
+            int n_thr = n_wgs * wg_size;
+            cgh.parallel_for(::sycl::nd_range<1>(n_thr, wg_size),
+                    batch_normalization_fwd_kernel);
+        });
+    else
+        return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+            auto data = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+            auto scale = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SCALE); //added
+            auto src1 = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC_1);
+            auto shift = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SHIFT);
+            auto mean = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_MEAN);
+            auto var = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_VARIANCE);
+            auto dst = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+            auto ws = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_WORKSPACE);
+            batch_normalization_fwd_kernel_vec_t1
+                    batch_normalization_fwd_kernel1(pd()->conf_, data, scale,
+                            shift, dst, mean, var, ws, src1);
+            const int block_size = pd()->conf_.block_size;
+            const int wg_size = pd()->conf_.wg_size;
+            int work_per_wg = wg_size * block_size;
+            int n_wgs = (pd()->C() + work_per_wg - 1) / work_per_wg;
+            int n_thr = n_wgs * wg_size;
+            cgh.parallel_for(::sycl::nd_range<1>(n_thr, wg_size),
+                    batch_normalization_fwd_kernel1);
+        });
+}
+
+status_t ref_batch_normalization_bwd_t::pd_t::init_conf() {
+    conf_ = sycl_batch_normalization_conf_t();
+    conf_.ndims = ndims();
+    conf_.flags = desc()->flags;
+    conf_.block_size = (16);
+    conf_.wg_size = (32);
+    conf_.prop_kind = desc_.prop_kind;
+    conf_.use_scale = use_scale();
+    conf_.use_shift = use_shift();
+    conf_.data_md = sycl_md_t(src_md(0));
+    conf_.dst1_md = sycl_md_t(dst_md(0));
+    conf_.diff_data_md = sycl_md_t(diff_src_md(0));
+    conf_.diff_src1_md = sycl_md_t(diff_dst_md(1));
+    conf_.data_scaleshift_md = sycl_md_t(weights_md(0));
+    conf_.diff_data_scaleshift_md = sycl_md_t(diff_weights_md(0));
+    conf_.diff_dst_md = sycl_md_t(diff_dst_md(0));
+    conf_.stat_md = sycl_md_t(stat_md());
+    conf_.var_md = sycl_md_t(src_md(2));
+    conf_.dst_md = sycl_md_t(dst_md(0));
+    conf_.ws_md = sycl_md_t(workspace_md(0));
+    int work_per_wg = conf_.wg_size * conf_.block_size;
+    int n_wgs = (C() + work_per_wg - 1) / work_per_wg;
+    conf_.n_thr = n_wgs * conf_.wg_size;
+    conf_.zero_dims = has_zero_dim_memory();
+    conf_.N = MB();
+    conf_.C = C();
+    conf_.D = D();
+    conf_.H = H();
+    conf_.W = W();
+
+    conf_.batch_norm_epsilon = desc()->batch_norm_epsilon;
+    conf_.fuse_norm_relu = fuse_norm_relu();
+    conf_.fuse_norm_add_relu = fuse_norm_add_relu();
+    conf_.calculate_diff_stats = !use_global_stats();
+    conf_.alpha = alpha();
+
+    return status::success;
+}
+
+status_t ref_batch_normalization_bwd_t::init(engine_t *engine) {
+    const auto kid
+            = ::sycl::get_kernel_id<batch_normalization_bwd_kernel_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_batch_normalization_bwd_t::execute_backward(
+        const exec_ctx_t &ctx) const {
+
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto data = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+        auto diff_data = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto diff_src1 = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC_1);
+        auto scale = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SCALE);
+        auto diff_scale
+                = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SCALE); //added
+        auto diff_shift = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SHIFT);
+        auto mean = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MEAN);
+        auto var = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_VARIANCE);
+        auto dst = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+        auto diff_dst = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto ws = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_WORKSPACE);
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+        int work_per_wg = wg_size * block_size;
+        int n_wgs = (pd()->C() + work_per_wg - 1) / work_per_wg;
+        int n_thr = n_wgs * wg_size;
+        batch_normalization_bwd_kernel_vec_t batch_normalization_bwd_kernel(
+                pd()->conf_, data, diff_data, scale, diff_scale, diff_shift,
+                mean, var, diff_dst, dst, ws, diff_src1);
+
+        cgh.parallel_for(::sycl::nd_range<1>(n_thr, wg_size),
+                batch_normalization_bwd_kernel);
+    });
+}
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/sycl/ref_batch_normalization.hpp
+++ b/src/gpu/sycl/ref_batch_normalization.hpp
@@ -1,0 +1,154 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_REF_BATCH_NORMALIZATION_HPP
+#define GPU_SYCL_REF_BATCH_NORMALIZATION_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/utils.hpp"
+#include "gpu/gpu_batch_normalization_pd.hpp"
+#include "gpu/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+#include "sycl/sycl_stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct ref_batch_normalization_fwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_batch_normalization_fwd_pd_t {
+        using gpu_batch_normalization_fwd_pd_t::
+                gpu_batch_normalization_fwd_pd_t;
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_batch_normalization_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            const memory_desc_wrapper data_d(src_md(0));
+            const memory_desc_wrapper dst_d(dst_md(0));
+
+            const bool ok = is_fwd()
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && (utils::everyone_is(
+                                f32, src_md()->data_type, dst_md()->data_type)
+                            || utils::everyone_is(bf16, src_md()->data_type,
+                                    dst_md()->data_type)
+                            || utils::everyone_is(f16, src_md()->data_type,
+                                    dst_md()->data_type)
+                            || utils::everyone_is(s8, src_md()->data_type,
+                                    dst_md()->data_type))
+                    && check_scale_shift_data_type()
+                    && (attr()->has_default_values()
+                            || with_relu_post_op(is_training()))
+                    && set_default_formats_common()
+                    && memory_desc_wrapper(src_md(0))
+                            == memory_desc_wrapper(dst_md(0));
+            if (!ok) return status::unimplemented;
+            if (src_md(0)->data_type == s8 && !stats_is_src())
+                return status::unimplemented;
+            if (is_training() && (fuse_norm_relu() || fuse_norm_add_relu()))
+                init_default_ws(8);
+            return init_conf();
+        }
+        status_t init_conf();
+        sycl_batch_normalization_conf_t conf_;
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+struct ref_batch_normalization_bwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_batch_normalization_bwd_pd_t {
+        using gpu_batch_normalization_bwd_pd_t::
+                gpu_batch_normalization_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_batch_normalization_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            const memory_desc_wrapper data_d(src_md(0));
+            const memory_desc_wrapper diff_data_d(diff_src_md(0));
+            const memory_desc_wrapper stat_d(src_md(1));
+            const memory_desc_wrapper diff_data_scaleshift_d(
+                    diff_weights_md(0));
+            const memory_desc_wrapper diff_dst_d(diff_dst_md(0));
+            const memory_desc_wrapper var_d(src_md(2));
+
+            bool ok = !is_fwd()
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && (diff_dst_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && (utils::everyone_is(f32, src_md()->data_type,
+                                diff_dst_md()->data_type,
+                                diff_src_md()->data_type)
+                            || utils::everyone_is(bf16, src_md()->data_type,
+                                    diff_dst_md()->data_type,
+                                    diff_src_md()->data_type)
+                            || utils::everyone_is(f16, src_md()->data_type,
+                                    diff_dst_md()->data_type,
+                                    diff_src_md()->data_type))
+                    && check_scale_shift_data_type()
+                    && attr()->has_default_values()
+                    && set_default_formats_common()
+                    && memory_desc_wrapper(diff_src_md())
+                            == memory_desc_wrapper(diff_dst_md());
+
+            if (!ok) return status::unimplemented;
+            if (fuse_norm_relu() || fuse_norm_add_relu()) {
+                init_default_ws(8);
+                if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;
+            }
+            return init_conf();
+        }
+
+        status_t init_conf();
+        sycl_batch_normalization_conf_t conf_;
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_backward(ctx);
+    }
+
+private:
+    status_t execute_backward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -137,10 +137,51 @@ struct sycl_resampling_conf_t {
     sycl_post_ops_t post_ops;
 };
 
+struct sycl_batch_normalization_conf_t {
+    prop_kind_t prop_kind;
+    int ndims;
+    size_t n_thr;
+    unsigned flags;
+    size_t wk_size;
+    int block_size;
+    int wg_size;
+    bool use_scale;
+    bool use_shift;
+    float alpha;
+    bool dir;
+    sycl_md_t data_md;
+    sycl_md_t src1_md;
+    sycl_md_t dst1_md;
+    sycl_md_t diff_data_md;
+    sycl_md_t diff_src1_md;
+    sycl_md_t data_scaleshift_md;
+    sycl_md_t diff_data_scaleshift_md;
+    sycl_md_t stat_md;
+    sycl_md_t var_md;
+    sycl_md_t ws_md;
+    sycl_md_t dst_md;
+    sycl_md_t diff_dst_md;
+    dim_t N;
+    dim_t C;
+    dim_t D;
+    dim_t H;
+    dim_t W;
+    float batch_norm_epsilon;
+    bool save_stats;
+    bool calculate_stats;
+    bool calculate_diff_stats;
+    bool fuse_norm_relu;
+    bool fuse_norm_add_relu;
+    bool zero_dims;
+    bool is_training;
+    bool with_relu;
+};
+
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_shuffle_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_resampling_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_batch_normalization_conf_t);
 
 } // namespace sycl
 } // namespace gpu


### PR DESCRIPTION
# Description

Introducing SYCL backend for the oneDNN Batch Normalization primitive. This contains support for Batch normalization functionality in both forward and backward propagations.

# Supported scope:
Supported Data Types:
Forward : f32, bf16, f16, s8
Backward : f32, bf16, f16

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Testing Scope
`benchdnn :passed`

##Test Outputs
Please refer the test output files below.
[Batchnorm_test_outputs.zip](https://github.com/oneapi-src/oneDNN/files/10976836/Batchnorm_test_outputs.zip)

