### PR TITLE
benchdnn:gpu: miopen:conv:post_op:sum: Introduce precision threshold for AMD failing tests

### DIFF
--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -414,6 +414,15 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
             trh *= (MAX2(1, pow(10, 0.4 * log_const)));
         }
     }
+
+    if (is_amd_gpu()) {
+        for (auto post_op_used : prb->attr.post_ops.entry) {
+            if (post_op_used.is_sum_kind() && prb->dt[1] == dnnl_f16) {
+                trh = 4e-3f;
+            }
+        }
+    }
+
     cmp.set_threshold(trh);
 
     const float zpp = (1.f - get_non_zero_trust_percent(prb, kind)) * 100.f;


### PR DESCRIPTION
# Description

Proposing the introduction of a larger precision threshold for convolutions with the sum post op which are running in f16 on AMD hardware. Currently encountered the following failures:

Fixes 
```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic64ih360iw640oc64oh360ow640kh3kw3ph1pw1n"1d69cd1c28e88467798af244e7d8840f*40"

```

```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic320ih66oc320oh64kh3ph0n"9096a8618b9c2d54286b2dd9766c2f12*10"

```

```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic640ih34oc640oh32kh3ph0n"a99223e1292e767214307f1093cd9639*10"

```

```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic640ih32oc640oh32kh1ph0n"cee0dda4d6defe16ce21f69a8afcbeb7*10"

```

```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic1280ih18oc1280oh16kh3ph0n"0baacd5721533eff70b4b6c07246bd82*10"

```

```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic1280ih16oc1280oh16kh1ph0n"6eb8b207034607aa964715fb14b07444*10"

```

```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic1280ih10oc1280oh8kh3ph0n"071c23860ac68b5e581c044defc34ef0*14"

```

```
--conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --dt=f16:f16:f16 --attr-post-ops=sum:0.618 mb1ic1280ih8oc1280oh8kh1ph0n"f7e8bfe8f912409e9d1217a09409e1fe*2"

```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
