### PR TITLE
Skip cxx compiler check for '-fsycl' flag on Windows

### DIFF
--- a/cmake/dpcpp_driver_check.cmake
+++ b/cmake/dpcpp_driver_check.cmake
@@ -32,7 +32,7 @@ include(CheckCXXSourceCompiles)
 function(CHECK_COMPILER_DRIVER)
     # Check if the CXX compiler supports `-fsycl` flag.
     if(NOT WIN32)
-    CHECK_CXX_COMPILER_FLAG(-fsycl SYCL_FLAG_SUPPORTED)
+        CHECK_CXX_COMPILER_FLAG(-fsycl SYCL_FLAG_SUPPORTED)
         if(NOT SYCL_FLAG_SUPPORTED)
             message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} doesn't support -fsycl flag.")
         endif()

--- a/cmake/dpcpp_driver_check.cmake
+++ b/cmake/dpcpp_driver_check.cmake
@@ -31,9 +31,11 @@ include(CheckCXXSourceCompiles)
 # Intel oneAPI DPC++ Compiler.
 function(CHECK_COMPILER_DRIVER)
     # Check if the CXX compiler supports `-fsycl` flag.
+    if(NOT WIN32)
     CHECK_CXX_COMPILER_FLAG(-fsycl SYCL_FLAG_SUPPORTED)
-    if(NOT SYCL_FLAG_SUPPORTED)
-        message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} doesn't support -fsycl flag.")
+        if(NOT SYCL_FLAG_SUPPORTED)
+            message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} doesn't support -fsycl flag.")
+        endif()
     endif()
 
     if(CMAKE_BASE_NAME MATCHES "(icx|icpx|dpcpp)")


### PR DESCRIPTION
# Description

Per-title, skips cxx compiler check for '-fsycl' flag on Windows platform. The motivation is to resolve build failure of IPEX-xpu on native windows. 