### PR TITLE
Fixed Gtest Failures for Convolution - HIP Backend

### DIFF
--- a/src/gpu/amd/miopen_convolution.hpp
+++ b/src/gpu/amd/miopen_convolution.hpp
@@ -428,10 +428,10 @@ struct miopen_convolution_bwd_weights_t : public primitive_t {
             }
             if (!ok) return status::unimplemented;
 
-            if (!check_format()) return status::unimplemented;
-
             impl_.reset(new miopen_convolution_impl_bwd_weights_t());
             if (check_for_zero_dims()) { return impl_->init_zero_dims(this); };
+
+            if (!check_format()) return status::unimplemented;
 
             return impl_->init(engine, this);
         }

--- a/tests/gtests/test_convolution_backward_data_common.hpp
+++ b/tests/gtests/test_convolution_backward_data_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
+* Copyright 2016-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -116,8 +116,36 @@ protected:
                                 p.formats.weights_format, p.aalgorithm)),
                 "format is not supported.");
 
+        SKIP_IF_HIP(!(hip_check_format_tags(p.formats.src_format)
+                            && hip_check_format_tags(p.formats.dst_format)
+                            && (hip_check_format_tags(p.formats.weights_format)
+                                    || (impl::utils::one_of(
+                                            p.formats.weights_format,
+                                            /* weights formats */
+                                            memory::format_tag::gowi,
+                                            memory::format_tag::gohwi,
+                                            memory::format_tag::godhwi,
+                                            memory::format_tag::owi,
+                                            memory::format_tag::ohwi,
+                                            memory::format_tag::odhwi)))
+                            && data_traits<data_t_diff_src>::data_type
+                                    == memory::data_type::f32
+                            && data_traits<data_t_diff_dst>::data_type
+                                    == memory::data_type::f32
+                            && data_traits<data_t_wei>::data_type
+                                    == memory::data_type::f32
+                            && check_hip_alg_format(p.formats.dst_format,
+                                    p.formats.weights_format, p.aalgorithm)),
+                "Format is not supported.");
+
         catch_expected_failures(
                 [=]() { Test(); }, p.expect_to_fail, p.expected_status);
+    }
+
+    bool hip_check_format_tags(memory::format_tag tag) {
+        return impl::utils::one_of(tag, memory::format_tag::ab,
+                memory::format_tag::abc, memory::format_tag::abcd,
+                memory::format_tag::abcde, memory::format_tag::abcdef);
     }
 
     bool cuda_check_format_tags(memory::format_tag tag) {
@@ -129,6 +157,19 @@ protected:
     }
 
     bool check_cuda_alg_format(memory::format_tag dst_fmt,
+            memory::format_tag wei_fmt, algorithm alg) {
+        bool res = dst_fmt == wei_fmt;
+        if (alg == dnnl::algorithm::convolution_winograd) {
+            res = res
+                    && impl::utils::one_of(wei_fmt, memory::format_tag::ab,
+                            memory::format_tag::abc, memory::format_tag::abcd,
+                            memory::format_tag::abcde,
+                            memory::format_tag::abcdef);
+        }
+        return res;
+    }
+
+    bool check_hip_alg_format(memory::format_tag dst_fmt,
             memory::format_tag wei_fmt, algorithm alg) {
         bool res = dst_fmt == wei_fmt;
         if (alg == dnnl::algorithm::convolution_winograd) {

--- a/tests/gtests/test_convolution_eltwise_forward_common.hpp
+++ b/tests/gtests/test_convolution_eltwise_forward_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2022 Intel Corporation
+* Copyright 2018-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -144,12 +144,37 @@ protected:
                                         memory::format_tag::ohwi,
                                         memory::format_tag::odhwi))),
                 "Format is not supported.");
