### PR TITLE
src:cpu:aarch64 add closing bracket to mayiuse_bf16

### DIFF
--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -215,6 +215,8 @@ static inline bool mayiuse_atomic() {
 static inline bool mayiuse_bf16() {
     using namespace Xbyak_aarch64::util;
     return cpu().isBf16Supported();
+}
+
 } // namespace
 
 /* whatever is required to generate string literals... */


### PR DESCRIPTION
# Description
Adds a missing closing bracket to mayiuse_bf16() based off of [this PR](https://github.com/oneapi-src/oneDNN/pull/1594).
To reproduce, simply build for aarch on master which produces errors such as...
```
/code/oneDNN/src/cpu/aarch64/cpu_isa_traits.hpp:38:16: note: to match this '{'

   38 | namespace dnnl {
      |                ^

make[1]: *** [CMakeFiles/Makefile2:540: src/common/CMakeFiles/dnnl_common.dir/all] Error 2

[ 32%] Built target dnnl_cpu_aarch64_xbyak_aarch64

make[1]: *** [CMakeFiles/Makefile2:566: src/cpu/CMakeFiles/dnnl_cpu.dir/all] Error 2

make: *** [Makefile:146: all] Error 2
```
# Checklist
## General
- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
## Performance improvements
- [ ] Have you submitted performance data that demonstrates performance improvements? N/A
### Bug fixes
- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests? N/A