### PR TITLE
gpu: sycl: eltwise: Reduce size of kernel arguments

### DIFF
--- a/src/gpu/generic/sycl/ref_eltwise.cpp
+++ b/src/gpu/generic/sycl/ref_eltwise.cpp
@@ -39,6 +39,9 @@ status_t ref_sycl_eltwise_fwd_t::pd_t::init_conf() {
     conf_.h = H();
     conf_.w = W();
 
+    if (attr()->post_ops_.len() > sycl_post_ops_t::max_post_ops) {
+        return status::unimplemented;
+    }
     conf_.post_po_len = attr()->post_ops_.len();
     conf_.post_ops = sycl_post_ops_t(attr());
 

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -69,7 +69,7 @@ struct sycl_eltwise_conf_t {
     dim_t wg_size;
     dim_t wk_size;
     dim_t post_po_len;
-    xpu::sycl::md_t binary_src_arr[8];
+    xpu::sycl::md_t binary_src_arr[sycl::sycl_post_ops_t::max_post_ops];
     sycl_post_ops_t post_ops;
 };
 


### PR DESCRIPTION
# Description

This MR slightly refactors the eltwise SYCL kernel to remove some unused data that was stored in the conf struct passed to the kernel. As a result, the size of the struct is reduced, allowing the kernel to run on some specific devices with a lower kernel argument size limit.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
