### PR TITLE
Use installed Arm Compute Library

### DIFF
--- a/cmake/FindACL.cmake
+++ b/cmake/FindACL.cmake
@@ -24,14 +24,12 @@
 find_path(ACL_INCLUDE_DIR
   NAMES arm_compute/graph.h
   PATHS ENV ACL_ROOT_DIR
-  NO_DEFAULT_PATH
   )
 
 find_library(ACL_LIBRARY
   NAMES arm_compute
   PATHS ENV ACL_ROOT_DIR
-  PATH_SUFFIXES build
-  NO_DEFAULT_PATH
+  PATH_SUFFIXES lib build
   )
 
 include(FindPackageHandleStandardArgs)
@@ -56,7 +54,7 @@ if(ACL_FOUND)
   find_library(ACL_GRAPH_LIBRARY
     NAMES arm_compute_graph
     PATHS ENV ACL_ROOT_DIR
-    PATH_SUFFIXES build
+    PATH_SUFFIXES lib build
     )
 
   list(APPEND ACL_INCLUDE_DIRS

--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
 * Copyright 2020 FUJITSU LIMITED
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,8 +37,6 @@
 #if DNNL_AARCH64_USE_ACL
 // For checking if fp16 isa is supported on the platform
 #include "arm_compute/core/CPP/CPPTypes.h"
-// For setting the number of threads for ACL
-#include "src/common/cpuinfo/CpuInfo.h"
 #endif
 #endif
 
@@ -208,7 +206,7 @@ unsigned get_num_cores() {
 #if DNNL_X64
     return x64::cpu().getNumCores(Xbyak::util::CoreLevel);
 #elif DNNL_AARCH64_USE_ACL
-    return arm_compute::cpuinfo::num_threads_hint();
+    return aarch64::cpu().getNumCores(Xbyak_aarch64::util::CoreLevel);
 #else
     return 1;
 #endif


### PR DESCRIPTION
# Description

Instead of requiring users to download and build Arm Compute Library themselves, use the version installed on the system. Additionally, only use public header files.

Fixes #1599

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?