### PR TITLE
Backport cpu: aarch64: matmul: Optimize (A^T)*(B^T) and fuse sum post-op in acl_matmul

### DIFF
--- a/src/cpu/aarch64/acl_post_ops.cpp
+++ b/src/cpu/aarch64/acl_post_ops.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Arm Ltd. and affiliates
+* Copyright 2022-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ namespace aarch64 {
 
 status_t acl_post_ops_t::execute(const exec_ctx_t &ctx, void *src_orig) const {
 
-    int post_op_index = 0;
+    int post_op_index = post_op_start_index_;
 
     // As these are post ops, this src will also be our dst. If we have a sum
     // post op, the src/dst will start off in a temporary, then change to

--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Arm Ltd. and affiliates
+* Copyright 2022-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ struct acl_post_ops_t {
     // init the acl_post_ops_t. Note that this function modifies the passed in
     // post ops by setting the preferred memory formats
     status_t init(engine_t *engine, post_ops_t &post_ops,
-            const memory_desc_t &dst_md) {
+            const memory_desc_t &dst_md, int post_op_start_index = 0) {
+
+        post_op_start_index_ = post_op_start_index;
 
         CHECK(post_ops.set_default_formats(&dst_md));
         dst_data_type = dst_md.data_type;
@@ -41,7 +43,7 @@ struct acl_post_ops_t {
         sum_index = -1;
         post_op_primitives = {};
 
-        for (int i = 0; i < post_ops.len(); i++) {
+        for (int i = post_op_start_index; i < post_ops.len(); i++) {
             auto &po = post_ops.entry_[i];
 
             if (po.is_sum()) {
@@ -135,7 +137,8 @@ struct acl_post_ops_t {
     // formats
     status_t init(engine_t *engine, post_ops_t &base_post_ops,
             const memory_desc_t &dst_md,
-            arm_compute::ActivationLayerInfo &act_info_to_fuse) {
+            arm_compute::ActivationLayerInfo &act_info_to_fuse,
+            int post_op_start_index = 0) {
 
         CHECK(base_post_ops.set_default_formats(&dst_md));
         dst_data_type = dst_md.data_type;
@@ -149,18 +152,11 @@ struct acl_post_ops_t {
                     "eltwise post op scale must be 1 (no scale)");
             CHECK(acl_utils::convert_to_acl_act(first_po, act_info_to_fuse));
 
-            // Copy all but the first, because it has been fused
-            post_ops_t post_ops;
-            for (int idx = 1; idx < base_post_ops.len(); ++idx) {
-                // Construct empty entry then copy, so that we can check for failure
-                post_ops.entry_.emplace_back();
-                post_ops.entry_.back() = base_post_ops.entry_[idx];
-            }
-            return init(engine, post_ops, dst_md);
-
+            // post_op_start_index + 1 to skip the fused eltwise
+            return init(engine, base_post_ops, dst_md, post_op_start_index + 1);
         } else {
             // Nothing to fuse, just copy all post ops
-            return init(engine, base_post_ops, dst_md);
+            return init(engine, base_post_ops, dst_md, post_op_start_index);
         }
     }
 
@@ -179,6 +175,9 @@ struct acl_post_ops_t {
 private:
     // Index of the sum post op if there is one, < 0 means no sum
     int sum_index = -1;
+    // Index of the first post op this primitive executes. This is typically the
+    // number of post ops which were fused.
+    int post_op_start_index_ = 0;
     data_type_t dst_data_type;
     // Vector of primitives used to execute the post ops. They are constructed
     // in init to be either acl_binary_t (for sum, add, sub, div, mul, min and

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -175,7 +175,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
 
 status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
         acl_matmul_conf_t &amp, memory_desc_t &dst_md) {
-    if (amp.use_dst_acc) {
+    if (amp.use_dst_acc_for_sum) {
         const memory_desc_wrapper dst_d(&dst_md);
         scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
                 dst_d.nelems(), dst_d.data_type_size());

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Arm Ltd. and affiliates
+* Copyright 2021-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ namespace aarch64 {
 
 namespace acl_matmul_utils {
 
-status_t init_conf_matmul_fixed_format(acl_matmul_conf_t &amp,
-        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
-        const matmul_desc_t &md, const primitive_attr_t &attr) {
+template <bool IsFixedFormat>
+status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+        memory_desc_t &wei_md, memory_desc_t &dst_md, const matmul_desc_t &md,
+        const primitive_attr_t &attr) {
 
     const memory_desc_wrapper src_d(&src_md);
     const memory_desc_wrapper wei_d(&wei_md);
@@ -57,151 +58,137 @@ status_t init_conf_matmul_fixed_format(acl_matmul_conf_t &amp,
     // The two innermost dimensions can be transposed, but the batch dimensions
     // must be the outermost
     using namespace format_tag;
-    auto src_tag = memory_desc_matches_one_of_tag(
-            src_md, abcd, abdc, abc, acb, ab, ba);
-    auto dst_tag = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab, ba);
-    ACL_CHECK_SUPPORT(utils::one_of(format_tag::undef, src_tag, dst_tag),
-            "Format tag is undefined");
+    if (IsFixedFormat) {
+        auto src_tag = memory_desc_matches_one_of_tag(
+                src_md, abcd, abdc, abc, acb, ab, ba);
+        auto dst_tag
+                = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab, ba);
+        ACL_CHECK_SUPPORT(utils::one_of(format_tag::undef, src_tag, dst_tag),
+                "Format tag is undefined");
+    } else {
+        auto src_tag = memory_desc_matches_one_of_tag(
+                src_md, acdb, abcd, abdc, abc, acb, ab, ba);
+        auto wei_tag = memory_desc_matches_one_of_tag(
+                wei_md, acdb, abcd, abdc, abc, acb, ab, ba);
+        auto dst_tag = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab);
+        ACL_CHECK_SUPPORT(
+                utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
+                "Format tag is undefined");
+    }
 
-    // Transpose A (src)
+    // Transpose A (src) and/or B (wei). Transpose B is not needed for fixed format.
     amp.is_transA = helper.transA() == 'T';
+    amp.is_transB = IsFixedFormat ? false : helper.transB() == 'T';
+
+    // Do (BA)^T instead of (A^T)(B^T), if the cost of transposing (BA)
+    // which is ~M*N, is less than the cost of tranposing A and B which
+    // is ~(M*K + K*N).
+    amp.do_transC = amp.is_transA && amp.is_transB && M * N <= K * (M + N);
 
     auto acl_src_data_t = acl_utils::get_acl_data_t(src_md.data_type);
     auto acl_wei_data_t = acl_utils::get_acl_data_t(wei_md.data_type);
     auto acl_dst_data_t = acl_utils::get_acl_data_t(dst_md.data_type);
 
-    if (amp.is_transA)
+    if (amp.is_transA && !amp.do_transC) {
         amp.src_acc_info = arm_compute::TensorInfo(
                 arm_compute::TensorShape(M, K, 1, src_batch), 1,
                 acl_src_data_t);
-
-    amp.src_tensor_info = arm_compute::TensorInfo(
-            arm_compute::TensorShape(K, M, 1, src_batch), 1, acl_src_data_t);
-    amp.wei_tensor_info = arm_compute::TensorInfo(
-            arm_compute::TensorShape(N, K, wei_batch), 1, acl_wei_data_t);
-    amp.dst_tensor_info = arm_compute::TensorInfo(
-            arm_compute::TensorShape(N, M, 1, dst_batch), 1, acl_dst_data_t);
-
-    // Validate ACL transpose
-    if (amp.is_transA)
-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
-                &amp.src_acc_info, &amp.src_tensor_info));
-
-    bool is_fastmath_enabled = utils::one_of(
-            attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any);
-    amp.gemm_info.set_fast_math(is_fastmath_enabled);
-
-    amp.gemm_info.set_fixed_format(true);
-
-    // WeightFormat::ANY tells ACL we can handle any format
-    amp.gemm_info.set_weight_format(arm_compute::WeightFormat::ANY);
-
-    // Get the format that the ACL kernel will expect the weights to be
-    // in (if a kernel exists). Note that these are referred to as fixed format
-    // kernels, because they require one specific weights format
-    arm_compute::WeightFormat expected_weight_format;
-    ACL_CHECK_VALID(arm_compute::NEGEMM::has_opt_impl(expected_weight_format,
-            &amp.src_tensor_info, &amp.wei_tensor_info, nullptr,
-            &amp.dst_tensor_info, 1.0f, 0.0f, amp.gemm_info));
-
-    // Set gemm weights info to the one returned by has_opt_impl
-    amp.gemm_info.set_weight_format(expected_weight_format);
-
-    // has_opt_impl may return a non fast math kernel, even if we requested one
-    amp.gemm_info.set_fast_math(
-            arm_compute::is_fixed_format_fast_math(expected_weight_format));
-
-    // Logical dimension indices
-    dim_t innermost_dim = wei_md.ndims - 1;
-    dim_t N_dim = innermost_dim;
-    dim_t K_dim = innermost_dim - 1;
-
-    // The logical indices of dimensions related to the batch, ordered from
-    // innermost to outermost
-    std::vector<dim_t> batch_dims = {};
-    for (dim_t i = K_dim - 1; i >= 0; --i)
-        batch_dims.push_back(i);
-
-    acl_utils::reorder_to_weight_format(amp.wei_tensor_info, wei_md,
-            expected_weight_format, K_dim, N_dim, {}, batch_dims);
-
-    return status::success;
-}
-
-status_t init_conf_matmul_non_fixed_format(acl_matmul_conf_t &amp,
-        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
-        const matmul_desc_t &md, const primitive_attr_t &attr) {
-
-    const memory_desc_wrapper src_d(&src_md);
-    const memory_desc_wrapper wei_d(&wei_md);
-    const memory_desc_wrapper dst_d(&dst_md);
-
-    cpu::matmul::matmul_helper_t helper(src_d, wei_d, dst_d);
-    const dim_t M = helper.M();
-    const dim_t N = helper.N();
-    const dim_t K = helper.K();
-    const dim_t dst_batch = helper.batch();
-    const dim_t src_batch = helper.src_batch();
-    const dim_t wei_batch = helper.wei_batch();
-
-    // ACL supports broadcast for 3D shapes, and 4D shapes
-    // for e.g when ab in abcd is 1x1
-    bool batch_ok = IMPLICATION(src_batch > 1, wei_batch == 1)
-            && IMPLICATION(wei_batch > 1, src_batch == 1);
-    ACL_CHECK_SUPPORT(src_d.ndims() == 4 && src_batch != wei_batch && !batch_ok,
-            "matmul broadcast supported only for 3D shapes and 4D shapes when "
-            "ab is 1x1");
-
-    // ACL does not support bias
-    bool with_bias = md.bias_desc.format_kind != format_kind::undef;
-    ACL_CHECK_SUPPORT(with_bias, "ACL does not support bias for matmul");
-
-    using namespace format_tag;
-    auto src_tag = memory_desc_matches_one_of_tag(
-            src_md, acdb, abcd, abdc, abc, acb, ab, ba);
-    auto wei_tag = memory_desc_matches_one_of_tag(
-            wei_md, acdb, abcd, abdc, abc, acb, ab, ba);
-    auto dst_tag = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab);
-    ACL_CHECK_SUPPORT(
-            utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
-            "Format tag is undefined");
-
-    // Transpose A (src) or B (wei)
-    amp.is_transA = helper.transA() == 'T';
-    amp.is_transB = helper.transB() == 'T';
-    auto acl_src_data_t = acl_utils::get_acl_data_t(src_md.data_type);
-    auto acl_wei_data_t = acl_utils::get_acl_data_t(wei_md.data_type);
-    auto acl_dst_data_t = acl_utils::get_acl_data_t(dst_md.data_type);
-
-    if (amp.is_transA)
-        amp.src_acc_info = arm_compute::TensorInfo(
-                arm_compute::TensorShape(M, K, 1, src_batch), 1,
-                acl_src_data_t);
-    if (amp.is_transB)
+    }
+    if (amp.is_transB && !amp.do_transC) {
         amp.wei_acc_info = arm_compute::TensorInfo(
                 arm_compute::TensorShape(K, N, wei_batch), 1, acl_wei_data_t);
+    }
+    if (amp.do_transC) {
+        amp.dst_acc_info = arm_compute::TensorInfo(
+                arm_compute::TensorShape(M, N, 1, dst_batch), 1,
+                acl_dst_data_t);
+        amp.src_tensor_info = arm_compute::TensorInfo(
+                arm_compute::TensorShape(M, K, src_batch), 1, acl_src_data_t);
+        amp.wei_tensor_info = arm_compute::TensorInfo(
+                arm_compute::TensorShape(K, N, 1, wei_batch), 1,
+                acl_wei_data_t);
+    } else {
+        amp.src_tensor_info = arm_compute::TensorInfo(
+                arm_compute::TensorShape(K, M, 1, src_batch), 1,
+                acl_src_data_t);
+        amp.wei_tensor_info = arm_compute::TensorInfo(
+                arm_compute::TensorShape(N, K, wei_batch), 1, acl_wei_data_t);
+    }
 
-    amp.src_tensor_info = arm_compute::TensorInfo(
-            arm_compute::TensorShape(K, M, 1, src_batch), 1, acl_src_data_t);
-    amp.wei_tensor_info = arm_compute::TensorInfo(
-            arm_compute::TensorShape(N, K, wei_batch), 1, acl_wei_data_t);
     amp.dst_tensor_info = arm_compute::TensorInfo(
             arm_compute::TensorShape(N, M, 1, dst_batch), 1, acl_dst_data_t);
+
+    // Validate ACL transpose
+    if (amp.is_transA && !amp.do_transC)
+        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+                &amp.src_acc_info, &amp.src_tensor_info));
+    if (amp.is_transB && !amp.do_transC)
+        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+                &amp.wei_acc_info, &amp.wei_tensor_info));
+    if (amp.do_transC)
+        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+                &amp.dst_acc_info, &amp.dst_tensor_info));
 
     bool is_fastmath_enabled = utils::one_of(
             attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any);
     amp.gemm_info.set_fast_math(is_fastmath_enabled);
 
-    // Validate ACL transpose
-    if (amp.is_transA)
-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
-                &amp.src_acc_info, &amp.src_tensor_info));
-    if (amp.is_transB)
-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
-                &amp.wei_acc_info, &amp.wei_tensor_info));
+    if (IsFixedFormat) {
+        amp.gemm_info.set_fixed_format(true);
+
+        // WeightFormat::ANY tells ACL we can handle any format
+        amp.gemm_info.set_weight_format(arm_compute::WeightFormat::ANY);
+
+        // Get the format that the ACL kernel will expect the weights to be
+        // in (if a kernel exists). Note that these are referred to as fixed format
+        // kernels, because they require one specific weights format
+        arm_compute::WeightFormat expected_weight_format;
+        ACL_CHECK_VALID(
+                arm_compute::NEGEMM::has_opt_impl(expected_weight_format,
+                        &amp.src_tensor_info, &amp.wei_tensor_info, nullptr,
+                        &amp.dst_tensor_info, 1.0f, 0.0f, amp.gemm_info));
+
+        // Set gemm weights info to the one returned by has_opt_impl
+        amp.gemm_info.set_weight_format(expected_weight_format);
+
+        // has_opt_impl may return a non fast math kernel, even if we requested one
+        amp.gemm_info.set_fast_math(
+                arm_compute::is_fixed_format_fast_math(expected_weight_format));
+
+        // Logical dimension indices
+        dim_t innermost_dim = wei_md.ndims - 1;
+        dim_t N_dim = innermost_dim;
+        dim_t K_dim = innermost_dim - 1;
+
+        // The logical indices of dimensions related to the batch, ordered from
+        // innermost to outermost
+        std::vector<dim_t> batch_dims = {};
+        for (dim_t i = K_dim - 1; i >= 0; --i)
+            batch_dims.push_back(i);
+
+        acl_utils::reorder_to_weight_format(amp.wei_tensor_info, wei_md,
+                expected_weight_format, K_dim, N_dim, {}, batch_dims);
+    }
 
     return status::success;
 }
