### PR TITLE
[aarch64] update acl conv2dinfo constructor and bump ACL min version to 23.11

### DIFF
--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -83,7 +83,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 23.11 --arch armv8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 23.11 --arch armv8a --multi_isa --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -114,7 +114,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 23.11 --arch armv8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 23.11 --arch armv8a --multi_isa --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/.drone.yml
+++ b/.github/automation/.drone.yml
@@ -29,7 +29,7 @@ steps:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get update && apt-get install -y git build-essential cmake scons gcc-10 g++-10
   - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 1 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 1
-  - .github/automation/build_acl.sh  --version 23.02.1 --arch armv8a --multi_isa --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 23.11 --arch armv8a --multi_isa --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -83,7 +83,7 @@ steps:
   - .github/automation/env/clang.sh
   - export CC=clang
   - export CXX=clang++
-  - .github/automation/build_acl.sh  --version 23.02.1 --arch armv8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 23.11 --arch armv8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 
@@ -114,7 +114,7 @@ steps:
   image: ubuntu:18.04
   commands:
   - apt-get update && apt-get install -y git build-essential cmake scons
-  - .github/automation/build_acl.sh  --version 23.02.1 --arch armv8a --root-dir $(pwd)/ComputeLibrary
+  - .github/automation/build_acl.sh  --version 23.11 --arch armv8a --root-dir $(pwd)/ComputeLibrary
   - .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build --acl-dir $(pwd)/ComputeLibrary
   - .github/automation/test.sh --test-kind gtest --build-dir $(pwd)/build --report-dir $(pwd)/report
 

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -56,6 +56,6 @@ cd $ACL_DIR
 
 scons --silent $MAKE_NP Werror=0 debug=0 neon=1 opencl=0 embed_kernels=0 \
     os=linux arch=$ACL_ARCH build=native multi_isa=$ACL_MULTI_ISA_SUPPORT \
-    experimental_fixed_format_kernels=1
+    fixed_format_kernels=1
 
 exit $?

--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -18,7 +18,7 @@
 # *******************************************************************************
 
 # Compute Library build defaults
-ACL_VERSION="v23.02.1"
+ACL_VERSION="v23.11"
 ACL_DIR="${PWD}/ComputeLibrary"
 ACL_ARCH="armv8a"
 ACL_MULTI_ISA_SUPPORT=0

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ integration. Compute Library is an open-source library for machine learning appl
 and provides AArch64 optimized implementations of core functions. This functionality currently
 requires that Compute Library is downloaded and built separately, see
 [Build from Source](https://oneapi-src.github.io/oneDNN/dev_guide_build.html).
-oneDNN only supports Compute Library versions 23.02.1 or later.
+oneDNN only supports Compute Library versions 23.11 or later.
 
 > **WARNING**
 >

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -31,7 +31,7 @@ endif()
 
 find_package(ACL REQUIRED)
 
-set(ACL_MINIMUM_VERSION "23.02.1")
+set(ACL_MINIMUM_VERSION "23.11")
 
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -258,7 +258,7 @@ For a debug build of oneDNN it is advisable to specify a Compute Library build
 which has also been built with debug enabled.
 
 @warning
-oneDNN only supports builds with Compute Library v23.02.1 or later.
+oneDNN only supports builds with Compute Library v23.11 or later.
 
 #### Vendor BLAS libraries
 oneDNN can use a standard BLAS library for GEMM operations.

--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -345,7 +345,7 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
                                 acp.dilation_info,
                                 acp.act_info,
                                 acp.fast_math,
-                                1, {}, acp.weights_info)));
+                                1, acp.weights_info)));
     // clang-format on
 
     return status::success;

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -51,7 +51,6 @@ struct acl_indirect_gemm_resource_t : public resource_t {
                                     acp.act_info,
                                     acp.fast_math,
                                     1,
-                                    {},
                                     acp.weights_info));
         // clang-format on
 


### PR DESCRIPTION
ACL 23.11 cleanedup some of the legacy post-ops from conv2dinfo. this commit is to update the oneDNN ACL wrapper functions to work with the newer ACL version

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?cd
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
