### PR TITLE
doc: add aarch64 build and test info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ oneDNN project is part of the [UXL Foundation] and is an implementation
 of the [oneAPI specification] for oneDNN component.
 
 The library is optimized for Intel(R) Architecture Processors, Intel Graphics,
-and Arm\* 64-bit Architecture (AArch64)-based processors. oneDNN has
+and Arm(R) 64-bit Architecture (AArch64)-based processors. oneDNN has
 experimental support for the following architectures: NVIDIA\* GPU,
 AMD\* GPU, OpenPOWER\* Power ISA (PPC64), IBMz\* (s390x), and RISC-V.
 
@@ -81,16 +81,19 @@ oneDNN supports platforms based on the following architectures:
 > **experimental** with limited testing validation.
 
 The library is optimized for the following CPUs:
-* Intel Atom(R) processor (at least Intel SSE4.1 support is required)
-* Intel Core(TM) processor (at least Intel SSE4.1 support is required)
-* Intel Core Ultra processors (formerly Meteor Lake)
-* Intel Xeon(R) processor E3, E5, and E7 family (formerly Sandy Bridge,
-  Ivy Bridge, Haswell, and Broadwell)
-* Intel Xeon Scalable processor (formerly Skylake, Cascade Lake, Cooper
-  Lake, Ice Lake, Sapphire Rapids, and Emerald Rapids)
-* Intel Xeon CPU Max Series (formerly Sapphire Rapids HBM)
-* future Intel Xeon Scalable processors (code name Sierra Forest
+* Intel 64/AMD64 architecture
+  * Intel Atom(R) processor (at least Intel SSE4.1 support is required)
+  * Intel Core(TM) processor (at least Intel SSE4.1 support is required)
+  * Intel Core Ultra processors (formerly Meteor Lake)
+  * Intel Xeon(R) processor E3, E5, and E7 family (formerly Sandy Bridge,
+    Ivy Bridge, Haswell, and Broadwell)
+  * Intel Xeon Scalable processor (formerly Skylake, Cascade Lake, Cooper
+    Lake, Ice Lake, Sapphire Rapids, and Emerald Rapids)
+  * Intel Xeon CPU Max Series (formerly Sapphire Rapids HBM)
+  * future Intel Xeon Scalable processors (code name Sierra Forest
 and Granite Rapids)
+* AArch64 architecture
+  * Arm Neoverse(TM) N1 and V1 processors
 
 On a CPU based on Intel 64 or on AMD64 architecture, oneDNN detects
 the instruction set architecture (ISA) at runtime and uses just-in-time (JIT)
@@ -99,12 +102,6 @@ Future ISAs may have initial support in the library disabled by default and
 require the use of run-time controls to enable them. See
 [CPU dispatcher control] for more details.
 
-On a CPU based on Arm AArch64 architecture, oneDNN can be built with Arm Compute
-Library (ACL) integration. ACL is an open-source library for machine learning
-applications and provides AArch64 optimized implementations of core functions.
-This functionality currently requires that ACL is downloaded and built
-separately; see [Build from Source]. oneDNN only supports Compute Library
-versions 23.11 or later.
 
 > **WARNING**
 >
@@ -129,7 +126,6 @@ oneDNN supports systems meeting the following requirements:
 * Operating system with Intel 64 / Arm 64 / Power / IBMz architecture support
 * C++ compiler with C++11 standard support
 * [CMake] 2.8.12 or later
-* [Arm Compute Library (ACL)] for builds using ACL on AArch64.
 
 The following tools are required to build oneDNN documentation:
 * [Doxygen] 1.8.5 or later
@@ -141,7 +137,6 @@ Configurations of CPU and GPU engines may introduce additional build time
 dependencies.
 
 [CMake]: https://cmake.org/download/
-[Arm Compute Library (ACL)]: https://github.com/arm-software/ComputeLibrary
 [Doxygen]: http://www.doxygen.nl/download.html#srcbin
 [Doxyrest]: https://github.com/vovkos/doxyrest
 [Sphinx]: https://www.sphinx-doc.org/en/master/usage/installation.html
@@ -170,6 +165,15 @@ Intel C++ Compiler.
 
 [Threading Building Blocks (TBB)]: https://www.threadingbuildingblocks.org/
 [Intel oneAPI DPC++/C++ Compiler]: https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compiler.html
+
+On a CPU based on Arm AArch64 architecture, oneDNN CPU engine can be built with
+[Arm Compute Library (ACL)] integration. ACL is an open-source library for
+machine learning applications and provides AArch64 optimized implementations
+of core functions. This functionality currently requires that ACL is downloaded
+and built separately. See [Build from Source] section of the Developer Guide for
+details. oneDNN only supports Compute Library versions 24.04 or later.
+
+[Arm Compute Library (ACL)]: https://github.com/arm-software/ComputeLibrary
 
 ### GPU Engine
 
@@ -299,6 +303,13 @@ on macOS 11 (Big Sur) with
 * Apple LLVM version 13.0
 * [Intel oneAPI DPC++/C++ Compiler] 2024.0
 
+on Ubuntu 20.04 AArch64 with
+* GNU Compiler Collection 7.0, 8.0, 9.0, 10.0
+* Clang\* 9.0, 17.0
+* [Arm Compiler for Linux] 24.04
+* [Arm Compute Library (ACL)] built for armv8-a arch, latest stable version
+available at the time of release
+
 GPU engine was validated on Ubuntu\* 22.04 with
 * GNU Compiler Collection 7.2, 8.1, and 9.1
 * Clang 7.1, 8.0, 9.0
@@ -314,6 +325,7 @@ time of release
 
 [Intel Software for General Purpose GPU capabilities]: https://dgpu-docs.intel.com/index.html
 [Intel Arc & Iris Xe Graphics Driver]: https://www.intel.com/content/www/us/en/download/785597/intel-arc-iris-xe-graphics-windows.html
+[Arm Compiler for Linux]: https://developer.arm.com/Tools%20and%20Software/Arm%20Compiler%20for%20Linux
 
 # Applications Enabled with oneDNN
 
@@ -439,6 +451,8 @@ who consume oneDNN.
 Intel, the Intel logo, Arc, Intel Atom, Intel Core, Iris,
 OpenVINO, the OpenVINO logo, Pentium, VTune, and Xeon are trademarks
 of Intel Corporation or its subsidiaries.
+
+Arm and Neoverse are trademarks, or registered trademarks of Arm Ltd.
 
 \* Other names and brands may be claimed as the property of others.
 


### PR DESCRIPTION
# Description

This pull request updates the README.md with some specific build and test information for aarch64

- Added Arm Neoverse N1/V1 to list of CPU this library is optimized for.
- Added Arm section to the Validated Configurations for CPU Engine with the configuration that is currently being tested by Arm.
- Bumped version of ACL ( Arm Compute Library ) that is recommended for use with oneDNN to 24.04.