### PR TITLE
cpu: aarch64: matmul: Move allocation of temporary tensors to scratchpad in acl_matmul

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018-2024 Intel Corporation
+* Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -170,7 +170,8 @@ struct acl_matmul_t : public primitive_t {
             }
 
             auto scratchpad = scratchpad_registry().registrar();
-            CHECK(acl_matmul_utils::init_scratchpad(scratchpad, amp_, dst_md_));
+            CHECK(acl_matmul_utils::init_scratchpad(
+                    scratchpad, amp_, src_md_, weights_md_, dst_md_));
 
             return status::success;
         }

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -174,10 +174,26 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
 }
 
 status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
-        acl_matmul_conf_t &amp, memory_desc_t &dst_md) {
+        const acl_matmul_conf_t &amp, const memory_desc_t &src_md,
+        const memory_desc_t &weights_md, const memory_desc_t &dst_md) {
     if (amp.use_dst_acc_for_sum) {
         const memory_desc_wrapper dst_d(&dst_md);
         scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
+                dst_d.nelems(), dst_d.data_type_size());
+    }
+    if (amp.is_transA) {
+        const memory_desc_wrapper src_d(&src_md);
+        scratchpad.book(memory_tracking::names::key_matmul_src_trans,
+                src_d.nelems(), src_d.data_type_size());
+    }
+    if (amp.is_transB) {
+        const memory_desc_wrapper wei_d(&weights_md);
+        scratchpad.book(memory_tracking::names::key_matmul_wei_trans,
+                wei_d.nelems(), wei_d.data_type_size());
+    }
+    if (amp.do_transC) {
+        const memory_desc_wrapper dst_d(&dst_md);
+        scratchpad.book(memory_tracking::names::key_matmul_dst_trans,
                 dst_d.nelems(), dst_d.data_type_size());
     }
     return status::success;

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -63,7 +63,8 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
         const primitive_attr_t &attr);
 
 status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
-        acl_matmul_conf_t &amp, memory_desc_t &dst_md);
+        const acl_matmul_conf_t &amp, const memory_desc_t &src_md,
+        const memory_desc_t &weights_md, const memory_desc_t &dst_md);
 
 } // namespace acl_matmul_utils
 


### PR DESCRIPTION
# Description

Introduce 3 new scrathpad memory key names.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
