### PR TITLE
Add jit support for reorder from FP32 to BF16

### DIFF
--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2018-2023 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
+* Copyright 2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -65,6 +66,7 @@ enum cpu_isa_bit_t : unsigned {
     sve_256_bit = 1u << 2,
     sve_384_bit = 1u << 3,
     sve_512_bit = 1u << 4,
+    bf16_bit = 1u << 5
 };
 
 enum cpu_isa_t : unsigned {
@@ -74,6 +76,7 @@ enum cpu_isa_t : unsigned {
     sve_256 = sve_256_bit | sve_128,
     sve_384 = sve_384_bit | sve_256,
     sve_512 = sve_512_bit | sve_384,
+    feat_bf16 = ebf16_bit,
     isa_all = ~0u,
 };
 
@@ -196,6 +199,7 @@ static inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
         case sve_512:
             return cpu().has(XBYAK_AARCH64_HWCAP_SVE)
                     && cpu().getSveLen() >= SVE_512;
+        case feat_bf16: return getauxval(AT_HWCAP2) & (1UL << 14);
         case isa_undef: return true;
         case isa_all: return false;
     }

--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -66,7 +66,6 @@ enum cpu_isa_bit_t : unsigned {
     sve_256_bit = 1u << 2,
     sve_384_bit = 1u << 3,
     sve_512_bit = 1u << 4,
-    bf16_bit = 1u << 5
 };
 
 enum cpu_isa_t : unsigned {
@@ -76,7 +75,6 @@ enum cpu_isa_t : unsigned {
     sve_256 = sve_256_bit | sve_128,
     sve_384 = sve_384_bit | sve_256,
     sve_512 = sve_512_bit | sve_384,
-    feat_bf16 = ebf16_bit,
     isa_all = ~0u,
 };
 
@@ -199,7 +197,6 @@ static inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
         case sve_512:
             return cpu().has(XBYAK_AARCH64_HWCAP_SVE)
                     && cpu().getSveLen() >= SVE_512;
-        case feat_bf16: return getauxval(AT_HWCAP2) & (1UL << 14);
         case isa_undef: return true;
         case isa_all: return false;
     }
@@ -215,10 +212,9 @@ static inline bool mayiuse_atomic() {
     return cpu().isAtomicSupported();
 }
 
-inline bool isa_has_bf16(cpu_isa_t isa) {
-    return false;
-}
-
+static inline bool mayiuse_bf16() {
+    using namespace Xbyak_aarch64::util;
+    return cpu().isBf16Supported();
 } // namespace
 
 /* whatever is required to generate string literals... */

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
@@ -39,6 +39,13 @@
 #include <asm/hwcap.h>
 #endif
 
+/* Linux kernel used in Ubuntu 20.04 does not have HWCAP2_BF16 definition. */
+#ifdef AT_HWCAP2
+#ifndef HWCAP2_BF16
+#define HWCAP2_BF16 (1UL << 14)
+#endif
+#endif
+
 namespace Xbyak_aarch64 {
 namespace util {
 #define XBYAK_AARCH64_ERROR_ fprintf(stderr, "%s, %d, Error occurrs during read cache infomation.\n", __FILE__, __LINE__);
@@ -383,7 +390,7 @@ private:
   }
 
   void setHwCap() {
-    unsigned long hwcap = getauxval(AT_HWCAP);
+    const unsigned long hwcap = getauxval(AT_HWCAP);
     if (hwcap & HWCAP_ATOMICS)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ATOMIC;
 
@@ -391,8 +398,10 @@ private:
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FP;
     if (hwcap & HWCAP_ASIMD)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
-#ifdef HWCAP2_BF16
-    if (hwcap & HWCAP2_BF16)
+
+#ifdef AT_HWCAP2
+    const unsigned long hwcap2 = getauxval(AT_HWCAP2);
+    if (hwcap2 & HWCAP2_BF16)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_BF16;
 #endif
 

--- a/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2022 Intel Corporation
+* Copyright 2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,6 +34,8 @@ const impl_list_map_t &regular_f32_bf16_impl_list_map() {
 
             DNNL_NON_X64_ONLY(REG_SR_BIDIR(f32, any, bf16, nChw16c))
             DNNL_NON_X64_ONLY(REG_SR_BIDIR(f32, any, bf16, nCdhw16c))
+
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
 
             DNNL_NON_X64_ONLY(REG_SR(f32, oihw, bf16, OIhw8i16o2i, fmt_order::keep))
             DNNL_NON_X64_ONLY(REG_SR(f32, goihw, bf16, gOIhw8i16o2i, fmt_order::keep))


### PR DESCRIPTION
# Description

This code adds JIT support for reorder primitive when converting from FP32 to BF16. Running reorder for 768x768 shape from FP32 memory format ba to BF16 memory format BA4b4a on Neoverse-V1 hardware (which supports BF16) improves performance by ~40x with 8 threads.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?
  See above for one example

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
