### PR TITLE
gtests: gpu: amd: Fix to a subset of gtests failures

### DIFF
--- a/tests/gtests/test_concat.cpp
+++ b/tests/gtests/test_concat.cpp
@@ -101,6 +101,7 @@ protected:
 
     void SetUp() override {
         auto data_type = data_traits<data_t>::data_type;
+        SKIP_IF_HIP(true, "Concat operator is not supported");
         SKIP_IF(unsupported_data_type(data_type),
                 "Engine does not support this data type.");
         concat_test_params_t p

--- a/tests/gtests/test_group_normalization.cpp
+++ b/tests/gtests/test_group_normalization.cpp
@@ -46,6 +46,8 @@ private:
 
 protected:
     void SetUp() override {
+        SKIP_IF_HIP(
+                true, "Group Normalization operator is not supported in HIP");
         p = ::testing::TestWithParam<
                 group_normalization_test_params_t>::GetParam();
 

--- a/tests/gtests/test_iface_attr_quantization.cpp
+++ b/tests/gtests/test_iface_attr_quantization.cpp
@@ -107,6 +107,8 @@ TEST_F(attr_quantization_test_t, TestBinary) {
 }
 
 TEST_F(attr_quantization_test_t, TestConcat) {
+    // Operator is not supported in the AMD backend
+    SKIP_IF_HIP(true, "Concat operator is not supported in HIP");
     memory::desc md {{1, 16, 3, 3}, data_type::s8, tag::abcd};
     CHECK_OK(concat::primitive_desc(eng, 1, {md, md}));
 
@@ -122,6 +124,8 @@ TEST_F(attr_quantization_test_t, TestConcat) {
 TEST_F(attr_quantization_test_t, TestConv) {
     // Datatype u8 is not supported in the Nvidia backend
     SKIP_IF_CUDA(true, "Unsupported datatype for CUDA");
+    // src, wei and dst needs to have same datatype. Just s8 it is supported.
+    SKIP_IF_HIP(true, "Unsupported datatype for HIP");
     memory::desc src_md {{1, 16, 7, 7}, data_type::u8, tag::any};
     memory::desc wei_md {{32, 16, 3, 3}, data_type::s8, tag::any};
     memory::desc dst_md {{1, 32, 7, 7}, data_type::s32, tag::any};
@@ -175,6 +179,8 @@ TEST_F(attr_quantization_test_t, TestConv) {
 TEST_F(attr_quantization_test_t, TestConvGroup) {
     // Datatype u8 is not supported in the Nvidia backend
     SKIP_IF_CUDA(true, "Unsupported datatype for CUDA");
+    // src, wei and dst needs to have same datatype. Just s8 it is supported.
+    SKIP_IF_HIP(true, "Unsupported datatype for HIP");
     const int g = 2;
     memory::desc src_md {{1, 16, 7, 7}, data_type::u8, tag::any};
     memory::desc wei_md {{g, 32 / g, 16 / g, 3, 3}, data_type::s8, tag::any};
@@ -231,6 +237,8 @@ TEST_F(attr_quantization_test_t, TestConvGroup) {
 }
 
 TEST_F(attr_quantization_test_t, TestDeconv) {
+    // src, wei and dst needs to have same datatype. Just s8 it is supported.
+    SKIP_IF_HIP(true, "Unsupported datatype for HIP");
     memory::desc src_md {{1, 16, 7, 7}, data_type::u8, tag::any};
     memory::desc wei_md {{32, 16, 3, 3}, data_type::s8, tag::any};
     memory::desc dst_md {{1, 32, 7, 7}, data_type::s8, tag::any};
@@ -276,6 +284,8 @@ TEST_F(attr_quantization_test_t, TestDeconv) {
 }
 
 TEST_F(attr_quantization_test_t, TestDeconvGroup) {
+    // src, wei and dst needs to have same datatype. Just s8 it is supported.
+    SKIP_IF_HIP(true, "Unsupported datatype for HIP");
     const int g = 2;
     memory::desc src_md {{1, 16, 7, 7}, data_type::u8, tag::any};
     memory::desc wei_md {{g, 32 / g, 16 / g, 3, 3}, data_type::s8, tag::any};
@@ -323,6 +333,9 @@ TEST_F(attr_quantization_test_t, TestDeconvGroup) {
 
 TEST_F(attr_quantization_test_t, TestEltwise) {
     for (auto dt : {data_type::f32, data_type::s8}) {
+        // s8 is not supported in HIP
+        if (is_amd_gpu(get_test_engine()) && dt == data_type::s8) continue;
+
         memory::desc md {{1, 16, 3, 3}, dt, tag::abcd};
 
         CHECK_OK(eltwise_forward::primitive_desc(
@@ -342,6 +355,8 @@ TEST_F(attr_quantization_test_t, TestEltwise) {
 TEST_F(attr_quantization_test_t, TestInnerProduct) {
     // Datatype u8 is not supported in the Nvidia backend
     SKIP_IF_CUDA(true, "Unsupported datatype for CUDA");
+    // src, wei needs to be s8 and dst be s32.
+    SKIP_IF_HIP(true, "Unsupported datatype for HIP");
     memory::desc src_md {{1, 16, 7, 7}, data_type::u8, tag::any};
     memory::desc wei_md {{32, 16, 7, 7}, data_type::s8, tag::any};
     memory::desc dst_md {{1, 32}, data_type::s32, tag::any};
@@ -360,6 +375,7 @@ TEST_F(attr_quantization_test_t, TestInnerProduct) {
 
 TEST_F(attr_quantization_test_t, TestLNorm) {
     SKIP_IF_CUDA(true, "Layer normalization primitive not supported for CUDA");
+    SKIP_IF_HIP(true, "Layer normalization primitive not supported for HIP");
 
     memory::desc md {{1, 16, 16}, data_type::s8, tag::abc};
     memory::desc stat_md {{1, 16}, data_type::f32, tag::ab};
@@ -476,6 +492,8 @@ CPU_TEST_F(attr_quantization_test_t, TestMatmulBatch) {
 }
 
 TEST_F(attr_quantization_test_t, TestPool) {
+    // Datatype s8 is not supported in the Nvidia backend
+    SKIP_IF_HIP(true, "Unsupported datatype for AMD");
     memory::desc src_md {{1, 16, 8, 8}, data_type::s8, tag::abcd};
     memory::desc dst_md {{1, 16, 4, 4}, data_type::s8, tag::abcd};
 
@@ -497,6 +515,7 @@ TEST_F(attr_quantization_test_t, TestPool) {
 
 TEST_F(attr_quantization_test_t, TestPReLU) {
     SKIP_IF_CUDA(true, "Unsupported primitive not supported for CUDA");
+    SKIP_IF_HIP(true, "Unsupported primitive not supported for HIP");
     memory::desc data_md {{1, 16, 3, 3}, data_type::f32, tag::abcd};
     memory::desc weights_md {{1, 16, 3, 3}, data_type::f32, tag::abcd};
 
@@ -527,6 +546,7 @@ CPU_TEST_F(attr_quantization_test_t, TestReorder) {
 
 TEST_F(attr_quantization_test_t, TestRNN) {
     SKIP_IF_CUDA(true, "RNN primitive not supported for CUDA");
+    SKIP_IF_HIP(true, "RNN primitive not supported for HIP");
     // Int8 RNN relies on packed API solely which is available only for X64.
 #if !DNNL_X64
     return;
@@ -581,6 +601,7 @@ TEST_F(attr_quantization_test_t, TestRNN) {
 
 TEST_F(attr_quantization_test_t, TestShuffle) {
     SKIP_IF_CUDA(true, "Shuffle primitive not supported for CUDA");
+    SKIP_IF_HIP(true, "Shuffle primitive not supported for HIP");
     memory::desc md {{1, 16, 3, 3}, data_type::f32, tag::abcd};
 
     CHECK_OK(shuffle_forward::primitive_desc pd(
@@ -613,6 +634,7 @@ TEST_F(attr_quantization_test_t, TestSoftmax) {
 }
 
 TEST_F(attr_quantization_test_t, TestSum) {
+    SKIP_IF_HIP(true, "Unsupported operator for HIP");
     memory::desc md {{1, 16, 3, 3}, data_type::s8, tag::abcd};
     CHECK_OK(sum::primitive_desc(eng, {1.f, 1.f}, {md, md}));
     CHECK_UNIMPL(sum::primitive_desc(

--- a/tests/gtests/test_iface_pd_iter.cpp
+++ b/tests/gtests/test_iface_pd_iter.cpp
@@ -84,22 +84,28 @@ TEST_F(pd_iter_test_t, UnsupportedPrimitives) {
 
     ASSERT_EQ(dnnl_reorder_primitive_desc_create(
                       &reorder_pd, mds[0], engine, mds[1], engine, nullptr),
-            ok);
-    ASSERT_EQ(dnnl_concat_primitive_desc_create(
-                      &concat_pd, engine, nullptr, 2, 0, mds, nullptr),
-            ok);
-    ASSERT_EQ(dnnl_sum_primitive_desc_create(
-                      &sum_pd, engine, mds[0], 2, scales, mds, nullptr),
-            ok);
-
+            ok);    
     ASSERT_EQ(
             dnnl_primitive_desc_next_impl(reorder_pd), dnnl_last_impl_reached);
-    ASSERT_EQ(dnnl_primitive_desc_next_impl(concat_pd), dnnl_last_impl_reached);
-    ASSERT_EQ(dnnl_primitive_desc_next_impl(sum_pd), dnnl_last_impl_reached);
+            ASSERT_EQ(dnnl_primitive_desc_destroy(reorder_pd), ok);
 
-    ASSERT_EQ(dnnl_primitive_desc_destroy(reorder_pd), ok);
-    ASSERT_EQ(dnnl_primitive_desc_destroy(concat_pd), ok);
-    ASSERT_EQ(dnnl_primitive_desc_destroy(sum_pd), ok);
+    // concat and sum operator are not supported for HIP
+    if (!is_amd_gpu(get_test_engine())) {
+        ASSERT_EQ(dnnl_concat_primitive_desc_create(
+                          &concat_pd, engine, nullptr, 2, 0, mds, nullptr),
+                ok);
+        ASSERT_EQ(dnnl_sum_primitive_desc_create(
+                          &sum_pd, engine, mds[0], 2, scales, mds, nullptr),
+                ok);
+
+        ASSERT_EQ(dnnl_primitive_desc_next_impl(concat_pd),
+                dnnl_last_impl_reached);
+        ASSERT_EQ(
+                dnnl_primitive_desc_next_impl(sum_pd), dnnl_last_impl_reached);
+
+        ASSERT_EQ(dnnl_primitive_desc_destroy(concat_pd), ok);
+        ASSERT_EQ(dnnl_primitive_desc_destroy(sum_pd), ok);
+    }
 
     ASSERT_EQ(dnnl_memory_desc_destroy(mds[0]), ok);
     ASSERT_EQ(dnnl_memory_desc_destroy(mds[1]), ok);

--- a/tests/gtests/test_iface_pd_iter.cpp
+++ b/tests/gtests/test_iface_pd_iter.cpp
@@ -84,10 +84,10 @@ TEST_F(pd_iter_test_t, UnsupportedPrimitives) {
 
     ASSERT_EQ(dnnl_reorder_primitive_desc_create(
                       &reorder_pd, mds[0], engine, mds[1], engine, nullptr),
-            ok);    
+            ok);
     ASSERT_EQ(
             dnnl_primitive_desc_next_impl(reorder_pd), dnnl_last_impl_reached);
-            ASSERT_EQ(dnnl_primitive_desc_destroy(reorder_pd), ok);
+    ASSERT_EQ(dnnl_primitive_desc_destroy(reorder_pd), ok);
 
     // concat and sum operator are not supported for HIP
     if (!is_amd_gpu(get_test_engine())) {

--- a/tests/gtests/test_layer_normalization.cpp
+++ b/tests/gtests/test_layer_normalization.cpp
@@ -64,6 +64,7 @@ private:
 protected:
     void SetUp() override {
         SKIP_IF_CUDA(true, "Layer normalization not supported by CUDA.");
+        SKIP_IF_HIP(true, "Layer normalization not supported by HIP.");
         p = ::testing::TestWithParam<decltype(p)>::GetParam();
 
         SKIP_IF(unsupported_data_type(p.src_dt)

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -264,7 +264,8 @@ protected:
         aa.po_eltwise = true;
         aa.po_prelu = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
         aa.po_sum = true;
-        aa.scales = true;
+        // scales are not supported by HIP
+        aa.scales = !is_amd_gpu(eng);
         bool is_int8 = impl::utils::one_of(src_md.get_data_type(),
                 memory::data_type::s8, memory::data_type::u8);
         if (is_int8) aa.zp = true;

--- a/tests/gtests/test_prelu.cpp
+++ b/tests/gtests/test_prelu.cpp
@@ -48,6 +48,7 @@ protected:
         p = ::testing::TestWithParam<prelu_test_params_t>::GetParam();
 
         SKIP_IF_CUDA(true, "Prelu primitive not supported by CUDA");
+        SKIP_IF_HIP(true, "Prelu primitive not supported by HIP");
 
         SKIP_IF(unsupported_data_type(p.src_dt, p.wei_dt, p.dst_dt),
                 "Engine does not support this data type.");

--- a/tests/gtests/test_primitive_cache_mt.cpp
+++ b/tests/gtests/test_primitive_cache_mt.cpp
@@ -45,6 +45,7 @@ TEST(primitive_cache_mt_test, TestGeneralCase) {
 }
 
 TEST(primitive_cache_mt_test, TestNestedCase) {
+    SKIP_IF_HIP(true, "Sum operator is not supported by HIP");
     using tag = memory::format_tag;
     using dt = memory::data_type;
 

--- a/tests/gtests/test_reorder_common.hpp
+++ b/tests/gtests/test_reorder_common.hpp
@@ -136,7 +136,7 @@ protected:
                           || supported_blocking(prec_i, p.fmt_i))
                         && (supported_format(p.fmt_o)
                                 || supported_blocking(prec_o, p.fmt_o))),
-                "Unsupported cuda format tag/ data type");
+                "Unsupported hip format tag/ data type");
 #endif
 
         catch_expected_failures([&]() { RunTest(eng_i, eng_o); },

--- a/tests/gtests/test_resampling.cpp
+++ b/tests/gtests/test_resampling.cpp
@@ -360,17 +360,11 @@ protected:
 using resampling_test_float = resampling_test_t<float>;
 
 #define EXPAND_SIZES_3D(...) \
-    5, { \
-        __VA_ARGS__ \
-    }
+    5, { __VA_ARGS__ }
 #define EXPAND_SIZES_2D(mb, c, ih, iw, oh, ow, fh, fw) \
-    4, { \
-        mb, c, 1, ih, iw, 1, oh, ow, 1.f, fh, fw \
-    }
+    4, { mb, c, 1, ih, iw, 1, oh, ow, 1.f, fh, fw }
 #define EXPAND_SIZES_1D(mb, c, iw, ow, fw) \
-    3, { \
-        mb, c, 1, 1, iw, 1, 1, ow, 1.f, 1.f, fw \
-    }
+    3, { mb, c, 1, 1, iw, 1, 1, ow, 1.f, 1.f, fw }
 
 TEST_P(resampling_test_float, TestsResampleF32) {}
 

--- a/tests/gtests/test_resampling.cpp
+++ b/tests/gtests/test_resampling.cpp
@@ -223,6 +223,8 @@ protected:
                 tag, dnnl_abc, dnnl_abcd, dnnl_acb, dnnl_acdb);
     }
     void SetUp() override {
+        SKIP_IF_HIP(
+                true, "Resampling operator is not supported by hip backend");
         p = ::testing::TestWithParam<decltype(p)>::GetParam();
         SKIP_IF_CUDA(p.aalgorithm == algorithm::resampling_nearest,
                 "nearet algorithm is not supported for cudnn backend");
@@ -358,11 +360,17 @@ protected:
 using resampling_test_float = resampling_test_t<float>;
 
 #define EXPAND_SIZES_3D(...) \
-    5, { __VA_ARGS__ }
+    5, { \
+        __VA_ARGS__ \
+    }
 #define EXPAND_SIZES_2D(mb, c, ih, iw, oh, ow, fh, fw) \
-    4, { mb, c, 1, ih, iw, 1, oh, ow, 1.f, fh, fw }
+    4, { \
+        mb, c, 1, ih, iw, 1, oh, ow, 1.f, fh, fw \
+    }
 #define EXPAND_SIZES_1D(mb, c, iw, ow, fw) \
-    3, { mb, c, 1, 1, iw, 1, 1, ow, 1.f, 1.f, fw }
+    3, { \
+        mb, c, 1, 1, iw, 1, 1, ow, 1.f, 1.f, fw \
+    }
 
 TEST_P(resampling_test_float, TestsResampleF32) {}
 

--- a/tests/gtests/test_shuffle.cpp
+++ b/tests/gtests/test_shuffle.cpp
@@ -46,6 +46,7 @@ protected:
         p = ::testing::TestWithParam<shuffle_test_params_t>::GetParam();
 
         SKIP_IF_CUDA(true, "Shuffle primitive not supported by CUDA");
+        SKIP_IF_HIP(true, "Shuffle primitive not supported by HIP");
 
         SKIP_IF(unsupported_data_type(p.src_dt, p.dst_dt),
                 "Engine does not support this data type.");

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -37,6 +37,8 @@ protected:
 };
 
 TEST_F(iface_sum_test_t, SumTestDstDataTypeCompliance) {
+    SKIP_IF_HIP(true, "Sum operator is not supported by HIP");
+
     using dt = memory::data_type;
 
     const dt src_dt = dt::s8;
@@ -141,6 +143,7 @@ protected:
                 dnnl_aBcde4b);
     }
     void SetUp() override {
+        SKIP_IF_HIP(true, "Sum operator is not supported by HIP");
         src_data_type = data_traits<src_data_t>::data_type;
         dst_data_type = data_traits<dst_data_t>::data_type;
         sum_test_params p


### PR DESCRIPTION
# Description

While running the Google test suite using MIOpen we get several errors that need to be addressed. This PR solves:

* test_concat
* test_eltwise
* test_group_normalization.cpp
* test_iface_attr_quantization.cpp
* test_iface_pd_iter.cpp
* test_layer_normalization.cpp
* test_matmul.cpp
* test_prelu.cpp
* test_primitive_cache_mt.cpp
* test_reorder_common.hpp
* test_resampling.cpp
* test_shuffle.cpp
* test_sum.cpp

# Version
Latest Main

# Environment
## Hardware
Mi210 AMD GPU

## Build
```bash
cmake .. -DCMAKE_BUILD_TYPE=Debug -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP -DDNNL_GPU_VENDOR=AMD -DONEDNN_BUILD_GRAPH=OFF
```

## Run
```bash
ctest --output-on-failure -E benchdnn --timeout 800
```

# Observed Behavior

Check the [gtests.txt](https://github.com/oneapi-src/oneDNN/files/14837250/gtests.txt) file for additional information.

```bash
83% tests passed, 38 tests failed out of 227

Total Test time (real) = 316.90 sec

The following tests FAILED:
	 11 - test_concat_gpu (Failed)
	 13 - test_concat_buffer_gpu (Failed)
	 46 - test_cross_engine_reorder_buffer (Failed)
	 52 - test_eltwise_gpu (Failed)
	 54 - test_eltwise_buffer_gpu (Failed)
	 56 - test_group_normalization_gpu (Failed)
	 58 - test_group_normalization_buffer_gpu (Failed)
	 64 - test_iface_attr_quantization_gpu (Failed)
	 66 - test_iface_attr_quantization_buffer_gpu (Failed)
	 76 - test_iface_pd_gpu (Failed)
	 78 - test_iface_pd_buffer_gpu (Failed)
	 80 - test_iface_pd_iter_gpu (Failed)
	 82 - test_iface_pd_iter_buffer_gpu (Failed)
	 88 - test_iface_runtime_dims_gpu (Failed)
	 90 - test_iface_runtime_dims_buffer_gpu (Failed)
	100 - test_inner_product_backward_data_gpu (Failed)
	102 - test_inner_product_backward_data_buffer_gpu (Failed)
	104 - test_inner_product_backward_weights_gpu (Failed)
	106 - test_inner_product_backward_weights_buffer_gpu (Failed)
	108 - test_inner_product_forward_gpu (Failed)
	110 - test_inner_product_forward_buffer_gpu (Failed)
	112 - test_layer_normalization_gpu (Failed)
	114 - test_layer_normalization_buffer_gpu (Failed)
	120 - test_matmul_gpu (Failed)
	122 - test_matmul_buffer_gpu (Failed)
	136 - test_prelu_gpu (Failed)
	138 - test_prelu_buffer_gpu (Failed)
	140 - test_primitive_cache_mt_gpu (Failed)
	142 - test_primitive_cache_mt_buffer_gpu (Failed)
	148 - test_reorder_gpu (Failed)
	150 - test_reorder_buffer_gpu (Failed)
	152 - test_resampling_gpu (Failed)
	154 - test_resampling_buffer_gpu (Failed)
	160 - test_shuffle_gpu (Failed)
	162 - test_shuffle_buffer_gpu (Failed)
	168 - test_sum_gpu (Failed)
	170 - test_sum_buffer_gpu (Failed)
	227 - test_api_sycl (Subprocess aborted)
```

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?
