### PR TITLE
gpu: sycl: bnorm: lnorm: Fix debug mode asserts

### DIFF
--- a/src/gpu/sycl/batch_normalizations_kernels.hpp
+++ b/src/gpu/sycl/batch_normalizations_kernels.hpp
@@ -74,7 +74,7 @@ struct batch_normalization_fwd_kernel_vec_t {
 private:
     const xpu::sycl::md_t &data_md() const { return conf_.data_md; }
     const xpu::sycl::md_t &src1_md() const { return conf_.src1_md; }
-    const xpu::sycl::md_t &ws_md() const { return conf_.ws_md; }
+    const data_type_t &ws_dt() const { return conf_.ws_dt; }
     const xpu::sycl::md_t &data_scaleshift_md() const {
         return conf_.data_scaleshift_md;
     }
@@ -134,12 +134,10 @@ private:
                     if (bn_res <= 0) {
                         bn_res = 0;
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 0, ws_ptr(), d_off);
                     } else {
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 1, ws_ptr(), d_off);
                     }
                 }
 
@@ -150,12 +148,10 @@ private:
                     if (bn_res <= 0) {
                         bn_res = 0;
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 0, ws_ptr(), d_off);
                     } else {
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 1, ws_ptr(), d_off);
                     }
                 }
 
@@ -223,7 +219,7 @@ struct batch_normalization_fwd_kernel_vec_t1 {
 private:
     const xpu::sycl::md_t &data_md() const { return conf_.data_md; }
     const xpu::sycl::md_t &src1_md() const { return conf_.src1_md; }
-    const xpu::sycl::md_t &ws_md() const { return conf_.ws_md; }
+    const data_type_t &ws_dt() const { return conf_.ws_dt; }
     const xpu::sycl::md_t &data_scaleshift_md() const {
         return conf_.data_scaleshift_md;
     }
@@ -312,12 +308,10 @@ private:
                     if (bn_res <= 0) {
                         bn_res = 0;
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 0, ws_ptr(), d_off);
                     } else {
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 1, ws_ptr(), d_off);
                     }
                 }
 
@@ -328,12 +322,10 @@ private:
                     if (bn_res <= 0) {
                         bn_res = 0;
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 0, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 0, ws_ptr(), d_off);
                     } else {
                         if (conf_.is_training)
-                            store_float_value(
-                                    ws_md().data_type(), 1, ws_ptr(), d_off);
+                            store_float_value(ws_dt(), 1, ws_ptr(), d_off);
                     }
                 }
 
@@ -392,7 +384,7 @@ struct batch_normalization_bwd_kernel_vec_t {
             xpu::sycl::in_memory_arg_t &stat, xpu::sycl::in_memory_arg_t &var,
             xpu::sycl::in_memory_arg_t &diff_dst,
             xpu::sycl::in_memory_arg_t &dst, xpu::sycl::in_memory_arg_t &ws,
-            xpu::sycl::in_memory_arg_t &diff_src1)
+            xpu::sycl::out_memory_arg_t &diff_src1)
         : conf_(conf)
         , data_(data)
         , diff_data_(diff_data)
