### PR TITLE
Sycl support for oneDNN resampling primitive

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -41,6 +41,7 @@
 #include "gpu/sycl/ref_binary.hpp"
 #include "gpu/sycl/ref_prelu.hpp"
 #include "gpu/sycl/ref_shuffle.hpp"
+#include "gpu/sycl/ref_resampling.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -251,6 +252,8 @@ constexpr dnnl::impl::impl_list_item_t sycl_cuda_impl_list[] = {
         // Resampling
         INSTANCE(cudnn_resampling_fwd_t)
         INSTANCE(cudnn_resampling_bwd_t)
+        INSTANCE(sycl::ref_resampling_fwd_t)
+        INSTANCE(sycl::ref_resampling_bwd_t)
 
         // Reduction
         INSTANCE(cudnn_reduction_t)

--- a/src/gpu/sycl/ref_resampling.cpp
+++ b/src/gpu/sycl/ref_resampling.cpp
@@ -1,0 +1,185 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/sycl/ref_resampling.hpp"
+#include "gpu/sycl/resampling_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+status_t ref_resampling_fwd_t::pd_t::init_conf() {
+    conf_ = sycl_resampling_conf_t();
+
+    conf_.src_dt = src_md(0)->data_type;
+    conf_.dst_dt = dst_md()->data_type;
+
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+
+    conf_.MB = MB();
+    conf_.C = C();
+    conf_.ID = ID();
+    conf_.IH = IH();
+    conf_.IW = IW();
+    conf_.OD = OD();
+    conf_.OH = OH();
+    conf_.OW = OW();
+
+    for (int i = 0; i < DNNL_MAX_NDIMS; i++) {
+        conf_.dst_dims[i] = dst_md()->dims[i];
+    }
+    conf_.dst_ndims = dst_md()->ndims;
+    auto nelems_A = memory_desc_wrapper(src_md(0)).nelems();
+    conf_.work_amount = nelems_A;
+    int work_per_wg = conf_.wg_size * conf_.block_size;
+    int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+    conf_.n_thr = n_wgs * conf_.wg_size;
+
+    conf_.src_md = sycl_md_t(src_md(0));
+    conf_.dst_md = sycl_md_t(dst_md());
+
+    conf_.alg = desc()->alg_kind;
+    const auto *att = attr();
+    const auto &attr_po = att->post_ops_;
+    conf_.po_len = attr_po.len();
+
+    for (auto i = 0; i < attr_po.len(); ++i) {
+        if (attr_po.contain(primitive_kind::binary, i)) {
+            dnnl::impl::memory_desc_t mem = attr_po.entry_[i].binary.src1_desc;
+            conf_.src1_md[i] = sycl_md_t(&mem);
+        }
+    }
+    conf_.post_ops = sycl_post_ops_t(attr());
+    return status::success;
+}
+
+status_t ref_resampling_fwd_t::init(engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<resampling_kernel_fwd_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_resampling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
+    parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto src_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+        auto dst_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+
+        auto post_v0 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1);
+        auto post_v1 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(1) | DNNL_ARG_SRC_1);
+        auto post_v2 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(2) | DNNL_ARG_SRC_1);
+        auto post_v3 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(3) | DNNL_ARG_SRC_1);
+        auto post_v4 = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_MULTIPLE_POST_OP(4) | DNNL_ARG_SRC_1);
+
+        auto nelems_A = memory_desc_wrapper(pd()->src_md(0)).nelems();
+        resampling_kernel_fwd_vec_t resampling_fwd_kernel(pd()->conf_,
+                src_mem_arg, dst_mem_arg, post_v0, post_v1, post_v2, post_v3,
+                post_v4);
+
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+
+        int work_per_wg = wg_size * block_size;
+        int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+        int n_thr = n_wgs * wg_size;
+        cgh.parallel_for(
+                ::sycl::nd_range<1>(n_thr, wg_size), resampling_fwd_kernel);
+    });
+
+    return status::success;
+}
+
+status_t ref_resampling_bwd_t::pd_t::init_conf() {
+    conf_ = sycl_resampling_conf_t();
+
+    conf_.diff_src_md = sycl_md_t(diff_src_md(0));
+    conf_.diff_dst_md = sycl_md_t(diff_dst_md());
+
+    conf_.src_dt = src_md(0)->data_type;
+    conf_.dst_dt = dst_md()->data_type;
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+    conf_.dst_ndims = dst_md()->ndims;
+    auto nelems_A = memory_desc_wrapper(diff_src_md(0)).nelems();
+    conf_.work_amount = nelems_A;
+    int work_per_wg = conf_.wg_size * conf_.block_size;
+    int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+    conf_.n_thr = n_wgs * conf_.wg_size;
+    conf_.alg = desc()->alg_kind;
+
+    conf_.MB = MB();
+    conf_.C = C();
+    conf_.ID = ID();
+    conf_.IH = IH();
+    conf_.IW = IW();
+    conf_.OD = OD();
+    conf_.OH = OH();
+    conf_.OW = OW();
+
+    for (int i = 0; i < DNNL_MAX_NDIMS; i++) {
+        conf_.dst_dims[i] = dst_md()->dims[i];
+    }
+    return status::success;
+}
+
+status_t ref_resampling_bwd_t::init(engine_t *engine) {
+    if (pd()->conf_.alg == alg_kind::resampling_nearest) {
+        const auto kid = ::sycl::get_kernel_id<resampling_kernel_bwd_vec_t>();
+        CHECK(create_kernel(engine, kid, &kernel_));
+    } else {
+        const auto kid = ::sycl::get_kernel_id<resampling_kernel_bwd_vec1_t>();
+        CHECK(create_kernel(engine, kid, &kernel_));
+    }
+    return status::success;
+}
+
+status_t ref_resampling_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto dst_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto src_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
+
+        auto nelems_A = memory_desc_wrapper(pd()->diff_src_md(0)).nelems();
+
+        resampling_kernel_bwd_vec_t resampling_bwd_kernel(
+                pd()->conf_, dst_mem_arg, src_mem_arg);
+
+        resampling_kernel_bwd_vec1_t resampling_bwd_kernel1(
+                pd()->conf_, dst_mem_arg, src_mem_arg);
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+
+        int work_per_wg = wg_size * block_size;
+        int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
+        int n_thr = n_wgs * wg_size;
+        if (pd()->conf_.alg == alg_kind::resampling_nearest) {
+            cgh.parallel_for(
+                    ::sycl::nd_range<1>(n_thr, wg_size), resampling_bwd_kernel);
+        } else {
+            cgh.parallel_for(::sycl::nd_range<1>(n_thr, wg_size),
+                    resampling_bwd_kernel1);
+        }
+    });
+}
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/sycl/ref_resampling.hpp
+++ b/src/gpu/sycl/ref_resampling.hpp
@@ -1,0 +1,129 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_REF_RESAMPLING_HPP
+#define GPU_SYCL_REF_RESAMPLING_HPP
+
+#include "gpu/gpu_resampling_pd.hpp"
+#include "gpu/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+#include "sycl/sycl_stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct ref_resampling_fwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_resampling_fwd_pd_t {
+        using gpu_resampling_fwd_pd_t::gpu_resampling_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_resampling_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            using namespace prop_kind;
+            using namespace alg_kind;
+            using sm = primitive_attr_t::skip_mask_t;
+            const memory_desc_wrapper src_d(src_md(0));
+            const memory_desc_wrapper dst_d(dst_md(0));
+
+            const bool ok = src_md()->data_type == dst_md()->data_type
+                    && set_default_params() == status::success
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && (utils::everyone_is(
+                                s8, src_md(0)->data_type, dst_md(0)->data_type)
+                            || utils::everyone_is(u8, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(f32, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(bf16, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(f16, src_md(0)->data_type,
+                                    dst_md(0)->data_type)
+                            || utils::everyone_is(s32, src_md(0)->data_type,
+                                    dst_md(0)->data_type))
+                    && attr()->has_default_values(sm::post_ops)
+                    && attr_.set_default_formats(dst_md(0)) == status::success;
+
+            if (!ok) { return status::unimplemented; }
+            return init_conf();
+        }
+
+        status_t init_conf();
+        sycl_resampling_conf_t conf_;
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+struct ref_resampling_bwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_resampling_bwd_pd_t {
+        using gpu_resampling_bwd_pd_t::gpu_resampling_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_resampling_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            const memory_desc_wrapper diff_dst_d(diff_dst_md(0));
+            const memory_desc_wrapper diff_src_d(diff_src_md(0));
+
+            bool ok = !is_fwd() && set_default_params() == status::success
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && (diff_dst_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && attr()->has_default_values();
+            if (!ok) return status::unimplemented;
+            return init_conf();
+        }
+
+        status_t init_conf();
+        sycl_resampling_conf_t conf_;
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_backward(ctx);
+    }
+
+private:
+    status_t execute_backward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/resampling_kernels.hpp
+++ b/src/gpu/sycl/resampling_kernels.hpp
@@ -1,0 +1,381 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_RESAMPLING_KERNELS_HPP
+#define GPU_SYCL_RESAMPLING_KERNELS_HPP
+
+#include "common/dnnl_thread.hpp"
+#include "common/dnnl_traits.hpp"
+#include "gpu/sycl/resampling_utils.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct resampling_kernel_fwd_vec_t {
+    resampling_kernel_fwd_vec_t(const sycl_resampling_conf_t &conf,
+            sycl_in_memory_arg_t &src, sycl_out_memory_arg_t &dst,
+            sycl_in_memory_arg_t &src_1, sycl_in_memory_arg_t &src_2,
+            sycl_in_memory_arg_t &src_3, sycl_in_memory_arg_t &src_4,
+            sycl_in_memory_arg_t &src_5)
+        : conf_(conf)
+        , src_(src)
+        , dst_(dst)
+        , src_1_(src_1)
+        , src_2_(src_2)
+        , src_3_(src_3)
+        , src_4_(src_4)
+        , src_5_(src_5) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        dim_t MB = conf_.MB;
+        dim_t C = conf_.C;
+
+        dim_t ID = conf_.ID;
+        dim_t IH = conf_.IH;
+        dim_t IW = conf_.IW;
+
+        dim_t OD = conf_.OD;
+        dim_t OH = conf_.OH;
+        dim_t OW = conf_.OW;
+
+        auto lin_interp = [&](float c0, float c1, float w) {
+            return c0 * w + c1 * (1 - w);
+        };
+        auto bilin_interp = [&](float c00, float c01, float c10, float c11,
+                                    float w0, float w1) {
+            return lin_interp(
+                    lin_interp(c00, c10, w0), lin_interp(c01, c11, w0), w1);
+        };
+        auto trilin_interp = [&](float c000, float c001, float c010, float c011,
+                                     float c100, float c101, float c110,
+                                     float c111, float w0, float w1, float w2) {
+            return lin_interp(bilin_interp(c000, c010, c100, c110, w0, w1),
+                    bilin_interp(c001, c011, c101, c111, w0, w1), w2);
+        };
+
+        const dim_t work_amount = MB * C * OD * OH * OW;
+        if (work_amount == 0) return;
+
+        dim_t start {0}, end {0};
+        balance211(work_amount, conf_.n_thr, ithr, start, end);
+        dim_t mb {0}, c {0}, od {0}, oh {0}, ow {0};
+        utils::nd_iterator_init(start, mb, MB, c, C, od, OD, oh, OH, ow, OW);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+
+            const dim_t data_p_off = get_offset(dst_md(), mb, c, od, oh, ow);
+
+            const dim_t data_l_off
+                    = (((mb * C + c) * OD + od) * OH + oh) * OW + ow;
+
+            float dst = 0.f;
+
+            if (conf_.alg == alg_kind::resampling_nearest) {
+                const dim_t id = resampling_utils::nearest_idx(od, OD, ID);
+                const dim_t ih = resampling_utils::nearest_idx(oh, OH, IH);
+                const dim_t iw = resampling_utils::nearest_idx(ow, OW, IW);
+
+                dst = load_float_value(src_md().data_type(), src_ptr(),
+                        get_offset(src_md(), mb, c, id, ih, iw));
+
+            } else if (conf_.alg == alg_kind::resampling_linear) {
+
+                auto id = resampling_utils::linear_coeffs_t(od, OD, ID);
+                auto iw = resampling_utils::linear_coeffs_t(ow, OW, IW);
+                auto ih = resampling_utils::linear_coeffs_t(oh, OH, IH);
+                float src_l[8] = {0};
+                for_(int i = 0; i < 2; i++)
+                for_(int j = 0; j < 2; j++)
+                for (int k = 0; k < 2; k++) {
+                    src_l[4 * i + 2 * j + k]
+                            = load_float_value(src_md().data_type(), src_ptr(),
+                                    get_offset(src_md(), mb, c, id.idx[i],
+                                            ih.idx[j], iw.idx[k]));
+                }
+                dst = trilin_interp(src_l[0], src_l[1], src_l[2], src_l[3],
+                        src_l[4], src_l[5], src_l[6], src_l[7], id.wei[0],
+                        ih.wei[0], iw.wei[0]);
+            }
+
+            ::sycl::vec<float, 8> dst_arr;
+            for (int idx = 0; idx < conf_.po_len; ++idx) {
+                float r = 0.0f;
+                if (conf_.post_ops.get_post_op_kind(idx)
+                        == primitive_kind::binary) {
+                    if (idx == 0) { r = dst_value(src_1_, idx, data_l_off); }
+                    if (idx == 1) { r = dst_value(src_2_, idx, data_l_off); }
+                    if (idx == 2) { r = dst_value(src_3_, idx, data_l_off); }
+                    if (idx == 3) { r = dst_value(src_4_, idx, data_l_off); }
+                    if (idx == 4) { r = dst_value(src_5_, idx, data_l_off); }
+                    dst_arr[idx] = r;
+                }
+            }
+            auto dst_sum = load_float_value(
+                    dst_md().data_type(), dst_ptr(), data_p_off);
+
+            dst = conf_.post_ops.apply(dst, dst_sum, dst_arr);
+            store_float_value(dst_md().data_type(), dst, dst_ptr(), data_p_off);
+            utils::nd_iterator_step(mb, MB, c, C, od, OD, oh, OH, ow, OW);
+        }
+    }
+
+private:
+    const sycl_md_t &src_md() const { return conf_.src_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+
+    void *src_ptr() const { return src_.get_pointer(); }
+    void *src_1_ptr() const { return src_1_.get_pointer(); }
+    void *src_2_ptr() const { return src_2_.get_pointer(); }
+    void *src_3_ptr() const { return src_3_.get_pointer(); }
+    void *src_4_ptr() const { return src_4_.get_pointer(); }
+    void *src_5_ptr() const { return src_5_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+
+    void *gen_ptr(sycl_in_memory_arg_t gen_) const {
+        return gen_.get_pointer();
+    }
+
+    static dim_t get_offset(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: assert(!"Invalid tensor dimension in pooling");
+        }
+        return 0;
+    }
+
+    float dst_value(sycl_in_memory_arg_t arr, int idx, int offset) const {
+        auto src1_desc = conf_.src1_md[idx];
+        dim_t src_dim[DNNL_MAX_NDIMS];
+        auto src_dim_ = src1_desc.dims();
+
+        for (int j = 0; j < src1_desc.ndims(); j++) {
+            src_dim[j] = src_dim_[j];
+        }
+        const auto off = get_binary_src1_off(
+                src1_desc, src_dim, offset, conf_.dst_dims, conf_.dst_ndims);
+        auto dst = load_float_value(src1_desc.data_type(), gen_ptr(arr), off);
+        return dst;
+    }
+
+    dim_t get_binary_src1_off(const sycl_md_t &src1_md, const dim_t *src_dim,
+            const dim_t l_offset, const dim_t *dst_dims,
+            const int dst_ndims) const {
+
+        const int mask_binary_po
+                = utils::get_dims_mask(dst_dims, src_dim, dst_ndims);
+
+        return get_po_tensor_off(
+                src1_md, l_offset, dst_dims, dst_ndims, mask_binary_po);
+    }
+
+    dim_t get_po_tensor_off(const sycl_md_t &tensor_md, const dim_t l_offset,
+            const dim_t *dst_dims, const int dst_ndims, int mask) const {
+
+        dims_t l_dims_po {};
+        get_l_dims_po(l_dims_po, l_offset, dst_dims, dst_ndims, mask);
+
+        return tensor_md.off_v(l_dims_po);
+    }
+
+    void get_l_dims_po(dims_t &l_dims_po, const dim_t l_offset,
+            const dim_t *dst_dims, const int dst_ndims, int mask) const {
+        utils::l_dims_by_l_offset(l_dims_po, l_offset, dst_dims, dst_ndims);
+        utils::apply_mask_on_dims(l_dims_po, dst_ndims, mask);
+    }
+
+    sycl_resampling_conf_t conf_;
+
+    sycl_in_memory_arg_t src_;
+    sycl_out_memory_arg_t dst_;
+    sycl_in_memory_arg_t src_1_;
+    sycl_in_memory_arg_t src_2_;
+    sycl_in_memory_arg_t src_3_;
+    sycl_in_memory_arg_t src_4_;
+    sycl_in_memory_arg_t src_5_;
+};
+
+struct resampling_kernel_bwd_vec_t {
+    resampling_kernel_bwd_vec_t(const sycl_resampling_conf_t &conf,
+            sycl_in_memory_arg_t &diff_dst, sycl_out_memory_arg_t &diff_src)
+        : conf_(conf), diff_dst_(diff_dst), diff_src_(diff_src) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        dim_t MB = conf_.MB;
+        dim_t C = conf_.C;
+
+        dim_t ID = conf_.ID;
+        dim_t IH = conf_.IH;
+        dim_t IW = conf_.IW;
+
+        dim_t OD = conf_.OD;
+        dim_t OH = conf_.OH;
+        dim_t OW = conf_.OW;
+
+        const dim_t work_amount = MB * C * ID * IH * IW;
+        if (work_amount == 0) return;
+
+        dim_t start {0}, end {0};
+        balance211(work_amount, conf_.n_thr, ithr, start, end);
+        dim_t mb {0}, c {0}, id {0}, ih {0}, iw {0};
+        utils::nd_iterator_init(start, mb, MB, c, C, id, ID, ih, IH, iw, IW);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+
+            if (conf_.alg == alg_kind::resampling_nearest) {
+                const dim_t od_start = resampling_utils::ceil_idx(
+                        ((float)id * OD / ID) - 0.5f);
+                const dim_t oh_start = resampling_utils::ceil_idx(
+                        ((float)ih * OH / IH) - 0.5f);
+                const dim_t ow_start = resampling_utils::ceil_idx(
+                        ((float)iw * OW / IW) - 0.5f);
+                const dim_t od_end = resampling_utils::ceil_idx(
+                        ((id + 1.f) * OD / ID) - 0.5f);
+                const dim_t oh_end = resampling_utils::ceil_idx(
+                        ((ih + 1.f) * OH / IH) - 0.5f);
+                const dim_t ow_end = resampling_utils::ceil_idx(
+                        ((iw + 1.f) * OW / IW) - 0.5f);
+
+                float ds = 0;
+                for_(dim_t od = od_start; od < od_end; od++)
+                for_(dim_t oh = oh_start; oh < oh_end; oh++)
+                for (dim_t ow = ow_start; ow < ow_end; ow++)
+                    ds += load_float_value(diff_dst_md().data_type(),
+                            diff_dst_ptr(),
+                            get_offset(diff_dst_md(), mb, c, od, oh, ow));
+                store_float_value(diff_src_md().data_type(), ds, diff_src_ptr(),
+                        get_offset(diff_src_md(), mb, c, id, ih, iw));
+            }
+            utils::nd_iterator_step(mb, MB, c, C, id, ID, ih, IH, iw, IW);
+        }
+    }
+
+private:
+    const sycl_md_t &diff_src_md() const { return conf_.diff_src_md; }
+    const sycl_md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+
+    void *diff_src_ptr() const { return diff_src_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+
+    static dim_t get_offset(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: assert(!"Invalid tensor dimension in pooling");
+        }
+        return 0;
+    }
+
+    sycl_resampling_conf_t conf_;
+    sycl_in_memory_arg_t diff_dst_;
+    sycl_out_memory_arg_t diff_src_;
+};
+
+struct resampling_kernel_bwd_vec1_t {
+    resampling_kernel_bwd_vec1_t(const sycl_resampling_conf_t &conf,
+            sycl_in_memory_arg_t &diff_dst, sycl_out_memory_arg_t &diff_src)
+        : conf_(conf), diff_dst_(diff_dst), diff_src_(diff_src) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        dim_t MB = conf_.MB;
+        dim_t C = conf_.C;
+
+        dim_t ID = conf_.ID;
+        dim_t IH = conf_.IH;
+        dim_t IW = conf_.IW;
+
+        dim_t OD = conf_.OD;
+        dim_t OH = conf_.OH;
+        dim_t OW = conf_.OW;
+
+        const dim_t work_amount = MB * C * ID * IH * IW;
+        if (work_amount == 0) return;
+        dim_t start {0}, end {0};
+        balance211(work_amount, conf_.n_thr, ithr, start, end);
+        dim_t mb {0}, c {0}, id {0}, ih {0}, iw {0};
+        utils::nd_iterator_init(start, mb, MB, c, C, id, ID, ih, IH, iw, IW);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            resampling_utils::bwd_linear_coeffs_t d(id, OD, ID);
+            resampling_utils::bwd_linear_coeffs_t h(ih, OH, IH);
+            resampling_utils::bwd_linear_coeffs_t w(iw, OW, IW);
+
+            float ds = 0;
+            for_(int i = 0; i < 2; i++)
+            for_(int j = 0; j < 2; j++)
+            for_(int k = 0; k < 2; k++)
+            for_(dim_t od = d.start[i]; od < d.end[i]; od++)
+            for_(dim_t oh = h.start[j]; oh < h.end[j]; oh++)
+            for (dim_t ow = w.start[k]; ow < w.end[k]; ow++) {
+                const float weight_d
+                        = resampling_utils::linear_weight(i, od, OD, ID);
+                const float weight_h
+                        = resampling_utils::linear_weight(j, oh, OH, IH);
+                const float weight_w
+                        = resampling_utils::linear_weight(k, ow, OW, IW);
+
+                float dd = load_float_value(diff_dst_md().data_type(),
+                        diff_dst_ptr(),
+                        get_offset(diff_dst_md(), mb, c, od, oh, ow));
+                ds += dd * weight_d * weight_h * weight_w;
+            }
+            store_float_value(diff_src_md().data_type(), ds, diff_src_ptr(),
+                    get_offset(diff_src_md(), mb, c, id, ih, iw));
+            utils::nd_iterator_step(mb, MB, c, C, id, ID, ih, IH, iw, IW);
+        }
+    }
+
+private:
+    const sycl_md_t &diff_src_md() const { return conf_.diff_src_md; }
+    const sycl_md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+
+    void *diff_src_ptr() const { return diff_src_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+
+    static dim_t get_offset(
+            const sycl_md_t &mdw, dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
+        switch (mdw.ndims()) {
+            case 3: return mdw.off(n, c, w);
+            case 4: return mdw.off(n, c, h, w);
+            case 5: return mdw.off(n, c, d, h, w);
+            default: assert(!"Invalid tensor dimension in pooling");
+        }
+        return 0;
+    }
+
+    sycl_resampling_conf_t conf_;
+    sycl_in_memory_arg_t diff_dst_;
+    sycl_out_memory_arg_t diff_src_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/resampling_utils.hpp
+++ b/src/gpu/sycl/resampling_utils.hpp
@@ -1,0 +1,103 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_RESAMPLING_UTILS_HPP
+#define GPU_SYCL_RESAMPLING_UTILS_HPP
+
+#include "common/c_types_map.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+using namespace impl::sycl;
+
+namespace resampling_utils {
+
+static inline float linear_map(dim_t y, dim_t y_max, dim_t x_max) {
+    return ((y + 0.5f) * x_max / y_max) - 0.5f;
+}
+static inline dim_t nearest_idx(dim_t y, dim_t y_max, dim_t x_max) {
+    return (dim_t)roundf(linear_map(y, y_max, x_max));
+}
+static inline dim_t ceil_idx(float x) {
+    if (x < 0) return (dim_t)0;
+    return (dim_t)x == x ? (dim_t)x : (dim_t)x + 1;
+}
+static inline float linear_weight(int i, dim_t x, dim_t y_max, dim_t x_max) {
+    float s = linear_map(x, y_max, x_max);
+    float w = nstl::abs(s - (dim_t)s);
+    return i == 0 ? 1.f - w : w;
+};
+
+struct linear_coeffs_t {
+    linear_coeffs_t(dim_t y, dim_t y_max, dim_t x_max) {
+        float s = linear_map(y, y_max, x_max);
+        idx[0] = left(s);
+        idx[1] = right(s, x_max);
+        wei[1] = nstl::abs(s - saturate<float>(idx[0]));
+        wei[0] = 1.f - wei[1];
+    }
+    // left and right index of source image used for interpolation
+    dim_t idx[2];
+    // left and right interpolation weights
+    float wei[2];
+
+private:
+    static dim_t right(float s, dim_t x_max) {
+        return nstl::min(ceil_idx(s), x_max - 1);
+    }
+    static dim_t left(float s) { return nstl::max((dim_t)s, (dim_t)0); }
+};
+
+struct bwd_linear_coeffs_t {
+    bwd_linear_coeffs_t(dim_t x, dim_t y_max, dim_t x_max) {
+        start[0] = x == 0 ? 0 : left_start(x, y_max, x_max);
+        start[1] = right_start(x, y_max, x_max);
+        end[0] = left_end(x, y_max, x_max);
+        end[1] = x == x_max - 1 ? y_max : right_end(x, y_max, x_max);
+    }
+    // index range (from start to end) of source image used as left and right
+    // edge for interpolation
+    dim_t start[2], end[2];
+
+private:
+    static dim_t left_start(dim_t x, dim_t y_max, dim_t x_max) {
+        return ceil_idx(linear_map(x, x_max, y_max));
+    }
+    static dim_t left_end(dim_t x, dim_t y_max, dim_t x_max) {
+        return nstl::min(ceil_idx(linear_map(x + 1, x_max, y_max)), y_max);
+    }
+    static dim_t right_start(dim_t x, dim_t y_max, dim_t x_max) {
+        float s = linear_map(x - 1, x_max, y_max);
+        return s < 0 ? 0 : (dim_t)(s) + 1;
+    }
+    static dim_t right_end(dim_t x, dim_t y_max, dim_t x_max) {
+        float s = linear_map(x, x_max, y_max);
+        return nstl::min(s < 0 ? 0 : (dim_t)s + 1, y_max);
+    }
+};
+
+} // namespace resampling_utils
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/sycl_math_utils.hpp
+++ b/src/gpu/sycl/sycl_math_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,6 +53,16 @@ relu_fwd(T s, A alpha) {
 template <typename T, typename A, typename U = rem_ref<T>>
 inline U linear_fwd(T s, A alpha, A beta) {
     return impl::math::linear_fwd(s, alpha, beta);
+}
+
+template <typename T, typename A, typename U = rem_ref<T>>
+inline U clip_fwd(T s, A alpha, A beta) {
+    return impl::math::clip_fwd(s, alpha, beta);
+}
+
+template <typename T, typename A, typename U = rem_ref<T>>
+inline U clip_v2_fwd(T s, A alpha, A beta) {
+    return impl::math::clip_v2_fwd(s, alpha, beta);
 }
 
 // Math functions that work with `sycl::vec`.

--- a/src/gpu/sycl/sycl_post_ops.hpp
+++ b/src/gpu/sycl/sycl_post_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ struct ref_eltwise_fwd_t {
     ref_eltwise_fwd_t(alg_kind_t alg, float alpha, float beta, float scale)
         : alg_(alg), alpha_(alpha), beta_(beta), scale_(scale) {
         using namespace alg_kind;
-        assert(utils::one_of(alg_, eltwise_relu, eltwise_linear));
+        assert(utils::one_of(alg_, eltwise_relu, eltwise_linear, eltwise_clip,
+                eltwise_clip_v2));
     }
 
     ref_eltwise_fwd_t(const post_ops_t::entry_t::eltwise_t &eltwise)
@@ -74,6 +75,8 @@ struct ref_eltwise_fwd_t {
         switch (alg) {
             case eltwise_relu: d = relu_fwd(s, alpha); break;
             case eltwise_linear: d = linear_fwd(s, alpha, beta); break;
+            case eltwise_clip: d = clip_fwd(s, alpha, beta); break;
+            case eltwise_clip_v2: d = clip_v2_fwd(s, alpha, beta); break;
             default: d = ::sycl::nan(0u);
         }
         return d;
@@ -84,6 +87,51 @@ private:
     float alpha_;
     float beta_;
     float scale_;
+};
+
+struct ref_binary_op_t {
+    ref_binary_op_t() = default;
+    ref_binary_op_t(alg_kind_t alg, memory_desc_t src1) : alg_(alg) {
+        src1_desc = &src1;
+        using namespace alg_kind;
+        assert(utils::one_of(alg_, binary_add, binary_div, binary_max,
+                binary_min, binary_mul, binary_sub, binary_ge, binary_gt,
+                binary_le, binary_lt, binary_eq, binary_ne));
+    }
+
+    ref_binary_op_t(const post_ops_t::entry_t::binary_t &binary)
+        : ref_binary_op_t(binary.alg, binary.src1_desc) {}
+
+    float compute(float s0, float s1) const { return compute(alg_, s0, s1); }
+
+    static float compute(alg_kind_t alg, float s0, float s1) {
+        using namespace alg_kind;
+        using namespace math;
+
+        float d = 0.f;
+        switch (alg) {
+            case binary_add: d = s0 + s1; break;
+            case binary_div: d = s0 / s1; break;
+            case binary_min: d = ::sycl::min(s0, s1); break;
+            case binary_max: d = ::sycl::max(s0, s1); break;
+            case binary_mul: d = s0 * s1; break;
+            case binary_sub: d = s0 - s1; break;
+            case binary_ge: d = (float)((s0 >= s1) * -1); break;
+            case binary_gt: d = (float)((s0 > s1) * -1); break;
+            case binary_le: d = (float)((s0 <= s1) * -1); break;
+            case binary_lt: d = (float)((s0 < s1) * -1); break;
+            case binary_eq: d = (float)((s0 == s1) * -1); break;
+            case binary_ne: d = (float)((s0 != s1) * -1); break;
+            default: d = ::sycl::nan(0u);
+        }
+        return d;
+    }
+
+    inline memory_desc_t *Get_src1_desc() const { return src1_desc; }
+
+private:
+    alg_kind_t alg_;
+    memory_desc_t *src1_desc;
 };
 
 struct sycl_post_ops_t {
@@ -102,6 +150,7 @@ struct sycl_post_ops_t {
 
         int sum_idx = 0;
         int eltwise_idx = 0;
+        int binary_idx = 0;
 
         for (auto i = 0; i < attr_po.len(); ++i) {
             if (attr_po.contain(sum, i)) {
@@ -111,6 +160,10 @@ struct sycl_post_ops_t {
                 post_op_kinds_[i] = eltwise;
                 eltwise_post_ops_[eltwise_idx++]
                         = ref_eltwise_fwd_t(attr_po.entry_[i].eltwise);
+            } else if (attr_po.contain(binary, i)) {
+                post_op_kinds_[i] = binary;
+                binary_post_ops_[binary_idx++]
+                        = ref_binary_op_t(attr_po.entry_[i].binary);
             }
         }
         n_post_ops_ = attr_po.len();
@@ -164,15 +217,50 @@ struct sycl_post_ops_t {
         return acc;
     }
 
+    template <int width>
+    float apply(float acc, float dst_sum, ::sycl::vec<float, width> dst) const {
+        using namespace primitive_kind;
+
+        if (n_post_ops_ == 0) return acc;
+
+        int binary_idx = 0;
+        int sum_idx = 0;
+        int eltwise_idx = 0;
+        for (auto i = 0; i < n_post_ops_; ++i) {
+            switch (post_op_kinds_[i]) {
+                case eltwise:
+                    acc = eltwise_post_ops_[eltwise_idx++].compute(acc);
+                    break;
+                case binary:
+                    acc = binary_post_ops_[binary_idx++].compute(acc, dst[i]);
+                    break;
+                case sum: acc += sum_scales_[sum_idx++] * dst_sum; break;
+                default: acc = ::sycl::nan(0u);
+            }
+        }
+        return acc;
+    }
+
+    inline int get_post_op() const { return n_post_ops_; }
+
+    inline primitive_kind_t get_post_op_kind(int i) const {
+        return post_op_kinds_[i];
+    }
+
+    inline ref_binary_op_t get_binary_post_op(int i) const {
+        return binary_post_ops_[i];
+    }
+
 private:
     float sum_scales_[max_post_ops];
-
+    ref_binary_op_t binary_post_ops_[max_post_ops];
     ref_eltwise_fwd_t eltwise_post_ops_[max_post_ops];
     primitive_kind_t post_op_kinds_[max_post_ops];
     // Indicates the actual number of post ops.
     int n_post_ops_;
 };
 
+CHECK_SYCL_KERNEL_ARG_TYPE(ref_binary_op_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(ref_eltwise_fwd_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_post_ops_t);
 

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -100,9 +100,47 @@ struct sycl_shuffle_conf_t {
     dim_t work_amount;
 };
 
+struct sycl_resampling_conf_t {
+    dim_t MB;
+    dim_t C;
+    dim_t ID;
+    dim_t IH;
+    dim_t IW;
+    dim_t OD;
+    dim_t OH;
+    dim_t OW;
+    dims_t dst_dims;
+    int dst_ndims;
+    int po_len;
+    size_t work_amount;
+
+    data_type_t src_dt;
+    data_type_t dst_dt;
+
+    sycl_md_t src_md;
+    sycl_md_t src1_md[8];
+    sycl_md_t dst_md;
+    sycl_md_t diff_src_md;
+    sycl_md_t diff_dst_md;
+
+    alg_kind_t alg;
+    float src_scale;
+    bool do_scale_src;
+    int broadcast_dims[sycl_md_t::max_dims];
+    int ndims;
+    bool is_tensor_op;
+
+    int block_size;
+    int wg_size;
+    size_t n_thr;
+
+    sycl_post_ops_t post_ops;
+};
+
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_shuffle_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_resampling_conf_t);
 
 } // namespace sycl
 } // namespace gpu

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -112,7 +112,7 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
     if (is_nvidia_gpu()) {
         // cuDNN precision is different from ref one due to different
         // computation algorithm used for resampling.
-        trh = prb->ddt == dnnl_f16 ? 4e-2 : 2e-5;
+        trh = (prb->ddt == dnnl_f16 || prb->sdt == dnnl_bf16) ? 4e-2 : 2e-5;
     }
     cmp.set_threshold(trh);
 


### PR DESCRIPTION
# Description
Introducing SYCL backend for oneDNN Resampling primitive. This contains support for Resampling functionality. 

# Supported Scope
Supported Data Types:
Forward/ Backward : s8, u8, f32, bf16, f16, s32 

Post-Ops:
sum, eltwise, binary


## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
[test_resampling.txt](https://github.com/oneapi-src/oneDNN/files/10979958/test_resampling.txt)

