### PR TITLE
Adding support for Deconvolution Primitive

### DIFF
--- a/src/gpu/amd/miopen_convolution.hpp
+++ b/src/gpu/amd/miopen_convolution.hpp
@@ -95,10 +95,11 @@ struct miopen_convolution_fwd_t : public primitive_t {
             ok = ok && memory_format_ok(&weights_md_);
             ok = ok && memory_format_ok(&dst_md_);
             if (with_bias()) ok = ok && memory_format_ok(&bias_md_);
-            ok = ok && check_format();
             if (!ok) return status::unimplemented;
 
             if (check_for_zero_dims()) return status::success;
+
+            if (!check_format()) return status::unimplemented;
 
             const bool use_temp_dst = attr()->post_ops_.len() > 0;
             if (use_temp_dst) {
@@ -311,10 +312,11 @@ struct miopen_convolution_bwd_data_t : public primitive_t {
                 ok = ok && memory_format_ok(&bias_md_);
                 ok = ok && bias_md_.data_type == diff_dst_md_.data_type;
             }
-            ok = ok && check_format();
             if (!ok) return status::unimplemented;
 
             if (check_for_zero_dims()) return status::success;
+
+            if (!check_format()) return status::unimplemented;
 
             impl_.reset(new miopen_convolution_impl_bwd_data_t());
             return impl_->init(engine, this);
@@ -424,8 +426,9 @@ struct miopen_convolution_bwd_weights_t : public primitive_t {
                 ok = ok && memory_format_ok(&diff_bias_md_);
                 ok = ok && diff_bias_md_.data_type == diff_dst_md_.data_type;
             }
-            ok = ok && check_format();
             if (!ok) return status::unimplemented;
+
+            if (!check_format()) return status::unimplemented;
 
             impl_.reset(new miopen_convolution_impl_bwd_weights_t());
             if (check_for_zero_dims()) { return impl_->init_zero_dims(this); };

--- a/src/gpu/amd/miopen_convolution_impl.hpp
+++ b/src/gpu/amd/miopen_convolution_impl.hpp
@@ -750,11 +750,11 @@ protected:
                 x, scratchpad, ws_size, solutions[selected_sol].solution_id);
 
         if (with_bias) {
-            int alpha2 = 0;
+            float alpha2 = 0;
             miopenTensorOp_t tensorOp = miopenTensorOpAdd;
-            MIOPEN_EXECUTE_FUNC_V(miopenOpTensor, handle, tensorOp, &bias_alpha,
-                    descs[io::bias], bias, &alpha2, descs[io::y], y, &bias_beta,
-                    descs[io::x], x);
+            MIOPEN_EXECUTE_FUNC_V(miopenOpTensor, handle, tensorOp, &alpha2,
+                    descs[io::x], x, &bias_alpha, descs[io::bias], bias,
+                    &bias_beta, descs[io::x], x);
         }
     }
 