@@ -416,9 +408,9 @@ struct batch_normalization_bwd_kernel_vec_t {
 private:
     const xpu::sycl::md_t &data_md() const { return conf_.data_md; }
     const xpu::sycl::md_t &diff_data_md() const { return conf_.diff_data_md; }
-    const xpu::sycl::md_t &diff_src1_md() const { return conf_.diff_src1_md; }
+    const data_type_t &diff_src1_dt() const { return conf_.diff_src1_dt; }
     const xpu::sycl::md_t &stat_d() const { return conf_.stat_md; }
-    const xpu::sycl::md_t &ws_md() const { return conf_.ws_md; }
+    const data_type_t &ws_dt() const { return conf_.ws_dt; }
     const xpu::sycl::md_t &data_scaleshift_md() const {
         return conf_.data_scaleshift_md;
     }
@@ -499,17 +491,15 @@ private:
                         diff_dst_md().data_type(), diff_dst_ptr(),
                         DATA_OFF(diff_data_md(), n, c, d, h, w)));
                 if (conf_.fuse_norm_relu
-                        && !load_float_value(
-                                ws_md().data_type(), ws_ptr(), s_off))
+                        && !load_float_value(ws_dt(), ws_ptr(), s_off))
                     dd = 0;
 
                 if (conf_.fuse_norm_add_relu) {
                     dd = ::dnnl::impl::math::relu_bwd(dd,
-                            load_float_value(
-                                    ws_md().data_type(), ws_ptr(), s_off),
+                            load_float_value(ws_dt(), ws_ptr(), s_off),
                             conf_.alpha);
-                    store_float_value(diff_src1_md().data_type(), dd,
-                            diff_src1_ptr(), s_off);
+                    store_float_value(
+                            diff_src1_dt(), dd, diff_src1_ptr(), s_off);
                 }
 
                 diff_gamma
@@ -543,17 +533,15 @@ private:
                         diff_dst_md().data_type(), diff_dst_ptr(), dd_off));
 
                 if (conf_.fuse_norm_relu
-                        && !load_float_value(
-                                ws_md().data_type(), ws_ptr(), s_off))
+                        && !load_float_value(ws_dt(), ws_ptr(), s_off))
                     dd = 0;
 
                 if (conf_.fuse_norm_add_relu) {
                     dd = ::dnnl::impl::math::relu_bwd(dd,
-                            load_float_value(
-                                    ws_md().data_type(), ws_ptr(), s_off),
+                            load_float_value(ws_dt(), ws_ptr(), s_off),
                             conf_.alpha);
-                    store_float_value(diff_src1_md().data_type(), dd,
-                            diff_src1_ptr(), s_off);
+                    store_float_value(
+                            diff_src1_dt(), dd, diff_src1_ptr(), s_off);
                 }
 
                 float v_diff_src = dd;
@@ -587,7 +575,7 @@ private:
     xpu::sycl::in_memory_arg_t diff_dst_;
     xpu::sycl::in_memory_arg_t dst_;
     xpu::sycl::in_memory_arg_t ws_;
-    xpu::sycl::in_memory_arg_t diff_src1_;
+    xpu::sycl::out_memory_arg_t diff_src1_;
 };
 
 } // namespace sycl

--- a/src/gpu/sycl/layer_normalizations_kernels.hpp
+++ b/src/gpu/sycl/layer_normalizations_kernels.hpp
@@ -67,8 +67,7 @@ private:
     const xpu::sycl::md_t &data_scaleshift_md() const {
         return conf_.data_scaleshift_md;
     }
-    const xpu::sycl::md_t &var_md() const { return conf_.var_md; }
-    const xpu::sycl::md_t &stat_d() const { return conf_.stat_d; }
+    const data_type_t &var_dt() const { return conf_.var_dt; }
     const xpu::sycl::md_t &dst_md() const { return conf_.dst_md; }
 
     const unsigned flags() const { return conf_.flags; }
@@ -89,8 +88,7 @@ private:
         const size_t s_off = conf_.stat_md.off_l(idx);
         auto v_mean
                 = load_float_value(stat_md().data_type(), stat_ptr(), s_off);
-        auto v_variance
-                = load_float_value(var_md().data_type(), var_ptr(), s_off);
+        auto v_variance = load_float_value(var_dt(), var_ptr(), s_off);
         dim_t C = conf_.C;
 
         float sqrt_variance = sqrtf(v_variance + eps);
@@ -177,8 +175,7 @@ private:
     const xpu::sycl::md_t &data_scaleshift_md() const {
         return conf_.data_scaleshift_md;
     }
-    const xpu::sycl::md_t &var_md() const { return conf_.var_md; }
-    const xpu::sycl::md_t &stat_d() const { return conf_.stat_d; }
+    const data_type_t &var_dt() const { return conf_.var_dt; }
     const xpu::sycl::md_t &dst_md() const { return conf_.dst_md; }
 
     const unsigned flags() const { return conf_.flags; }
