### PR TITLE
[aarch64] add sbgemm inner product op

### DIFF
--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -94,19 +94,24 @@ struct acl_inner_product_fwd_t : public primitive_t {
         status_t init(engine_t *engine) {
             using namespace data_type;
             using smask_t = primitive_attr_t::skip_mask_t;
+            const format_kind_t weights_format_kind_received
+                    = weights_md_.format_kind;
             const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
                     && attr()->has_default_values(smask_t::post_ops, f16);
             const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
                     && attr()->has_default_values(
                             smask_t::post_ops | smask_t::fpmath_mode, f32);
+            const bool is_weights_md_format_ok
+                    = utils::one_of(weights_format_kind_received,
+                            format_kind::any, format_kind::blocked);
             const bool ok = is_fwd() && !has_zero_dim_memory()
                     && utils::one_of(true, is_fp16_ok, is_fp32_ok)
-                    && weights_md_.format_kind == format_kind::any
-                    && set_default_params() == status::success;
+                    && is_weights_md_format_ok
+                    && set_default_params(true) == status::success;
 
             if (!ok) return status::unimplemented;
 
-            CHECK(init_conf_ip(engine));
+            CHECK(init_conf_ip(engine, weights_format_kind_received));
 
             return status::success;
         }
@@ -115,7 +120,8 @@ struct acl_inner_product_fwd_t : public primitive_t {
 
         acl_post_ops_t post_ops;
 
-        status_t init_conf_ip(engine_t *engine) {
+        status_t init_conf_ip(
+                engine_t *engine, format_kind_t weights_format_kind_received) {
 
             ACL_CHECK_SUPPORT(src_md()->ndims != weights_md()->ndims,
                     "source and weights dimensions must match");
@@ -257,9 +263,18 @@ struct acl_inner_product_fwd_t : public primitive_t {
                     return status::unimplemented;
             }
 
+            const memory_desc_t weights_md_received = weights_md_;
             acl_utils::reorder_to_weight_format(aip.wei_tensor_info,
                     weights_md_, expected_weight_format, inner_dim, o_dim,
                     remaining_dims, {});
+
+            ACL_CHECK_SUPPORT(
+                    (weights_format_kind_received == format_kind::blocked)
+                            && !(dnnl_memory_desc_equal(
+                                    &weights_md_received, &weights_md_)),
+                    "specific blocked format not supported by ACL, use "
+                    "format_kind_t::any to find a supported blocked format for "
+                    "your platform");
 
             // clang-format off
 

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -101,11 +101,16 @@ struct acl_inner_product_fwd_t : public primitive_t {
             const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
                     && attr()->has_default_values(
                             smask_t::post_ops | smask_t::fpmath_mode, f32);
+            const bool is_fp32_bf16_ok
+                    = expect_data_types(f32, bf16, f32, f32, undef)
+                    && attr()->has_default_values(
+                            smask_t::post_ops | smask_t::fpmath_mode, f32);
             const bool is_weights_md_format_ok
                     = utils::one_of(weights_format_kind_received,
                             format_kind::any, format_kind::blocked);
             const bool ok = is_fwd() && !has_zero_dim_memory()
-                    && utils::one_of(true, is_fp16_ok, is_fp32_ok)
+                    && utils::one_of(
+                            true, is_fp16_ok, is_fp32_ok, is_fp32_bf16_ok)
                     && is_weights_md_format_ok
                     && set_default_params(true) == status::success;
 

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -83,6 +83,15 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,
         }},
+        /* With graph compilation, we are able to reorder and pre-pack the weights during the model load
+         * and compilation phase itself so that redundant and on-the-fly reorders can be avoided.
+         * This primitive definition is to support gemm fastmath mode for the compile scenario where src is
+         * in fp32 and weights are in bf16
+         */
+        {{forward, f32, bf16, f32}, {
+            CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
+            nullptr,
+        }},
         {{backward_data, f32, f32, f32}, REG_BWD_PK({
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx>) // bf32
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core>)

--- a/tests/benchdnn/inputs/ip/test_ip_acl
+++ b/tests/benchdnn/inputs/ip/test_ip_acl
@@ -24,3 +24,11 @@
 --wtag=abx,axb
 # 2d-spatial dimensions
 --batch=shapes_googlenet_v1
+
+# Tests for external blocked weights layout.
+--reset
+--dir=FWD_I
+--skip-impl='ref,jit'
+--allow-enum-tags-only=0
+--wtag=Ab8a
+--batch=shapes_bert


### PR DESCRIPTION
# Description
Added sbgemm inner product op to enable PyTorch torch.compile() and bf16 fastmath kernels to work together on aarch64.

Fixes # (github issue)

# Checklist

## General

- [x ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
same pass rate as in main branch.
- [x] Have you formatted the code using clang-format?

## Performance improvements
1. torch.compile() with fp32 inner product kernel showed up to 5.8x perf improvement on AWS c7g instance
2. torch.compile() with bf16 inner product kernel showed another 1.25x perf improvement on AWS c7g instance
- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
