### PR TITLE
build: workaround for MS STL breaking change

### DIFF
--- a/src/common/layer_normalization_pd.hpp
+++ b/src/common/layer_normalization_pd.hpp
@@ -215,7 +215,10 @@ struct layer_normalization_fwd_pd_t : public layer_normalization_pd_t {
                 + n_binary_po_inputs();
     }
     int n_outputs() const override {
-        return 1 + 2 * (!stats_are_src()) * is_training();
+        // Originally as '1 + 2 * (!stats_are_src()) * is_training()',
+        // had to be worked around MSVC bug not copying inlined bodies
+        // of stats_are_src() and is_training().
+        return (!stats_are_src() && is_training()) ? 3 : 1;
     }
 
 protected:


### PR DESCRIPTION
MSVC 19.40.33812.0 has a bug that results in incorrect optimizations and breaks all layer normalization tests.
