### PR TITLE
src:cpu:aarch64: Removes unnecessary copy_from

### DIFF
--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -154,7 +154,7 @@ struct acl_post_ops_t {
             for (int idx = 1; idx < base_post_ops.len(); ++idx) {
                 // Construct empty entry then copy, so that we can check for failure
                 post_ops.entry_.emplace_back();
-                post_ops.entry_.back().copy_from(base_post_ops.entry_[idx]);
+                post_ops.entry_.back() = base_post_ops.entry_[idx];
             }
             return init(engine, post_ops, dst_md);
 


### PR DESCRIPTION
# Description

A recent commit removed the use of `copy_from` from dnnl_post_ops.
https://github.com/oneapi-src/oneDNN/commit/b77a0cc7e11494f81a4d24f474d2d6f893789c5d

However, one instance, in `src/cpu/aarch64/acl_post_ops.hpp` was not updated, leading to a build failure on AArch64 platforms.

This PR removes the `copy_from` call from `src/cpu/aarch64/acl_post_ops.hpp`.

Note: to reproduce the error, build oneDNN on AArch64 with `-DDNNL_AARCH64_USE_ACL=ON` set and the location of a Compute Library build specified through the `ACL_ROOT_DIR` environment variable

```
ACL_ROOT_DIR=<path_to_acl> cmake -DDNNL_CPU_RUNTIME=OMP -DDNNL_BUILD_FOR_CI=ON -DDNNL_AARCH64_USE_ACL=ON ../. && make -j
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

