### PR TITLE
tests:cpu:aarch64 Fix failing deconv tests related to f64 data type.

### DIFF
--- a/src/common/deconvolution_pd.hpp
+++ b/src/common/deconvolution_pd.hpp
@@ -170,6 +170,8 @@ protected:
         return ok;
     }
 
+    /// This function body follows
+    /// convolution_pd_t::expect_data_types(...)
     bool expect_data_types(data_type_t src_dt, data_type_t wei_dt,
             data_type_t bia_dt, data_type_t dst_dt) const {
         bool ok = true

--- a/src/common/deconvolution_pd.hpp
+++ b/src/common/deconvolution_pd.hpp
@@ -169,6 +169,20 @@ protected:
         }
         return ok;
     }
+
+    bool expect_data_types(data_type_t src_dt, data_type_t wei_dt,
+            data_type_t bia_dt, data_type_t dst_dt) const {
+        bool ok = true
+                && (src_dt == data_type::undef
+                        || invariant_src_md()->data_type == src_dt)
+                && (wei_dt == data_type::undef
+                        || invariant_wei_md()->data_type == wei_dt)
+                && (dst_dt == data_type::undef
+                        || invariant_dst_md()->data_type == dst_dt);
+        if (with_bias() && bia_dt != data_type::undef)
+            ok = ok && invariant_bia_md()->data_type == bia_dt;
+        return ok;
+    }
 };
 
 struct deconvolution_fwd_pd_t : public deconvolution_pd_t {

--- a/src/cpu/aarch64/acl_deconvolution.hpp
+++ b/src/cpu/aarch64/acl_deconvolution.hpp
@@ -107,6 +107,8 @@ struct acl_deconvolution_fwd_t : public primitive_t {
             const bool ok = is_fwd() // Only forward deconvolutions
                     && utils::one_of(
                             desc()->alg_kind, alg_kind::deconvolution_direct)
+                    && (expect_data_types(f16, f16, f16, f16)
+                            || expect_data_types(f32, f32, f32, f32))
                     && attr()->has_default_values(
                             primitive_attr_t::skip_mask_t::post_ops,
                             dst_data_t);
@@ -153,7 +155,6 @@ struct acl_deconvolution_fwd_t : public primitive_t {
                     = desc_.bias_desc.format_kind != format_kind::undef;
 
             // Data type
-
             auto acl_src_data_t = acl_utils::get_acl_data_t(src_data_t);
             auto acl_wei_data_t = acl_utils::get_acl_data_t(wei_data_t);
             auto acl_dst_data_t = acl_utils::get_acl_data_t(dst_data_t);


### PR DESCRIPTION
# Description

This PR provides a fix for deconv test failures related to the f64 data type. This failure was exposed by the recent changes to how groups are handled in BenchDNN, which has seen previously skipped cases being dispatched to ACL (including these f64 ones). The test failures were observed when calling deconv functions from Compute Library for the Arm(r) architecture (ACL). Benchdnn's failure test is:

ctest -R test_benchdnn_deconv_ci_cpu

The test failed due to an issue with the ACL not having deconv operation for f64 data type. This resulted in an invalid data type error and caused the failure. To mitigate this problem, this PR checks the validity of the data type before it reaches the ACL, and skips the test when necessary to prevent further issues.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?