### PR TITLE
SYCL kernel support added for LRN

### DIFF
--- a/src/gpu/nvidia/cudnn_lrn.hpp
+++ b/src/gpu/nvidia/cudnn_lrn.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,8 +42,12 @@ struct cudnn_lrn_fwd_t : public primitive_t {
 
         status_t init(engine_t *) {
             using namespace data_type;
+            using namespace format_tag;
 
-            bool ok = is_fwd()
+            const memory_desc_wrapper src_d(src_md());
+
+            const bool ok = is_fwd()
+                    && IMPLICATION(ndims() == 5, src_d.matches_tag(abcde))
                     && desc()->alg_kind == alg_kind::lrn_across_channels
                     && utils::one_of(src_md()->data_type, f32, f16)
                     && src_md()->data_type == dst_md()->data_type

--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -42,6 +42,7 @@
 #include "gpu/sycl/ref_binary.hpp"
 #include "gpu/sycl/ref_eltwise.hpp"
 #include "gpu/sycl/ref_layer_normalizations.hpp"
+#include "gpu/sycl/ref_lrn.hpp"
 #include "gpu/sycl/ref_prelu.hpp"
 #include "gpu/sycl/ref_resampling.hpp"
 #include "gpu/sycl/ref_shuffle.hpp"
@@ -241,6 +242,8 @@ constexpr dnnl::impl::impl_list_item_t sycl_cuda_impl_list[] = {
         // LRN
         INSTANCE(cudnn_lrn_fwd_t)
         INSTANCE(cudnn_lrn_bwd_t)
+        INSTANCE(sycl::ref_sycl_lrn_fwd_t)
+        INSTANCE(sycl::ref_sycl_lrn_bwd_t)
 
         // Inner Product
         INSTANCE(cudnn_gemm_inner_product_fwd_t)

--- a/src/gpu/sycl/lrn_kernels.hpp
+++ b/src/gpu/sycl/lrn_kernels.hpp
@@ -1,0 +1,339 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_LRN_KERNELS_HPP
+#define GPU_SYCL_LRN_KERNELS_HPP
+
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct lrn_fwd_kernel_vec_t {
+    lrn_fwd_kernel_vec_t(const sycl_lrn_conf_t &conf, sycl_in_memory_arg_t &src,
+            sycl_out_memory_arg_t &dst, const format_tag_t &tag)
+        : conf_(conf), src_(src), dst_(dst), tag_(tag) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        auto sg = item.get_sub_group();
+        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
+        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
+        size_t wi_offset_t = sg.get_local_id();
+        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
+        size_t base_idx = offset_t * conf_.block_size;
+
+        auto data_off = [=](dim_t &mb, dim_t &c, dim_t &d, dim_t &h, dim_t &w) {
+            switch (tag_) {
+                case format_tag::nchw:
+                    return mb * conf_.stride_mb + c * conf_.h * conf_.w
+                            + h * conf_.w + w;
+                case format_tag::nhwc:
+                    return mb * conf_.stride_mb + h * conf_.w * conf_.c
+                            + w * conf_.c + c;
+                default:
+                    if (conf_.ndims >= 5) return src_md().off(mb, c, d, h, w);
+                    if (conf_.ndims >= 4) return src_md().off(mb, c, h, w);
+                    if (conf_.ndims >= 3) return src_md().off(mb, c, w);
+                    return src_md().off(mb, c);
+            }
+        };
+
+        auto ker = [=](dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow) {
+            float sum = 0;
+            const dim_t half_size = (conf_.size - 1) / 2;
+            if (conf_.alg_kind == alg_kind::lrn_across_channels) {
+                const dim_t c_st = nstl::max(oc - half_size + 0, (dim_t)0);
+                const dim_t c_en = nstl::min(oc + half_size + 1, conf_.c);
+
+                for (dim_t c = c_st; c < c_en; ++c) {
+                    const auto s_off = data_off(mb, c, od, oh, ow);
+                    const auto s = load_float_value(
+                            src_md().data_type(), src_ptr(), s_off);
+                    sum += s * s;
+                }
+            } else {
+                dim_t d_st = nstl::max(od - half_size + 0, (dim_t)0);
+                dim_t d_en = nstl::min(od + half_size + 1, conf_.d);
+                dim_t h_st = nstl::max(oh - half_size + 0, (dim_t)0);
+                dim_t h_en = nstl::min(oh + half_size + 1, conf_.h);
+                dim_t w_st = nstl::max(ow - half_size + 0, (dim_t)0);
+                dim_t w_en = nstl::min(ow + half_size + 1, conf_.w);
+                for_(dim_t d = d_st; d < d_en; ++d)
+                for_(dim_t h = h_st; h < h_en; ++h)
+                for (dim_t w = w_st; w < w_en; ++w) {
+                    const auto s_off = data_off(mb, oc, d, h, w);
+                    const auto s = load_float_value(
+                            src_md().data_type(), src_ptr(), s_off);
+                    sum += s * s;
+                }
+            }
+            sum = conf_.k + conf_.alpha * sum / conf_.compute_n_summands;
+            const auto s_off = data_off(mb, oc, od, oh, ow);
+            const auto s
+                    = load_float_value(src_md().data_type(), src_ptr(), s_off);
+            return (s * fast_negative_powf(sum, conf_.beta));
+        };
+
+        auto operation = [=](dim_t &mb, dim_t &c, dim_t &d, dim_t &h,
+                                 dim_t &w) {
+            if (format_tag::nhwc == tag_) {
+                const dim_t off = mb * conf_.stride_mb + h * conf_.w * conf_.c
+                        + w * conf_.c + c;
+                auto val = ker(mb, c, 0, h, w);
+                store_float_value(dst_md().data_type(), val, dst_ptr(), off);
+            } else {
+                const dim_t off = data_off(mb, c, d, h, w);
+                auto val = ker(mb, c, d, h, w);
+                store_float_value(dst_md().data_type(), val, dst_ptr(), off);
+            }
+        };
+
+        for (dim_t blk_idx = 0; blk_idx < conf_.block_size; blk_idx++) {
+            dim_t idx = base_idx + blk_idx;
+            if (idx < conf_.wk_size) {
+                dim_t N = conf_.mb;
+                dim_t C = conf_.c;
+                dim_t D = conf_.d;
+                dim_t H = conf_.h;
+                dim_t W = conf_.w;
+
+                dim_t n = (idx / (C * D * H * W)) % N;
+                dim_t c = (idx / (D * H * W)) % C;
+                dim_t d = (idx / (H * W)) % D;
+                dim_t h = (idx / (W)) % H;
+                dim_t w = (idx / (1)) % W;
+
+                operation(n, c, d, h, w);
+            }
+        }
+    }
+
+    inline float fast_negative_powf(float omega, float beta) const {
+        float Y;
+        if (beta == 0.75f) {
+            Y = ::sycl::sqrt(1.0f / (::sycl::sqrt(omega) * omega));
+        } else {
+            Y = 1.0f / ::sycl::pow(omega, beta);
+        }
+        return Y;
+    }
+
+private:
+    const sycl_md_t &src_md() const { return conf_.src_md; }
+    const sycl_md_t &dst_md() const { return conf_.dst_md; }
+
+    void *src_ptr() const { return src_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+
+    sycl_lrn_conf_t conf_;
+    sycl_in_memory_arg_t src_;
+    sycl_out_memory_arg_t dst_;
+    format_tag_t tag_;
+};
+
+struct lrn_bwd_kernel_vec_t {
+    lrn_bwd_kernel_vec_t(const sycl_lrn_conf_t &conf, sycl_in_memory_arg_t &src,
+            sycl_in_memory_arg_t &diff_dst, sycl_out_memory_arg_t &diff_src,
+            const format_tag_t &tag)
+        : conf_(conf)
+        , src_(src)
+        , diff_dst_(diff_dst)
+        , diff_src_(diff_src)
+        , tag_(tag) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        auto sg = item.get_sub_group();
+        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
+        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
+        size_t wi_offset_t = sg.get_local_id();
+        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
+        size_t base_idx = offset_t * conf_.block_size;
+
+        auto data_off = [&](dim_t &mb, dim_t &c, dim_t &d, dim_t &h,
+                                dim_t &w) -> dim_t {
+            switch (tag_) {
+                case format_tag::nchw:
+                    return mb * conf_.stride_mb + c * conf_.h * conf_.w
+                            + h * conf_.w + w;
+                case format_tag::nhwc:
+                    return mb * conf_.stride_mb + h * conf_.w * conf_.c
+                            + w * conf_.c + c;
+                default:
+                    if (conf_.ndims >= 5) return src_md().off(mb, c, d, h, w);
+                    if (conf_.ndims >= 4) return src_md().off(mb, c, h, w);
+                    if (conf_.ndims >= 3) return src_md().off(mb, c, w);
+                    return src_md().off(mb, c);
+            }
+        };
+
+        auto get_omega = [=](dim_t &mb, dim_t &oc, dim_t &od, dim_t &oh,
+                                 dim_t &ow) {
+            auto sum = 0;
+            const dim_t half_size = (conf_.size - 1) / 2;
+            if (conf_.alg_kind == alg_kind::lrn_across_channels) {
+                const dim_t c_st = nstl::max(oc - half_size + 0, (dim_t)0);
+                const dim_t c_en = nstl::min(oc + half_size + 1, conf_.c);
+
+                for (dim_t c = c_st; c < c_en; ++c) {
+                    const auto s_off = data_off(mb, c, od, oh, ow);
+                    const auto s = load_float_value(
+                            src_md().data_type(), src_ptr(), s_off);
+                    sum += s * s;
+                }
+            } else {
+                dim_t d_st = nstl::max(od - half_size + 0, (dim_t)0);
+                dim_t d_en = nstl::min(od + half_size + 1, conf_.d);
+                dim_t h_st = nstl::max(oh - half_size + 0, (dim_t)0);
+                dim_t h_en = nstl::min(oh + half_size + 1, conf_.h);
+                dim_t w_st = nstl::max(ow - half_size + 0, (dim_t)0);
+                dim_t w_en = nstl::min(ow + half_size + 1, conf_.w);
+                for_(dim_t d = d_st; d < d_en; ++d)
+                for_(dim_t h = h_st; h < h_en; ++h)
+                for (dim_t w = w_st; w < w_en; ++w) {
+                    const auto s_off = data_off(mb, oc, d, h, w);
+                    const auto s = load_float_value(
+                            src_md().data_type(), src_ptr(), s_off);
+                    sum += s * s;
+                }
+            }
+            return (conf_.k + conf_.alpha * sum / conf_.compute_n_summands);
+        };
+
+        auto ker = [=](dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow) {
+            float A = 0, B = 0;
+            const dim_t half_size = (conf_.size - 1) / 2;
+            if (conf_.alg_kind == alg_kind::lrn_across_channels) {
+                const dim_t c_st = nstl::max(oc - half_size + 0, (dim_t)0);
+                const dim_t c_en = nstl::min(oc + half_size + 1, conf_.c);
+
+                for (dim_t c = c_st; c < c_en; c++) {
+                    const auto off = data_off(mb, c, od, oh, ow);
+                    const auto omega = get_omega(mb, c, od, oh, ow);
+                    const auto omega_in_beta
+                            = fast_negative_powf(omega, conf_.beta);
+
+                    const auto dst_val = load_float_value(
+                            diff_dst_md().data_type(), diff_dst_ptr(), off);
+                    const auto tmp = omega_in_beta * dst_val;
+                    if (c == oc) A = tmp;
+                    const auto src_val = load_float_value(
+                            src_md().data_type(), src_ptr(), off);
+                    B += (src_val * tmp / omega);
+                }
+            } else {
+                dim_t d_st = nstl::max(od - half_size + 0, (dim_t)0);
+                dim_t d_en = nstl::min(od + half_size + 1, conf_.d);
+                dim_t h_st = nstl::max(oh - half_size + 0, (dim_t)0);
+                dim_t h_en = nstl::min(oh + half_size + 1, conf_.h);
+                dim_t w_st = nstl::max(ow - half_size + 0, (dim_t)0);
+                dim_t w_en = nstl::min(ow + half_size + 1, conf_.w);
+                for_(dim_t d = d_st; d < d_en; ++d)
+                for_(dim_t h = h_st; h < h_en; ++h)
+                for (dim_t w = w_st; w < w_en; ++w) {
+                    const auto off = data_off(mb, oc, d, h, w);
+                    const auto omega = get_omega(mb, oc, d, h, w);
+                    const auto omega_in_beta
+                            = fast_negative_powf(omega, conf_.beta);
+
+                    const auto dst_val = load_float_value(
+                            diff_dst_md().data_type(), diff_dst_ptr(), off);
+                    const auto tmp = omega_in_beta * dst_val;
+                    if (d == od && h == oh && w == ow) A = tmp;
+                    const auto src_val = load_float_value(
+                            src_md().data_type(), src_ptr(), off);
+                    B += (src_val * tmp / omega);
+                }
+            }
+            const auto off = data_off(mb, oc, od, oh, ow);
+            const auto src_val
+                    = load_float_value(src_md().data_type(), src_ptr(), off);
+            B *= (2.0f * conf_.alpha * conf_.beta * src_val
+                    / conf_.compute_n_summands);
+            return (A - B);
+        };
+
+        auto operation
+                = [=](dim_t &mb, dim_t &c, dim_t &d, dim_t &h, dim_t &w) {
+                      if (format_tag::nhwc == tag_) {
+                          const dim_t off = mb * conf_.stride_mb
+                                  + h * conf_.w * conf_.c + w * conf_.c + c;
+                          auto val = ker(mb, c, 0, h, w);
+                          store_float_value(diff_src_md().data_type(), val,
+                                  diff_src_ptr(), off);
+                      } else {
+                          const dim_t off = data_off(mb, c, d, h, w);
+                          auto val = ker(mb, c, d, h, w);
+                          store_float_value(diff_src_md().data_type(), val,
+                                  diff_src_ptr(), off);
+                      }
+                  };
+
+        for (dim_t blk_idx = 0; blk_idx < conf_.block_size; blk_idx++) {
+            dim_t idx = base_idx + blk_idx;
+            if (idx < conf_.wk_size) {
+                dim_t N = conf_.mb;
+                dim_t C = conf_.c;
+                dim_t D = conf_.d;
+                dim_t H = conf_.h;
+                dim_t W = conf_.w;
+
+                dim_t n = (idx / (C * D * H * W)) % N;
+                dim_t c = (idx / (D * H * W)) % C;
+                dim_t d = (idx / (H * W)) % D;
+                dim_t h = (idx / (W)) % H;
+                dim_t w = (idx / (1)) % W;
+
+                operation(n, c, d, h, w);
+            }
+        }
+    }
+
+    inline float fast_negative_powf(float omega, float beta) const {
+        float Y;
+        if (beta == 0.75f) {
+            Y = ::sycl::sqrt(1.0f / (::sycl::sqrt(omega) * omega));
+        } else {
+            Y = 1.0f / ::sycl::pow(omega, beta);
+        }
+        return Y;
+    }
+
+private:
+    const sycl_md_t &src_md() const { return conf_.src_md; }
+    const sycl_md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+    const sycl_md_t &diff_src_md() const { return conf_.diff_src_md; }
+
+    void *src_ptr() const { return src_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+    void *diff_src_ptr() const { return diff_src_.get_pointer(); }
+
+    sycl_lrn_conf_t conf_;
+    sycl_in_memory_arg_t src_;
+    sycl_in_memory_arg_t diff_dst_;
+    sycl_out_memory_arg_t diff_src_;
+    format_tag_t tag_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/ref_lrn.cpp
+++ b/src/gpu/sycl/ref_lrn.cpp
@@ -1,0 +1,152 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/sycl/ref_lrn.hpp"
+#include "gpu/sycl/lrn_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+using namespace impl::sycl;
+status_t ref_sycl_lrn_fwd_t::pd_t::init_conf() {
+    conf_ = sycl_lrn_conf_t();
+    conf_.src_md = sycl_md_t(src_md());
+    conf_.dst_md = sycl_md_t(dst_md());
+    conf_.alg_kind = desc()->alg_kind;
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+
+    const memory_desc_wrapper data_d(src_md());
+    conf_.mb = MB();
+    conf_.c = C();
+    conf_.d = D();
+    conf_.h = H();
+    conf_.w = W();
+    conf_.stride_mb = data_d.blocking_desc().strides[0];
+    conf_.ndims = data_d.ndims();
+    conf_.wk_size = data_d.nelems();
+    conf_.alpha = static_cast<float>(desc()->lrn_alpha);
+    conf_.beta = static_cast<float>(desc()->lrn_beta);
+    conf_.k = static_cast<float>(desc()->lrn_k);
+    conf_.size = desc()->local_size;
+
+    if (desc()->alg_kind == alg_kind::lrn_across_channels) {
+        conf_.compute_n_summands = conf_.size;
+    } else { // within_channel
+        dim_t n_summands = 1;
+        for (auto d = conf_.ndims - 2; d > 0; --d)
+            n_summands *= conf_.size;
+        conf_.compute_n_summands = n_summands;
+    }
+    return status::success;
+}
+
+status_t ref_sycl_lrn_fwd_t::init(engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<lrn_fwd_kernel_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_sycl_lrn_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
+    using namespace alg_kind;
+    using namespace format_tag;
+
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto src_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+        auto dst_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+
+        const auto block_size = pd()->conf_.block_size;
+        const auto wg_size = pd()->conf_.wg_size;
+        const auto t_work = pd()->conf_.wk_size;
+        const auto wg_work = wg_size * block_size;
+        const auto wg_cnt = (t_work + wg_work - 1) / wg_work;
+        auto n_thr = wg_cnt * wg_size;
+        n_thr = n_thr < 1 ? 1 : n_thr;
+        const format_tag_t tag = pd()->dat_tag_;
+
+        lrn_fwd_kernel_vec_t lrn_fwd_kernel_(
+                pd()->conf_, src_mem_arg, dst_mem_arg, tag);
+
+        cgh.parallel_for(::sycl::nd_range<1>(n_thr, wg_size), lrn_fwd_kernel_);
+    });
+}
+
+status_t ref_sycl_lrn_bwd_t::pd_t::init_conf() {
+    conf_ = sycl_lrn_conf_t();
+    conf_.src_md = sycl_md_t(src_md());
+    conf_.diff_dst_md = sycl_md_t(diff_dst_md());
+    conf_.diff_src_md = sycl_md_t(diff_src_md());
+    conf_.alg_kind = desc()->alg_kind;
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+
+    const memory_desc_wrapper data_d(src_md());
+    conf_.mb = MB();
+    conf_.c = C();
+    conf_.d = D();
+    conf_.h = H();
+    conf_.w = W();
+    conf_.stride_mb = data_d.blocking_desc().strides[0];
+    conf_.ndims = data_d.ndims();
+    conf_.wk_size = data_d.nelems();
+    conf_.alpha = static_cast<float>(desc()->lrn_alpha);
+    conf_.beta = static_cast<float>(desc()->lrn_beta);
+    conf_.k = static_cast<float>(desc()->lrn_k);
+    conf_.size = desc()->local_size;
+    if (desc()->alg_kind == alg_kind::lrn_across_channels) {
+        conf_.compute_n_summands = conf_.size;
+    } else { // within_channel
+        dim_t n_summands = 1;
+        for (auto d = conf_.ndims - 2; d > 0; --d)
+            n_summands *= conf_.size;
+        conf_.compute_n_summands = n_summands;
+    }
+
+    return status::success;
+}
+
+status_t ref_sycl_lrn_bwd_t::init(engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<lrn_bwd_kernel_vec_t>();
+    return create_kernel(engine, kid, &kernel_);
+}
+
+status_t ref_sycl_lrn_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
+    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto diff_src_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+        auto diff_dst_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto diff_src_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
+
+        const format_tag_t tag = pd()->dat_tag_;
+
+        lrn_bwd_kernel_vec_t lrn_bwd_kernel_(pd()->conf_, diff_src_arg,
+                diff_dst_mem_arg, diff_src_mem_arg, tag);
+
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+        const int t_work = pd()->conf_.wk_size;
+        int wg_work = wg_size * block_size;
+        int wg_cnt = (t_work + wg_work - 1) / wg_work;
+        int wg_thr = wg_cnt * wg_size;
+        wg_thr = wg_thr < 1 ? 1 : wg_thr;
+        cgh.parallel_for(::sycl::nd_range<1>(wg_thr, wg_size), lrn_bwd_kernel_);
+    });
+}
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/sycl/ref_lrn.hpp
+++ b/src/gpu/sycl/ref_lrn.hpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef GPU_SYCL_REF_LRN_HPP
+#define GPU_SYCL_REF_LRN_HPP
+
+#include "gpu/gpu_lrn_pd.hpp"
+#include "gpu/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct ref_sycl_lrn_fwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_lrn_fwd_pd_t {
+        using gpu_lrn_fwd_pd_t::gpu_lrn_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_lrn_fwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace format_tag;
+            using namespace data_type;
+
+            const memory_desc_wrapper src_d(src_md());
+            const memory_desc_wrapper dst_d(dst_md());
+
+            bool ok = is_fwd()
+                    && utils::one_of(src_md()->data_type, f32, bf16, f16)
+                    && utils::everyone_is(
+                            src_md()->data_type, dst_md()->data_type)
+                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && attr()->has_default_values()
+                    && set_default_formats_common() && src_d == dst_d;
+
+            if (!ok) return status::unimplemented;
+            dat_tag_ = memory_desc_matches_one_of_tag(*src_md(), nchw, nhwc);
+            return init_conf();
+        }
+
+        sycl_lrn_conf_t conf_;
+        format_tag_t dat_tag_;
+
+    private:
+        status_t init_conf();
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    compute::kernel_t kernel_;
+};
+
+struct ref_sycl_lrn_bwd_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_lrn_bwd_pd_t {
+        using gpu_lrn_bwd_pd_t::gpu_lrn_bwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_sycl_lrn_bwd_t);
+
+        status_t init(engine_t *engine) {
+            using namespace format_tag;
+            using namespace data_type;
+
+            const memory_desc_wrapper diff_src_d(diff_src_md());
+            const memory_desc_wrapper diff_dst_d(diff_dst_md());
+
+            bool ok = !is_fwd()
+                    && utils::one_of(src_md()->data_type, f32, bf16, f16)
+                    && utils::everyone_is(src_md()->data_type,
+                            diff_src_md()->data_type, diff_dst_md()->data_type)
+                    && attr()->has_default_values()
+                    && set_default_formats_common() && diff_dst_d == diff_src_d;
+
+            if (!ok) return status::unimplemented;
+
+            dat_tag_ = memory_desc_matches_one_of_tag(*src_md(), nchw, nhwc);
+            return init_conf();
+        }
+
+        sycl_lrn_conf_t conf_;
+        format_tag_t dat_tag_;
+
+    private:
+        status_t init_conf();
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_backward(ctx);
+    }
+
+private:
+    status_t execute_backward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    compute::kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -261,6 +261,32 @@ struct sycl_softmax_conf_t {
     dim_t channels;
 };
 
