### PR TITLE
cpu: aarch64: Expand ARM SVE support in jit_uni_softmax

### DIFF
--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2023 Intel Corporation
-* Copyright 2020-2023 FUJITSU LIMITED
+* Copyright 2020-2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -316,7 +316,7 @@ struct jit_softmax_base_t : public jit_generator {
     }
 
     void prepare_mask() {
-        if (isa == sve_512) {
+        if (isa == sve_512 || isa == sve_256) {
             sub_imm(X_TRANSLATOR_STACK, X_TRANSLATOR_STACK, 64 * 2, X_TMP_0);
             str(p_shuff0, ptr(X_TRANSLATOR_STACK, 0, MUL_VL));
             str(p_shuff1, ptr(X_TRANSLATOR_STACK, 1, MUL_VL));
@@ -328,7 +328,7 @@ struct jit_softmax_base_t : public jit_generator {
     }
 
     void restore_mask() {
-        assert(isa == sve_512);
+        assert(isa == sve_512 || isa == sve_256);
 
         ldr(p_shuff0, ptr(X_TRANSLATOR_STACK, 0, MUL_VL));
         ldr(p_shuff1, ptr(X_TRANSLATOR_STACK, 1, MUL_VL));
@@ -665,6 +665,283 @@ struct jit_softmax_t<sve_512> : public jit_softmax_base_t<sve_512> {
     }
 }; // namespace aarch64
 
+template <>
+struct jit_softmax_t<sve_256> : public jit_softmax_base_t<sve_256> {
+    PReg tail_opmask = p2;
+
+    void store(const XReg &addr, const ZReg &vmm, data_type_t dt,
+            bool tail = false) {
+        PReg opmask = P_ALL_ONE;
+        bool tail_mask_valid = false;
+        auto effective_addr = addr;
+        TReg src_vmm = vmm;
+
+        if (tail) {
+            if (dt == data_type::f32) {
+                if (axis_is_blocked_) {
+                    src_vmm = vzero;
+                    eor(vzero.d, vzero.d, vzero.d);
+                    mov(src_vmm.s, tail_opmask / T_m, vmm.s);
+                    effective_addr = addr;
+                } else {
+                    effective_addr = addr;
+                    tail_mask_valid = true;
+                }
+            } else { // int8 store instructions assume mask on register
+                tail_mask_valid = true;
+            }
+        }
+
+        if (tail_mask_valid) opmask = tail_opmask;
+
+        switch (dt) {
+            case data_type::f32:
+                st1w(src_vmm.s, opmask, ptr(effective_addr));
+                break;
+            case data_type::u8:
+                eor(vzero.d, vzero.d, vzero.d); // since vzero might be spoiled
+                saturate_f32(vmm, vzero, vsaturation_ubound, data_type::u8,
+                        P_ALL_ONE);
+                frinti(vmm.s, P_ALL_ONE / T_m, vmm.s);
+                fcvtzu(vmm.s, P_ALL_ONE / T_m, vmm.s);
+                smin(vmm.s, 127);
+                st1b(vmm.s, opmask, ptr(effective_addr));
+                // Need to restore data back to fp32 since we apply exp after
+                // storing and data should be fp32.
+                if (is_logsoftmax_) scvtf(vmm.s, opmask / T_m, vmm.s);
+                break;
+            case data_type::s8:
+                saturate_f32(vmm, vzero, vsaturation_ubound, data_type::s8,
+                        P_ALL_ONE);
+                frinti(vmm.s, opmask / T_m, vmm.s);
+                fcvtzs(vmm.s, opmask / T_m, vmm.s);
+                smin(vmm.s, 127);
+                smax(vmm.s, -128);
+                st1b(vmm.s, opmask, ptr(effective_addr));
+                // Need to restore data back to fp32 since we apply exp after
+                // storing and data should be fp32.
+                if (is_logsoftmax_) scvtf(vmm.s, opmask / T_m, vmm.s);
+                break;
+            default: assert(!"unsupported"); break;
+        }
+    };
+
+    void load(const TReg &vmm, const XReg &addr, data_type_t dt,
+            bool tail = false) {
+        PReg tmp_mask = P_ALL_ONE;
+        ZRegS effective_vmm = vmm.s;
+
+        if (tail) tmp_mask = tail_opmask;
+
+        switch (dt) {
+            case data_type::f32:
+                ld1w(effective_vmm, tmp_mask, ptr(addr));
+                break;
+            case data_type::u8:
+                ld1b(effective_vmm, tmp_mask / T_z, ptr(addr));
+                scvtf(effective_vmm, P_ALL_ONE / T_m, effective_vmm);
+                break;
+            case data_type::s8:
+                ld1sb(effective_vmm, tmp_mask / T_z, ptr(addr));
+                scvtf(effective_vmm, P_ALL_ONE / T_m, effective_vmm);
+                break;
+            default: assert(!"unsupported"); break;
+        }
+    };
+
+    void prepare_tail_mask() override {
+        const int sw_tail = axis_simd_tail_;
+        PRegS p = tail_opmask.s;
+        switch (sw_tail) {
+            case 16: ptrue(p, VL16); break;
+            case 8: ptrue(p, VL8); break;
+            case 7: ptrue(p, VL7); break;
+            case 6: ptrue(p, VL6); break;
+            case 5: ptrue(p, VL5); break;
+            case 4: ptrue(p, VL4); break;
+            case 3: ptrue(p, VL3); break;
+            case 2: ptrue(p, VL2); break;
+            case 1: ptrue(p, VL1); break;
+            default:
+                index(vtmp.s, 1, 1);
+                cmple(p, P_ALL_ONE / T_z, vtmp.s, sw_tail);
+                break;
+        }
+    }
+
+    void get_horizontal_op(const ZReg &v, const ZReg &vtmp, op_t op) override {
+        mov(vtmp.d, v.d);
+        ext(vtmp.b, v.b, 16);
+        perform_op(v, vtmp, op);
+        mov(vtmp.s, P_ALL_ONE / T_m, v.s);
+        mov(v_tmp0.s, P_ALL_ONE / T_m, v.s);
+        ext(v_tmp0.b, v.b, 24);
+        ext(vtmp.b, v.b, 32);
+        mov(vtmp.s, p_shuff0 / T_m, v_tmp0.s);
+        perform_op(v, vtmp, op);
+        trn1(vtmp.s, v.s, v.s);
+        trn2(v_tmp0.s, v.s, v.s);
+        mov(vtmp.s, p_shuff1 / T_m, v_tmp0.s);
+        perform_op(v, vtmp, op);
+    }
+
+    void accumulate_vmax() override {
+        // flush to -FLT_MAX before accumulation
+        mov(vmax.d, vneg_flt_max.d);
+
+        axis_loop([&](int unroll, bool tail = false) {
+            for (int i = 0; i < unroll; i++) {
+                TReg vreg_tmp_src = TReg(i + 1);
+                load(vreg_tmp_src, src_ptr(src_axis_stride_ * i),
+                        src_d_.data_type(), tail);
+                if (tail) {
+                    uni_fmax(vmax, vmax, vreg_tmp_src, tail_opmask);
+                } else {
+                    uni_fmax(vmax, vmax, vreg_tmp_src);
+                }
+            }
+        });
+
+        get_horizontal_op(vmax, vtmp = vsum, op_t::max);
+    }
+
+    void accumulate_vsum() override {
+        // Initialize saturation vector register
+        if (utils::one_of(dst_d_.data_type(), data_type::u8, data_type::s8)) {
+            init_saturate_f32(vzero, vsaturation_ubound, reg_tmp,
+                    data_type::f32, dst_d_.data_type());
+        }
+
+        eor(vsum.d, vsum.d, vsum.d); // flush to zero before accumulation
+
+        axis_loop([&](int unroll, bool tail = false) {
+            for (int i = 0; i < unroll; i++) {
+                TReg vreg_tmp_src = TReg(i + 1);
+                load(vreg_tmp_src, src_ptr(src_axis_stride_ * i),
+                        src_d_.data_type(), tail);
+                fsub(vreg_tmp_src.s, vreg_tmp_src.s, vmax.s);
+                if (is_logsoftmax_) { // store before applying exp
+                    if (need_scratchpad_) {
+                        store(interim_ptr(interim_axis_stride_ * i),
+                                vreg_tmp_src, data_type::f32, tail);
+                    } else {
+                        store(dst_ptr(dst_axis_stride_ * i), vreg_tmp_src,
+                                dst_d_.data_type(), tail);
+                    }
+                }
+                exp_injector_->compute_vector(vreg_tmp_src.getIdx());
+                if (tail)
+                    fadd(vsum.s, tail_opmask / T_m, vreg_tmp_src.s);
+                else
+                    fadd(vsum.s, vsum.s, vreg_tmp_src.s);
+                if (is_softmax_) { // store after applying exp
+                    if (need_scratchpad_) {
+                        store(interim_ptr(interim_axis_stride_ * i),
+                                vreg_tmp_src, data_type::f32, tail);
+                    } else {
+                        store(dst_ptr(dst_axis_stride_ * i), vreg_tmp_src,
+                                dst_d_.data_type(), tail);
+                    }
+                }
+            }
+        });
+
+        get_horizontal_op(vsum, vtmp = vmax, op_t::sum);
+        if (is_softmax_) {
+            mov(v_tmp0.d, vsum.d);
+            mov(vsum.d, P_ALL_ONE, vone.d);
+            fdiv(vsum.s, P_ALL_ONE / T_m, v_tmp0.s);
+        }
+        if (is_logsoftmax_) log_injector_->compute_vector(vsum.getIdx());
+    }
+
+    void compute_dst() override {
+        axis_loop([&](int unroll, bool tail = false) {
+            for (int i = 0; i < unroll; i++) {
+                ZReg vreg_tmp_src = ZReg(i + 1);
+                if (need_scratchpad_) {
+                    load(vreg_tmp_src, interim_ptr(interim_axis_stride_ * i),
+                            data_type::f32, tail);
+                } else {
+                    load(vreg_tmp_src, dst_ptr(dst_axis_stride_ * i),
+                            dst_d_.data_type(), tail);
+                }
+
+                if (is_softmax_) {
+                    fmul(vreg_tmp_src.s, vreg_tmp_src.s, vsum.s);
+                }
+                if (is_logsoftmax_) {
+                    fsub(vreg_tmp_src.s, vreg_tmp_src.s, vsum.s);
+                }
+
+                TReg vscale = vmax;
+                ldr(vscale, ptr(reg_src_scales));
+                fmul(vreg_tmp_src.s, vreg_tmp_src.s, vscale.s);
+                // Reserved spot for post-ops injector.
+                ldr(vscale, ptr(reg_dst_scales));
+                fmul(vreg_tmp_src.s, vreg_tmp_src.s, vscale.s);
+                store(dst_ptr(dst_axis_stride_ * i), vreg_tmp_src,
+                        dst_d_.data_type(), tail);
+            }
+        });
+    }
+
+    void accumulate_vsbr() override {
+        eor(vsbr.d, vsbr.d, vsbr.d); // flush to zero before accumulation
+
+        axis_loop([&](int unroll, bool tail = false) {
+            for (int i = 0; i < unroll; i++) {
+                ZReg vreg_tmp_dst = ZReg(i * 2 + 1);
+                ZReg vreg_tmp_diff_dst = ZReg(i * 2 + 2);
+                load(vreg_tmp_diff_dst, diff_dst_ptr(diff_dst_axis_stride_ * i),
+                        diff_dst_d_.data_type(), tail);
+                if (is_softmax_) {
+                    load(vreg_tmp_dst, dst_ptr(dst_axis_stride_ * i),
+                            dst_d_.data_type(), tail);
+                    fmul(vreg_tmp_diff_dst.s, vreg_tmp_diff_dst.s,
+                            vreg_tmp_dst.s);
+                }
+                fadd(vsbr.s, vsbr.s, vreg_tmp_diff_dst.s);
+            }
+        });
+
+        get_horizontal_op(vsbr, vtmp = vmax, op_t::sum);
+    }
+
+    void compute_diff_src() override {
+        axis_loop([&](int unroll, bool tail = false) {
+            for (int i = 0; i < unroll; i++) {
+                ZReg vreg_tmp_dst = ZReg(i * 2 + 1);
+                ZReg vreg_tmp_diff_dst = ZReg(i * 2 + 2);
+                load(vreg_tmp_dst, dst_ptr(dst_axis_stride_ * i),
+                        dst_d_.data_type(), tail);
+                load(vreg_tmp_diff_dst, diff_dst_ptr(diff_dst_axis_stride_ * i),
+                        diff_dst_d_.data_type(), tail);
+                if (is_softmax_) {
+                    fsub(vreg_tmp_diff_dst.s, vreg_tmp_diff_dst.s, vsbr.s);
+                    fmul(vreg_tmp_diff_dst.s, vreg_tmp_dst.s,
+                            vreg_tmp_diff_dst.s);
+                }
+                if (is_logsoftmax_) {
+                    exp_injector_->compute_vector(vreg_tmp_dst.getIdx());
+                    fmls(vreg_tmp_diff_dst.s, P_ALL_ONE / T_m, vreg_tmp_dst.s,
+                            vsbr.s);
+                }
+                store(diff_src_ptr(src_axis_stride_ * i), vreg_tmp_diff_dst,
+                        src_d_.data_type(), tail);
+            }
+        });
+    }
+
+    void initialization_hook() override {}
+
+    jit_softmax_t(const softmax_pd_t *pd) : jit_softmax_base_t(pd) {}
+
+    void operator()(const call_params_t *p) override {
+        return jit_generator::operator()(p);
+    }
+}; // namespace aarch64
+
 template <cpu_isa_t isa>
 jit_uni_softmax_fwd_t<isa>::jit_uni_softmax_fwd_t(const pd_t *apd)
     : primitive_t(apd)
@@ -812,6 +1089,8 @@ private:
 /* struct instantiation */
 template struct jit_uni_softmax_fwd_t<sve_512>;
 template struct jit_uni_softmax_bwd_t<sve_512>;
+template struct jit_uni_softmax_fwd_t<sve_256>;
+template struct jit_uni_softmax_bwd_t<sve_256>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2020-2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -75,7 +75,8 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
             const auto dst_dt = dst_md()->data_type;
             bool ok = mayiuse(isa) && is_fwd() && !has_zero_dim_memory()
                     && utils::one_of(src_dt, f32, s8, u8)
-                    && utils::one_of(dst_dt, f32, s8, u8) && mayiuse(sve_512)
+                    && utils::one_of(dst_dt, f32, s8, u8)
+                    && (mayiuse(sve_512) || mayiuse(sve_256))
                     && attr()->has_default_values(skip_mask_t::scales_runtime)
                     && attr_scales_ok()
                     && set_default_formats() == status::success;
@@ -154,7 +155,8 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
                     && utils::one_of(dst_md()->data_type, f32)
                     && utils::one_of(diff_dst_md()->data_type, f32)
                     && utils::one_of(diff_src_md()->data_type, f32)
-                    && mayiuse(sve_512) && attr()->has_default_values()
+                    && (mayiuse(sve_512) || mayiuse(sve_256))
+                    && attr()->has_default_values()
                     && set_default_formats() == status::success;
             if (!ok) return status::unimplemented;
 

--- a/src/cpu/cpu_softmax_list.cpp
+++ b/src/cpu/cpu_softmax_list.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2023 Intel Corporation
-* Copyright 2021 FUJITSU LIMITED
+* Copyright 2021-2024 FUJITSU LIMITED
 * Copyright 2021-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +45,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
         {{forward}, {
             CPU_INSTANCE_X64(jit_uni_softmax_fwd_t)
             CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve_512>)
+            CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64_ACL(acl_softmax_fwd_t)
             CPU_INSTANCE(ref_softmax_fwd_t)
             nullptr,
@@ -52,6 +53,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
         {{backward}, REG_BWD_PK({
             CPU_INSTANCE_X64(jit_uni_softmax_bwd_t)
             CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve_512>)
+            CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve_256>)
             CPU_INSTANCE(ref_softmax_bwd_t)
             nullptr,
         })},


### PR DESCRIPTION
# Description

Enhancement: Expand ARM SVE support in **jit_uni_softmax**
 
This commit enhances the existing ARM SVE support in jit_uni_softmax to include additional vector length compatibility. The changes made are for implementation of different ARM SVE vector length.

Major Code changes:
• Introduce a new struct to accommodate the extended ARM SVE vector length, similar to the sve_512 struct.
• Modify the **get_horizontal_op** function accordingly for enhanced vector length.

# Checklist

## General

- [✓] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? Yes
       Test output is same with and without this commit.
       

1. make test output:

       99% tests passed, 2 tests failed out of 160

        Total Test time (real) =  50.68 sec
        
        The following tests FAILED:
                144 - test_graph_unit_dnnl_conv_usm_cpu (Failed)
                149 - test_graph_unit_dnnl_large_partition_usm_cpu (Failed)
        Errors while running CTest
        Output from these tests are in: /home/deepesh/pull_request/oneDNN/build/Testing/Temporary/LastTest.log
        Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
        make: *** [Makefile:71: test] Error 8
        

2. make test_benchdnn_* output:

        make: *** No rule to make target 'test_benchdnn_*'.  Stop.
        

3. make test_benchdnn_softmax_ci_cpu/fast output:

        tests:6144 passed:1384 skipped:4736 mistrusted:24 unimplemented:0 invalid_arguments:0 failed:0 listed:0
        total: 13.70s; fill: 1.39s (10%); compute_ref: 0.47s (3%); compare: 0.87s (6%);
- [✓] Have you formatted the code using clang-format? Yes


cc: @kawakami-k , @davsva01 