### PR TITLE
Fix performance degradation from oneDNN 3.1 to oneDNN 3.2

### DIFF
--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -346,7 +346,8 @@ algorithms:
   Networks by A. Lavin and S. Gray](https://arxiv.org/abs/1509.09308). The
   Winograd algorithm often results in the best performance, but it is
   applicable only to particular shapes. Winograd supports
-  GPU (f16 and f32).
+  GPU (f16 and f32) and AArch64 CPU engines. Winograd does not support
+  threadpool on AArch64 CPU engines.
 
 - _Implicit GEMM_. The convolution operation is reinterpreted in terms of
   matrix-matrix multiplication by rearranging the source data into a
@@ -376,7 +377,8 @@ fall back to an explicit GEMM algorithm.
 @anchor dg_winograd_conv
 ### Winograd Convolution
 
-oneDNN supports the Winograd convolution algorithm only on GPU engine.
+oneDNN supports the Winograd convolution algorithm on GPU and AArch64 CPU systems.
+Winograd does not support threadpool on AArch64 CPU systems.
 
 The following side effects should be weighed against the (potential)
 performance boost achieved from using the Winograd algorithm:

--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -205,7 +205,7 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
     // clang-format on
 
     // ACL Winograd is not prepared for fixed format kernels
-    if (cd.alg_kind == alg_kind::convolution_winograd) {
+    if (acp.alg_winograd) {
         const bool is_1d = ndims == 3;
         const bool is_3d = ndims == 5;
         // Compute Library Winograd unsupported shape scenarios
@@ -370,6 +370,7 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
     // clang-format on
 
     // General Compute Library checks, memory tags are also set there
+    acp.alg_winograd = true;
     CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
 
     const bool shape_ok

--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -351,7 +351,6 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
     return status::success;
 }
 
-#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
 status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
@@ -399,7 +398,6 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
 
     return status::success;
 }
-#endif
 
 status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -42,6 +42,10 @@ struct acl_conv_conf_t {
     // If this is true, the result of the convolution goes into a temporarily
     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
     bool use_dst_acc;
+    // Tells that the selected algorithm is Winograd. This is needed because the
+    // algorithm can be set to algorithm::convolution_auto and later on we need to
+    // skip fixed-format protocol as ACL Winograd does not support it.
+    bool alg_winograd;
     arm_compute::TensorInfo src_tensor_info;
     arm_compute::TensorInfo wei_tensor_info;
     arm_compute::TensorInfo bia_tensor_info;

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -71,6 +71,12 @@ status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
         const primitive_attr_t &attr);
 
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, const convolution_desc_t &cd,
+        const primitive_attr_t &attr);
+#endif
 } // namespace acl_convolution_utils
 
 template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,

--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -71,12 +71,10 @@ status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
         const primitive_attr_t &attr);
 
-#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
 status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
         const primitive_attr_t &attr);
-#endif
 } // namespace acl_convolution_utils
 
 template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,

--- a/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+++ b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
@@ -71,7 +71,9 @@ void process_workloads(std::vector<IScheduler::Workload> &workloads,
 }
 
 ThreadpoolScheduler::ThreadpoolScheduler() {
-    _num_threads = num_threads_hint();
+    using namespace dnnl::impl::threadpool_utils;
+    // Set number of threads to one when threadpool is not available.
+    _num_threads = get_active_threadpool() == nullptr ? 1 : num_threads_hint();
 }
 
 ThreadpoolScheduler::~ThreadpoolScheduler() = default;

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright 2020-2023 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_winograd_convolution.hpp"
+
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+status_t acl_wino_convolution_fwd_t::execute_forward(
+        const exec_ctx_t &ctx) const {
+    // Lock here is needed because resource_mapper does not support
+    // concurrent multithreaded access.
+    std::lock_guard<std::mutex> _lock {this->mtx};
+    // Retrieve primitive resource and configured Compute Library objects
+    auto *acl_resource
+            = ctx.get_resource_mapper()->get<acl_wino_resource_t>(this);
+    acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &acl_wino_obj
+            = acl_resource->get_acl_obj();
+
+    return execute_forward_conv_acl<
+            acl_obj_t<arm_compute::NEWinogradConvolutionLayer>, pd_t, data_t>(
+            ctx, acl_wino_obj, pd());
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -16,8 +16,6 @@
 
 #include "cpu/aarch64/acl_winograd_convolution.hpp"
 
-#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
-
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -43,5 +41,3 @@ status_t acl_wino_convolution_fwd_t::execute_forward(
 } // namespace cpu
 } // namespace impl
 } // namespace dnnl
