### PR TITLE
gpu: sycl: concat: implemented

### DIFF
--- a/src/gpu/gpu_concat_list.cpp
+++ b/src/gpu/gpu_concat_list.cpp
@@ -24,6 +24,10 @@
 #include "gpu/intel/ocl/simple_concat.hpp"
 #endif
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
+#include "gpu/sycl/ref_concat.hpp"
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace gpu {
@@ -36,6 +40,7 @@ constexpr impl_list_item_t impl_list[] = REG_CONCAT_P({
         GPU_CONCAT_INSTANCE_INTEL(intel::ocl::gen9_concat_t)
         GPU_CONCAT_INSTANCE_INTEL(intel::ocl::multi_concat_t)
         GPU_CONCAT_INSTANCE_GENERIC(generic::ref_concat_t)
+        GPU_CONCAT_INSTANCE_GENERIC_SYCL(sycl::ref_concat_t)
         nullptr,
 });
 // clang-format on

--- a/src/gpu/sycl/ref_concat.cpp
+++ b/src/gpu/sycl/ref_concat.cpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+* Copyright 2022-2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/sycl/ref_concat.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+using namespace impl::sycl;
+
+status_t ref_concat_t::pd_t::init_conf() {
+    conf_ = sycl_concat_conf_t();
+    conf_.n = n_inputs();
+
+    return status::success;
+}
+
+status_t ref_concat_t::init(engine_t *engine) {
+    const size_t n = pd()->reorder_pds_.size();
+    reorders_.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        CHECK(pd()->reorder_pds_[i]->create_primitive(
+                reorders_[i], engine, cache_blob()));
+    }
+
+    return status::success;
+}
+
+status_t ref_concat_t::execute(const exec_ctx_t &ctx) const {
+    using namespace memory_tracking::names;
+
+    exec_args_t r_args;
+    std::unique_ptr<memory_t> p_reorder_mem_data;
+    for (auto i = 0; i < pd()->conf_.n; ++i) {
+        memory_arg_t dst_mem_arg = {ctx.args().at(DNNL_ARG_DST).mem, false};
+        r_args[DNNL_ARG_SRC] = ctx.args().at(DNNL_ARG_MULTIPLE_SRC + i);
+        r_args[DNNL_ARG_DST] = dst_mem_arg;
+        exec_ctx_t r_ctx(ctx, std::move(r_args));
+        CHECK(reorders_[i]->execute(r_ctx));
+    }
+    return status::success;
+}
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/sycl/ref_concat.hpp
+++ b/src/gpu/sycl/ref_concat.hpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+* Copyright 2022-2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_REF_CONCAT_HPP
+#define GPU_SYCL_REF_CONCAT_HPP
+
+#include "common/primitive.hpp"
+#include "common/reorder.hpp"
+#include "common/reorder_pd.hpp"
+#include "gpu/gpu_concat_pd.hpp"
+#include "gpu/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/sycl/sycl_io_helper.hpp"
+#include "gpu/sycl/sycl_post_ops.hpp"
+#include "gpu/sycl/sycl_primitive_conf.hpp"
+#include "gpu/sycl/sycl_q10n.hpp"
+#include "sycl/sycl_stream.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace sycl {
+
+struct ref_concat_t : public sycl_gpu_primitive_t {
+    using sycl_gpu_primitive_t::sycl_gpu_primitive_t;
+
+    struct pd_t : public gpu_concat_pd_t {
+        using gpu_concat_pd_t::gpu_concat_pd_t;
+
+        DECLARE_CONCAT_PD_t("dpcpp:ref:any", ref_concat_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+
+            const memory_desc_wrapper dst_d(dst_md());
+
+            const bool ok = set_default_params() == status::success
+                    && attr()->has_default_values();
+            if (!ok) return status::unimplemented;
+
+            const int n = n_inputs();
+            reorder_pds_.resize(n);
+            reorder_mds_.resize(n);
+            dims_t offset = {0, 0, 0, 0, 0, 0};
+            for (auto i = 0; i < n; ++i) {
+                const memory_desc_wrapper src_d_n(src_md(i));
+
+                CHECK(memory_desc_init_submemory(
+                        reorder_mds_[i], *dst_md(), src_d_n.dims(), offset));
+                primitive_attr_t r_attr;
+                CHECK(reorder_primitive_desc_create(reorder_pds_[i], engine,
+                        src_md(i), &reorder_mds_[i], &r_attr));
+                offset[concat_dim()] += src_d_n.dims()[concat_dim()];
+            }
+
+            return init_conf();
+        }
+
+        sycl_concat_conf_t conf_;
+        std::vector<memory_desc_t> reorder_mds_;
+        std::vector<std::shared_ptr<primitive_desc_t>> reorder_pds_;
+
+    private:
+        status_t init_conf();
+    };
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::vector<std::shared_ptr<primitive_t>> reorders_;
+};
+
+} // namespace sycl
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/sycl/reorder_kernels.hpp
+++ b/src/gpu/sycl/reorder_kernels.hpp
@@ -89,8 +89,8 @@ struct reorder_kernel_t {
                 }
 
                 int dst_idx = dst_md().off_v(off);
-                auto src = load_float_value(
-                        src_md().data_type(), src_ptr(), idx);
+                auto src = load_float_value(src_md().data_type(), src_ptr(),
+                        idx + src_md().offset0());
                 auto dst = load_float_value(
                         dst_md().data_type(), dst_ptr(), dst_idx);
 

--- a/src/gpu/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/sycl/sycl_primitive_conf.hpp
@@ -50,6 +50,10 @@ struct sycl_binary_conf_t {
     sycl_post_ops_t post_ops;
 };
 
+struct sycl_concat_conf_t {
+    int n;
+};
+
 struct sycl_eltwise_conf_t {
     prop_kind_t prop_kind;
     xpu::sycl::md_t src_md;


### PR DESCRIPTION
Implements concat primitive by calling reorder for each of the inputs.

Also adds support for offset in reorder.