### PR TITLE
cpu: sycl: bugfix engine creation

### DIFF
--- a/src/sycl/sycl_engine_base.hpp
+++ b/src/sycl/sycl_engine_base.hpp
@@ -39,8 +39,8 @@ class sycl_engine_base_t : public gpu::intel::compute::compute_engine_t {
 public:
     sycl_engine_base_t(engine_kind_t kind, const ::sycl::device &dev,
             const ::sycl::context &ctx, size_t index)
-        : gpu::intel::compute::compute_engine_t(new xpu::sycl::engine_impl_t(
-                engine_kind::gpu, dev, ctx, index)) {}
+        : gpu::intel::compute::compute_engine_t(
+                new xpu::sycl::engine_impl_t(kind, dev, ctx, index)) {}
 
     status_t init() override {
         CHECK(init_impl());

--- a/src/xpu/sycl/utils.cpp
+++ b/src/xpu/sycl/utils.cpp
@@ -155,14 +155,17 @@ bool are_equal(const ::sycl::device &lhs, const ::sycl::device &rhs) {
     // Only one host device exists.
     if (lhs_be == backend_t::host) return true;
 
-#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL \
+        || DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
     if (lhs_be == backend_t::opencl) {
         // Use wrapper objects to avoid memory leak.
         auto lhs_ocl_handle = compat::get_native<cl_device_id>(lhs);
         auto rhs_ocl_handle = compat::get_native<cl_device_id>(rhs);
         return lhs_ocl_handle == rhs_ocl_handle;
     }
+#endif
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
     if (lhs_be == backend_t::level0) {
         return gpu::intel::sycl::compare_ze_devices(lhs, rhs);
     }


### PR DESCRIPTION
Fixes two bugs that were recently introduced to main and prevent running benchdnn tests on Nvidia and AMD backends. Both bugs cause creation of CPU SYCL engine to fail. They are:
 - The `kind` of `sycl_engine_base_t` is hardcoded to `engine_kind::gpu` making it impossible to create a CPU SYCL engine. This was introduced in commit 6e248387e6de095dd7c6945be71220359b0f7378
 - The OpenCL path of `are_equal` function for devices is not enabled when SYCL is selected for CPU backend, but it should be. This was introduced in commit ae1dbfe605be02a65049538ca6d884fd1c6e906b