### PR TITLE
Adding Support for Batch Normalization Primitive - HIP Backend

### DIFF
--- a/src/gpu/amd/miopen_batch_normalization.cpp
+++ b/src/gpu/amd/miopen_batch_normalization.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_batch_normalization.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_batch_normalization_fwd_t::execute(
+        const exec_ctx_t &ctx) const {
+    return miopen_batch_normalization_common_t::execute(
+            ctx, ctx.stream()->engine(), pd());
+}
+
+status_t miopen_batch_normalization_bwd_t::execute(
+        const exec_ctx_t &ctx) const {
+    return miopen_batch_normalization_common_t::execute(
+            ctx, ctx.stream()->engine(), pd());
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_batch_normalization.hpp
+++ b/src/gpu/amd/miopen_batch_normalization.hpp
@@ -1,0 +1,215 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_BATCH_NORMALIZATION_HPP
+#define GPU_AMD_MIOPEN_BATCH_NORMALIZATION_HPP
+
+#include <miopen/miopen.h>
+
+#include "common/batch_normalization_pd.hpp"
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+#include "gpu/amd/miopen_batch_normalization_executor.hpp"
+#include "gpu/amd/miopen_batch_normalization_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_batch_normalization_common_t {
+    template <typename pd_t>
+    static status_t execute(
+            const exec_ctx_t &ctx, engine_t *engine, const pd_t *pd) {
+        if (memory_desc_wrapper(pd->src_md()).has_zero_dim()) {
+            return status::success;
+        }
+        return pd->executor_->execute(ctx, engine, pd->bnorm_impl_);
+    }
+
+    template <typename pd_t>
+    static void init_ws(const pd_t *pd, memory_desc_t &ws_md) {
+
+        const auto wrap = memory_desc_wrapper(pd->src_md());
+        const auto y_size
+                = wrap.nelems() * types::data_type_size(data_type::f32);
+        // Mean and variance are always f32.
+        const size_t mean_invvar_size
+                = 2 * pd->C() * types::data_type_size(data_type::f32);
+        const dims_t ws_size
+                = {(dim_t)(y_size * pd->fuse_norm_relu() + mean_invvar_size)};
+
+        memory_desc_init_by_tag(
+                ws_md, 1, ws_size, data_type::u8, format_tag::x);
+    }
+};
+
+struct miopen_batch_normalization_fwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public batch_normalization_fwd_pd_t {
+        using batch_normalization_fwd_pd_t::batch_normalization_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_batch_normalization_fwd_t);
+
+        status_t init(engine_t *) {
+            using namespace data_type;
+            using namespace types;
+
+            const auto norm_flags_supported
+                    = normalization_flags::use_global_stats
+                    | normalization_flags::fuse_norm_relu
+                    | normalization_flags::use_scale
+                    | normalization_flags::use_shift;
+            if ((~norm_flags_supported & desc()->flags) != 0)
+                return status::unimplemented;
+
+            const auto attr_skip_mask = primitive_attr_t::skip_mask_t::post_ops;
+
+            bool ok = is_fwd() && utils::one_of(src_md()->data_type, f32, f16)
+                    && src_md()->data_type == dst_md()->data_type
+                    && check_scale_shift_data_type()
+                    && attr()->has_default_values(attr_skip_mask)
+                    && IMPLICATION(!attr()->has_default_values(),
+                            attr()->post_ops_.len() == 1 && with_relu_post_op())
+                    && IMPLICATION(utils::one_of(src_md()->data_type, f16),
+                            !is_training() && stats_is_src())
+                    && set_default_formats_common()
+                    && memory_desc_wrapper(src_md())
+                            == memory_desc_wrapper(dst_md())
+                    && src_md()->format_desc.blocking.inner_nblks == 0
+                    && check_format();
+
+            if (!ok) return status::unimplemented;
+
+            if (is_training()) {
+                miopen_batch_normalization_common_t::init_ws(this, ws_md_);
+            }
+
+            if (use_global_stats()) {
+                bnorm_impl_.reset(
+                        new miopen_batch_normalization_fwd_stats_impl_t());
+            } else {
+                bnorm_impl_.reset(new miopen_batch_normalization_fwd_impl_t());
+            }
+
+            executor_.reset(new bnorm_exec_fwd_t());
+
+            return bnorm_impl_->init(this);
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(src_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd, format_tag::abcde)
+                    && memory_desc_wrapper(dst_md()).matches_one_of_tag(
+                            format_tag::a, format_tag::ab, format_tag::abc,
+                            format_tag::abcd, format_tag::abcde));
+        }
+
+        std::shared_ptr<miopen_batch_normalization_impl_base_t> bnorm_impl_;
+        std::shared_ptr<bnorm_exec_base_t> executor_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+struct miopen_batch_normalization_bwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public batch_normalization_bwd_pd_t {
+        pd_t(const batch_normalization_desc_t *adesc,
+                const primitive_attr_t *attr,
+                const batch_normalization_fwd_pd_t *hint_fwd_pd)
+            : batch_normalization_bwd_pd_t(adesc, attr, hint_fwd_pd) {}
+
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_batch_normalization_bwd_t);
+
+        status_t init(engine_t *) {
+            using namespace data_type;
+            using namespace types;
+
+            const auto norm_flags_supported
+                    = normalization_flags::fuse_norm_relu
+                    | normalization_flags::use_scale
+                    | normalization_flags::use_shift;
+            if ((~norm_flags_supported & desc()->flags) != 0)
+                return status::unimplemented;
+
+            bool ok = !is_fwd()
+                    && (utils::everyone_is(f32, src_md()->data_type,
+                            diff_src_md()->data_type, diff_dst_md()->data_type))
+                    && check_scale_shift_data_type()
+                    && attr()->has_default_values()
+                    && set_default_formats_common()
+                    && memory_desc_wrapper(diff_src_md())
+                            == memory_desc_wrapper(diff_dst_md())
+                    && src_md()->format_desc.blocking.inner_nblks == 0
+                    && diff_src_md()->format_desc.blocking.inner_nblks == 0
+                    && check_format();
+            if (!ok) return status::unimplemented;
+
+            miopen_batch_normalization_common_t::init_ws(this, ws_md_);
+            if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;
+
+            if (fuse_norm_relu()) {
+                bnorm_impl_.reset(
+                        new miopen_batch_normalization_bwd_relu_impl_t());
+            } else {
+                bnorm_impl_.reset(new miopen_batch_normalization_bwd_impl_t());
+            }
+
+            executor_.reset(new bnorm_exec_bwd_t());
+
+            return bnorm_impl_->init(this);
+        }
+
+        bool check_format() const {
+            // Only abx formats are supported
+            return (memory_desc_wrapper(diff_src_md())
+                            .matches_one_of_tag(format_tag::a, format_tag::ab,
+                                    format_tag::abc, format_tag::abcd,
+                                    format_tag::abcde)
+                    && memory_desc_wrapper(diff_dst_md())
+                               .matches_one_of_tag(format_tag::a,
+                                       format_tag::ab, format_tag::abc,
+                                       format_tag::abcd, format_tag::abcde));
+        }
+
+        std::shared_ptr<miopen_batch_normalization_impl_base_t> bnorm_impl_;
+        std::shared_ptr<bnorm_exec_base_t> executor_;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_batch_normalization_executor.hpp
+++ b/src/gpu/amd/miopen_batch_normalization_executor.hpp
@@ -1,0 +1,324 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_BATCH_NORMALIZATION_EXECUTOR_HPP
+#define GPU_AMD_MIOPEN_BATCH_NORMALIZATION_EXECUTOR_HPP
+
+#include "common/batch_normalization_pd.hpp"
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+#include "gpu/amd/miopen_batch_normalization_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+#include "sycl/sycl_memory_storage_helper.hpp"
+#include "sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct bnorm_exec_base_t {
+    virtual status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            const std::shared_ptr<miopen_batch_normalization_impl_base_t>
+                    bnorm_impl) const = 0;
+    virtual ~bnorm_exec_base_t() = default;
+
+protected:
+    template <::sycl::access::mode mean_var_m = ::sycl::access::mode::write>
+    void interop_task_fwd(
+            std::shared_ptr<miopen_batch_normalization_impl_base_t> bnorm_impl,
+            engine_t *engine, ::sycl::handler &cgh,
+            amd::sycl_hip_stream_t *hip_stream,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read> arg_src,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write> arg_dst,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read> arg_scale,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_scale_buf,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read> arg_shift,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_shift_buf,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_wkspace,
+            bool use_scale, bool use_shift, bool init_global_stats,
+            impl::sycl::sycl_memory_arg_t<mean_var_m> arg_mean = {},
+            impl::sycl::sycl_memory_arg_t<mean_var_m> arg_var = {}) const {
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(engine);
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            if (!use_scale)
+                init_scaleshift(sc, ih, hip_stream, arg_scale_buf, 1.f,
+                        bnorm_impl->C());
+            if (!use_shift)
+                init_scaleshift(sc, ih, hip_stream, arg_shift_buf, 0.f,
+                        bnorm_impl->C());
+            if (init_global_stats)
+                init_mean_var(
+                        sc, ih, hip_stream, arg_mean, arg_var, bnorm_impl->C());
+
+            auto *x = arg_src.get_native_pointer(ih);
+            auto *y = arg_dst.get_native_pointer(ih);
+            auto *mean = arg_mean.get_native_pointer(ih);
+            auto *var = arg_var.get_native_pointer(ih);
+
+            auto *scale = use_scale
+                    ? static_cast<uint8_t *>(arg_scale.get_native_pointer(ih))
+                    : static_cast<uint8_t *>(
+                            arg_scale_buf.get_native_pointer(ih));
+
+            uint8_t *shift = use_shift
+                    ? static_cast<uint8_t *>(arg_shift.get_native_pointer(ih))
+                    : static_cast<uint8_t *>(
+                            arg_shift_buf.get_native_pointer(ih));
+            uint8_t *y_prime = nullptr, *save_mean = nullptr,
+                    *save_var = nullptr;
+
+            if (!arg_wkspace.empty()) {
+                save_mean = static_cast<uint8_t *>(
+                        arg_wkspace.get_native_pointer(ih));
+                save_var = save_mean + bnorm_impl->mean_var_size_bytes();
+                y_prime = save_var + bnorm_impl->mean_var_size_bytes();
+            }
+
+            std::shared_ptr<bnorm_args_t> args(new bnorm_fwd_args_t(x, y, mean,
+                    var, scale, shift, y_prime, save_mean, save_var));
+            bnorm_impl->execute(handle, args);
+        });
+    }
+
+    void interop_task_bwd(
+            std::shared_ptr<miopen_batch_normalization_impl_base_t> bnorm_impl,
+            engine_t *engine, ::sycl::handler &cgh,
+            amd::sycl_hip_stream_t *hip_stream,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read> arg_src,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read>
+                    arg_diff_dst,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_diff_src,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read> arg_scale,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_scale_buf,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_diff_scale,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_diff_scale_buf,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_diff_shift,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_diff_shift_buf,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read>
+                    arg_wkspace,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read_write>
+                    arg_temp_relu,
+            bool use_scale, bool use_shift) const {
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(engine);
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            if (!use_scale)
+                init_scaleshift(sc, ih, hip_stream, arg_scale_buf, 1.f,
+                        bnorm_impl->C());
+            if (!use_scale)
+                init_scaleshift(sc, ih, hip_stream, arg_diff_scale_buf, 1.f,
+                        bnorm_impl->C());
+            if (!use_shift)
+                init_scaleshift(sc, ih, hip_stream, arg_diff_shift_buf, 0.f,
+                        bnorm_impl->C());
+
+            auto *x = arg_src.get_native_pointer(ih);
+            auto *dy = arg_diff_dst.get_native_pointer(ih);
+            auto *dx = arg_diff_src.get_native_pointer(ih);
+
+            auto *scale = use_scale
+                    ? static_cast<uint8_t *>(arg_scale.get_native_pointer(ih))
+                    : static_cast<uint8_t *>(
+                            arg_scale_buf.get_native_pointer(ih));
+            auto *diff_scale = use_scale
+                    ? static_cast<uint8_t *>(
+                            arg_diff_scale.get_native_pointer(ih))
+                    : static_cast<uint8_t *>(
+                            arg_diff_scale_buf.get_native_pointer(ih));
+            uint8_t *diff_shift = use_shift
+                    ? static_cast<uint8_t *>(
+                            arg_diff_shift.get_native_pointer(ih))
+                    : static_cast<uint8_t *>(
+                            arg_diff_shift_buf.get_native_pointer(ih));
+
+            auto *save_mean = static_cast<uint8_t *>(
+                    arg_wkspace.get_native_pointer(ih));
+            auto *save_var = save_mean + bnorm_impl->mean_var_size_bytes();
+            auto *wkspace = save_var + bnorm_impl->mean_var_size_bytes();
+            auto *relu_dy = arg_temp_relu.get_native_pointer(ih);
+
+            std::shared_ptr<bnorm_args_t> args(
+                    new bnorm_bwd_args_t(x, dx, dy, save_mean, save_var, scale,
+                            diff_scale, diff_shift, wkspace, relu_dy));
+            bnorm_impl->execute(handle, args);
+        });
+    }
+
+    template <typename T = float>
+    void init_scaleshift(hip_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            amd::sycl_hip_stream_t *hip_stream, T, float, size_t) const {}
+
+    template <typename T = float>
+    void init_scaleshift(hip_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            amd::sycl_hip_stream_t *hip_stream,
+            impl::sycl::sycl_memory_arg_t<::sycl::access::mode::write>
+                    arg_scale,
+            float val, const size_t n) const {
+
+        hip_stream->interop_task([&](::sycl::handler &cgh) {
+            T *scale_ptr = static_cast<T *>(arg_scale.get_native_pointer(ih));
+            HIP_EXECUTE_FUNC(hipMemsetD32Async,
+                    reinterpret_cast<hipDeviceptr_t>(scale_ptr),
+                    reinterpret_cast<int &>(val), n,
+                    hip_stream->get_underlying_stream());
+            HIP_EXECUTE_FUNC(hipDeviceSynchronize);
+        });
+    }
+
+    // Handle the cases when mean and var are read-only accessors or nullptr
+    template <typename T, typename U>
+    void init_mean_var(hip_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            amd::sycl_hip_stream_t *hip_stream, T, U, const size_t) const {}
+
+    template <typename T = float>
+    void init_mean_var(hip_sycl_scoped_context_handler_t &sc,
+            const compat::interop_handle &ih,
+            amd::sycl_hip_stream_t *hip_stream,
+            impl::sycl::sycl_memory_arg_t<::sycl::access_mode::write> arg_mean,
+            impl::sycl::sycl_memory_arg_t<::sycl::access_mode::write> arg_var,
+            const size_t n) const {
+        constexpr T mean_var_val = 0;
+        hip_stream->interop_task([&](::sycl::handler &cgh) {
+            T *mean_ptr = static_cast<T *>(arg_mean.get_native_pointer(ih));
+            T *var_ptr = static_cast<T *>(arg_var.get_native_pointer(ih));
+            HIP_EXECUTE_FUNC(hipMemsetD32Async,
+                    reinterpret_cast<hipDeviceptr_t>(mean_ptr), mean_var_val, n,
+                    hip_stream->get_underlying_stream());
+            HIP_EXECUTE_FUNC(hipMemsetD32Async,
+                    reinterpret_cast<hipDeviceptr_t>(var_ptr), mean_var_val, n,
+                    hip_stream->get_underlying_stream());
+            HIP_EXECUTE_FUNC(hipDeviceSynchronize);
+        });
+    }
+};
+
+struct bnorm_exec_fwd_t : public bnorm_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            std::shared_ptr<miopen_batch_normalization_impl_base_t> bnorm_impl)
+            const override {
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+        const bool use_global_stats = bnorm_impl->use_global_stats();
+        const bool use_scale = bnorm_impl->use_scale();
+        const bool use_shift = bnorm_impl->use_shift();
+        auto n_channels = bnorm_impl->C();
+        ::sycl::buffer<uint8_t> scale_buf(n_channels * sizeof(float));
+        ::sycl::buffer<uint8_t> shift_buf(n_channels * sizeof(float));
+
+        return hip_stream->interop_task([&](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+            auto arg_scale = CTX_IN_SYCL_MEMORY(DNNL_ARG_SCALE);
+            auto arg_scale_buf = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::write>(scale_buf, cgh);
+            auto arg_shift = CTX_IN_SYCL_MEMORY(DNNL_ARG_SHIFT);
+            auto arg_shift_buf = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::write>(shift_buf, cgh);
+            auto arg_wkspace = bnorm_impl->is_training()
+                    ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
+                    : impl::sycl::sycl_memory_arg_t<
+                            ::sycl::access::mode::write>();
+
+            if (!use_global_stats) {
+                const bool init_global_stats = bnorm_impl->is_training();
+                auto arg_mean = CTX_OUT_SYCL_MEMORY(DNNL_ARG_MEAN);
+                auto arg_var = CTX_OUT_SYCL_MEMORY(DNNL_ARG_VARIANCE);
+                interop_task_fwd(bnorm_impl, engine, cgh, hip_stream, arg_src,
+                        arg_dst, arg_scale, arg_scale_buf, arg_shift,
+                        arg_shift_buf, arg_wkspace, use_scale, use_shift,
+                        init_global_stats, arg_mean, arg_var);
+            } else {
+                const bool init_global_stats = true;
+                auto arg_mean = CTX_IN_SYCL_MEMORY(DNNL_ARG_MEAN);
+                auto arg_var = CTX_IN_SYCL_MEMORY(DNNL_ARG_VARIANCE);
+                interop_task_fwd(bnorm_impl, engine, cgh, hip_stream, arg_src,
+                        arg_dst, arg_scale, arg_scale_buf, arg_shift,
+                        arg_shift_buf, arg_wkspace, use_scale, use_shift,
+                        init_global_stats, arg_mean, arg_var);
+            }
+        });
+    }
+};
+
+struct bnorm_exec_bwd_t : public bnorm_exec_base_t {
+    status_t execute(const exec_ctx_t &ctx, engine_t *engine,
+            std::shared_ptr<miopen_batch_normalization_impl_base_t> bnorm_impl)
+            const override {
+        amd::sycl_hip_stream_t *hip_stream
+                = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+        const bool use_scale = bnorm_impl->use_scale();
+        const bool use_shift = bnorm_impl->use_shift();
+        auto n_channels = bnorm_impl->C();
+        ::sycl::buffer<uint8_t> scale_buf(n_channels * sizeof(float));
+        ::sycl::buffer<uint8_t> diff_scale_buf(n_channels * sizeof(float));
+        ::sycl::buffer<uint8_t> diff_shift_buf(n_channels * sizeof(float));
+
+        return hip_stream->interop_task([&](::sycl::handler &cgh) {
+            auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+            auto arg_diff_dst = CTX_IN_SYCL_MEMORY(DNNL_ARG_DIFF_DST);
+            auto arg_diff_src = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SRC);
+            auto arg_scale = CTX_IN_SYCL_MEMORY(DNNL_ARG_SCALE);
+            auto arg_scale_buf = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::write>(scale_buf, cgh);
+            auto arg_diff_scale = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SCALE);
+            auto arg_diff_scale_buf = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::write>(diff_scale_buf, cgh);
+            auto arg_diff_shift = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DIFF_SHIFT);
+            auto arg_diff_shift_buf = impl::sycl::sycl_memory_arg_t<
+                    ::sycl::access::mode::write>(diff_shift_buf, cgh);
+            auto arg_wkspace = CTX_IN_SYCL_MEMORY(DNNL_ARG_WORKSPACE);
+            auto arg_temp_relu
+                    = CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::key_none);
+
+            interop_task_bwd(bnorm_impl, engine, cgh, hip_stream, arg_src,
+                    arg_diff_dst, arg_diff_src, arg_scale, arg_scale_buf,
+                    arg_diff_scale, arg_diff_scale_buf, arg_diff_shift,
+                    arg_diff_shift_buf, arg_wkspace, arg_temp_relu, use_scale,
+                    use_shift);
+        });
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_batch_normalization_impl.hpp
+++ b/src/gpu/amd/miopen_batch_normalization_impl.hpp
@@ -1,0 +1,362 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_BATCH_NORMALIZATION_IMPL_HPP
+#define GPU_AMD_MIOPEN_BATCH_NORMALIZATION_IMPL_HPP
+
+#include "gpu/amd/sycl_hip_utils.hpp"
+#include <miopen/miopen.h>
+
+#define MIOPEN_BN_MIN_EPSILON 1e-5
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct bnorm_args_t {
+public:
+    bnorm_args_t(void *x, void *mean, void *var, void *scale, void *bias)
+        : x_(x), mean_(mean), var_(var), scale_(scale), bias_(bias) {}
+
+    void *x_, *mean_, *var_, *scale_, *bias_;
+};
+
+struct bnorm_fwd_args_t : public bnorm_args_t {
+    bnorm_fwd_args_t(void *x, void *y, void *mean, void *var, void *scale,
+            void *bias, void *y_prime, void *save_mean, void *save_var)
+        : bnorm_args_t::bnorm_args_t(x, mean, var, scale, bias)
+        , y_(y)
+        , y_prime_(y_prime)
+        , save_mean_(save_mean)
+        , save_var_(save_var) {}
+
+    void *y_, *y_prime_, *save_mean_, *save_var_;
+};
+
+struct bnorm_bwd_args_t : public bnorm_args_t {
+    bnorm_bwd_args_t(void *x, void *dx, void *dy, void *mean, void *var,
+            void *scale, void *diff_scale, void *diff_bias, void *wkspace,
+            void *relu_dx)
+        : bnorm_args_t(x, mean, var, scale, nullptr)
+        , dx_(dx)
+        , dy_(dy)
+        , diff_scale_(diff_scale)
+        , diff_bias_(diff_bias)
+        , wkspace_(wkspace)
+        , relu_dx_(relu_dx) {}
+
+    void *dx_, *dy_, *diff_scale_, *diff_bias_, *wkspace_, *relu_dx_;
+};
+
+struct miopen_batch_normalization_impl_base_t {
+    virtual ~miopen_batch_normalization_impl_base_t() {
+        for (size_t i = 0; i < NUM_IO; ++i) {
+            if (tensor_descs_[i]) {
+                MIOPEN_EXECUTE_FUNC_V(
+                        miopenDestroyTensorDescriptor, tensor_descs_[i]);
+            }
+        }
+
+        if ((fuse_norm_relu_ || with_relu_postop_) && act_desc_) {
+            MIOPEN_EXECUTE_FUNC_V(miopenDestroyActivationDescriptor, act_desc_);
+        }
+    }
+
+    virtual status_t init(batch_normalization_pd_t *pd) = 0;
+
+    virtual void execute(miopenHandle_t handle,
+            std::shared_ptr<bnorm_args_t> args) const = 0;
+
+    bool is_bwd_d() const { return is_bwd_data_; }
+    bool is_training() const { return is_training_; }
+    bool use_global_stats() const { return use_global_stats_; }
+    bool use_scale() const { return use_scale_; }
+    bool use_shift() const { return use_shift_; }
+    bool fuse_norm_relu() const { return fuse_norm_relu_; }
+    std::size_t dt_size() const { return dt_size_; }
+    std::size_t mean_var_size_bytes() { return mean_var_size_bytes_; }
+    uint8_t default_mean_var() const { return 0; }
+    int C() const { return nchannels_; }
+
+protected:
+    status_t init_common(batch_normalization_pd_t *pd) {
+        ndims_ = pd->ndims() < 4 ? 4 : pd->ndims();
+        if (ndims_ > 5) { return status::invalid_arguments; }
+
+        memory_desc_wrapper wrap(pd->src_md());
+        use_scale_ = pd->use_scale();
+        use_shift_ = pd->use_shift();
+        fuse_norm_relu_ = pd->fuse_norm_relu();
+        is_training_ = pd->is_training();
+        use_global_stats_ = pd->use_global_stats();
+        is_bwd_data_ = pd->desc()->prop_kind == prop_kind::backward_data;
+        dt_size_ = types::data_type_size(wrap.data_type());
+        nchannels_ = pd->C();
+        // Mean and variance are always f32.
+        mean_var_size_bytes_
+                = nchannels_ * types::data_type_size(data_type::f32);
+        eps_ = pd->desc()->batch_norm_epsilon;
+        y_prime_size_ = wrap.nelems() * types::data_type_size(data_type::f32);
+        with_relu_postop_ = pd->with_relu_post_op();
+
+        auto n = static_cast<float>(pd->MB() * pd->D() * pd->H() * pd->W());
+        var_scaling_factor_ = (n - 1.f) / n;
+
+        convert_dims(pd->src_md()->padded_dims, dims_[src], pd->ndims());
+        convert_dims(pd->src_md()->format_desc.blocking.strides, strides_[src],
+                pd->ndims());
+
+        CHECK(convert_data_type(pd->src_md(), &data_types_[src]));
+
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs_[src],
+                data_types_[src], ndims_, dims_[src], strides_[src]));
+        CHECK(create_and_set_scaleshift_desc());
+
+        if (fuse_norm_relu_ || with_relu_postop_) {
+            CHECK(create_and_set_activation_desc());
+        }
+
+        return status::success;
+    }
+
+    virtual status_t create_and_set_scaleshift_desc() {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(
+                miopenCreateTensorDescriptor, &tensor_descs_[scl]));
+
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenDeriveBNTensorDescriptor,
+                tensor_descs_[scl], tensor_descs_[src], mode_));
+
+        return status::success;
+    }
+
+    virtual status_t create_and_set_activation_desc() {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(
+                miopenCreateActivationDescriptor, &act_desc_));
+
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetActivationDescriptor, act_desc_,
+                miopenActivationRELU, activAlpha, activBeta, activGamma));
+
+        return status::success;
+    }
+
+    virtual status_t to_population_variance(
+            miopenHandle_t handle, void *var) const {
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenScaleTensor, handle,
+                tensor_descs_[scl], var, &var_scaling_factor_));
+        return status::success;
+    }
+
+    enum io { src = 0, dst, scl, NUM_IO };
+    miopenDataType_t data_types_[NUM_IO];
+    miopenTensorDescriptor_t tensor_descs_[NUM_IO] = {};
+    miopenActivationDescriptor_t act_desc_;
+    miopenBatchNormMode_t mode_ = miopenBNSpatial;
+    int dims_[NUM_IO][DNNL_MAX_NDIMS];
+    int strides_[NUM_IO][DNNL_MAX_NDIMS];
+    int ndims_, nchannels_;
+    float alpha_ = 1.f, beta = 0.f;
+    double relu_coef_ = 0.0;
+    double factor_ = 1.0;
+    double eps_ = MIOPEN_BN_MIN_EPSILON;
+    float var_scaling_factor_ = 0.f;
+    bool use_scale_ = false;
+    bool use_shift_ = false;
+    bool fuse_norm_relu_ = false;
+    bool with_relu_postop_ = false;
+    bool use_global_stats_ = false;
+    bool is_training_ = false;
+    bool is_bwd_data_ = false;
+    double activAlpha = 0.0;
+    double activBeta;
+    double activGamma;
+    std::size_t y_prime_size_;
+    std::size_t dt_size_, mean_var_size_bytes_;
+};
+
+struct miopen_batch_normalization_fwd_impl_t
+    : public miopen_batch_normalization_impl_base_t {
+    using miopen_batch_normalization_impl_base_t::
+            miopen_batch_normalization_impl_base_t;
+
+    status_t init(batch_normalization_pd_t *pd) override {
+        init_common(pd);
+
+        convert_dims(pd->dst_md()->padded_dims, dims_[dst], pd->ndims());
+        convert_dims(pd->dst_md()->format_desc.blocking.strides, strides_[dst],
+                pd->ndims());
+
+        CHECK(convert_data_type(pd->dst_md(), &data_types_[dst]));
+
+        CHECK(create_and_set_tensor_descriptor(&tensor_descs_[dst],
+                data_types_[dst], ndims_, dims_[dst], strides_[dst]));
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle,
+            std::shared_ptr<bnorm_args_t> args) const override {
+        auto fwd_args = static_cast<bnorm_fwd_args_t *>(args.get());
+
+        MIOPEN_EXECUTE_FUNC(miopenBatchNormalizationForwardTraining, handle,
+                mode_, (void *)&alpha_, (void *)&beta, tensor_descs_[src],
+                fwd_args->x_, tensor_descs_[dst], fwd_args->y_,
+                tensor_descs_[scl], fwd_args->scale_, fwd_args->bias_, factor_,
+                fwd_args->mean_, fwd_args->var_, eps_, fwd_args->save_mean_,
+                fwd_args->save_var_);
+
+        if (is_training_) { to_population_variance(handle, fwd_args->var_); }
+
+        if (fuse_norm_relu_ || with_relu_postop_) { do_relu(handle, fwd_args); }
+    }
+
+protected:
+    void do_relu(miopenHandle_t handle, bnorm_fwd_args_t *fwd_args) const {
+        if (is_training_ && fuse_norm_relu_) {
+            // Copy the result to the workspace
+            int alpha2 = 0;
+            miopenTensorOp_t tensorOp = miopenTensorOpAdd;
+
+            MIOPEN_EXECUTE_FUNC(miopenOpTensor, handle, tensorOp, &alpha_,
+                    tensor_descs_[dst], fwd_args->y_, &alpha2,
+                    tensor_descs_[dst], fwd_args->y_, &beta, tensor_descs_[dst],
+                    fwd_args->y_prime_);
+        }
+        MIOPEN_EXECUTE_FUNC(miopenActivationForward, handle, act_desc_, &alpha_,
+                tensor_descs_[dst], fwd_args->y_, &beta, tensor_descs_[dst],
+                fwd_args->y_);
+    }
+};
+
+struct miopen_batch_normalization_fwd_stats_impl_t
+    : public miopen_batch_normalization_fwd_impl_t {
+
+    status_t init(batch_normalization_pd_t *pd) override {
+        return miopen_batch_normalization_fwd_impl_t::init(pd);
+    }
+
+    void execute(miopenHandle_t handle,
+            std::shared_ptr<bnorm_args_t> args) const override {
+        auto fwd_args = static_cast<bnorm_fwd_args_t *>(args.get());
+
+        MIOPEN_EXECUTE_FUNC(miopenBatchNormalizationForwardInference, handle,
+                mode_, (void *)&alpha_, (void *)&beta, tensor_descs_[src],
+                fwd_args->x_, tensor_descs_[dst], fwd_args->y_,
+                tensor_descs_[scl], fwd_args->scale_, fwd_args->bias_,
+                fwd_args->mean_, fwd_args->var_, eps_);
+
+        if (fuse_norm_relu_ || with_relu_postop_) { do_relu(handle, fwd_args); }
+    }
+};
+
+struct miopen_batch_normalization_bwd_impl_t
+    : public miopen_batch_normalization_impl_base_t {
+
+    status_t init(batch_normalization_pd_t *pd) override {
+        init_common(pd);
+
+        convert_dims(pd->diff_src_md()->padded_dims, diff_dims_[diff_src],
+                pd->ndims());
+        convert_dims(pd->diff_dst_md()->padded_dims, diff_dims_[diff_dst],
+                pd->ndims());
+        convert_dims(pd->diff_src_md()->format_desc.blocking.strides,
+                strides_[diff_src], pd->ndims());
+        convert_dims(pd->diff_dst_md()->format_desc.blocking.strides,
+                strides_[diff_dst], pd->ndims());
+
+        CHECK(convert_data_type(
+                pd->diff_src_md(), &diff_data_types_[diff_src]));
+        CHECK(convert_data_type(
+                pd->diff_dst_md(), &diff_data_types_[diff_dst]));
+
+        CHECK(create_and_set_tensor_descriptor(&diff_tensor_descs_[diff_src],
+                diff_data_types_[diff_src], ndims_, diff_dims_[diff_src],
+                strides_[diff_src]));
+        CHECK(create_and_set_tensor_descriptor(&diff_tensor_descs_[diff_dst],
+                diff_data_types_[diff_dst], ndims_, diff_dims_[diff_dst],
+                strides_[diff_dst]));
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle,
+            std::shared_ptr<bnorm_args_t> args) const override {
+        auto bwd_args = static_cast<bnorm_bwd_args_t *>(args.get());
+
+        MIOPEN_EXECUTE_FUNC(miopenBatchNormalizationBackward, handle, mode_,
+                &a_data_diff_, &b_data_diff_, &a_param_diff_, &b_param_diff_,
+                tensor_descs_[src], bwd_args->x_, diff_tensor_descs_[diff_dst],
+                bwd_args->dy_, diff_tensor_descs_[diff_src], bwd_args->dx_,
+                tensor_descs_[scl], bwd_args->scale_, bwd_args->diff_scale_,
+                bwd_args->diff_bias_, eps_, bwd_args->mean_, bwd_args->var_);
+    }
+
+    ~miopen_batch_normalization_bwd_impl_t() {
+        for (size_t i = 0; i < NUM_DIFF; i++) {
+            if (diff_tensor_descs_[i]) {
+                MIOPEN_EXECUTE_FUNC_V(
+                        miopenDestroyTensorDescriptor, diff_tensor_descs_[i]);
+            }
+        }
+    }
+
+protected:
+    const float a_data_diff_ = 1.f, b_data_diff_ = 0.f;
+    const float a_param_diff_ = 1.f, b_param_diff_ = 0.f;
+
+    enum diff_tensors { diff_src = 0, diff_dst, NUM_DIFF };
+    int diff_dims_[NUM_DIFF][DNNL_MAX_NDIMS];
+    miopenTensorDescriptor_t diff_tensor_descs_[NUM_DIFF] = {};
+    miopenDataType_t diff_data_types_[NUM_DIFF];
+};
+
+struct miopen_batch_normalization_bwd_relu_impl_t
+    : public miopen_batch_normalization_bwd_impl_t {
+
+    status_t init(batch_normalization_pd_t *pd) override {
+        pd->scratchpad_registry().registrar().book(
+                memory_tracking::names::key_none,
+                memory_desc_wrapper(pd->diff_dst_md()).size(), size_t(1));
+
+        return miopen_batch_normalization_bwd_impl_t::init(pd);
+    }
+
+    void execute(miopenHandle_t handle,
+            std::shared_ptr<bnorm_args_t> args) const override {
+        auto bwd_args = static_cast<bnorm_bwd_args_t *>(args.get());
+
+        MIOPEN_EXECUTE_FUNC(miopenActivationBackward, handle, act_desc_,
+                &alpha_, diff_tensor_descs_[dst], bwd_args->wkspace_,
+                diff_tensor_descs_[dst], bwd_args->dy_, diff_tensor_descs_[dst],
+                bwd_args->wkspace_, &beta, diff_tensor_descs_[dst],
+                bwd_args->relu_dx_);
+
+        MIOPEN_EXECUTE_FUNC(miopenBatchNormalizationBackward, handle, mode_,
+                &a_data_diff_, &b_data_diff_, &a_param_diff_, &b_param_diff_,
+                tensor_descs_[src], bwd_args->x_, diff_tensor_descs_[dst],
+                bwd_args->relu_dx_, diff_tensor_descs_[src], bwd_args->dx_,
+                tensor_descs_[scl], bwd_args->scale_, bwd_args->diff_scale_,
+                bwd_args->diff_bias_, eps_, bwd_args->mean_, bwd_args->var_);
+    }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/sycl_hip_engine.cpp
+++ b/src/gpu/amd/sycl_hip_engine.cpp
@@ -22,6 +22,7 @@
 #include "miopen/miopen.h"
 #include "sycl/sycl_utils.hpp"
 
+#include "gpu/amd/miopen_batch_normalization.hpp"
 #include "gpu/amd/miopen_binary.hpp"
 #include "gpu/amd/miopen_convolution.hpp"
 #include "gpu/amd/miopen_eltwise.hpp"
@@ -191,6 +192,9 @@ constexpr dnnl::impl::impl_list_item_t sycl_hip_impl_list[] = {
         INSTANCE(miopen_convolution_fwd_t)
         INSTANCE(miopen_convolution_bwd_data_t)
         INSTANCE(miopen_convolution_bwd_weights_t)
+        // Batch Normalization
+        INSTANCE(miopen_batch_normalization_fwd_t)
+        INSTANCE(miopen_batch_normalization_bwd_t)
         nullptr,
 };
 // clang-format on

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -421,11 +421,12 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
     const bool bnorm_single_pass = false;
 #endif
 
-    const bool use_relaxed_validation = is_nvidia_gpu() || bnorm_single_pass;
+    const bool use_relaxed_validation
+            = is_nvidia_gpu() || is_amd_gpu() || bnorm_single_pass;
     if (use_relaxed_validation) {
-        // Nvidia: cuDNN stores unbiased variance which requires rescaling by
-        // `(N - 1) / N`, where `N = MB * Spatial`. Hence, we cannot set the
-        // threshold to 0...
+        // Nvidia (cuDNN) and AMD (MIOpen): store unbiased variance which
+        // requires rescaling by `(N - 1) / N`, where `N = MB * Spatial`.
+        // Hence, we cannot set the threshold to 0...
         // Also mean could be computed using a single pass formula.
         //
         // On Intel GPUs mean and variance could be rounded incorrectly because

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -386,6 +386,12 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {
+    // MIOpen cannot handle inplace cases correctly.
+    if (is_amd_gpu() && prb->inplace) {
+        res->state = SKIPPED;
+        return;
+    }
+
     // See `skip_invalid_inplace` for details.
     if (prb->inplace) {
         skip_invalid_inplace(res, prb->dt, prb->dt, prb->tag, prb->tag);


### PR DESCRIPTION
# Description

Introducing AMD backend for the oneDNN Batch Normalization Primitive.

**Supported Data Types:**
Forward Training  : f32
Forward Inference : f32, f16
Backward : f32

**Testing scope:**
benchdnn: Passed
gtest: API tests passed, Batch normalization tests passed

**Benchdnn log files:**
[test_bnorm_all_plain.log](https://github.com/oneapi-src/oneDNN/files/11061934/test_bnorm_all_plain.log)
[test_bnorm_ci.log](https://github.com/oneapi-src/oneDNN/files/11061936/test_bnorm_ci.log)
[test_bnorm_all_blocked.log](https://github.com/oneapi-src/oneDNN/files/11061937/test_bnorm_all_blocked.log)

**Gtest log files:**
[test_batch_normalization.log](https://github.com/oneapi-src/oneDNN/files/11061946/test_batch_normalization.log)
[test_batch_normalization_buffer.log](https://github.com/oneapi-src/oneDNN/files/11061949/test_batch_normalization_buffer.log)

[test_api_buffer.log](https://github.com/oneapi-src/oneDNN/files/11061952/test_api_buffer.log)
[test_api_sycl.log](https://github.com/oneapi-src/oneDNN/files/11061954/test_api_sycl.log)
[test_internals.log](https://github.com/oneapi-src/oneDNN/files/11061956/test_internals.log)
[test_regression.log](https://github.com/oneapi-src/oneDNN/files/11061958/test_regression.log)

**Limitations:**
1) s8 and bf16 datatypes are not supported.
2) f16 is supported partially (only for Forward Inference)
3) Only abx tag (NCHW format) is supported
4) Blocked formats are not supported

**Note:**
Some combinations are not supported for Batch Normalization AMD backend if source and destination tensors are same.

## General
- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

Some references from miopen :
https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2012
