### PR TITLE
build:cmake:aarch64 refine alerts and replace ENV{ACL_ROOT_DIR}

### DIFF
--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -34,9 +34,13 @@ find_package(ACL REQUIRED)
 set(ACL_MINIMUM_VERSION "23.11")
 
 if(ACL_FOUND)
-    file(GLOB_RECURSE ACL_VERSION_FILE $ENV{ACL_ROOT_DIR}/*/arm_compute_version.embed)
+    file(GLOB_RECURSE ACL_VERSION_FILE ${ACL_INCLUDE_DIR}/*/arm_compute_version.embed)
     if ("${ACL_VERSION_FILE}" STREQUAL "")
-        message(WARNING "Build may fail: Could not determine ACL version (minimum required is ${ACL_MINIMUM_VERSION})")
+        message(WARNING
+            "Build may fail. Could not determine ACL version.\n"
+            "Supported ACL versions:\n"
+            "- minimum required is ${ACL_MINIMUM_VERSION}\n"
+        )
     else()
         file(READ ${ACL_VERSION_FILE} ACL_VERSION_STRING)
         string(REGEX MATCH "v([0-9]+\\.[0-9]+\\.?[0-9]*)" ACL_VERSION "${ACL_VERSION_STRING}")
@@ -44,9 +48,15 @@ if(ACL_FOUND)
         if ("${ACL_VERSION}" VERSION_EQUAL "0.0")
             # Unreleased ACL versions come with version string "v0.0-unreleased", and may not be compatible with oneDNN.
             # It is recommended to use the latest release of ACL.
-            message(WARNING "Build may fail: Using unreleased ACL version (minimum required is ${ACL_MINIMUM_VERSION})")
+            message(WARNING
+                "Build may fail. Using unreleased ACL version.\n"
+                "Supported ACL versions:\n"
+                "- minimum required is ${ACL_MINIMUM_VERSION}\n"
+            )
         elseif("${ACL_VERSION}" VERSION_LESS "${ACL_MINIMUM_VERSION}")
-            message(FATAL_ERROR "Detected ACL version ${ACL_VERSION}, but minimum required is ${ACL_MINIMUM_VERSION}")
+            message(FATAL_ERROR
+                "Detected ACL version ${ACL_VERSION}, but minimum required is ${ACL_MINIMUM_VERSION}\n"
+            )
         endif()
     endif()
 


### PR DESCRIPTION
# Description

Refine alerts and replace ENV{ACL_ROOT_DIR}.

Improve warnings and fatal_errors format and
replace ENV{ACL_ROOT_DIR} with {ACL_INCLUDE_DIR}.

ENV variable can be inconsistent with the cached variable, therefore use the cached path to Arm Compute Library.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