--- a/src/gpu/amd/miopen_deconvolution.cpp
+++ b/src/gpu/amd/miopen_deconvolution.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_deconvolution.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_deconvolution_bwd_weights_t::execute_bias(
+        const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->diff_dst_md(0)).has_zero_dim())
+        return status::success;
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_diff_bias = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_BIAS);
+        auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            void *bias = arg_diff_bias.get_native_pointer(ih);
+            void *y = arg_diff_dst.get_native_pointer(ih);
+
+            impl_->execute_bias(handle, y, bias);
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_deconvolution.hpp
+++ b/src/gpu/amd/miopen_deconvolution.hpp
@@ -1,0 +1,466 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_DECONVOLUTION_HPP
+#define GPU_AMD_MIOPEN_DECONVOLUTION_HPP
+
+#include <miopen/miopen.h>
+
+#include "common/c_types_map.hpp"
+#include "common/deconvolution_pd.hpp"
+#include "common/primitive_desc_iterator.hpp"
+#include "gpu/amd/miopen_convolution.hpp"
+#include "gpu/amd/miopen_deconvolution_impl.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+namespace {
+static status_t compute_blocked_format(
+        bool with_groups, const memory_desc_t *oi_md, memory_desc_t *io_md) {
+    /* Computes blocking for *i*o* format from *o*i* format */
+    bool sanity_check_ok = true && oi_md->ndims == io_md->ndims
+            && oi_md->format_kind == format_kind::blocked;
+    if (!sanity_check_ok) return status::invalid_arguments;
+
+    const blocking_desc_t &oi_blk = oi_md->format_desc.blocking;
+    blocking_desc_t io_blk = io_md->format_desc.blocking;
+
+    io_md->format_kind = format_kind::blocked;
+    io_blk = oi_blk;
+
+    const int ID_OC = 0 + with_groups;
+    const int ID_IC = 1 + with_groups;
+
+    nstl::swap(io_blk.strides[ID_OC], io_blk.strides[ID_IC]);
+    for (int i_blk = 0; i_blk < io_blk.inner_nblks; ++i_blk) {
+        if (utils::one_of(io_blk.inner_idxs[i_blk], ID_OC, ID_IC)) {
+            io_blk.inner_idxs[i_blk]
+                    = (io_blk.inner_idxs[i_blk] == ID_OC ? ID_IC : ID_OC);
+        }
+    }
+
+    return memory_desc_init_by_blocking_desc(*io_md, io_blk);
+}
+
+static status_t conv_descr_create(
+        const deconvolution_desc_t *dd, convolution_desc_t *cd) {
+    using namespace prop_kind;
+    alg_kind_t alg_kind = dd->alg_kind == alg_kind::deconvolution_direct
+            ? alg_kind::convolution_direct
+            : alg_kind::convolution_winograd;
+
+    const memory_desc_t *src_md, *dst_md, *d_weights_d;
+    prop_kind_t prop_kind;
+    memory_desc_t c_weights_d;
+    if (utils::one_of(dd->prop_kind, forward_training, forward_inference)) {
+        prop_kind = backward_data;
+        src_md = &dd->dst_desc;
+        dst_md = &dd->src_desc;
+        d_weights_d = &dd->weights_desc;
+    } else if (dd->prop_kind == backward_data) {
+        prop_kind = forward_training;
+        src_md = &dd->diff_dst_desc;
+        dst_md = &dd->diff_src_desc;
+        d_weights_d = &dd->weights_desc;
+    } else {
+        prop_kind = dd->prop_kind;
+        src_md = &dd->diff_dst_desc;
+        dst_md = &dd->src_desc;
+        d_weights_d = &dd->diff_weights_desc;
+    }
+
+    const bool with_groups = d_weights_d->ndims == src_md->ndims + 1;
+
+    /* create weights desc for convolution */
+    c_weights_d = *d_weights_d;
+
+    const int ID_OC = 0 + with_groups;
+    const int ID_IC = 1 + with_groups;
+
+    nstl::swap(c_weights_d.dims[ID_OC], c_weights_d.dims[ID_IC]);
+    nstl::swap(c_weights_d.padded_dims[ID_OC], c_weights_d.padded_dims[ID_IC]);
+    nstl::swap(c_weights_d.padded_offsets[ID_OC],
+            c_weights_d.padded_offsets[ID_IC]);
+
+    if (c_weights_d.format_kind != format_kind::any)
+        CHECK(compute_blocked_format(with_groups, d_weights_d, &c_weights_d));
+
+    return conv_desc_init(cd, prop_kind, alg_kind, src_md, &c_weights_d,
+            prop_kind != backward_weights ? &dd->bias_desc : nullptr, dst_md,
+            dd->strides, dd->dilates, dd->padding[0], dd->padding[1]);
+}
+} // namespace
+
+struct miopen_deconvolution_fwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public deconvolution_fwd_pd_t {
+        pd_t(const deconvolution_desc_t *adesc, const primitive_attr_t *attr,
+                const deconvolution_fwd_pd_t *hint_fwd_pd)
+            : deconvolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
+            , conv_pd_(nullptr) {}
+
+        pd_t(const pd_t &other)
+            : deconvolution_fwd_pd_t(other)
+            , conv_pd_(other.conv_pd_->clone())
+            , conv_supports_bias_(other.conv_supports_bias_)
+            , dst_tag_(other.dst_tag_) {}
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_deconvolution_fwd_t);
+
+        status_t init_convolution(engine_t *engine) {
+            using namespace format_tag;
+            using namespace data_type;
+
+            convolution_desc_t cd;
+            CHECK(conv_descr_create(desc(), &cd));
+            primitive_attr_t conv_attr = *attr();
+            primitive_desc_iterator_t it(
+                    engine, (op_desc_t *)&cd, &conv_attr, nullptr);
+            while (++it != it.end()) {
+                conv_pd_ = *it;
+                conv_supports_bias_ = static_cast<convolution_bwd_data_pd_t *>(
+                        conv_pd_.get())
+                                              ->support_bias();
+                bool ref_deconv_supports_bias = true
+                        && desc()->accum_data_type == data_type::f32
+                        && utils::one_of(desc()->dst_desc.data_type, f32, f16)
+                        && IMPLICATION(desc()->src_desc.data_type == f16,
+                                memory_desc_matches_one_of_tag(
+                                        *conv_pd_->diff_src_md(),
+                                        utils::pick(ndims() - 3, ncw, nchw,
+                                                ncdhw)));
+                bool ok = true
+                        && conv_pd_->weights_md()->extra.flags == 0
+                        /* deconv reference code can process only f32 bias */
+                        && IMPLICATION(with_bias(),
+                                conv_supports_bias_
+                                        || ref_deconv_supports_bias);
+                if (ok) return status::success;
+            }
+            conv_pd_.reset();
+            return status::unimplemented;
+        }
+
+        status_t init(engine_t *engine) {
+            using namespace format_tag;
+            bool ok = true && is_fwd();
+            ok = ok
+                    && utils::one_of(desc()->alg_kind,
+                            alg_kind::deconvolution_direct,
+                            alg_kind::deconvolution_winograd);
+            ok = ok && attr_.has_default_values();
+            ok = ok
+                    && (utils::everyone_is(data_type::f32,
+                                desc()->src_desc.data_type,
+                                desc()->weights_desc.data_type,
+                                desc()->dst_desc.data_type)
+                            || utils::everyone_is(data_type::f16,
+                                    desc()->src_desc.data_type,
+                                    desc()->weights_desc.data_type,
+                                    desc()->dst_desc.data_type));
+
+            if (ok) {
+                CHECK(init_convolution(engine));
+                if (weights_md_.format_kind == format_kind::any) {
+                    CHECK(compute_blocked_format(with_groups(),
+                            conv_pd_->weights_md(), &desc_.weights_desc));
+                    weights_md_ = desc_.weights_desc;
+                }
+                if (src_md_.format_kind == format_kind::any)
+                    src_md_ = *conv_pd_->diff_dst_md();
+                if (dst_md_.format_kind == format_kind::any)
+                    dst_md_ = *conv_pd_->diff_src_md();
+                if (bias_md_.format_kind == format_kind::any)
+                    CHECK(memory_desc_init_by_tag(bias_md_, x));
+
+                dst_tag_ = memory_desc_matches_one_of_tag(dst_md_,
+                        utils::pick(ndims() - 3, ncw, nchw, ncdhw),
+                        utils::pick(ndims() - 3, nCw4c, nChw4c, nCdhw4c));
+                init_scratchpad();
+                return status::success;
+            }
+
+            return status::unimplemented;
+        }
+
+        void init_scratchpad() {
+            auto scratchpad = scratchpad_registry().registrar();
+            scratchpad.book(memory_tracking::names::key_nested,
+                    conv_pd_->scratchpad_registry());
+        }
+
+        std::shared_ptr<primitive_desc_t> conv_pd_;
+        bool conv_supports_bias_;
+        format_tag_t dst_tag_;
+    };
+
+    ~miopen_deconvolution_fwd_t() {}
+
+    virtual status_t init(engine_t *engine) {
+        return pd()->conv_pd_->create_primitive(conv_p_, engine);
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const {
+        using namespace memory_tracking::names;
+        const auto &args = ctx.args();
+        exec_args_t conv_args;
+        conv_args[DNNL_ARG_DIFF_DST] = args.at(DNNL_ARG_SRC);
+        conv_args[DNNL_ARG_WEIGHTS] = args.at(DNNL_ARG_WEIGHTS);
+        conv_args[DNNL_ARG_DIFF_SRC] = args.at(DNNL_ARG_DST);
+        if (pd()->with_bias())
+            conv_args[DNNL_ARG_BIAS] = args.at(DNNL_ARG_BIAS);
+        exec_ctx_t conv_ctx(ctx.stream(), std::move(conv_args));
+
+        nested_scratchpad_t ns(ctx, key_nested, conv_p_);
+        conv_ctx.set_scratchpad_grantor(ns.grantor());
+        // Executing the convolution kernel
+        status_t status = conv_p_->execute(conv_ctx);
+        return status;
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::shared_ptr<primitive_t> conv_p_;
+};
+
+struct miopen_deconvolution_bwd_data_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public deconvolution_bwd_data_pd_t {
+        pd_t(const deconvolution_desc_t *adesc, const primitive_attr_t *attr,
+                const deconvolution_fwd_pd_t *hint_fwd_pd)
+            : deconvolution_bwd_data_pd_t(adesc, attr, hint_fwd_pd)
+            , conv_pd_(nullptr) {}
+
+        pd_t(const pd_t &other)
+            : deconvolution_bwd_data_pd_t(other)
+            , conv_pd_(other.conv_pd_->clone()) {}
+
+        ~pd_t() {}
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_deconvolution_bwd_data_t);
+
+        status_t init_convolution(engine_t *engine) {
+            convolution_desc_t cd;
+            CHECK(conv_descr_create(desc(), &cd));
+            primitive_attr_t conv_attr = *attr();
+            primitive_desc_iterator_t it(
+                    engine, (op_desc_t *)&cd, &conv_attr, nullptr);
+            while (++it != it.end()) {
+                conv_pd_ = *it;
+                return status::success;
+            }
+            return status::unimplemented;
+        }
+
+        status_t init(engine_t *engine) {
+
+            bool ok = true && desc()->prop_kind == prop_kind::backward_data
+                    && (utils::everyone_is(data_type::f32,
+                                desc()->diff_src_desc.data_type,
+                                desc()->weights_desc.data_type,
+                                desc()->diff_dst_desc.data_type)
+                            || utils::everyone_is(data_type::f16,
+                                    desc()->weights_desc.data_type,
+                                    desc()->diff_dst_desc.data_type))
+                    && utils::one_of(desc()->diff_src_desc.data_type,
+                            data_type::f16, data_type::f32)
+                    && desc()->alg_kind == alg_kind::deconvolution_direct
+                    && attr()->has_default_values();
+
+            if (ok) {
+                CHECK(init_convolution(engine));
+                if (weights_md_.format_kind == format_kind::any) {
+                    CHECK(compute_blocked_format(with_groups(),
+                            conv_pd_->weights_md(), &desc_.weights_desc));
+                    weights_md_ = desc_.weights_desc;
+                }
+                if (diff_src_md_.format_kind == format_kind::any)
+                    diff_src_md_ = *conv_pd_->dst_md();
+                if (diff_dst_md_.format_kind == format_kind::any)
+                    diff_dst_md_ = *conv_pd_->src_md();
+                init_scratchpad();
+                return status::success;
+            }
+
+            return status::unimplemented;
+        }
+
+        void init_scratchpad() {
+            auto scratchpad = scratchpad_registry().registrar();
+            scratchpad.book(memory_tracking::names::key_nested,
+                    conv_pd_->scratchpad_registry());
+        }
+
+        std::shared_ptr<primitive_desc_t> conv_pd_;
+    };
+
+    ~miopen_deconvolution_bwd_data_t() {}
+
+    virtual status_t init(engine_t *engine) {
+        return pd()->conv_pd_->create_primitive(conv_p_, engine);
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const {
+        using namespace memory_tracking::names;
+        const auto &args = ctx.args();
+        exec_args_t conv_args;
+        conv_args[DNNL_ARG_SRC] = args.at(DNNL_ARG_DIFF_DST);
+        conv_args[DNNL_ARG_WEIGHTS] = args.at(DNNL_ARG_WEIGHTS);
+        conv_args[DNNL_ARG_DST] = args.at(DNNL_ARG_DIFF_SRC);
+        if (!types::is_zero_md(pd()->scratchpad_md()))
+            conv_args[DNNL_ARG_SCRATCHPAD] = args.at(DNNL_ARG_SCRATCHPAD);
+        exec_ctx_t conv_ctx(ctx.stream(), std::move(conv_args));
+
+        nested_scratchpad_t ns(ctx, key_nested, conv_p_);
+        conv_ctx.set_scratchpad_grantor(ns.grantor());
+        // Executing the convolution kernel
+        status_t status = conv_p_->execute(conv_ctx);
+        return status;
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::shared_ptr<primitive_t> conv_p_;
+};
+
+struct miopen_deconvolution_bwd_weights_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public deconvolution_bwd_weights_pd_t {
+        pd_t(const deconvolution_desc_t *adesc, const primitive_attr_t *attr,
+                const deconvolution_fwd_pd_t *hint_fwd_pd)
+            : deconvolution_bwd_weights_pd_t(adesc, attr, hint_fwd_pd)
+            , conv_pd_(nullptr) {}
+
+        pd_t(const pd_t &other)
+            : deconvolution_bwd_weights_pd_t(other)
+            , conv_pd_(other.conv_pd_->clone()) {}
+
+        ~pd_t() {}
+
+        DECLARE_COMMON_PD_T(
+                "hip:miopen:any", miopen_deconvolution_bwd_weights_t);
+
+        status_t init_convolution(engine_t *engine) {
+            convolution_desc_t cd;
+            CHECK(conv_descr_create(desc(), &cd));
+            primitive_attr_t conv_attr = *attr();
+            primitive_desc_iterator_t it(
+                    engine, (op_desc_t *)&cd, &conv_attr, nullptr);
+            while (++it != it.end()) {
+                conv_pd_ = *it;
+                if (conv_pd_ == nullptr) return status::out_of_memory;
+                return status::success;
+            }
+            return status::unimplemented;
+        }
+
+        status_t init(engine_t *engine) {
+            using namespace format_tag;
+            bool ok = true && desc()->prop_kind == prop_kind::backward_weights
+                    && (utils::everyone_is(data_type::f32,
+                                desc()->src_desc.data_type,
+                                desc()->diff_weights_desc.data_type,
+                                desc()->diff_dst_desc.data_type)
+                            || utils::everyone_is(data_type::f16,
+                                    desc()->diff_dst_desc.data_type,
+                                    desc()->src_desc.data_type))
+                    && utils::one_of(
+                            desc()->alg_kind, alg_kind::deconvolution_direct)
+                    && attr()->has_default_values()
+                    && utils::one_of(desc()->diff_weights_desc.data_type,
+                            data_type::f16, data_type::f32);
+            if (ok) {
+                CHECK(init_convolution(engine));
+                if (diff_weights_md_.format_kind == format_kind::any) {
+                    CHECK(compute_blocked_format(with_groups(),
+                            conv_pd_->diff_weights_md(),
+                            &desc_.diff_weights_desc));
+                    diff_weights_md_ = desc_.diff_weights_desc;
+                }
+                if (src_md_.format_kind == format_kind::any)
+                    src_md_ = *conv_pd_->diff_dst_md();
+                if (diff_dst_md_.format_kind == format_kind::any)
+                    diff_dst_md_ = *conv_pd_->src_md();
+                if (diff_bias_md_.format_kind == format_kind::any)
+                    CHECK(memory_desc_init_by_tag(diff_bias_md_, x));
+                init_scratchpad();
+                return status::success;
+            }
+
+            return status::unimplemented;
+        }
+
+        void init_scratchpad() {
+            auto scratchpad = scratchpad_registry().registrar();
+            scratchpad.book(memory_tracking::names::key_nested,
+                    conv_pd_->scratchpad_registry());
+        }
+
+        std::shared_ptr<primitive_desc_t> conv_pd_;
+    };
+
+    ~miopen_deconvolution_bwd_weights_t() {}
+
+    virtual status_t init(engine_t *engine) {
+        if (pd()->with_bias()) {
+            if (pd()->ndims() > MIOPEN_DIM_MAX)
+                return status::invalid_arguments;
+
+            impl_ = std::make_shared<miopen_deconvolution_bwd_bias_impl_t>();
+            impl_->init(pd()->invariant_dst_md(), pd()->invariant_bia_md());
+        }
+        return pd()->conv_pd_->create_primitive(conv_p_, engine);
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const {
+        using namespace memory_tracking::names;
+        const auto &args = ctx.args();
+        exec_args_t conv_args;
+        conv_args[DNNL_ARG_DIFF_DST] = args.at(DNNL_ARG_SRC);
+        conv_args[DNNL_ARG_SRC] = args.at(DNNL_ARG_DIFF_DST);
+        conv_args[DNNL_ARG_DIFF_WEIGHTS] = args.at(DNNL_ARG_DIFF_WEIGHTS);
+        if (!types::is_zero_md(pd()->scratchpad_md()))
+            conv_args[DNNL_ARG_SCRATCHPAD] = args.at(DNNL_ARG_SCRATCHPAD);
+
+        exec_ctx_t conv_ctx(ctx, std::move(conv_args));
+
+        nested_scratchpad_t ns(ctx, key_nested, conv_p_);
+        conv_ctx.set_scratchpad_grantor(ns.grantor());
+        status_t status = conv_p_->execute(conv_ctx);
+        if (status != status::success) return status;
+
+        if (pd()->with_bias()) { return execute_bias(ctx); }
+        return status::success;
+    }
+
+    status_t execute_bias(const exec_ctx_t &ctx) const;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::shared_ptr<primitive_t> conv_p_;
+    std::shared_ptr<miopen_deconvolution_bwd_bias_impl_t> impl_;
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_deconvolution_impl.hpp
+++ b/src/gpu/amd/miopen_deconvolution_impl.hpp
@@ -1,0 +1,93 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_DECONVOLUTION_IMPL_HPP
+#define GPU_AMD_MIOPEN_DECONVOLUTION_IMPL_HPP
+
+#include <miopen/miopen.h>
+
+#include "common/c_types_map.hpp"
+#include "common/deconvolution_pd.hpp"
+#include "gpu/amd/miopen_convolution_pd.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_deconvolution_bwd_bias_impl_t {
+protected:
+    enum io { y = 0, bias, NUM_IO };
+    memory_desc_t dnnl_descs[NUM_IO];
+    miopenTensorDescriptor_t descs[NUM_IO];
+    int dims[NUM_IO][DNNL_MAX_NDIMS];
+    int strides[NUM_IO][DNNL_MAX_NDIMS];
+    int ndims[NUM_IO];
+    miopenDataType_t data_types[NUM_IO];
+
+public:
+    ~miopen_deconvolution_bwd_bias_impl_t() {
+        for (size_t i = 0; i < NUM_IO; i++) {
+            if (descs[i]) {
+                MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, descs[i]);
+            }
+        }
+    }
+
+    status_t init(const memory_desc_t *dst, const memory_desc_t *bia) {
+        dnnl_descs[y] = *dst;
+        dnnl_descs[bias] = *bia;
+
+        ndims[y] = dnnl_descs[y].ndims;
+        ndims[bias] = dnnl_descs[bias].ndims;
+        convert_dims(dnnl_descs[y].padded_dims, dims[y], ndims[y]);
+        CHECK(convert_data_type(&dnnl_descs[y], &data_types[y]));
+        CHECK(convert_data_type(&dnnl_descs[bias], &data_types[bias]));
+        convert_dims(dnnl_descs[y].format_desc.blocking.strides, strides[y],
+                ndims[y]);
+        ndims[y] = std::max(4, ndims[y]);
+        convert_dims(dnnl_descs[bias].format_desc.blocking.strides,
+                strides[bias], ndims[bias], ndims[y]);
+        convert_dims(dnnl_descs[bias].padded_dims, dims[bias], ndims[bias],
+                ndims[y]);
+        std::swap(dims[bias][0], dims[bias][1]);
+        ndims[bias] = ndims[y];
+        CHECK(create_and_set_tensor_descriptor(
+                &descs[y], data_types[y], ndims[y], dims[y], strides[y]));
+        CHECK(create_and_set_tensor_descriptor(&descs[bias], data_types[bias],
+                ndims[bias], dims[bias], strides[bias]));
+
+        return status::success;
+    }
+
+    void execute_bias(miopenHandle_t handle, void *y, void *bias) const {
+        const float bias_alpha = 1.0f;
+        const float bias_beta = 0.0f;
+        MIOPEN_EXECUTE_FUNC_V(miopenConvolutionBackwardBias, handle,
+                &bias_alpha, descs[io::y], y, &bias_beta, descs[io::bias],
+                bias);
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -25,6 +25,7 @@
 #include "gpu/amd/miopen_batch_normalization.hpp"
 #include "gpu/amd/miopen_binary.hpp"
 #include "gpu/amd/miopen_convolution.hpp"
+#include "gpu/amd/miopen_deconvolution.hpp"
 #include "gpu/amd/miopen_eltwise.hpp"
 #include "gpu/amd/miopen_gemm_inner_product.hpp"
 #include "gpu/amd/miopen_lrn.hpp"
@@ -195,6 +196,11 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         // Batch Normalization
         INSTANCE(miopen_batch_normalization_fwd_t)
         INSTANCE(miopen_batch_normalization_bwd_t)
+        // Deconvolution
+        INSTANCE(miopen_deconvolution_fwd_t)
+        INSTANCE(miopen_deconvolution_bwd_data_t)
+        INSTANCE(miopen_deconvolution_bwd_weights_t)
+
         nullptr,
 };
 // clang-format on


### PR DESCRIPTION
# Description

Introducing AMD backend for the oneDNN Deconvolution primitive.

**Supported scope:**
Supported Data Types:
Forward : f32, f16, s8
Backward data : f32, f16
Backward weight : f32, f16
Supported Tags : stag= abx wtag=abx datg=abx, stag=axb wtag=axb dtag=axb
NOTE: MIOpen supports Uniform Data Types and Uniform Layouts Representation


**Limitations:**
Non-uniform tags and Non-uniform datatypes are not supported.
https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2007


**Testing scope:**
Benchdnn: Passed
Gtests: API tests passed

---------**Benchdnn Logs**----------
[test_deconv_ci.log](https://github.com/oneapi-src/oneDNN/files/11061718/test_deconv_ci.log)
[test_deconv_all.log](https://github.com/oneapi-src/oneDNN/files/11061719/test_deconv_all.log)

---------**Gtests Logs**----------
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/11061738/test_internals.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/11061739/test_regression.log)
[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/11061741/test_api_buffer.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/11061742/test_api_sycl.log)
[test_deconvolution.log](https://github.com/oneapi-src/oneDNN/files/11061743/test_deconvolution.log)
[test_deconvolution_buffer.log](https://github.com/oneapi-src/oneDNN/files/11061768/test_deconvolution_buffer.log)


## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?