+struct sycl_lrn_conf_t {
+    sycl_md_t src_md;
+    sycl_md_t dst_md;
+    sycl_md_t diff_dst_md;
+    sycl_md_t diff_src_md;
+    alg_kind_t alg_kind;
+
+    dim_t mb;
+    dim_t c;
+    dim_t d;
+    dim_t h;
+    dim_t w;
+    dim_t stride_mb;
+    dim_t ndims;
+    dim_t tag_blk_sz;
+    dim_t size;
+    dim_t compute_n_summands;
+    float alpha;
+    float beta;
+    float k;
+
+    int block_size;
+    int wg_size;
+    int wk_size;
+};
+
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_shuffle_conf_t);
@@ -269,6 +295,7 @@ CHECK_SYCL_KERNEL_ARG_TYPE(sycl_batch_normalization_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_softmax_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_layer_normalization_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_eltwise_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_lrn_conf_t);
 
 } // namespace sycl
 } // namespace gpu


### PR DESCRIPTION
# Description

Introducing SYCL backend for the oneDNN LRN (Local Response Normalization) primitive. This contains support for LRN functionality in both forward and backward propagations.

# Supported scope
Supported Data Types:
Forward/ Backward : f32, bf16, f16

# Tested Hardware
Nvidia Tesla T4

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Testing Scope
`benchdnn : passed`

## Test Output Files
[test_lrn_gpu_output.txt](https://github.com/oneapi-src/oneDNN/files/11059393/test_lrn_gpu_output.txt)
[test_lrn_ci_output.txt](https://github.com/oneapi-src/oneDNN/files/11059394/test_lrn_ci_output.txt)
[test_lrn_all_output.txt](https://github.com/oneapi-src/oneDNN/files/11059395/test_lrn_all_output.txt)



