### PR TITLE
gpu: miopen: pooling: Fixes strides in 1D pooling

### DIFF
--- a/src/gpu/amd/miopen_pooling_impl.hpp
+++ b/src/gpu/amd/miopen_pooling_impl.hpp
@@ -86,9 +86,13 @@ protected:
             // [n, c, w, 1]
             dims_[src][3] = dims_[src][2];
             dims_[src][2] = 1;
+            strides_[src][2] = dims_[src][3];
+            strides_[src][3] = 1;
 
             dims_[dst][3] = dims_[dst][2];
             dims_[dst][2] = 1;
+            strides_[dst][2] = dims_[dst][3];
+            strides_[dst][3] = 1;
 
             // Set kernel dimensions to [1, kw]
             kernel_dims_[1] = kernel_dims_[0];


### PR DESCRIPTION
# Description

Currently, when performing 1D pooling in the AMD backend, the src/dst tensor strides are set as `[c*w, w, 1, 0]` which is incorrect because the dimensions are set to be `[n, c, 1, w]`. Thus, this MR updates the strides to the correct format of `[c*w, w, w, 1]`.