### PR TITLE
fixup: cpu: aarch64: Expand ARM SVE support for matrix multiplication

### DIFF
--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -35,12 +35,8 @@
 #endif
 
 #define DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_name) \
-    const char *name() const override { \
-        return STRINGIFY(jit_name); \
-    } \
-    const char *source_file() const override { \
-        return __FILE__; \
-    }
+    const char *name() const override { return STRINGIFY(jit_name); } \
+    const char *source_file() const override { return __FILE__; }
 
 static const size_t CSIZE = sizeof(uint32_t);
 

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -711,6 +711,10 @@ private:
         return code;
     }
 
+    inline bool is_valid_isa(cpu_isa_t isa) {
+        return is_subset(isa, max_cpu_isa_) && mayiuse(isa);
+    }
+    
     static inline bool is_initialized() {
         /* At the moment, Xbyak_aarch64 does not have GetError()\
          so that return dummy result. */

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -35,8 +35,12 @@
 #endif
 
 #define DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_name) \
-    const char *name() const override { return STRINGIFY(jit_name); } \
-    const char *source_file() const override { return __FILE__; }
+    const char *name() const override { \
+        return STRINGIFY(jit_name); \
+    } \
+    const char *source_file() const override { \
+        return __FILE__; \
+    }
 
 static const size_t CSIZE = sizeof(uint32_t);
 
@@ -714,7 +718,7 @@ private:
     inline bool is_valid_isa(cpu_isa_t isa) {
         return is_subset(isa, max_cpu_isa_) && mayiuse(isa);
     }
-    
+
     static inline bool is_initialized() {
         /* At the moment, Xbyak_aarch64 does not have GetError()\
          so that return dummy result. */

--- a/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
@@ -225,13 +225,13 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
         , is_f32(everyone_is(data_type::f32, conf_->src_dt, conf_->wei_dt))
         , is_bf32(conf_->is_bf32)
         , is_dynamic_src_ld(conf_->is_runtime_M) {
-            MAYBE_UNUSED(m_loop_src_shift);
-            MAYBE_UNUSED(k_loop_src_shift);
-            MAYBE_UNUSED(m_loop_dst_shift);
-            MAYBE_UNUSED(is_bf32);
-            MAYBE_UNUSED(is_dynamic_src_ld);
-            MAYBE_UNUSED(k_loop_dst_shift);
-        }
+        MAYBE_UNUSED(m_loop_src_shift);
+        MAYBE_UNUSED(k_loop_src_shift);
+        MAYBE_UNUSED(m_loop_dst_shift);
+        MAYBE_UNUSED(is_bf32);
+        MAYBE_UNUSED(is_dynamic_src_ld);
+        MAYBE_UNUSED(k_loop_dst_shift);
+    }
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -253,7 +253,6 @@ private:
     const bool is_f32;
     const bool is_bf32;
     const bool is_dynamic_src_ld;
-    
 
     opmask_t kFFFF = p1;
     opmask_t k3333 = p1;
@@ -486,9 +485,9 @@ struct jit_brgemm_matmul_copy_b_f32_t : public jit_brgemm_matmul_copy_b_t,
         , src_stride_(conf_->wei_tag == acbd ? conf_->copy_B_wei_stride
                                              : conf_->N * typesize_in_)
         , tr_src_stride_(conf_->LDB * typesize_out_) {
-            MAYBE_UNUSED(src_stride_);
-            MAYBE_UNUSED(tr_src_stride_);
-        }
+        MAYBE_UNUSED(src_stride_);
+        MAYBE_UNUSED(tr_src_stride_);
+    }
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }

--- a/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
@@ -224,7 +224,14 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
         , k_loop_dst_shift(rows_step * tr_typesize)
         , is_f32(everyone_is(data_type::f32, conf_->src_dt, conf_->wei_dt))
         , is_bf32(conf_->is_bf32)
-        , is_dynamic_src_ld(conf_->is_runtime_M) {}
+        , is_dynamic_src_ld(conf_->is_runtime_M) {
+            MAYBE_UNUSED(m_loop_src_shift);
+            MAYBE_UNUSED(k_loop_src_shift);
+            MAYBE_UNUSED(m_loop_dst_shift);
+            MAYBE_UNUSED(is_bf32);
+            MAYBE_UNUSED(is_dynamic_src_ld);
+            MAYBE_UNUSED(k_loop_dst_shift);
+        }
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }
@@ -246,6 +253,7 @@ private:
     const bool is_f32;
     const bool is_bf32;
     const bool is_dynamic_src_ld;
+    
 
     opmask_t kFFFF = p1;
     opmask_t k3333 = p1;
@@ -477,7 +485,10 @@ struct jit_brgemm_matmul_copy_b_f32_t : public jit_brgemm_matmul_copy_b_t,
         , typesize_in_(types::data_type_size(dt_in_))
         , src_stride_(conf_->wei_tag == acbd ? conf_->copy_B_wei_stride
                                              : conf_->N * typesize_in_)
-        , tr_src_stride_(conf_->LDB * typesize_out_) {}
+        , tr_src_stride_(conf_->LDB * typesize_out_) {
+            MAYBE_UNUSED(src_stride_);
+            MAYBE_UNUSED(tr_src_stride_);
+        }
 
     void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
     status_t create_kernel() override { return jit_generator::create_kernel(); }

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -822,7 +822,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     // required granularity for k dimension
     bgmmc.required_k_granularity = 1;
-    VCONDCHECK_BG(bgmmc.required_k_granularity > 0, VERBOSE_BLOCKING_FAIL);
+    VCONDCHECK_BG(bgmmc.required_k_granularity > 0, VERBOSE_BLOCKING_FAIL, "");
     bgmmc.wei_k_blk = data_type_vnni_simd_elems<sve_512>(bgmmc.wei_dt);
 
     VCHECK_BG(bm_conf_utils.set_or_check_tags(src_md, dst_md, bias_md),
@@ -920,7 +920,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     // - K_blk, batch_size
     // - nthr_K
     VCHECK_BG(compute_blocking_heuristic(bgmmc, bm_conf_utils),
-            VERBOSE_BLOCKING_FAIL);
+            VERBOSE_BLOCKING_FAIL, "");
 
     if (bgmmc.wei_n_blk > bgmmc.N_blk
             && IMPLICATION(
@@ -934,7 +934,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                 = bm_conf_utils.wei_down_convert_to_vnni();
     }
 
-    VCHECK_BG(bm_conf_utils.set_B_flags(weights_md), VERBOSE_BLOCKING_FAIL);
+    VCHECK_BG(bm_conf_utils.set_B_flags(weights_md), VERBOSE_BLOCKING_FAIL, "");
 
     bgmmc.M_tail = bgmmc.is_runtime_M ? 0 : bgmmc.M % bgmmc.M_blk;
     bgmmc.N_tail = bgmmc.N % bgmmc.N_blk;


### PR DESCRIPTION
This PR is raised in order to remove build warnings after merging the PR : https://github.com/oneapi-src/oneDNN/pull/1818.

We have just added the third parameter as an empty string for the functions VCONDCHECK_BG, and VCHECK_BG in the file src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp.
 