### PR TITLE
Add missing include <cstdint> for int64_t

### DIFF
--- a/tests/benchdnn/utils/dims.hpp
+++ b/tests/benchdnn/utils/dims.hpp
@@ -18,6 +18,7 @@
 #define UTILS_DIMS_T_HPP
 
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
# Description

In Musl environment build of oneDNN-3.3.3 (up to current main branch) with tests fails with:
```
In file included from /var/tmp/portage/dev-libs/oneDNN-3.3.3/work/oneDNN-3.3.3/tests/benchdnn/utils/dims.cpp:19:
/var/tmp/portage/dev-libs/oneDNN-3.3.3/work/oneDNN-3.3.3/tests/benchdnn/utils/dims.hpp:25:28: error: 'int64_t' was not declared in this scope
   25 | using dims_t = std::vector<int64_t>;
      |                            ^~~~~~~
/var/tmp/portage/dev-libs/oneDNN-3.3.3/work/oneDNN-3.3.3/tests/benchdnn/utils/dims.hpp:24:1: note: 'int64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   23 | #include <vector>
  +++ |+#include <cstdint>
   24 | 
```

This PR adds `#include <cstdint>` and fixes the build.

See also: https://bugs.gentoo.org/922778
