### PR TITLE
Update brgemm.cpp fix typo

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -299,7 +299,7 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
     //       happen for bf32, where isa during this check is avx512_core and isa
     //       at kernel creation time is avx512_core_amx_bf16. It just so happens
     //       that the behavior of `post_ops_ok` is identical for those two isas,
-    //       but there is no gaurentee that will always be the case.
+    //       but there is no guarantee that will always be the case.
     if ((brg->with_binary && !dst_md)
             || !injector::post_ops_ok(
                     post_ops_ok_args_t(brg->isa_impl, {sum, eltwise, binary},


### PR DESCRIPTION
# Description

Fixes -  Simple typo caught while using. gaurentee --> guarantee
No other changes made. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?