### PR TITLE
Fix issue #1727 pooling primitive fail

### DIFF
--- a/src/gpu/nvidia/cudnn_pooling.hpp
+++ b/src/gpu/nvidia/cudnn_pooling.hpp
@@ -42,6 +42,8 @@ struct cudnn_pooling_common_t {
         const auto src_size = src_wrap.nelems();
         const auto dst_size = dst_wrap.nelems();
 
+        // Add a byte of extra memory in abx case to ensure the hash generated
+        // is different from the axb case. This is a workaround for issue #1727
         const auto tag = get_tag(is_fwd ? *pd->dst_md() : *pd->diff_dst_md());
         dim_t ws_offset = 0;
         if (utils::one_of(tag, format_tag::ab, format_tag::abc,

--- a/src/gpu/nvidia/cudnn_pooling.hpp
+++ b/src/gpu/nvidia/cudnn_pooling.hpp
@@ -41,7 +41,15 @@ struct cudnn_pooling_common_t {
 
         const auto src_size = src_wrap.nelems();
         const auto dst_size = dst_wrap.nelems();
-        const dims_t ws_size = {(dim_t)(src_size + dst_size)};
+
+        const auto tag = get_tag(is_fwd ? *pd->dst_md() : *pd->diff_dst_md());
+        dim_t ws_offset = 0;
+        if (utils::one_of(tag, format_tag::ab, format_tag::abc,
+                    format_tag::abcd, format_tag::abcde)) {
+            ws_offset = 1;
+        }
+
+        const dims_t ws_size = {(dim_t)(src_size + dst_size + ws_offset)};
 
         memory_desc_init_by_tag(
                 ws_md, 1, ws_size, src_wrap.data_type(), format_tag::x);

--- a/src/gpu/nvidia/cudnn_pooling.hpp
+++ b/src/gpu/nvidia/cudnn_pooling.hpp
@@ -44,7 +44,7 @@ struct cudnn_pooling_common_t {
 
         // Add a byte of extra memory in abx case to ensure the hash generated
         // is different from the axb case. This is a workaround for issue #1727
-        const auto tag = get_tag(is_fwd ? *pd->dst_md() : *pd->diff_dst_md());
+        const auto tag = get_tag(is_fwd ? *pd->src_md() : *pd->diff_src_md());
         dim_t ws_offset = 0;
         if (utils::one_of(tag, format_tag::ab, format_tag::abc,
                     format_tag::abcd, format_tag::abcde)) {
@@ -185,7 +185,7 @@ struct cudnn_pooling_bwd_t : public primitive_t {
                             has_bf16_support(sycl_engine->device()));
             if (!ok) return status::unimplemented;
 
-            init_mem_by_tag(get_tag(diff_dst_md_), diff_src_md_);
+            init_mem_by_tag(get_tag(*hint_fwd_pd_->src_md()), diff_src_md_);
 
             init_ws(this, ws_md_);
             if (!compare_ws(hint_fwd_pd_)) return status::unimplemented;


### PR DESCRIPTION
# Description

The issue is due to the cache finding and using an equivalent _abx_ primitive descriptor for an _axb_ operation (and vice-versa)
- This causes an issue because the workspace contains the input and output from the forward pass. Thus, the shape does matter in this case.

## Solution
To fix the problem a byte of extra memory was added when setting the size of the workspace in the primitive descriptor for the _abx_ case and not for the _axb_ case (or vice-versa)
- 	This causes the hash generated to be different in both cases
- 	Has no effect on other primitives/backends

Fixes #1727 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

