### PR TITLE
graph: interface: backend: Fix memory_order enum name for C++20

### DIFF
--- a/src/graph/backend/dnnl/constant_cache.cpp
+++ b/src/graph/backend/dnnl/constant_cache.cpp
@@ -158,9 +158,9 @@ void constant_cache_t::evict(size_t n) {
                     // important, therefore we can safely use the weakest memory
                     // ordering (relaxed).
                     return left.second.timestamp_.load(
-                                   std::memory_order::memory_order_relaxed)
+                                   std::memory_order_relaxed)
                             < right.second.timestamp_.load(
-                                    std::memory_order::memory_order_relaxed);
+                                    std::memory_order_relaxed);
                 });
         evicted_size += it->second.value_.get()->size();
         auto res = constant_map().erase(it->first);

--- a/src/graph/interface/allocator.hpp
+++ b/src/graph/interface/allocator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -61,9 +61,7 @@ public:
     // occur!
 
     // This function increments the reference count
-    void retain() {
-        counter_.fetch_add(1, std::memory_order::memory_order_relaxed);
-    }
+    void retain() { counter_.fetch_add(1, std::memory_order_relaxed); }
 
     // This function decrements the reference count. If the reference count is
     // decremented to zero, the object will be destroyed.

--- a/src/graph/interface/backend.cpp
+++ b/src/graph/interface/backend.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Intel Corporation
+* Copyright 2021-2023 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -86,12 +86,12 @@ public:
     }
 
     int load() const {
-        return static_cast<int>(constant_cache_enabled_.load(
-                std::memory_order::memory_order_relaxed));
+        return static_cast<int>(
+                constant_cache_enabled_.load(std::memory_order_relaxed));
     }
     void store(int flag) {
-        constant_cache_enabled_.store(static_cast<bool>(flag),
-                std::memory_order::memory_order_relaxed);
+        constant_cache_enabled_.store(
+                static_cast<bool>(flag), std::memory_order_relaxed);
     }
 };
 

--- a/src/graph/interface/partition_cache.cpp
+++ b/src/graph/interface/partition_cache.cpp
@@ -227,9 +227,9 @@ void lru_compiled_partition_cache_t::evict(size_t n) {
                     // important, therefore we can safely use the weakest memory
                     // ordering (relaxed).
                     return left.second.timestamp_.load(
-                                   std::memory_order::memory_order_relaxed)
+                                   std::memory_order_relaxed)
                             < right.second.timestamp_.load(
-                                    std::memory_order::memory_order_relaxed);
+                                    std::memory_order_relaxed);
                 });
         auto res = cache_mapper().erase(it->first);
         UNUSED(res);


### PR DESCRIPTION
# Description

`std::memory_order` is an enum in pre-C++20, and is an enum class in C++20.
In pre-C++20, its members are intended to be referred as `std::memory_order_relaxed` or so, but in oneDNN, it's referred as `std::memory_order::memory_order_relaxed`.
That style is not valid after C++20, as the member is renamed to `std::memory_order::relaxed`.

This PR drops unneeded `memory_order::`, so that the source is compatible to C++20.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
