### PR TITLE
rfcs: extend vtune integration with pd_info

### DIFF
--- a/rfcs/20230524-vtune-pdinfo-task/README.md
+++ b/rfcs/20230524-vtune-pdinfo-task/README.md
@@ -9,11 +9,11 @@ benchdnn.
 
 
 However, it is hard to correlate verbose output to the overall
-application execution. Vtune in general does a better job at that as
-it contains call stack and nested task information.
+application execution. Linux Perf and Vtune in general do a better job
+at that as they contain call stack and nested task information.
 
-So currently, users are left to run Vtune for profiling their whole
-application, and try to map primitive execution calls in the Vtune
+So currently, users are left to run profilers on their whole
+application, and try to map primitive execution calls in the profiler
 trace to the oneDNN verbose output. This is tedious and error prone.
 
 Furthermore, Vtune integration is enabled by default whereas oneDNN
@@ -38,3 +38,9 @@ from Vtune trace, the user will get each primitives grouped by
 primitive kind task, then within each of these groups they will get
 the list of primitives effectively executed as shown in verbose trace
 (so unique primitive descriptor).
+
+As an extra step, we can also align jit dump output names to align
+with kernel name calls, that users of JIT_DUMP functionality can know
+which binary was called in which primitive execution.  Here, when
+registering jit kernel to the profiler (VTune/Linux prof), we will
+have to pass the binary filename.

--- a/rfcs/20230524-vtune-pdinfo-task/README.md
+++ b/rfcs/20230524-vtune-pdinfo-task/README.md
@@ -1,0 +1,40 @@
+Proposal for Vtune integration extension
+
+# 1. Problem statement
+
+The main way for oneDNN to efficiently collect information during an
+application run is to use oneDNN verbose mode. This generates one line
+per primitive execution, and allow for easily create reproducers using
+benchdnn.
+
+
+However, it is hard to correlate verbose output to the overall
+application execution. Vtune in general does a better job at that as
+it contains call stack and nested task information.
+
+So currently, users are left to run Vtune for profiling their whole
+application, and try to map primitive execution calls in the Vtune
+trace to the oneDNN verbose output. This is tedious and error prone.
+
+Furthermore, Vtune integration is enabled by default whereas oneDNN
+verbose is not. So in practice, users collect Vtune information, ask
+the oneDNN team to investigate an issue, and are left with no way to
+generate a simple reproducer which stalls investigation and problem
+resolution. At that point they have to rerun their application with
+ONEDNN_VERBOSE enabled, which can be impossible sometime due to
+limited availabily of hardware, or the duration of the workload.
+
+# 2. Proposal
+
+The proposal is to rely on the existing Vtune integration in oneDNN
+and expose a new level `ONEDNN_ITT_TASK_LEVEL=3`, that would create a
+task per unique primitive descriptor (`pd->info()` internally). This
+way each task under Vtune would contain similar information as oneDNN
+verbose output, which in turn would allow to easily obtain benchdnn
+reproducers from Vtune trace.
+
+Because levels are inclusive, oneDNN will use nested itt tasks, so
+from Vtune trace, the user will get each primitives grouped by
+primitive kind task, then within each of these groups they will get
+the list of primitives effectively executed as shown in verbose trace
+(so unique primitive descriptor).


### PR DESCRIPTION
This is a proposal to introduce a new ITT_TASK level, in order for users to get benchdnn reproducers from Vtune trace.
This allows for:
- better correlation of oneDNN execution calls with the rest of the application, as vtune generates call stack and nested tasks
- better usability, as the users will no more need to separately generate the ONEDNN_VERBOSE output to get benchdnn reproducers.


[rendered document](https://github.com/oneapi-src/oneDNN/blob/09c09d05a6b47efd90c851f7b7e32578a046f437/rfcs/20230524-vtune-pdinfo-task/README.md)