### PR TITLE
cpu: aarch64: binary: add check for repeated sum postop

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
@@ -139,11 +139,10 @@ enum post_op_type { sum = 0, eltwise, binary };
 struct post_ops_ok_args_t {
     post_ops_ok_args_t(const cpu_isa_t isa,
             const std::vector<post_op_type> &accepted_post_op_types,
-            const post_ops_t &post_ops,
-            const memory_desc_wrapper *dst_d = nullptr,
-            const bool sum_at_pos_0_only = false,
-            const bool sum_requires_scale_one = false,
+            const post_ops_t &post_ops, const memory_desc_wrapper *dst_d,
+            const bool sum_at_pos_0_only, const bool sum_requires_scale_one,
             const bool sum_requires_zp_zero = true,
+            const bool sum_requires_same_params = true,
             const bcast_set_t &enabled_bcast_strategy = default_strategies());
 
     const cpu_isa_t isa;
@@ -153,6 +152,7 @@ struct post_ops_ok_args_t {
     const bool sum_at_pos_0_only;
     const bool sum_requires_scale_one;
     const bool sum_requires_zp_zero;
+    const bool sum_requires_same_params;
     const bcast_set_t enabled_bcast_strategy;
 };
 

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.cpp
@@ -718,9 +718,9 @@ status_t jit_sve_512_1x1_conv_kernel::init_conf(jit_1x1_conv_conf_t &jcp,
     static constexpr bool sum_at_pos_0_only = true;
     static constexpr bool sum_requires_scale_one = true;
     static constexpr bool sum_requires_zp_zero = true;
-    const bool post_ops_ok_ = post_ops_ok({sve_512, {eltwise, binary, sum},
-            jcp.post_ops, &dst_d, sum_at_pos_0_only, sum_requires_scale_one,
-            sum_requires_zp_zero});
+    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(jcp.isa,
+            {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
+            sum_requires_scale_one, sum_requires_zp_zero));
     if (!post_ops_ok_) return status::unimplemented;
 
     bool args_ok = true && jcp.ngroups == 1 && jcp.src_tag == required_dat_tag

--- a/src/cpu/aarch64/jit_uni_binary.hpp
+++ b/src/cpu/aarch64/jit_uni_binary.hpp
@@ -99,7 +99,7 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     static bool post_ops_ok(const primitive_attr_t *attr,
             const memory_desc_wrapper &src0_d, const memory_desc_wrapper &dst_d,
-            const bool is_src1_different_layouts);
+            const bool is_src1_different_layouts, const cpu_isa_t isa);
 
     std::unique_ptr<binary_kernel_t> kernel_;
     // used only in bcast_c_blocked strategy if tail exists


### PR DESCRIPTION
# Description
 
This patch fixes 
`benchdnn --binary --attr-post-ops=sum+relu+sum:2 8x8x3x5:8x8x3x5_n"multisum"` on AArch64 SVE environment.

# How to reproduce

- OS: CentOS 8
- CPU: Fujitsu A64FX (Armv8.2-a + SVE)
- oneDNN: commit 6d1a18ce22c29edc012a5637f198b6b146536c65
- build command: `.github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --cmake-opt -DONEDNN_BUILD_GRAPH=OFF`

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

Some test patterns for `ip` and `resampling` of `benchdnn` failed, but I confirmed that these are not a side effect of this patch.

```
benchdnn --engine=cpu --ip --batch=test_ip_all | tail -n 2 | head -n 1
tests:12781 passed:4150 skipped:8346 mistrusted:31 unimplemented:0 invalid_arguments:0 failed:254 listed:0

benchdnn --engine=cpu --resampling --batch=test_resampling_all | tail -n 2 | head -n 1
tests:5256 passed:3184 skipped:1960 mistrusted:16 unimplemented:0 invalid_arguments:0 failed:96 listed:0
```
- [x] Have you formatted the code using clang-format?
