### PR TITLE
cpu: aarch64: Expand ARM SVE support in jit_uni_pool_kernel

### DIFF
--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -158,8 +158,9 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
                             && !(jpp.alg == pooling_max
                                     && block_size > L3_cache_size_per_core)));
 
-    ncsp_fmt_tag = ((forward_ncsp_allowed || backward_ncsp_allowed)
-                           && utils::one_of(isa, sve_512, sve_256) && ndims <= 5)
+    ncsp_fmt_tag
+            = ((forward_ncsp_allowed || backward_ncsp_allowed)
+                      && utils::one_of(isa, sve_512, sve_256) && ndims <= 5)
             ? utils::pick(ndims - 3, ncw, nchw, ncdhw)
             : format_tag::undef;
 

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2017-2023 Intel Corporation
 * Copyright 2018 YANDEX LLC
-* Copyright 2020-2023 FUJITSU LIMITED
+* Copyright 2020-2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -121,7 +121,10 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
     jpp.ndims = ndims;
     jpp.mb = src_d.dims()[0];
     jpp.c_without_padding = src_d.dims()[1];
-    jpp.c_block = 16;
+    switch (isa) {
+        case sve_512: jpp.c_block = 16; break;
+        default: jpp.c_block = 8; break;
+    }
 
     jpp.alg = pd.alg_kind;
     jpp.tmp_md = memory_desc_t();
@@ -156,7 +159,7 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
                                     && block_size > L3_cache_size_per_core)));
 
     ncsp_fmt_tag = ((forward_ncsp_allowed || backward_ncsp_allowed)
-                           && isa == sve_512 && ndims <= 5)
+                           && utils::one_of(isa, sve_512, sve_256) && ndims <= 5)
             ? utils::pick(ndims - 3, ncw, nchw, ncdhw)
             : format_tag::undef;
 
@@ -541,7 +544,7 @@ inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
                     } else {
                         add_imm(X_DEFAULT_ADDR, aux_reg_input, input_offset,
                                 X_TMP_0);
-                        ldr(z_tmp0, ptr(X_DEFAULT_ADDR));
+                        ld1w(z_tmp0.s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
                         fadd(accvr, accvr, z_tmp0.s);
                     }
                 }
@@ -889,6 +892,11 @@ void jit_uni_pool_kernel<isa>::generate() {
 
     this->preamble();
 
+    size_t simd_w_ = cpu_isa_traits<isa>::vlen / sizeof(float);
+
+    if (simd_w_ != cpu_sveLen / sizeof(float))
+        set_preg(P_ALL_ONE.s, simd_w_, X_TMP_0, X_TMP_1);
+
     Label idx_table;
 
     int ow = jpp.ow;
@@ -1051,6 +1059,7 @@ void jit_uni_pool_kernel<isa>::generate() {
 }
 
 template struct jit_uni_pool_kernel<sve_512>;
+template struct jit_uni_pool_kernel<sve_256>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2017-2022 Intel Corporation
 * Copyright 2018 YANDEX LLC
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2020-2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2023 Intel Corporation
-* Copyright 2020-2023 FUJITSU LIMITED
+* Copyright 2020-2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1267,6 +1267,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
 
 template struct jit_uni_pooling_fwd_t<sve_512, data_type::f32>;
 template struct jit_uni_pooling_bwd_t<sve_512, data_type::f32>;
+template struct jit_uni_pooling_fwd_t<sve_256, data_type::f32>;
+template struct jit_uni_pooling_bwd_t<sve_256, data_type::f32>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_uni_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_pooling.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2022 Intel Corporation
-* Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2020-2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/cpu_pooling_list.cpp
+++ b/src/cpu/cpu_pooling_list.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2023 Intel Corporation
-* Copyright 2020 FUJITSU LIMITED
+* Copyright 2020-2024 FUJITSU LIMITED
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,6 +62,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_pooling_fwd_t<avx, f32>)
             CPU_INSTANCE_X64(jit_uni_pooling_fwd_t<sse41, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_pooling_fwd_t<sve_512, f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_pooling_fwd_t<sve_256, f32>)
             CPU_INSTANCE_AARCH64_ACL(acl_pooling_fwd_t)
             CPU_INSTANCE_RV64GCV(riscv_nchw_pooling_fwd_t<f32>)
             CPU_INSTANCE(nchw_pooling_fwd_t<bf16>)
@@ -91,6 +92,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_pooling_bwd_t<avx, f32>)
             CPU_INSTANCE_X64(jit_uni_pooling_bwd_t<sse41, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_pooling_bwd_t<sve_512, f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_pooling_bwd_t<sve_256, f32>)
             CPU_INSTANCE(nchw_pooling_bwd_t<bf16>)
             CPU_INSTANCE(nchw_pooling_bwd_t<f32>)
             CPU_INSTANCE(nchw_pooling_bwd_t<f16>)


### PR DESCRIPTION
# Description
Enhancement: Expand ARM SVE support in jit_uni_pool_kernel

This commit enhances the existing ARM SVE support in jit_uni_pooling to include additional vector length compatibility. The changes made are for implementation of different ARM SVE vector length.

Major Code changes:
• Updated the block size definition to accommodate other SVE vector length.
• Added 'OR' condition to extend support for other SVE vector while assigning value of 'ncsp_fmt_tag'.
• Predicate registers are set according to isa vector length.
• ldr is replaced by ld1w instruction for average pooling

# Checklist
## General

- [✓] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? Yes
Test output is same with and without this commit.

1. make test 
```
98% tests passed, 4 tests failed out of 162

Total Test time (real) =  98.14 sec

The following tests FAILED:
         84 - test_shuffle (Subprocess aborted)
        145 - test_graph_unit_dnnl_conv_usm_cpu (Failed)
        150 - test_graph_unit_dnnl_large_partition_usm_cpu (Failed)
        158 - test_graph_unit_dnnl_sdp_decomp_usm_cpu (Subprocess aborted)
Errors while running CTest
Output from these tests are in: /home/vishwas/oneDNN/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8

```

2. make test_benchdnn_modeC_pool_ci_cpu/fast 

```
tests:3840 passed:2700 skipped:1140 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 8.71s; fill: 2.78s (32%); compute_ref: 1.65s (19%); compare: 1.96s (22%);
```

3. make test_benchdnn_*
```make: *** No rule to make target 'test_benchdnn_*'.  Stop.```

### gtests

4 ./test_pooling_forward
```
[----------] Global test environment tear-down
[==========] 296 tests from 52 test suites ran. (4546 ms total)
[  PASSED  ] 296 tests.
```

5 ./test_pooling_backward
```
[----------] Global test environment tear-down
[==========] 155 tests from 24 test suites ran. (2493 ms total)
[  PASSED  ] 155 tests.
```

- [✓] Have you formatted the code using clang-format? Yes
