### PR TITLE
cpu: aarch64: softmax: fall back to ref if stag != dtag

### DIFF
--- a/src/cpu/aarch64/acl_softmax.hpp
+++ b/src/cpu/aarch64/acl_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -94,12 +94,13 @@ struct acl_softmax_fwd_t : public primitive_t {
         status_t init(engine_t *engine) {
 
             bool ok = is_fwd()
-                    // ACL only supports matching src/dst data types
-                    && src_md()->data_type == dst_md()->data_type
+                    && set_default_formats() == status::success
+                    // ACL only supports matching src/dst (this must come after
+                    // set_default_formats() to handle format_kind::any)
+                    && *src_md() == *dst_md()
                     && utils::one_of(
                             src_md()->data_type, data_type::f32, data_type::f16)
-                    && attr()->has_default_values()
-                    && set_default_formats() == status::success;
+                    && attr()->has_default_values();
             if (!ok) return status::unimplemented;
 
             // Get memory desc to find sizes and dims


### PR DESCRIPTION
`acl_softmax` would return incorrect answer if stag did not match dtag, for example
```sh
./benchdnn -v5 --softmax --stag=axb --dtag=abx 2x19x16x64
```
This patch fixes that by falling back to ref if stag != dtag.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Bug fixes
- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests? Not adding new tests because there is no new functionality, just restricting existing functionality.