+
+        SKIP_IF_HIP(
+                !(hip_check_format_tags(p.formats.src_format, data_type_src)
+                        && hip_check_format_tags(
+                                p.formats.dst_format, data_type_dst)
+                        && (hip_check_format_tags(
+                                    p.formats.weights_format, data_type_wei)
+                                || impl::utils::one_of(p.formats.weights_format,
+                                        /* weights formats */
+                                        memory::format_tag::gowi,
+                                        memory::format_tag::gohwi,
+                                        memory::format_tag::godhwi,
+                                        memory::format_tag::owi,
+                                        memory::format_tag::ohwi,
+                                        memory::format_tag::odhwi))),
+                "Format is not supported.");
+
         SKIP_IF_CUDA(p.alg != algorithm::eltwise_relu
                         && p.alg != algorithm::eltwise_tanh
                         && p.alg != algorithm::eltwise_elu
                         && p.alg != algorithm::eltwise_logistic,
                 "Unsupported algorithm type for CUDA");
         SKIP_IF_CUDA(p.alg == algorithm::eltwise_relu && p.eltwise_alpha != 0.0,
+                "DNNL only supports relu w/ slope=0 for integers");
+
+        SKIP_IF_HIP(p.alg != algorithm::eltwise_relu
+                        && p.alg != algorithm::eltwise_tanh
+                        && p.alg != algorithm::eltwise_elu
+                        && p.alg != algorithm::eltwise_logistic,
+                "Unsupported algorithm type for HIP");
+        SKIP_IF_HIP(p.alg == algorithm::eltwise_relu || p.eltwise_alpha != 0.0,
                 "DNNL only supports relu w/ slope=0 for integers");
 
         catch_expected_failures(
@@ -162,6 +187,15 @@ protected:
                         memory::format_tag::abcde, memory::format_tag::abcdef,
                         memory::format_tag::acb, memory::format_tag::acdb,
                         memory::format_tag::acdeb))
+                || (dt == memory::data_type::s8
+                        && impl::utils::one_of(tag, memory::format_tag::aBcd4b,
+                                memory::format_tag::aBcde4b)));
+    }
+
+    bool hip_check_format_tags(memory::format_tag tag, memory::data_type dt) {
+        return ((impl::utils::one_of(tag, memory::format_tag::ab,
+                        memory::format_tag::abc, memory::format_tag::abcd,
+                        memory::format_tag::abcde, memory::format_tag::abcdef))
                 || (dt == memory::data_type::s8
                         && impl::utils::one_of(tag, memory::format_tag::aBcd4b,
                                 memory::format_tag::aBcde4b)));

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
+* Copyright 2016-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,6 +60,8 @@ protected:
         auto eng = get_test_engine();
         memory::data_type data_type = data_traits<data_t>::data_type;
         SKIP_IF_CUDA((p.expected_src_fmt == BLK || p.expected_dst_fmt == BLK),
+                "unsupported format");
+        SKIP_IF_HIP((p.expected_src_fmt == BLK || p.expected_dst_fmt == BLK),
                 "unsupported format");
         ASSERT_EQ(data_type, dnnl::memory::data_type::f32);
 

--- a/tests/gtests/test_convolution_forward_common.hpp
+++ b/tests/gtests/test_convolution_forward_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
+* Copyright 2016-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -146,6 +146,22 @@ protected:
                                         memory::format_tag::odhwi))),
                 "Format is not supported.");
 
+        SKIP_IF_HIP(
+                !(hip_check_format_tags(p.formats.src_format, data_type_src)
+                        && hip_check_format_tags(
+                                p.formats.dst_format, data_type_dst)
+                        && (hip_check_format_tags(
+                                    p.formats.weights_format, data_type_wei)
+                                || impl::utils::one_of(p.formats.weights_format,
+                                        /* weights formats */
+                                        memory::format_tag::gowi,
+                                        memory::format_tag::gohwi,
+                                        memory::format_tag::godhwi,
+                                        memory::format_tag::owi,
+                                        memory::format_tag::ohwi,
+                                        memory::format_tag::odhwi))),
+                "Format is not supported.");
+
         catch_expected_failures(
                 [=]() { Test(); }, p.expect_to_fail, p.expected_status);
     }
