### PR TITLE
cpu: x64: brgconv: Fix null pointer dereference in dnnl::impl::cpu::x64::brgemm_convolution_fwd_t()

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1204,7 +1204,7 @@ status_t brgemm_convolution_fwd_t<isa, use_inversion>::execute(
         char *inp_buffer = (jcp.exec_type == exec_trans)
                 ? inp_p_buffer + src_dsz * ithr * jcp.inp_buffer_size
                 : nullptr;
-        if (is_amx) {
+        if (is_amx && inp_buffer) {
             // Workaround: for some machines SEGFAULT possible on tile load
             // if the page was not touched before it
             for (dim_t i = 0; i < jcp.inp_buffer_size;


### PR DESCRIPTION
# Description

The bug was found by Svace static analysis tool:

1. null pointer can be assigned to inp_buffer
2. then it is dereferenced via inp_buffer[i]

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
