### PR TITLE
Adding support for Reorder Primitive HIP Backend

### DIFF
--- a/src/gpu/amd/README.md
+++ b/src/gpu/amd/README.md
@@ -337,3 +337,11 @@ and `miopenBatchNormalizationBackward` operations.
 * Backward pass supports only `f32` data types.
 * Blocked formats are not supported.
 * Only `NCDHW`, `NCHW`, `NCW`, `NC` formats are supported.
+
+### Reorder
+
+The `miopenTransform` function is the equivalent of oneDNN reorder function.
+
+* Per dimension scaling is not supported (a single alpha and beta value is
+  accepted by the transform tensor function).
+* Supported data types: `f32`

--- a/src/gpu/amd/miopen_reorder.cpp
+++ b/src/gpu/amd/miopen_reorder.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/amd/miopen_reorder.hpp"
+#include "gpu/amd/sycl_hip_scoped_context.hpp"
+#include "gpu/amd/sycl_hip_stream.hpp"
+
+#include "sycl/sycl_memory_storage_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+status_t miopen_reorder_t::execute(const exec_ctx_t &ctx) const {
+    memory_desc_wrapper src_mdw(pd()->src_md());
+    if (src_mdw.size() == 0) { return status::success; }
+
+    amd::sycl_hip_stream_t *hip_stream
+            = utils::downcast<amd::sycl_hip_stream_t *>(ctx.stream());
+    return hip_stream->interop_task([&](::sycl::handler &cgh) {
+        auto arg_src = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC);
+        auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
+        auto arg_src_scale
+                = CTX_IN_SYCL_MEMORY(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
+        auto arg_dst_scale
+                = CTX_IN_SYCL_MEMORY(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
+            auto &sycl_engine = *utils::downcast<sycl_hip_engine_t *>(
+                    hip_stream->engine());
+            auto sc = hip_sycl_scoped_context_handler_t(sycl_engine);
+            auto handle = hip_stream->get_miopen_handle();
+
+            void *src_ = arg_src.get_native_pointer(ih);
+            void *dst_ = arg_dst.get_native_pointer(ih);
+
+            auto a = static_cast<uint8_t *>(src_)
+                    + pd()->reorder_->src_offset_in_bytes();
+            auto b = static_cast<uint8_t *>(dst_)
+                    + pd()->reorder_->dst_offset_in_bytes();
+
+            void *src_sc = arg_src_scale.get_native_pointer(ih);
+            void *dst_sc = arg_dst_scale.get_native_pointer(ih);
+
+            pd()->reorder_->execute(handle, a, b, src_sc, dst_sc);
+        });
+    });
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_reorder.hpp
+++ b/src/gpu/amd/miopen_reorder.hpp
@@ -1,0 +1,143 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_REORDER_HPP
+#define GPU_AMD_MIOPEN_REORDER_HPP
+
+#include "common/memory_desc_wrapper.hpp"
+#include "common/primitive.hpp"
+#include "common/reorder_pd.hpp"
+#include "gpu/amd/miopen_reorder_impl.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_reorder_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public reorder_pd_t {
+        using reorder_pd_t::reorder_pd_t;
+        DECLARE_COMMON_PD_T("hip:miopen:any", miopen_reorder_t);
+
+        // Function to verify data and memory format.
+        bool valid_data_n_mem_format() const {
+            bool ok = src_md()->ndims == dst_md()->ndims
+                    // MIOpen doesn't support conversion between data types.
+                    && src_md()->data_type == dst_md()->data_type
+                    && utils::one_of(src_md()->data_type, data_type::f32);
+
+            // MIOpen only supports blocking for Int8
+            if (!utils::one_of(src_md()->data_type, data_type::s8)
+                    && src_md()->format_desc.blocking.inner_nblks > 0)
+                return false;
+
+            if (!utils::one_of(dst_md()->data_type, data_type::s8)
+                    && dst_md()->format_desc.blocking.inner_nblks > 0)
+                return false;
+
+            // MIOpen supports blocking only on channel dimension C
+            if (dst_md()->format_desc.blocking.inner_nblks > 1
+                    || src_md()->format_desc.blocking.inner_nblks > 1)
+                return false;
+
+            if (utils::one_of(src_md()->data_type, data_type::s8)
+                    && src_md()->format_desc.blocking.inner_nblks == 1) {
+                ok = ok && memory_desc_matches_nchw_vect_c(src_md());
+            }
+
+            if (utils::one_of(dst_md()->data_type, data_type::s8)
+                    && dst_md()->format_desc.blocking.inner_nblks == 1) {
+                ok = ok && memory_desc_matches_nchw_vect_c(dst_md());
+            }
+
+            return ok;
+        }
+
+        bool scales_ok() const {
+            const auto &scales = attr()->scales_;
+            const auto &supported_args = {DNNL_ARG_FROM, DNNL_ARG_TO};
+            if (!scales.has_default_values(supported_args)) return false;
+            // MIOpen does not support scaling per dimension.
+            for (auto arg : supported_args)
+                if (scales.get(arg).mask_ != 0) return false;
+            return true;
+        }
+
+        bool post_ops_ok() const {
+            // only sum post-op is supported
+            const auto &p = attr()->post_ops_;
+            return p.len() == 0 || (p.len() == 1 && p.entry_[0].is_sum(false));
+        }
+
+        bool check_for_zero_dims() const {
+            return has_zero_dims(src_md(0)->dims, src_md(0)->ndims)
+                    || has_zero_dims(dst_md()->dims, dst_md()->ndims);
+        }
+
+        status_t init(
+                engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
+            const auto attr_skip_mask
+                    = primitive_attr_t::skip_mask_t::scales_runtime
+                    | primitive_attr_t::skip_mask_t::post_ops;
+            const bool ok = true && (engine == dst_engine)
+                    && src_engine->kind() == engine_kind::gpu
+                    && valid_data_n_mem_format()
+                    && attr()->has_default_values(attr_skip_mask) && scales_ok()
+                    && post_ops_ok();
+
+            if (!ok) return status::unimplemented;
+
+            reorder_.reset(new miopen_reorder_stride_t());
+            return reorder_->init(this);
+        }
+
+        std::shared_ptr<miopen_reorder_generic_t> reorder_;
+
+    private:
+        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
+                const primitive_attr_t *attr, engine_t *src_engine,
+                const memory_desc_t *src_md, engine_t *dst_engine,
+                const memory_desc_t *dst_md) {
+            auto _pd = new pd_t(attr, src_engine->kind(), src_md,
+                    dst_engine->kind(), dst_md);
+            if (_pd == nullptr) return status::out_of_memory;
+            if (_pd->init(engine, src_engine, dst_engine) != status::success) {
+                delete _pd;
+                return status::unimplemented;
+            }
+            _pd->init_scratchpad_md();
+            return safe_ptr_assign<reorder_pd_t>(*reorder_pd, _pd);
+        }
+        friend dnnl::impl::impl_list_item_t;
+    };
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/amd/miopen_reorder_impl.cpp
+++ b/src/gpu/amd/miopen_reorder_impl.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include "common/engine.hpp"
+#include "common/impl_list_item.hpp"
+#include "gpu/amd/miopen_reorder.hpp"
+#include "gpu/amd/sycl_hip_engine.hpp"
+#include "gpu/ocl/cross_engine_reorder.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+namespace {
+
+#define REORDER_INSTANCE(...) \
+    impl_list_item_t( \
+            impl_list_item_t::reorder_type_deduction_helper_t<__VA_ARGS__>()),
+
+// clang-format off
+constexpr impl_list_item_t hip_reorder_impl_list[] = {
+        REORDER_INSTANCE(gpu::ocl::cross_engine_reorder_t::pd_t)
+        REORDER_INSTANCE(miopen_reorder_t::pd_t)
+        nullptr,
+};
+// clang-format on
+
+} // namespace
+
+const impl_list_item_t *
+hip_gpu_engine_impl_list_t::get_reorder_implementation_list(
+        const memory_desc_t *, const memory_desc_t *) {
+    return hip_reorder_impl_list;
+}
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/amd/miopen_reorder_impl.hpp
+++ b/src/gpu/amd/miopen_reorder_impl.hpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2022 Codeplay Software Limited
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_AMD_MIOPEN_REORDER_IMPL_HPP
+#define GPU_AMD_MIOPEN_REORDER_IMPL_HPP
+
+#include "common/type_helpers.hpp"
+#include "gpu/amd/sycl_hip_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace amd {
+
+struct miopen_reorder_generic_t {
+public:
+    virtual status_t init(const reorder_pd_t *pd) = 0;
+
+    virtual void execute(miopenHandle_t handle, void *src, void *dst,
+            void *src_scale, void *dst_scale) const = 0;
+
+    virtual ~miopen_reorder_generic_t() {
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, src_desc_);
+        MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, dst_desc_);
+    }
+
+    int dst_offset_in_bytes() { return dst_offset_in_bytes_; }
+    int src_offset_in_bytes() { return src_offset_in_bytes_; }
+
+protected:
+    miopenDataType_t src_data_type_;
+    miopenDataType_t dst_data_type_;
+    int ndims_;
+    int dims_[DNNL_MAX_NDIMS];
+    miopenTensorDescriptor_t src_desc_;
+    miopenTensorDescriptor_t dst_desc_;
+    float alpha_, beta_;
+    int dst_offset_in_bytes_ = 0;
+    int src_offset_in_bytes_ = 0;
+    int nelems;
+
+    data_type_t src_dt;
+    data_type_t dst_dt;
+};
+
+// This structure is used when the memory format does not include blocking
+struct miopen_reorder_stride_t : public miopen_reorder_generic_t {
+public:
+    status_t init(const reorder_pd_t *pd) override {
+        // If any of the dimensions are 0 we should not continue with creating
+        // MIOpen descriptors
+        memory_desc_wrapper src_mdw(pd->src_md());
+        if (src_mdw.size() == 0) { return status::success; }
+
+        if (src_mdw.has_runtime_dims_or_strides()) {
+            return status::unimplemented;
+        }
+
+        nelems = src_mdw.nelems();
+
+        // Validity checks
+        assert(pd->dst_md()->ndims == pd->src_md()->ndims);
+        dst_offset_in_bytes_ = pd->dst_md()->offset0
+                * types::data_type_size(pd->dst_md()->data_type);
+        src_offset_in_bytes_ = pd->src_md()->offset0
+                * types::data_type_size(pd->src_md()->data_type);
+        beta_ = pd->beta();
+
+        CHECK(convert_data_type(pd->src_md(), &src_data_type_));
+        CHECK(convert_data_type(pd->dst_md(), &dst_data_type_));
+
+        convert_dims(pd->dst_md()->dims, dims_, pd->dst_md()->ndims);
+        convert_dims(pd->src_md()->format_desc.blocking.strides, src_strides_,
+                pd->src_md()->ndims);
+        convert_dims(pd->dst_md()->format_desc.blocking.strides, dst_strides_,
+                pd->dst_md()->ndims);
+
+        ndims_ = pd->dst_md()->ndims > 4 ? pd->dst_md()->ndims : 4;
+
+        bool vectorized = has_different_block_size(pd->src_md(), pd->dst_md());
+        if (!vectorized) {
+            adjust_dim_for_dnn(dims_, pd->dst_md()->ndims, pd->src_md());
+            adjust_stride_for_dnn(
+                    src_strides_, pd->dst_md()->ndims, pd->src_md());
+            adjust_stride_for_dnn(
+                    dst_strides_, pd->dst_md()->ndims, pd->dst_md());
+            ndims_ = pd->dst_md()->ndims >= 4 ? pd->dst_md()->ndims
+                            + pd->dst_md()->format_desc.blocking.inner_nblks
+                                              : 4;
+        }
+        convert_data_type(pd->src_md(), &src_data_type_, vectorized);
+        convert_data_type(pd->dst_md(), &dst_data_type_, vectorized);
+
+        src_dt = pd->src_md()->data_type;
+        dst_dt = pd->dst_md()->data_type;
+
+        // Create and set source tensor descriptor
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenCreateTensorDescriptor, &src_desc_));
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetTensorDescriptor, src_desc_,
+                src_data_type_, ndims_, dims_, src_strides_));
+
+        // Create and set destination tensor descriptor
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenCreateTensorDescriptor, &dst_desc_));
+        CHECK(MIOPEN_EXECUTE_FUNC_S(miopenSetTensorDescriptor, dst_desc_,
+                dst_data_type_, ndims_, dims_, dst_strides_));
+
+        return status::success;
+    }
+
+    void execute(miopenHandle_t handle, void *src, void *dst, void *src_scale,
+            void *dst_scale) const override {
+        float alpha = 1.0f;
+        if (src_scale) {
+            float host_src_scale = 1.0f;
+            HIP_EXECUTE_FUNC(hipMemcpy, (HIPdeviceptr)&host_src_scale,
+                    (HIPdeviceptr)src_scale, sizeof(float), hipMemcpyDefault);
+            alpha *= host_src_scale;
+        }
+        float beta = beta_;
+        if (dst_scale) {
+            float host_dst_scale = 1.0f;
+            HIP_EXECUTE_FUNC(hipMemcpy, (HIPdeviceptr)&host_dst_scale,
+                    (HIPdeviceptr)dst_scale, sizeof(float), hipMemcpyDefault);
+            alpha /= host_dst_scale;
+            beta /= host_dst_scale;
+        }
+
+        MIOPEN_EXECUTE_FUNC(miopenTransformTensor, handle, &alpha, src_desc_,
+                src, &beta, dst_desc_, dst);
+    }
+
+private:
+    int src_strides_[DNNL_MAX_NDIMS];
+    int dst_strides_[DNNL_MAX_NDIMS];
+
+    using miopen_reorder_generic_t::miopen_reorder_generic_t;
+};
+
+} // namespace amd
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // GPU_AMD_MIOPEN_REORDER_IMPL_HPP

