### PR TITLE
cpu: aarch64: fix xbyak functions for /sys access failures cherrypick#1773

### DIFF
--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_linux.h
@@ -144,8 +144,13 @@ private:
     regex_t regexBuf;
     regmatch_t match[1];
 
-    if (regcomp(&regexBuf, regex, REG_EXTENDED) != 0)
-      throw ERR_INTERNAL;
+    if (regcomp(&regexBuf, regex, REG_EXTENDED) != 0) {
+      /* There are platforms with /sys not mounted. return empty buffers
+       * in these scenarios
+       */
+      buf[0] = '\0';
+      return 0;
+    }
 
     const int retVal = regexec(&regexBuf, path, 1, match, 0);
     regfree(&regexBuf);
@@ -187,8 +192,12 @@ private:
       regex_t regexBuf;
       regmatch_t match[2];
 
-      if (regcomp(&regexBuf, "index[0-9]*$", REG_EXTENDED) != 0)
-        throw ERR_INTERNAL;
+      if (regcomp(&regexBuf, "index[0-9]*$", REG_EXTENDED) != 0) {
+        /* There are platforms with /sys not mounted. return gracefully
+         * in these scenarios
+         */
+        goto init_and_return_false;
+      }
 
       if (regexec(&regexBuf, dp->d_name, 1, match, 0) == 0) { // Found index[1-9][0-9]. directory
         char *dir_name = buf0;
@@ -438,12 +447,15 @@ private:
 
     FILE *file = fopen(path_midr_el1, "r");
     if (file == nullptr) {
-      throw Error(ERR_INTERNAL);
+      /* There are platforms with /sys not mounted. return empty buffer
+       * in these scenarios
+       */
+      buf[0] = '\0';
       return;
     }
 
     if (fread(buf, sizeof(char), 64, file) == 0) {
-      throw Error(ERR_INTERNAL);
+      cacheInfo_.midr_el1 = 0xFE << 24;
       return;
     }
 

--- a/src/cpu/aarch64/xbyak_aarch64/src/util_impl_mac.h
+++ b/src/cpu/aarch64/xbyak_aarch64/src/util_impl_mac.h
@@ -102,18 +102,21 @@ private:
     size_t val = 0;
     size_t len = sizeof(val);
 
+    /* There are platforms with /sys not mounted. skip
+     * handling HW caps for such platforms.
+     */
     if (sysctlbyname(hw_opt_atomics, &val, &len, NULL, 0) != 0)
-      throw Error(ERR_INTERNAL);
+      type_ = 0;
     else
       type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_ATOMIC : 0;
 
     if (sysctlbyname(hw_opt_fp, &val, &len, NULL, 0) != 0)
-      throw Error(ERR_INTERNAL);
+      type_ = 0;
     else
       type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_FP : 0;
 
     if (sysctlbyname(hw_opt_neon, &val, &len, NULL, 0) != 0)
-      throw Error(ERR_INTERNAL);
+      type_ = 0;
     else
       type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_ADVSIMD : 0;
   }


### PR DESCRIPTION
There are platforms with /sys not mounted. skip handling HW caps for such platforms.

This fixes the issue# pytorch/pytorch#115482

I ran subset of benchdnn tests on aarch64 Linux (AWS Graviton3) platform, but didn't test on Mac.

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
