### PR TITLE
gpu: nvidia: Fix race condition in host task

### DIFF
--- a/src/gpu/nvidia/cudnn_batch_normalization_executor.hpp
+++ b/src/gpu/nvidia/cudnn_batch_normalization_executor.hpp
@@ -61,7 +61,7 @@ protected:
             impl::sycl::sycl_memory_arg_t<mean_var_m> arg_mean = {},
             impl::sycl::sycl_memory_arg_t<mean_var_m> arg_var = {}) const {
 
-        compat::host_task(cgh, [&](const compat::interop_handle &ih) {
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(engine);
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();
@@ -130,7 +130,7 @@ protected:
             impl::sycl::sycl_memory_arg_t<::sycl::access::mode::read_write>
                     arg_temp_relu,
             bool use_scale, bool use_shift) const {
-        compat::host_task(cgh, [&](const compat::interop_handle &ih) {
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(engine);
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);
             auto handle = cuda_stream->get_cudnn_handle();

--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -49,7 +49,7 @@ status_t cudnn_binary_t::execute(const exec_ctx_t &ctx) const {
         auto arg_src_1 = CTX_IN_SYCL_MEMORY(DNNL_ARG_SRC_1);
         auto arg_dst = CTX_OUT_SYCL_MEMORY(DNNL_ARG_DST);
 
-        compat::host_task(cgh, [&](const compat::interop_handle &ih) {
+        compat::host_task(cgh, [=](const compat::interop_handle &ih) {
             auto &sycl_engine = *utils::downcast<sycl_cuda_engine_t *>(
                     cuda_stream->engine());
             auto sc = cuda_sycl_scoped_context_handler_t(sycl_engine);


### PR DESCRIPTION
All of the host_tasks used in `amd` and `nvidia` capture by value, except for these ones. They were segfaulting occasionally because oneDNN classes don't do any ref counting (at least for Nvidia/AMD). This fixes that