### PR TITLE
gpu: sycl: remove deprecated sycl::get_native() for obtaining cuda context

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_engine.cpp
+++ b/src/gpu/nvidia/sycl_cuda_engine.cpp
@@ -121,7 +121,7 @@ status_t sycl_cuda_engine_t::set_cudnn_handle() {
 }
 
 CUcontext sycl_cuda_engine_t::get_underlying_context() const {
-    return compat::get_native<CUcontext>(context());
+    return compat::get_native_context(device());
 }
 
 CUdevice sycl_cuda_engine_t::get_underlying_device() const {
@@ -142,7 +142,7 @@ status_t sycl_cuda_engine_t::underlying_context_type() {
     // on titanrx. So we must run it once and store the variable
     // in primary_context_;
     CUcontext primary, current;
-    CUcontext desired = compat::get_native<CUcontext>(context());
+    CUcontext desired = compat::get_native_context(device());
     CUdevice cuda_device = compat::get_native<CUdevice>(device());
     CHECK(CUDA_EXECUTE_FUNC_S(cuCtxGetCurrent, &current));
 

--- a/src/gpu/nvidia/sycl_cuda_stream.cpp
+++ b/src/gpu/nvidia/sycl_cuda_stream.cpp
@@ -49,7 +49,7 @@ CUstream sycl_cuda_stream_t::get_underlying_stream() {
 
 // the sycl_cuda_stream_t will not own this. it is an observer pointer
 CUcontext sycl_cuda_stream_t::get_underlying_context() {
-    return compat::get_native<CUcontext>(queue_->get_context());
+    return compat::get_native_context(queue_->get_device());
 }
 
 // the sycl_cuda_stream_t will not own this. it is an observer pointer


### PR DESCRIPTION
# Description

This PR refactors the usage of `sycl::get_native` for obtaining the native cuda context which was throwing warnings.