### PR TITLE
Add f32->tf32 in the description for dnnl_fpmath_mode_any

### DIFF
--- a/include/oneapi/dnnl/dnnl_common.hpp
+++ b/include/oneapi/dnnl/dnnl_common.hpp
@@ -421,7 +421,7 @@ enum class fpmath_mode {
     f16 = dnnl_fpmath_mode_f16,
     /// Implicit f32->tf32 conversions allowed
     tf32 = dnnl_fpmath_mode_tf32,
-    /// Implicit f32->f16 or f32->bf16 conversions allowed
+    /// Implicit f32->f16, f32->tf32 or f32->bf16 conversions allowed
     any = dnnl_fpmath_mode_any
 };
 

--- a/include/oneapi/dnnl/dnnl_common_types.h
+++ b/include/oneapi/dnnl/dnnl_common_types.h
@@ -117,7 +117,7 @@ typedef enum {
     dnnl_fpmath_mode_bf16,
     /// Implicit f32->f16 conversions allowed
     dnnl_fpmath_mode_f16,
-    /// Implicit f32->f16 or f32->bf16 conversions allowed
+    /// Implicit f32->f16, f32->tf32 or f32->bf16 conversions allowed
     dnnl_fpmath_mode_any,
     /// Implicit f32->tf32 conversions allowed
     dnnl_fpmath_mode_tf32,


### PR DESCRIPTION
**Description**

Adds "f32->tf32" which was missing in the description for dnnl_fpmath_mode_any

Fixes #1542 