### PR TITLE
Updated the scale for softmax sycl

### DIFF
--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -259,6 +259,8 @@ struct sycl_softmax_conf_t {
     dim_t inner_size;
     dim_t outer_size;
     dim_t channels;
+    bool do_scale_src;
+    bool do_scale_dst;
 };
 
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);


### PR DESCRIPTION
### Description
This PR extends softmax SYCL kernel support for the scale part . 

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Test Output:
[test_softmax_all.txt](https://github.com/oneapi-src/oneDNN/files/11061162/test_softmax_all.txt)
[test_softmax_gpu.txt](https://github.com/oneapi-src/oneDNN/files/11061159/test_softmax_gpu.txt)
[test_softmax_ci.txt](https://github.com/oneapi-src/oneDNN/files/11061160/test_softmax_ci.txt)
