### PR TITLE
cpu: aarch64: conv: Removing fall through to oneDNN reference implementation for depthwise convolution when padding greater then kernel

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Arm Ltd. and affiliates
+* Copyright 2020-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -106,10 +106,6 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
     // On the other hand l(t)_pad are guaranteed to be non-negative.
     const int r_pad = std::max(static_cast<int>(cd.padding[1][1]), 0);
     const int b_pad = std::max(static_cast<int>(cd.padding[1][0]), 0);
-
-    if (is_depthwise
-            && (t_pad >= kh || b_pad >= kh || l_pad >= kw || r_pad >= kw))
-        return status::unimplemented;
 
     acp.padstride_info = arm_compute::PadStrideInfo(stride_w, stride_h,
             static_cast<unsigned int>(l_pad), static_cast<unsigned int>(r_pad),


### PR DESCRIPTION
# Description

Remove fall through to oneDNN reference implementation for depthwise convolution when padding greater then kernel as it offers significant performance increase.

Fixes https://github.com/oneapi-src/oneDNN/issues/1807

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements
![perf_improvement](https://github.com/oneapi-src/oneDNN/assets/8950173/e96c5972-d738-4656-b07c-bb2c6507e200)

- [X] Have you submitted performance data that demonstrates performance improvements?