### PR TITLE
benchdnn: gpu: miopen: eltwise: Fixes some comparison issues when f16 is used

### DIFF
--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -334,6 +334,20 @@ bool eltwise_alg_returns_nan_or_inf(const attr_t &attr) {
     return false;
 }
 
+bool miopen_check_correctness(const prb_t *prb,
+        const compare::compare_t::driver_check_func_args_t &args) {
+    if (!is_amd_gpu()) return false;
+
+    // MIOpen generates outputs that are 1ulp in some cases
+    // this extra case needs to be addressed
+    if ((prb->alg == alg_t::ELU || prb->alg == alg_t::LOGISTIC
+                || prb->alg == alg_t::SRELU)
+            && ((prb->dir & FLAG_FWD) && (prb->dt == dnnl_f16))) {
+        return args.diff <= epsilon_dt(args.dt);
+    }
+    return false;
+}
+
 void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
         const args_t &ref_args) {
     const float trh
@@ -354,13 +368,8 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &source
                         = ((prb->dir & FLAG_BWD) && prb->use_dst()) ? dst : src;
                 const float s = source.get_elem(args.idx);
-                if ((check_abs_err(prb, s, args.trh))
-                        || ((prb->alg == alg_t::ELU
-                                    || prb->alg == alg_t::LOGISTIC
-                                    || prb->alg == alg_t::SRELU)
-                                && ((prb->dir & FLAG_FWD)
-                                        && (prb->dt == dnnl_f16)
-                                        && (is_amd_gpu()))))
+                if (check_abs_err(prb, s, args.trh)
+                        || miopen_check_correctness(prb, args))
                     return args.diff <= args.trh;
                 if (prb->attr.post_ops.binary_index() != -1)
                     return args.diff <= args.trh;

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -368,12 +368,11 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &source
                         = ((prb->dir & FLAG_BWD) && prb->use_dst()) ? dst : src;
                 const float s = source.get_elem(args.idx);
-                if (check_abs_err(prb, s, args.trh)
-                        || miopen_check_correctness(prb, args))
+                if (check_abs_err(prb, s, args.trh))
                     return args.diff <= args.trh;
                 if (prb->attr.post_ops.binary_index() != -1)
                     return args.diff <= args.trh;
-                return false;
+                return miopen_check_correctness(prb, args);
             };
     cmp.set_driver_check_function(eltwise_add_check);
 }

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -354,12 +354,13 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &source
                         = ((prb->dir & FLAG_BWD) && prb->use_dst()) ? dst : src;
                 const float s = source.get_elem(args.idx);
-                if (check_abs_err(prb, s, args.trh))
-                    return args.diff <= args.trh;
-                if ((prb->alg == alg_t::ELU || prb->alg == alg_t::LOGISTIC
-                            || prb->alg == alg_t::SRELU)
-                        && ((prb->dir & FLAG_FWD) && (prb->dt == dnnl_f16)
-                                && (is_amd_gpu())))
+                if (check_abs_err(prb, s, args.trh)
+                        || (prb->alg == alg_t::ELU
+                                   || prb->alg == alg_t::LOGISTIC
+                                   || prb->alg == alg_t::SRELU)
+                                && ((prb->dir & FLAG_FWD)
+                                        && (prb->dt == dnnl_f16)
+                                        && (is_amd_gpu())))
                     return args.diff <= args.trh;
                 if (prb->attr.post_ops.binary_index() != -1)
                     return args.diff <= args.trh;

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -354,11 +354,13 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &source
                         = ((prb->dir & FLAG_BWD) && prb->use_dst()) ? dst : src;
                 const float s = source.get_elem(args.idx);
-                if ((check_abs_err(prb, s, args.trh) || (prb->alg == alg_t::ELU)
-                            || (prb->alg == alg_t::LOGISTIC)
-                            || (prb->alg == alg_t::SRELU))
-                        && (prb->dir & FLAG_FWD) && (prb->dt == dnnl_f16)
-                        && (is_amd_gpu()))
+                if ((check_abs_err(prb, s, args.trh))
+                        || ((prb->alg == alg_t::ELU
+                                    || prb->alg == alg_t::LOGISTIC
+                                    || prb->alg == alg_t::SRELU)
+                                && ((prb->dir & FLAG_FWD)
+                                        && (prb->dt == dnnl_f16)
+                                        && (is_amd_gpu()))))
                     return args.diff <= args.trh;
                 if (prb->attr.post_ops.binary_index() != -1)
                     return args.diff <= args.trh;

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -354,13 +354,11 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &source
                         = ((prb->dir & FLAG_BWD) && prb->use_dst()) ? dst : src;
                 const float s = source.get_elem(args.idx);
