### PR TITLE
Add declarations of explicit specializations and instantiations.

### DIFF
--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include <cassert>
+#include <type_traits>
 
 #include "cpu/x64/jit_avx512_core_bf16cvt.hpp"
 #include "cpu/x64/utils/jit_io_helper.hpp"
@@ -553,16 +554,13 @@ void jit_io_helper_t<Vmm>::load(const Xbyak::Address &src_addr,
     }
 }
 
-template <>
-void jit_io_helper_t<Xbyak::Zmm>::load_byte_by_byte(
-        const Xbyak::Address &src_addr, const Xbyak::Zmm &dst_vmm,
-        const int load_size) {
-    assert("Load byte by byte is not supported for Zmms.");
-}
-
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::load_byte_by_byte(const Xbyak::Address &src_addr,
         const Vmm &dst_vmm, const int load_size) {
+    static constexpr bool is_zmm = std::is_same<Vmm, Xbyak::Zmm>::value;
+    UNUSED(is_zmm);
+    assert(!is_zmm && "Load byte by byte is not supported for Zmms.");
+
     host_->uni_vxorps(dst_vmm, dst_vmm, dst_vmm);
     host_->load_data(data_type_, dst_vmm, src_addr, load_size);
 
@@ -706,15 +704,13 @@ void jit_io_helper_t<Vmm>::saturate(const Vmm &vmm) {
     host_->uni_vcvtps2dq(vmm, vmm);
 }
 
-template <>
-void jit_io_helper_t<Xbyak::Zmm>::store_byte_by_byte(const Xbyak::Zmm &src_zmm,
-        const Xbyak::Address &dst_addr, const int store_size) {
-    assert("Store byte by byte is not supported for Zmms.");
-}
-
 template <typename Vmm>
 void jit_io_helper_t<Vmm>::store_byte_by_byte(const Vmm &src_vmm,
         const Xbyak::Address &dst_addr, const int store_size) {
+    static constexpr bool is_zmm = std::is_same<Vmm, Xbyak::Zmm>::value;
+    UNUSED(is_zmm);
+    assert(!is_zmm && "Store byte by byte is not supported for Zmms.");
+
     const bool is_i8 = utils::one_of(data_type_, data_type::s8, data_type::u8);
     const bool is_xf16
             = utils::one_of(data_type_, data_type::bf16, data_type::f16);

--- a/src/cpu/x64/utils/jit_io_helper.hpp
+++ b/src/cpu/x64/utils/jit_io_helper.hpp
@@ -247,6 +247,27 @@ private:
             storage_;
 };
 
+template <>
+void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
+        const Xbyak::Zmm &indices_vmm, const Xbyak::Zmm &dst_vmm,
+        const bool tail);
+template <>
+void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
+        const Xbyak::Ymm &indices_vmm, const Xbyak::Ymm &dst_vmm,
+        const bool tail);
+template <>
+void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
+        const Xbyak::Xmm &indices_vmm, const Xbyak::Xmm &dst_vmm,
+        const bool tail);
+
+extern template class jit_io_helper_t<Xbyak::Zmm>;
+extern template class jit_io_helper_t<Xbyak::Ymm>;
+extern template class jit_io_helper_t<Xbyak::Xmm>;
+
+extern template class jit_io_multi_dt_helper_t<Xbyak::Zmm>;
+extern template class jit_io_multi_dt_helper_t<Xbyak::Ymm>;
+extern template class jit_io_multi_dt_helper_t<Xbyak::Xmm>;
+
 } // namespace io
 } // namespace x64
 } // namespace cpu


### PR DESCRIPTION
# Description

Adds declarations of explicit template specializations and explicit template instantiations to the header file that defines the primary template.

Currently, code that uses the specializations in question will accidentally and erroneously specialize the primary template. The reason this appears to "work" is a pure accident due to the way the linker currently works. The code violates the one-definition-rule, and all programs depending on it are ill-formed, no diagnostic required (i.e. running all such programs has undefined behaviour).

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
