### PR TITLE
[aarch64] set the build flag to "-mcpu=generic"

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -218,9 +218,13 @@ elseif(UNIX OR MINGW)
              if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
                  set(DEF_ARCH_OPT_FLAGS "-O3")
              endif()
-             # For native compilation tune for the host processor
              if (CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
-                 append(DEF_ARCH_OPT_FLAGS "-mcpu=native")
+                 # Defaults to a generic cpu target, equivalent to setting -mtune=generic -march=armv8-a.
+                 # This ensures no implementation specific tuning, or architectural features beyond
+                 # armv8-a are used, for portability across AArch64 systems.
+                 # The DNNL_ARCH_OPT_FLAGS build option can be used to override these defaults
+                 # to optimise for a specific cpu, or revision of the Armv8 architecture.
+                 append(DEF_ARCH_OPT_FLAGS "-mcpu=generic")
              endif()
         elseif(DNNL_TARGET_ARCH STREQUAL "PPC64")
              if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -315,9 +319,13 @@ elseif(UNIX OR MINGW)
             if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
                 set(DEF_ARCH_OPT_FLAGS "-O3")
             endif()
-            # For native compilation tune for the host processor
             if (CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
-                append(DEF_ARCH_OPT_FLAGS "-mcpu=native")
+                 # Defaults to a generic cpu target, equivalent to setting -mtune=generic -march=armv8-a.
+                 # This ensures no implementation specific tuning, or architectural features beyond
+                 # armv8-a are used, for portability across AArch64 systems.
+                 # The DNNL_ARCH_OPT_FLAGS build option can be used to override these defaults
+                 # to optimise for a specific cpu, or revision of the Armv8 architecture.
+                 append(DEF_ARCH_OPT_FLAGS "-mcpu=generic")
             endif()
         elseif(DNNL_TARGET_ARCH STREQUAL "PPC64")
             if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION


# Description

this change is required to support binary compatibility across all armv8 platforms.

Fixes # (github issue)
This fixes issue on PyTorch  repo: 
https://github.com/pytorch/pytorch/issues/109312

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