+
+status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
+        acl_matmul_conf_t &amp, memory_desc_t &dst_md) {
+    if (amp.use_dst_acc) {
+        const memory_desc_wrapper dst_d(&dst_md);
+        scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
+                dst_d.nelems(), dst_d.data_type_size());
+    }
+    return status::success;
+}
+
+template status_t init_conf_matmul<true>(acl_matmul_conf_t &amp,
+        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
+        const matmul_desc_t &md, const primitive_attr_t &attr);
+template status_t init_conf_matmul<false>(acl_matmul_conf_t &amp,
+        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
+        const matmul_desc_t &md, const primitive_attr_t &attr);
 
 } // namespace acl_matmul_utils
 

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -45,7 +45,7 @@ struct acl_matmul_conf_t {
     bool do_transC;
     // If this is true, the result of the matmul goes into a temporarily
     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
-    bool use_dst_acc;
+    bool use_dst_acc_for_sum;
     arm_compute::TensorInfo src_tensor_info;
     arm_compute::TensorInfo wei_tensor_info;
     arm_compute::TensorInfo dst_tensor_info;
@@ -53,7 +53,6 @@ struct acl_matmul_conf_t {
     arm_compute::TensorInfo wei_acc_info;
     arm_compute::TensorInfo dst_acc_info;
     arm_compute::GEMMInfo gemm_info;
-    float alpha;
 };
 
 namespace acl_matmul_utils {

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Arm Ltd. and affiliates
+* Copyright 2021-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,9 +30,11 @@ struct acl_matmul_obj_t {
     arm_compute::NEGEMM gemm;
     arm_compute::NETranspose transA;
     arm_compute::NETranspose transB;
+    arm_compute::NETranspose transC;
     arm_compute::Tensor src_tensor;
     arm_compute::Tensor src_acc_tensor;
     arm_compute::Tensor wei_acc_tensor;
+    arm_compute::Tensor dst_acc_tensor;
     arm_compute::Tensor wei_tensor;
     arm_compute::Tensor dst_tensor;
 };
@@ -40,27 +42,29 @@ struct acl_matmul_obj_t {
 struct acl_matmul_conf_t {
     bool is_transA;
     bool is_transB;
+    bool do_transC;
     // If this is true, the result of the matmul goes into a temporarily
     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
     bool use_dst_acc;
     arm_compute::TensorInfo src_tensor_info;
-    arm_compute::TensorInfo src_acc_info;
-    arm_compute::TensorInfo wei_acc_info;
     arm_compute::TensorInfo wei_tensor_info;
     arm_compute::TensorInfo dst_tensor_info;
+    arm_compute::TensorInfo src_acc_info;
+    arm_compute::TensorInfo wei_acc_info;
+    arm_compute::TensorInfo dst_acc_info;
     arm_compute::GEMMInfo gemm_info;
     float alpha;
 };
 
 namespace acl_matmul_utils {
 
-status_t init_conf_matmul_fixed_format(acl_matmul_conf_t &amp,
-        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
-        const matmul_desc_t &md, const primitive_attr_t &attr);
+template <bool IsFixedFormat>
+status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+        memory_desc_t &wei_md, memory_desc_t &dst_md, const matmul_desc_t &md,
+        const primitive_attr_t &attr);
 
-status_t init_conf_matmul_non_fixed_format(acl_matmul_conf_t &amp,
-        memory_desc_t &src_md, memory_desc_t &wei_md, memory_desc_t &dst_md,
-        const matmul_desc_t &md, const primitive_attr_t &attr);
+status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
+        acl_matmul_conf_t &amp, memory_desc_t &dst_md);
 
 } // namespace acl_matmul_utils
 


### PR DESCRIPTION
# Description

This is a backport of #1889 and #1892 

**Backport cpu: aarch64: matmul: Optimize (A^T)*(B^T) in acl_matmul**
Computes (B*A)^T instead of (A^T)*(B^T) when the cost of transposing (B*A) is cheaper. This improves performance by ~1.25x for square matrices and even higher for
tall-skinny/fat-short matrices.

It also reduces code duplication and moves allocation of dst accumulator from ACL to scratchpad memory in oneDNN

**Backport cpu: aarch64: matmul: fuse sum post op in acl matmul**
Fuse the sum post op in acl matmul by setting the accumulate flag to
true in arm_compute::GEMMInfo. This speeds up the post op and saves
allocating a temporary dst sized tensor.

We also added `_for_sum` to `use_dst_acc` flag to stop it being confused
with the `dst_acc` used for transposing.

Change the way we deal with fused eltwise (as well as the new sum) to
fix segfaults when binary ops followed fused ops.


Fixes # (github issue)

# Checklist

## General

- [ YES ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ YES ] Have you formatted the code using clang-format?

## Performance improvements

- [ YES ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
