### PR TITLE
gpu: sycl: resampling: Reduce argument size

### DIFF
--- a/src/gpu/sycl/ref_resampling.cpp
+++ b/src/gpu/sycl/ref_resampling.cpp
@@ -25,20 +25,8 @@ namespace sycl {
 status_t ref_resampling_fwd_t::pd_t::init_conf() {
     conf_ = sycl_resampling_conf_t();
 
-    conf_.src_dt = src_md(0)->data_type;
-    conf_.dst_dt = dst_md()->data_type;
-
     conf_.block_size = 16;
     conf_.wg_size = 32;
-
-    conf_.MB = MB();
-    conf_.C = C();
-    conf_.ID = ID();
-    conf_.IH = IH();
-    conf_.IW = IW();
-    conf_.OD = OD();
-    conf_.OH = OH();
-    conf_.OW = OW();
 
     for (int i = 0; i < DNNL_MAX_NDIMS; i++) {
         conf_.dst_dims[i] = dst_md()->dims[i];
@@ -56,6 +44,9 @@ status_t ref_resampling_fwd_t::pd_t::init_conf() {
     conf_.alg = desc()->alg_kind;
     const auto *att = attr();
     const auto &attr_po = att->post_ops_;
+    if (attr_po.len() > sycl_post_ops_t::max_post_ops) {
+        return dnnl_unimplemented;
+    }
     conf_.po_len = attr_po.len();
 
     for (auto i = 0; i < attr_po.len(); ++i) {
@@ -113,8 +104,6 @@ status_t ref_resampling_bwd_t::pd_t::init_conf() {
     conf_.diff_src_md = xpu::sycl::md_t(diff_src_md(0));
     conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md());
 
-    conf_.src_dt = src_md(0)->data_type;
-    conf_.dst_dt = dst_md()->data_type;
     conf_.block_size = 16;
     conf_.wg_size = 32;
     conf_.dst_ndims = dst_md()->ndims;
@@ -124,15 +113,6 @@ status_t ref_resampling_bwd_t::pd_t::init_conf() {
     int n_wgs = (nelems_A + work_per_wg - 1) / work_per_wg;
     conf_.n_thr = n_wgs * conf_.wg_size;
     conf_.alg = desc()->alg_kind;
-
-    conf_.MB = MB();
-    conf_.C = C();
-    conf_.ID = ID();
-    conf_.IH = IH();
-    conf_.IW = IW();
-    conf_.OD = OD();
-    conf_.OH = OH();
-    conf_.OW = OW();
 
     for (int i = 0; i < DNNL_MAX_NDIMS; i++) {
         conf_.dst_dims[i] = dst_md()->dims[i];

--- a/src/gpu/sycl/resampling_kernels.hpp
+++ b/src/gpu/sycl/resampling_kernels.hpp
@@ -50,16 +50,20 @@ struct resampling_kernel_fwd_vec_t {
 
     void operator()(::sycl::nd_item<1> item) const {
         size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
-        dim_t MB = conf_.MB;
-        dim_t C = conf_.C;
 
-        dim_t ID = conf_.ID;
-        dim_t IH = conf_.IH;
-        dim_t IW = conf_.IW;
+        const auto &src_ndims = conf_.src_md.ndims();
+        const auto &src_dims = conf_.src_md.dims();
+        dim_t MB = src_dims[0];
+        dim_t C = src_dims[1];
+        dim_t ID = src_ndims >= 5 ? src_dims[src_ndims - 3] : 1;
+        dim_t IH = src_ndims >= 4 ? src_dims[src_ndims - 2] : 1;
+        dim_t IW = src_ndims >= 3 ? src_dims[src_ndims - 1] : 1;
 
-        dim_t OD = conf_.OD;
-        dim_t OH = conf_.OH;
-        dim_t OW = conf_.OW;
+        const auto &dst_ndims = conf_.dst_md.ndims();
+        const auto &dst_dims = conf_.dst_md.dims();
+        dim_t OD = dst_ndims >= 5 ? dst_dims[dst_ndims - 3] : 1;
+        dim_t OH = dst_ndims >= 4 ? dst_dims[dst_ndims - 2] : 1;
+        dim_t OW = dst_ndims >= 3 ? dst_dims[dst_ndims - 1] : 1;
 
         auto lin_interp = [&](float c0, float c1, float w) {
             return c0 * w + c1 * (1 - w);
@@ -229,16 +233,21 @@ struct resampling_kernel_bwd_vec_t {
     void operator()(::sycl::nd_item<1> item) const {
 
         size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
-        dim_t MB = conf_.MB;
-        dim_t C = conf_.C;
 
-        dim_t ID = conf_.ID;
-        dim_t IH = conf_.IH;
-        dim_t IW = conf_.IW;
+        const auto &diff_src_ndims = conf_.diff_src_md.ndims();
+        const auto &diff_src_dims = conf_.diff_src_md.dims();
+        dim_t MB = diff_src_dims[0];
+        dim_t C = diff_src_dims[1];
 
-        dim_t OD = conf_.OD;
-        dim_t OH = conf_.OH;
-        dim_t OW = conf_.OW;
+        dim_t ID = diff_src_ndims >= 5 ? diff_src_dims[diff_src_ndims - 3] : 1;
+        dim_t IH = diff_src_ndims >= 4 ? diff_src_dims[diff_src_ndims - 2] : 1;
+        dim_t IW = diff_src_ndims >= 3 ? diff_src_dims[diff_src_ndims - 1] : 1;
+
+        const auto &diff_dst_ndims = conf_.diff_dst_md.ndims();
+        const auto &diff_dst_dims = conf_.diff_dst_md.dims();
+        dim_t OD = diff_dst_ndims >= 5 ? diff_dst_dims[diff_dst_ndims - 3] : 1;
+        dim_t OH = diff_dst_ndims >= 4 ? diff_dst_dims[diff_dst_ndims - 2] : 1;
+        dim_t OW = diff_dst_ndims >= 3 ? diff_dst_dims[diff_dst_ndims - 1] : 1;
 
         const dim_t work_amount = MB * C * ID * IH * IW;
         if (work_amount == 0) return;
@@ -308,16 +317,21 @@ struct resampling_kernel_bwd_vec1_t {
 
     void operator()(::sycl::nd_item<1> item) const {
         size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
-        dim_t MB = conf_.MB;
-        dim_t C = conf_.C;
 
-        dim_t ID = conf_.ID;
-        dim_t IH = conf_.IH;
-        dim_t IW = conf_.IW;
+        const auto &diff_src_ndims = conf_.diff_src_md.ndims();
+        const auto &diff_src_dims = conf_.diff_src_md.dims();
+        dim_t MB = diff_src_dims[0];
+        dim_t C = diff_src_dims[1];
 
-        dim_t OD = conf_.OD;
-        dim_t OH = conf_.OH;
-        dim_t OW = conf_.OW;
+        dim_t ID = diff_src_ndims >= 5 ? diff_src_dims[diff_src_ndims - 3] : 1;
+        dim_t IH = diff_src_ndims >= 4 ? diff_src_dims[diff_src_ndims - 2] : 1;
+        dim_t IW = diff_src_ndims >= 3 ? diff_src_dims[diff_src_ndims - 1] : 1;
+
+        const auto &diff_dst_ndims = conf_.diff_dst_md.ndims();
+        const auto &diff_dst_dims = conf_.diff_dst_md.dims();
+        dim_t OD = diff_dst_ndims >= 5 ? diff_dst_dims[diff_dst_ndims - 3] : 1;
+        dim_t OH = diff_dst_ndims >= 4 ? diff_dst_dims[diff_dst_ndims - 2] : 1;
+        dim_t OW = diff_dst_ndims >= 3 ? diff_dst_dims[diff_dst_ndims - 1] : 1;
 
         const dim_t work_amount = MB * C * ID * IH * IW;
         if (work_amount == 0) return;

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -128,24 +128,13 @@ struct sycl_shuffle_conf_t {
 };
 
 struct sycl_resampling_conf_t {
-    dim_t MB;
-    dim_t C;
-    dim_t ID;
-    dim_t IH;
-    dim_t IW;
-    dim_t OD;
-    dim_t OH;
-    dim_t OW;
     dims_t dst_dims;
     int dst_ndims;
     int po_len;
     size_t work_amount;
 
-    data_type_t src_dt;
-    data_type_t dst_dt;
-
     xpu::sycl::md_t src_md;
-    xpu::sycl::md_t src1_md[8];
+    xpu::sycl::md_t src1_md[sycl_post_ops_t::max_post_ops];
     xpu::sycl::md_t dst_md;
     xpu::sycl::md_t diff_src_md;
     xpu::sycl::md_t diff_dst_md;
@@ -154,7 +143,6 @@ struct sycl_resampling_conf_t {
     float src_scale;
     bool do_scale_src;
     int broadcast_dims[xpu::sycl::md_t::max_dims];
-    int ndims;
     bool is_tensor_op;
 
     int block_size;
@@ -296,7 +284,7 @@ struct sycl_lrn_conf_t {
 
 struct sycl_pooling_conf_t {
     xpu::sycl::md_t src_md;
-    xpu::sycl::md_t src1_md[8];
+    xpu::sycl::md_t src1_md[5];
     xpu::sycl::md_t dst_md;
     xpu::sycl::md_t ws_md;
     xpu::sycl::md_t diff_src_md;

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -284,6 +284,7 @@ struct sycl_lrn_conf_t {
 
 struct sycl_pooling_conf_t {
     xpu::sycl::md_t src_md;
+    // The size "5" is lower than DNNL_MAX_NDIMS because only 5 dimension formats are supported.
     xpu::sycl::md_t src1_md[5];
     xpu::sycl::md_t dst_md;
     xpu::sycl::md_t ws_md;


### PR DESCRIPTION
# Description

This PR reduces the size of arguments passed to the resampling SYCL kernel to be below 2048 bytes by making the following changes:
- Reduce the size of the `src_md1` array. In the kernel only the first 5 elements of the array (https://github.com/oneapi-src/oneDNN/blob/main/src/gpu/sycl/resampling_kernels.hpp#L131) are accessed.
- The tensor dimensions (MB, IC, IH, IW, etc.) don't need to be passed explicitly as the memory descriptors passed to the kernel contain this information.
- Remove some unused variables from the conf struct.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
