### PR TITLE
qualify the function saturate with q10n:: specifier to prevent ambiguity

### DIFF
--- a/src/cpu/s390x/gemmu16.cpp
+++ b/src/cpu/s390x/gemmu16.cpp
@@ -50,7 +50,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
                 for (dim_t i = 0; i < m; i++) {
                     double val = alpha * (double)Ctemp[j * ldCtemp + i] + co[0];
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(val)));
+                            nearbyint(q10n::saturate<int32_t, double>(val)));
                 }
             }
         } else {
@@ -59,7 +59,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
                     double val = beta * (double)gPtr(i, j)
                             + alpha * (double)Ctemp[j * ldCtemp + i] + co[0];
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(val)));
+                            nearbyint(q10n::saturate<int32_t, double>(val)));
                 }
             }
         }
@@ -69,7 +69,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
                 for (dim_t i = 0; i < m; i++) {
                     double val = alpha * (double)Ctemp[j * ldCtemp + i] + co[i];
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(val)));
+                            nearbyint(q10n::saturate<int32_t, double>(val)));
                 }
             }
         } else {
@@ -78,7 +78,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
                     double val = beta * (double)gPtr(i, j)
                             + alpha * (double)Ctemp[j * ldCtemp + i] + co[i];
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(val)));
+                            nearbyint(q10n::saturate<int32_t, double>(val)));
                 }
             }
         }
@@ -89,7 +89,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
                 for (dim_t i = 0; i < m; i++) {
                     double val = alpha * (double)Ctemp[j * ldCtemp + i] + co[j];
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(val)));
+                            nearbyint(q10n::saturate<int32_t, double>(val)));
                 }
             }
         } else {
@@ -98,7 +98,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
                     double val = beta * (double)gPtr(i, j)
                             + alpha * (double)Ctemp[j * ldCtemp + i] + co[j];
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(val)));
+                            nearbyint(q10n::saturate<int32_t, double>(val)));
                 }
             }
         }
@@ -107,7 +107,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
             for (dim_t j = 0; j < n; j++) {
                 for (dim_t i = 0; i < m; i++) {
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(
+                            nearbyint(q10n::saturate<int32_t, double>(
                                     alpha * (double)Ctemp[j * ldCtemp + i])));
                 }
             }
@@ -117,7 +117,7 @@ __attribute__((noinline)) void addResults(offset_type offsetType, dim_t m,
                     double val = beta * (double)gPtr(i, j)
                             + alpha * (double)Ctemp[j * ldCtemp + i];
                     gPtr(i, j) = static_cast<int32_t>(
-                            nearbyint(saturate<int32_t, double>(val)));
+                            nearbyint(q10n::saturate<int32_t, double>(val)));
                 }
             }
         }


### PR DESCRIPTION
# Description

qualify the function `saturate ` with `q10n::` specifier to prevent ambiguity

Fixes #1929 

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
