### PR TITLE
aarch64: fix random print and obstacles to run on Windows/MacOS on Arm

### DIFF
--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -50,7 +50,8 @@ typedef enum {
 
 // Callee-saved registers
 constexpr Xbyak_aarch64::Operand::Code abi_save_gpr_regs[]
-        = {Xbyak_aarch64::Operand::X19, Xbyak_aarch64::Operand::X20,
+        = {Xbyak_aarch64::Operand::X16, Xbyak_aarch64::Operand::X17,
+                Xbyak_aarch64::Operand::X19, Xbyak_aarch64::Operand::X20,
                 Xbyak_aarch64::Operand::X21, Xbyak_aarch64::Operand::X22,
                 Xbyak_aarch64::Operand::X23, Xbyak_aarch64::Operand::X24,
                 Xbyak_aarch64::Operand::X25, Xbyak_aarch64::Operand::X26,

--- a/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_1x1_conv_kernel.hpp
@@ -84,7 +84,7 @@ private:
     reg64_t reg_bcast_loop_work = x17;
 
     /* Temporay registers */
-    reg64_t reg_tmp_imm = x18; // tmp for add_imm
+    reg64_t reg_tmp_imm = x27; // tmp for add_imm
     reg64_t reg_tmp_ofs = x19; // tmp reg to calc bwd wei offset in out_load
 
     reg64_t reg_load_dim_tail_mask = aux_reg_load_data;

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.cpp
@@ -3777,11 +3777,11 @@ void jit_sve_512_conv_bwd_weights_kernel_f32::compute_od_loop_partial() {
 
     mov(reg_input_d_org, reg_input_d);
     mov(reg_output_d_org, reg_output_d);
-    mov(reg_d_index_org, reg_d_index);
+    str(reg_d_index, pre_ptr(X_SP, -8));
 
     compute_oh_loop_common();
 
-    mov(reg_d_index, reg_d_index_org);
+    ldr(reg_d_index, post_ptr(X_SP, 8));
     mov(reg_output_d, reg_output_d_org);
     mov(reg_input_d, reg_input_d_org);
 

--- a/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_conv_kernel.hpp
@@ -102,7 +102,7 @@ private:
     reg64_t reg_prev_wei_addr = x16;
     reg64_t reg_tmp_imm = x17;
 
-    reg64_t reg_out_org = x18; // dst base addr (3d)
+    reg64_t reg_out_org = x27; // dst base addr (3d)
     reg64_t reg_oi_org = x19; // base oi (3d)
     reg64_t aux_reg_ker_d_org = x20;
     reg64_t reg_ker_org = x21; // ker base addr (3d)
@@ -280,7 +280,7 @@ private:
     reg64_t reg_prev_bcast_addr2 = x17;
     reg64_t reg_prev_bcast_addr3 = x21;
     reg64_t reg_tmp_imm = x16;
-    reg64_t reg_tmp_addr = x18;
+    reg64_t reg_tmp_addr = x27;
 
     reg64_t reg_src_prf_org = x19;
     reg64_t reg_src_org = x20;
@@ -475,8 +475,7 @@ private:
 
     reg64_t reg_kd_count_org = x16;
     reg64_t reg_input_d_org = x17;
-    reg64_t reg_output_d_org = x18;
-    reg64_t reg_d_index_org = x19;
+    reg64_t reg_output_d_org = x19;
 
     reg64_t reg_input_org = x24;
     reg64_t reg_kernel_org = x22;

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
@@ -267,15 +267,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
             auto base = reg_out;
             auto re = get_offset(aux_output_offset);
 
-            auto reg_tmp_adr = ((j % 4) == 0) ? reg_tmp0_adr
-                    : ((j % 4) == 1)          ? reg_tmp1_adr
-                    : ((j % 4) == 2)          ? reg_tmp2_adr
-                                              : reg_tmp3_adr;
-            auto reg_tmp_imm = ((j % 4) == 0) ? reg_tmp0_imm
-                    : ((j % 4) == 1)          ? reg_tmp1_imm
-                    : ((j % 4) == 2)          ? reg_tmp2_imm
-                                              : reg_tmp3_imm;
-            add_imm(reg_tmp_adr, base, re, reg_tmp_imm);
+            add_imm(reg_tmp0_adr, base, re, reg_tmp0_imm);
 
             auto vmm = vmm_out(j, k);
 
@@ -283,16 +275,16 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
             switch (jcp.dst_dt) {
                 case data_type::f32:
                 case data_type::s32:
-                    st1w(vmm.s, _mask, ptr(reg_tmp_adr));
+                    st1w(vmm.s, _mask, ptr(reg_tmp0_adr));
                     break;
                 case data_type::s8:
                     smin(vmm.s, 127);
                     smax(vmm.s, -128);
-                    st1b(vmm.s, _mask, ptr(reg_tmp_adr));
+                    st1b(vmm.s, _mask, ptr(reg_tmp0_adr));
                     break;
                 case data_type::u8:
                     umin(vmm.s, 255);
-                    st1b(vmm.s, _mask, ptr(reg_tmp_adr));
+                    st1b(vmm.s, _mask, ptr(reg_tmp0_adr));
                     break;
                 default: assert(!"unknown dst_dt");
             }
@@ -567,19 +559,9 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker(int ur_w, int pad_l,
                                 ld1rw(vmm_inp(jj, nb_oc_block).s, mask_all_one,
                                         ptr(base, static_cast<int32_t>(re)));
                             else {
-                                auto reg_tmp_adr = ((jj % 4) == 0)
-                                        ? reg_tmp0_adr
-                                        : ((jj % 4) == 1) ? reg_tmp1_adr
-                                        : ((jj % 4) == 2) ? reg_tmp2_adr
-                                                          : reg_tmp3_adr;
-                                auto reg_tmp_imm = ((jj % 4) == 0)
-                                        ? reg_tmp0_imm
-                                        : ((jj % 4) == 1) ? reg_tmp1_imm
-                                        : ((jj % 4) == 2) ? reg_tmp2_imm
-                                                          : reg_tmp3_imm;
-                                add_imm(reg_tmp_adr, base, re, reg_tmp_imm);
+                                add_imm(reg_tmp0_adr, base, re, reg_tmp0_imm);
                                 ld1rw(vmm_inp(jj, nb_oc_block).s, mask_all_one,
-                                        ptr(reg_tmp_adr));
+                                        ptr(reg_tmp0_adr));
                             }
                         }
                         if (!jcp.signed_input)

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
@@ -110,14 +110,9 @@ private:
     XReg reg_stack = x22; // translator stack register
 
     /* Temporay registers */
-    XReg reg_tmp0_imm = x18; // tmp for add_imm
-    XReg reg_tmp1_imm = x19; // tmp for add_imm
-    XReg reg_tmp2_imm = x20; // tmp for add_imm
-    XReg reg_tmp3_imm = x21; // tmp for add_imm
-    XReg reg_tmp0_adr = x23; // tmp for address value
-    XReg reg_tmp1_adr = x24; // tmp for address value
-    XReg reg_tmp2_adr = x25; // tmp for address value
-    XReg reg_tmp3_adr = x26; // tmp for address value
+    XReg reg_tmp0_imm = x23; // tmp for add_imm
+    XReg reg_tmp1_imm = x24; // tmp for add_imm
+    XReg reg_tmp0_adr = x25; // tmp for address value
 
     const PReg ktail_mask = p2;
     const PReg kblend_mask = p8;

--- a/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
-* Copyright 2021-2022 Intel Corporation
-* Copyright 2022 FUJITSU LIMITED
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2022-2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -73,7 +73,7 @@ private:
     reg64_t reg_tmp_imm = x15;
     reg64_t reg_kernel_stack = x16;
     reg64_t reg_input_stack = x17;
-    reg64_t reg_output_stack = x18;
+    reg64_t reg_output_stack = x27;
     reg64_t reg_bias_stack = x19;
     reg64_t reg_tmp_addr = x20;
 

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -1628,8 +1628,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
 
         eor(reg_off_in_, reg_off_in_, reg_off_in_);
         eor(reg_off_out_, reg_off_out_, reg_off_out_);
-        mov(x_ptr_in_off, reg_ptr_in_);
-        mov(x_ptr_out_off, reg_ptr_out_);
+
         if (prb_.src_scale_type == scale_type_t::MANY)
             mov(x_ptr_src_scale_off, reg_ptr_src_scales_);
         if (prb_.dst_scale_type == scale_type_t::MANY)
@@ -1868,10 +1867,6 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         ldr(reg_ptr_in_, ptr(X_TMP_0));
         ldr(reg_ptr_out_, ptr(X_TMP_1));
 
-        mov(x_ptr_in_off, reg_ptr_in_);
-        mov(x_ptr_out_off, reg_ptr_out_);
-        mov(x_ptr_comp_off, reg_ptr_comp_);
-
         if (sveLen) { /* SVE is available. */
             ptrue(p_lsb_256.b, VL32);
             ptrue(p_lsb_128.b, VL16);
@@ -1965,11 +1960,11 @@ private:
     /* Note: x22 - x28 are already used as temporal registgers
        in jit_generator.hpp.
        x_ptr_(in|out|scale|comp)_off keeps (base + offset) address. */
-    XReg x_ptr_in_off = x16;
-    XReg x_ptr_out_off = x18;
-    XReg x_ptr_comp_off = x17;
+    XReg x_ptr_in_off = reg_ptr_in_;
+    XReg x_ptr_out_off = reg_ptr_out_;
+    XReg x_ptr_comp_off = reg_ptr_comp_;
     XReg x_ptr_src_scale_off = x19;
-    XReg x_ptr_dst_scale_off = x12;
+    XReg x_ptr_dst_scale_off = x29;
 
     /* Caution: Chose predicate registers not used by x64's implementation. */
     PReg p_lsb_256 = p7;

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
@@ -252,7 +252,6 @@ private:
         */
         end_ptr = buf;
         while ('\0' != *buf) {
-          printf("%s\n", buf);
           start = strtol(buf, &end_ptr, 10);
           if ('\0' == *end_ptr) {
             sharing_cores += 1;

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_windows.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_windows.h
@@ -41,6 +41,7 @@ class CpuInfoWindows : public CpuInfo {
 public:
   CpuInfoWindows() {
     init();
+    setHwCap();
     setCacheHierarchy();
     setImplementer();
   }
@@ -97,6 +98,13 @@ private:
     numCores_[0] = numCores_[1];
 
     setLastDataCacheLevel();
+  }
+
+  void setHwCap() {
+    if (IsProcessorFeaturePresent(PF_ARM_V8_INSTRUCTIONS_AVAILABLE))
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
+    if (IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE))
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_ATOMIC;
   }
 };
 


### PR DESCRIPTION
# Description

This patch contains the following updates. 

- Fix random print of Xbyak_aarch64 https://github.com/oneapi-src/oneDNN/issues/1633
- Fix clobbering x16-x18 registers in JIT-ed code. It prevented `ctest` to work on Windows/MacOS on Arm.
- Add H/W-capability detection for Windows on Arm.

https://github.com/oneapi-src/oneDNN/files/10745455/arm64-msvc-onednn.patch is also required for building oneDNN on Windows on Arm.
I expect it will be pull-requested by Linaro developers.
