### PR TITLE
Fuse sum post op acl matmul

### DIFF
--- a/src/cpu/aarch64/acl_post_ops.cpp
+++ b/src/cpu/aarch64/acl_post_ops.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Arm Ltd. and affiliates
+* Copyright 2022-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ namespace aarch64 {
 
 status_t acl_post_ops_t::execute(const exec_ctx_t &ctx, void *src_orig) const {
 
-    int post_op_index = 0;
+    int post_op_index = post_op_start_index_;
 
     // As these are post ops, this src will also be our dst. If we have a sum
     // post op, the src/dst will start off in a temporary, then change to

--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Arm Ltd. and affiliates
+* Copyright 2022-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ struct acl_post_ops_t {
     // init the acl_post_ops_t. Note that this function modifies the passed in
     // post ops by setting the preferred memory formats
     status_t init(engine_t *engine, post_ops_t &post_ops,
-            const memory_desc_t &dst_md) {
+            const memory_desc_t &dst_md, int post_op_start_index = 0) {
+
+        post_op_start_index_ = post_op_start_index;
 
         CHECK(post_ops.set_default_formats(&dst_md));
         dst_data_type = dst_md.data_type;
@@ -41,7 +43,7 @@ struct acl_post_ops_t {
         sum_index = -1;
         post_op_primitives = {};
 
-        for (int i = 0; i < post_ops.len(); i++) {
+        for (int i = post_op_start_index; i < post_ops.len(); i++) {
             auto &po = post_ops.entry_[i];
 
             if (po.is_sum()) {
@@ -135,7 +137,8 @@ struct acl_post_ops_t {
     // formats
     status_t init(engine_t *engine, post_ops_t &base_post_ops,
             const memory_desc_t &dst_md,
-            arm_compute::ActivationLayerInfo &act_info_to_fuse) {
+            arm_compute::ActivationLayerInfo &act_info_to_fuse,
+            int post_op_start_index = 0) {
 
         CHECK(base_post_ops.set_default_formats(&dst_md));
         dst_data_type = dst_md.data_type;
@@ -149,18 +152,11 @@ struct acl_post_ops_t {
                     "eltwise post op scale must be 1 (no scale)");
             CHECK(acl_utils::convert_to_acl_act(first_po, act_info_to_fuse));
 
-            // Copy all but the first, because it has been fused
-            post_ops_t post_ops;
-            for (int idx = 1; idx < base_post_ops.len(); ++idx) {
-                // Construct empty entry then copy, so that we can check for failure
-                post_ops.entry_.emplace_back();
-                post_ops.entry_.back() = base_post_ops.entry_[idx];
-            }
-            return init(engine, post_ops, dst_md);
-
+            // post_op_start_index + 1 to skip the fused eltwise
+            return init(engine, base_post_ops, dst_md, post_op_start_index + 1);
         } else {
             // Nothing to fuse, just copy all post ops
-            return init(engine, base_post_ops, dst_md);
+            return init(engine, base_post_ops, dst_md, post_op_start_index);
         }
     }
 
@@ -179,6 +175,9 @@ struct acl_post_ops_t {
 private:
     // Index of the sum post op if there is one, < 0 means no sum
     int sum_index = -1;
+    // Index of the first post op this primitive executes. This is typically the
+    // number of post ops which were fused.
+    int post_op_start_index_ = 0;
     data_type_t dst_data_type;
     // Vector of primitives used to execute the post ops. They are constructed
     // in init to be either acl_binary_t (for sum, add, sub, div, mul, min and

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -175,7 +175,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
 
 status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
         acl_matmul_conf_t &amp, memory_desc_t &dst_md) {
-    if (amp.use_dst_acc) {
+    if (amp.use_dst_acc_for_sum) {
         const memory_desc_wrapper dst_d(&dst_md);
         scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
                 dst_d.nelems(), dst_d.data_type_size());

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -45,7 +45,7 @@ struct acl_matmul_conf_t {
     bool do_transC;
     // If this is true, the result of the matmul goes into a temporarily
     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
-    bool use_dst_acc;
+    bool use_dst_acc_for_sum;
     arm_compute::TensorInfo src_tensor_info;
     arm_compute::TensorInfo wei_tensor_info;
     arm_compute::TensorInfo dst_tensor_info;
@@ -53,7 +53,6 @@ struct acl_matmul_conf_t {
     arm_compute::TensorInfo wei_acc_info;
     arm_compute::TensorInfo dst_acc_info;
     arm_compute::GEMMInfo gemm_info;
-    float alpha;
 };
 
 namespace acl_matmul_utils {


### PR DESCRIPTION
# Description

Fuse the sum post op in acl matmul by setting the accumulate flag to true in arm_compute::GEMMInfo. This speeds up the post op and saves allocating a temporary dst sized tensor.

For example
```
OMP_NUM_THREADS=16 ./benchdnn --mode=p --matmul --attr-post-ops=sum,sum+relu:0 1024x256:256x2048
```
is ~12% faster and uses 1.2kB less peak memory.

We also added `_for_sum` to `use_dst_acc` flag to stop it being confused with the `dst_acc` used for transposing.

Change the way we deal with fused eltwise (as well as the new sum) to fix segfaults when binary ops followed fused ops.

This PR includes the commit from #1889 because it builds on top of it.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
