### PR TITLE
cpu: aarch64: conv: Update direct vs indirect conv heuristics

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -314,8 +314,10 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
         const primitive_attr_t &attr) {
     if (weights_md.ndims != 4) return status::unimplemented;
 
-    // Indirect is slower for small convolution kernels
-    if (weights_md.dims[2] == 1 && weights_md.dims[3] == 1)
+    // Indirect is slower for small convolution kernels, except when src, weight and dst are BF16
+    if (weights_md.dims[2] == 1 && weights_md.dims[3] == 1
+            && !everyone_is(data_type::bf16, src_md.data_type,
+                    weights_md.data_type, dst_md.data_type))
         return status::unimplemented;
 
     CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));

--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -320,10 +320,6 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
 
     CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
 
-    // Indirect is slower than gemm for low thread counts, except for fast math
-    if (dnnl_get_max_threads() < 28 && !acp.fast_math)
-        return status::unimplemented;
-
     // If we do not need to pad input channels for fast math mode then it would
     // be faster to run convolution with im2row instead of using indirect kernel
     int block_by = arm_compute::block_by(acp.weights_info.weight_format());


### PR DESCRIPTION
# Description
 Update direct vs indirect conv heuristics
- Remove fall through to direct conv for low thread counts: the previous heuristic is outdated and no longer optimal
- Do not fall though to direct conv for small convolutions when the datatype is BF16: indirect conv is faster when source, weight, destination are of type BF16

Fixes # (github issue)

# Checklist

## General

- [ YES ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ YES ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
