### PR TITLE
src:cpu:aarch64 Fix naming issue for threadpool builds

### DIFF
--- a/src/cpu/aarch64/acl_thread.cpp
+++ b/src/cpu/aarch64/acl_thread.cpp
@@ -55,7 +55,7 @@ void acl_set_benchmark_scheduler_default() {
 #endif
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-void acl_set_threadpool_scheduler() {
+void acl_set_tp_scheduler() {
     static std::once_flag flag_once;
     // Create threadpool scheduler
     std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
@@ -80,7 +80,7 @@ void acl_set_threadpool_num_threads() {
     }
 }
 // Swap BenchmarkScheduler for custom scheduler builds (i.e. ThreadPoolScheduler)
-void acl_set_benchmark_scheduler_tp() {
+void acl_set_tp_benchmark_scheduler() {
     static std::once_flag flag_once;
     // Create threadpool scheduler
     std::unique_ptr<arm_compute::IScheduler> threadpool_scheduler


### PR DESCRIPTION
# Description

Building oneDNN with ACL and DNNL_CPU_RUNTIME=THREADPOOL currently fails at compile time with below error:
```
/usr/bin/ld: ../src/libdnnl.so.3.1: undefined reference to `dnnl::impl::cpu::aarch64::acl_thread_utils::acl_set_tp_benchmark_scheduler()'

/usr/bin/ld: ../src/libdnnl.so.3.1: undefined reference to `dnnl::impl::cpu::aarch64::acl_thread_utils::acl_set_tp_scheduler()'

clang: error: linker command failed with exit code 1 (use -v to see invocation)
            ^
```

oneDNN build line:
```
ACL_ROOT_DIR=/PATH/TO/ACL cmake   -DCMAKE_BUILD_TYPE=RELEASE -DDNNL_CPU_RUNTIME=THREADPOOL -DDNNL_AARCH64_USE_ACL=ON  -D_DNNL_TEST_THREADPOOL_IMPL=EIGEN -DEigen3_DIR=/path/to/Eigen
```

Commit where issue was first noticed https://github.com/oneapi-src/oneDNN/pull/1598/

This patch fixes call to renamed function acl_set_tp_benchmark_scheduler() instead of acl_set_benchmark_scheduler_tp() and acl_set_tp_scheduler() instead of acl_set_threadpool_scheduler().

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?


## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?