### PR TITLE
Fix FindBLAS.cmake compatibility with MKL 2024.0

### DIFF
--- a/cmake/FindBLAS.cmake
+++ b/cmake/FindBLAS.cmake
@@ -480,6 +480,8 @@ if(BLA_VENDOR MATCHES "Intel" OR BLA_VENDOR STREQUAL "All")
           "compiler/lib/${BLAS_mkl_ARCH_NAME}"
           "mkl/lib" "mkl/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
           "mkl/lib/${BLAS_mkl_ARCH_NAME}"
+          "mkl/latest/lib" "mkl/latest/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "mkl/latest/lib/${BLAS_mkl_ARCH_NAME}"
           "lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}")
 
       foreach(IT ${BLAS_SEARCH_LIBS})


### PR DESCRIPTION
# Description

I am building oneDNN using the Intel oneAPI compiler and MKL version 2024.0.0. I get this error at configuration time:
```
MKLROOT=/opt/intel/oneapi cmake \
        -DCMAKE_INSTALL_PREFIX=/opt/onednn \
        -DCMAKE_INSTALL_LIBDIR=lib \
        -DDNNL_LIBRARY_TYPE=STATIC \
        -DDNNL_BLAS_VENDOR=MKL \
        /home/src/oneDNN
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
-- The C compiler identification is IntelLLVM 2024.0.0
-- The CXX compiler identification is IntelLLVM 2024.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/intel/oneapi/compiler/2024.0/bin/icx - skipped
-- Detecting C compile features
[...]
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found OpenMP_C: -fiopenmp  
-- Found OpenMP_CXX: -fiopenmp  
-- Found OpenMP: TRUE   
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find BLAS (missing: BLAS_LIBRARIES)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindBLAS.cmake:951 (find_package_handle_standard_args)
  cmake/blas.cmake:66 (find_package)
  CMakeLists.txt:126 (include)


-- Configuring incomplete, errors occurred!
```

I see in `cmake/FindBLAS.cmake` that oneDNN expects to find the MKL libraries under an `mkl/lib/` directory, among other places. However, my oneAPI install has the MKL under a versioned directory:
```
$ find /opt/intel -name libmkl_rt.so
/opt/intel/oneapi/mkl/2024.0/lib/libmkl_rt.so
/opt/intel/oneapi/mkl/2024.0/lib32/libmkl_rt.so
/opt/intel/oneapi/2024.0/lib/libmkl_rt.so
/opt/intel/oneapi/2024.0/lib32/libmkl_rt.so
```

That noted, I also get the same configuration error with any of these settings:
```
MKLROOT=/opt/intel/oneapi/mkl
MKLROOT=/opt/intel/oneapi/mkl/2024.0
MKLROOT=/opt/intel/oneapi/2024.0
```

If I look in the `mkl/` directory, I see that there is a handy `latest` symlink to avoid hard-coding the version:
```
$ ls -l /opt/intel/oneapi/mkl/
total 4
drwxr-xr-x 10 root root 4096 Jan 29 21:31 2024.0
lrwxrwxrwx  1 root root    6 Jan 29 21:31 latest -> 2024.0
```

If I add `mkl/latest/lib` and variations to `BLAS_mkl_LIB_PATH_SUFFIXES`, then configuration succeeds, and I am able to build and test oneDNN without issue.

The version of the Intel compiler/libraries I am using is fairly new, and I suspect the oneDNN build may not have been tested against it before now.