### PR TITLE
gpu: cuda/miopen: bugfix missing headers

### DIFF
--- a/src/gpu/amd/sycl_hip_scoped_context.cpp
+++ b/src/gpu/amd/sycl_hip_scoped_context.cpp
@@ -31,30 +31,20 @@ namespace amd {
 hip_sycl_scoped_context_handler_t::hip_sycl_scoped_context_handler_t(
         const sycl_hip_engine_t &engine)
     : need_to_recover_(false) {
-    try {
-        HIP_EXECUTE_FUNC(hipCtxGetCurrent, &original_);
-        auto desired = engine.get_underlying_context();
-        currentDevice_ = engine.get_underlying_device();
+    HIP_EXECUTE_FUNC(hipCtxGetCurrent, &original_);
+    auto desired = engine.get_underlying_context();
+    currentDevice_ = engine.get_underlying_device();
 
-        if (original_ != desired) {
-
-            HIP_EXECUTE_FUNC(hipCtxSetCurrent, desired);
-            need_to_recover_ = original_ != nullptr;
-        }
-    } catch (const std::runtime_error &e) {
-        error::wrap_c_api(status::runtime_error, e.what());
+    if (original_ != desired) {
+        HIP_EXECUTE_FUNC(hipCtxSetCurrent, desired);
+        need_to_recover_ = original_ != nullptr;
     }
 }
 
 hip_sycl_scoped_context_handler_t::
         ~hip_sycl_scoped_context_handler_t() noexcept(false) {
-
-    try {
-        HIP_EXECUTE_FUNC(hipDevicePrimaryCtxRelease, currentDevice_);
-        if (need_to_recover_) { HIP_EXECUTE_FUNC(hipCtxSetCurrent, original_); }
-    } catch (const std::runtime_error &e) {
-        error::wrap_c_api(status::runtime_error, e.what());
-    }
+    HIP_EXECUTE_FUNC(hipDevicePrimaryCtxRelease, currentDevice_);
+    if (need_to_recover_) { HIP_EXECUTE_FUNC(hipCtxSetCurrent, original_); }
 }
 
 #pragma clang diagnostic pop

--- a/src/gpu/amd/sycl_hip_stream.cpp
+++ b/src/gpu/amd/sycl_hip_stream.cpp
@@ -113,10 +113,7 @@ status_t sycl_hip_stream_t::interop_task(
         });
         this->sycl_ctx().get_sycl_deps().events = {event};
         return status::success;
-    } catch (std::runtime_error &e) {
-        error::wrap_c_api(status::runtime_error, e.what());
-        return status::runtime_error;
-    }
+    } catch (std::runtime_error &e) { return status::runtime_error; }
 }
 
 } // namespace amd

--- a/src/gpu/nvidia/sycl_cuda_stream.cpp
+++ b/src/gpu/nvidia/sycl_cuda_stream.cpp
@@ -112,10 +112,7 @@ status_t sycl_cuda_stream_t::interop_task(
         });
         this->sycl_ctx().get_sycl_deps().events = {event};
         return status::success;
-    } catch (std::runtime_error &e) {
-        error::wrap_c_api(status::runtime_error, e.what());
-        return status::runtime_error;
-    }
+    } catch (std::runtime_error &e) { return status::runtime_error; }
 }
 
 } // namespace nvidia


### PR DESCRIPTION
A recent change broke the build for cuda and miopen backends. This PR adds the header includes that are missing and are breaking the build.