-                if (check_abs_err(prb, s, args.trh)
-                        || (prb->alg == alg_t::ELU
-                                   || prb->alg == alg_t::LOGISTIC
-                                   || prb->alg == alg_t::SRELU)
-                                && ((prb->dir & FLAG_FWD)
-                                        && (prb->dt == dnnl_f16)
-                                        && (is_amd_gpu())))
+                if ((check_abs_err(prb, s, args.trh) || (prb->alg == alg_t::ELU)
+                            || (prb->alg == alg_t::LOGISTIC)
+                            || (prb->alg == alg_t::SRELU))
+                        && (prb->dir & FLAG_FWD) && (prb->dt == dnnl_f16)
+                        && (is_amd_gpu()))
                     return args.diff <= args.trh;
                 if (prb->attr.post_ops.binary_index() != -1)
                     return args.diff <= args.trh;

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -356,6 +356,11 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const float s = source.get_elem(args.idx);
                 if (check_abs_err(prb, s, args.trh))
                     return args.diff <= args.trh;
+                if ((prb->alg == alg_t::ELU || prb->alg == alg_t::LOGISTIC
+                            || prb->alg == alg_t::SRELU)
+                        && ((prb->dir & FLAG_FWD) && (prb->dt == dnnl_f16)
+                                && (is_amd_gpu())))
+                    return args.diff <= args.trh;
                 if (prb->attr.post_ops.binary_index() != -1)
                     return args.diff <= args.trh;
                 return false;


### PR DESCRIPTION
# Description

There are some precision issues when the algorithm for **eltwise** is **logistic**, **elu**, or **srelu**. MiOpen fails in those cases when the **f16** datatype is used. This PR solves that problem by adjusting the comparison with the computed reference.

# Version
Latest Master

# Environment
### Hardware
Mi210 AMD GPU
### Software
ROCm Version 5.6.1
Intel(R) oneAPI DPC++/C++ Compiler 2024.0.2 (2024.0.2.20231213)

### Build
```bash
cmake .. -DCMAKE_BUILD_TYPE=Debug -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP -DDNNL_GPU_VENDOR=AMD -DONEDNN_BUILD_GRAPH=OFF
```
### Run
```bash
./benchdnn --mode=C -v1 --engine=gpu --eltwise --batch=test_eltwise_gpu
```
# Observed Behavior
Several errors like this:
```bash
create: --eltwise --engine=gpu --dir=FWD_I --dt=f16 --tag=axb --alg=logistic --alpha=0 --beta=0 --inplace=true 5x16x3
run: --eltwise --engine=gpu --dir=FWD_I --dt=f16 --tag=axb --alg=logistic --alpha=0 --beta=0 --inplace=true 5x16x3
[  18][DST][0:6:0] exp_f32: 4.53979e-05 exp: 4.54187e-05 got: 4.53591e-05 diff:5.96046e-08 rdiff:0.00131234
[  42][DST][0:14:0] exp_f32:    0.487018 exp:    0.487061 got:    0.486572 diff:0.000488281 rdiff:0.00100251
[ 172][DST][3:9:1] exp_f32:    0.490091 exp:     0.48999 got:    0.490479 diff:0.000488281 rdiff:0.000996512
[ 174][DST][3:10:0] exp_f32: 4.53979e-05 exp: 4.54187e-05 got: 4.53591e-05 diff:5.96046e-08 rdiff:0.00131234
[ 198][DST][4:2:0] exp_f32:    0.483344 exp:    0.483398 got:     0.48291 diff:0.000488281 rdiff:0.0010101
[COMPARE_STATS][DST]: trh=0.000976562 max_diff:0.000488281 max_rdiff:0.00131234
23964:FAILED (errors:5 total:240) __REPRO: --eltwise --engine=gpu --dir=FWD_I --dt=f16 --tag=axb --alg=logistic --alpha=0 --beta=0 --inplace=true 5x16x3
create: --eltwise --engine=gpu --dir=FWD_I --dt=f16 --tag=axb --alg=logistic --alpha=0 --beta=0 5x16x3
run: --eltwise --engine=gpu --dir=FWD_I --dt=f16 --tag=axb --alg=logistic --alpha=0 --beta=0 5x16x3
[  18][DST][0:6:0] exp_f32: 4.53979e-05 exp: 4.54187e-05 got: 4.53591e-05 diff:5.96046e-08 rdiff:0.00131234
[  42][DST][0:14:0] exp_f32:    0.487018 exp:    0.487061 got:    0.486572 diff:0.000488281 rdiff:0.00100251
[ 172][DST][3:9:1] exp_f32:    0.490091 exp:     0.48999 got:    0.490479 diff:0.000488281 rdiff:0.000996512
[ 174][DST][3:10:0] exp_f32: 4.53979e-05 exp: 4.54187e-05 got: 4.53591e-05 diff:5.96046e-08 rdiff:0.00131234
[ 198][DST][4:2:0] exp_f32:    0.483344 exp:    0.483398 got:     0.48291 diff:0.000488281 rdiff:0.0010101
[COMPARE_STATS][DST]: trh=0.000976562 max_diff:0.000488281 max_rdiff:0.00131234
23965:FAILED (errors:5 total:240) __REPRO: --eltwise --engine=gpu --dir=FWD_I --dt=f16 --tag=axb --alg=logistic --alpha=0 --beta=0 5x16x3
```