### PR TITLE
gpu: sycl: fix broken build

### DIFF
--- a/src/gpu/sycl/sycl_math_utils.hpp
+++ b/src/gpu/sycl/sycl_math_utils.hpp
@@ -94,7 +94,7 @@ inline U logsigmoid_fwd(T s) {
 template <typename T, typename U = rem_ref<T>>
 inline U mish_fwd(T s) {
     float e = soft_relu_fwd<float>(s);
-    float l = (float)(::sycl::tanh<float>((float)e));
+    float l = (float)(::sycl::tanh((float)e));
     float val = s * l;
     return (U)(val);
 }


### PR DESCRIPTION
# Description

The math functions in SYCL are not templated, e.g.

```c++
inline double acosh(double a0) __NOEXC {
  return __sycl_std::__invoke_acosh<double>(a0);
}
...
inline float tanh(float a0) __NOEXC {
  return __sycl_std::__invoke_tanh<float>(a0);
}

inline double tanh(double a0) __NOEXC {
  return __sycl_std::__invoke_tanh<double>(a0);
}
```
The templated versions work on `sycl::vec`s, which is what was causing the issue. Fixes #1750 .