### PR TITLE
src: cpu: aarch64: Add ACL GELU erf

### DIFF
--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -88,7 +88,8 @@ struct acl_eltwise_fwd_t : public primitive_t {
             using namespace dnnl::impl::alg_kind;
             if (src_d.data_type() == f16
                     && utils::one_of(desc_.alg_kind, eltwise_tanh,
-                            eltwise_logistic, eltwise_soft_relu, eltwise_elu)) {
+                            eltwise_logistic, eltwise_soft_relu, eltwise_elu,
+                            eltwise_gelu_erf)) {
                 return status::unimplemented;
             }
 

--- a/src/cpu/aarch64/acl_utils.cpp
+++ b/src/cpu/aarch64/acl_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Arm Ltd. and affiliates
+* Copyright 2021-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -104,6 +104,9 @@ status_t convert_to_acl_act(alg_kind_t eltwise_alg, float alpha, float beta,
             // Switching order of alpha and beta makes the two equivalent.
             act_info = ActivationLayerInfo(
                     act_func::LU_BOUNDED_RELU, beta, alpha);
+            break;
+        case eltwise_gelu_erf:
+            act_info = ActivationLayerInfo(act_func::GELU);
             break;
         default: act_info = ActivationLayerInfo(); return status::unimplemented;
     }


### PR DESCRIPTION
# Description

Add ACL implementation of GELU erf. On CPUs with SVE, we will continue to use the jit eltwise impl, but this will accelerate GELU on CPUs with Arm® Neon™ by replacing ref. It will also allow impls making use of the `acl_post_ops_t` to work with GELU erf post ops. E.g. matmul+GELU erf will now use ACL rather than ref.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