@@ -196,7 +193,7 @@ private:
     inline void compute_alg_n(int idx) const {
         if (conf_.zero_dims && conf_.calculate_stats && conf_.save_stats) {
             store_float_value(stat_md().data_type(), 0, stat_out_ptr(), idx);
-            store_float_value(var_md().data_type(), 0, var_out_ptr(), idx);
+            store_float_value(var_dt(), 0, var_out_ptr(), idx);
         }
         float eps = epsilon();
         const size_t s_off = conf_.stat_md.off_l(idx);
@@ -261,8 +258,7 @@ private:
         if (conf_.calculate_stats && conf_.save_stats) {
             store_float_value(
                     stat_md().data_type(), v_mean, stat_out_ptr(), s_off);
-            store_float_value(
-                    var_md().data_type(), v_variance, var_out_ptr(), s_off);
+            store_float_value(var_dt(), v_variance, var_out_ptr(), s_off);
         }
     }
 
@@ -307,7 +303,6 @@ struct layer_normalization_bwd_kernel_vec_t {
 private:
     const xpu::sycl::md_t &data_md() const { return conf_.data_md; }
     const xpu::sycl::md_t &diff_data_md() const { return conf_.diff_data_md; }
-    const xpu::sycl::md_t &stat_d() const { return conf_.stat_d; }
     const xpu::sycl::md_t &stat_md() const { return conf_.stat_md; }
     const xpu::sycl::md_t &data_scaleshift_md() const {
         return conf_.data_scaleshift_md;
@@ -315,7 +310,7 @@ private:
     const xpu::sycl::md_t &diff_data_scaleshift_md() const {
         return conf_.diff_data_scaleshift_md;
     }
-    const xpu::sycl::md_t &var_md() const { return conf_.var_md; }
+    const data_type_t &var_dt() const { return conf_.var_dt; }
     const xpu::sycl::md_t &diff_dst_md() const { return conf_.diff_dst_md; }
     const xpu::sycl::md_t &dst_md() const { return conf_.dst_md; }
     const unsigned flags() const { return conf_.flags; }
@@ -360,8 +355,7 @@ private:
                                s_off = stat_md().off_l(n);
 
                     float inv_sqrt_variance = 1.f
-                            / sqrtf(load_float_value(var_md().data_type(),
-                                            var_ptr(), s_off)
+                            / sqrtf(load_float_value(var_dt(), var_ptr(), s_off)
                                     + eps); //stat
                     float s = load_float_value(
                             data_md().data_type(), data_ptr(), src_off);
@@ -428,7 +422,6 @@ struct layer_normalization_bwd_kernel_vec2_t {
 private:
     const xpu::sycl::md_t &data_md() const { return conf_.data_md; }
     const xpu::sycl::md_t &diff_data_md() const { return conf_.diff_data_md; }
-    const xpu::sycl::md_t &stat_d() const { return conf_.stat_d; }
     const xpu::sycl::md_t &stat_md() const { return conf_.stat_md; }
     const xpu::sycl::md_t &data_scaleshift_md() const {
         return conf_.data_scaleshift_md;
@@ -436,7 +429,7 @@ private:
     const xpu::sycl::md_t &diff_data_scaleshift_md() const {
         return conf_.diff_data_scaleshift_md;
     }
-    const xpu::sycl::md_t &var_md() const { return conf_.var_md; }
+    const data_type_t &var_dt() const { return conf_.var_dt; }
     const xpu::sycl::md_t &diff_dst_md() const { return conf_.diff_dst_md; }
 
     const unsigned flags() const { return conf_.flags; }
@@ -461,9 +454,7 @@ private:
         for (dim_t n = start_n; n < end_n; ++n) {
             const size_t s_off = stat_md().off_l(n);
             float inv_sqrt_variance = 1.f
-                    / sqrtf(load_float_value(
-                                    var_md().data_type(), var_ptr(), s_off)
-                            + eps);
+                    / sqrtf(load_float_value(var_dt(), var_ptr(), s_off) + eps);
             float dd_gamma = 0.f;
             float dd_gamma_x = 0.f;
             if (conf_.calculate_diff_stats) {

--- a/src/gpu/sycl/ref_batch_normalization.cpp
+++ b/src/gpu/sycl/ref_batch_normalization.cpp
@@ -33,21 +33,27 @@ status_t ref_batch_normalization_fwd_t::pd_t::init_conf() {
     conf_.ndims = ndims();
     conf_.flags = desc()->flags;
     conf_.wk_size = memory_desc_wrapper(src_md(0)).nelems();
-    conf_.src1_md = xpu::sycl::md_t(dst_md(3));
-    conf_.dst1_md = xpu::sycl::md_t(dst_md(0));
+    // Here and below only set the memory descriptors in `conf_` if they are used
+    // by the current configuration. Setting them uncoditionally triggers the
+    // assertion in xpu::sycl::md_t's constructor in Debug mode.
+    if (fuse_norm_add_relu()) { conf_.src1_md = xpu::sycl::md_t(dst_md(3)); }
     conf_.block_size = 16;
     conf_.wg_size = 32;
     conf_.dir = !is_fwd();
     conf_.use_scale = use_scale();
     conf_.use_shift = use_shift();
     conf_.data_md = xpu::sycl::md_t(src_md(0));
-    conf_.data_scaleshift_md = xpu::sycl::md_t(weights_md(0));
-    conf_.stat_md = stats_is_src() ? xpu::sycl::md_t(src_md(1))
-                                   : xpu::sycl::md_t(dst_md(1));
+    if (use_scale() || use_shift()) {
+        conf_.data_scaleshift_md = xpu::sycl::md_t(weights_md(0));
+    }
+    if (is_training() || use_global_stats()) {
+        conf_.stat_md = stats_is_src() ? xpu::sycl::md_t(src_md(1))
+                                       : xpu::sycl::md_t(dst_md(1));
+        conf_.var_md = stats_is_src() ? xpu::sycl::md_t(src_md(2))
+                                      : xpu::sycl::md_t(dst_md(2));
+    }
     conf_.dst_md = xpu::sycl::md_t(dst_md(0));
-    conf_.var_md = stats_is_src() ? xpu::sycl::md_t(src_md(2))
-                                  : xpu::sycl::md_t(dst_md(2));
-    conf_.ws_md = xpu::sycl::md_t(workspace_md(0));
+    if (is_training()) { conf_.ws_dt = workspace_md(0)->data_type; }
     int work_per_wg = conf_.wg_size * conf_.block_size;
     int n_wgs = (C() + work_per_wg - 1) / work_per_wg;
     conf_.n_thr = n_wgs * conf_.wg_size;
@@ -64,7 +70,9 @@ status_t ref_batch_normalization_fwd_t::pd_t::init_conf() {
     conf_.zero_dims = has_zero_dim_memory();
     conf_.is_training = is_training();
     conf_.with_relu = with_relu_post_op(is_training());
-    conf_.alpha = alpha();
+    if (conf_.fuse_norm_add_relu || conf_.fuse_norm_relu || conf_.with_relu) {
+        conf_.alpha = alpha();
+    }
 
     return status::success;
 }
@@ -138,16 +146,20 @@ status_t ref_batch_normalization_bwd_t::pd_t::init_conf() {
     conf_.use_scale = use_scale();
     conf_.use_shift = use_shift();
     conf_.data_md = xpu::sycl::md_t(src_md(0));
-    conf_.dst1_md = xpu::sycl::md_t(dst_md(0));
     conf_.diff_data_md = xpu::sycl::md_t(diff_src_md(0));
-    conf_.diff_src1_md = xpu::sycl::md_t(diff_dst_md(1));
-    conf_.data_scaleshift_md = xpu::sycl::md_t(weights_md(0));
-    conf_.diff_data_scaleshift_md = xpu::sycl::md_t(diff_weights_md(0));
-    conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md(0));
+    if (fuse_norm_add_relu()) {
+        conf_.diff_src1_dt = diff_dst_md(1)->data_type;
+    }
+    if (use_scale() || use_shift()) {
+        conf_.data_scaleshift_md = xpu::sycl::md_t(weights_md(0));
+        conf_.diff_data_scaleshift_md = xpu::sycl::md_t(diff_weights_md(0));
+    }
     conf_.stat_md = xpu::sycl::md_t(stat_md());
     conf_.var_md = xpu::sycl::md_t(src_md(2));
-    conf_.dst_md = xpu::sycl::md_t(dst_md(0));
-    conf_.ws_md = xpu::sycl::md_t(workspace_md(0));
+    conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md(0));
+    if (fuse_norm_add_relu() || fuse_norm_relu()) {
+        conf_.ws_dt = workspace_md(0)->data_type;
+    }
     int work_per_wg = conf_.wg_size * conf_.block_size;
     int n_wgs = (C() + work_per_wg - 1) / work_per_wg;
     conf_.n_thr = n_wgs * conf_.wg_size;
@@ -162,7 +174,7 @@ status_t ref_batch_normalization_bwd_t::pd_t::init_conf() {
     conf_.fuse_norm_relu = fuse_norm_relu();
     conf_.fuse_norm_add_relu = fuse_norm_add_relu();
     conf_.calculate_diff_stats = !use_global_stats();
-    conf_.alpha = alpha();
+    if (fuse_norm_add_relu()) { conf_.alpha = alpha(); }
 
     return status::success;
 }
@@ -179,7 +191,7 @@ status_t ref_batch_normalization_bwd_t::execute_backward(
     return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         auto data = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
         auto diff_data = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
-        auto diff_src1 = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC_1);
+        auto diff_src1 = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC_1);
         auto scale = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SCALE);
         auto diff_scale
                 = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SCALE); //added

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -173,8 +173,7 @@ struct sycl_layer_normalization_conf_t {
     xpu::sycl::md_t scale;
     xpu::sycl::md_t shift;
     xpu::sycl::md_t stat_md;
-    xpu::sycl::md_t stat_d;
-    xpu::sycl::md_t var_md;
+    data_type_t var_dt;
     xpu::sycl::md_t dst_md;
     xpu::sycl::md_t diff_dst_md;
     dim_t wk_size;
@@ -220,14 +219,13 @@ struct sycl_batch_normalization_conf_t {
     bool dir;
     xpu::sycl::md_t data_md;
     xpu::sycl::md_t src1_md;
-    xpu::sycl::md_t dst1_md;
     xpu::sycl::md_t diff_data_md;
-    xpu::sycl::md_t diff_src1_md;
+    data_type_t diff_src1_dt;
     xpu::sycl::md_t data_scaleshift_md;
     xpu::sycl::md_t diff_data_scaleshift_md;
     xpu::sycl::md_t stat_md;
     xpu::sycl::md_t var_md;
-    xpu::sycl::md_t ws_md;
+    data_type_t ws_dt;
     xpu::sycl::md_t dst_md;
     xpu::sycl::md_t diff_dst_md;
     dim_t N;


### PR DESCRIPTION
# Description

This MR adds the following changes:
- Conditionally set sycl_md_t members that are not use if a specific flag is not set to avoid hitting assert in https://github.com/oneapi-src/oneDNN/blob/main/src/xpu/sycl/types.hpp#L116 in Debug mode
- Fix an issue where batch norm's `diff_src1` was loaded as an input parameter, instead of an output parameter resulting in another assertion failure
- sycl_md_ts wrapping workspace memory descriptor were failing the `format_kind::blocked` assertion too, so they were replaced with just the data type, rather than the full md (only the datatype of the workspace is used in the kernel). This also results in a significant reduction of the conf's size.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?