### PR TITLE
src:cpu:aarc64: extend ACL max pooling primitive

### DIFF
--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2023 Intel Corporation
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -139,15 +139,6 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
         res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
         return;
     }
-
-#if DNNL_AARCH64_USE_ACL
-    // Since ACL supports only forward pass.
-    // Ref: https://github.com/oneapi-src/oneDNN/issues/1205
-    if (prb->dir & FLAG_BWD) {
-        res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
-        return;
-    }
-#endif
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/gtests/test_pooling_backward.cpp
+++ b/tests/gtests/test_pooling_backward.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2016-2023 Intel Corporation
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#ifndef DNNL_AARCH64_USE_ACL // Ref: https://github.com/oneapi-src/oneDNN/issues/1205
 
 #include "dnnl_test_common.hpp"
 #include "gtest/gtest.h"
@@ -1189,4 +1188,3 @@ GPU_INSTANTIATE_TEST_SUITE_P(TestPooling_ncdhw, pooling_bwd_test_float,
                                 5, 5, 5, 1, 1, 1, 1, 1, 1)}));
 
 } // namespace dnnl
-#endif // DNNL_AARCH64_USE_ACL

--- a/tests/gtests/test_pooling_forward.cpp
+++ b/tests/gtests/test_pooling_forward.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2016-2023 Intel Corporation
+* Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -359,11 +360,6 @@ using pooling_test_s8 = pooling_test_t<int8_t>;
 using pooling_test_u8 = pooling_test_t<uint8_t>;
 using pooling_test_s32 = pooling_test_t<int32_t>;
 using pool_test_params_float = pool_test_params_t;
-
-// Since ACL supports only forward, to avoid triggering workspace check which is not available.
-#if DNNL_AARCH64_USE_ACL
-#define forward_training forward_inference
-#endif
 
 // sizes with explicit opposite side paddings
 #define EXPAND_SIZES_3D_XPADD(...) \


### PR DESCRIPTION
# Description

This patch extends the current Compute Library for the Arm® architecture (ACL) implementation of the pooling primitive to also include forward training cases for max pooling, and to include previously rejected cases where padding >= kernel size.
When benchmarking on a Neoverse-N1 cpu, The additional cases are up to 40x faster than oneDNN reference kernels. The results are similar on Neoverse-V1. The included performance heuristic has been updated to cover new cases, and avoid selecting ACL when reference kernels are faster. For instance, for thread count > 1, in the max pooling forward training cases, and with memory format NHWC, ACL is faster than reference when the per thread problem size is larger than 2048. (here problem size is defined as MB x IC x OH x OW x KH x KW).

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
