### PR TITLE
cpu: aarch64: conv: Removing fall through to oneDNN reference impleme…

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Arm Ltd. and affiliates
+* Copyright 2020-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -106,10 +106,6 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
     // On the other hand l(t)_pad are guaranteed to be non-negative.
     const int r_pad = std::max(static_cast<int>(cd.padding[1][1]), 0);
     const int b_pad = std::max(static_cast<int>(cd.padding[1][0]), 0);
-
-    if (is_depthwise
-            && (t_pad >= kh || b_pad >= kh || l_pad >= kw || r_pad >= kw))
-        return status::unimplemented;
 
     acp.padstride_info = arm_compute::PadStrideInfo(stride_w, stride_h,
             static_cast<unsigned int>(l_pad), static_cast<unsigned int>(r_pad),


### PR DESCRIPTION
…ntation for depthwise convolution when padding greater then kernel

Change-Id: Ic04b5f0c4dc1c5c8a5a9d2b0cfb68d62335aef41

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
