### PR TITLE
[aarch64] add tensor dilation parameter configuration for acl depthwise conv

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -351,7 +351,9 @@ status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
     ACL_CHECK_VALID(arm_compute::NEDepthwiseConvolutionLayer::validate(
             &acp.src_tensor_info, &acp.wei_tensor_info,
             acp.with_bias ? &acp.bia_tensor_info : nullptr,
-            &acp.dst_tensor_info, acp.padstride_info));
+            &acp.dst_tensor_info, acp.padstride_info,
+            1, // depth multiplier default value
+            acp.act_info, acp.dilation_info));
 
     return status::success;
 }

--- a/src/cpu/aarch64/acl_depthwise_convolution.hpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
@@ -46,7 +46,8 @@ struct acl_depthwise_convolution_resource_t : public resource_t {
             &acl_obj_->dst_tensor,
             acp.padstride_info,
             1, // depth multiplier default value
-            acp.act_info);
+            acp.act_info,
+            acp.dilation_info);
 
         // clang-format on
         return status::success;


### PR DESCRIPTION

# Description

add tensor dilation parameter configuration for acl depthwise convolution kernels.

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

The issue is, if we run any convolution shape with dilation, oneDNN was picking the reference kernels instead of ACL and hence the performance was poor. This PR fixes the oneDNN ACL convolution kernel wrapper to pass the dilation parameters to the ACL kernel configuration and run. With the PR, I've observed around 3.75x performance improvement for the dilation convolution tensor processing on AWS Graviton3 based c7g instance with 1vcpu.

How to test#
Run the below benchdnn shape to test the feature and measure performance.

with this PR, ACL convolution kernel is picked up

```
oneDNN/build/tests/benchdnn$ ./benchdnn --conv --stag=any --dtag=any --wtag=any g512mb1_ic512oc512_ih1oh1kh1sh1dh0ph0_iw104ow104kw87sw1dw1pw86

onednn_verbose,exec,cpu,convolution,depthwise_convolution:acl,forward_training,src_f32::blocked:acdb:f0 wei_f32::blocked:decab:f0 bia_f32::blocked:a:f0 dst_f32::blocked:acdb:f0,attr-fpmath:bf16 ,alg:convolution_direct,g512mb1_ic512oc512_ih1oh1kh1sh1dh0ph0_iw104ow104kw87sw1dw1pw86,1.07397
```

Without the PR, gemm:ref kernel was pickedup

```
oneDNN/build/tests/benchdnn$ ./benchdnn --conv --stag=any --dtag=any --wtag=any g512mb1_ic512oc512_ih1oh1kh1sh1dh0ph0_iw104ow104kw87sw1dw1pw86

onednn_verbose,exec,cpu,convolution,gemm:ref,forward_training,src_f32::blocked:abcd:f0 wei_f32::blocked:abcde:f0 bia_f32::blocked:a:f0 dst_f32::blocked:abcd:f0,attr-fpmath:bf16 ,alg:convolution_direct,g512mb1_ic512oc512_ih1oh1kh1sh1dh0ph0_iw104ow104kw87sw1dw1pw86,4.0271

```



# Checklist

## General

- [x ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
-since the fix is specific to convolution kernels, I've run 'make test' and 'make test_benchdnn_conv_ci' tests only. there are no regressions with this change.
- [x ] Have you formatted the code using clang-format?

## Performance improvements

- [ x] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