--- a/src/gpu/amd/sycl_hip_engine.hpp
+++ b/src/gpu/amd/sycl_hip_engine.hpp
@@ -36,12 +36,7 @@ namespace amd {
 class hip_gpu_engine_impl_list_t {
 public:
     static const impl_list_item_t *get_reorder_implementation_list(
-            const memory_desc_t *src_md, const memory_desc_t *dst_md) {
-        static impl_list_item_t hip_reorder_impl_list[] = {
-                nullptr,
-        };
-        return hip_reorder_impl_list;
-    }
+            const memory_desc_t *src_md, const memory_desc_t *dst_md);
     static const dnnl::impl::impl_list_item_t *
     get_concat_implementation_list() {
         static impl_list_item_t hip_concat_impl_list[] = {

--- a/tests/gtests/test_reorder_common.hpp
+++ b/tests/gtests/test_reorder_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
+* Copyright 2019-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,6 +82,11 @@ protected:
                              && (supported_format(p.fmt_o)
                                      || supported_blocking(prec_o, p.fmt_o))),
                 "Unsupported cuda format tag/ data type");
+        SKIP_IF_HIP(!((supported_format(p.fmt_i)
+                              || supported_blocking(prec_i, p.fmt_i))
+                            && (supported_format(p.fmt_o)
+                                    || supported_blocking(prec_o, p.fmt_o))),
+                "Unsupported cuda format tag/ data type");
 
         catch_expected_failures(
                 [=]() {
@@ -120,6 +125,13 @@ protected:
                 = ::testing::TestWithParam<decltype(p)>::GetParam();
 
 #ifdef DNNL_SYCL_CUDA
+        SKIP_IF(!((supported_format(p.fmt_i)
+                          || supported_blocking(prec_i, p.fmt_i))
+                        && (supported_format(p.fmt_o)
+                                || supported_blocking(prec_o, p.fmt_o))),
+                "Unsupported cuda format tag/ data type");
+#endif
+#ifdef DNNL_SYCL_HIP
         SKIP_IF(!((supported_format(p.fmt_i)
                           || supported_blocking(prec_i, p.fmt_i))
                         && (supported_format(p.fmt_o)


### PR DESCRIPTION
# Description

Introducing AMD backend for the oneDNN Reorder Primitive.

## Supported Data Types
f32

## Testing Scope
Benchdnn:Passed
gtest: API tests passed, reorder tests passed except 2 tests cases

## Benchdnn log files:
[test_reorder_all.txt](https://github.com/oneapi-src/oneDNN/files/11102858/test_reorder_all.txt)
[test_reorder_ci.txt](https://github.com/oneapi-src/oneDNN/files/11102860/test_reorder_ci.txt)

## Gtest Log files:
[gtests_reorder_buffer.txt](https://github.com/oneapi-src/oneDNN/files/11102867/gtests_reorder_buffer.txt)
[gtests_reorder.txt](https://github.com/oneapi-src/oneDNN/files/11102868/gtests_reorder.txt)
[gtest_api_test.txt](https://github.com/oneapi-src/oneDNN/files/11102917/gtest_api_test.txt)
[gtest_api_buffer.txt](https://github.com/oneapi-src/oneDNN/files/11102918/gtest_api_buffer.txt)
[gtests_internals.txt](https://github.com/oneapi-src/oneDNN/files/11102919/gtests_internals.txt)
[gtests_regression.txt](https://github.com/oneapi-src/oneDNN/files/11102920/gtests_regression.txt)
[gtest_api_sycl.txt](https://github.com/oneapi-src/oneDNN/files/11102921/gtest_api_sycl.txt)



## Limitations:
1)s8,bf16,f16,u8 were not supported
2)Blocked formats not supported
3)Source and destination data types needs to be same

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

