### PR TITLE
aarch64: xbyak_aarch64: BFCVT/BFCVTN[2] for ASIMD and BF16-feature detection

### DIFF
--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl.cpp
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl.cpp
@@ -196,6 +196,7 @@ uint64_t Cpu::getSveLen() const { return info->getSveLen(); }
 Type Cpu::getType() const { return info->getType(); }
 bool Cpu::has(Type type) const { return (type & info->getType()) != 0; }
 bool Cpu::isAtomicSupported() const { return info->getType() & (Type)XBYAK_AARCH64_HWCAP_ATOMIC; }
+bool Cpu::isBf16Supported() const { return info->getType() & (Type)XBYAK_AARCH64_HWCAP_BF16; }
 
 } // namespace util
 } // namespace Xbyak_aarch64

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
@@ -385,16 +385,18 @@ private:
 
   void setHwCap() {
     unsigned long hwcap = getauxval(AT_HWCAP);
-    if (hwcap & HWCAP_ATOMICS) {
+    if (hwcap & HWCAP_ATOMICS)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ATOMIC;
-    }
 
-    if (hwcap & HWCAP_FP) {
+    if (hwcap & HWCAP_FP)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FP;
-    }
-    if (hwcap & HWCAP_ASIMD) {
+    if (hwcap & HWCAP_ASIMD)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
-    }
+#ifdef HWCAP2_BF16
+    if (hwcap & HWCAP2_BF16)
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_BF16;
+#endif
+
 #ifdef HWCAP_SVE
     /* Some old <sys/auxv.h> may not define HWCAP_SVE.
        In that case, SVE is treated as if it were not supported. */

--- a/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_impl.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_impl.h
@@ -1916,6 +1916,14 @@ void CodeGenerator::AdvSimd2RegMisc(uint32_t U, uint32_t opcode, const VRegVec &
 }
 
 // Advanced SIMD two-register miscellaneous
+void CodeGenerator::AdvSimd2RegMisc(uint32_t Q, uint32_t U, uint32_t opcode, const VRegVec &vd, const VRegVec &vn) {
+  uint32_t size = genSize(vn);
+
+  uint32_t code = concat({F(Q, 30), F(U, 29), F(0xe, 24), F(size, 22), F(1, 21), F(opcode, 12), F(2, 10), F(vn.getIdx(), 5), F(vd.getIdx(), 0)});
+  dd(code);
+}
+
+// Advanced SIMD two-register miscellaneous
 void CodeGenerator::AdvSimd2RegMiscZero(uint32_t U, uint32_t opcode, const VRegVec &vd, const VRegVec &vn, uint32_t zero) {
   verifyIncList(zero, {0}, ERR_ILLEGAL_CONST_VALUE);
   AdvSimd2RegMisc(U, opcode, vd, vn);

--- a/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_mnemonic.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/xbyak_aarch64_mnemonic.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019-2022 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1815,6 +1815,8 @@ void CodeGenerator::sqxtn(const VReg2S &vd, const VReg2D &vn) { AdvSimd2RegMisc(
 void CodeGenerator::sqxtn2(const VReg16B &vd, const VReg8H &vn) { AdvSimd2RegMisc(0, 20, vd, vn); }
 void CodeGenerator::sqxtn2(const VReg8H &vd, const VReg4S &vn) { AdvSimd2RegMisc(0, 20, vd, vn); }
 void CodeGenerator::sqxtn2(const VReg4S &vd, const VReg2D &vn) { AdvSimd2RegMisc(0, 20, vd, vn); }
+void CodeGenerator::bfcvtn(const VReg4H &vd, const VReg4S &vn) { AdvSimd2RegMisc(0, 0, 22, vd, vn); }
+void CodeGenerator::bfcvtn2(const VReg8H &vd, const VReg4S &vn) { AdvSimd2RegMisc(1, 0, 22, vd, vn); }
 void CodeGenerator::rev32(const VReg8B &vd, const VReg8B &vn) { AdvSimd2RegMisc(1, 0, vd, vn); }
 void CodeGenerator::rev32(const VReg4H &vd, const VReg4H &vn) { AdvSimd2RegMisc(1, 0, vd, vn); }
 void CodeGenerator::rev32(const VReg16B &vd, const VReg16B &vn) { AdvSimd2RegMisc(1, 0, vd, vn); }
@@ -3051,6 +3053,7 @@ void CodeGenerator::fmov(const DReg &vd, const DReg &vn) { FpDataProc1Reg(0, 0, 
 void CodeGenerator::fabs(const DReg &vd, const DReg &vn) { FpDataProc1Reg(0, 0, 1, 1, vd, vn); }
 void CodeGenerator::fneg(const DReg &vd, const DReg &vn) { FpDataProc1Reg(0, 0, 1, 2, vd, vn); }
 void CodeGenerator::fsqrt(const DReg &vd, const DReg &vn) { FpDataProc1Reg(0, 0, 1, 3, vd, vn); }
+void CodeGenerator::bfcvt(const HReg &vd, const SReg &vn) { FpDataProc1Reg(0, 0, 1, 6, vd, vn); }
 void CodeGenerator::frintn(const DReg &vd, const DReg &vn) { FpDataProc1Reg(0, 0, 1, 8, vd, vn); }
 void CodeGenerator::frintp(const DReg &vd, const DReg &vn) { FpDataProc1Reg(0, 0, 1, 9, vd, vn); }
 void CodeGenerator::frintm(const DReg &vd, const DReg &vn) { FpDataProc1Reg(0, 0, 1, 10, vd, vn); }

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -398,6 +398,7 @@ class CodeGenerator : public CodeArray {
   void AdvSimd3SameExtraRotate(uint32_t U, uint32_t op32, const VRegVec &vd, const VRegVec &vn, const VRegVec &vm, uint32_t rotate);
   void AdvSimd2RegMisc(uint32_t U, uint32_t opcode, const VRegVec &vd, const VRegVec &vn);
   void AdvSimd2RegMisc(uint32_t U, uint32_t opcode, const VRegVec &vd, const VRegVec &vn, uint32_t sh);
+  void AdvSimd2RegMisc(uint32_t Q, uint32_t U, uint32_t opcode, const VRegVec &vd, const VRegVec &vn);
   void AdvSimd2RegMiscZero(uint32_t U, uint32_t opcode, const VRegVec &vd, const VRegVec &vn, uint32_t zero);
   void AdvSimd2RegMiscSz(uint32_t U, uint32_t size, uint32_t opcode, const VRegVec &vd, const VRegVec &vn);
   void AdvSimd2RegMiscSz0x(uint32_t U, uint32_t opcode, const VRegVec &vd, const VRegVec &vn);

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_mnemonic_def.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_mnemonic_def.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019-2022 FUJITSU LIMITED
+ * Copyright 2019-2023 FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1815,6 +1815,8 @@ void sqxtn(const VReg2S &vd, const VReg2D &vn);
 void sqxtn2(const VReg16B &vd, const VReg8H &vn);
 void sqxtn2(const VReg8H &vd, const VReg4S &vn);
 void sqxtn2(const VReg4S &vd, const VReg2D &vn);
+void bfcvtn(const VReg4H &vd, const VReg4S &vn);
+void bfcvtn2(const VReg8H &vd, const VReg4S &vn);
 void rev32(const VReg8B &vd, const VReg8B &vn);
 void rev32(const VReg4H &vd, const VReg4H &vn);
 void rev32(const VReg16B &vd, const VReg16B &vn);
@@ -3051,6 +3053,7 @@ void fmov(const DReg &vd, const DReg &vn);
 void fabs(const DReg &vd, const DReg &vn);
 void fneg(const DReg &vd, const DReg &vn);
 void fsqrt(const DReg &vd, const DReg &vn);
+void bfcvt(const HReg &vd, const SReg &vn);
 void frintn(const DReg &vd, const DReg &vn);
 void frintp(const DReg &vd, const DReg &vn);
 void frintm(const DReg &vd, const DReg &vn);

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
@@ -62,6 +62,7 @@ enum hwCap_t {
   XBYAK_AARCH64_HWCAP_FP = 1 << 2,
   XBYAK_AARCH64_HWCAP_SVE = 1 << 3,
   XBYAK_AARCH64_HWCAP_ATOMIC = 1 << 4,
+  XBYAK_AARCH64_HWCAP_BF16 = 1 << 5,
 };
 
 struct implementer_t {
@@ -108,6 +109,7 @@ public:
   uint64_t getSveLen() const;
   bool has(Type type) const;
   bool isAtomicSupported() const;
+  bool isBf16Supported() const;
 };
 
 } // namespace util


### PR DESCRIPTION
# Description

This PR updates Xbyak_aarch64 into the latest version, which supports BFCVT/BFCVTN/BFCVTN2 instructions for ASIMD and BF16-feature detection. This PR helps https://github.com/oneapi-src/oneDNN/pull/1594

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

