### PR TITLE
Handle code paths that are assuming Linux just because __GNUC__ is defined

### DIFF
--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
@@ -37,7 +37,7 @@
 #include <unordered_set>
 #include <vector>
 
-#if (defined(__GNUC__) || defined(__APPLE__)) && !defined(__MINGW64__)
+#if (defined(__GNUC__) || defined(__APPLE__)) && !defined(_WIN32)
 #ifndef XBYAK_USE_MMAP_ALLOCATOR
 #define XBYAK_USE_MMAP_ALLOCATOR
 #endif
@@ -46,7 +46,7 @@
 #include <cmath>
 #include <functional>
 
-#if defined(__GNUC__) && !defined(__MINGW64__)
+#if defined(__GNUC__) && !defined(_WIN32)
 #include <cassert>
 #include <stdlib.h>
 #include <sys/mman.h>

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
@@ -37,7 +37,7 @@
 #include <unordered_set>
 #include <vector>
 
-#if defined(__GNUC__) || defined(__APPLE__)
+#if (defined(__GNUC__) || defined(__APPLE__)) && !defined(__MINGW64__)
 #ifndef XBYAK_USE_MMAP_ALLOCATOR
 #define XBYAK_USE_MMAP_ALLOCATOR
 #endif
@@ -46,7 +46,7 @@
 #include <cmath>
 #include <functional>
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__MINGW64__)
 #include <cassert>
 #include <stdlib.h>
 #include <sys/mman.h>

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -20,7 +20,7 @@
 static const size_t CSIZE = sizeof(uint32_t);
 
 inline void *AlignedMalloc(size_t size, size_t alignment) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW64__)
   return _aligned_malloc(size, alignment);
 #else
   void *p;
@@ -30,7 +30,7 @@ inline void *AlignedMalloc(size_t size, size_t alignment) {
 }
 
 inline void AlignedFree(void *p) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW64__)
   _aligned_free(p);
 #else
   free(p);
@@ -277,7 +277,7 @@ public:
     default:
       return false;
     }
-#if defined(__GNUC__) || defined(__APPLE__)
+#if (defined(__GNUC__) || defined(__APPLE__)) && !defined(__MINGW64__)
     size_t pageSize = inner::getPageSize();
     size_t iaddr = reinterpret_cast<size_t>(addr);
     size_t roundAddr = iaddr & ~(pageSize - static_cast<size_t>(1));

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -20,7 +20,7 @@
 static const size_t CSIZE = sizeof(uint32_t);
 
 inline void *AlignedMalloc(size_t size, size_t alignment) {
-#if defined(_MSC_VER) || defined(__MINGW64__)
+#if defined(_WIN32)
   return _aligned_malloc(size, alignment);
 #else
   void *p;
@@ -30,7 +30,7 @@ inline void *AlignedMalloc(size_t size, size_t alignment) {
 }
 
 inline void AlignedFree(void *p) {
-#if defined(_MSC_VER) || defined(__MINGW64__)
+#if defined(_WIN32)
   _aligned_free(p);
 #else
   free(p);
@@ -277,7 +277,7 @@ public:
     default:
       return false;
     }
-#if (defined(__GNUC__) || defined(__APPLE__)) && !defined(__MINGW64__)
+#if (defined(__GNUC__) || defined(__APPLE__)) && !defined(_WIN32)
     size_t pageSize = inner::getPageSize();
     size_t iaddr = reinterpret_cast<size_t>(addr);
     size_t roundAddr = iaddr & ~(pageSize - static_cast<size_t>(1));

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
@@ -20,7 +20,7 @@ enum { DEFAULT_MAX_CODE_SIZE = 4096 };
 namespace inner {
 
 inline size_t getPageSize() {
-#if defined(__GNUC__) && !defined(__MINGW64__)
+#if defined(__GNUC__) && !defined(_WIN32)
   static const size_t pageSize = sysconf(_SC_PAGESIZE);
 #else
   static const size_t pageSize = 4096;

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
@@ -20,7 +20,7 @@ enum { DEFAULT_MAX_CODE_SIZE = 4096 };
 namespace inner {
 
 inline size_t getPageSize() {
-#if defined (__GNUC__) && !defined(__MINGW64__)
+#if defined(__GNUC__) && !defined(__MINGW64__)
   static const size_t pageSize = sysconf(_SC_PAGESIZE);
 #else
   static const size_t pageSize = 4096;

--- a/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
+++ b/src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_inner.h
@@ -20,7 +20,7 @@ enum { DEFAULT_MAX_CODE_SIZE = 4096 };
 namespace inner {
 
 inline size_t getPageSize() {
-#ifdef __GNUC__
+#if defined (__GNUC__) && !defined(__MINGW64__)
   static const size_t pageSize = sysconf(_SC_PAGESIZE);
 #else
   static const size_t pageSize = 4096;

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -328,7 +328,7 @@ bool skip_start(res_t *res, int idx) {
     return false;
 }
 
-#if defined(_WIN32) && !defined(__GNUC__)
+#if defined(_WIN32)
 #include <windows.h>
 #define PATH_MAX MAX_PATH
 static char *dirname(char *path) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -839,7 +839,7 @@ bool is_f64_supported(const dnnl_engine_t &engine) {
     return false;
 }
 
-#if defined(_WIN32) && !defined(__GNUC__)
+#if defined(_WIN32)
 #include "windows.h"
 
 static size_t get_cpu_ram_size() {


### PR DESCRIPTION
# Description

Handle code paths that are assuming Linux just because `__GNUC__` is defined.

Fixes #1803

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?


