### PR TITLE
src:cpu:aarch64 Add benchmark scheduler for acl verbose

### DIFF
--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018-2023 Intel Corporation
+* Copyright 2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -144,6 +145,9 @@ uint32_t get_verbose(int verbosity_flag_hint = verbose_t::none) {
                 return k |= verbose_t::create_profile | verbose_t::exec_profile;
             if (s == "profile_create") return k |= verbose_t::create_profile;
             if (s == "profile_exec") return k |= verbose_t::exec_profile;
+            // Enable profiling to external libraries
+            if (s == "profile_externals")
+                return k |= verbose_t::profile_externals;
             // we extract debug info debug_info=XX. ignore if debuginfo is invalid.
             if (s.rfind("debuginfo=", 0) == 0)
                 return k |= verbose_t::make_debuginfo(
@@ -186,6 +190,9 @@ bool verbose_has_exec_check() {
 };
 bool verbose_has_exec_profile() {
     return get_verbose(verbose_t::exec_profile) & verbose_t::exec_profile;
+};
+bool verbose_has_profile_externals() {
+    return get_verbose() & verbose_t::profile_externals;
 };
 int verbose_debuginfo() {
     return get_verbose() >> 24;

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018-2023 Intel Corporation
+* Copyright 2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -130,6 +131,7 @@ struct verbose_t {
         create_profile = 1 << 5,
         exec_check = 1 << 6,
         exec_profile = 1 << 7,
+        profile_externals = 1 << 8,
         // the upper 8 bits are reserved for devinfo levels
         debuginfo = 1 << 24,
         //
@@ -145,6 +147,7 @@ bool verbose_has_create_dispatch();
 bool verbose_has_create_profile();
 bool verbose_has_exec_check();
 bool verbose_has_exec_profile();
+bool verbose_has_profile_externals();
 
 int verbose_debuginfo();
 

--- a/src/common/verbose_msg.hpp
+++ b/src/common/verbose_msg.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023 Intel Corporation
+* Copyright 2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,6 +28,7 @@
 #define VERBOSE_dispatch ":dispatch"
 #define VERBOSE_debug ":debug"
 #define VERBOSE_profile ""
+#define VERBOSE_external ":external"
 
 // verbose messages
 #define VERBOSE_NULL_ARG "one of the mandatory arguments is nullptr"

--- a/src/cpu/aarch64/acl_benchmark_scheduler.cpp
+++ b/src/cpu/aarch64/acl_benchmark_scheduler.cpp
@@ -1,0 +1,78 @@
+/*******************************************************************************
+* Copyright 2023 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_benchmark_scheduler.hpp"
+#include "common/verbose.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+using namespace arm_compute;
+
+BenchmarkScheduler::BenchmarkScheduler(IScheduler &real_scheduler)
+    : _real_scheduler(real_scheduler) {}
+
+BenchmarkScheduler::~BenchmarkScheduler() = default;
+
+void BenchmarkScheduler::set_num_threads(unsigned int num_threads) {
+    _real_scheduler.set_num_threads(num_threads);
+}
+
+void BenchmarkScheduler::set_num_threads_with_affinity(
+        unsigned int num_threads, BindFunc func) {
+    _real_scheduler.set_num_threads_with_affinity(num_threads, func);
+}
+
+unsigned int BenchmarkScheduler::num_threads() const {
+    return _real_scheduler.num_threads();
+}
+
+void BenchmarkScheduler::schedule(ICPPKernel *kernel, const Hints &hints) {
+    double start_ms = get_msec();
+    _real_scheduler.schedule(kernel, hints);
+    double duration_ms = get_msec() - start_ms;
+    const char *name = kernel->name();
+    VPROF(start_ms, exec, VERBOSE_external, name, duration_ms);
+}
+
+void BenchmarkScheduler::schedule_op(ICPPKernel *kernel, const Hints &hints,
+        const Window &window, ITensorPack &tensors) {
+    double start_ms = get_msec();
+    _real_scheduler.schedule_op(kernel, hints, window, tensors);
+    double duration_ms = get_msec() - start_ms;
+    const char *name = kernel->name();
+    VPROF(start_ms, exec, VERBOSE_external, name, duration_ms);
+}
+
+void BenchmarkScheduler::run_tagged_workloads(
+        std::vector<Workload> &workloads, const char *tag) {
+    double start_ms = get_msec();
+    _real_scheduler.run_tagged_workloads(workloads, tag);
+    double duration_ms = get_msec() - start_ms;
+    const char *name = tag != nullptr ? tag : "Unknown";
+    VPROF(start_ms, exec, VERBOSE_external, name, duration_ms);
+}
+
+void BenchmarkScheduler::run_workloads(std::vector<Workload> &workloads) {
+    ARM_COMPUTE_UNUSED(workloads);
+    ARM_COMPUTE_ERROR("Can't be reached");
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_benchmark_scheduler.hpp
+++ b/src/cpu/aarch64/acl_benchmark_scheduler.hpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+* Copyright 2023 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef CPU_AARCH64_ACL_BENCHMARK_SCHEDULER_HPP
+#define CPU_AARCH64_ACL_BENCHMARK_SCHEDULER_HPP
+
+#include "arm_compute/core/CPP/ICPPKernel.h"
+#include "arm_compute/runtime/IScheduler.h"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+// BenchmarkScheduler implement's ACL IScheduler interface and acts as an interceptor scheduler
+// when DNNL_VERBOSE=profile,profile_externals. It intercepts calls made by the actual scheduler used by ACL and adds
+// timers to benchmark execution time of ACL kernels and store kernel information.
+class BenchmarkScheduler final : public arm_compute::IScheduler {
+public:
+    BenchmarkScheduler(IScheduler &real_scheduler);
+
+    ~BenchmarkScheduler();
+
+    void set_num_threads(unsigned int num_threads) override;
+    unsigned int num_threads() const override;
+    void set_num_threads_with_affinity(
+            unsigned int num_threads, BindFunc func) override;
+    void schedule(arm_compute::ICPPKernel *kernel,
+            const arm_compute::IScheduler::Hints &hints) override;
+    void schedule_op(arm_compute::ICPPKernel *kernel,
+            const arm_compute::IScheduler::Hints &hints,
+            const arm_compute::Window &window,
+            arm_compute::ITensorPack &tensors) override;
+
+protected:
+    void run_workloads(std::vector<Workload> &workloads) override;
+    void run_tagged_workloads(
+            std::vector<Workload> &workloads, const char *tag) override;
+
+private:
+    IScheduler &_real_scheduler;
+};
+
+#endif // CPU_AARCH64_ACL_BENCHMARK_SCHEDULER_HPP
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_thread.cpp
+++ b/src/cpu/aarch64/acl_thread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#include "cpu/aarch64/acl_thread.hpp"
 
+#include "cpu/aarch64/acl_thread.hpp"
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 #include "cpu/aarch64/acl_threadpool_scheduler.hpp"
 #endif
+#include "cpu/aarch64/acl_benchmark_scheduler.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -38,10 +39,23 @@ void acl_thread_bind() {
         arm_compute::Scheduler::get().set_num_threads(max_threads);
     });
 }
+// Swap BenchmarkScheduler for default ACL scheduler builds (i.e. CPPScheduler, OMPScheduler)
+void acl_set_benchmark_scheduler_default() {
+    static std::once_flag flag_once;
+    arm_compute::IScheduler *_real_scheduler = &arm_compute::Scheduler::get();
+    std::shared_ptr<arm_compute::IScheduler> benchmark_scheduler
+            = std::make_unique<BenchmarkScheduler>(*_real_scheduler);
+    // set Benchmark scheduler in ACL
+    std::call_once(flag_once, [&]() {
+        arm_compute::Scheduler::set(
+                std::static_pointer_cast<arm_compute::IScheduler>(
+                        benchmark_scheduler));
+    });
+}
 #endif
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-void acl_set_custom_scheduler() {
+void acl_set_threadpool_scheduler() {
     static std::once_flag flag_once;
     // Create threadpool scheduler
     std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
@@ -65,7 +79,38 @@ void acl_set_threadpool_num_threads() {
         });
     }
 }
+// Swap BenchmarkScheduler for custom scheduler builds (i.e. ThreadPoolScheduler)
+void acl_set_benchmark_scheduler_tp() {
+    static std::once_flag flag_once;
+    // Create threadpool scheduler
+    std::unique_ptr<arm_compute::IScheduler> threadpool_scheduler
+            = std::make_unique<ThreadpoolScheduler>();
+    arm_compute::IScheduler *_real_scheduler = nullptr;
+    _real_scheduler = threadpool_scheduler.release();
+    // Create benchmark scheduler and set TP as real scheduler
+    std::shared_ptr<arm_compute::IScheduler> benchmark_scheduler
+            = std::make_unique<BenchmarkScheduler>(*_real_scheduler);
+    std::call_once(flag_once,
+            [&]() { arm_compute::Scheduler::set(benchmark_scheduler); });
+}
 #endif
+
+void set_acl_threading() {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    acl_thread_bind();
+    if (verbose_has_profile_externals()) {
+        acl_set_benchmark_scheduler_default();
+    }
+#endif
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    if (verbose_has_profile_externals()) {
+        acl_set_tp_benchmark_scheduler();
+    } else {
+        acl_set_tp_scheduler();
+    }
+
+#endif
+}
 
 } // namespace acl_thread_utils
 

--- a/src/cpu/aarch64/acl_thread.hpp
+++ b/src/cpu/aarch64/acl_thread.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #define CPU_AARCH64_ACL_THREAD_HPP
 
 #include "common/dnnl_thread.hpp"
+#include "common/verbose.hpp"
 
 #include "arm_compute/runtime/Scheduler.h"
 
@@ -29,15 +30,23 @@ namespace aarch64 {
 namespace acl_thread_utils {
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+// Number of threads in Compute Library is set by OMP_NUM_THREADS
+// dnnl_get_max_threads() == OMP_NUM_THREADS
 void acl_thread_bind();
+// Swap BenchmarkScheduler for default ACL scheduler builds (i.e. CPPScheduler, OMPScheduler)
+// for DNNL_VERBOSE=profile,profile_externals
+void acl_set_benchmark_scheduler_default();
 #endif
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 // Retrieve threadpool size during primitive execution and set ThreadpoolScheduler num_threads
-void acl_set_custom_scheduler();
+void acl_set_tp_scheduler();
 void acl_set_threadpool_num_threads();
+// Swap BenchmarkScheduler for custom scheduler builds (i.e. ThreadPoolScheduler) for DNNL_VERBOSE=profile,profile_externals
+void acl_set_tp_benchmark_scheduler();
 #endif
-
+// Set threading for ACL
+void set_acl_threading();
 } // namespace acl_thread_utils
 
 } // namespace aarch64

--- a/src/cpu/cpu_engine.hpp
+++ b/src/cpu/cpu_engine.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2016-2022 Intel Corporation
-* Copyright 2020-2022 Arm Ltd. and affiliates
+* Copyright 2020-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -164,16 +164,7 @@ public:
         *engine = new cpu_engine_t();
 
 #if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
-        // Number of threads in Compute Library is set by OMP_NUM_THREADS
-        // dnnl_get_max_threads() == OMP_NUM_THREADS
-        dnnl::impl::cpu::aarch64::acl_thread_utils::acl_thread_bind();
-#endif
-
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-        // Set ACL scheduler for threadpool runtime
-        dnnl::impl::cpu::aarch64::acl_thread_utils::acl_set_custom_scheduler();
-#endif
+        dnnl::impl::cpu::aarch64::acl_thread_utils::set_acl_threading();
 #endif
         return status::success;
     };


### PR DESCRIPTION
# Description

This PR covers the implementation for enabling ACL verbose functionality that can capture low-level kernel information from [Compute Library for the Arm® Architecture (ACL)](https://github.com/ARM-software/ComputeLibrary) and kernel timing measurements and present the results in a oneDNN-style verbose output. RFC is available here: https://github.com/oneapi-src/oneDNN/pull/1581
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [X] Have you published an RFC for the new feature?
- [X] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?