-
-#endif // DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -1,0 +1,151 @@
+/*******************************************************************************
+* Copyright 2020-2023 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+#define CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+
+#include "cpu/cpu_convolution_pd.hpp"
+
+#include "cpu/aarch64/acl_convolution_utils.hpp"
+
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct acl_wino_resource_t : public resource_t {
+    acl_wino_resource_t()
+        : acl_wino_obj_(utils::make_unique<
+                acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>()) {}
+
+    status_t configure(const acl_conv_conf_t &acp) {
+        if (!acl_wino_obj_) return status::out_of_memory;
+
+        // Init Compute Library tensors based on info from descriptor
+        acl_wino_obj_->src_tensor.allocator()->init(acp.src_tensor_info);
+        acl_wino_obj_->wei_tensor.allocator()->init(acp.wei_tensor_info);
+        acl_wino_obj_->dst_tensor.allocator()->init(acp.dst_tensor_info);
+        acl_wino_obj_->bia_tensor.allocator()->init(acp.bia_tensor_info);
+
+        // clang-format off
+        acl_wino_obj_->conv.configure(
+            &acl_wino_obj_->src_tensor,
+            &acl_wino_obj_->wei_tensor,
+            acp.with_bias ? &acl_wino_obj_->bia_tensor : nullptr,
+            &acl_wino_obj_->dst_tensor,
+            acp.padstride_info,
+            acp.act_info,
+            true); // to support 5x5, 7x7 filter shapes in addition to 3x3
+        // clang-format on
+
+        return status::success;
+    }
+
+    acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &get_acl_obj() const {
+        return *acl_wino_obj_;
+    }
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_wino_resource_t);
+
+private:
+    std::unique_ptr<acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>
+            acl_wino_obj_;
+}; // acl_wino_resource_t
+
+struct acl_wino_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
+            , acp_()
+            , post_ops() {}
+
+        DECLARE_COMMON_PD_T(
+                "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, f16);
+            const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, f32);
+            bool ok = is_fwd()
+                    && utils::one_of(desc()->alg_kind,
+                            alg_kind::convolution_auto,
+                            alg_kind::convolution_winograd)
+                    && utils::one_of(true, is_fp16_ok, is_fp32_ok)
+                    && !has_zero_dim_memory();
+            if (!ok) return status::unimplemented;
+
+            CHECK(acl_convolution_utils::init_conf_wino(acp_, src_md_,
+                    weights_md_, dst_md_, bias_md_, *desc(), *attr()));
+
+            set_default_alg_kind(alg_kind::convolution_winograd);
+
+            CHECK(post_ops.init(
+                    engine, attr_.post_ops_, dst_md_, acp_.act_info));
+            acp_.use_dst_acc = post_ops.has_sum();
+
+            return status::success;
+        }
+
+        acl_conv_conf_t acp_;
+        acl_post_ops_t post_ops;
+    };
+
+    acl_wino_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const override {
+        if (mapper.has_resource(this)) return status::success;
+
+        auto r = utils::make_unique<acl_wino_resource_t>();
+        if (!r) return status::out_of_memory;
+
+        // Configure the resource based on information from primitive descriptor
+        CHECK(r->configure(pd()->acp_));
+        mapper.add(this, std::move(r));
+
+        CHECK(pd()->post_ops.create_resource(engine, mapper));
+
+        return status::success;
+    }
+
+    ~acl_wino_convolution_fwd_t() {}
+
+    typedef typename prec_traits<data_type::f32>::type data_t;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    // To guard the const execute_forward(), the mutex must be 'mutable'
+    mutable std::mutex mtx;
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+}; // acl_wino_convolution_fwd_t
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+#endif // CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -21,7 +21,6 @@
 
 #include "cpu/aarch64/acl_convolution_utils.hpp"
 
-#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -91,6 +90,8 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
                             alg_kind::convolution_winograd)
                     && utils::one_of(true, is_fp16_ok, is_fp32_ok)
                     && !has_zero_dim_memory();
+
+            ok = ok && DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL;
             if (!ok) return status::unimplemented;
 
             CHECK(acl_convolution_utils::init_conf_wino(acp_, src_md_,
@@ -147,5 +148,4 @@ private:
 } // namespace impl
 } // namespace dnnl
 
-#endif // DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
 #endif // CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -24,7 +24,77 @@ namespace matmul {
 
 using namespace data_type;
 
-status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
+status_t acl_matmul_t::execute_forward_non_fixed_format(
+        const exec_ctx_t &ctx) const {
+
+    status_t status = status::success;
+    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+
+    bool is_transA = pd()->amp_.is_transA;
+    bool is_transB = pd()->amp_.is_transB;
+    bool use_dst_acc = pd()->amp_.use_dst_acc;
+
+    std::lock_guard<std::mutex> _lock {this->mtx};
+    auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
+    acl_matmul_obj_t &acl_obj = acl_resource->get_acl_obj();
+    // Run transpose kernel
+    if (is_transA && !is_transB) {
+        acl_obj.src_tensor.allocator()->allocate();
+        acl_obj.src_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(src_base));
+        acl_obj.transA.run();
+        acl_obj.wei_tensor.allocator()->import_memory(
+                const_cast<data_t *>(wei_base));
+    } else if (is_transB && !is_transA) {
+        acl_obj.wei_tensor.allocator()->allocate();
+        acl_obj.wei_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(wei_base));
+        acl_obj.transB.run();
+        acl_obj.src_tensor.allocator()->import_memory(
+                const_cast<data_t *>(src_base));
+    } else if (is_transA && is_transB) {
+        acl_obj.src_tensor.allocator()->allocate();
+        acl_obj.src_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(src_base));
+        acl_obj.wei_tensor.allocator()->allocate();
+        acl_obj.wei_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(wei_base));
+        acl_obj.transA.run();
+        acl_obj.transB.run();
+    } else {
+        acl_obj.src_tensor.allocator()->import_memory(
+                const_cast<data_t *>(src_base));
+        acl_obj.wei_tensor.allocator()->import_memory(
+                const_cast<data_t *>(wei_base));
+    }
+
+    if (use_dst_acc) {
+        // Put the result in a new tensor, it will be accumulated to the dst
+        // during the post ops
+        acl_obj.dst_tensor.allocator()->allocate();
+    } else {
+        auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+        acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+    }
+
+    acl_obj.gemm.run();
+
+    acl_obj.src_tensor.allocator()->free();
+    acl_obj.wei_tensor.allocator()->free();
+    if (is_transA) acl_obj.src_acc_tensor.allocator()->free();
+    if (is_transB) acl_obj.wei_acc_tensor.allocator()->free();
+
+    void *dst = acl_obj.dst_tensor.buffer();
+    pd()->post_ops.execute(ctx, dst);
+
+    acl_obj.dst_tensor.allocator()->free();
+
+    return status;
+}
+
+status_t acl_matmul_t::execute_forward_fixed_format(
+        const exec_ctx_t &ctx) const {
 
     status_t status = status::success;
     auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -17,9 +17,9 @@
 #ifndef ACL_MATMUL_HPP
 #define ACL_MATMUL_HPP
 
-#include "cpu/aarch64/matmul/acl_matmul_utils.hpp"
-
+#include "common/utils.hpp"
 #include "cpu/aarch64/acl_post_ops.hpp"
+#include "cpu/aarch64/matmul/acl_matmul_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -106,6 +106,11 @@ struct acl_matmul_t : public primitive_t {
                 CHECK(acl_matmul_utils::init_conf_matmul_fixed_format(
                         amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
             } else {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+                // to avoid seg. fault in case threadpool is enabled and its pointer is null
+                if (threadpool_utils::get_active_threadpool() == nullptr)
+                    return status::unimplemented;
+#endif
                 CHECK(acl_matmul_utils::init_conf_matmul_non_fixed_format(
                         amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
             }

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -58,7 +58,7 @@ status_t init_conf_matmul_fixed_format(acl_matmul_conf_t &amp,
     // must be the outermost
     using namespace format_tag;
     auto src_tag = memory_desc_matches_one_of_tag(
-            src_md, acdb, abcd, abdc, abc, acb, ab, ba);
+            src_md, abcd, abdc, abc, acb, ab, ba);
     auto dst_tag = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab, ba);
     ACL_CHECK_SUPPORT(utils::one_of(format_tag::undef, src_tag, dst_tag),
             "Format tag is undefined");

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -82,12 +82,6 @@ status_t init_conf_matmul_fixed_format(acl_matmul_conf_t &amp,
     amp.dst_tensor_info = arm_compute::TensorInfo(
             arm_compute::TensorShape(N, M, 1, dst_batch), 1, acl_dst_data_t);
 
-    // Set alpha (output scaling)
-    // TODO: Add runtime scales support. Creation time scales will be remove
-    // in 3.0.
-    amp.alpha = 1.0f; // default value
-    if (!attr.output_scales_.has_default_values()) return status::unimplemented;
-
     // Validate ACL transpose
     if (amp.is_transA)
         ACL_CHECK_VALID(arm_compute::NETranspose::validate(
@@ -108,7 +102,7 @@ status_t init_conf_matmul_fixed_format(acl_matmul_conf_t &amp,
     arm_compute::WeightFormat expected_weight_format;
     ACL_CHECK_VALID(arm_compute::NEGEMM::has_opt_impl(expected_weight_format,
             &amp.src_tensor_info, &amp.wei_tensor_info, nullptr,
-            &amp.dst_tensor_info, amp.alpha, 0.0f, amp.gemm_info));
+            &amp.dst_tensor_info, 1.0f, 0.0f, amp.gemm_info));
 
     // Set gemm weights info to the one returned by has_opt_impl
     amp.gemm_info.set_weight_format(expected_weight_format);
@@ -197,12 +191,6 @@ status_t init_conf_matmul_non_fixed_format(acl_matmul_conf_t &amp,
     bool is_fastmath_enabled = utils::one_of(
             attr.fpmath_mode_, fpmath_mode::bf16, fpmath_mode::any);
     amp.gemm_info.set_fast_math(is_fastmath_enabled);
-
-    // Set alpha (output scaling)
-    // TODO: Add runtime scales support. Creation time scales will be remove
-    // in 3.0.
-    amp.alpha = 1.0f; // default value
-    if (!attr.output_scales_.has_default_values()) return status::unimplemented;
 
     // Validate ACL transpose
     if (amp.is_transA)

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -29,19 +29,23 @@ namespace aarch64 {
 struct acl_matmul_obj_t {
     arm_compute::NEGEMM gemm;
     arm_compute::NETranspose transA;
+    arm_compute::NETranspose transB;
     arm_compute::Tensor src_tensor;
     arm_compute::Tensor src_acc_tensor;
+    arm_compute::Tensor wei_acc_tensor;
     arm_compute::Tensor wei_tensor;
     arm_compute::Tensor dst_tensor;
 };
 
 struct acl_matmul_conf_t {
     bool is_transA;
+    bool is_transB;
     // If this is true, the result of the matmul goes into a temporarily
     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
     bool use_dst_acc;
     arm_compute::TensorInfo src_tensor_info;
     arm_compute::TensorInfo src_acc_info;
+    arm_compute::TensorInfo wei_acc_info;
     arm_compute::TensorInfo wei_tensor_info;
     arm_compute::TensorInfo dst_tensor_info;
     arm_compute::GEMMInfo gemm_info;
@@ -50,9 +54,13 @@ struct acl_matmul_conf_t {
 
 namespace acl_matmul_utils {
 
-status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
-        memory_desc_t &wei_md, memory_desc_t &dst_md, const matmul_desc_t &md,
-        const primitive_attr_t &attr);
+status_t init_conf_matmul_fixed_format(acl_matmul_conf_t &amp,
+        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
+        const matmul_desc_t &md, const primitive_attr_t &attr);
+
+status_t init_conf_matmul_non_fixed_format(acl_matmul_conf_t &amp,
+        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
+        const matmul_desc_t &md, const primitive_attr_t &attr);
 
 } // namespace acl_matmul_utils
 

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -64,6 +64,9 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/acl_depthwise_convolution.hpp"
 #include "cpu/aarch64/acl_gemm_convolution.hpp"
 #include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+#include "cpu/aarch64/acl_winograd_convolution.hpp"
+#endif
 #endif
 using namespace dnnl::impl::cpu::aarch64;
 #endif
@@ -101,6 +104,9 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_SSE41(jit_sse41_1x1_convolution_fwd_t)
             CPU_INSTANCE_AVX2(jit_avx2_convolution_fwd_t)
             CPU_INSTANCE_SSE41(jit_sse41_convolution_fwd_t)
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+            CPU_INSTANCE_AARCH64_ACL(acl_wino_convolution_fwd_t)
+#endif
             CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
             CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
             CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
@@ -182,6 +188,9 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2, true>)
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+            CPU_INSTANCE_AARCH64_ACL(acl_wino_convolution_fwd_t)
+#endif
             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f16>)
             CPU_INSTANCE(ref_convolution_fwd_t)

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -64,9 +64,7 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/acl_depthwise_convolution.hpp"
 #include "cpu/aarch64/acl_gemm_convolution.hpp"
 #include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
-#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
 #include "cpu/aarch64/acl_winograd_convolution.hpp"
-#endif
 #endif
 using namespace dnnl::impl::cpu::aarch64;
 #endif
@@ -104,9 +102,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_SSE41(jit_sse41_1x1_convolution_fwd_t)
             CPU_INSTANCE_AVX2(jit_avx2_convolution_fwd_t)
             CPU_INSTANCE_SSE41(jit_sse41_convolution_fwd_t)
-#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
             CPU_INSTANCE_AARCH64_ACL(acl_wino_convolution_fwd_t)
-#endif
             CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
             CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
             CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
@@ -188,9 +184,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2, true>)
-#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
             CPU_INSTANCE_AARCH64_ACL(acl_wino_convolution_fwd_t)
-#endif
             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f16>)
             CPU_INSTANCE(ref_convolution_fwd_t)

--- a/tests/gtests/test_iface_wino_convolution.cpp
+++ b/tests/gtests/test_iface_wino_convolution.cpp
@@ -53,6 +53,12 @@ protected:
         const bool is_gpu = get_test_engine_kind() == engine::kind::gpu;
         input_f32.wino_supported = is_gpu;
         input_f16.wino_supported = is_gpu;
+#elif DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+        const bool is_cpu = get_test_engine_kind() == engine::kind::cpu;
+        input_f32.wino_supported = is_cpu;
+        input_f16.wino_supported = is_cpu;
+#endif
 #endif
     }
 };


### PR DESCRIPTION
# Description

This is to fix a matmul performance degradation from oneDNN 3.1 to oneDNN 3.2, as reported by
https://github.com/oneapi-src/oneDNN/issues/1691. The regression is a side effect of the implementation
of support for fixed format kernels from Compute Library for the Arm(r) architecture (ACL). As a result,
oneDNN falls back to the ref. impl. when memory::format_tag::any for the weights input is not selected.
This change re-enables support for other memory formats by passing the work to non fixed-format kernels
in these cases.

This update, in addition, restores the ACL Winograd convolution implementation that was previously
removed.

In general, the performance improvement brought by this fix is:

   * matmul: >500x improvement for Neoverse-V1.
   * winograd: >3x for Neoverse-V1.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
    At the present, we have a failing test (cpu-tutorials-matmul-matmul-quantization-cpp) when using
    oneDNN with Threadpool and is reported here https://github.com/oneapi-src/oneDNN/issues/1719.
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?