### PR TITLE
rfcs: graph api: add python binding

### DIFF
--- a/rfcs/20230720-graph-python-api/README.md
+++ b/rfcs/20230720-graph-python-api/README.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-There are two major motivations for adding a python binding of oneDNN graph API
+There are three major motivations for adding python binding of oneDNN graph API
 in oneDNN repository.
 
 - It is easier to construct tests, examples, and bug reproducers with python
@@ -13,108 +13,32 @@ in oneDNN repository.
 - It is required by integrating oneDNN graph into PyTorch 2.0 torch.compile API.
   Having the python binding inside oneDNN repository will largely reduce the
   amount of integration code as well as the maintenance effort in PyTorch.
-  Otherwise, the framework developers will have to the binding on the framework
-  side (e.g., [PyTorch#105883](https://github.com/pytorch/pytorch/pull/105883)).
+  Otherwise, the framework developers will have to implement the binding on the
+  framework side (e.g., [PyTorch#105883](https://github.com/pytorch/pytorch/pull/105883)).
+- In addition to C/C++ API, it provides another API option (python API) for users
+  to call oneDNN, catering to the preferences of the deep learning community.
 
 Though it brings benefits, adding a python binding of graph API in oneDNN
 repository also introduces new challenges to oneDNN project. The design options
 and challenges will be discussed in the following sections.
 
-## Pybind11
-
-[Pybind11](https://github.com/pybind/pybind11) is widely used in the deep
-learning framework community for exposing C++ APIs and types through python
-binding and achieving the inter-operability between C++ and python. Pybind11 has
-been adopted in PyTorch, TensorFlow, and MLIR. More information about pybind11
-can be found at the
-[documentation](https://pybind11.readthedocs.io/en/stable/index.html).
-
-It is recommended to follow the convention in the deep learning community and
-use pybind11 for the python binding of graph API. With that, it requires to
-include pybind11 into oneDNN repository and build system. We can achieve that by
-either adding pybind11 as a git submodule of oneDNN or copying pybind11 source
-code into oneDNN repository. According to the existing maintenance methodology
-for gtest and xbyak source code in oneDNN, it is recommended to copy pybind11
-source code and maintain it inside oneDNN repository.
-
-[License of pybind11](https://github.com/pybind/pybind11/blob/master/LICENSE)
-allows it to be modified and redistributed.
-
-## Source code placement
-
-As the proposal is focusing on the python binding of oneDNN graph API, it is
-suggested to place pybind11 source code and the binding implementation into
-`src/graph/` folder. A new folder `src/graph/python/` will be created for the
-purpose.
-
-Test cases implemented with python API will be placed in `tests/python/`.
-
 ## Implementation
 
-A PoC for the python binding code with pybind11 can be found in [the attachment
+A PoC for the python binding code can be found in [the attachment
 of this RFC](./src/binding.cpp).
 
-## Build option
-
-Graph python API is an optional feature for oneDNN users. A new cmake option
-will be defined and exposed to control the feature at the library build stage.
-The new option will take effect only when the existing ONEDNN_BUILD_GRAPH option
-is enabled.
-
-With `ONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON`, the binding code will be built and
-a .so file will be generated in the build directory of oneDNN.
-
-| CMake option                      | Value               | Description |
-| ---                               | ---                 | ---         |
-| ONEDNN_BUILD_GRAPH_PYTHON_BINDING | ON / OFF (default)  | Enable / disable graph API python binding. |
-
-## Installation
-
-There is no extra change for cmake building command except for setting
-`ONEDNN_BUILD_GRAPH_PYTHON_BINDING` to `ON`.
-
-```bash
-cmake -DONEDNN_BUILD_GRAPH=ON -DONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON ..
-make -j
-```
-
-After building finished, an auto-generated file `setup.py` will be put
-under `${ONEDNN_ROOT}/dnnl_graph` folder.
-
-The users will need to build and install the python package wheel by themselves
-by executing commands, for example:
-
-```bash
-cd ${ONEDNN_ROOT}/dnnl_graph
-
-# or directly install via `python setup.py install`
-python setup.py bdist_wheel
-
-# The generated wheel file will be located at dist/ folder
-cd dist
-pip install dnnl_graph-3.2.0-cp310-cp310-linux_x86_64.whl
-```
-
-After the installation, one can import the package in the corresponding python
-interpreter by:
-
-```python
-# or from dnnl_graph import *
-import dnnl_graph
-```
-
-## Low level python API
-
-As demonstrated in the implementation, C++ APIs will be exposed through python
-binding directly without extra wrappers or abstractions. With thin and simple
-python binding layer, we can reduce the potential bugs in the binding code and
-python code, simplify the validation effort, and provide a similar programming
+In this PoC, C++ APIs are exposed through python binding directly without
+extra wrappers or abstractions. With thin and simple python binding layer,
+we can reduce the potential bugs in the binding code and python code,
+simplify the validation effort, and provide a similar programming
 model as the C++ API. Another reason of keeping python API low level is that it
-already meets the current requirements of PyTorch integration. But it also makes
-the python API less pythonic and less easy-of-use. High level python wrapper or
-modules can be added when the request emerges.
+already meets the current requirements of PyTorch integration. However,
+this design consideration also makes the python API less pythonic and less
+ease-of-use. High level python wrapper or modules can be added when the request
+emerges.
 
-The python code example for creating op and logical tensors as follows:
+With python binding implemented, the python code example for creating op and
+logical tensors is as follows:
 
 ```python
 from dnnl_graph import *
@@ -142,7 +66,32 @@ g.finalize()
 p = g.get_partitions(partition.fusion)
 ```
 
-## Runtime objects
+### Limitation
+
+There are some limitations of the above implementation though.
+
+Regarding tensor memory:
+- Passing tensor memory between numpy and oneDNN library through graph python
+  API without copy can be achieved with
+  [pybind11](https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#).
+- But passing tensor memory between frameworks and oneDNN library may need more
+  investigation. In PyTorch, [torch.Tensor.data_ptr()](https://pytorch.org/docs/stable/generated/torch.Tensor.data_ptr.html)
+  can return the memory buffer address as a python integer number to
+  the library through python API. This solution has been validated with a set of models.
+  In TensorFlow, in C++ API, [tensorflow::TensorBuffer](https://www.tensorflow.org/api_docs/cc/class/tensorflow/tensor-buffer)
+  has data() method which returns pointer to the memory buffer, while in python API,
+  [tf.Tensor](https://www.tensorflow.org/api_docs/python/tf/Tensor)
+  does not allow to get raw data pointer. 
+- [dlpack](https://github.com/dmlc/dlpack) is another option for exchanging tensor memory between frameworks, which has been
+  widely adopted in [NumPy](https://numpy.org/doc/stable/release/1.22.0-notes.html#add-nep-47-compatible-dlpack-support),
+  [PyTorch](https://pytorch.org/docs/stable/dlpack.html),
+  [Tensorflow](https://www.tensorflow.org/api_docs/python/tf/experimental/dlpack/from_dlpack),
+  [TVM](https://tvm.apache.org/docs/reference/api/python/contrib.html#module-tvm.contrib.dlpack), etc.
+  To interact with dlpack, oneDNN graph's [Tensor](https://oneapi-src.github.io/oneDNN/class_dnnl_graph_tensor.html#details-classdnnl-1-1graph-1-1tensor)
+  needs to map from/to dlpack’s [DLManagedTensor](https://github.com/dmlc/dlpack/blob/master/include/dlpack/dlpack.h#L157-L170),
+  which will require API changes in oneDNN graph API.
+
+Regarding runtime objects:
 
 - Custom thread pool interface is not exposed and runtime threading object is
   not supported on python API. The reason is that we have not found a way on the
@@ -150,20 +99,113 @@ p = g.get_partitions(partition.fusion)
   object, and pass it to the library through python API.
 - Similarly, allocator API is not exposed at this moment due to the same reason.
   The API is not required by the current PyTorch inductor integration.
-- Passing tensor memory between numpy and oneDNN library through graph python
-  API without copy can be achieved with
-  [pybind11](https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#).
-  But passing tensor memory between frameworks and oneDNN library may need more
-  investigation. Currently, a workaround is developed on PyTorch side to pass
-  the memory buffer address as a python integer number into the library through
-  python API. The workaround has been validated with a set of models.
-- On GPU side, for testing purpose, we can rely on [dpctl
-  package](https://github.com/IntelPython/dpctl) to create and manage SYCL
-  runtime objects (queue, device, and context) and pass them to the library
-  through python API. It may require the frameworks to also integrate dpctl and
-  share the SYCL runtime objects between the framework and the library.
+- On GPU side, SYCL runtime objects (queue, device, and context) are not covered.
+  The reason is that it will bring framework header dependencies in order to share
+  the SYCL runtime objects between the framework and the library.
 
-## Versioning
+## Source code placement
+
+As mentioned above, there are some limitations of putting the source code of graph
+API python binding inside oneDNN repo. So to ensure a comprehensive discussion, we
+present three viable options for managing the source code.
+
+- Option 1: put the source code of graph API python binding inside oneDNN repo.
+  - Pros: single source of code makes it easy for code management and framework integration.
+  - Cons: there is currently uncertainty regarding the use of the python API as an
+    integration point for other frameworks beyond PyTorch, which limits its potential
+    use cases. Also, an integration into oneDNN will bring framework header dependencies
+    for GPU support.
+
+- Option 2: create a separate repository to host the source code of graph API python
+  binding.
+  - Pros: as a separate repository, it’s more flexible and easier to extend, and it
+    will have less impact to oneDNN.
+  - Cons: starting a new repository can be expensive and require additional effort
+    for code management and alignment between repositories (the new repository,
+    oneDNN, and frameworks). Framework needs to incorporate the separate repository
+    into its 3rd party in order to use the python binding.
+
+- Option 3: put the source code of graph API python binding as part of PyTorch.
+  - Pros: currently the main request of graph API python binding is from PyTorch,
+    PyTorch team already has the implementation in the PR. This option also has
+    less impact to oneDNN, and there's no need to start a new repository.
+  - Cons: more code to upstream to PyTorch, which leads to concerns from the community.
+
+As the request from PyTorch is to support option 1, below discusses more details
+about option 1.
+
+### Folder structure
+As the python binding is focusing on oneDNN graph API, it is
+suggested to place the binding implementation into `src/graph/` folder.
+A new folder `src/graph/python/` will be created for the purpose.
+
+Test cases implemented with python API will be placed in `tests/python/`.
+
+### Dependency of pybind11
+
+As indicated in the implementation, the graph API's python binding will require
+the introduction of a new dependency on pybind11. [Pybind11](https://github.com/pybind/pybind11)
+is widely used in the deep learning framework community for exposing C++ APIs
+and types through python binding and achieving the inter-operability between
+C++ and python. It has been adopted in PyTorch, TensorFlow, and MLIR.
+More information about pybind11 can be found at the
+[documentation](https://pybind11.readthedocs.io/en/stable/index.html).
+
+Pybind11 can be utilized in one of three ways: by adding it as a git submodule of
+oneDNN, copying its source code into the repository, or using cmake to find it
+in the environment.
+
+To reduce the burden of source code maintenance, it's suggested to utilize cmake
+to find pybind11 in the environment, instead of incorporating it as a git submodule
+or copying its source code into the oneDNN repository.
+
+### Build option
+
+Graph python API is an optional feature for oneDNN users. A new cmake option
+will be defined and exposed to control the feature at the library build stage.
+The new option will take effect only when the existing ONEDNN_BUILD_GRAPH option
+is enabled.
+
+With `ONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON`, the binding code will be built and
+a .so file will be generated in the build directory of oneDNN.
+
+| CMake option                      | Value               | Description |
+| ---                               | ---                 | ---         |
+| ONEDNN_BUILD_GRAPH_PYTHON_BINDING | ON / OFF (default)  | Enable / disable graph API python binding. |
+
+```bash
+cmake -DONEDNN_BUILD_GRAPH=ON -DONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON ..
+make -j
+```
+
+### Installation
+
+After building finished, an auto-generated file `setup.py` will be generated
+under `${ONEDNN_ROOT}/dnnl_graph` folder.
+
+Users will need to build and install the python package wheel by themselves
+by executing following commands:
+
+```bash
+cd ${ONEDNN_ROOT}/dnnl_graph
+
+# or directly install via `python setup.py install`
+python setup.py bdist_wheel
+
+# The generated wheel file will be located at dist/ folder
+cd dist
+pip install dnnl_graph-3.2.0-cp310-cp310-linux_x86_64.whl
+```
+
+After the installation, one can import the package in the corresponding python
+interpreter by:
+
+```python
+# or from dnnl_graph import *
+import dnnl_graph
+```
+
+### Versioning
 
 Graph API python binding shares the same versioning schema of oneDNN project and
 maintains backward compatibility in the minor versions under the same major
@@ -171,7 +213,7 @@ version. The python API works with the library C++ implementation under the same
 commit. Adding a new C++ API may require to change the python binding code to
 expose the same functionality through python API.
 
-## Validation
+### Validation
 
 - As mentioned in the motivation, python API as a testing and validation utility
   for the library, it does not require additional validation for the utility
@@ -182,7 +224,7 @@ expose the same functionality through python API.
   the existing benchdnn graph test suites for the library performance and
   correctness validation.
 
-## Documentation
+### Documentation
 
 Graph python API will not be part of oneDNN specification. If we only take the
 python binding as a testing and validation utility, we will only need to provide
@@ -190,15 +232,14 @@ documents along with the source code. But if we also take the python binding as
 the integration point for frameworks, we will need to provide documents via
 oneDNN document webpage.
 
-## Feature status
+## Decision
 
-We do see the value of exposing graph API python binding as a utility for
-library validation. But due to uncertainty of using the python API as an
-integration point for other frameworks besides PyTorch and the limitations of
-exposing runtime objects through python API as mentioned above, it's proposed to
-add the graph API python binding as an experimental feature for oneDNN firstly.
-We will track the python API usage in both library validation and frameworks
-integration and review its maturity in the future before converting it as a
-production feature of the library.
+Option 1 will bring PyTorch header dependencies for GPU support. With upstreaming
+GPU support this part can’t be ignored. Putting it into oneDNN will make it hard
+to keep oneDNN and PyTorch aligned. For example, if new PyTorch requires new
+bindings or headers, oneDNN will have to make a new release with updated bindings
+for PyTorch.
+
+The decision is to go with option 2 or 3, depending on PyTorch team's preference.
 
 (EOD)

--- a/rfcs/20230720-graph-python-api/README.md
+++ b/rfcs/20230720-graph-python-api/README.md
@@ -1,0 +1,188 @@
+# Graph API: Add Python binding
+
+## Motivation
+
+There are two major motivations for adding a python binding of oneDNN graph API
+in oneDNN repository.
+
+- It is easier to construct tests, examples, and bug reproducers with python
+  API. It helps to avoid boilerplate C++ code which requires explicit types and
+  declarations. It also helps to interoperate with other python packages. For
+  example, we can perform numeric correctness check with numpy or deep learning
+  frameworks easily with python code.
+- It is required by integrating oneDNN graph into PyTorch 2.0 torch.compile API.
+  Having the python binding inside oneDNN repository will largely reduce the
+  amount of integration code as well as the maintenance effort in PyTorch.
+  Otherwise, the framework developers will have to the binding on the framework
+  side (e.g., [PyTorch#105883](https://github.com/pytorch/pytorch/pull/105883)).
+
+Though it brings benefits, adding a python binding of graph API in oneDNN
+repository also introduces new challenges to oneDNN project. The design options
+and challenges will be discussed in the following sections.
+
+## Pybind11
+
+[Pybind11](https://github.com/pybind/pybind11) is widely used in the deep
+learning framework community for exposing C++ APIs and types through python
+binding and achieving the inter-operability between C++ and python. Pybind11 has
+been adopted in PyTorch, TensorFlow, and MLIR. More information about pybind11
+can be found at the
+[documentation](https://pybind11.readthedocs.io/en/stable/index.html).
+
+It is recommended to follow the convention in the deep learning community and
+use pybind11 for the python binding of graph API. With that, it requires to
+include pybind11 into oneDNN repository and build system. We can achieve that by
+either adding pybind11 as a git submodule of oneDNN or copying pybind11 source
+code into oneDNN repository. According to the existing maintenance methodology
+for gtest and xbyak source code in oneDNN, it is recommended to copy pybind11
+source code and maintain it inside oneDNN repository.
+
+[License of pybind11](https://github.com/pybind/pybind11/blob/master/LICENSE)
+allows it to be modified and redistributed.
+
+## Source code placement
+
+As the proposal is focusing on the python binding of oneDNN graph API, it is
+suggested to place pybind11 source code and the binding implementation into
+src/graph/ folder. A new folder src/graph/python/ will be created for the
+purpose.
+
+Test cases implemented with python API will be placed in tests/python/.
+
+## Implementation
+
+A PoC for the python binding code with pybind11 can be found in [the attachment
+of this RFC](./src/binding.cpp).
+
+## Build option
+
+Graph python API is an optional feature for oneDNN users. A new cmake option
+will be defined and exposed to control the feature at the library build stage.
+The new option will take effect only when the existing ONEDNN_BUILD_GRAPH option
+is enabled.
+
+With ONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON, the binding code will be built and a
+python package wheel will be generated in the build directory of oneDNN.
+
+| CMake option                      | Value               | Description |
+| ---                               | ---                 | ---         |
+| ONEDNN_BUILD_GRAPH_PYTHON_BINDING | ON / OFF (default)  | Enable / disable graph API python binding. |
+
+## Installation
+
+The users will need to install the python package wheel by themselves by
+executing, for example:
+
+```bash
+# The name dnng is just for demonstration and can be changed in implementation.
+ pip install dnng-0.2.0-cp37-cp37m-linux_x86_64.whl
+```
+
+After the installation, one can import the package in the corresponding python
+interpreter by:
+
+```python
+import dnng
+# or,
+from dnng import *
+```
+
+## Low level python API
+
+As demonstrated in the implementation, C++ APIs will be exposed through python
+binding directly without extra wrappers or abstractions. With thin and simple
+python binding layer, we can reduce the potential bugs in the binding code and
+python code, simplify the validation effort, and provide a similar programming
+model as the C++ API. Another reason of keeping python API low level is that it
+already meets the current requirements of PyTorch integration. But it also makes
+the python API less pythonic and less easy-of-use. High level python wrapper or
+modules can be added when the request emerges.
+
+The python code example for creating op and logical tensors as follows:
+
+```python
+from dnng import *
+
+# init op
+matmul0 = op(0, op.MatMul, "matmul0")
+matmul0.set_attr(op.transpose_a, False)
+matmul0.set_attr(op.transpose_b, True)
+
+lt0 = logical_tensor(0, logical_tensor.f32, [64, 1280], logical_tensor.strided, logical_tensor.variable)
+lt1 = logical_tensor(1, logical_tensor.f32, [1280, 1280], logical_tensor.strided, logical_tensor.constant)
+lt2 = logical_tensor(2, logical_tensor.f32, [64, 1280], logical_tensor.strided, logical_tensor.variable)
+
+matmul0.add_inputs([lt0, lt1])
+matmul0.add_output(lt2)
+
+# init graph
+g = graph(engine.cpu)
+g.add_op(matmul0, True)
+
+# finalize graph
+g.finalize()
+
+# get partitions
+p = g.get_partitions(partition.fusion)
+```
+
+## Runtime objects
+
+- Custom thread pool interface is not exposed and runtime threading object is
+  not supported on python API. The reason is that we have not found a way on the
+  framework side to extract runtime threading object, wrap it into a python
+  object, and pass it to the library through python API.
+- Similarly, allocator API is not exposed at this moment due to the same reason.
+  The API is not required by the current PyTorch inductor integration.
+- Passing tensor memory between numpy and oneDNN library through graph python
+  API without copy can be achieved with
+  [pybind11](https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#).
+  But passing tensor memory between frameworks and oneDNN library may need more
+  investigation. Currently, a workaround is developed on PyTorch side to pass
+  the memory buffer address as a python integer number into the library through
+  python API. The workaround has been validated with a set of models.
+- On GPU side, for testing purpose, we can rely on [dpctl
+  package](https://github.com/IntelPython/dpctl) to create and manage SYCL
+  runtime objects (queue, device, and context) and pass them to the library
+  through python API. It may require the frameworks to also integrate dpctl and
+  share the SYCL runtime objects between the framework and the library.
+
+## Versioning
+
+Graph API python binding shares the same versioning schema of oneDNN project and
+maintains backward compatibility in the minor versions under the same major
+version. The python API works with the library C++ implementation under the same
+commit. Adding a new C++ API may require to change the python binding code to
+expose the same functionality through python API.
+
+## Validation
+
+- As mentioned in the motivation, python API as a testing and validation utility
+  for the library, it does not require additional validation for the utility
+  itself.
+- Because python API is also used as the integration point for PyTorch, we need
+  to add basic API tests and backward compatibility tests in oneDNN library.
+- As the python binding layer is very thin by design, we can continue to rely on
+  the existing benchdnn graph test suites for the library performance and
+  correctness validation.
+
+## Documentation
+
+Graph python API will not be part of oneDNN specification. If we only take the
+python binding as a testing and validation utility, we will only need to provide
+documents along with the source code. But if we also take the python binding as
+the integration point for frameworks, we will need to provide documents via
+oneDNN document webpage.
+
+## Feature status
+
+We do see the value of exposing graph API python binding as a utility for
+library validation. But due to uncertainty of using the python API as an
+integration point for other frameworks besides PyTorch and the limitations of
+exposing runtime objects through python API as mentioned above, it's proposed to
+add the graph API python binding as an experimental feature for oneDNN firstly.
+We will track the python API usage in both library validation and frameworks
+integration and review its maturity in the future before converting it as a
+production feature of the library.
+
+(EOD)

--- a/rfcs/20230720-graph-python-api/README.md
+++ b/rfcs/20230720-graph-python-api/README.md
@@ -44,10 +44,10 @@ allows it to be modified and redistributed.
 
 As the proposal is focusing on the python binding of oneDNN graph API, it is
 suggested to place pybind11 source code and the binding implementation into
-src/graph/ folder. A new folder src/graph/python/ will be created for the
+`src/graph/` folder. A new folder `src/graph/python/` will be created for the
 purpose.
 
-Test cases implemented with python API will be placed in tests/python/.
+Test cases implemented with python API will be placed in `tests/python/`.
 
 ## Implementation
 
@@ -61,8 +61,8 @@ will be defined and exposed to control the feature at the library build stage.
 The new option will take effect only when the existing ONEDNN_BUILD_GRAPH option
 is enabled.
 
-With ONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON, the binding code will be built and a
-python package wheel will be generated in the build directory of oneDNN.
+With `ONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON`, the binding code will be built and
+a .so file will be generated in the build directory of oneDNN.
 
 | CMake option                      | Value               | Description |
 | ---                               | ---                 | ---         |
@@ -70,21 +70,37 @@ python package wheel will be generated in the build directory of oneDNN.
 
 ## Installation
 
-The users will need to install the python package wheel by themselves by
-executing, for example:
+There is no extra change for cmake building command except for setting
+`ONEDNN_BUILD_GRAPH_PYTHON_BINDING` to `ON`.
 
 ```bash
-# The name dnng is just for demonstration and can be changed in implementation.
- pip install dnng-0.2.0-cp37-cp37m-linux_x86_64.whl
+cmake -DONEDNN_BUILD_GRAPH=ON -DONEDNN_BUILD_GRAPH_PYTHON_BINDING=ON ..
+make -j
+```
+
+After building finished, an auto-generated file `setup.py` will be put
+under `${ONEDNN_ROOT}/dnnl_graph` folder.
+
+The users will need to build and install the python package wheel by themselves
+by executing commands, for example:
+
+```bash
+cd ${ONEDNN_ROOT}/dnnl_graph
+
+# or directly install via `python setup.py install`
+python setup.py bdist_wheel
+
+# The generated wheel file will be located at dist/ folder
+cd dist
+pip install dnnl_graph-3.2.0-cp310-cp310-linux_x86_64.whl
 ```
 
 After the installation, one can import the package in the corresponding python
 interpreter by:
 
 ```python
-import dnng
-# or,
-from dnng import *
+# or from dnnl_graph import *
+import dnnl_graph
 ```
 
 ## Low level python API
@@ -101,7 +117,7 @@ modules can be added when the request emerges.
 The python code example for creating op and logical tensors as follows:
 
 ```python
-from dnng import *
+from dnnl_graph import *
 
 # init op
 matmul0 = op(0, op.MatMul, "matmul0")

--- a/rfcs/20230720-graph-python-api/src/binding.cpp
+++ b/rfcs/20230720-graph-python-api/src/binding.cpp
@@ -1,0 +1,549 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "pybind11/numpy.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+#include <sstream>
+
+#include "oneapi/dnnl/dnnl_graph.hpp"
+
+#ifdef ONEDNN_BUILD_WITH_SYCL
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#elif __has_include(<CL/sycl.hpp>)
+#include <CL/sycl.hpp>
+#else
+#error "Unsupported compiler"
+#endif
+#include "dpctl4pybind11.hpp"
+#include "oneapi/dnnl/dnnl_graph_sycl.hpp"
+#endif
+
+using cpartition = dnnl::graph::compiled_partition;
+using engine = dnnl::graph::engine;
+using graph = dnnl::graph::graph;
+using logical_tensor = dnnl::graph::logical_tensor;
+using op = dnnl::graph::op;
+using partition = dnnl::graph::partition;
+using stream = dnnl::graph::stream;
+using tensor = dnnl::graph::tensor;
+
+namespace dnnl {
+namespace graph {
+namespace binding {
+
+void bind_cpartition(pybind11::module &m) {
+    pybind11::class_<cpartition> cp(m, "compiled_partition");
+
+    cp.def(pybind11::init<>());
+    cp.def("query_logical_tensor", &cpartition::query_logical_tensor);
+    cp.def("get_inplace_ports", &cpartition::get_inplace_ports);
+    cp.def("execute", &cpartition::execute);
+}
+
+const std::string engine_kind2str(engine::kind v) {
+    if (v == engine::kind::any) return "any";
+    if (v == engine::kind::cpu) return "cpu";
+    if (v == engine::kind::gpu) return "gpu";
+    return "unknown engine_kind";
+}
+
+auto eng2string = [](const engine &eng) {
+    std::stringstream ss;
+    ss << "engine(kind = " << engine_kind2str(eng.get_kind()) << ")";
+    return ss.str();
+};
+
+void bind_engine(pybind11::module &m) {
+    pybind11::class_<engine> eng(m, "engine");
+
+    eng.def(pybind11::init<engine::kind, int>());
+#ifdef ONEDNN_BUILD_WITH_SYCL
+    eng.def(pybind11::init([](const sycl::device &adevice,
+                                   const sycl::context &acontext) {
+        static dnnl::graph::allocator alloc {};
+        auto aengine = dnnl::graph::sycl_interop::make_engine_with_allocator(
+                adevice, acontext, alloc);
+        return aengine;
+    }));
+#endif
+    eng.def("get_kind", &engine::get_kind);
+    eng.def("__repr__", eng2string);
+
+    pybind11::enum_<engine::kind>(eng, "kind")
+            .value("any", engine::kind::any)
+            .value("cpu", engine::kind::cpu)
+            .value("gpu", engine::kind::gpu)
+            .export_values();
+}
+
+void bind_graph(pybind11::module &m) {
+    pybind11::class_<graph> g(m, "graph");
+
+    g.def(pybind11::init<engine::kind>());
+    g.def(pybind11::init<engine::kind, dnnl::graph::fpmath_mode>());
+    g.def("add_op", &graph::add_op);
+    g.def("finalize", &graph::finalize);
+    g.def("is_finalized", &graph::is_finalized);
+    g.def("get_partitions", &graph::get_partitions);
+
+    pybind11::enum_<dnnl::graph::fpmath_mode>(g, "fpmath_mode")
+            .value("strict", dnnl::graph::fpmath_mode::strict)
+            .value("bf16", dnnl::graph::fpmath_mode::bf16)
+            .value("f16", dnnl::graph::fpmath_mode::f16)
+            .value("any", dnnl::graph::fpmath_mode::any)
+            .value("tf32", dnnl::graph::fpmath_mode::tf32)
+            .export_values();
+}
+
+const std::string data_type2str(logical_tensor::data_type v) {
+#define CASE(x) \
+    case (logical_tensor::data_type::x): return #x
+
+    switch (v) {
+        CASE(undef);
+        CASE(f16);
+        CASE(bf16);
+        CASE(f32);
+        CASE(s32);
+        CASE(s8);
+        CASE(u8);
+        CASE(boolean);
+        default: return "unknown data type";
+    }
+
+#undef CASE
+}
+
+const std::string layout_type2str(logical_tensor::layout_type v) {
+    if (v == logical_tensor::layout_type::undef) return "undef";
+    if (v == logical_tensor::layout_type::any) return "any";
+    if (v == logical_tensor::layout_type::strided) return "strided";
+    if (v == logical_tensor::layout_type::opaque) return "opaque";
+    return "unknown layout_type";
+}
+
+const std::string dims2string(const std::vector<int64_t> &dims) {
+    std::stringstream ss;
+    ss << "(";
+    const char *delimer = "";
+    for (const auto &d : dims) {
+        ss << delimer << d;
+        delimer = ", ";
+    }
+    ss << ")";
+    return ss.str();
+};
+
+auto lt2string = [](const logical_tensor &lt) {
+    std::stringstream ss;
+    ss << "logical_tensor(id = " << lt.get_id()
+       << ", dtype = " << data_type2str(lt.get_data_type())
+       << ", layout = " << layout_type2str(lt.get_layout_type())
+       << ", shape = " << dims2string(lt.get_dims());
+    if (lt.get_layout_type() == logical_tensor::layout_type::opaque) {
+        ss << ", layout_id = " << lt.get_layout_id();
+    } else {
+        ss << ", stride = " << dims2string(lt.get_strides());
+    }
+    ss << ")";
+    return ss.str();
+};
+
+void bind_logical_tensor(pybind11::module &m) {
+    pybind11::class_<logical_tensor> lt(m, "logical_tensor");
+
+    lt.def(pybind11::init<size_t, logical_tensor::data_type, int32_t,
+            logical_tensor::layout_type, logical_tensor::property_type>());
+    lt.def(pybind11::init<size_t, logical_tensor::data_type,
+            logical_tensor::dims, logical_tensor::layout_type,
+            logical_tensor::property_type>());
+    lt.def(pybind11::init<size_t, logical_tensor::data_type,
+            logical_tensor::dims, logical_tensor::dims,
+            logical_tensor::property_type>());
+    lt.def("get_id", &logical_tensor::get_id);
+    lt.def("get_data_type", &logical_tensor::get_data_type);
+    lt.def("get_layout_type", &logical_tensor::get_layout_type);
+    lt.def("get_property_type", &logical_tensor::get_property_type);
+    lt.def("get_layout_id", &logical_tensor::get_layout_id);
+    lt.def("get_mem_size", &logical_tensor::get_mem_size);
+    lt.def("get_dims", &logical_tensor::get_dims);
+    lt.def("get_strides", &logical_tensor::get_strides);
+    lt.def("__repr__", lt2string);
+
+    pybind11::enum_<logical_tensor::data_type>(lt, "data_type")
+            .value("dt_undef", logical_tensor::data_type::undef)
+            .value("f16", logical_tensor::data_type::f16)
+            .value("bf16", logical_tensor::data_type::bf16)
+            .value("f32", logical_tensor::data_type::f32)
+            .value("s32", logical_tensor::data_type::s32)
+            .value("s8", logical_tensor::data_type::s8)
+            .value("u8", logical_tensor::data_type::u8)
+            .value("boolean", logical_tensor::data_type::boolean)
+            .export_values();
+
+    pybind11::enum_<logical_tensor::layout_type>(lt, "layout_type")
+            .value("lt_undef", logical_tensor::layout_type::undef)
+            .value("any", logical_tensor::layout_type::any)
+            .value("strided", logical_tensor::layout_type::strided)
+            .value("opaque", logical_tensor::layout_type::opaque)
+            .export_values();
+
+    pybind11::enum_<logical_tensor::property_type>(lt, "property_type")
+            .value("pt_undef", logical_tensor::property_type::undef)
+            .value("variable", logical_tensor::property_type::variable)
+            .value("constant", logical_tensor::property_type::constant)
+            .export_values();
+}
+
+template <class T>
+void set_op_attribute(op &aop, T x, op::attr attr) {
+    if (pybind11::isinstance<pybind11::list>(x)) {
+        if (pybind11::isinstance<pybind11::int_>(
+                    x.template cast<pybind11::list>()[0])) {
+            std::vector<int64_t> int_attr = {};
+            for (auto val : x.template cast<pybind11::list>()) {
+                int_attr.push_back(val.template cast<int64_t>());
+            }
+            aop.set_attr<std::vector<int64_t>>(attr, int_attr);
+        } else if (pybind11::isinstance<pybind11::float_>(
+                           x.template cast<pybind11::list>()[0])) {
+            std::vector<float> int_attr = {};
+            for (auto val : x.template cast<pybind11::list>()) {
+                int_attr.push_back(val.template cast<float>());
+            }
+            aop.set_attr<std::vector<float>>(attr, int_attr);
+        } else {
+            assert(!"unknown vector type");
+        }
+    } else if (pybind11::isinstance<pybind11::bool_>(x)) {
+        aop.set_attr<bool>(attr, x.template cast<bool>());
+    } else if (pybind11::isinstance<pybind11::int_>(x)) {
+        aop.set_attr<int64_t>(attr, x.template cast<int64_t>());
+    } else if (pybind11::isinstance<pybind11::float_>(x)) {
+        aop.set_attr<float>(attr, x.template cast<float>());
+    } else if (pybind11::isinstance<pybind11::str>(x)) {
+        aop.set_attr<std::string>(attr, x.template cast<std::string>());
+    } else {
+        assert(!"unknown attribute type");
+    }
+}
+
+void bind_op(pybind11::module &m) {
+    pybind11::class_<op> opr(m, "op");
+
+    opr.def(pybind11::init<size_t, op::kind, std::string>());
+    opr.def("set_attr", [](op &aop, op::attr key, pybind11::object val) {
+        set_op_attribute(aop, val, key);
+    });
+    opr.def("add_input", &op::add_input);
+    opr.def("add_inputs", &op::add_inputs);
+    opr.def("add_output", &op::add_output);
+    opr.def("add_outputs", &op::add_outputs);
+
+    pybind11::enum_<op::kind>(opr, "kind")
+            .value("Abs", op::kind::Abs)
+            .value("AbsBackward", op::kind::AbsBackward)
+            .value("Add", op::kind::Add)
+            .value("AvgPool", op::kind::AvgPool)
+            .value("AvgPoolBackward", op::kind::AvgPoolBackward)
+            .value("BatchNormForwardTraining",
+                    op::kind::BatchNormForwardTraining)
+            .value("BatchNormInference", op::kind::BatchNormInference)
+            .value("BatchNormTrainingBackward",
+                    op::kind::BatchNormTrainingBackward)
+            .value("BiasAdd", op::kind::BiasAdd)
+            .value("BiasAddBackward", op::kind::BiasAddBackward)
+            .value("Clamp", op::kind::Clamp)
+            .value("ClampBackward", op::kind::ClampBackward)
+            .value("Concat", op::kind::Concat)
+            .value("Convolution", op::kind::Convolution)
+            .value("ConvolutionBackwardData", op::kind::ConvolutionBackwardData)
+            .value("ConvolutionBackwardWeights",
+                    op::kind::ConvolutionBackwardWeights)
+            .value("ConvTranspose", op::kind::ConvTranspose)
+            .value("ConvTransposeBackwardData",
+                    op::kind::ConvTransposeBackwardData)
+            .value("ConvTransposeBackwardWeights",
+                    op::kind::ConvTransposeBackwardWeights)
+            .value("Dequantize", op::kind::Dequantize)
+            .value("Divide", op::kind::Divide)
+            .value("DynamicDequantize", op::kind::DynamicDequantize)
+            .value("DynamicQuantize", op::kind::DynamicQuantize)
+            .value("Elu", op::kind::Elu)
+            .value("EluBackward", op::kind::EluBackward)
+            .value("End", op::kind::End)
+            .value("Exp", op::kind::Exp)
+            .value("GELU", op::kind::GELU)
+            .value("GELUBackward", op::kind::GELUBackward)
+            .value("HardSigmoid", op::kind::HardSigmoid)
+            .value("HardSigmoidBackward", op::kind::HardSigmoidBackward)
+            .value("HardSwish", op::kind::HardSwish)
+            .value("HardSwishBackward", op::kind::HardSwishBackward)
+            .value("Interpolate", op::kind::Interpolate)
+            .value("InterpolateBackward", op::kind::InterpolateBackward)
+            .value("LayerNorm", op::kind::LayerNorm)
+            .value("LayerNormBackward", op::kind::LayerNormBackward)
+            .value("LeakyReLU", op::kind::LeakyReLU)
+            .value("Log", op::kind::Log)
+            .value("LogSoftmax", op::kind::LogSoftmax)
+            .value("LogSoftmaxBackward", op::kind::LogSoftmaxBackward)
+            .value("MatMul", op::kind::MatMul)
+            .value("Maximum", op::kind::Maximum)
+            .value("MaxPool", op::kind::MaxPool)
+            .value("MaxPoolBackward", op::kind::MaxPoolBackward)
+            .value("Minimum", op::kind::Minimum)
+            .value("Mish", op::kind::Mish)
+            .value("MishBackward", op::kind::MishBackward)
+            .value("Multiply", op::kind::Multiply)
+            .value("Pow", op::kind::Pow)
+            .value("PReLU", op::kind::PReLU)
+            .value("PReLUBackward", op::kind::PReLUBackward)
+            .value("Quantize", op::kind::Quantize)
+            .value("Reciprocal", op::kind::Reciprocal)
+            .value("ReduceL1", op::kind::ReduceL1)
+            .value("ReduceL2", op::kind::ReduceL2)
+            .value("ReduceMax", op::kind::ReduceMax)
+            .value("ReduceMean", op::kind::ReduceMean)
+            .value("ReduceMin", op::kind::ReduceMin)
+            .value("ReduceProd", op::kind::ReduceProd)
+            .value("ReduceSum", op::kind::ReduceSum)
+            .value("ReLU", op::kind::ReLU)
+            .value("ReLUBackward", op::kind::ReLUBackward)
+            .value("Reorder", op::kind::Reorder)
+            .value("Round", op::kind::Round)
+            .value("Select", op::kind::Select)
+            .value("Sigmoid", op::kind::Sigmoid)
+            .value("SigmoidBackward", op::kind::SigmoidBackward)
+            .value("SoftMax", op::kind::SoftMax)
+            .value("SoftMaxBackward", op::kind::SoftMaxBackward)
+            .value("SoftPlus", op::kind::SoftPlus)
+            .value("SoftPlusBackward", op::kind::SoftPlusBackward)
+            .value("Sqrt", op::kind::Sqrt)
+            .value("SqrtBackward", op::kind::SqrtBackward)
+            .value("Square", op::kind::Square)
+            .value("SquaredDifference", op::kind::SquaredDifference)
+            .value("StaticReshape", op::kind::StaticReshape)
+            .value("StaticTranspose", op::kind::StaticTranspose)
+            .value("Subtract", op::kind::Subtract)
+            .value("Tanh", op::kind::Tanh)
+            .value("TanhBackward", op::kind::TanhBackward)
+            .value("TypeCast", op::kind::TypeCast)
+            .value("Wildcard", op::kind::Wildcard)
+            .export_values();
+
+    pybind11::enum_<op::attr>(opr, "attr")
+            .value("undef", op::attr::undef)
+            .value("alpha", op::attr::alpha)
+            .value("beta", op::attr::beta)
+            .value("epsilon", op::attr::epsilon)
+            .value("max", op::attr::max)
+            .value("min", op::attr::min)
+            .value("momentum", op::attr::momentum)
+            .value("scales", op::attr::scales)
+            .value("axis", op::attr::axis)
+            .value("begin_norm_axis", op::attr::begin_norm_axis)
+            .value("groups", op::attr::groups)
+            .value("axes", op::attr::axes)
+            .value("dilations", op::attr::dilations)
+            .value("dst_shape", op::attr::dst_shape)
+            .value("kernel", op::attr::kernel)
+            .value("order", op::attr::order)
+            .value("output_padding", op::attr::output_padding)
+            .value("pads_begin", op::attr::pads_begin)
+            .value("pads_end", op::attr::pads_end)
+            .value("shape", op::attr::shape)
+            .value("sizes", op::attr::sizes)
+            .value("src_shape", op::attr::src_shape)
+            .value("strides", op::attr::strides)
+            .value("weights_shape", op::attr::weights_shape)
+            .value("zps", op::attr::zps)
+            .value("exclude_pad", op::attr::exclude_pad)
+            .value("keep_dims", op::attr::keep_dims)
+            .value("keep_stats", op::attr::keep_stats)
+            .value("per_channel_broadcast", op::attr::per_channel_broadcast)
+            .value("special_zero", op::attr::special_zero)
+            .value("transpose_a", op::attr::transpose_a)
+            .value("transpose_b", op::attr::transpose_b)
+            .value("use_affine", op::attr::use_affine)
+            .value("use_dst", op::attr::use_dst)
+            .value("auto_broadcast", op::attr::auto_broadcast)
+            .value("auto_pad", op::attr::auto_pad)
+            .value("coordinate_transformation_mode",
+                    op::attr::coordinate_transformation_mode)
+            .value("data_format", op::attr::data_format)
+            .value("mode", op::attr::mode)
+            .value("qtype", op::attr::qtype)
+            .value("rounding_type", op::attr::rounding_type)
+            .value("weights_format", op::attr::weights_format)
+            .export_values();
+}
+
+void bind_partition(pybind11::module &m) {
+    pybind11::class_<partition> p(m, "partition");
+
+    p.def(pybind11::init<>());
+    p.def("get_ops_num", &partition::get_ops_num);
+    p.def("get_ops", &partition::get_ops);
+    p.def("get_id", &partition::get_id);
+    p.def("is_supported", &partition::is_supported);
+    p.def("get_input_ports", &partition::get_input_ports);
+    p.def("get_output_ports", &partition::get_output_ports);
+    p.def("get_engine_kind", &partition::get_engine_kind);
+    p.def("compile", &partition::compile);
+
+    pybind11::enum_<partition::policy>(p, "policy")
+            .value("fusion", partition::policy::fusion)
+            .value("debug", partition::policy::debug)
+            .export_values();
+}
+
+void bind_stream(pybind11::module &m) {
+    pybind11::class_<stream> strm(m, "stream");
+
+    strm.def(pybind11::init<engine &>());
+    strm.def("wait", &stream::wait);
+}
+
+static size_t size_of(logical_tensor::data_type dtype) {
+    switch (dtype) {
+        case logical_tensor::data_type::f32:
+        case logical_tensor::data_type::s32: return 4U;
+        case logical_tensor::data_type::s8:
+        case logical_tensor::data_type::u8: return 1U;
+        case logical_tensor::data_type::f16:
+        case logical_tensor::data_type::bf16: return 2U;
+        case logical_tensor::data_type::boolean: return sizeof(bool);
+        default: return 0;
+    }
+}
+
+static std::string format_string(logical_tensor::data_type dtype) {
+    switch (dtype) {
+        case logical_tensor::data_type::f32:
+        case logical_tensor::data_type::f16:
+        case logical_tensor::data_type::bf16:
+            return pybind11::format_descriptor<float>::format();
+            break;
+        case logical_tensor::data_type::u8:
+            return pybind11::format_descriptor<uint8_t>::format();
+            break;
+        case logical_tensor::data_type::s8:
+            return pybind11::format_descriptor<int8_t>::format();
+            break;
+        case logical_tensor::data_type::boolean:
+            return pybind11::format_descriptor<bool>::format();
+            break;
+        case logical_tensor::data_type::s32:
+            return pybind11::format_descriptor<int32_t>::format();
+            break;
+        default: throw std::runtime_error("unknown data type");
+    }
+}
+
+pybind11::buffer_info to_buffer_info(tensor &t, logical_tensor &lt) {
+    auto strides = lt.get_strides();
+    auto shapes = lt.get_dims();
+    auto dtype = lt.get_data_type();
+    std::transform(strides.begin(), strides.end(), strides.begin(),
+            [&](int64_t i) { return i * size_of(dtype); });
+    return pybind11::buffer_info(t.get_data_handle(), /* Pointer to buffer */
+            size_of(dtype), /* Size of one scalar */
+            format_string(dtype), /* Python struct-style format descriptor */
+            shapes.size(), /* Number of dimensions */
+            shapes, /* Buffer dimensions */
+            strides);
+}
+
+void bind_tensor(pybind11::module &m) {
+    pybind11::class_<tensor> t(m, "tensor", pybind11::buffer_protocol());
+
+    t.def(pybind11::init(
+            [](logical_tensor &lt, engine &eng, pybind11::buffer b) {
+                auto bufinfo = b.request();
+                return tensor(lt, eng, bufinfo.ptr);
+            }));
+    t.def(pybind11::init([](logical_tensor &lt, engine &eng) {
+        return tensor(lt, eng, nullptr);
+    }));
+#ifdef ONEDNN_BUILD_WITH_SYCL
+    t.def(pybind11::init([](logical_tensor &lt, engine &eng,
+                                 dpctl::tensor::usm_ndarray matrix) {
+        return tensor(lt, eng, matrix.get_data());
+    }));
+#endif
+    t.def("get_engine", &tensor::get_engine);
+    t.def(
+            "from_numpy",
+            [](tensor &x, pybind11::buffer b) {
+                auto bufinfo = b.request();
+                x.set_data_handle(bufinfo.ptr);
+            },
+            pybind11::arg("b"));
+    t.def(
+            "to_numpy",
+            [](tensor &x, logical_tensor &lt) {
+                auto bufinfo = to_buffer_info(x, lt);
+                return pybind11::array(bufinfo);
+            },
+            pybind11::arg("lt"));
+}
+
+void bind_status(pybind11::module &m) {
+    pybind11::enum_<dnnl::graph::status>(m, "status")
+            .value("success", dnnl::graph::status::success)
+            .value("out_of_memory", dnnl::graph::status::out_of_memory)
+            .value("invalid_arguments", dnnl::graph::status::invalid_arguments)
+            .value("unimplemented", dnnl::graph::status::unimplemented)
+            .value("last_impl_reached", dnnl::graph::status::last_impl_reached)
+            .value("runtime_error", dnnl::graph::status::runtime_error)
+            .value("not_required", dnnl::graph::status::not_required)
+            .value("invalid_graph", dnnl::graph::status::invalid_graph)
+            .value("invalid_graph_op", dnnl::graph::status::invalid_graph_op)
+            .value("invalid_shape", dnnl::graph::status::invalid_shape)
+            .value("invalid_data_type", dnnl::graph::status::invalid_data_type)
+            .export_values();
+}
+
+void bind(pybind11::module &m) {
+    m.doc() = R"pbdoc(
+        oneDNN Graph API Python binding
+        -------------------------------
+        .. currentmodule:: dnng
+        .. autosummary::
+           :toctree: _generate
+    )pbdoc";
+
+    bind_status(m);
+    bind_graph(m);
+    bind_logical_tensor(m);
+    bind_engine(m);
+    bind_op(m);
+    bind_tensor(m);
+    bind_partition(m);
+    bind_cpartition(m);
+    bind_stream(m);
+}
+
+PYBIND11_MODULE(dnng, m) {
+    bind(m);
+}
+
+} // namespace binding
+} // namespace graph
+} // namespace dnnl


### PR DESCRIPTION
This is to propose adding python binding for onDNN graph API.

The rendered document can be found at [link](https://github.com/TaoLv/mkl-dnn/blob/lvtao/rfc/python-api/rfcs/20230720-graph-python-api/README.md).