### PR TITLE
Avoid invalid `munmap`

### DIFF
--- a/src/cpu/jit_utils/linux_perf/linux_perf.cpp
+++ b/src/cpu/jit_utils/linux_perf/linux_perf.cpp
@@ -92,7 +92,6 @@ private:
     }
 
     void finalize() {
-        if (failed_) return;
         close_file();
         delete_marker();
     }

--- a/src/cpu/jit_utils/linux_perf/linux_perf.cpp
+++ b/src/cpu/jit_utils/linux_perf/linux_perf.cpp
@@ -173,7 +173,7 @@ private:
         long page_size = sysconf(_SC_PAGESIZE);
         if (page_size == -1) return false;
         marker_size_ = (size_t)page_size;
-        void* addr = mmap(nullptr, marker_size_, PROT_READ | PROT_EXEC,
+        void *addr = mmap(nullptr, marker_size_, PROT_READ | PROT_EXEC,
                 MAP_PRIVATE, fd_, 0);
         if (addr == MAP_FAILED) return false;
         marker_addr_ = addr;

--- a/src/cpu/jit_utils/linux_perf/linux_perf.cpp
+++ b/src/cpu/jit_utils/linux_perf/linux_perf.cpp
@@ -175,20 +175,15 @@ private:
         marker_size_ = (size_t)page_size;
         void* addr = mmap(nullptr, marker_size_, PROT_READ | PROT_EXEC,
                 MAP_PRIVATE, fd_, 0);
-        if (addr == MAP_FAILED) {
-            marker_addr_ = nullptr;
-            return false;
-        } else {
-            marker_addr_ = addr;
-            return true;
-        }
+        if (addr == MAP_FAILED) return false;
+        marker_addr_ = addr;
+        return true;
     }
 
     void delete_marker() {
-        if (marker_addr_) {
-            munmap(marker_addr_, marker_size_);
-            marker_addr_ = nullptr;
-        }
+        if (!marker_addr_) return;
+        munmap(marker_addr_, marker_size_);
+        marker_addr_ = nullptr;
     }
 
     static uint64_t get_timestamp(bool use_tsc) {

--- a/src/cpu/jit_utils/linux_perf/linux_perf.cpp
+++ b/src/cpu/jit_utils/linux_perf/linux_perf.cpp
@@ -174,13 +174,22 @@ private:
         long page_size = sysconf(_SC_PAGESIZE);
         if (page_size == -1) return false;
         marker_size_ = (size_t)page_size;
-        marker_addr_ = mmap(nullptr, marker_size_, PROT_READ | PROT_EXEC,
+        void* addr = mmap(nullptr, marker_size_, PROT_READ | PROT_EXEC,
                 MAP_PRIVATE, fd_, 0);
-        return marker_addr_ != MAP_FAILED;
+        if (addr == MAP_FAILED) {
+            marker_addr_ = nullptr;
+            return false;
+        } else {
+            marker_addr_ = addr;
+            return true;
+        }
     }
 
     void delete_marker() {
-        if (marker_addr_) munmap(marker_addr_, marker_size_);
+        if (marker_addr_) {
+            munmap(marker_addr_, marker_size_);
+            marker_addr_ = nullptr;
+        }
     }
 
     static uint64_t get_timestamp(bool use_tsc) {


### PR DESCRIPTION
The value in `marker_addr_` is updated even if it is invalid, i.e. `(void*) -1` This could then be passed to `munmap` which is clearly wrong as that expects a valid pointer.

Make sure to store only a valid pointer in `marker_addr_` ~and `nullptr` on failure as `marker_size` has also been updated so the `munmap` call using the old pointer would be wrong~. Additionally reset it after the `munmap` call to avoid unmapping it again similar to how the file descriptors are reset

Motivation: I observe a double free in PyTorch 2.1 using oneDNN 3.1.1 and found https://github.com/oneapi-src/oneDNN/commit/3480b0c0fa0eb6eacfeafc4527eb3cc981636673 fixing a potential double free wondering how that could even happen. Point is `close_file()` is save to call multiple times as it resets the fd but `delete_marker()` is not

I even think the more correct solution is to call `delete_marker` at the start of `create_marker` as the current implementation might create a new `mmap` without releasing an old one. I didn't do that yet to keep the changes small and gather insight if you agree with that reasoning.