@@ -156,6 +172,15 @@ protected:
                         memory::format_tag::abcde, memory::format_tag::abcdef,
                         memory::format_tag::acb, memory::format_tag::acdb,
                         memory::format_tag::acdeb))
+                || (dt == memory::data_type::s8
+                        && impl::utils::one_of(tag, memory::format_tag::aBcd4b,
+                                memory::format_tag::aBcde4b)));
+    }
+
+    bool hip_check_format_tags(memory::format_tag tag, memory::data_type dt) {
+        return ((impl::utils::one_of(tag, memory::format_tag::ab,
+                        memory::format_tag::abc, memory::format_tag::abcd,
+                        memory::format_tag::abcde, memory::format_tag::abcdef))
                 || (dt == memory::data_type::s8
                         && impl::utils::one_of(tag, memory::format_tag::aBcd4b,
                                 memory::format_tag::aBcde4b)));

--- a/tests/gtests/test_iface_wino_convolution.cpp
+++ b/tests/gtests/test_iface_wino_convolution.cpp
@@ -119,6 +119,7 @@ TEST_F(wino_conv_test_t, TestLargePadding) {
 }
 
 TEST_F(wino_conv_test_t, TestUnsupportedKernel) {
+    SKIP_IF_HIP(true, "Unsupported test case.");
     for (const auto &input : {input_f32, input_f16, input_int8}) {
         if (unsupported_data_type(input.dat_dt)
                 || unsupported_data_type(input.wei_dt))


### PR DESCRIPTION
# Description

Fixed Gtest failures for Convolution - HIP Backend

Testing scope:
gtest: API tests passed, Convolution tests passed


[gtest_test_convolution_backward_data_f32.log](https://github.com/oneapi-src/oneDNN/files/11062503/gtest_test_convolution_backward_data_f32.log)
[gtest_test_convolution_backward_data_f32_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062504/gtest_test_convolution_backward_data_f32_buffer.log)
[gtest_test_convolution_backward_weights_f32.log](https://github.com/oneapi-src/oneDNN/files/11062505/gtest_test_convolution_backward_weights_f32.log)
[gtest_test_convolution_backward_weights_f32_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062506/gtest_test_convolution_backward_weights_f32_buffer.log)
[gtest_test_convolution_eltwise_forward_f32.log](https://github.com/oneapi-src/oneDNN/files/11062507/gtest_test_convolution_eltwise_forward_f32.log)
[gtest_test_convolution_eltwise_forward_f32_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062508/gtest_test_convolution_eltwise_forward_f32_buffer.log)
[gtest_test_convolution_eltwise_forward_x8s8f32s32.log](https://github.com/oneapi-src/oneDNN/files/11062509/gtest_test_convolution_eltwise_forward_x8s8f32s32.log)
[gtest_test_convolution_eltwise_forward_x8s8f32s32_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062510/gtest_test_convolution_eltwise_forward_x8s8f32s32_buffer.log)
[gtest_test_convolution_format_any.log](https://github.com/oneapi-src/oneDNN/files/11062511/gtest_test_convolution_format_any.log)
[gtest_test_convolution_format_any_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062512/gtest_test_convolution_format_any_buffer.log)
[gtest_test_convolution_forward_f32.log](https://github.com/oneapi-src/oneDNN/files/11062514/gtest_test_convolution_forward_f32.log)
[gtest_test_convolution_forward_f32_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062515/gtest_test_convolution_forward_f32_buffer.log)
[gtest_test_convolution_forward_u8s8fp.log](https://github.com/oneapi-src/oneDNN/files/11062516/gtest_test_convolution_forward_u8s8fp.log)
[gtest_test_convolution_forward_u8s8fp_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062517/gtest_test_convolution_forward_u8s8fp_buffer.log)
[gtest_test_convolution_forward_u8s8s32.log](https://github.com/oneapi-src/oneDNN/files/11062518/gtest_test_convolution_forward_u8s8s32.log)
[gtest_test_convolution_forward_u8s8s32_buffer.log](https://github.com/oneapi-src/oneDNN/files/11062519/gtest_test_convolution_forward_u8s8s32_buffer.log)


## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
