### PR TITLE
cpu: aarch64: Extend ARM SVE Support for BRGEMM General and 1x1 Forward Convolution.

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_containers.hpp
@@ -95,28 +95,6 @@ private:
     std::map<const brgemm_t *, const brgemm_kernel_t *> brgemm_map_;
 };
 
-struct brgemm_palette_container_t {
-    typedef std::array<char, 64> S_t;
-
-    brgemm_palette_container_t() {}
-    brgemm_palette_container_t(size_t ns) { resize(ns); }
-    void resize(size_t ns) { refs_.resize(ns); }
-
-    inline const char *operator[](int idx) const { return refs_[idx]->data(); }
-
-    bool insert(int idx, const brgemm_t *brg);
-    bool insert(int idx, const brgemm_t &brg) { return insert(idx, &brg); }
-
-    inline void maybe_tile_configure(int &idx, int new_idx) const {
-        if (idx == new_idx) return;
-        idx = new_idx;
-    }
-
-private:
-    std::vector<const S_t *> refs_;
-    std::set<S_t> set_;
-};
-
 } // namespace brgemm_containers
 
 } // namespace aarch64

--- a/src/cpu/aarch64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_containers.hpp
@@ -95,6 +95,28 @@ private:
     std::map<const brgemm_t *, const brgemm_kernel_t *> brgemm_map_;
 };
 
+struct brgemm_palette_container_t {
+    typedef std::array<char, 64> S_t;
+
+    brgemm_palette_container_t() {}
+    brgemm_palette_container_t(size_t ns) { resize(ns); }
+    void resize(size_t ns) { refs_.resize(ns); }
+
+    inline const char *operator[](int idx) const { return refs_[idx]->data(); }
+
+    bool insert(int idx, const brgemm_t *brg);
+    bool insert(int idx, const brgemm_t &brg) { return insert(idx, &brg); }
+
+    inline void maybe_tile_configure(int &idx, int new_idx) const {
+        if (idx == new_idx) return;
+        idx = new_idx;
+    }
+
+private:
+    std::vector<const S_t *> refs_;
+    std::set<S_t> set_;
+};
+
 } // namespace brgemm_containers
 
 } // namespace aarch64

--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -231,6 +231,17 @@ static inline bool mayiuse_bf16() {
     return cpu().isBf16Supported();
 }
 
+static inline int isa_num_vregs(cpu_isa_t isa) {
+    if (isa == sve_512)
+        return cpu_isa_traits<sve_512>::n_vregs;
+    else if (isa == sve_256)
+        return cpu_isa_traits<sve_256>::n_vregs;
+    else if (isa == sve_128)
+        return cpu_isa_traits<sve_128>::n_vregs;
+    else
+        return 0;
+};
+
 } // namespace
 
 /* whatever is required to generate string literals... */

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -1,0 +1,562 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/cpu_primitive.hpp"
+#include "cpu/scale_utils.hpp"
+
+#include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
+#include "cpu/aarch64/jit_brgemm_1x1_conv.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+using namespace nstl;
+using namespace data_type;
+
+#define ndims_pick(v5, v4, v3) \
+    ((ndims == 5) ? (v5) : (ndims == 4) ? (v4) : (ndims == 3) ? (v3) : 0)
+
+template <cpu_isa_t isa>
+status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
+    using namespace data_type;
+    using namespace utils;
+
+    const auto src_type = src_md(0)->data_type;
+    const auto wei_type = weights_md(0)->data_type;
+    const auto dst_type = dst_md(0)->data_type;
+    const bool is_int8 = one_of(src_type, u8, s8);
+
+    using skip_mask_t = primitive_attr_t::skip_mask_t;
+    auto skip_mask = skip_mask_t::post_ops | skip_mask_t::sum_dt
+            | skip_mask_t::zero_points_runtime;
+    if (one_of(src_type, u8, s8)) skip_mask |= skip_mask_t::scales_runtime;
+
+    bool ok = is_fwd() && set_default_alg_kind(alg_kind::convolution_direct)
+            && expect_data_types(src_type, wei_type, data_type::undef, dst_type,
+                    data_type::undef)
+            && IMPLICATION(is_int8,
+                    one_of(bias_md_.data_type, data_type::undef, f32, s32, s8,
+                            u8))
+            && IMPLICATION(!is_int8,
+                    one_of(bias_md_.data_type, data_type::undef, f32, src_type))
+            && attr()->has_default_values(skip_mask, dst_type)
+            && attr()->post_ops_.check_sum_consistency(dst_type, is_int8)
+            && !has_zero_dim_memory() && zero_points_ok() && arg_scales_ok();
+    if (!ok) return status::unimplemented;
+
+    CHECK(brgemm_convolution_utils::init_1x1_conf(jcp_, isa, *desc(), src_md_,
+            weights_md_, dst_md_, bias_md_, attr_, dnnl_get_max_threads()));
+
+    brgs_ = std::make_shared<brgemm_containers::brgemm_desc_container_t>(16);
+
+    const float alpha = 1.0;
+    const float beta = 1.0;
+    const auto &p = attr()->post_ops_;
+    const int sum_idx = p.find(primitive_kind::sum);
+    with_sum = (sum_idx != -1);
+    sum_scale = with_sum ? p.entry_[sum_idx].sum.scale : 0.0;
+
+    ic_chunks = div_up(jcp_.nb_ic, jcp_.nb_ic_blocking);
+    need_postwork = jcp_.with_bias || jcp_.with_eltwise || jcp_.with_binary
+            || (one_of(src_type, u8, s8) && wei_type == s8) // oscales needed
+            || (jcp_.dst_dt != jcp_.acc_dt) || jcp_.with_sum;
+
+    int i_init_begin = (ic_chunks == 1) ? 1 : 0;
+    int i_init_end = 2;
+
+    for_(int i_M = 0; i_M < 2; i_M++)
+    for_(int i_N = 0; i_N < 2; i_N++)
+    for_(int i_K = 0; i_K < 2; i_K++)
+    for (int i_init = i_init_begin; i_init < i_init_end; i_init++) {
+        auto vbeta = (i_init) ? 0 : beta;
+        auto vM = (i_M) ? jcp_.M_tail : jcp_.M;
+        auto vN = (i_N) ? jcp_.N_tail : jcp_.N;
+        auto vK = (i_K) ? jcp_.K_tail : jcp_.K;
+        const auto brg_idx = get_brg_idx(i_init, i_M, i_N, i_K);
+        if (vM == 0 || vN == 0 || vK == 0) continue;
+        brgemm_t brg;
+        brgemm_strides_t brg_strides;
+        brg_strides.stride_a = jcp_.brg_stride_a;
+        brg_strides.stride_b = jcp_.brg_stride_b;
+        const auto strides_ptr
+                = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
+        CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, src_type, wei_type,
+                false, false, brgemm_row_major, alpha, vbeta, jcp_.LDA,
+                jcp_.LDB, jcp_.LDC, vM, vN, vK, strides_ptr));
+
+        auto LDD = jcp_.oc_without_padding;
+        brg.with_sum = with_sum;
+        brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
+        CHECK(brgemm_desc_set_postops(
+                &brg, attr(), &dst_md_, LDD, jcp_.bia_dt));
+        brgs_->insert(brg_idx, brg);
+    }
+
+    auto scratchpad = scratchpad_registry().registrar();
+    brgemm_convolution_utils::init_scratchpad(scratchpad, jcp_);
+    if (jcp_.with_scales)
+        book_precomputed_scales(scratchpad, attr()->scales_, OC(),
+                jcp_.scale_adjust_factor != 1.0f);
+
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
+    auto ndims = pd()->ndims();
+    if (ndims < 3 || ndims > 5) assert(!"Invalid ndims!");
+
+    const auto &jcp = pd()->jcp_;
+
+    ID = ndims_pick(jcp.id, 1, 1);
+    IH = ndims_pick(jcp.ih, jcp.ih, 1);
+    IW = jcp.iw;
+
+    OD = ndims_pick(jcp.od, 1, 1);
+    OH = ndims_pick(jcp.oh, jcp.oh, 1);
+    OW = jcp.ow;
+
+    SD = ndims_pick(jcp.stride_d, 1, 1);
+    SH = ndims_pick(jcp.stride_h, jcp.stride_h, 1);
+    SW = jcp.stride_w;
+
+    bia_dsz = jcp.bia_dsz;
+    acc_dsz = jcp.acc_dsz;
+    src_dsz = jcp.src_dsz;
+    wei_dsz = jcp.wei_dsz;
+
+    // const variables used for address calculations
+    src_w_sz = (dim_t)IW * jcp.ngroups * jcp.ic_without_padding;
+    src_h_sz = IH * src_w_sz;
+    src_d_sz = ID * src_h_sz;
+    dst_w_sz = (dim_t)OW * jcp.oc_without_padding;
+    dst_h_sz = OH * dst_w_sz;
+    dst_d_sz = OD * dst_h_sz;
+
+    const auto src_type = pd()->src_md(0)->data_type;
+
+    const auto last_ic_block = data_type_vnni_granularity(src_type);
+
+    wei_ic_stride = jcp.wei_plain ? jcp.oc_without_padding : jcp.oc_block;
+    wei_ocb_stride = jcp.wei_plain
+            ? jcp.oc_block
+            : (dim_t)rnd_up(jcp.ic, last_ic_block) * jcp.oc_block;
+    wei_g_stride = jcp.wei_plain ? jcp.oc : jcp.nb_oc * wei_ocb_stride;
+
+    if (jcp.is_rtus) {
+        CHECK(safe_ptr_assign(rtus_kernel_,
+                new jit_sve_core_brgemm_conv_trans_kernel::
+                        jit_sve_core_brgemm_conv_rtus_kernel_t(jcp)));
+        CHECK(rtus_kernel_->create_kernel());
+    }
+    int i_init_begin = (pd()->ic_chunks == 1) ? 1 : 0;
+    int i_init_end = 2;
+
+    const auto &brgs = *(pd()->brgs_);
+
+    for_(int i_M = 0; i_M < 2; i_M++)
+    for_(int i_N = 0; i_N < 2; i_N++)
+    for_(int i_K = 0; i_K < 2; i_K++)
+    for (int i_init = i_init_begin; i_init < i_init_end; i_init++) {
+        auto brg_idx = get_brg_idx(i_init, i_M, i_N, i_K);
+        auto brg = brgs[brg_idx];
+        if (brg != nullptr && brg->bcast_dim > 0 && brg->load_dim > 0
+                && brg->reduce_dim > 0 && !brg_kernels_[brg_idx]) {
+            CHECK(brg_kernels_.insert(brg_idx, brg));
+        }
+    }
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
+        const char *__restrict src, char *__restrict inp_buffer,
+        uint8_t *__restrict inp_buffer_mask, int g, int n, int icc, int od,
+        int oh, int ow) const {
+    const auto &jcp = pd()->jcp_;
+    if (!jcp.is_rtus) return;
+    assert(jcp.is_os_blocking);
+    const size_t src_dt_size = jcp.src_dsz;
+
+    const auto os = (od * OH + oh) * OW + ow;
+    const auto osb = os / jcp.os_block;
+
+    uint8_t *bmask = &inp_buffer_mask[icc * jcp.nb_os + osb];
+    if (bmask && *bmask) return; // skip if already masked
+    if (bmask) *bmask = 1; // set mask to skip next time
+
+    const auto g_ic = g * jcp.ic_without_padding
+            + icc * jcp.nb_ic_blocking * jcp.ic_block;
+
+    auto call_kernel = [&](int nh, int nw, int od, int oh, int ow) {
+        assert(nh == 0 || (nw == 0 && ow == 0));
+        if (utils::everyone_is(0, nh, nw)) return;
+        const int id = od * jcp.stride_d;
+        const int ih = oh * jcp.stride_h;
+        const int iw = ow * jcp.stride_w;
+        const auto inp_offset = n * src_d_sz + id * src_h_sz + ih * src_w_sz
+                + iw * jcp.ngroups * jcp.ic_without_padding + g_ic;
+        auto p = jit_sve_core_brgemm_conv_trans_kernel::
+                jit_brgemm_conv_trans_kernel_call_s();
+        p.h_count = nh;
+        p.owb = nw;
+        p.src = src + src_dt_size * inp_offset;
+        p.dst = inp_buffer;
+        (*rtus_kernel_)(&p);
+        inp_buffer += src_dt_size * (nh * jcp.ow + nw) * jcp.LDA;
+    };
+
+    const bool is_os_tail = jcp.os - os < jcp.os_block;
+    int count = is_os_tail ? jcp.M_tail : jcp.M;
+
+    if (count < OW || ow > 0) {
+        // copy to end of row
+        const auto nw = nstl::min(count, OW - ow);
+        call_kernel(0, nw, od, oh, ow);
+        count -= nw;
+        if (count == 0) return;
+        ow = 0;
+        oh = (oh + 1) % OH;
+        if (oh == 0) od++;
+    }
+
+    while (od < OD) {
+        // copy to end of column
+        const auto nh = nstl::min(count / OW, OH - oh);
+        call_kernel(nh, 0, od, oh, ow);
+        count -= nh * OW;
+        if (count == 0) return;
+        oh = (oh + nh) % OH;
+        if (oh == 0) od++;
+        if (count < OW) {
+            // copy partial row
+            const auto nw = count;
+            call_kernel(0, nw, od, oh, ow);
+            return;
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
+        const brgemm_exec_ctx_t &brgemm_ctx, int ithr,
+        brgemm_batch_element_t *const __restrict brg_batch,
+        char *const c_buffer, const char *inp_buffer, int g, int n, int ocb,
+        int od, int oh, int ow, int icc, int *last_brg_idx,
+        const float *oscales, int32_t src_zp_vals, int32_t *src_zp_comp,
+        int32_t *dst_zp_vals, int32_t *s8s8_compensation,
+        const float *dst_scales) const {
+
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper weights_d(pd()->weights_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const size_t src_dt_size = types::data_type_size(src_d.data_type());
+    const size_t wei_dt_size = types::data_type_size(weights_d.data_type());
+    const size_t dst_dt_size = types::data_type_size(dst_d.data_type());
+
+    const char *const __restrict src = brgemm_ctx.src;
+    const char *const __restrict weights = brgemm_ctx.weights;
+    const char *const __restrict bias = brgemm_ctx.bias;
+    char *const __restrict dst = brgemm_ctx.dst;
+    const std::vector<const void *> &post_ops_binary_rhs_arg_vec
+            = brgemm_ctx.post_ops_binary_rhs_arg_vec;
+
+    const auto &jcp = pd()->jcp_;
+    auto ndims = pd()->ndims();
+
+    const int id = ndims_pick(od * SD, 0, 0);
+    const int ih = ndims_pick(oh * SH, oh * SH, 0);
+    const int iw = ow * SW;
+
+    const int oc = ocb * jcp.oc_block;
+    const int g_oc = g * jcp.oc + oc;
+
+    const int icb = icc * jcp.nb_ic_blocking;
+    const int ic = icb * jcp.ic_block;
+    const int g_ic = g * jcp.ic + ic;
+
+    const bool kernel_init = (icc == 0);
+
+    const auto os = (od * OH + oh) * OW + ow;
+
+    const bool is_os_tail = jcp.is_os_blocking ? (jcp.os - os < jcp.os_block)
+                                               : (OW - ow < jcp.ow_block);
+    const bool is_oc_tail = (jcp.oc - oc < jcp.oc_block);
+    const bool is_ic_tail = (icc == pd()->ic_chunks - 1
+            && ((jcp.ic - ic) % jcp.ic_block != 0));
+
+    const auto src_offset = n * src_d_sz + id * src_h_sz + ih * src_w_sz
+            + iw * jcp.ngroups * jcp.ic_without_padding + g_ic;
+    const auto src_base
+            = jcp.is_rtus ? inp_buffer : src + src_dt_size * src_offset;
+    const auto wei_offset = g * wei_g_stride + ocb * wei_ocb_stride;
+    const auto wei_base = weights + wei_dt_size * wei_offset;
+    const auto ptr_D = dst
+            + dst_dt_size
+                    * (n * dst_d_sz + od * dst_h_sz + oh * dst_w_sz
+                            + ow * jcp.oc_without_padding + g_oc);
+    char *const ptr_C = (jcp.use_buffer) ? c_buffer : (char *)ptr_D;
+
+    const auto bias_w
+            = bias ? bias + (bias_d.blk_off(g_oc) * bia_dsz) : nullptr;
+    const auto nb_ic_b = nstl::min(jcp.nb_ic_blocking, jcp.nb_ic - icb)
+            - (is_ic_tail ? 1 : 0);
+
+    const auto comp_offset = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+    int32_t *src_zp_comp_ptr
+            = (jcp.src_zero_point && icc == pd()->ic_chunks - 1)
+            ? &src_zp_comp[comp_offset]
+            : nullptr;
+    int32_t *s8s8_comp_ptr
+            = (jcp.s8s8_compensation_required && icc == pd()->ic_chunks - 1)
+            ? &s8s8_compensation[comp_offset]
+            : nullptr;
+
+    const auto call_brgemm = [=](int brg_idx, int ic_block_s, int n_ic_blocks,
+                                     bool do_postops) {
+        brgemm_palettes_.maybe_tile_configure(*last_brg_idx, brg_idx);
+
+        for (int k = 0; k < n_ic_blocks; k++) {
+            const auto ic_off = (ic_block_s + k) * jcp.ic_block;
+            const auto src_ic = ic_off;
+            const auto wei_ic = ic + ic_off;
+            const auto ptr_A = src_base + src_dt_size * src_ic;
+            const auto ptr_B = wei_base + wei_dt_size * wei_ic * wei_ic_stride;
+            brg_batch[k].ptr.A = ptr_A;
+            brg_batch[k].ptr.B = ptr_B;
+            brg_batch[k].vvpad.top = 0;
+            brg_batch[k].vvpad.bottom = 0;
+        }
+
+        const auto brg_ker = brg_kernels_[brg_idx];
+        if (do_postops) {
+            const brgemm_post_ops_data_t post_ops_data {
+                    static_cast<const void *>(bias_w),
+                    &oscales[jcp.is_oc_scale * g_oc],
+                    post_ops_binary_rhs_arg_vec.data(),
+                    static_cast<size_t>(g_oc), 0, dst, 0,
+                    static_cast<void *>(src_zp_comp_ptr), nullptr,
+                    static_cast<void *>(dst_zp_vals), false, src_zp_vals, false,
+                    false, dst_scales};
+
+            void *scratch = static_cast<void *>(s8s8_comp_ptr);
+            brgemm_kernel_execute_postops(brg_ker, n_ic_blocks, brg_batch,
+                    (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch);
+        } else {
+            void *scratch = static_cast<void *>(s8s8_comp_ptr);
+            brgemm_kernel_execute(
+                    brg_ker, n_ic_blocks, brg_batch, (void *)ptr_C, scratch);
+        }
+    };
+
+    const auto do_post_work = (pd()->need_postwork || jcp.use_buffer)
+            && icc == pd()->ic_chunks - 1;
+
+    if (nb_ic_b > 0) {
+        const auto brg_idx
+                = get_brg_idx(kernel_init, is_os_tail, is_oc_tail, false);
+        call_brgemm(brg_idx, 0, nb_ic_b, do_post_work && !is_ic_tail);
+    }
+    if (is_ic_tail) {
+        const auto use_init_ker = (kernel_init && nb_ic_b == 0);
+        const auto brg_idx
+                = get_brg_idx(use_init_ker, is_os_tail, is_oc_tail, true);
+
+        call_brgemm(brg_idx, nb_ic_b, 1, do_post_work);
+    }
+}
+
+template <cpu_isa_t isa>
+status_t brgemm_1x1_convolution_fwd_t<isa>::execute_forward_all(
+        const exec_ctx_t &ctx) const {
+
+    brgemm_exec_ctx_t brgemm_ctx(ctx, pd());
+
+    const memory_tracking::grantor_t scratchpad = ctx.get_scratchpad_grantor();
+
+    const auto &jcp = pd()->jcp_;
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    DEFINE_ARG_SCALES_BUFFER(src_scales, DNNL_ARG_SRC);
+    DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
+    DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
+
+    const float *oscales = precompute_scales(ctx.get_scratchpad_grantor(),
+            src_scales, wei_scales, pd()->OC(), pd()->attr(),
+            jcp.scale_adjust_factor);
+
+    DEFINE_ZERO_POINT_VALUE(src_zero_point, DNNL_ARG_SRC);
+    DEFINE_ZERO_POINT_VALUE(dst_zero_point, DNNL_ARG_DST);
+
+    const auto extra_data_offset
+            = weights_d.size() - weights_d.additional_buffer_size();
+    auto w = const_cast<char *>(brgemm_ctx.weights);
+    int32_t *s8s8_compensation = (jcp.s8s8_compensation_required)
+            ? reinterpret_cast<int32_t *>(w + extra_data_offset)
+            : nullptr;
+    int32_t *zp_compensation = (jcp.src_zero_point)
+            ? reinterpret_cast<int32_t *>(&w[extra_data_offset])
+                    + (jcp.s8s8_compensation_required
+                                    ? jcp.s8s8_comp_buffer_size
+                                    : 0)
+            : nullptr;
+    int32_t *dst_zp_vals = jcp.dst_zero_point ? &dst_zero_point : nullptr;
+
+    brgemm_batch_element_t *const brg_batch_global
+            = (jcp.brg_type != brgemm_strd)
+            ? scratchpad.template get<brgemm_batch_element_t>(
+                    key_brgemm_primitive_batch)
+            : nullptr;
+    char *const c_buffer_global = (jcp.use_buffer)
+            ? scratchpad.template get<char>(key_brgemm_primitive_buffer)
+            : nullptr;
+    char *inp_buffer_base = (jcp.is_rtus)
+            ? scratchpad.template get<char>(key_conv_brgemm_inp_buffer)
+            : nullptr;
+    uint8_t *inp_buffer_mask_base = (jcp.is_rtus)
+            ? scratchpad.template get<uint8_t>(key_conv_brgemm_inp_buffer_mask)
+            : nullptr;
+
+    if (jcp.is_os_blocking) {
+        const int os_chunks = div_up(jcp.nb_os, jcp.nb_os_blocking);
+        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_oc * os_chunks;
+
+#define BRGC_WO(...) \
+    parallel(pd()->jcp_.nthr, [&](const int ithr, const int nthr) { \
+        if (ithr >= work_amount) return; \
+        brgemm_batch_element_t *const brg_batch \
+                = brg_batch_global + (size_t)ithr * jcp.adjusted_batch_size; \
+        char *const c_buffer = (jcp.use_buffer) \
+                ? c_buffer_global + ithr * acc_dsz * jcp.LDC * jcp.M \
+                : nullptr; \
+        char *inp_buffer = (jcp.is_rtus) \
+                ? inp_buffer_base + ithr * src_dsz * jcp.inp_buffer_size \
+                : nullptr; \
+        uint8_t *__restrict inp_buffer_mask = (jcp.is_rtus) \
+                ? inp_buffer_mask_base + ithr * jcp.inp_buffer_mask_size \
+                : nullptr; \
+        int last_n = -1; \
+        int last_g = -1; \
+        int last_brg_idx = -1; \
+        int start {0}, end {0}; \
+        balance211(work_amount, nthr, ithr, start, end); \
+        int n {0}, g {0}, ocb {0}, oss {0}; \
+        nd_iterator_init(start, __VA_ARGS__); \
+        for (auto work = start; work < end; work++) { \
+            if (jcp.is_rtus && (last_n != n || last_g != g)) \
+                std::memset(inp_buffer_mask, 0, jcp.inp_buffer_mask_size); \
+            const auto osb_start = oss * jcp.nb_os_blocking; \
+            const auto osb_range \
+                    = nstl::min(jcp.nb_os - osb_start, jcp.nb_os_blocking); \
+            for (int osb = 0; osb < osb_range; osb++) { \
+                const int os = (osb_start + osb) * jcp.os_block; \
+                const int od = os / (OH * OW); \
+                const int oh = (os % (OH * OW)) / OW; \
+                const int ow = os % OW; \
+                char *inp_buffer_sp = (jcp.is_rtus) \
+                        ? inp_buffer + src_dsz * os * jcp.LDA \
+                        : nullptr; \
+                for (int icc = 0; icc < pd()->ic_chunks; icc++) { \
+                    if (jcp.is_rtus) \
+                        maybe_rtus(ithr, brgemm_ctx.src, inp_buffer_sp, \
+                                inp_buffer_mask, g, n, icc, od, oh, ow); \
+                    exec_ker(brgemm_ctx, ithr, brg_batch, c_buffer, \
+                            inp_buffer_sp, g, n, ocb, od, oh, ow, icc, \
+                            &last_brg_idx, oscales, src_zero_point, \
+                            zp_compensation, dst_zp_vals, s8s8_compensation, \
+                            dst_scales); \
+                } \
+            } \
+            last_n = n; \
+            last_g = g; \
+            nd_iterator_step(__VA_ARGS__); \
+        } \
+    });
+
+        if (jcp.loop_order == loop_ndhwgc)
+            BRGC_WO(n, jcp.mb, oss, os_chunks, g, jcp.ngroups, ocb, jcp.nb_oc)
+        else if (jcp.loop_order == loop_ngcdhw)
+            BRGC_WO(n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc, oss, os_chunks)
+        else
+            assert(!"Unknown loop order");
+
+#undef BRGC_WO
+
+    } else {
+        const int work_amount
+                = jcp.mb * jcp.ngroups * jcp.nb_oc * OD * OH * jcp.nb_ow;
+
+#define BRGC_WO(...) \
+    parallel(pd()->jcp_.nthr, [&](const int ithr, const int nthr) { \
+        if (ithr >= work_amount) return; \
+        brgemm_batch_element_t *const brg_batch \
+                = brg_batch_global + (size_t)ithr * jcp.adjusted_batch_size; \
+        char *const c_buffer = (jcp.use_buffer) \
+                ? c_buffer_global + ithr * acc_dsz * jcp.LDC * jcp.M \
+                : nullptr; \
+        int last_brg_idx = -1; \
+        int start {0}, end {0}; \
+        balance211(work_amount, nthr, ithr, start, end); \
+        int n {0}, g {0}, ocb {0}, od {0}, oh {0}, owb {0}; \
+        nd_iterator_init(start, __VA_ARGS__); \
+        for (auto work = start; work < end; work++) { \
+            for (int icc = 0; icc < pd()->ic_chunks; icc++) { \
+                const int ow = owb * jcp.ow_block; \
+                exec_ker(brgemm_ctx, ithr, brg_batch, c_buffer, nullptr, g, n, \
+                        ocb, od, oh, ow, icc, &last_brg_idx, oscales, \
+                        src_zero_point, zp_compensation, dst_zp_vals, \
+                        s8s8_compensation, dst_scales); \
+            } \
+            nd_iterator_step(__VA_ARGS__); \
+        } \
+    });
+
+        if (jcp.loop_order == loop_ndhwgc)
+            BRGC_WO(n, jcp.mb, od, OD, oh, OH, owb, jcp.nb_ow, g, jcp.ngroups,
+                    ocb, jcp.nb_oc)
+        else if (jcp.loop_order == loop_ngcdhw)
+            BRGC_WO(n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc, od, OD, oh, OH,
+                    owb, jcp.nb_ow)
+        else
+            assert(!"Unknown loop order");
+
+#undef BRGC_WO
+    }
+
+    return status::success;
+}
+
+template struct brgemm_1x1_convolution_fwd_t<sve_512>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -340,8 +340,6 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
 
     const auto call_brgemm = [=](int brg_idx, int ic_block_s, int n_ic_blocks,
                                      bool do_postops) {
-        brgemm_palettes_.maybe_tile_configure(*last_brg_idx, brg_idx);
-
         for (int k = 0; k < n_ic_blocks; k++) {
             const auto ic_off = (ic_block_s + k) * jcp.ic_block;
             const auto src_ic = ic_off;

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
@@ -138,7 +138,6 @@ private:
     }
 
     brgemm_containers::brgemm_kernel_container_t brg_kernels_ {16};
-    brgemm_containers::brgemm_palette_container_t brgemm_palettes_ {16};
 
     std::unique_ptr<jit_sve_core_brgemm_conv_trans_kernel::
                     jit_sve_core_brgemm_conv_rtus_kernel_t>

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
@@ -1,0 +1,164 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_BRGEMM_1X1_CONV_HPP
+#define CPU_AARCH64_JIT_BRGEMM_1X1_CONV_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/cpu_convolution_pd.hpp"
+#include "cpu/platform.hpp"
+
+#include "cpu/aarch64/brgemm/brgemm.hpp"
+#include "cpu/aarch64/brgemm/brgemm_containers.hpp"
+#include "cpu/aarch64/cpu_barrier.hpp"
+#include "cpu/aarch64/cpu_reducer.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_utils.hpp"
+#include "cpu/aarch64/jit_brgemm_post_ops.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa>
+struct brgemm_1x1_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
+            , with_sum(false)
+            , sum_scale(0) {}
+
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgconv_1x1:", isa, ""),
+                brgemm_1x1_convolution_fwd_t);
+
+        status_t init(engine_t *engine);
+
+        std::shared_ptr<brgemm_containers::brgemm_desc_container_t> brgs_;
+        bool with_sum;
+        float sum_scale;
+
+        bool need_postwork;
+        int ic_chunks;
+
+        jit_brgemm_conv_conf_t jcp_;
+
+    protected:
+        bool arg_scales_ok() const {
+            std::vector<int> supported_args
+                    = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
+            return attr_scales_ok(supported_args);
+        }
+        bool zero_points_ok() const {
+            // Only common zero points are supported -> mask should only be 0
+            int mask_src = 0, mask_dst = 0;
+            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
+            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
+            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
+                    && mask_src == 0 && mask_dst == 0;
+        }
+    };
+
+    brgemm_1x1_convolution_fwd_t(const pd_t *apd)
+        : primitive_t(apd), bias_d(pd()->weights_md(1)) {}
+
+    ~brgemm_1x1_convolution_fwd_t() {}
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        execute_forward_all(ctx);
+
+        if (pd()->wants_zero_pad_dst()) ctx.memory(DNNL_ARG_DST)->zero_pad(ctx);
+
+        return status::success;
+    }
+
+protected:
+    status_t init(engine_t *engine) override;
+
+private:
+    //  brgemm convolution execution context
+    struct brgemm_exec_ctx_t {
+        brgemm_exec_ctx_t(const exec_ctx_t &ctx, const pd_t *pd)
+            : src(CTX_IN_MEM(const char *, DNNL_ARG_SRC))
+            , weights(CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS))
+            , bias(CTX_IN_MEM(const char *, DNNL_ARG_BIAS))
+            , dst(CTX_OUT_MEM(char *, DNNL_ARG_DST))
+            , post_ops_binary_rhs_arg_vec(binary_injector::prepare_binary_args(
+                      pd->attr()->post_ops_, ctx)) {}
+        const char *const __restrict src;
+        const char *const __restrict weights;
+        const char *const __restrict bias;
+        char *const __restrict dst;
+        const std::vector<const void *> post_ops_binary_rhs_arg_vec;
+    };
+
+    void maybe_rtus(int ithr, const char *__restrict src,
+            char *__restrict inp_buffer, uint8_t *__restrict inp_buffer_mask,
+            int g, int n, int icc, int od, int oh, int ow) const;
+    void exec_ker(const brgemm_exec_ctx_t &brgemm_ctx, int ithr,
+            brgemm_batch_element_t *const __restrict brg_batch,
+            char *const c_buffer, const char *inp_buffer, int g, int n, int ocb,
+            int od, int oh, int ow, int icc, int *last_brg_idx,
+            const float *oscales, int32_t src_zp_vals, int32_t *src_zp_comp,
+            int32_t *dst_zp_vals, int32_t *s8s8_compensation,
+            const float *dst_scales) const;
+    status_t execute_forward_all(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    static int get_brg_idx(bool do_initialization, int is_M_tail,
+            bool is_N_tail, bool is_K_tail) {
+        return (((int)do_initialization * 2 + (int)is_M_tail) * 2
+                       + (int)is_N_tail)
+                * 2
+                + (int)is_K_tail;
+    }
+
+    static int get_ker_po_idx(int is_M_tail, bool is_N_tail) {
+        return (int)is_M_tail * 2 + (int)is_N_tail;
+    }
+
+    brgemm_containers::brgemm_kernel_container_t brg_kernels_ {16};
+    brgemm_containers::brgemm_palette_container_t brgemm_palettes_ {16};
+
+    std::unique_ptr<jit_sve_core_brgemm_conv_trans_kernel::
+                    jit_sve_core_brgemm_conv_rtus_kernel_t>
+            rtus_kernel_;
+
+    const memory_desc_wrapper bias_d;
+
+    int ID, IH, IW, OD, OH, OW, SD, SH, SW;
+    size_t bia_dsz, acc_dsz, src_dsz, wei_dsz;
+    // const variables used for address calculations
+    dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz;
+    dim_t wei_g_stride, wei_ic_stride, wei_ocb_stride;
+    dim_t wei_kw_stride, wei_kh_stride, wei_kd_stride;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -778,7 +778,6 @@ status_t brgemm_convolution_fwd_t<isa, use_inversion>::init(engine_t *engine) {
 
     // ---- Initialize arrays ---------------------
     brgemm_kernels_.resize(_pd->brgs_sz_);
-    brgemm_palettes_.resize(_pd->brgs_sz_);
 
     // #TODO: this needed only if we have d/h padding more then kd/kh
     int M_begin = 0;
@@ -1674,7 +1673,6 @@ void brgemm_convolution_fwd_t<isa, use_inversion>::ker_base(
                                      bool do_only_comp) {
         if (k_l <= 0) return;
         const auto brg_ker = brgemm_kernels_[brg_idx];
-        brgemm_palettes_.maybe_tile_configure(btc.cur_brg_idx, brg_idx);
 
         assert(jcp.brg_type != brgemm_static_offs);
         _pd->init_batch(btc.icc, src_base, wei_base, n_ic_blocks, ic_block_s,
@@ -1850,7 +1848,6 @@ void brgemm_convolution_fwd_t<isa, use_inversion>::ker_trans(
                                      bool do_postops) {
         if (k_l <= 0) return;
         const auto brg_ker = brgemm_kernels_[brg_idx];
-        brgemm_palettes_.maybe_tile_configure(btc.cur_brg_idx, brg_idx);
 
         const auto kh_ee = jcp.kh_sets > 1 ? kh_b + 1 : kh_e;
         const auto pbuf_base = inp_buffer
@@ -1963,8 +1960,6 @@ void brgemm_convolution_fwd_t<isa, use_inversion>::ker_vpad(
     const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
                                      int comp_ker_offs, bool do_postops) {
         const auto brg_ker = brgemm_kernels_[brg_idx];
-
-        brgemm_palettes_.maybe_tile_configure(btc.cur_brg_idx, brg_idx);
 
         assert(jcp.brg_type != brgemm_static_offs);
         _pd->init_batch(btc.icc, src_base, wei_base, n_ic_blocks, ic_block_s,

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -1,0 +1,2040 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "cpu/cpu_primitive.hpp"
+#include "cpu/scale_utils.hpp"
+
+#include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
+#include "cpu/aarch64/jit_brgemm_conv.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+using namespace nstl;
+using namespace data_type;
+
+using namespace jit_sve_core_brgemm_conv_trans_kernel;
+using namespace jit_uni_brgemm_conv_comp_pad_kernel;
+
+#define ndims_pick(v5, v4, v3) \
+    ((ndims == 5) ? (v5) : (ndims == 4) ? (v4) : (ndims == 3) ? (v3) : 0)
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::pd_t::init_batch(int icc,
+        const char *src_base, const char *wei_base, int n_ic_blocks,
+        int ic_block_s, int iid_b, int iih_b, int iiw_b,
+        const dim_t *const __restrict kw_top_vpads,
+        const dim_t *const __restrict kw_bottom_vpads, int kd_b, int kd_e,
+        int kh_b, int kh_e, int kw_b, int kw_e, int k_l,
+        brgemm_batch_element_t *brg_batch) const {
+    const char *ptrA {nullptr};
+    const char *ptrB {nullptr};
+    const auto &jcp = jcp_;
+
+    const int icb = icc * jcp.nb_ic_blocking;
+    const int ic = icb * jcp.ic_block;
+
+    for (int i_icb = 0; i_icb < n_ic_blocks; i_icb++) {
+        const auto ic_off = (ic_block_s + i_icb) * jcp.ic_block;
+        const auto wei_ic = ic + ic_off;
+        const auto n_icb_off = i_icb * k_l;
+        const auto src_base_shift = (jcp.exec_type == exec_trans)
+                ? (jcp.copy_block_only ? 0 : (i_icb * pbuf_d_sz))
+                : ic_off;
+        const auto src_base_ic = src_base + src_base_shift * src_dsz;
+        const auto wei_base_ic = wei_base + wei_ic * wei_ic_offset;
+        const auto need_A_B = (jcp.use_uker
+                && (jcp.brg_type == brgemm_offs
+                        || jcp.brg_type == brgemm_static_offs));
+
+        auto k = 0;
+        for (int kd = kd_b; kd < kd_e; kd++) {
+            const auto id = iid_b + kd * DD;
+            const auto src_base_kd = src_base_ic + id * src_d_offset;
+            const auto wei_kd = maybe_invert(kd, KD);
+            const auto wei_base_kd = wei_base_ic + wei_kd * wei_kd_offset;
+            for (int kh = kh_b; kh < kh_e; kh++) {
+                const auto ih = (jcp.exec_type == exec_trans && jcp.kh_sets > 1)
+                        ? iih_b
+                        : (iih_b + kh * DH);
+                const auto src_base_kh = src_base_kd + ih * adj_src_h_offset;
+                const auto wei_kh = maybe_invert(kh, KH);
+                const auto wei_base_kh = wei_base_kd + wei_kh * wei_kh_offset;
+
+                for (int kw = kw_b; kw < kw_e; kw++) {
+                    const auto iw = iiw_b + kw * DW;
+                    const auto b_idx = n_icb_off + k;
+                    const auto A_addr = src_base_kh + iw * src_iw_offset;
+                    // general wei layout is gOdhwI<block_o><block_i>
+                    const auto wei_kw = maybe_invert(kw, KW);
+                    const auto B_addr = wei_base_kh + wei_kw * wei_kw_offset;
+                    if (b_idx == 0 && need_A_B) {
+                        ptrA = A_addr;
+                        ptrB = B_addr;
+                    }
+
+                    if (jcp.brg_type == brgemm_addr) {
+                        brg_batch[b_idx].ptr.A = A_addr;
+                        brg_batch[b_idx].ptr.B = B_addr;
+                    } else if (jcp.brg_type == brgemm_offs
+                            || jcp.brg_type == brgemm_static_offs) {
+                        brg_batch[b_idx].offset.A = (dim_t)A_addr - (dim_t)ptrA;
+                        brg_batch[b_idx].offset.B = (dim_t)B_addr - (dim_t)ptrB;
+                    }
+                    if (jcp.max_vpad != 0) {
+                        brg_batch[b_idx].vvpad.top = kw_top_vpads[kw];
+                        brg_batch[b_idx].vvpad.bottom = kw_bottom_vpads[kw];
+                    }
+
+                    k++;
+                }
+            }
+        }
+    }
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+inline void brgemm_convolution_fwd_t<isa, use_inversion>::pd_t::get_A_B(int icc,
+        const char *src_base, const char *wei_base, int ic_block_s, int iid_b,
+        int iih_b, int iiw_b, int kd_b, int kh_b, const void *&ptrA,
+        const void *&ptrB) const {
+    const int icb = icc * jcp_.nb_ic_blocking;
+    const int ic = icb * jcp_.ic_block;
+
+    // for brgemm_static_offs we need only base A_addr and B_addr
+    const auto ic_off = ic_block_s * jcp_.ic_block;
+    const auto wei_ic = ic + ic_off;
+    const auto src_base_shift = (jcp_.exec_type == exec_trans) ? 0 : ic_off;
+    const auto src_base_ic = src_base + src_base_shift * src_dsz;
+    const auto wei_base_ic = wei_base + wei_ic * wei_ic_offset;
+
+    const auto id = iid_b + kd_b * DD;
+    const auto src_base_kd = src_base_ic + id * src_d_offset;
+    const auto wei_kd = maybe_invert(kd_b, KD);
+    const auto wei_base_kd = wei_base_ic + wei_kd * wei_kd_offset;
+    const auto has_kh_sets = (jcp_.exec_type == exec_trans && jcp_.kh_sets > 1);
+    const auto ih = iih_b + (has_kh_sets ? 0 : kh_b * DH);
+    const auto src_base_kh = src_base_kd + ih * adj_src_h_offset;
+    const auto wei_kh = maybe_invert(kh_b, KH);
+    const auto wei_base_kh = wei_base_kd + wei_kh * wei_kh_offset;
+
+    ptrA = src_base_kh + iiw_b * src_iw_offset;
+    const auto wei_kw = maybe_invert(0, KW);
+    ptrB = wei_base_kh + wei_kw * wei_kw_offset;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+status_t brgemm_convolution_fwd_t<isa, use_inversion>::pd_t::add_brg_descriptor(
+        int vM, int i_N, int i_K, int i_init, int kd_b, int kd_e, int kh_b,
+        int kh_e) {
+
+    const auto src_type = src_md(0)->data_type;
+    const auto wei_type = weights_md(0)->data_type;
+
+    const float alpha = 1.0;
+    const float beta = 1.0;
+
+    auto vbeta = (i_init) ? 0 : beta;
+    auto vN = (i_N) ? jcp_.N_tail : jcp_.N;
+    auto vK = (i_K) ? jcp_.K_tail : jcp_.K;
+    auto vbrgM = jcp_.use_M_mask ? (vM == jcp_.M ? jcp_.brgM : jcp_.brgM_tail)
+                                 : vM;
+    auto brg_idx
+            = get_brg_idx(vM - 1, i_init, i_N, i_K, kd_b, kd_e, kh_b, kh_e);
+    // if brgemm_t already created then skip this iteration
+    if ((*brgemm_descriptors_)[brg_idx] != nullptr) return status::success;
+    if (vN == 0 || vK == 0) return status::success;
+
+    brgemm_attr_t brgattr;
+    // if need post_ops and there are no intermediate calculations
+    // (like ic_chunks > 1 or blocking by kernel) we don't need
+    // code without post-ops in brgemm kernel
+    if (need_postwork && ic_chunks == 1 && KD_BLOCK == KD && KH_BLOCK == KH
+            && KW_BLOCK == KW)
+        brgattr.postops_only = true;
+
+    std::vector<char> bd_mask;
+    if (jcp_.use_M_mask) {
+        auto sm_size = vbrgM;
+        bd_mask.resize(sm_size);
+        if (jcp_.is_os_blocking) {
+            int ibrgM = 0;
+            int iM = 0;
+            for (int hh = 0; hh < jcp_.oh_block; hh++) {
+                auto M_mask = (iM >= vM) ? 0 : 1;
+                for (int ww = 0; ww < jcp_.ow_block && ibrgM < sm_size;
+                        ww++, ibrgM++, iM += M_mask) {
+                    bd_mask[ibrgM] = M_mask;
+                }
+                for (int kk = 0; kk < jcp_.oskip && ibrgM < sm_size;
+                        kk++, ibrgM++) {
+                    bd_mask[ibrgM] = 0;
+                }
+            }
+            for (; ibrgM < sm_size; ibrgM++) {
+                bd_mask[ibrgM] = 0;
+            }
+        } else {
+            for (int ibrgM = 0; ibrgM < sm_size; ibrgM++) {
+                bd_mask[ibrgM] = 1;
+            }
+        }
+    }
+
+    std::vector<brgemm_batch_element_t> stoffs;
+    if (jcp_.brg_type == brgemm_static_offs) {
+        const auto KH_SETS = jcp_.kh_sets;
+        const auto KW_SETS = jcp_.kw_sets;
+
+        assert(jcp_.exec_type == exec_trans);
+        const auto kd_f = nstl::min(kd_e, kd_b + KD_BLOCK);
+        const auto kh_f = nstl::min(kh_e, kh_b + KH_BLOCK);
+        const auto k_l = (kd_f - kd_b) * (KH_SETS > 1 ? 1 : (kh_f - kh_b))
+                * (KW_SETS > 1 ? 1 : KW);
+
+        assert(jcp_.nb_ic % jcp_.nb_ic_blocking == 0);
+        const auto nb_ic_blocks = jcp_.nb_ic_blocking;
+
+        if (k_l > 0) {
+
+            const auto kh_ee = KH_SETS > 1 ? kh_b + 1 : kh_f;
+            const auto kw_e = KW_SETS > 1 ? 1 : KW;
+
+            stoffs.resize(jcp_.max_batch + 1);
+
+            init_batch(0, nullptr, nullptr, nb_ic_blocks, 0, 0, 0, 0, nullptr,
+                    nullptr, kd_b, kd_f, kh_b, kh_ee, 0, kw_e, k_l,
+                    stoffs.data());
+
+        } else {
+            // if k_l is 0 then it means the batchsize is 0
+            return status::success;
+        }
+    }
+
+    const auto kd_l = nstl::min(KD_BLOCK, kd_e - kd_b);
+    const auto kh_l = nstl::min(KH_BLOCK, kh_e - kh_b);
+    const auto bs = kd_l * kh_l * jcp_.kw;
+
+    brgemm_t brg;
+    brgattr.bd_mask = bd_mask.data();
+    brgattr.static_offsets = stoffs.data();
+    brgemm_strides_t brg_strides;
+    brg_strides.stride_a = jcp_.brg_stride_a;
+    brg_strides.stride_b = jcp_.brg_stride_b;
+    brg.req_cal_comp_pads = jcp_.req_brg_comp_pad
+            && (jcp_.src_zero_point || jcp_.s8s8_compensation_required);
+    const auto strides_ptr
+            = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
+    CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, src_type, wei_type, false,
+            false, brgemm_row_major, alpha, vbeta, jcp_.LDA, jcp_.LDB, jcp_.LDC,
+            vbrgM, vN, vK, strides_ptr));
+    brgattr.use_uker = jcp_.use_uker;
+    brgattr.use_interleave_stores = jcp_.use_interleave_stores;
+    brgattr.hint_prefetching = jcp_.hint_prefetching;
+    brgattr.max_bs = bs;
+    brgattr.hint_ununroll_bd_loop = jcp_.ununroll_bd_loop;
+    brgattr.hint_innermost_loop = jcp_.brgemm_bd_loop_innermost
+            ? brgemm_bd_loop_innermost
+            : brgemm_innermost_undef;
+    brgattr.hint_expected_A_size = 0;
+    brgattr.hint_expected_B_size = 0;
+    brgattr.hint_expected_C_size = 0;
+
+    brgattr.wary_tail_read = false;
+    brgattr.bd_mask_level = jcp_.use_M_mask;
+
+    brgattr.max_top_vpad = jcp_.max_vpad;
+    brgattr.max_bottom_vpad = jcp_.max_vpad;
+    brgattr.fpmath_mode = attr()->fpmath_.mode_;
+    brgattr.K_koef = (float)bs / KW;
+
+    CHECK(brgemm_desc_set_attr(&brg, brgattr));
+
+    auto LDD = jcp_.oc_without_padding;
+    brg.with_sum = with_sum;
+    brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
+    CHECK(brgemm_desc_set_postops(&brg, attr(), &dst_md_, LDD, jcp_.bia_dt));
+
+    brgemm_descriptors_->insert(brg_idx, brg, bd_mask, stoffs);
+
+    return status::success;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+status_t brgemm_convolution_fwd_t<isa, use_inversion>::pd_t::init(
+        engine_t *engine) {
+    using namespace data_type;
+    using namespace utils;
+    brgemm_descriptors_
+            = std::make_shared<brgemm_containers::brgemm_desc_container_t>();
+    ndims = cpu_convolution_fwd_pd_t::ndims();
+
+    const auto src_type = src_md(0)->data_type;
+    const auto wei_type = weights_md(0)->data_type;
+    const auto dst_type = dst_md(0)->data_type;
+    const bool is_int8 = one_of(src_type, u8, s8);
+
+    // The following check will detect if this implementation is being
+    // executed through a BWD_D Convolution call and prevent the primitive from
+    // executing 'use_inversion == true' as FWD. This can only work if the
+    // diff_src_desc and diff_dst_desc are defined in the aforementioned.
+    const convolution_desc_t &cd = *desc();
+    if (use_inversion
+            && one_of(true, types::is_zero_md(&cd.diff_src_desc),
+                    types::is_zero_md(&cd.diff_dst_desc)))
+        return status::unimplemented;
+
+    using skip_mask_t = primitive_attr_t::skip_mask_t;
+    auto skip_mask = skip_mask_t::post_ops | skip_mask_t::sum_dt
+            | skip_mask_t::zero_points_runtime;
+    if (is_int8) skip_mask |= skip_mask_t::scales_runtime;
+
+    bool ok = is_fwd() && set_default_alg_kind(alg_kind::convolution_direct)
+            && IMPLICATION(is_int8,
+                    one_of(bias_md_.data_type, data_type::undef, f32, s32, s8,
+                            u8))
+            && IMPLICATION(!is_int8,
+                    one_of(bias_md_.data_type, data_type::undef, f32, src_type))
+            && attr()->has_default_values(skip_mask, dst_type)
+            && attr()->post_ops_.check_sum_consistency(dst_type, is_int8)
+            && !has_zero_dim_memory() && zero_points_ok() && arg_scales_ok();
+    if (!ok) return status::unimplemented;
+
+    CHECK(brgemm_convolution_utils::init_conf(jcp_, isa, *desc(), src_md_,
+            weights_md_, dst_md_, bias_md_, attr_, dnnl_get_max_threads()));
+
+    const auto adj_M = nstl::max(jcp_.M, jcp_.M_tail);
+
+    // 1. The unrolled kernel can be used for exec_trans and exec_base.
+    // For exec_base it makes sense to use unrolled kernel only if
+    // there is no padding by width.
+    // 2. For exec_trans block by kw is always KW
+    assert(IMPLICATION(jcp_.use_uker,
+            false && one_of(jcp_.exec_type, exec_base, exec_trans)));
+    assert(IMPLICATION(jcp_.use_interleave_stores, jcp_.use_uker));
+
+    bs_c = 0;
+
+    KD = ndims_pick(jcp_.kd, 1, 1);
+    KH = ndims_pick(jcp_.kh, jcp_.kh, 1);
+    KW = jcp_.kw;
+
+    EXT_KD = ndims_pick(jcp_.ext_kd, 1, 1);
+    EXT_KH = ndims_pick(jcp_.ext_kh, jcp_.ext_kh, 1);
+    EXT_KW = jcp_.ext_kw;
+
+    IDP = ndims_pick(jcp_.idp, 1, 1);
+    IHP = ndims_pick(jcp_.ihp, jcp_.ihp, 1);
+    IWP = jcp_.iwp;
+
+    KS = KD * KH * KW;
+    KD_BLOCK = ndims_pick(jcp_.kd_block, 1, 1);
+    KH_BLOCK = ndims_pick(jcp_.kh_block, jcp_.kh_block, 1);
+    KW_BLOCK = jcp_.kw_block;
+    KD_BLOCK_PAD = ndims_pick(jcp_.kd_block_pad, 1, 1);
+    KH_BLOCK_PAD = ndims_pick(jcp_.kh_block_pad, jcp_.kh_block_pad, 1);
+    ID = ndims_pick(jcp_.id, 1, 1);
+    IH = ndims_pick(jcp_.ih, jcp_.ih, 1);
+    IW = jcp_.iw;
+    OD = ndims_pick(jcp_.od, 1, 1);
+    OH = ndims_pick(jcp_.oh, jcp_.oh, 1);
+    OW = jcp_.ow;
+    SD = ndims_pick(jcp_.stride_d, 1, 1);
+    SH = ndims_pick(jcp_.stride_h, jcp_.stride_h, 1);
+    SW = jcp_.stride_w;
+    FP = ndims_pick(jcp_.f_pad, 0, 0);
+    TP = ndims_pick(jcp_.t_pad, jcp_.t_pad, 0);
+    LP = jcp_.l_pad;
+    DD = ndims_pick(jcp_.dilate_d, 0, 0) + 1;
+    DH = ndims_pick(jcp_.dilate_h, jcp_.dilate_h, 0) + 1;
+    DW = jcp_.dilate_w + 1;
+
+    bia_dsz = jcp_.bia_dsz;
+    acc_dsz = jcp_.acc_dsz;
+    src_dsz = jcp_.src_dsz;
+    wei_dsz = jcp_.wei_dsz;
+    dst_dsz = jcp_.dst_dsz;
+
+    // const variables used for address calculations
+    src_w_sz = static_cast<dim_t>(IW) * jcp_.ngroups * jcp_.ic_without_padding;
+    src_h_sz = IH * src_w_sz;
+    src_d_sz = ID * src_h_sz;
+    dst_w_sz = static_cast<dim_t>(OW) * jcp_.oc_without_padding;
+    dst_h_sz = OH * dst_w_sz;
+    dst_d_sz = OD * dst_h_sz;
+
+    wei_kw_stride = static_cast<dim_t>(jcp_.icp)
+            * (jcp_.wei_plain ? jcp_.oc_without_padding : jcp_.oc_block);
+    wei_kh_stride = KW * wei_kw_stride;
+    wei_kd_stride = KH * wei_kh_stride;
+    wei_ocb_stride = jcp_.wei_plain ? jcp_.oc_block : KD * wei_kd_stride;
+    wei_g_stride = jcp_.wei_plain ? jcp_.oc : jcp_.nb_oc * wei_ocb_stride;
+    wei_ic_stride = jcp_.wei_plain ? jcp_.oc_without_padding : jcp_.oc_block;
+
+    const auto IC_BLOCK = jcp_.ic_block;
+    const auto KH_SETS = jcp_.kh_sets;
+    const auto KW_SETS = jcp_.kw_sets;
+
+    if (jcp_.copy_block_only) {
+        assert(jcp_.exec_type == exec_trans && "Missing copy kernel");
+        const auto iw_block = jit_sve_core_brgemm_conv_trans_kernel_t::dst_w(
+                jcp_, jcp_.ow_block);
+        const auto ih_block = get_inp_size(IHP, jcp_.oh_block, KH, SH, DH - 1);
+        const auto id_block = get_inp_size(IDP, jcp_.od_block, KD, SD, DD - 1);
+
+        pbuf_w_sz = (dim_t)IC_BLOCK * KH_SETS * KW_SETS * iw_block;
+        pbuf_h_sz = pbuf_w_sz * ih_block;
+        pbuf_d_sz = pbuf_h_sz * id_block;
+
+    } else {
+        pbuf_w_sz = (dim_t)IC_BLOCK * KH_SETS * KW_SETS * IWP;
+        pbuf_h_sz = pbuf_w_sz * IHP;
+        pbuf_d_sz = pbuf_h_sz * IDP;
+    }
+
+    adj_src_h_sz = (jcp_.exec_type == exec_trans) ? pbuf_h_sz : src_h_sz;
+    adj_src_h_offset
+            = src_dsz * (jcp_.exec_type == exec_trans ? pbuf_w_sz : src_w_sz);
+
+    src_iw_offset = static_cast<dim_t>(src_dsz)
+            * (jcp_.exec_type == exec_trans
+                            ? jcp_.ic_block * jcp_.kh_sets * jcp_.kw_sets
+                            : jcp_.ngroups * jcp_.ic_without_padding);
+    src_d_offset = static_cast<dim_t>(src_dsz) * adj_src_h_sz;
+    wei_ic_offset = static_cast<dim_t>(wei_dsz) * wei_ic_stride;
+    wei_kd_offset = static_cast<dim_t>(wei_dsz) * wei_kd_stride;
+    wei_kh_offset = static_cast<dim_t>(wei_dsz) * wei_kh_stride
+            * ((jcp_.exec_type == exec_trans && jcp_.kh_sets > 1) ? 0 : 1);
+    wei_kw_offset = static_cast<dim_t>(wei_dsz) * wei_kw_stride;
+
+    batchsizes.resize(KD * KD * KH * KH);
+    fill(batchsizes.begin(), batchsizes.end(), -1);
+
+    if (jcp_.use_uker) {
+
+        assert(KD % KD_BLOCK == 0);
+        assert(KH % KH_BLOCK == 0);
+
+        for (int iod = 0; iod < jcp_.od; iod++) {
+            const int iid = iod * SD - FP;
+            const int kd_s = div_up(max(0, -iid), DD);
+            const int kd_f
+                    = KD - div_up(max(0, iid - ID + (KD - 1) * DD + 1), DD);
+            const auto kd_l = nstl::min(KD_BLOCK, kd_f - kd_s);
+            for (int ioh = 0; ioh < jcp_.oh; ioh++) {
+
+                const auto iih = ioh * SH - TP;
+                const auto kh_s
+                        = jcp_.is_os_blocking ? 0 : div_up(max(0, -iih), DH);
+                const auto kh_f
+                        = KH - div_up(max(0, iih - IH + (KH - 1) * DH + 1), DH);
+                const auto kh_l = nstl::min(KH_BLOCK, kh_f - kh_s);
+                const auto bs = kd_l * kh_l * jcp_.kw;
+                if (bs <= 0) continue;
+
+                const auto bs_idx = get_bs_idx(kd_s, kd_f, kh_s, kh_f);
+                if (batchsizes[bs_idx] == -1) {
+                    batchsizes[bs_idx] = bs_c;
+                    bs_c++;
+                }
+            }
+        }
+    } else {
+        batchsizes[get_bs_idx(0, KD, 0, KH)] = bs_c;
+        bs_c++;
+    }
+
+    brgs_sz_ = bs_c * adj_M * 2 * 2 * 2;
+    brgemm_descriptors_->resize(brgs_sz_);
+
+    const auto &p = attr()->post_ops_;
+    const int sum_idx = p.find(primitive_kind::sum);
+    with_sum = (sum_idx != -1);
+
+    // os_blocking is supported for exec_trans only
+    assert(IMPLICATION(jcp_.exec_type != exec_trans, !jcp_.is_os_blocking));
+    assert(IMPLICATION(jcp_.is_os_blocking,
+            jcp_.os_block % jcp_.ow == 0 && jcp_.os_block / jcp_.ow <= jcp_.oh
+                    && jcp_.os_block / jcp_.ow == jcp_.oh_block));
+
+    ic_chunks = div_up(jcp_.nb_ic, jcp_.nb_ic_blocking);
+    need_postwork = jcp_.with_bias || jcp_.with_eltwise || jcp_.with_binary
+            || (one_of(src_type, u8, s8) && wei_type == s8) // oscales needed
+            || (jcp_.dst_dt != jcp_.acc_dt) || jcp_.with_sum || jcp_.use_M_mask
+            || jcp_.src_zero_point || jcp_.dst_zero_point;
+
+    const int M_begin = 0;
+    const int M_end = nstl::max(jcp_.M, jcp_.M_tail);
+    const int N_begin = 0;
+    const int N_end = (jcp_.N_tail == jcp_.N) ? 1 : 2;
+    const int K_begin = 0;
+    const int K_end = (jcp_.K_tail == 0) ? 1 : 2;
+    const int i_init_begin
+            = (IMPLICATION(jcp_.K_tail != 0, jcp_.K_tail == jcp_.K)
+                      && jcp_.exec_type == exec_trans
+                      && div_up(jcp_.nb_ic, jcp_.nb_ic_blocking) == 1
+                      && KD_BLOCK == KD && KH_BLOCK == KH)
+            ? 1
+            : 0;
+    int i_init_end = 2;
+
+    for (int vM = M_end; vM > M_begin; vM--) {
+        // init only needed brgemm descriptors
+        if ((one_of(jcp_.exec_type, exec_trans, exec_vpad)
+                    || (jcp_.exec_type == exec_base && jcp_.l_pad == 0
+                            && jcp_.r_pad == 0))
+                && vM != jcp_.M && vM != jcp_.M_tail)
+            continue;
+        for_(int kd_b = 0; kd_b < KD; kd_b++)
+        for_(int kd_e = 1; kd_e <= KD; kd_e++)
+        for_(int kh_b = 0; kh_b < KH; kh_b++)
+        for (int kh_e = 1; kh_e <= KH; kh_e++) {
+            if (batchsizes[get_bs_idx(kd_b, kd_e, kh_b, kh_e)] == -1) continue;
+            for_(int i_init = i_init_begin; i_init < i_init_end; i_init++)
+            for_(int i_N = N_begin; i_N < N_end; i_N++)
+            for (int i_K = K_begin; i_K < K_end; i_K++) {
+                CHECK(add_brg_descriptor(
+                        vM, i_N, i_K, i_init, kd_b, kd_e, kh_b, kh_e));
+            }
+        }
+    }
+
+    auto scratchpad = scratchpad_registry().registrar();
+    brgemm_convolution_utils::init_scratchpad(scratchpad, jcp_);
+    if (jcp_.with_scales)
+        book_precomputed_scales(scratchpad, attr()->scales_, OC(),
+                jcp_.scale_adjust_factor != 1.0f);
+
+    return status::success;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+brgemm_convolution_fwd_t<isa, use_inversion>::brgemm_convolution_fwd_t(
+        const pd_t *apd)
+    : primitive_t(apd), bias_d(pd()->weights_md(1)) {}
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::get_kw_range(
+        int ow, int &kw_s, int &kw_full_s, int &kw_full_f, int &kw_f) const {
+    // This function needed for exec_base only
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+    // TODO: calculate these values instead direct loop by kw
+
+    const bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
+    const auto M = is_ow_tail ? jcp.ow_tail : jcp.ow_block;
+    kw_s = kw_full_s = kw_full_f = kw_f = -1;
+    for (int kw = 0; kw < jcp.kw; kw++) {
+        int ow_s {0}, ow_f {0};
+        get_ow_range(ow, kw, ow_s, ow_f);
+        if (ow_s < ow_f) {
+            if (kw_s == -1) kw_s = kw;
+            kw_f = kw + 1;
+            if (ow_f - ow_s == M) {
+                if (kw_full_s == -1) kw_full_s = kw;
+                kw_full_f = kw + 1;
+            }
+        }
+    }
+    if (kw_f == -1) {
+        kw_s = 0;
+        kw_f = 0;
+    }
+    if (kw_full_f == -1) kw_full_s = kw_full_f = kw_f;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+inline void brgemm_convolution_fwd_t<isa, use_inversion>::get_ow_range(
+        int ow, int kw, int &ow_s, int &ow_f) const {
+    // This function needed for exec_base only
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    const bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
+    const auto M = is_ow_tail ? jcp.ow_tail : jcp.ow_block;
+
+    const auto IW = jcp.iw;
+    const auto SW = jcp.stride_w;
+    const auto LP = jcp.l_pad;
+    const auto DW = jcp.dilate_w + 1;
+
+    const auto iiw = ow * SW - LP;
+    auto iw_lp = iiw + kw * DW;
+    const auto iw_rp = iw_lp + (M - 1) * SW - IW + 1;
+    ow_s = ow;
+
+    int ker_idx = 0;
+    if (iw_lp < 0) {
+        iw_lp = nstl::abs(iw_lp);
+        ker_idx += div_up(iw_lp, SW);
+        ow_s += ker_idx;
+    }
+    if (iw_rp > 0) ker_idx += div_up(iw_rp, SW);
+    ow_f = ow_s + (M - ker_idx);
+    ow_s = nstl::min(ow_s, ow + M);
+    ow_f = nstl::min(nstl::max(ow_f, ow_s), ow + M);
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+status_t brgemm_convolution_fwd_t<isa, use_inversion>::add_brg_kernel(int M,
+        int i_N, int i_K, int i_init, int kd_b, int kd_e, int kh_b, int kh_e) {
+    if (M <= 0) return status::success;
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+    const auto &brgs = *(_pd->brgemm_descriptors_);
+
+    auto N = (i_N) ? jcp.N_tail : jcp.N;
+    auto K = (i_K) ? jcp.K_tail : jcp.K;
+    if (N <= 0 || K <= 0) return status::success;
+    auto brg_idx
+            = _pd->get_brg_idx(M - 1, i_init, i_N, i_K, kd_b, kd_e, kh_b, kh_e);
+    auto brg = brgs[brg_idx];
+    if (!brgemm_kernels_[brg_idx] && brg && brg->bcast_dim > 0
+            && brg->load_dim > 0 && brg->reduce_dim > 0) {
+        CHECK(brgemm_kernels_.insert(brg_idx, brg));
+    }
+    return status::success;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+status_t brgemm_convolution_fwd_t<isa, use_inversion>::add_po_kernel(
+        brgemm_t *bcfg, int ker_idx, bool is_init) {
+    if (!bcfg) return status::success;
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    bcfg->LDD = (is_init && jcp.use_buffer) ? jcp.LDC : jcp.LDD;
+    bcfg->dt_c = (!is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // inp
+    bcfg->dt_d = (is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // out
+    bcfg->alpha = !is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer);
+    bcfg->beta = is_init ? 0 : 1;
+    CHECK(safe_ptr_assign(kernels_po_[ker_idx],
+            new jit_brgemm_kernel_post_ops(jcp, *bcfg, *_pd->attr())));
+    kernels_po_[ker_idx]->create_kernel();
+    return status::success;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::add_po_kernels(
+        int i_N, int init_bcast_dim, int po_bcast_dim) {
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+    const auto &brgs = *(_pd->brgemm_descriptors_);
+
+    auto N = (i_N) ? jcp.N_tail : jcp.N;
+    if (N <= 0) return;
+    auto i_K = (jcp.K_tail > 0);
+
+    const auto brg_idx = _pd->get_any_brg_idx(i_N, i_K);
+
+    if (init_bcast_dim > 0) {
+        if (brgs[brg_idx]) {
+            auto init_cfg = *(brgs[brg_idx]);
+            auto ker_init_idx = get_ker_po_idx(init_bcast_dim - 1, false, i_N);
+            if (init_cfg.load_dim > 0 && kernels_po_[ker_init_idx] == nullptr) {
+                init_cfg.bcast_dim = init_bcast_dim;
+                add_po_kernel(&init_cfg, ker_init_idx, true);
+            }
+        }
+    }
+
+    if ((_pd->need_postwork || jcp.use_buffer) && po_bcast_dim > 0) {
+        if (brgs[brg_idx]) {
+            auto po_cfg = *(brgs[brg_idx]);
+            auto ker_po_idx = get_ker_po_idx(po_bcast_dim - 1, true, i_N);
+            if (po_cfg.load_dim > 0 && kernels_po_[ker_po_idx] == nullptr) {
+                po_cfg.bcast_dim = po_bcast_dim;
+                add_po_kernel(&po_cfg, ker_po_idx, false);
+            }
+        }
+    }
+}
+template <cpu_isa_t isa, bool use_inversion>
+int brgemm_convolution_fwd_t<isa, use_inversion>::get_comp_ker_idx(
+        const int kd_b, const int kd_e, const int kh_b, const int kh_e,
+        const int kw_b, const int kw_e) const {
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    if (!jcp.req_cal_comp_pad) return 0;
+
+    assert(kd_e > kd_b && kh_e > kh_b);
+    for (int k = 0; k < jcp.ker_ranges_size; k++) {
+        if (kd_b == kd_bs[k] && kd_e == kd_es[k] && kh_b == kh_bs[k]
+                && kh_e == kh_es[k] && kw_b == kw_bs[k] && kw_e == kw_es[k]) {
+            return k;
+        }
+    }
+
+    return -1;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+inline int brgemm_convolution_fwd_t<isa, use_inversion>::get_comp_offset(
+        const int g, const int ocb, const int ow, const int kd_b,
+        const int kd_e, const int kh_b, const int kh_e, const int kw_b,
+        const int kw_e) const {
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    if (!jcp.src_zero_point && !jcp.s8s8_compensation_required) return 0;
+
+    const auto comp_idx = get_comp_ker_idx(kd_b, kd_e, kh_b, kh_e, kw_b, kw_e);
+    assert(IMPLICATION(jcp.req_cal_comp_pad, comp_idx >= 0));
+
+    return jcp.req_cal_comp_pad
+            ? g * comp_ocb_sz + ocb * comp_ker_sz + comp_idx * comp_kw_sz
+            : (g * jcp.nb_oc + ocb) * jcp.oc_block;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+status_t brgemm_convolution_fwd_t<isa, use_inversion>::init(engine_t *engine) {
+
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    bia_dsz = jcp.bia_dsz;
+    acc_dsz = jcp.acc_dsz;
+    src_dsz = jcp.src_dsz;
+    wei_dsz = jcp.wei_dsz;
+    dst_dsz = jcp.dst_dsz;
+
+    auto ndims = _pd->ndims;
+    if (ndims < 3 || ndims > 5) assert(!"Invalid ndims!");
+
+    KD = ndims_pick(jcp.kd, 1, 1);
+    KH = ndims_pick(jcp.kh, jcp.kh, 1);
+    KW = jcp.kw;
+
+    EXT_KD = ndims_pick(jcp.ext_kd, 1, 1);
+    EXT_KH = ndims_pick(jcp.ext_kh, jcp.ext_kh, 1);
+    EXT_KW = jcp.ext_kw;
+
+    IDP = ndims_pick(jcp.idp, 1, 1);
+    IHP = ndims_pick(jcp.ihp, jcp.ihp, 1);
+    IWP = jcp.iwp;
+
+    KS = KD * KH * KW;
+    KD_BLOCK = ndims_pick(jcp.kd_block, 1, 1);
+    KH_BLOCK = ndims_pick(jcp.kh_block, jcp.kh_block, 1);
+    KW_BLOCK = jcp.kw_block;
+    KD_BLOCK_PAD = ndims_pick(jcp.kd_block_pad, 1, 1);
+    KH_BLOCK_PAD = ndims_pick(jcp.kh_block_pad, jcp.kh_block_pad, 1);
+    ID = ndims_pick(jcp.id, 1, 1);
+    IH = ndims_pick(jcp.ih, jcp.ih, 1);
+    IW = jcp.iw;
+    OD = ndims_pick(jcp.od, 1, 1);
+    OH = ndims_pick(jcp.oh, jcp.oh, 1);
+    OW = jcp.ow;
+    SD = ndims_pick(jcp.stride_d, 1, 1);
+    SH = ndims_pick(jcp.stride_h, jcp.stride_h, 1);
+    SW = jcp.stride_w;
+    FP = ndims_pick(jcp.f_pad, 0, 0);
+    TP = ndims_pick(jcp.t_pad, jcp.t_pad, 0);
+    LP = jcp.l_pad;
+    DD = ndims_pick(jcp.dilate_d, 0, 0) + 1;
+    DH = ndims_pick(jcp.dilate_h, jcp.dilate_h, 0) + 1;
+    DW = jcp.dilate_w + 1;
+
+    // const variables used for address calculations
+    src_w_sz = static_cast<dim_t>(IW) * jcp.ngroups * jcp.ic_without_padding;
+    src_h_sz = IH * src_w_sz;
+    src_d_sz = ID * src_h_sz;
+    dst_w_sz = static_cast<dim_t>(OW) * jcp.oc_without_padding;
+    dst_h_sz = OH * dst_w_sz;
+    dst_d_sz = OD * dst_h_sz;
+
+    comp_kw_sz = static_cast<dim_t>(jcp.oc_block);
+    comp_ker_sz = jcp.ker_ranges_size * comp_kw_sz;
+    comp_ocb_sz = jcp.nb_oc * comp_ker_sz;
+
+    need_compensation = (jcp.src_zero_point || jcp.s8s8_compensation_required)
+            && !jcp.req_brg_comp_pad;
+
+    // ---- Initialize arrays ---------------------
+    brgemm_kernels_.resize(_pd->brgs_sz_);
+    brgemm_palettes_.resize(_pd->brgs_sz_);
+
+    // #TODO: this needed only if we have d/h padding more then kd/kh
+    int M_begin = 0;
+    int M_end = (jcp.M_tail == jcp.M) ? 1 : 2;
+    int N_begin = 0;
+    int N_end = (jcp.N_tail == jcp.N) ? 1 : 2;
+    int K_begin = 0;
+    int K_end = (jcp.K_tail == 0) ? 1 : 2;
+    int i_init_begin = (IMPLICATION(jcp.K_tail != 0, jcp.K_tail == jcp.K)
+                               && jcp.exec_type == exec_trans
+                               && div_up(jcp.nb_ic, jcp.nb_ic_blocking) == 1
+                               && KD_BLOCK == KD && KH_BLOCK == KH)
+            ? 1
+            : 0;
+    int i_init_end = 2;
+
+    int num_po_kernels = nstl::max(jcp.M, jcp.M_tail);
+    kernels_po_.resize(num_po_kernels * 2 * 2);
+    for (int i = 0; i < num_po_kernels; i++) {
+        for_(int i_init = 0; i_init < 2; i_init++)
+        for (int i_N = 0; i_N < 2; i_N++)
+            kernels_po_[get_ker_po_idx(i, i_init, i_N)] = nullptr;
+    }
+
+    if (jcp.exec_type == exec_trans) {
+        CHECK(safe_ptr_assign(copy_to_pbuffer_,
+                new jit_sve_core_brgemm_conv_trans_kernel_t(jcp)));
+        CHECK(copy_to_pbuffer_->create_kernel());
+    }
+
+    if (jcp.req_cal_comp_pad) {
+        CHECK(safe_ptr_assign(comp_vpad_pbuffer_,
+                new jit_uni_brgemm_conv_comp_pad_kernel_t(jcp)));
+        CHECK(comp_vpad_pbuffer_->create_kernel());
+    }
+
+    for_(int kd_b = 0; kd_b < KD; kd_b++)
+    for_(int kd_e = 1; kd_e <= KD; kd_e++)
+    for_(int kh_b = 0; kh_b < KH; kh_b++)
+    for (int kh_e = 1; kh_e <= KH; kh_e++) {
+        if (_pd->batchsizes[_pd->get_bs_idx(kd_b, kd_e, kh_b, kh_e)] == -1)
+            continue;
+
+        for_(int i_N = N_begin; i_N < N_end; i_N++)
+        for_(int i_M = M_begin; i_M < M_end; i_M++)
+        for_(int i_init = i_init_begin; i_init < i_init_end; i_init++)
+        for (int i_K = K_begin; i_K < K_end; i_K++) {
+            auto M = (i_M) ? jcp.M_tail : jcp.M;
+            if (M <= 0) continue;
+            add_brg_kernel(M, i_N, i_K, i_init, kd_b, kd_e, kh_b, kh_e);
+        }
+    }
+
+    for_(int i_N = N_begin; i_N < N_end; i_N++)
+    for (int i_M = M_begin; i_M < M_end; i_M++) {
+        // init "init" and "po" kernels for cases then we never call brgemm kernels
+        // e.g. for d/h padded and dilated filter areas
+        const bool filter_in_padding = jcp.f_pad > EXT_KD
+                || jcp.back_pad > EXT_KD || jcp.t_pad > EXT_KH
+                || jcp.b_pad > EXT_KH;
+        // note: overly simplistic condition. Ideally, the condition would
+        // only detect cases where there is strictly no overlap between the
+        // input and filter.
+        const bool dilate_no_overlap
+                = jcp.dilate_d >= jcp.id || jcp.dilate_h >= jcp.ih;
+        if (IMPLICATION(jcp.exec_type == exec_trans,
+                    filter_in_padding || dilate_no_overlap)) {
+            auto M = (i_M) ? jcp.M_tail : jcp.M;
+            add_po_kernels(i_N, M, M);
+        }
+    }
+
+    if (jcp.exec_type == exec_base) {
+        // create brgemm kernels for ow_blocks with padded areas and
+        // apply post-ops on final iteration by kw to padded areas in ow_block
+        int kw_s {0}, kw_full_s {0}, kw_full_f {0}, kw_f {0}, ow_s {0},
+                ow_f {0};
+        for (int ow = 0; ow < OW; ow += jcp.ow_block) {
+            get_kw_range(ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            for (int kw = kw_s; kw < kw_f; kw++) {
+                get_ow_range(ow, kw, ow_s, ow_f);
+                if (ow_f - ow_s <= 0) continue;
+
+                auto M = ow_f - ow_s;
+                if (M <= 0) continue;
+                for_(int kd_b = 0; kd_b < KD; kd_b++)
+                for_(int kd_e = 1; kd_e <= KD; kd_e++)
+                for_(int kh_b = 0; kh_b < KH; kh_b++)
+                for (int kh_e = 1; kh_e <= KH; kh_e++) {
+                    if (_pd->batchsizes[_pd->get_bs_idx(kd_b, kd_e, kh_b, kh_e)]
+                            == -1)
+                        continue;
+                    for_(int i_init = 0; i_init < 2; i_init++)
+                    for_(int i_N = 0; i_N < 2; i_N++)
+                    for (int i_K = 0; i_K < 2; i_K++) {
+                        add_brg_kernel(
+                                M, i_N, i_K, i_init, kd_b, kd_e, kh_b, kh_e);
+                    }
+                }
+            }
+
+            bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
+            for_(int i_N = 0; i_N < 2; i_N++)
+            for (int i_side = 0; i_side < 2; i_side++) {
+                auto M = is_ow_tail ? jcp.M_tail : jcp.M;
+                if (M <= 0) continue;
+                get_ow_range(ow, kw_s, ow_s, ow_f);
+                const auto init_bcast_dim
+                        = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
+                get_ow_range(ow, kw_f - 1, ow_s, ow_f);
+                const auto po_bcast_dim
+                        = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
+                add_po_kernels(i_N, init_bcast_dim, po_bcast_dim);
+            }
+
+            if (kw_f == jcp.kw && kw_s == 0) break;
+        }
+
+        for (int ow = (jcp.nb_ow - 1) * jcp.ow_block; ow >= 0;
+                ow -= jcp.ow_block) {
+            get_kw_range(ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            for (int kw = kw_s; kw < kw_f; kw++) {
+                get_ow_range(ow, kw, ow_s, ow_f);
+                if (ow_f - ow_s <= 0) continue;
+
+                auto M = ow_f - ow_s;
+                if (M <= 0) continue;
+                for_(int kd_b = 0; kd_b < KD; kd_b++)
+                for_(int kd_e = 1; kd_e <= KD; kd_e++)
+                for_(int kh_b = 0; kh_b < KH; kh_b++)
+                for (int kh_e = 1; kh_e <= KH; kh_e++) {
+                    if (_pd->batchsizes[_pd->get_bs_idx(kd_b, kd_e, kh_b, kh_e)]
+                            == -1)
+                        continue;
+                    for_(int i_init = 0; i_init < 2; i_init++)
+                    for_(int i_N = 0; i_N < 2; i_N++)
+                    for (int i_K = 0; i_K < 2; i_K++) {
+                        add_brg_kernel(
+                                M, i_N, i_K, i_init, kd_b, kd_e, kh_b, kh_e);
+                    }
+                }
+            }
+
+            bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
+
+            for_(int i_N = 0; i_N < 2; i_N++)
+            for (int i_side = 0; i_side < 2; i_side++) {
+                auto M = is_ow_tail ? jcp.M_tail : jcp.M;
+                if (M <= 0) continue;
+                get_ow_range(ow, kw_s, ow_s, ow_f);
+                const auto init_bcast_dim
+                        = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
+                get_ow_range(ow, kw_f - 1, ow_s, ow_f);
+                const auto po_bcast_dim
+                        = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
+                add_po_kernels(i_N, init_bcast_dim, po_bcast_dim);
+            }
+
+            if (kw_f == jcp.kw && kw_s == 0) break;
+        }
+    }
+
+    // pre-calculated values
+    if (jcp.exec_type == exec_vpad) {
+        owb_kw_top_vpads.resize(jcp.nb_ow * jcp.kw);
+        owb_kw_bottom_vpads.resize(jcp.nb_ow * jcp.kw);
+
+        for (int owb = 0; owb < jcp.nb_ow; owb++) {
+            const int ow = owb * jcp.ow_block;
+            const bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
+            const int ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
+            const auto ow_l = ow_e - ow_b;
+            MAYBE_UNUSED(ow_l);
+            assert(0 <= ow_l && ow_l <= jcp.ow_block);
+            const auto iiw_b = ow_b * SW - LP;
+            const auto iiw_e = (ow_e - 1) * SW - LP + 1;
+            const auto iiw_l = iiw_e - iiw_b;
+            for (int kw = 0; kw < KW; kw++) {
+                const auto iw = iiw_b + kw * DW;
+                const auto top_vpad = iw >= 0 ? 0 : div_up(abs(iw), SW);
+                const auto bottom_vpad
+                        = iw + iiw_l <= IW ? 0 : div_up(iw + iiw_l - IW, SW);
+                assert(top_vpad == 0 || bottom_vpad == 0);
+                owb_kw_top_vpads[owb * KW + kw] = top_vpad;
+                owb_kw_bottom_vpads[owb * KW + kw] = bottom_vpad;
+            }
+        }
+    }
+
+    // pre-calculate unique kernel combination
+    if (jcp.req_cal_comp_pad) {
+        std::set<std::vector<int>> unique_kernels;
+        size_t k = 0;
+        kd_bs.resize(jcp.ker_ranges_size);
+        kd_es.resize(jcp.ker_ranges_size);
+        kh_bs.resize(jcp.ker_ranges_size);
+        kh_es.resize(jcp.ker_ranges_size);
+        kw_bs.resize(jcp.ker_ranges_size);
+        kw_es.resize(jcp.ker_ranges_size);
+
+        const auto update_kernels = [&](int kd_b, int kd_e, int kh_b, int kh_e,
+                                            int kw_b, int kw_e) {
+            unique_kernels.insert({kd_b, kd_e, kh_b, kh_e, kw_b, kw_e});
+            if (k == unique_kernels.size()) return;
+            kd_bs[k] = kd_b;
+            kd_es[k] = kd_e;
+            kh_bs[k] = kh_b;
+            kh_es[k] = kh_e;
+            kw_bs[k] = kw_b;
+            kw_es[k] = kw_e;
+            k++;
+            assert(k <= static_cast<size_t>(jcp.ker_ranges_size));
+        };
+
+        for_(int odb = 0; odb < jcp.nb_od; odb++)
+        for_(int ohb = 0; ohb < jcp.nb_oh; ohb++)
+        for (int owb = 0; owb < jcp.nb_ow; owb++) {
+            auto od_begin = odb * jcp.od_block;
+            auto od_end = nstl::min(OD, od_begin + jcp.od_block);
+            auto oh_begin = ohb * jcp.oh_block;
+            auto oh_end = jcp.is_os_blocking
+                    ? oh_begin + 1
+                    : nstl::min(OH, oh_begin + jcp.oh_block);
+            for_(int od = od_begin; od < od_end; od++)
+            for (int oh = oh_begin; oh < oh_end; oh++) {
+                int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
+                const int ow = owb * jcp.ow_block;
+                const int iid = ndims_pick(od * SD - FP, 0, 0);
+                const int kd_s
+                        = ndims_pick(div_up(nstl::max(0, -iid), DD), 0, 0);
+                const int kd_f = ndims_pick(
+                        KD - div_up(max(0, iid - ID + (KD - 1) * DD + 1), DD),
+                        1, 1);
+                const int iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
+                const auto kh_s_ = div_up(max(0, -iih), DH);
+                const auto kh_s = ndims_pick(kh_s_, kh_s_, 0);
+                const auto kh_f_
+                        = KH - div_up(max(0, iih - IH + (KH - 1) * DH + 1), DH);
+                const auto kh_f = ndims_pick(kh_f_, kh_f_, 1);
+                get_kw_range(ow, kw_s, kw_full_s, kw_full_f, kw_f);
+                if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s) {
+                    if (jcp.exec_type == exec_vpad) {
+                        update_kernels(kd_s, kd_f, kh_s, kh_f, 0, KW);
+                    } else if (jcp.exec_type == exec_base) {
+                        if (kw_s < kw_full_s) {
+                            for (auto kw = kw_s; kw < kw_full_s; kw++) {
+                                update_kernels(
+                                        kd_s, kd_f, kh_s, kh_f, kw, kw + 1);
+                            }
+                        }
+                        if (kw_full_s < kw_full_f) {
+                            for (auto kw = kw_full_s; kw < kw_full_f;
+                                    kw += KW_BLOCK) {
+                                const auto kw_e
+                                        = nstl::min(kw_full_f, kw + KW_BLOCK);
+                                update_kernels(
+                                        kd_s, kd_f, kh_s, kh_f, kw, kw_e);
+                            }
+                        }
+                        if (kw_full_f < kw_f) {
+                            for (auto kw = kw_full_f; kw < kw_f; kw++) {
+                                update_kernels(
+                                        kd_s, kd_f, kh_s, kh_f, kw, kw + 1);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ker_vpad_sz = k;
+    }
+
+    return status::success;
+}
+template <cpu_isa_t isa, bool use_inversion>
+struct brgemm_convolution_fwd_t<isa, use_inversion>::brgemm_thread_ctx_t {
+    brgemm_thread_ctx_t(brgemm_exec_ctx_t &brgemm_ctx_, int ithr_,
+            brgemm_batch_element_t *__restrict brg_batch_, char *c_buffer_,
+            char *wsp_tile_)
+        : brgemm_ctx(brgemm_ctx_)
+        , ithr(ithr_)
+        , brg_batch(brg_batch_)
+        , c_buffer(c_buffer_)
+        , wsp_tile(wsp_tile_) {}
+
+    brgemm_exec_ctx_t &brgemm_ctx;
+    int ithr {0};
+    brgemm_batch_element_t *__restrict brg_batch {nullptr};
+    char *c_buffer {nullptr};
+    char *wsp_tile {nullptr};
+    int cur_brg_idx {-1};
+    int g {0}, n {0}, ocb {0};
+    int od {0}, odb {0}, oh {0}, ohb {0}, owb {0};
+    int icc = 0;
+    const float *oscales {nullptr};
+    int32_t src_zp_vals {0};
+    int32_t *src_zp_comp_ptr {nullptr};
+    int32_t *dst_zp_vals {nullptr};
+    int32_t *s8s8_comp_ptr {nullptr};
+    const float *dst_scales {nullptr};
+};
+
+template <cpu_isa_t isa, bool use_inversion>
+status_t brgemm_convolution_fwd_t<isa, use_inversion>::execute(
+        const exec_ctx_t &ctx) const {
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    DEFINE_ZERO_POINT_VALUE(src_zero_point, DNNL_ARG_SRC);
+    DEFINE_ZERO_POINT_VALUE(dst_zero_point, DNNL_ARG_DST);
+
+    DEFINE_ARG_SCALES_BUFFER(src_scales, DNNL_ARG_SRC);
+    DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
+    DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
+
+    const float *oscales = precompute_scales(ctx.get_scratchpad_grantor(),
+            src_scales, wei_scales, _pd->OC(), _pd->attr(),
+            jcp.scale_adjust_factor);
+
+    brgemm_exec_ctx_t brgemm_ctx(ctx, _pd);
+
+    const char *const __restrict src = brgemm_ctx.src;
+    const char *const __restrict wei = brgemm_ctx.weights;
+    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+
+    const auto extra_data_offset
+            = weights_d.size() - weights_d.additional_buffer_size();
+    auto w = const_cast<char *>(brgemm_ctx.weights);
+    const auto s8s8_comp_offset = jcp.req_cal_comp_pad
+            ? jcp.ngroups * jcp.nb_oc * jcp.kd * jcp.kh * jcp.kw * jcp.oc_block
+            : jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    int32_t *s8s8_compensation = jcp.s8s8_compensation_required
+            ? reinterpret_cast<int32_t *>(w + extra_data_offset)
+            : nullptr;
+    int32_t *zp_compensation = jcp.src_zero_point
+            ? reinterpret_cast<int32_t *>(&w[extra_data_offset])
+                    + (jcp.s8s8_compensation_required ? s8s8_comp_offset : 0)
+            : nullptr;
+
+    const memory_tracking::grantor_t scratchpad = ctx.get_scratchpad_grantor();
+    brgemm_batch_element_t *const __restrict brg_batch_global
+            = brgemm_convolution_utils::uses_batch_elements(
+                      jcp.brg_type, jcp.exec_type)
+            ? scratchpad.template get<brgemm_batch_element_t>(
+                    key_brgemm_primitive_batch)
+            : nullptr;
+    char *const __restrict c_buffer_global = (jcp.use_buffer)
+            ? scratchpad.template get<char>(key_brgemm_primitive_buffer)
+            : nullptr;
+
+    auto inp_p_buffer = (jcp.exec_type == exec_trans)
+            ? scratchpad.template get<char>(key_conv_brgemm_inp_buffer)
+            : nullptr;
+    auto inp_p_buffer_mask = (jcp.exec_type == exec_trans)
+            ? scratchpad.template get<uint8_t>(key_conv_brgemm_inp_buffer_mask)
+            : nullptr;
+    int32_t *src_zp_comp_base = jcp.src_zero_point
+            ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
+                       key_brgemm_primitive_zp_comp_a)
+                                    : zp_compensation)
+            : nullptr;
+    int32_t *s8s8_comp_base = jcp.s8s8_compensation_required
+            ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
+                       key_brgemm_primitive_buffer_comp)
+                                    : s8s8_compensation)
+            : nullptr;
+    const auto dst_zp_vals = jcp.dst_zero_point ? &dst_zero_point : nullptr;
+    const auto src_zp_vals = src_zero_point;
+
+    cal_compensation(wei, src_zp_comp_base, s8s8_comp_base);
+
+    // --------------- Parallel section ------------------------------
+    const dim_t work_amount = static_cast<dim_t>(jcp.mb) * jcp.ngroups
+            * jcp.nb_oc * jcp.nb_od * jcp.nb_oh * jcp.nb_ow;
+    // TODO: consider loop by icc be innermost because for current
+    // implementation if we use buffer then we accumulate in it only on row
+    // or made ic_chunks = 1 if use_buffer
+    // or (looks more general) increase buffer size to store several rows
+
+    parallel(jcp.nthr, [&](const int ithr, const int nthr) {
+        if (ithr >= work_amount) return;
+
+        brgemm_batch_element_t *const __restrict brg_batch = brg_batch_global
+                + static_cast<size_t>(ithr) * jcp.adjusted_batch_size;
+        char *const __restrict c_buffer = (jcp.use_buffer)
+                ? c_buffer_global + ithr * acc_dsz * jcp.buffer_size
+                : nullptr;
+        char *inp_buffer = (jcp.exec_type == exec_trans)
+                ? inp_p_buffer + src_dsz * ithr * jcp.inp_buffer_size
+                : nullptr;
+        uint8_t *__restrict inp_buffer_mask = (jcp.exec_type == exec_trans)
+                ? inp_p_buffer_mask + ithr * jcp.inp_buffer_mask_size
+                : nullptr;
+        char *const wsp_tile = nullptr;
+        dim_t start {0}, end {0};
+        balance211(work_amount, nthr, ithr, start, end);
+        int n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
+        if (jcp.loop_order == loop_ndhwgc)
+            nd_iterator_init(start, n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh,
+                    owb, jcp.nb_ow, g, jcp.ngroups, ocb, jcp.nb_oc);
+        else if (jcp.loop_order == loop_ngcdhw)
+            nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc,
+                    odb, jcp.nb_od, ohb, jcp.nb_oh, owb, jcp.nb_ow);
+        else
+            assert(!"Unknown loop order");
+
+        brgemm_thread_ctx_t btc(
+                brgemm_ctx, ithr, brg_batch, c_buffer, wsp_tile);
+
+        int last_n = -1;
+        int last_g = -1;
+        int last_icc = -1;
+        int last_odb = -1;
+        int last_ohb = -1;
+        int last_owb = -1;
+        for (auto work = start; work < end; work++) {
+            btc.g = g;
+            btc.n = n;
+            btc.ocb = ocb;
+            btc.odb = odb;
+            btc.ohb = ohb;
+            btc.owb = owb;
+            btc.oscales = oscales;
+            btc.src_zp_vals = src_zp_vals;
+            btc.dst_zp_vals = jcp.dst_zero_point ? dst_zp_vals : nullptr;
+            btc.src_zp_comp_ptr
+                    = jcp.src_zero_point ? src_zp_comp_base : nullptr;
+            btc.s8s8_comp_ptr
+                    = jcp.s8s8_compensation_required ? s8s8_comp_base : nullptr;
+            btc.dst_scales = dst_scales;
+
+            if (jcp.exec_type == exec_trans && (last_n != n || last_g != g)) {
+                if (!jcp.copy_block_only)
+                    std::memset(
+                            inp_buffer_mask, false, jcp.inp_buffer_mask_size);
+            }
+            auto od_begin = odb * jcp.od_block;
+            auto od_end = nstl::min(OD, od_begin + jcp.od_block);
+            auto oh_begin = ohb * jcp.oh_block;
+            // if is_os_blocking is true then we do only one iteration of loop
+            // by oh and process entire oh block in kernel call
+            auto oh_end = jcp.is_os_blocking
+                    ? oh_begin + 1
+                    : nstl::min(OH, oh_begin + jcp.oh_block);
+            for_(int od = od_begin; od < od_end; od++)
+            for (int oh = oh_begin; oh < oh_end; oh++) {
+                for (int icc = 0; icc < _pd->ic_chunks; icc++) {
+                    btc.od = od;
+                    btc.oh = oh;
+                    btc.icc = icc;
+
+                    if (jcp.exec_type == exec_base) {
+                        ker_base(btc);
+                    } else if (jcp.exec_type == exec_trans) {
+                        maybe_conv_inp(ithr, src, inp_buffer, inp_buffer_mask,
+                                g, n, icc, odb, ohb, owb, last_g, last_n,
+                                last_icc, last_odb, last_ohb, last_owb);
+                        ker_trans(btc, inp_buffer);
+                    } else if (jcp.exec_type == exec_vpad) {
+                        ker_vpad(btc);
+                    } else
+                        assert(!"Unknown exec type");
+                    last_n = n;
+                    last_g = g;
+                    last_icc = icc;
+                    last_odb = odb;
+                    last_ohb = ohb;
+                    last_owb = owb;
+                }
+            }
+            if (jcp.loop_order == loop_ndhwgc)
+                nd_iterator_step(n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh, owb,
+                        jcp.nb_ow, g, jcp.ngroups, ocb, jcp.nb_oc);
+            else if (jcp.loop_order == loop_ngcdhw)
+                nd_iterator_step(n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc, odb,
+                        jcp.nb_od, ohb, jcp.nb_oh, owb, jcp.nb_ow);
+            else
+                assert(!"Unknown loop order");
+        }
+    });
+
+    if (_pd->wants_zero_pad_dst()) ctx.memory(DNNL_ARG_DST)->zero_pad(ctx);
+
+    return status::success;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+status_t brgemm_convolution_fwd_t<isa, use_inversion>::cal_compensation(
+        const char *__restrict weights, int32_t *src_zp_buffer,
+        int32_t *s8s8_comp_buffer) const {
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    if (!jcp.req_cal_comp_pad) return status::success;
+
+    if (jcp.src_zero_point)
+        std::memset(src_zp_buffer, 0, sizeof(int32_t) * jcp.comp_a_buffer_size);
+    if (jcp.s8s8_compensation_required)
+        std::memset(s8s8_comp_buffer, 0,
+                sizeof(int32_t) * jcp.s8s8_comp_buffer_size);
+
+    const auto work_amount
+            = static_cast<dim_t>(jcp.ngroups) * jcp.nb_oc * ker_vpad_sz;
+    const auto is_small_shape = work_amount <= jcp.nthr
+            && (work_amount * jcp.oc_block * jcp.icp
+                    <= platform::get_per_core_cache_size(1));
+    const int nthr = is_small_shape ? 1 : jcp.nthr;
+
+    parallel(nthr, [&](const int ithr, const int nthr) {
+        if (ithr >= work_amount) return;
+
+        dim_t start {0}, end {0};
+        int g {0}, ocb {0}, k {0};
+        balance211(work_amount, nthr, ithr, start, end);
+        nd_iterator_init(start, g, jcp.ngroups, ocb, jcp.nb_oc, k, ker_vpad_sz);
+        for (auto work = start; work < end; work++) {
+            const dim_t kd_bb {kd_bs[k]}, kd_ee {kd_es[k]}, kh_bb {kh_bs[k]},
+                    kh_ee {kh_es[k]}, kw_bb {kw_bs[k]}, kw_ee {kw_es[k]};
+            assert(kd_ee > kd_bb && kh_ee > kh_bb && kw_ee > kw_bb);
+
+            const auto kd_b = maybe_invert_range(kd_bb, kd_ee, KD);
+            const auto kd_e = maybe_invert_range(kd_ee, kd_bb, KD);
+            const auto kh_b = maybe_invert_range(kh_bb, kh_ee, KH);
+            const auto kh_e = maybe_invert_range(kh_ee, kh_bb, KH);
+            const auto kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
+            const auto kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
+
+            const auto buffer_offs
+                    = g * comp_ocb_sz + ocb * comp_ker_sz + k * comp_kw_sz;
+            const auto wei_offs = g * _pd->wei_g_stride
+                    + ocb * _pd->wei_ocb_stride + kd_b * _pd->wei_kd_stride
+                    + kh_b * _pd->wei_kh_stride + kw_b * _pd->wei_kw_stride;
+
+            jit_brgemm_conv_comp_pad_call_s p;
+
+            p.kd_l = kd_e - kd_b;
+            p.kh_l = kh_e - kh_b;
+            p.kw_l = kw_e - kw_b;
+            p.ptr_in = &weights[wei_offs];
+            p.ptr_zp_out = jcp.src_zero_point ? &src_zp_buffer[buffer_offs]
+                                              : nullptr;
+            p.ptr_cp_out = jcp.s8s8_compensation_required
+                    ? &s8s8_comp_buffer[buffer_offs]
+                    : nullptr;
+            (*comp_vpad_pbuffer_)(&p);
+
+            nd_iterator_step(g, jcp.ngroups, ocb, jcp.nb_oc, k, ker_vpad_sz);
+        }
+    });
+    return status::success;
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::perform_outwork(
+        const brgemm_thread_ctx_t &btc, char *dst_base, const char *bias_w,
+        int ow, int g_oc, bool is_oc_tail, int ker_ow_s, int ker_ow_f, int kd_l,
+        int kh_l, bool maybe_do_init, bool do_postwork,
+        bool do_post_comp) const {
+
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    const auto do_init
+            = maybe_do_init && IMPLICATION(jcp.with_sum, jcp.use_buffer);
+    if (!do_init && !do_postwork) return;
+
+    assert(!jcp.is_os_blocking);
+
+    const bool is_ow_tail = (OW - ow < jcp.ow_block);
+
+    const auto M = is_ow_tail ? jcp.M_tail : jcp.M;
+    const auto kdh_l = kd_l * kh_l;
+    const auto ow_s = (kdh_l <= 0) ? ow : ker_ow_s;
+    const auto ow_f = (kdh_l <= 0) ? ow : ker_ow_f;
+    assert(ow <= ow_s && ow_s <= ow_f && ow_f <= ow + M);
+
+    brgemm_kernel_post_ops_t p;
+    if (do_postwork) {
+        p.ptr_bias = (void *)(bias_w);
+        p.ptr_scales = (void *)(&btc.oscales[jcp.is_oc_scale * g_oc]);
+        p.ptr_binary_post_ops_rhs
+                = btc.brgemm_ctx.post_ops_binary_rhs_arg_vec.data();
+        p.dst_orig = btc.brgemm_ctx.dst;
+        p.c_zp_values = btc.dst_zp_vals;
+        p.a_comp_val = btc.src_zp_vals;
+        p.ptr_dst_scales = (void *)btc.dst_scales;
+    }
+
+    auto call_outwork_ker = [&](bool is_postwork, bool has_postcomp,
+                                    int ow_pw_s, int ow_pw_l) {
+        auto ker_po_idx = get_ker_po_idx(ow_pw_l - 1, is_postwork, is_oc_tail);
+        const auto outwork_ker = kernels_po_[ker_po_idx].get();
+        assert(outwork_ker != nullptr && ow_pw_l == outwork_ker->brg.bcast_dim);
+        if (is_postwork) {
+            p.apply_comp = has_postcomp;
+            p.a_zp_compensation = has_postcomp && jcp.src_zero_point
+                    ? &btc.src_zp_comp_ptr[ow_pw_s * jcp.LDB]
+                    : btc.src_zp_comp_ptr;
+            p.s8s8_compensation = has_postcomp && jcp.s8s8_compensation_required
+                    ? &btc.s8s8_comp_ptr[ow_pw_s * jcp.LDB]
+                    : btc.s8s8_comp_ptr;
+
+            p.ptr_out = dst_base
+                    + dst_dsz
+                            * (btc.od * dst_h_sz + btc.oh * dst_w_sz
+                                    + ow_pw_s * jcp.oc_without_padding);
+            p.ptr_in = static_cast<void *>(
+                    jcp.use_buffer ? (
+                            btc.c_buffer + acc_dsz * (ow_pw_s - ow) * jcp.LDC)
+                                   : p.ptr_out);
+        } else {
+            p.apply_comp = has_postcomp;
+            char *const ptr_Cz = jcp.use_buffer
+                    ? (btc.c_buffer + acc_dsz * (ow_pw_s - ow) * jcp.LDC)
+                    : dst_base
+                            + dst_dsz
+                                    * (btc.od * dst_h_sz + btc.oh * dst_w_sz
+                                            + ow_pw_s * jcp.oc_without_padding);
+            p.ptr_out = static_cast<void *>(ptr_Cz);
+        }
+        (*outwork_ker)(&p);
+    };
+
+    if (ow < ow_s) {
+        // left side
+        const auto ow_pw_l = ow_s - ow;
+        if (do_init) call_outwork_ker(false, false, ow, ow_pw_l);
+        if (do_postwork) call_outwork_ker(true, do_post_comp, ow, ow_pw_l);
+    }
+    if (ow_f < ow + M) {
+        // right side
+        const auto ow_pw_l = ow + M - ow_f;
+        if (do_init) call_outwork_ker(false, false, ow_f, ow_pw_l);
+        if (do_postwork) call_outwork_ker(true, do_post_comp, ow_f, ow_pw_l);
+    }
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+inline void brgemm_convolution_fwd_t<isa, use_inversion>::call_brgemm_kernel(
+        const brgemm_thread_ctx_t &btc, const brgemm_kernel_t *brg_ker,
+        int batch_size, char *ptr_C, char *ptr_D, const char *bias_w, int g_oc,
+        bool do_postops, int comp_ker_offs, bool do_only_comp) const {
+
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+
+    assert(brg_ker != nullptr);
+
+    const auto do_only_pass_comp = !do_postops && jcp.src_zero_point
+            && (jcp.req_brg_comp_pad || jcp.max_vpad > 0);
+    const auto maybe_do_postops
+            = one_of(true, do_postops, do_only_comp, do_only_pass_comp);
+
+    assert(brgemm_convolution_utils::uses_batch_elements(
+            jcp.brg_type, jcp.exec_type));
+    const auto ptrA = btc.brg_batch[0].ptr.A;
+    const auto ptrB = btc.brg_batch[0].ptr.B;
+
+    if (maybe_do_postops) {
+        const auto src_zp_ptr = jcp.src_zero_point
+                ? &btc.src_zp_comp_ptr[comp_ker_offs]
+                : nullptr;
+        const auto s8s8_comp = jcp.s8s8_compensation_required
+                ? &btc.s8s8_comp_ptr[comp_ker_offs]
+                : nullptr;
+        const brgemm_post_ops_data_t post_ops_data {
+                static_cast<const char *>(bias_w),
+                &btc.oscales[jcp.is_oc_scale * g_oc],
+                btc.brgemm_ctx.post_ops_binary_rhs_arg_vec.data(),
+                static_cast<size_t>(g_oc), 0, btc.brgemm_ctx.dst, 0,
+                static_cast<void *>(src_zp_ptr), nullptr,
+                static_cast<void *>(btc.dst_zp_vals), false, btc.src_zp_vals,
+                do_only_comp, do_only_pass_comp, btc.dst_scales};
+
+        void *scratch = static_cast<void *>(s8s8_comp);
+
+        if (do_postops)
+            brgemm_kernel_execute_postops(brg_ker, batch_size, ptrA, ptrB,
+                    btc.brg_batch, ptr_C, ptr_D, post_ops_data, scratch);
+        else
+            brgemm_kernel_execute_postops(brg_ker, batch_size, ptrA, ptrB,
+                    btc.brg_batch, ptr_C, ptr_C, post_ops_data, scratch);
+    } else
+        brgemm_kernel_execute(brg_ker, batch_size, ptrA, ptrB, btc.brg_batch,
+                ptr_C, static_cast<void *>(btc.wsp_tile));
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::maybe_conv_inp(int ithr,
+        const char *__restrict src, char *__restrict inp_buffer,
+        uint8_t *__restrict inp_buffer_mask, int g, int n, int icc, int odb,
+        int ohb, int owb, int last_g, int last_n, int last_icc, int last_odb,
+        int last_ohb, int last_owb) const {
+
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+    const auto icb = icc * jcp.nb_ic_blocking;
+
+#define bmask(icb, odb, ohb, owb) \
+    inp_buffer_mask[(((icb)*jcp.nb_od + (odb)) * jcp.nb_oh + (ohb)) \
+                    * jcp.nb_ow \
+            + (owb)]
+
+    if (jcp.copy_block_only) {
+        if (last_g == g && last_n == n && last_icc == icc && last_odb == odb
+                && last_ohb == ohb && last_owb == owb)
+            return;
+    } else {
+        if (bmask(icb, odb, ohb, owb)) return;
+    }
+
+    auto cp = jit_brgemm_conv_trans_kernel_call_s();
+
+    const auto prev_odb = (jcp.copy_block_only || odb == 0
+                                  || bmask(icb, odb - 1, ohb, owb) == 0)
+            ? false
+            : true;
+
+    const auto prev_ohb = (jcp.copy_block_only || ohb == 0
+                                  || bmask(icb, odb, ohb - 1, owb) == 0)
+            ? false
+            : true;
+
+    const auto prev_odb_ohb
+            = (jcp.copy_block_only
+                      || (odb > 0 && ohb > 0
+                              && bmask(icb, odb - 1, ohb - 1, owb) == 0))
+            ? false
+            : true;
+
+    const auto ic = icb * jcp.ic_block;
+    const auto g_ic = g * jcp.ic + ic;
+    const auto oh = ohb * jcp.oh_block;
+    const auto ow = owb * jcp.ow_block;
+    const auto iw = nstl::max(0, ow * SW - LP);
+
+    int id_start {0}, id_end {0}, ih_start {0}, ih_end {0};
+    int virt_id_start {0}, virt_id_end {0}, virt_ih_start {0}, virt_ih_end {0};
+
+    auto get_start_end = [](int &start, int &end, int &virt_start,
+                                 int &virt_end, int b, int bs, int i, int o,
+                                 int s, int p, int k, int d, bool prev) {
+        const auto o_b = saturate(0, o, b * bs);
+        const auto prev_o_b = saturate(0, o, (b - 1) * bs);
+        const auto virt_cur_start = o_b * s - p;
+        const auto cur_start = saturate(0, i, virt_cur_start);
+        const auto virt_prev_start = prev_o_b * s - p;
+        const auto i_bs = get_inp_size(i, bs, k, s, d);
+        const auto virt_i_bs = calculate_end_padding(
+                0, bs, 0, s, calculate_extended_filter_size(k, d));
+        const auto virt_prev_end = prev ? virt_prev_start + virt_i_bs : -p;
+        const auto prev_end = prev ? saturate(0, i, virt_prev_end) : 0;
+        virt_start = nstl::max(virt_prev_end, virt_cur_start);
+        start = nstl::max(prev_end, cur_start);
+        virt_end = virt_cur_start + virt_i_bs;
+        end = saturate(0, i, cur_start + i_bs);
+    };
+    get_start_end(id_start, id_end, virt_id_start, virt_id_end, odb,
+            jcp.od_block, nstl::min(ID, IDP - FP), OD, SD, FP, KD, DD - 1,
+            prev_odb && prev_odb_ohb);
+    get_start_end(ih_start, ih_end, virt_ih_start, virt_ih_end, ohb,
+            jcp.oh_block, nstl::min(IH, IHP - TP), OH, SH, TP, KH, DH - 1,
+            prev_ohb && prev_odb_ohb);
+
+    // how many real data rows to copy (including padding)
+    const auto rows_to_copy = ih_end - ih_start;
+    cp.owb = owb;
+    cp.ic = ic;
+    const auto iw_buf = jcp.copy_block_only ? 0 : (ow * SW);
+    dim_t inp_offset_start, out_offset_start;
+
+    for (int kh = 0; kh < jcp.kh_sets; kh++) {
+        if (jcp.kh_sets > 1) {
+            assert(!jcp.is_os_blocking);
+            const auto ih_s = oh * SH + kh * DH - TP;
+            const auto ih_f = (oh + jcp.oh_block - 1) * SH + kh * DH - TP + 1;
+
+            cp.t_pad = max(0, -ih_s);
+            cp.b_pad = max(0, ih_f - jcp.ih);
+            cp.h_count = max(0, jcp.oh_block);
+            const auto ih_buf = (jcp.copy_block_only ? 0 : ih_start) + TP;
+
+            inp_offset_start = static_cast<dim_t>(n) * src_d_sz
+                    + max(ih_s, ih_start) * src_w_sz
+                    + iw * jcp.ngroups * jcp.ic_without_padding + g_ic;
+
+            // inp_buffer has physical padding
+            out_offset_start = (jcp.copy_block_only ? 0
+                                                    : static_cast<dim_t>(icb)
+                                                       * _pd->pbuf_d_sz)
+                    + ih_buf * _pd->pbuf_w_sz
+                    + (iw_buf * jcp.kh_sets + kh) * jcp.kw_sets * jcp.ic_block;
+        } else {
+            // For os_blocking:
+            // We have to zero top and bottom padding now
+            // taking into account that batch size is always the same (kh_s is 0 for os_blocking)
+            // TODO: extend M_mask (may be different for different kh) to avoid copying
+            // top/bottom padded rows and avoid extra calculations in kernel
+            // also for convolutions with pw == 0 the copy routine maybe not needed
+            cp.t_pad = jcp.is_os_blocking ? max(0, -virt_ih_start) : 0;
+            cp.b_pad = jcp.is_os_blocking ? max(0, virt_ih_end - IH) : 0;
+            cp.h_count = max(0, rows_to_copy) + cp.t_pad + cp.b_pad;
+            const auto ih_buf
+                    = (jcp.copy_block_only ? 0 : ih_start) + TP - cp.t_pad;
+
+            inp_offset_start = static_cast<dim_t>(n) * src_d_sz
+                    + ih_start * src_w_sz
+                    + iw * jcp.ngroups * jcp.ic_without_padding + g_ic;
+
+            // inp_buffer has physical padding
+            out_offset_start = (jcp.copy_block_only ? 0
+                                                    : static_cast<dim_t>(icb)
+                                                       * _pd->pbuf_d_sz)
+                    + ih_buf * _pd->pbuf_w_sz
+                    + iw_buf * jcp.ic_block * jcp.kh_sets * jcp.kw_sets;
+        }
+
+        for (int id = id_start; id < id_end; id++) {
+            const auto inp_offset = inp_offset_start + id * src_h_sz;
+            const auto id_buf = id - (jcp.copy_block_only ? id_start : 0) + FP;
+            const auto out_offset = out_offset_start + id_buf * _pd->pbuf_h_sz;
+            cp.src = src + src_dsz * inp_offset;
+            cp.dst = inp_buffer + src_dsz * out_offset;
+            (*copy_to_pbuffer_)(&cp);
+        }
+    }
+    if (!jcp.copy_block_only) bmask(icb, odb, ohb, owb) = 1;
+
+#undef bmask
+}
+
+#define BRGEMM_CONV_KER_HEADER \
+    const char *const __restrict src = btc.brgemm_ctx.src; \
+    const char *const __restrict weights = btc.brgemm_ctx.weights; \
+    const char *const __restrict bias = btc.brgemm_ctx.bias; \
+    const int oc = btc.ocb * jcp.oc_block; \
+    const int g_oc = btc.g * jcp.oc + oc; \
+    const int icb = btc.icc * jcp.nb_ic_blocking; \
+    const int ic = icb * jcp.ic_block; \
+    const int g_ic = btc.g * jcp.ic + ic; \
+    const int ow = btc.owb * jcp.ow_block; \
+    const int oh = btc.ohb * jcp.oh_block; \
+    const int iid = ndims_pick(btc.od * SD - FP, 0, 0); \
+    const int kd_s = ndims_pick(div_up(max(0, -iid), DD), 0, 0); \
+    const int kd_f = ndims_pick( \
+            KD - div_up(max(0, iid - ID + (KD - 1) * DD + 1), DD), 1, 1); \
+    const auto kd_l = kd_f - kd_s; \
+    const auto iih = ndims_pick(btc.oh * SH - TP, btc.oh * SH - TP, 0); \
+    const auto kh_s_ = div_up(max(0, -iih), DH); \
+    const auto kh_s = jcp.is_os_blocking ? 0 : ndims_pick(kh_s_, kh_s_, 0); \
+    const auto kh_f_ = KH - div_up(max(0, iih - IH + (KH - 1) * DH + 1), DH); \
+    const auto kh_f = ndims_pick(kh_f_, kh_f_, 1); \
+    const auto kh_l = kh_f - kh_s; \
+    const bool is_oc_tail = (jcp.oc - oc < jcp.oc_block); \
+    const bool is_ic_tail = (btc.icc == _pd->ic_chunks - 1 \
+            && ((jcp.ic - ic) % jcp.ic_block != 0)); \
+    const bool is_ow_tail = (OW - ow < jcp.ow_block); \
+    const bool is_oh_tail = (OH - oh < jcp.oh_block); \
+    const char *const __restrict bias_w \
+            = bias ? bias + (bias_d.blk_off(g_oc) * bia_dsz) : nullptr; \
+    const auto nb_ic_b = nstl::min(jcp.nb_ic_blocking, jcp.nb_ic - icb) \
+            - (is_ic_tail ? 1 : 0); \
+    char *const __restrict dst_base \
+            = btc.brgemm_ctx.dst + dst_dsz * (btc.n * dst_d_sz + g_oc); \
+    char *ptr_C; \
+    char *ptr_D; \
+    int kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0), iiw_b(0);
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::ker_base(
+        brgemm_thread_ctx_t &btc) const {
+
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+    auto ndims = _pd->ndims;
+
+    BRGEMM_CONV_KER_HEADER;
+    MAYBE_UNUSED(is_ow_tail);
+    MAYBE_UNUSED(is_oh_tail);
+
+    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0}, kw_b(0), kw_e(0);
+
+    get_kw_range(ow, kw_s, kw_full_s, kw_full_f, kw_f);
+
+    const auto src_base = src + src_dsz * (btc.n * src_d_sz + g_ic);
+    const auto wei_base = weights
+            + wei_dsz
+                    * (btc.g * _pd->wei_g_stride
+                            + btc.ocb * _pd->wei_ocb_stride);
+
+    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
+                                     int comp_ker_offs, bool do_postops,
+                                     bool do_only_comp) {
+        if (k_l <= 0) return;
+        const auto brg_ker = brgemm_kernels_[brg_idx];
+        brgemm_palettes_.maybe_tile_configure(btc.cur_brg_idx, brg_idx);
+
+        assert(jcp.brg_type != brgemm_static_offs);
+        _pd->init_batch(btc.icc, src_base, wei_base, n_ic_blocks, ic_block_s,
+                iid, iih, iiw_b, nullptr, nullptr, kd_b, kd_e, kh_b, kh_e, kw_b,
+                kw_e, k_l, btc.brg_batch);
+
+        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
+                bias_w, g_oc, do_postops, comp_ker_offs, do_only_comp);
+    };
+
+    const auto kdhw_loop = [&]() {
+        if (kw_e - kw_b <= 0) return;
+        int ow_b {0}, ow_e {0};
+        get_ow_range(ow, kw_b, ow_b, ow_e);
+
+        const auto do_init
+                = btc.icc == 0 && kd_b == kd_s && kh_b == kh_s && kw_b == kw_s;
+        const auto do_postwork = _pd->need_postwork
+                && btc.icc == (_pd->ic_chunks - 1) && kd_e == kd_f
+                && kh_e == kh_f && kw_e == kw_f;
+        const auto do_only_comp = need_compensation && kd_e == kd_f
+                && kh_e == kh_f && kw_e != kw_f
+                && btc.icc == (_pd->ic_chunks - 1);
+        if (ow_e - ow_b <= 0 && !do_init && !do_postwork) return;
+
+        k_l = (kd_e - kd_b) * (kh_e - kh_b) * (kw_e - kw_b);
+        iiw_b = ow_b * SW - LP;
+        ptr_D = dst_base
+                + dst_dsz
+                        * (btc.od * dst_h_sz + btc.oh * dst_w_sz
+                                + ow_b * jcp.oc_without_padding);
+        ptr_C = (jcp.use_buffer)
+                ? btc.c_buffer + acc_dsz * (ow_b - ow) * jcp.LDC
+                : static_cast<char *>(ptr_D);
+
+        const auto ow_l = ow_e - ow_b;
+        assert(0 <= ow_l && ow_l <= jcp.ow_block);
+
+        const auto comp_ker_offs = get_comp_offset(
+                btc.g, btc.ocb, ow_b, kd_s, kd_f, kh_s, kh_f, kw_b, kw_e);
+
+        const auto ker_i = ow_l - 1;
+        int kernel_idx[2][2];
+        kernel_idx[false][false] = _pd->get_brg_idx(
+                ker_i, false, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[true][false] = _pd->get_brg_idx(
+                ker_i, true, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[false][true] = _pd->get_brg_idx(
+                ker_i, false, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[true][true] = _pd->get_brg_idx(
+                ker_i, true, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+
+        if (ow_l > 0 && k_l > 0) {
+            if (nb_ic_b > 0) {
+                const auto brg_idx = kernel_idx[do_init][false];
+                call_brgemm(brg_idx, 0, nb_ic_b, comp_ker_offs,
+                        do_postwork && !is_ic_tail, do_only_comp);
+            }
+
+            if (is_ic_tail) {
+                const auto use_init_ker = (do_init && nb_ic_b == 0);
+                const auto brg_ic_tail_idx = kernel_idx[use_init_ker][true];
+                call_brgemm(brg_ic_tail_idx, nb_ic_b, 1, comp_ker_offs,
+                        do_postwork, do_only_comp);
+            }
+        }
+
+        perform_outwork(btc, dst_base, bias_w, ow, g_oc, is_oc_tail, ow_b, ow_e,
+                kd_l, kh_l, do_init, do_postwork, false);
+    };
+
+    if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s) {
+        // kw values with left padding
+        if (kw_s < kw_full_s) {
+            for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
+                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
+                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    for (auto kw = kw_s; kw < kw_full_s; kw++) {
+                        kw_b = kw;
+                        kw_e = kw + 1;
+                        kdhw_loop();
+                    }
+                }
+            }
+        }
+
+        // kw values covering full ow_block
+        if (kw_full_s < kw_full_f) {
+            for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
+                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+                for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
+                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                    for (kw_b = kw_full_s; kw_b < kw_full_f; kw_b += KW_BLOCK) {
+                        kw_e = nstl::min(kw_full_f, kw_b + KW_BLOCK);
+                        kdhw_loop();
+                    }
+                }
+            }
+        }
+
+        // kw values with right padding
+        if (kw_full_f < kw_f) {
+            for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
+                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
+                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    for (int kw = kw_full_f; kw < kw_f; kw++) {
+                        kw_b = kw;
+                        kw_e = kw + 1;
+                        kdhw_loop();
+                    }
+                }
+            }
+        }
+    } else {
+        const auto do_init = btc.icc == 0;
+        const auto do_postwork
+                = _pd->need_postwork && btc.icc == (_pd->ic_chunks - 1);
+        perform_outwork(btc, dst_base, bias_w, ow, g_oc, is_oc_tail, ow, ow,
+                kd_l, kh_l, do_init, do_postwork, false);
+    }
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::ker_trans(
+        brgemm_thread_ctx_t &btc, char *inp_buffer) const {
+
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+    auto ndims = _pd->ndims;
+
+    BRGEMM_CONV_KER_HEADER;
+    MAYBE_UNUSED(g_ic);
+    MAYBE_UNUSED(src);
+
+    const auto wei_base = weights
+            + wei_dsz
+                    * (btc.g * _pd->wei_g_stride
+                            + btc.ocb * _pd->wei_ocb_stride);
+    const int ow_b {ow},
+            ow_e {ow + (is_ow_tail ? jcp.ow % jcp.ow_block : jcp.ow_block)};
+    const int oh_b {oh},
+            oh_e {oh + (is_oh_tail ? jcp.oh % jcp.oh_block : jcp.oh_block)};
+    const auto iid_shift = jcp.copy_block_only
+            ? nstl::max(0, btc.odb * jcp.od_block * SD - FP)
+            : 0;
+    const auto iih_shift = jcp.copy_block_only
+            ? nstl::max(0, btc.ohb * jcp.oh_block * SH - TP)
+            : 0;
+    const auto iiw_shift
+            = jcp.copy_block_only ? (btc.owb * jcp.ow_block * SW) : 0;
+
+    const auto iid_b = iid + FP - iid_shift;
+    const auto iih_b = iih + TP - iih_shift;
+    iiw_b = ow_b * SW - iiw_shift;
+    ptr_D = dst_base
+            + dst_dsz
+                    * (btc.od * dst_h_sz + btc.oh * dst_w_sz
+                            + ow_b * jcp.oc_without_padding);
+    ptr_C = (jcp.use_buffer) ? btc.c_buffer + acc_dsz * (ow_b - ow) * jcp.LDC
+                             : static_cast<char *>(ptr_D);
+
+    const auto ow_l = ow_e - ow_b;
+    const auto oh_l = oh_e - oh_b;
+    assert(0 <= ow_l && ow_l <= jcp.ow_block && 0 <= oh_l
+            && oh_l <= jcp.oh_block);
+
+    const auto ker_i = (jcp.is_os_blocking ? oh_l * ow_l : ow_l) - 1;
+    const auto kw_e = jcp.kw_sets > 1 ? 1 : KW;
+
+    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
+                                     bool do_postops) {
+        if (k_l <= 0) return;
+        const auto brg_ker = brgemm_kernels_[brg_idx];
+        brgemm_palettes_.maybe_tile_configure(btc.cur_brg_idx, brg_idx);
+
+        const auto kh_ee = jcp.kh_sets > 1 ? kh_b + 1 : kh_e;
+        const auto pbuf_base = inp_buffer
+                + src_dsz
+                        * ((jcp.copy_block_only ? 0
+                                                : ((icb + ic_block_s)
+                                                        * _pd->pbuf_d_sz)));
+        const void *ptrA {nullptr}, *ptrB {nullptr};
+
+        if (jcp.brg_type == brgemm_static_offs) {
+            _pd->get_A_B(btc.icc, pbuf_base, wei_base, ic_block_s, iid_b, iih_b,
+                    iiw_b, kd_b, kh_b, ptrA, ptrB);
+            btc.brg_batch[0].ptr.A = ptrA;
+            btc.brg_batch[0].ptr.B = ptrB;
+        } else {
+            _pd->init_batch(btc.icc, pbuf_base, wei_base, n_ic_blocks,
+                    ic_block_s, iid_b, iih_b, iiw_b, nullptr, nullptr, kd_b,
+                    kd_e, kh_b, kh_ee, 0, kw_e, k_l, btc.brg_batch);
+        }
+
+        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
+                bias_w, g_oc, do_postops, 0, false);
+    };
+
+    const auto kdhw_loop = [&]() {
+        const auto do_init = btc.icc == 0 && kd_b == kd_s && kh_b == kh_s;
+        const auto do_postwork = _pd->need_postwork
+                && btc.icc == (_pd->ic_chunks - 1) && kd_e == kd_f
+                && kh_e == kh_f;
+        if (ow_e - ow_b <= 0 && !do_init && !do_postwork) return;
+
+        k_l = (kd_e - kd_b) * (jcp.kh_sets > 1 ? 1 : (kh_e - kh_b))
+                * (jcp.kw_sets > 1 ? 1 : KW);
+
+        int kernel_idx[2][2];
+        kernel_idx[false][false] = _pd->get_brg_idx(
+                ker_i, false, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[true][false] = _pd->get_brg_idx(
+                ker_i, true, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[false][true] = _pd->get_brg_idx(
+                ker_i, false, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[true][true] = _pd->get_brg_idx(
+                ker_i, true, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+
+        if (nb_ic_b > 0) {
+            const auto brg_idx = kernel_idx[do_init][false];
+            call_brgemm(brg_idx, 0, nb_ic_b, do_postwork && !is_ic_tail);
+        }
+
+        if (is_ic_tail) {
+            const auto use_init_ker = (do_init && nb_ic_b == 0);
+            const auto brg_ic_tail_idx = kernel_idx[use_init_ker][true];
+            call_brgemm(brg_ic_tail_idx, nb_ic_b, 1, do_postwork);
+        }
+    };
+
+    if (kd_f > kd_s && kh_f > kh_s) {
+        // kw values covering full ow_block
+        for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
+            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
+                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kdhw_loop();
+            }
+        }
+    } else {
+        const auto do_init = btc.icc == 0;
+        const auto do_postwork
+                = _pd->need_postwork && btc.icc == (_pd->ic_chunks - 1);
+        perform_outwork(btc, dst_base, bias_w, ow, g_oc, is_oc_tail, ow, ow,
+                kd_l, kh_l, do_init, do_postwork, false);
+    }
+}
+
+template <cpu_isa_t isa, bool use_inversion>
+void brgemm_convolution_fwd_t<isa, use_inversion>::ker_vpad(
+        brgemm_thread_ctx_t &btc) const {
+
+    const auto _pd = pd();
+    const auto &jcp = _pd->jcp_;
+    auto ndims = _pd->ndims;
+
+    BRGEMM_CONV_KER_HEADER;
+    MAYBE_UNUSED(is_oh_tail);
+
+    const char *const __restrict src_base
+            = src + src_dsz * (btc.n * src_d_sz + g_ic);
+    const char *const __restrict wei_base = weights
+            + wei_dsz
+                    * (btc.g * _pd->wei_g_stride
+                            + btc.ocb * _pd->wei_ocb_stride);
+
+    const int ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
+    iiw_b = ow_b * SW - LP;
+    ptr_D = dst_base
+            + dst_dsz
+                    * (btc.od * dst_h_sz + btc.oh * dst_w_sz
+                            + ow_b * jcp.oc_without_padding);
+    ptr_C = (jcp.use_buffer) ? btc.c_buffer + acc_dsz * (ow_b - ow) * jcp.LDC
+                             : static_cast<char *>(ptr_D);
+
+    const auto ow_l = ow_e - ow_b;
+    assert(0 <= ow_l && ow_l <= jcp.ow_block);
+    const auto ker_i = ow_l - 1;
+    const dim_t *const __restrict kw_top_vpads
+            = owb_kw_top_vpads.data() + btc.owb * KW;
+    const dim_t *const __restrict kw_bottom_vpads
+            = owb_kw_bottom_vpads.data() + btc.owb * KW;
+
+    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
+                                     int comp_ker_offs, bool do_postops) {
+        const auto brg_ker = brgemm_kernels_[brg_idx];
+
+        brgemm_palettes_.maybe_tile_configure(btc.cur_brg_idx, brg_idx);
+
+        assert(jcp.brg_type != brgemm_static_offs);
+        _pd->init_batch(btc.icc, src_base, wei_base, n_ic_blocks, ic_block_s,
+                iid, iih, iiw_b, kw_top_vpads, kw_bottom_vpads, kd_b, kd_e,
+                kh_b, kh_e, 0, KW, k_l, btc.brg_batch);
+
+        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
+                bias_w, g_oc, do_postops, comp_ker_offs, false);
+    };
+
+    const auto kdhw_loop = [&]() {
+        const auto do_init = btc.icc == 0 && kd_b == kd_s && kh_b == kh_s;
+        const auto do_postwork = _pd->need_postwork
+                && btc.icc == (_pd->ic_chunks - 1) && kd_e == kd_f
+                && kh_e == kh_f;
+
+        if (ow_e - ow_b <= 0 && !do_init && !do_postwork) return;
+
+        k_l = (kd_e - kd_b) * (kh_e - kh_b) * KW;
+        int kernel_idx[2][2];
+        kernel_idx[false][false] = _pd->get_brg_idx(
+                ker_i, false, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[true][false] = _pd->get_brg_idx(
+                ker_i, true, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[false][true] = _pd->get_brg_idx(
+                ker_i, false, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+        kernel_idx[true][true] = _pd->get_brg_idx(
+                ker_i, true, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+
+        const auto comp_offs = get_comp_offset(
+                btc.g, btc.ocb, ow, kd_b, kd_e, kh_b, kh_e, 0, KW);
+
+        if (nb_ic_b > 0) {
+            const auto brg_idx = kernel_idx[do_init][false];
+            call_brgemm(
+                    brg_idx, 0, nb_ic_b, comp_offs, do_postwork && !is_ic_tail);
+        }
+
+        if (is_ic_tail) {
+            const auto use_init_ker = (do_init && nb_ic_b == 0);
+            const auto brg_ic_tail_idx = kernel_idx[use_init_ker][true];
+            call_brgemm(brg_ic_tail_idx, nb_ic_b, 1, comp_offs, do_postwork);
+        }
+    };
+
+    if (kd_f > kd_s && kh_f > kh_s) {
+        // kw values covering full ow_block
+        for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
+            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
+                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kdhw_loop();
+            }
+        }
+    } else {
+        const auto do_init = btc.icc == 0;
+        const auto do_postwork
+                = _pd->need_postwork && btc.icc == (_pd->ic_chunks - 1);
+        perform_outwork(btc, dst_base, bias_w, ow, g_oc, is_oc_tail, ow, ow,
+                kd_l, kh_l, do_init, do_postwork, false);
+    }
+}
+
+#undef BRGEMM_CONV_KER_HEADER
+template struct brgemm_convolution_fwd_t<sve_512>;
+
+} // namespace aarch64
+
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.hpp
@@ -1,0 +1,287 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_BRGEMM_CONV_HPP
+#define CPU_AARCH64_JIT_BRGEMM_CONV_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/cpu_convolution_pd.hpp"
+#include "cpu/platform.hpp"
+
+#include "cpu/aarch64/brgemm/brgemm.hpp"
+#include "cpu/aarch64/brgemm/brgemm_containers.hpp"
+#include "cpu/aarch64/cpu_barrier.hpp"
+#include "cpu/aarch64/cpu_reducer.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_utils.hpp"
+#include "cpu/aarch64/jit_brgemm_post_ops.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa, bool use_inversion = false>
+struct brgemm_convolution_fwd_t : public primitive_t {
+
+    struct brgemm_thread_ctx_t;
+
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::hint_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
+            , with_sum(false) {}
+
+        ~pd_t() = default;
+
+        // ------- DECLARE_COMMON_PD_t -----
+        DECLARE_COMMON_PD_T(JIT_IMPL_NAME_HELPER("brgconv:", jcp_.isa, ""),
+                brgemm_convolution_fwd_t);
+
+        status_t init(engine_t *engine);
+
+        int brgs_sz_;
+        std::shared_ptr<brgemm_containers::brgemm_desc_container_t>
+                brgemm_descriptors_;
+        bool with_sum;
+        jit_brgemm_conv_conf_t jcp_;
+
+        int ic_chunks;
+        bool need_postwork;
+        dim_t wei_g_stride, wei_ic_stride, wei_ocb_stride;
+        dim_t wei_kw_stride, wei_kh_stride, wei_kd_stride;
+        dim_t pbuf_w_sz, pbuf_h_sz, pbuf_d_sz;
+
+        // batch sizes info for unrolled kernels
+        int bs_c;
+        std::vector<int> batchsizes;
+
+        inline size_t get_bs_idx(int kd_b, int kd_e, int kh_b, int kh_e) const {
+            assert(0 <= kd_b && kd_b < KD);
+            assert(1 <= kd_e && kd_e < KD + 1);
+            assert(0 <= kh_b && kh_b < KH);
+            assert(1 <= kh_e && kh_e < KH + 1);
+            return (((size_t)kd_b * KD + (kd_e - 1)) * KH + kh_b) * KH + kh_e
+                    - 1;
+        }
+
+        inline size_t get_brg_idx(int m, bool do_initialization, bool is_N_tail,
+                bool is_K_tail, int kd_b, int kd_e, int kh_b, int kh_e) const {
+            auto bs_idx = jcp_.use_uker
+                    ? batchsizes[get_bs_idx(kd_b, kd_e, kh_b, kh_e)]
+                    : 0;
+            if (bs_idx < 0) return 0;
+            return (((m * bs_c + bs_idx) * 2
+                            + static_cast<int>(do_initialization))
+                                   * 2
+                           + static_cast<int>(is_N_tail))
+                    * 2
+                    + static_cast<int>(is_K_tail);
+        }
+
+        int get_any_brg_idx(bool is_N_tail, bool is_K_tail) const {
+            // return first defined brgemm_descriptor for specified parameters
+            const int M_end = nstl::max(jcp_.M, jcp_.M_tail);
+            const bool N_begin = (jcp_.N == jcp_.N_tail) ? false : is_N_tail;
+            const bool N_end = (jcp_.N == jcp_.N_tail) ? true : is_N_tail;
+            const bool K_begin = (jcp_.K == jcp_.K_tail) ? false : is_K_tail;
+            const bool K_end = (jcp_.K == jcp_.K_tail) ? true : is_K_tail;
+            for_(int m = 0; m < M_end; m++)
+            for_(bool i_init : {false, true})
+            for_(bool i_N_tail : {N_begin, N_end})
+            for_(bool i_K_tail : {K_begin, K_end})
+            for_(int kd_b = 0; kd_b < KD; kd_b++)
+            for_(int kd_e = 1; kd_e <= KD; kd_e++)
+            for_(int kh_b = 0; kh_b < KH; kh_b++)
+            for (int kh_e = 1; kh_e <= KH; kh_e++) {
+                const auto brg_idx = get_brg_idx(
+                        m, i_init, i_N_tail, i_K_tail, kd_b, kd_e, kh_b, kh_e);
+                if ((*brgemm_descriptors_)[brg_idx]) return brg_idx;
+            }
+            return 0;
+        }
+
+        inline int maybe_invert(int k, int K) const {
+            return use_inversion ? K - 1 - k : k;
+        };
+
+        void init_batch(int icc, const char *src_base, const char *wei_base,
+                int n_ic_blocks, int ic_block_s, int iid_b, int iih_b,
+                int iiw_b, const dim_t *const __restrict kw_top_vpads,
+                const dim_t *const __restrict kw_bottom_vpads, int kd_b,
+                int kd_e, int kh_b, int kh_e, int kw_b, int kw_e, int k_l,
+                brgemm_batch_element_t *brg_batch) const;
+
+        void get_A_B(int icc, const char *src_base, const char *wei_base,
+                int ic_block_s, int iid_b, int iih_b, int iiw_b, int kd_b,
+                int kh_b, const void *&ptrA, const void *&ptrB) const;
+
+        status_t add_brg_descriptor(int M, int i_N, int i_K, int i_init,
+                int kd_b, int kd_e, int kh_b, int kh_e);
+
+        int ndims = 0;
+
+    protected:
+        bool arg_scales_ok() const {
+            std::vector<int> supported_args
+                    = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
+            return attr_scales_ok(supported_args);
+        }
+
+        bool zero_points_ok() const {
+            // Only common zero points are supported -> mask should only be 0
+            int mask_src = 0, mask_dst = 0;
+            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
+            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
+            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
+                    && mask_src == 0 && mask_dst == 0;
+        }
+
+        int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK,
+                KW_BLOCK, KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, IDP, IHP, IWP,
+                OD, OH, OW, SD, SH, SW, FP, TP, LP, DD, DH, DW;
+        size_t acc_dsz, bia_dsz, src_dsz, wei_dsz, dst_dsz;
+        dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz,
+                wei_ocb_sz;
+        dim_t adj_src_h_sz, adj_src_h_offset, src_iw_offset, src_d_offset,
+                wei_ic_offset, wei_kd_offset, wei_kh_offset, wei_kw_offset;
+    };
+
+    brgemm_convolution_fwd_t(const pd_t *apd);
+
+    ~brgemm_convolution_fwd_t() = default;
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+protected:
+    status_t init(engine_t *engine) override;
+
+private:
+    //  brgemm convolution execution context
+    struct brgemm_exec_ctx_t {
+        brgemm_exec_ctx_t(const exec_ctx_t &ctx, const pd_t *pd)
+            : src(CTX_IN_MEM(const char *, DNNL_ARG_SRC))
+            , weights(CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS))
+            , bias(CTX_IN_MEM(const char *, DNNL_ARG_BIAS))
+            , dst(CTX_OUT_MEM(char *, DNNL_ARG_DST))
+            , post_ops_binary_rhs_arg_vec(binary_injector::prepare_binary_args(
+                      pd->attr()->post_ops_, ctx)) {}
+        const char *const __restrict src;
+        const char *const __restrict weights;
+        const char *const __restrict bias;
+        char *const __restrict dst;
+        const std::vector<const void *> post_ops_binary_rhs_arg_vec;
+    };
+
+    inline static int get_ker_po_idx(int m, bool do_postwork, bool is_N_tail) {
+        return (m * 2 + static_cast<int>(do_postwork)) * 2
+                + static_cast<int>(is_N_tail);
+    }
+
+    inline static int get_inp_size(
+            int max_src_size, int dst_size, int k, int stride, int dilate) {
+        const auto res = nstl::min(max_src_size,
+                calculate_end_padding(0, dst_size, 0, stride,
+                        calculate_extended_filter_size(k, dilate)));
+        return res;
+    }
+
+    inline int maybe_invert_range(int k, int k_inv, int K) const {
+        return use_inversion ? K - k_inv : k;
+    };
+
+    void get_kw_range(
+            int ow, int &kw_s, int &kw_full_s, int &kw_full_e, int &kw_e) const;
+    void get_ow_range(int ow, int kw, int &ow_s, int &ow_e) const;
+
+    void ker_base(brgemm_thread_ctx_t &btc) const;
+    void ker_trans(brgemm_thread_ctx_t &btc, char *inp_buffer) const;
+    void ker_vpad(brgemm_thread_ctx_t &btc) const;
+
+    void perform_outwork(const brgemm_thread_ctx_t &btc, char *dst_base,
+            const char *bias_w, int ow, int g_oc, bool is_oc_tail, int ker_ow_s,
+            int ker_ow_f, int kd_l, int kh_l, bool maybe_do_init,
+            bool do_postwork, bool do_post_comp) const;
+
+    void call_brgemm_kernel(const brgemm_thread_ctx_t &btc,
+            const brgemm_kernel_t *brg_ker, int batch_size, char *ptr_C,
+            char *ptr_D, const char *bias_w, int g_oc, bool do_postops,
+            int comp_ker_offs, bool do_only_comp) const;
+
+    void maybe_conv_inp(int ithr, const char *__restrict src,
+            char *__restrict inp_buffer, uint8_t *__restrict inp_buffer_mask,
+            int g, int n, int icc, int odb, int ohb, int owb, int last_g,
+            int last_n, int last_icc, int last_odb, int last_ohb,
+            int last_owb) const;
+
+    status_t add_po_kernel(brgemm_t *bcfg, int ker_idx, bool is_init);
+    void add_po_kernels(int i_N, int init_bcast_dim, int po_bcast_dim);
+    status_t add_brg_kernel(int M, int i_N, int i_K, int i_init, int kd_b,
+            int kd_e, int kh_b, int kh_e);
+
+    status_t cal_compensation(const char *__restrict weights,
+            int32_t *src_zp_buffer, int32_t *s8s8_comp_buffer) const;
+    int get_comp_ker_idx(const int kd_b, const int kd_e, const int kh_b,
+            const int kh_e, const int kw_b, const int kw_e) const;
+    int get_comp_offset(const int g, const int ocb, const int ow,
+            const int kd_b, const int kd_e, const int kh_b, const int kh_e,
+            const int kw_b, const int kw_e) const;
+    inline const pd_t *pd() const {
+        return static_cast<const pd_t *>(primitive_t::pd().get());
+    }
+
+    brgemm_containers::brgemm_kernel_container_t brgemm_kernels_;
+    brgemm_containers::brgemm_palette_container_t brgemm_palettes_;
+
+    std::vector<std::unique_ptr<jit_brgemm_kernel_post_ops>> kernels_po_;
+    std::unique_ptr<jit_sve_core_brgemm_conv_trans_kernel::
+                    jit_sve_core_brgemm_conv_trans_kernel_t>
+            copy_to_pbuffer_;
+    std::unique_ptr<jit_generator> comp_vpad_pbuffer_;
+
+    size_t acc_dsz, bia_dsz, src_dsz, wei_dsz, dst_dsz;
+
+    const memory_desc_wrapper bias_d;
+
+    // pre - calculated values
+    std::vector<dim_t> owb_kw_top_vpads;
+    std::vector<dim_t> owb_kw_bottom_vpads;
+    std::vector<dim_t> kd_bs, kd_es, kh_bs, kh_es, kw_bs, kw_es;
+
+    int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
+            KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, IDP, IHP, IWP, OD, OH, OW,
+            SD, SH, SW, FP, TP, LP, DD, DH, DW;
+    dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz;
+    dim_t ker_vpad_sz, comp_ocb_sz, comp_ker_sz, comp_kw_sz;
+
+    bool need_compensation;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.hpp
@@ -251,7 +251,6 @@ private:
     }
 
     brgemm_containers::brgemm_kernel_container_t brgemm_kernels_;
-    brgemm_containers::brgemm_palette_container_t brgemm_palettes_;
 
     std::vector<std::unique_ptr<jit_brgemm_kernel_post_ops>> kernels_po_;
     std::unique_ptr<jit_sve_core_brgemm_conv_trans_kernel::

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -1,0 +1,290 @@
+/*******************************************************************************
+* Copyright 2022-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::utils;
+using namespace nstl;
+using namespace data_type;
+using namespace Xbyak_aarch64;
+
+namespace jit_uni_brgemm_conv_comp_pad_kernel {
+
+#define GET_OFF(field) offsetof(jit_brgemm_conv_comp_pad_call_s, field)
+
+jit_uni_brgemm_conv_comp_pad_kernel_t::jit_uni_brgemm_conv_comp_pad_kernel_t(
+        const jit_brgemm_conv_conf_t &ajcp)
+    : jcp_(ajcp)
+    , inp_dsz_(jcp_.wei_dsz)
+    , out_dsz_(jcp_.acc_dsz)
+    , nb_ic_(utils::div_up(jcp_.ic, 4))
+    , inp_ic_sz_(static_cast<size_t>(inp_dsz_) * jcp_.oc_block * 4)
+    , inp_kw_sz_(static_cast<size_t>(inp_dsz_) * jcp_.icp * jcp_.oc_block)
+    , inp_kh_sz_(static_cast<size_t>(jcp_.kw) * inp_kw_sz_)
+    , inp_kd_sz_(static_cast<size_t>(jcp_.kh) * inp_kh_sz_)
+    , isa_max_regs(isa_num_vregs(jcp_.isa)) {}
+
+size_t jit_uni_brgemm_conv_comp_pad_kernel_t::out_oc_offset(const int n) const {
+    return static_cast<size_t>(out_dsz_) * n * m_block2_;
+}
+size_t jit_uni_brgemm_conv_comp_pad_kernel_t::inp_ic_offset(
+        const int m_block, const int icb, const int m, const int n) const {
+    return static_cast<size_t>(inp_dsz_) * n * m_block2_ * last_ic_block_
+            + ((icb * m_block) + m) * inp_ic_sz_;
+}
+Xbyak_aarch64::ZReg jit_uni_brgemm_conv_comp_pad_kernel_t::accum(
+        const int n_block, const int m, const int n) const {
+    return Xbyak_aarch64::ZReg(m * n_block + n);
+}
+
+void jit_uni_brgemm_conv_comp_pad_kernel_t::store_accumulators(
+        const int m_block, const int n_block) {
+    if (jcp_.src_zero_point) {
+        for_(int m = 0; m < m_block; m++)
+        for (int n = 0; n < n_block; n++) {
+            str(vmm_zp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+
+            auto vmm = accum(n_block, m, n);
+            auto vmm_tmp = vmm_tmp_1();
+            auto vmm_zp = vmm_zp_shift;
+            ldr(vmm_tmp, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            add_imm(X_DEFAULT_ADDR, reg_zp_comp_out, out_oc_offset(n), X_TMP_0);
+            ldr(vmm_zp, ptr(X_DEFAULT_ADDR));
+
+            mul(vmm_tmp.s, P_ALL_ONE / T_m, vmm.s);
+            add(vmm_tmp.s, vmm_tmp.s, vmm_zp.s);
+            st1w(vmm_tmp.s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
+
+            ldr(vmm_zp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+        }
+    }
+
+    if (jcp_.s8s8_compensation_required) {
+        for_(int m = 0; m < m_block; m++)
+        for (int n = 0; n < n_block; n++) {
+            str(vmm_cp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+
+            auto vmm = accum(n_block, m, n);
+            auto vmm_tmp = vmm_tmp_1();
+            auto vmm_zp = vmm_cp_shift;
+            ldr(vmm_tmp, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+            add_imm(X_DEFAULT_ADDR, reg_comp_out, out_oc_offset(n), X_TMP_0);
+            ldr(vmm_zp, ptr(X_DEFAULT_ADDR));
+
+            mul(vmm_tmp.s, P_ALL_ONE / T_m, vmm.s);
+            add(vmm_tmp.s, vmm_tmp.s, vmm_zp.s);
+            st1w(vmm_tmp.s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
+
+            ldr(vmm_cp_shift, ptr(X_TRANSLATOR_STACK, -1, MUL_VL));
+        }
+    }
+}
+
+void jit_uni_brgemm_conv_comp_pad_kernel_t::zero_accumulators(
+        const int m_block, const int n_block) {
+    for_(int m = 0; m < m_block; m++)
+    for (int n = 0; n < n_block; n++) {
+        auto vmm = accum(n_block, m, n);
+        eor(vmm.d, vmm.d, vmm.d);
+    }
+}
+
+void jit_uni_brgemm_conv_comp_pad_kernel_t::compute(const int ic_step,
+        const int m_block, const int n_block, const int m_tail,
+        const bool is_mb_tail) {
+
+    for_(int ic = 0; ic < ic_step; ++ic)
+    for (int m = 0; m < m_block; ++m) {
+        if (is_mb_tail && (ic * m_block + m) >= m_tail) break;
+        for (int n = 0; n < n_block; ++n) {
+            auto vmm = accum(n_block, m, n);
+            const auto oc_offset = inp_ic_offset(m_block, ic, m, n);
+            add_imm(X_DEFAULT_ADDR, reg_aux_in, oc_offset, X_TMP_0);
+            ldr(vmm_tmp, ptr(X_DEFAULT_ADDR));
+            sdot(vmm.s, vmm_one_bytes.b, vmm_tmp.b);
+        }
+    }
+}
+
+void jit_uni_brgemm_conv_comp_pad_kernel_t::icb_loop(const int icb,
+        const int icb_tail, const int ic_step, const int m_block,
+        const int mb_tail, const int n_block) {
+    Xbyak_aarch64::Label label_icb_loop, label_loop_end;
+
+    mov(reg_aux_in, reg_aux_kw_in);
+    mov_imm(reg_icb, icb);
+
+    L(label_icb_loop);
+    {
+        cmp(reg_icb, 0);
+        b(EQ, label_loop_end);
+        compute(ic_step, m_block, n_block, 0, false);
+        add_imm(reg_aux_in, reg_aux_in, ic_step * m_block * inp_ic_sz_,
+                X_TMP_0);
+        sub(reg_icb, reg_icb, 1);
+        b(label_icb_loop);
+    }
+    L_aligned(label_loop_end);
+
+    if (icb_tail) compute(ic_step, mb_tail, n_block, icb_tail, true);
+}
+
+void jit_uni_brgemm_conv_comp_pad_kernel_t::khw_loop(const int icb,
+        const int icb_tail, const int ic_step, const int m_block,
+        const int mb_tail, const int n_block) {
+    Xbyak_aarch64::Label label_kw_loop, label_kw_end, label_kh_loop,
+            label_kh_end;
+    add_imm(reg_kh_l, param1, GET_OFF(kh_l), X_TMP_0);
+    mov(reg_aux_kh_in, reg_in);
+
+    L_aligned(label_kh_loop);
+    {
+        cmp(reg_kh_l, 0);
+        b(EQ, label_kh_end);
+        add_imm(reg_kw_l, param1, GET_OFF(kw_l), X_TMP_0);
+        mov(reg_aux_kw_in, reg_aux_kh_in);
+        L_aligned(label_kw_loop);
+        {
+            cmp(reg_kw_l, 0);
+            b(EQ, label_kw_end);
+            icb_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block);
+            add_imm(reg_aux_kw_in, reg_aux_kw_in, inp_kw_sz_, X_TMP_0);
+            sub(reg_kw_l, reg_kw_l, 1);
+            b(label_kw_loop);
+        }
+        L_aligned(label_kw_end);
+
+        add_imm(reg_aux_kh_in, reg_aux_kh_in, inp_kh_sz_, X_TMP_0);
+        sub(reg_kh_l, reg_kh_l, 1);
+        b(label_kh_loop);
+    }
+    L_aligned(label_kh_end);
+}
+
+void jit_uni_brgemm_conv_comp_pad_kernel_t::load_params() {
+    add_imm(reg_in, param1, GET_OFF(ptr_in), X_TMP_0);
+    add_imm(reg_zp_comp_out, param1, GET_OFF(ptr_zp_out), X_TMP_1);
+    add_imm(reg_comp_out, param1, GET_OFF(ptr_cp_out), X_TMP_2);
+}
+
+int jit_uni_brgemm_conv_comp_pad_kernel_t::compute_ic_step(
+        const int m_max_regs, const int m_block, const int n_block) const {
+    int best_ic_step = 1;
+    float best_block_eff = 0.f;
+
+    int max_ic_step
+            = nstl::min(static_cast<size_t>(m_block), div_up(nb_ic_, m_block));
+
+    // Introduce ic_step to increase kernel efficiency
+    // Compute the ic_step based on the optimal kernel efficiency
+    for (int ic_s = max_ic_step; ic_s >= 1; --ic_s) {
+        const auto blocks = ic_s * m_block;
+        const float block_disb
+                = static_cast<float>(nb_ic_) / rnd_up(nb_ic_, blocks);
+        const float eff = (static_cast<float>(n_block) * blocks)
+                / ((n_block + blocks) * max_ic_step);
+        const float block_eff = block_disb * eff;
+        float block_footprint = static_cast<float>(inp_dsz_) * blocks
+                * jcp_.oc_block * last_ic_block_;
+        if (block_footprint <= static_cast<float>(
+                    platform::get_per_core_cache_size(1))
+                && (block_eff > best_block_eff)) {
+            best_ic_step = ic_s;
+            best_block_eff = block_eff;
+        }
+    }
+
+    return best_ic_step;
+}
+
+void jit_uni_brgemm_conv_comp_pad_kernel_t::generate() {
+    preamble();
+
+    load_params();
+
+    // fill registers with byte ones
+    const auto reg32_scratch = WReg(reg_tmp.getIdx());
+    mov_imm(reg32_scratch, 0x1010101);
+    dup(vmm_one_bytes.s, reg32_scratch);
+
+    // fill register with -128 && -1
+    mov(reg32_scratch, -128);
+    dup(vmm_cp_shift.s, reg32_scratch);
+
+    mov(reg32_scratch, -1);
+    dup(vmm_zp_shift.s, reg32_scratch);
+
+    const bool is_int8_sve = (jcp_.src_dt == data_type::s8 || jcp_.src_dt == u8)
+            && jcp_.wei_dt == data_type::s8 && !jcp_.has_int8_vnni;
+    if (is_int8_sve) {
+        mov(reg32_scratch, 0x1);
+        dup(zmm_one_words.h, reg32_scratch);
+    }
+
+    const int max_regs = isa_max_regs
+            - (is_int8_sve ? 6 : (jcp_.s8s8_compensation_required ? 4 : 3));
+    const int nb = div_up(nstl::min(jcp_.oc, jcp_.oc_block), m_block2_);
+    const int nb2 = nb / n_max_regs_;
+    const int nb2_tail = nb % n_block2_;
+    const int n_block = (nb2 == 0) ? nstl::max(1, nb2_tail) : 4;
+
+    const size_t m_max_regs = max_regs / n_block;
+    const int m_block = nstl::min(m_max_regs, nb_ic_);
+    const int ic_step = compute_ic_step(m_max_regs, m_block, n_block);
+
+    assert(m_block * n_block <= max_regs);
+
+    const auto blocks = m_block * ic_step;
+    const auto icb = nb_ic_ / blocks;
+    const auto icb_tail = nb_ic_ % blocks;
+    const auto mb_tail = div_up(icb_tail, ic_step);
+
+    Label label_kd_loop, label_loop_end;
+    add_imm(reg_kd_l, param1, GET_OFF(kd_l), X_TMP_0);
+
+    zero_accumulators(m_block, n_block);
+
+    L_aligned(label_kd_loop);
+    {
+        cmp(reg_kd_l, 0);
+        b(EQ, label_loop_end);
+        khw_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block);
+        add_imm(reg_in, reg_in, inp_kd_sz_, X_TMP_0);
+        sub(reg_kd_l, reg_kd_l, 1);
+        b(label_kd_loop);
+    }
+    L_aligned(label_loop_end);
+
+    store_accumulators(m_block, n_block);
+
+    postamble();
+}
+
+} // namespace jit_uni_brgemm_conv_comp_pad_kernel
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -1,0 +1,122 @@
+/*******************************************************************************
+* Copyright 2022-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_BRGEMM_CONV_COMP_PAD_KERNEL_HPP
+#define CPU_AARCH64_JIT_BRGEMM_CONV_COMP_PAD_KERNEL_HPP
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace jit_uni_brgemm_conv_comp_pad_kernel {
+struct jit_brgemm_conv_comp_pad_call_s {
+    const void *ptr_in;
+    void *ptr_zp_out;
+    void *ptr_cp_out;
+    size_t kw_l;
+    size_t kh_l;
+    size_t kd_l;
+};
+
+struct jit_uni_brgemm_conv_comp_pad_kernel_t : public jit_generator {
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_brgemm_conv_comp_pad_kernel_t)
+
+    using XReg = const Xbyak_aarch64::XReg;
+
+    jit_uni_brgemm_conv_comp_pad_kernel_t(const jit_brgemm_conv_conf_t &ajcp);
+
+    ~jit_uni_brgemm_conv_comp_pad_kernel_t() = default;
+
+protected:
+    static constexpr bool is_ymm_ = true;
+
+    jit_brgemm_conv_conf_t jcp_;
+    const int inp_dsz_;
+    const int out_dsz_;
+    const size_t nb_ic_;
+    const size_t inp_ic_sz_;
+    const size_t inp_kw_sz_;
+    const size_t inp_kh_sz_;
+    const size_t inp_kd_sz_;
+    const int isa_max_regs;
+
+    // Register decomposition
+    const XReg param1 = abi_param1;
+    const XReg reg_in = x15;
+    const XReg reg_comp_out = x14;
+    const XReg reg_zp_comp_out = x13;
+
+    const XReg reg_kd_l = x12;
+    const XReg reg_kh_l = x11;
+    const XReg reg_kw_l = x10;
+    const XReg reg_icb = x9;
+
+    const XReg reg_aux_in = x8;
+    const XReg reg_aux_kh_in = x3;
+    const XReg reg_aux_kw_in = x6;
+    const XReg reg_tmp = x16;
+
+    Xbyak_aarch64::ZReg vmm_tmp = Xbyak_aarch64::ZReg(isa_max_regs - 1);
+    Xbyak_aarch64::ZReg vmm_one_bytes = Xbyak_aarch64::ZReg(isa_max_regs - 2);
+    Xbyak_aarch64::ZReg vmm_zp_shift = Xbyak_aarch64::ZReg(isa_max_regs - 3);
+    Xbyak_aarch64::ZReg vmm_cp_shift = Xbyak_aarch64::ZReg(isa_max_regs - 4);
+
+    Xbyak_aarch64::ZReg zmm_one_words = Xbyak_aarch64::ZReg(27);
+    Xbyak_aarch64::ZReg zmm_int8_temp = Xbyak_aarch64::ZReg(26);
+
+    const int last_ic_block_ = 4;
+    const int n_block2_ = 4;
+    const int m_block2_ = cpu_isa_traits<sve_512>::vlen / sizeof(int32_t);
+    const int n_max_regs_ = 4;
+
+    const Xbyak_aarch64::ZReg &vmm_tmp_1() const noexcept { return vmm_tmp; }
+
+    Xbyak_aarch64::ZReg accum(
+            const int n_block, const int m, const int n) const;
+    size_t out_oc_offset(const int n) const;
+    size_t inp_ic_offset(
+            const int m_block, const int icb, const int m, const int n) const;
+    int compute_ic_step(
+            const int m_max_regs, const int m_block, const int n_block) const;
+
+    void store_accumulators(const int m_block, const int n_block);
+    void zero_accumulators(const int m_block, const int n_block);
+    void compute(const int ic_step, const int m_block, const int n_block,
+            const int m_tail, const bool is_mb_tail);
+    void icb_loop(const int icb, const int icb_tail, const int ic_step,
+            const int m_block, const int mb_tail, const int n_block);
+    void khw_loop(const int icb, const int icb_tail, const int ic_step,
+            const int m_block, const int mb_tail, const int n_block);
+    void load_params();
+    void generate() override;
+};
+
+} // namespace jit_uni_brgemm_conv_comp_pad_kernel
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
@@ -1,0 +1,529 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_utils.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::utils;
+using namespace nstl;
+using namespace data_type;
+
+namespace jit_sve_core_brgemm_conv_trans_kernel {
+
+#define GET_OFF(field) offsetof(jit_brgemm_conv_trans_kernel_call_s, field)
+
+jit_sve_core_brgemm_conv_trans_kernel_t::
+        jit_sve_core_brgemm_conv_trans_kernel_t(
+                const jit_brgemm_conv_conf_t &ajcp)
+    : jcp(ajcp) {
+    inp_dsz = jcp.src_dsz;
+    ic_block_sz = inp_dsz * jcp.ic_block;
+    dst_w_block = dst_w(jcp, jcp.ow_block);
+    dst_stride = jcp.copy_block_only ? dst_w_block : jcp.iwp;
+    dst_w_offset = jcp.kh_sets * jcp.kw_sets * ic_block_sz;
+    dst_h_offset = dst_stride * dst_w_offset;
+    iw_size = inp_dsz * jcp.ngroups * jcp.ic_without_padding;
+    VL = cpu_isa_traits<sve_512>::vlen;
+    n_vec = jcp.ic_block / jcp.simd_w;
+    n_tail_vec = (jcp.ic_without_padding % jcp.ic_block) / jcp.simd_w;
+}
+
+int get_inp_size(int dst_size, int ext_k, int stride, int dilate) {
+    const auto res = calculate_end_padding(0, dst_size, 0, stride, ext_k);
+    return res;
+}
+
+int get_inp_start(int b, int b_size, int stride, int pad) {
+    return b * b_size * stride - pad;
+}
+
+int jit_sve_core_brgemm_conv_trans_kernel_t::inp_w(int out_w, int kw) const {
+    return get_inp_size(out_w, kw, jcp.stride_w, jcp.dilate_w);
+}
+
+int jit_sve_core_brgemm_conv_trans_kernel_t::inp_w(int out_w) const {
+    return inp_w(out_w, jcp.ext_kw);
+}
+
+int jit_sve_core_brgemm_conv_trans_kernel_t::dst_w(
+        const jit_brgemm_conv_conf_t &ajcp, int out_w) {
+    int res = 0;
+    if (ajcp.kw_sets > 1)
+        res = get_inp_size(out_w, 1, 1, ajcp.dilate_w);
+    else
+        res = get_inp_size(out_w, ajcp.ext_kw, ajcp.stride_w, ajcp.dilate_w);
+    if (ajcp.is_os_blocking) res = rnd_up(res, ajcp.stride_w);
+    return res;
+}
+
+int jit_sve_core_brgemm_conv_trans_kernel_t::inp_w_start(int owb) const {
+    return get_inp_start(owb, jcp.ow_block, jcp.stride_w, jcp.l_pad);
+}
+
+// use different vmovdqu32/16/8 due to case when tail mask used
+void jit_sve_core_brgemm_conv_trans_kernel_t::load(
+        const ZReg &x, const AdrNoOfs &addr) {
+    if (one_of(jcp.src_dt, f32, s32))
+        ldr(QReg(x.getIdx()), addr);
+    else if (one_of(jcp.src_dt, bf16, f16)) {
+        assert(!"Unknown type!\n");
+    } else if (one_of(jcp.src_dt, data_type::s8, data_type::u8)) {
+        assert(!"Unknown type!\n");
+    } else
+        assert(!"Unknown type!");
+}
+
+//for T_z
+void jit_sve_core_brgemm_conv_trans_kernel_t::load(
+        const ZReg &x, const PReg &p, const AdrNoOfs &addr) {
+    if (one_of(jcp.src_dt, f32, s32)) {
+        ld1rw(x.s, p, addr);
+    } else if (one_of(jcp.src_dt, bf16, f16)) {
+        assert(!"Unknown type!");
+    } else if (one_of(jcp.src_dt, data_type::s8, data_type::u8)) {
+        assert(!"Unknown type!");
+    } else
+        assert(!"Unknown type!");
+}
+
+void jit_sve_core_brgemm_conv_trans_kernel_t::store(
+        const AdrNoOfs &addr, const ZReg &x) {
+    if (one_of(jcp.src_dt, f32, s32))
+        str(QReg(x.getIdx()), addr);
+    else if (one_of(jcp.src_dt, bf16, f16))
+        assert(!"Unknown type!");
+    else if (one_of(jcp.src_dt, data_type::s8, data_type::u8))
+        assert(!"Unknown type!");
+    else
+        assert(!"Unknown type!");
+}
+
+// for T_z
+void jit_sve_core_brgemm_conv_trans_kernel_t::store(
+        const AdrNoOfs &addr, const PReg &p, const ZReg &x) {
+    if (one_of(jcp.src_dt, f32, s32)) {
+        st1w(zmm_zero.s, p, addr);
+    } else if (one_of(jcp.src_dt, bf16, f16))
+        assert(!"Unknown type!");
+    else if (one_of(jcp.src_dt, data_type::s8, data_type::u8))
+        assert(!"Unknown type!");
+    else
+        assert(!"Unknown type!");
+}
+
+void jit_sve_core_brgemm_conv_trans_kernel_t::zero_ic_block(
+        bool is_ic_tail, dim_t dst_off) {
+    bool has_block_tail = (jcp.ic_block % jcp.simd_w);
+
+    // TODO: use Xmm or Ymm moves for better small ic efficiency
+    auto nvec = is_ic_tail ? n_tail_vec : n_vec;
+    for (int iv = 0; iv < nvec; iv++) {
+        add_imm(X_DEFAULT_ADDR, aux_dst_ptr, dst_off + iv * VL, X_TMP_0);
+        store(ptr(X_DEFAULT_ADDR), zmm_zero);
+    }
+    //const auto last_dst_off = aux_dst_ptr + dst_off + nvec * VL;
+    add_imm(X_DEFAULT_ADDR, aux_dst_ptr, dst_off + nvec * VL, X_TMP_0);
+    if (is_ic_tail) {
+        if (has_block_tail) {
+            store(ptr(X_DEFAULT_ADDR), kblock_tail_mask, zmm_zero);
+        } else {
+            store(ptr(X_DEFAULT_ADDR), zmm_zero);
+        }
+    } else if (has_block_tail) {
+        store(ptr(X_DEFAULT_ADDR), kblock_tail_mask, zmm_zero);
+    }
+}
+
+void jit_sve_core_brgemm_conv_trans_kernel_t::copy_ic_block(bool is_ic_tail,
+        dim_t inp_off = 0, dim_t dst_off = 0, bool do_load = true) {
+    bool has_block_tail = (jcp.ic_block % jcp.simd_w);
+
+    // TODO: use Xmm or Ymm moves for better small ic efficiency
+    auto nvec = is_ic_tail ? n_tail_vec : n_vec;
+    for (int iv = 0; iv < nvec; iv++) {
+        if (do_load) {
+            add_imm(X_DEFAULT_ADDR, aux_inp_ptr, inp_off + iv * VL, X_TMP_0);
+            load(zmm_tmp, ptr(X_DEFAULT_ADDR));
+        }
+        add_imm(X_DEFAULT_ADDR, aux_dst_ptr, dst_off + iv * VL, X_TMP_0);
+        store(ptr(X_DEFAULT_ADDR), zmm_tmp);
+    }
+
+    if (is_ic_tail) {
+        if (do_load) {
+            add_imm(X_DEFAULT_ADDR, aux_inp_ptr, inp_off + nvec * VL, X_TMP_0);
+            load(zmm_tmp, ktail_mask, ptr(X_DEFAULT_ADDR));
+        }
+        if (has_block_tail) {
+            add_imm(X_DEFAULT_ADDR, aux_dst_ptr, dst_off + nvec * VL, X_TMP_0);
+            store(ptr(X_DEFAULT_ADDR), kblock_tail_mask, zmm_tmp);
+        } else {
+            add_imm(X_DEFAULT_ADDR, aux_dst_ptr, dst_off + nvec * VL, X_TMP_0);
+            store(ptr(X_DEFAULT_ADDR), zmm_tmp);
+        }
+    } else if (has_block_tail) {
+        if (do_load) {
+            add_imm(X_DEFAULT_ADDR, aux_inp_ptr, inp_off + nvec * VL, X_TMP_0);
+            load(zmm_tmp, kblock_tail_mask, ptr(X_DEFAULT_ADDR));
+        }
+        add_imm(X_DEFAULT_ADDR, aux_dst_ptr, dst_off + nvec * VL, X_TMP_0);
+        store(ptr(X_DEFAULT_ADDR), kblock_tail_mask, zmm_tmp);
+    }
+}
+
+void jit_sve_core_brgemm_conv_trans_kernel_t::generate() {
+    preamble();
+
+    ldr(inp_ptr, ptr(param1, uint32_t(GET_OFF(src))));
+    ldr(dst_ptr, ptr(param1, uint32_t(GET_OFF(dst))));
+    ldr(reg_hc, ptr(param1, uint32_t(GET_OFF(h_count))));
+    ldr(reg_t_pad, ptr(param1, uint32_t(GET_OFF(t_pad))));
+    ldr(reg_b_pad, ptr(param1, uint32_t(GET_OFF(b_pad))));
+    ldr(reg_owb, ptr(param1, uint32_t(GET_OFF(owb))));
+    ldr(reg_ic, ptr(param1, uint32_t(GET_OFF(ic))));
+
+    eor(zmm_zero.d, zmm_zero.d, zmm_zero.d);
+
+    if (jcp.ic_without_padding % jcp.ic_block) {
+        int tail_size = (jcp.ic_without_padding % jcp.ic_block) % jcp.simd_w;
+        set_preg(ktail_mask.s, tail_size, X_TMP_0, X_TMP_1);
+    }
+
+    if (jcp.ic_block % jcp.simd_w) {
+        int block_tail_size = jcp.ic_block % jcp.simd_w;
+        set_preg(kblock_tail_mask.s, block_tail_size, X_TMP_0, X_TMP_1);
+    }
+
+    auto icb_loop_body = [&](bool is_ic_tail) {
+        Label kh_label, no_kh_label, icb_label;
+        Label kh_tover_label, kh_bover_label;
+        Label no_kh_tover_label, no_kh_bover_label;
+
+        mov(aux_inp_ptr, inp_ptr);
+        mov(aux_dst_ptr, dst_ptr);
+
+        cmp_imm(reg_hc, 0, X_TMP_0);
+        b(LE, no_kh_bover_label);
+
+        cmp_imm(reg_t_pad, 0, X_TMP_0);
+        b(LE, no_kh_tover_label);
+
+        mov(kh_over, reg_t_pad);
+        L(kh_tover_label);
+        {
+            // TODO: adjust step to improve zeroing efficiency for small ic
+            for_(dim_t iw = 0; iw < dst_w_block; iw++)
+            for (int kw = 0; kw < jcp.kw_sets; kw++)
+                zero_ic_block(is_ic_tail, iw * dst_w_offset + kw * ic_block_sz);
+            add_imm(aux_dst_ptr, aux_dst_ptr, dst_h_offset, X_TMP_0);
+
+            subs(kh_over, kh_over, 1);
+            cmp_imm(kh_over, 0, X_TMP_0);
+            b(NE, kh_tover_label);
+        }
+        sub(reg_hc, reg_hc, reg_t_pad);
+        L(no_kh_tover_label);
+
+        cmp(reg_hc, reg_b_pad);
+        b(LE, no_kh_label);
+
+        L(kh_label);
+        {
+            copy_ow_block(is_ic_tail);
+            auto inp_h_offset = jcp.iw * iw_size;
+
+            add_imm(aux_inp_ptr, aux_inp_ptr, inp_h_offset, X_TMP_0);
+            add_imm(aux_dst_ptr, aux_dst_ptr, dst_h_offset, X_TMP_0);
+
+            sub_imm(reg_hc, reg_hc, 1, X_TMP_0);
+            cmp(reg_hc, reg_b_pad);
+            b(GT, kh_label);
+        }
+        L(no_kh_label);
+
+        cmp_imm(reg_hc, 0, X_TMP_0);
+        b(LE, no_kh_bover_label);
+
+        L(kh_bover_label);
+        {
+            // TODO: adjust step to improve zeroing efficiency for small ic
+            for_(dim_t iw = 0; iw < dst_w_block; iw++)
+            for (int kw = 0; kw < jcp.kw_sets; kw++)
+                zero_ic_block(is_ic_tail, iw * dst_w_offset + kw * ic_block_sz);
+            add_imm(aux_dst_ptr, aux_dst_ptr, dst_h_offset, X_TMP_0);
+
+            sub_imm(reg_hc, reg_hc, 1, X_TMP_0);
+            cmp_imm(reg_hc, 0, X_TMP_0);
+            b(NE, kh_bover_label);
+        }
+        L(no_kh_bover_label);
+
+        // End IC Loop
+        auto inp_cb_offset = ic_block_sz;
+        auto dst_cb_offset = jcp.ihp * dst_h_offset;
+
+        add_imm(inp_ptr, inp_ptr, inp_cb_offset, X_TMP_0);
+        add_imm(dst_ptr, dst_ptr, dst_cb_offset, X_TMP_0);
+    };
+
+    for (int icb = 0; icb < jcp.nb_ic_blocking; icb++) {
+        Label ic_tail_label, icb_continue_label;
+        add_imm(reg_ic, reg_ic, jcp.ic_block, X_TMP_0);
+        cmp_imm(reg_ic, jcp.ic, X_TMP_0);
+        b(GT, ic_tail_label);
+
+        icb_loop_body(false);
+        b(icb_continue_label);
+
+        L(ic_tail_label);
+        icb_loop_body(true);
+
+        L(icb_continue_label);
+    }
+
+    postamble();
+}
+
+void jit_sve_core_brgemm_conv_trans_kernel_t::copy_ow_block(bool is_ic_tail) {
+    if (jcp.nb_ow == 1) {
+        copy_ow_block_body(jcp.l_pad, jcp.ow_block, jcp.iw, is_ic_tail);
+        return;
+    }
+
+    Label copy_block_done_label;
+
+    int start_first_zero_block = -1;
+    int end_first_zero_block = -1;
+    int start_first_partial_block = -1;
+    int end_first_partial_block = -1;
+    int start_full_block = -1;
+    int end_full_block = -1;
+    int start_last_partial_block = -1;
+    int end_last_partial_block = -1;
+
+    const auto adj_iw = nstl::min(jcp.iw, jcp.iwp - jcp.l_pad);
+
+    int ow_block_tail = jcp.ow % jcp.ow_block;
+
+    for (int owb = 0; owb < jcp.nb_ow; owb++) {
+        const auto inp_block = inp_w(jcp.ow_block);
+        const auto inp_start = inp_w_start(owb);
+        const auto inp_end = inp_start + inp_block;
+        if (inp_start + inp_block < 0) {
+            if (start_first_zero_block == -1) start_first_zero_block = owb;
+            end_first_zero_block = owb;
+        } else if (inp_start < 0) {
+            if (start_first_partial_block == -1)
+                start_first_partial_block = owb;
+            end_first_partial_block = owb;
+        } else if (inp_start < adj_iw) {
+            if (inp_end <= adj_iw) {
+                if (start_full_block == -1) start_full_block = owb;
+                end_full_block = owb;
+            } else {
+                if (start_last_partial_block == -1)
+                    start_last_partial_block = owb;
+                end_last_partial_block = owb;
+            }
+        }
+    }
+
+    if (start_first_zero_block != -1) {
+        Label skip_first_zero_blocks;
+        cmp_imm(reg_owb, end_first_zero_block, X_TMP_0);
+        b(GT, skip_first_zero_blocks);
+        // zero block
+        copy_ow_block_body(0, jcp.ow_block, 0, is_ic_tail);
+        b(copy_block_done_label);
+
+        L(skip_first_zero_blocks);
+    }
+    if (start_first_partial_block != -1) {
+        for (int c = start_first_partial_block; c <= end_first_partial_block;
+                c++) {
+            int cur_ow_block = (c == jcp.nb_ow - 1 && ow_block_tail > 0)
+                    ? ow_block_tail
+                    : jcp.ow_block;
+            const auto inp_block = inp_w(cur_ow_block);
+            const auto inp_start = inp_w_start(c);
+            const auto inp_end = inp_start + inp_block;
+            const auto block_lpad = -inp_start;
+            const auto block_len = nstl::min(adj_iw, inp_end);
+            Label skip_first_partial_block;
+            cmp_imm(reg_owb, c, X_TMP_0);
+            b(NE, skip_first_partial_block);
+            copy_ow_block_body(block_lpad, jcp.ow_block, block_len, is_ic_tail);
+            b(copy_block_done_label);
+            L(skip_first_partial_block);
+        }
+    }
+    if (start_full_block != -1) {
+        Label skip_full_blocks;
+        cmp_imm(reg_owb, end_full_block, X_TMP_0);
+        b(GT, skip_full_blocks);
+        copy_ow_block_body(0, jcp.ow_block, inp_w(jcp.ow_block), is_ic_tail);
+        b(copy_block_done_label);
+
+        L(skip_full_blocks);
+    }
+    if (start_last_partial_block != -1) {
+        for (int c = start_last_partial_block; c <= end_last_partial_block;
+                c++) {
+            int cur_ow_block = (c == jcp.nb_ow - 1 && ow_block_tail > 0)
+                    ? ow_block_tail
+                    : jcp.ow_block;
+            const auto inp_block = inp_w(cur_ow_block);
+            const auto inp_start = inp_w_start(c);
+            const auto inp_end = inp_start + inp_block;
+            const auto block_lpad = 0;
+            const auto block_len = nstl::min(adj_iw, inp_end) - inp_start;
+            Label skip_last_partial_block;
+            cmp_imm(reg_owb, c, X_TMP_0);
+            b(NE, skip_last_partial_block);
+            copy_ow_block_body(block_lpad, cur_ow_block, block_len, is_ic_tail);
+            b(copy_block_done_label);
+
+            L(skip_last_partial_block);
+        }
+    }
+
+    // if not any above case then owb is among last zero blocks
+    // check is this needed and check may it be partial
+    copy_ow_block_body(0, jcp.ow_block, 0, is_ic_tail);
+
+    L(copy_block_done_label);
+}
+
+void jit_sve_core_brgemm_conv_trans_kernel_t::copy_ow_block_body(
+        int lpad, int ow_len, int iw_len, bool is_ic_tail) {
+    const auto dst_width = dst_w(jcp, ow_len);
+    const auto iw_stride = jcp.kw_sets > 1 ? jcp.stride_w : 1;
+    for_(int kw = 0; kw < jcp.kw_sets; kw++)
+    for (dim_t ind_w = 0; ind_w < dst_width; ind_w++) {
+        auto iw_idx = ind_w * iw_stride - lpad + kw * (jcp.dilate_w + 1);
+        auto dst_off = ind_w * dst_w_offset + kw * ic_block_sz;
+        if (iw_idx < 0 || iw_idx >= iw_len) {
+            // left or right padding
+            zero_ic_block(is_ic_tail, dst_off);
+        } else {
+            auto inp_off = iw_idx * iw_size;
+            copy_ic_block(is_ic_tail, inp_off, dst_off, true);
+        }
+    }
+}
+
+jit_sve_core_brgemm_conv_rtus_kernel_t::jit_sve_core_brgemm_conv_rtus_kernel_t(
+        const jit_brgemm_conv_conf_t &ajcp)
+    : jit_sve_core_brgemm_conv_trans_kernel_t(ajcp) {
+    ic_block_sz = inp_dsz * jcp.LDA; // output may or may not be zero padded
+    dst_h_offset = jcp.iwp * ic_block_sz;
+}
+
+void jit_sve_core_brgemm_conv_rtus_kernel_t::generate() {
+    preamble();
+
+    const XReg &reg_khp = reg_hc;
+    const XReg &reg_kwp = reg_owb;
+
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(src), X_TMP_0);
+    ldr(inp_ptr, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(dst), X_TMP_0);
+    ldr(dst_ptr, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(h_count), X_TMP_0);
+    ldr(reg_khp, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(owb), X_TMP_0);
+    ldr(reg_kwp, ptr(X_DEFAULT_ADDR));
+
+    if (jcp.ic_without_padding % jcp.ic_block) {
+        int tail_size = (jcp.ic_without_padding % jcp.ic_block) % jcp.simd_w;
+        set_preg(ktail_mask.s, tail_size, X_TMP_0, X_TMP_1);
+    }
+
+    if (jcp.ic_block % jcp.simd_w) {
+        int block_tail_size = jcp.ic_block % jcp.simd_w;
+        set_preg(kblock_tail_mask.s, block_tail_size, X_TMP_0, X_TMP_1);
+    }
+
+    assert(jcp.nb_ic_blocking == 1 && "TODO: support multi-batch case");
+
+    for (int icb = 0; icb < jcp.nb_ic_blocking; icb++) {
+        const bool is_ic_tail
+                = (icb + 1) * jcp.ic_block > jcp.ic_without_padding;
+        mov(aux_inp_ptr, inp_ptr);
+        mov(aux_dst_ptr, dst_ptr);
+
+        // Section 1: copy nw spatial elements in a row
+        Label label_kwp_begin, label_kwp_end;
+        cmp_imm(reg_kwp, 0, X_TMP_0);
+        b(LE, label_kwp_end);
+        L(label_kwp_begin);
+        {
+            copy_ic_block(is_ic_tail);
+
+            auto inp_w_step = jcp.stride_w * iw_size;
+            auto out_w_step = ic_block_sz;
+            add_imm(aux_inp_ptr, aux_inp_ptr, inp_w_step, X_TMP_0);
+            add_imm(aux_dst_ptr, aux_dst_ptr, out_w_step, X_TMP_0);
+
+            sub_imm(reg_kwp, reg_kwp, 1, X_TMP_0);
+            cmp_imm(reg_kwp, 0, X_TMP_0);
+            b(NE, label_kwp_begin);
+        }
+        L(label_kwp_end);
+
+        // Section 2: copy nh whole rows of OW spatial elements
+        Label label_khp_begin, label_khp_end;
+        cmp_imm(reg_khp, 0, X_TMP_0);
+        b(LE, label_khp_end);
+        L(label_khp_begin);
+        {
+            for (int ow = 0; ow < jcp.ow; ow++) {
+                auto inp_w_off = ow * jcp.stride_w * iw_size;
+                auto out_w_off = ow * ic_block_sz;
+                copy_ic_block(is_ic_tail, inp_w_off, out_w_off);
+            }
+
+            auto inp_h_step = jcp.stride_h * jcp.iw * iw_size;
+            auto out_h_step = jcp.ow * ic_block_sz;
+            add_imm(aux_inp_ptr, aux_inp_ptr, inp_h_step, X_TMP_0);
+            add_imm(aux_dst_ptr, aux_dst_ptr, out_h_step, X_TMP_0);
+
+            sub_imm(reg_khp, reg_khp, 1, X_TMP_0);
+            cmp_imm(reg_khp, 0, X_TMP_0);
+            b(NE, label_khp_begin);
+        }
+        L(label_khp_end);
+    }
+
+    postamble();
+}
+
+} // namespace jit_sve_core_brgemm_conv_trans_kernel
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
@@ -1,0 +1,118 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_BRGEMM_CONV_TRANS_KERNEL_HPP
+#define CPU_AARCH64_JIT_BRGEMM_CONV_TRANS_KERNEL_HPP
+
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace jit_sve_core_brgemm_conv_trans_kernel {
+struct jit_brgemm_conv_trans_kernel_call_s {
+    const void *src;
+    const void *dst;
+    size_t owb;
+    size_t ic;
+    size_t t_pad;
+    size_t h_count;
+    size_t b_pad;
+};
+
+struct jit_sve_core_brgemm_conv_trans_kernel_t : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_core_brgemm_conv_trans_kernel_t)
+
+    jit_sve_core_brgemm_conv_trans_kernel_t(const jit_brgemm_conv_conf_t &ajcp);
+
+    static int dst_w(const jit_brgemm_conv_conf_t &ajcp, int out_w);
+
+protected:
+    jit_brgemm_conv_conf_t jcp;
+    dim_t inp_dsz;
+    dim_t ic_block_sz;
+    dim_t iw_size, dst_w_block, dst_stride;
+    dim_t dst_h_offset, dst_w_offset;
+    dim_t VL, n_vec, n_tail_vec;
+
+    const XReg inp_ptr = x15;
+    const XReg dst_ptr = x14;
+
+    const XReg aux_inp_ptr = x13;
+    const XReg aux_dst_ptr = x12;
+
+    const XReg reg_hc = x10;
+
+    const XReg reg_ic = x9;
+
+    const XReg reg_owb = x2; //rdx;
+
+    const XReg kh_over = x8;
+    const XReg reg_t_pad = x0; //rax;
+    const XReg reg_b_pad = x3; //rbx;
+
+    const XReg reg_tmp = x6; //rsi;
+
+    const PReg ktail_mask = PReg(2);
+    const PReg kblock_tail_mask = PReg(3);
+
+    const ZReg zmm_tmp = ZReg(0);
+    const ZReg zmm_zero = ZReg(1);
+
+    void load(const ZReg &x, const AdrNoOfs &addr);
+    void load(const ZReg &x, const PReg &p, const AdrNoOfs &addr);
+
+    void store(const AdrNoOfs &addr, const ZReg &x);
+    void store(const AdrNoOfs &addr, const PReg &p, const ZReg &x);
+
+    void zero_ic_block(bool is_ic_tail, dim_t dst_off);
+    void copy_ic_block(
+            bool is_ic_tail, dim_t inp_off, dim_t dst_off, bool do_load);
+    void generate() override;
+    void copy_ow_block(bool is_ic_tail);
+    void copy_ow_block_body(int lpad, int ow_len, int iw_len, bool is_ic_tail);
+
+    int inp_w(int out_w) const;
+    int inp_w(int out_w, int kw) const;
+    int inp_w_start(int owb) const;
+};
+
+struct jit_sve_core_brgemm_conv_rtus_kernel_t
+    : jit_sve_core_brgemm_conv_trans_kernel_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_core_brgemm_conv_rtus_kernel_t)
+
+    jit_sve_core_brgemm_conv_rtus_kernel_t(const jit_brgemm_conv_conf_t &ajcp);
+
+private:
+    void generate() override;
+};
+
+} // namespace jit_sve_core_brgemm_conv_trans_kernel
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino+=l0,\:4,N-s

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -1,0 +1,2512 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "dnnl_types.h"
+
+#include "common/bfloat16.hpp"
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
+#include "cpu/aarch64/cpu_barrier.hpp"
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+#include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/aarch64/jit_brgemm_conv_utils.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/platform.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::status;
+using namespace dnnl::impl::format_tag;
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+using namespace prop_kind;
+using namespace data_type;
+
+namespace {
+bool allow_perf_heuristics(const jit_brgemm_conv_conf_t &jcp) {
+    // Disable performance heuristics for plain weights as there are no other
+    // optimized implementations.
+    if (jcp.wei_plain) return false;
+    return true;
+}
+} // namespace
+
+namespace brgemm_convolution_utils {
+
+bool is_any_eligible(const jit_brgemm_conv_conf_t &jcp) {
+    return (jcp.prop_kind == prop_kind::forward_inference || jcp.wei_plain
+            || one_of(jcp.wei_dt, data_type::s8, data_type::f16)
+            || one_of(jcp.isa, sve_512, sve_256));
+}
+
+inline status_t init_tag(format_tag_t &tag, memory_desc_t &md,
+        const memory_desc_wrapper &mdw, const format_tag_t tag_value,
+        bool any_eligible) {
+
+    if (mdw.format_kind() == format_kind::any) {
+        if (any_eligible) {
+            CHECK(memory_desc_init_by_tag(md, tag_value));
+            tag = tag_value;
+        } else {
+            tag = format_tag::undef;
+        }
+    } else {
+        tag = mdw.matches_one_of_tag(tag_value);
+    }
+
+    if (tag != tag_value) return status::unimplemented;
+
+    return status::success;
+}
+
+bool uses_batch_elements(
+        brgemm_batch_kind_t brg_type, conv_brgemm_exec_type_t exec_type) {
+    // Batch elements are required for all batch kinds except fixed strides.
+    // Batch elements are also required for virtual padding.
+    return IMPLICATION(brg_type == brgemm_strd, exec_type == exec_vpad);
+}
+
+bool post_ops_ok(jit_brgemm_conv_conf_t &jcp, primitive_attr_t &attr,
+        const memory_desc_wrapper &dst_d) {
+    using namespace injector;
+
+    const auto &post_ops = attr.post_ops_;
+
+    return injector::post_ops_ok(post_ops_ok_args_t(jcp.isa,
+            {sum, eltwise, binary}, post_ops, &dst_d,
+            false /*sum_at_pos_0_only*/, false /*sum_requires_scale_one*/,
+            false /*sum_requires_zp_zero*/, true /*sum_requires_same_params*/,
+            {broadcasting_strategy_t::per_oc, broadcasting_strategy_t::scalar,
+                    broadcasting_strategy_t::no_broadcast}));
+}
+
+bool is_groups_ok(jit_brgemm_conv_conf_t &jcp) {
+    // Enable grouped convs for the shapes not supported in direct convs
+    // direct approach only supports int8/bf16 grouped conv
+    // when channels per groups is at least multiple of 4
+    // and bf16 grouped conv with layout nxc on jit_bf16 impl
+    // TODO: remove this condition after the restriction on small ic is removed
+    return jcp.ngroups > 1
+            && IMPLICATION(one_of(jcp.src_dt, u8, s8, bf16),
+                    jcp.ic % 4 == 0 && jcp.oc % 4 == 0);
+}
+
+status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md) {
+    format_tag_t src_tag, dst_tag, wei_tag;
+    dst_tag = pick(jcp.ndims - 3, nwc, nhwc, ndhwc);
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bias_d(&bias_md);
+    const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
+    const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+
+    const bool is_1d = jcp.ndims == 3;
+    const bool is_2d = jcp.ndims == 4;
+    const bool is_3d = jcp.ndims == 5;
+
+    if (jcp.wei_plain) {
+        jcp.LDB = jcp.oc_without_padding;
+        if (is_3d) {
+            switch (vnni_granularity) {
+                case 1: wei_tag = with_groups ? dhwigo : dhwio; break;
+                case 2: wei_tag = with_groups ? gdhwIo2i : dhwIo2i; break;
+                case 4: wei_tag = with_groups ? gdhwIo4i : dhwIo4i; break;
+                default: return status::unimplemented;
+            }
+        } else if (is_1d) {
+            switch (vnni_granularity) {
+                case 1: wei_tag = with_groups ? wigo : wio; break;
+                case 2: wei_tag = with_groups ? gwIo2i : wIo2i; break;
+                case 4: wei_tag = with_groups ? gwIo4i : wIo4i; break;
+                default: return status::unimplemented;
+            }
+        } else {
+            assert(is_2d);
+            UNUSED(is_2d);
+            switch (vnni_granularity) {
+                case 1: wei_tag = with_groups ? hwigo : hwio; break;
+                case 2: wei_tag = with_groups ? ghwIo2i : hwIo2i; break;
+                case 4: wei_tag = with_groups ? ghwIo4i : hwIo4i; break;
+                default: return status::unimplemented;
+            }
+        }
+    } else {
+        jcp.LDB = jcp.oc_block;
+        if (jcp.oc_block == 64) {
+            if (is_3d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOdhwi64o : Odhwi64o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i64o2i
+                                                  : OdhwI16i64o2i;
+                        else
+                            wei_tag = with_groups ? gOdhwI64o2i : OdhwI64o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i64o4i
+                                                  : OdhwI16i64o4i;
+                        else
+                            wei_tag = with_groups ? gOdhwI64o4i : OdhwI64o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else if (is_1d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOwi64o : Owi64o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i64o2i : OwI16i64o2i;
+                        else
+                            wei_tag = with_groups ? gOwI64o2i : OwI64o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i64o4i : OwI16i64o4i;
+                        else
+                            wei_tag = with_groups ? gOwI64o4i : OwI64o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else {
+                assert(is_2d);
+                UNUSED(is_2d);
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOhwi64o : Ohwi64o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i64o2i
+                                                  : OhwI16i64o2i;
+                        else
+                            wei_tag = with_groups ? gOhwI64o2i : OhwI64o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i64o4i
+                                                  : OhwI16i64o4i;
+                        else
+                            wei_tag = with_groups ? gOhwI64o4i : OhwI64o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            }
+        } else if (jcp.oc_block == 48) {
+            if (is_3d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOdhwi48o : Odhwi48o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i48o2i
+                                                  : OdhwI16i48o2i;
+                        else
+                            wei_tag = with_groups ? gOdhwI48o2i : OdhwI48o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i48o4i
+                                                  : OdhwI16i48o4i;
+                        else
+                            wei_tag = with_groups ? gOdhwI48o4i : OdhwI48o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else if (is_1d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOwi48o : Owi48o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i48o2i : OwI16i48o2i;
+                        else
+                            wei_tag = with_groups ? gOwI48o2i : OwI48o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i48o4i : OwI16i48o4i;
+                        else
+                            wei_tag = with_groups ? gOwI48o4i : OwI48o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else {
+                assert(is_2d);
+                UNUSED(is_2d);
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOhwi48o : Ohwi48o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i48o2i
+                                                  : OhwI16i48o2i;
+                        else
+                            wei_tag = with_groups ? gOhwI48o2i : OhwI48o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i48o4i
+                                                  : OhwI16i48o4i;
+                        else
+                            wei_tag = with_groups ? gOhwI48o4i : OhwI48o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            }
+        } else if (jcp.oc_block == 32) {
+            if (is_3d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOdhwi32o : Odhwi32o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i32o2i
+                                                  : OdhwI16i32o2i;
+                        else
+                            wei_tag = with_groups ? gOdhwI32o2i : OdhwI32o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i32o4i
+                                                  : OdhwI16i32o4i;
+                        else
+                            wei_tag = with_groups ? gOdhwI32o4i : OdhwI32o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else if (is_1d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOwi32o : Owi32o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i32o2i : OwI16i32o2i;
+                        else
+                            wei_tag = with_groups ? gOwI32o2i : OwI32o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i32o4i : OwI16i32o4i;
+                        else
+                            wei_tag = with_groups ? gOwI32o4i : OwI32o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else {
+                assert(is_2d);
+                UNUSED(is_2d);
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOhwi32o : Ohwi32o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i32o2i
+                                                  : OhwI16i32o2i;
+                        else
+                            wei_tag = with_groups ? gOhwI32o2i : OhwI32o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i32o4i
+                                                  : OhwI16i32o4i;
+                        else
+                            wei_tag = with_groups ? gOhwI32o4i : OhwI32o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            }
+        } else if (jcp.oc_block == 24) {
+            if (is_3d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOdhwi24o : Odhwi24o; break;
+                    case 2:
+                        wei_tag = with_groups ? gOdhwI24o2i : OdhwI24o2i;
+                        break;
+                    case 4:
+                        wei_tag = with_groups ? gOdhwI24o4i : OdhwI24o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else if (is_1d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOwi24o : Owi24o; break;
+                    case 2: wei_tag = with_groups ? gOwI24o2i : OwI24o2i; break;
+                    case 4: wei_tag = with_groups ? gOwI24o4i : OwI24o4i; break;
+                    default: return status::unimplemented;
+                }
+            } else {
+                assert(is_2d);
+                UNUSED(is_2d);
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOhwi24o : Ohwi24o; break;
+                    case 2:
+                        wei_tag = with_groups ? gOhwI24o2i : OhwI24o2i;
+                        break;
+                    case 4:
+                        wei_tag = with_groups ? gOhwI24o4i : OhwI24o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            }
+        } else if (jcp.oc_block == 16) {
+            if (is_3d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOdhwi16o : Odhwi16o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i16o2i
+                                                  : OdhwI16i16o2i;
+                        else
+                            wei_tag = with_groups ? gOdhwI16o2i : OdhwI16o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOdhwI16i16o4i
+                                                  : OdhwI16i16o4i;
+                        else
+                            wei_tag = with_groups ? gOdhwI16o4i : OdhwI16o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else if (is_1d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOwi16o : Owi16o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i16o2i : OwI16i16o2i;
+                        else
+                            wei_tag = with_groups ? gOwI16o2i : OwI16o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOwI16i16o4i : OwI16i16o4i;
+                        else
+                            wei_tag = with_groups ? gOwI16o4i : OwI16o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else {
+                assert(is_2d);
+                UNUSED(is_2d);
+
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOhwi16o : Ohwi16o; break;
+                    case 2:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i16o2i
+                                                  : OhwI16i16o2i;
+                        else
+                            wei_tag = with_groups ? gOhwI16o2i : OhwI16o2i;
+                        break;
+                    case 4:
+                        if (jcp.is_ic_padded)
+                            wei_tag = with_groups ? gOhwI16i16o4i
+                                                  : OhwI16i16o4i;
+                        else
+                            wei_tag = with_groups ? gOhwI16o4i : OhwI16o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            }
+        } else if (jcp.oc_block == 8) {
+            if (is_3d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOdhwi8o : Odhwi8o; break;
+                    case 2:
+                        wei_tag = with_groups ? gOdhwI8o2i : OdhwI8o2i;
+                        break;
+                    case 4:
+                        wei_tag = with_groups ? gOdhwI8o4i : OdhwI8o4i;
+                        break;
+                    default: return status::unimplemented;
+                }
+            } else if (is_1d) {
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOwi8o : Owi8o; break;
+                    case 2: wei_tag = with_groups ? gOwI8o2i : OwI8o2i; break;
+                    case 4: wei_tag = with_groups ? gOwI8o4i : OwI8o4i; break;
+                    default: return status::unimplemented;
+                }
+            } else {
+                assert(is_2d);
+                UNUSED(is_2d);
+                switch (vnni_granularity) {
+                    case 1: wei_tag = with_groups ? gOhwi8o : Ohwi8o; break;
+                    case 2: wei_tag = with_groups ? gOhwI8o2i : OhwI8o2i; break;
+                    case 4: wei_tag = with_groups ? gOhwI8o4i : OhwI8o4i; break;
+                    default: return status::unimplemented;
+                }
+            }
+        } else {
+            return status::unimplemented;
+        }
+    }
+
+    src_tag = dst_tag;
+
+    const bool any_eligible = is_any_eligible(jcp);
+    CHECK(init_tag(jcp.src_tag, src_md, src_d, src_tag, any_eligible));
+    CHECK(init_tag(jcp.dst_tag, dst_md, dst_d, dst_tag, any_eligible));
+    CHECK(init_tag(jcp.wei_tag, weights_md, weights_d, wei_tag, true));
+
+    return status::success;
+}
+
+struct brg_blocking_t : public jit_brgemm_conv_conf_t {
+    struct array_in_loop_t {
+        dim_t itersize;
+        float repeatn;
+        float overlap;
+        void set(dim_t iter_s, float rpt, float ovlp = 1.f) {
+            itersize = iter_s;
+            repeatn = rpt;
+            overlap = ovlp;
+        }
+    };
+
+    struct loop_t {
+        array_in_loop_t src;
+        array_in_loop_t wei;
+        array_in_loop_t dst;
+    };
+
+    brg_blocking_t() {
+        // TODO: This is a broken form of initialization for a base class.
+        // Either set default values in a base class, or provide a proper
+        // default ctor, or take a `jit_brgemm_conv_conf_t` object to initialize
+        // a base class object.
+        jit_brgemm_conv_conf_t *base
+                = static_cast<jit_brgemm_conv_conf_t *>(this);
+        *base = jit_brgemm_conv_conf_t();
+        init();
+    }
+    brg_blocking_t(const jit_brgemm_conv_conf_t &jcp)
+        : jit_brgemm_conv_conf_t(jcp) {
+        init();
+    }
+    void init() {
+        ur = 0;
+        ur_block = 0;
+        ur_block_tail = 0;
+        eff = 0.f;
+        nb_kd = 0;
+        nb_kh = 0;
+        nb_kw = 0;
+        sp = 0;
+        sp_block = 0;
+        nb_sp = 0;
+        eff = 0;
+        max_regs = isa_num_vregs(isa);
+        bcast_simd = acc_simd_w;
+    }
+
+    int ur, ur_block, ur_block_tail;
+    int nb_kd, nb_kh, nb_kw;
+    int max_regs;
+    int bcast_simd;
+    float eff;
+    static unsigned L1;
+    static unsigned L2;
+    static unsigned L3;
+    // These are rough estimates of the latency (relative) of access to various
+    // cache levels. This is enough for an estimation of data access cost.
+    // TODO: Improve memory access estimates
+    static constexpr float L1_k = 1.f;
+    static constexpr float L2_k = 3.f;
+    static constexpr float L3_k = 15.f;
+    // TODO: At the moment, we are primarily evaluating the fit of the data into
+    // the L1/L2. Need to take into account the difference between the L3 and
+    // memory.
+    static constexpr float mem_k = 15.f;
+    static constexpr int bench_iterations = 1;
+
+    int sp, sp_block, nb_sp;
+    static thread_local int last_ic_block_size;
+
+    void get_from_jcp(const jit_brgemm_conv_conf_t &jcp) { *this = jcp; }
+    void save_to_jcp(jit_brgemm_conv_conf_t &jcp) const { jcp = *this; }
+
+    status_t estimate_brgemm_ur();
+    status_t get_brgemm_ur(
+            const primitive_attr_t *attr, const memory_desc_t &dst_md);
+
+    float io_k(dim_t src, dim_t wei, dim_t dst, float n, float pk,
+            bool is_broadcast, bool is_shared) const;
+
+    float io_k(const loop_t loop, const array_in_loop_t arr, float pk,
+            bool is_broadcast, bool is_shared) const;
+
+    void select_ic_block();
+
+    void update_blocks();
+    bool fast_check_oc_block() const;
+    float est_eff();
+    void iterate_ker_block(brg_blocking_t &best_brgb, int kd_block,
+            int kh_block, bool maybe_use_buffer, int max_ow_block_thr);
+    status_t calc_blocks();
+
+    bool fast_check_oc_block_1x1() const;
+    float est_eff_1x1();
+    void calc_blocks_1x1();
+
+    // utils
+    static int get_inp_size(
+            int max_src_size, int dst_size, int k, int stride, int dilate) {
+        auto adj_str = nstl::min(k, stride);
+        const auto res = nstl::min(max_src_size,
+                calculate_end_padding(0, dst_size, 0, adj_str,
+                        calculate_extended_filter_size(k, dilate)));
+        return res;
+    }
+
+    static float squeeze_val(float eff, float koeff) {
+        if (koeff <= 0) return 1;
+        if (koeff == 1) return eff;
+        const auto k = 1.f / koeff;
+        return (k > 1.f) ? (k - 1 + eff) / k : eff * koeff;
+    }
+
+    static int estimate_ur(int oc_block) {
+        const auto est_ur = (oc_block == 64)
+                ? 6
+                : ((oc_block == 48) ? 9 : ((oc_block == 32) ? 14 : 28));
+        return est_ur;
+    }
+
+    int inp_w(int out_w, int ker_w) const {
+        return get_inp_size(iw, out_w, ker_w, stride_w, dilate_w);
+    }
+
+    int rnd_simd(int val) const { return rnd_up(val, simd_w); }
+
+    int rnd_inp_simd(int out_w, int ker_w, int vic) const {
+        const auto vsp = inp_w(out_w, ker_w);
+        return ((stride_w == 1 && vic >= ic) ? rnd_up(vsp * vic, simd_w)
+                                             : vsp * rnd_up(vic, simd_w));
+    }
+
+    static constexpr int MAXNLOOPS = 32;
+    loop_t loop[MAXNLOOPS];
+};
+
+unsigned brg_blocking_t::L1;
+unsigned brg_blocking_t::L2;
+unsigned brg_blocking_t::L3;
+thread_local int brg_blocking_t::last_ic_block_size;
+
+float brg_blocking_t::io_k(dim_t src, dim_t wei, dim_t dst, float n, float pk,
+        bool is_broadcast, bool is_shared) const {
+    if (n < 1) return 0;
+    if (n == 1) return pk;
+    const auto amount = src * src_dsz + wei * wei_dsz + dst * dst_dsz
+            + (use_buffer ? dst * acc_dsz : 0);
+    const auto amount_L1 = is_broadcast ? src * src_dsz : amount;
+    const auto k = is_broadcast
+            ? ((amount_L1 < L1) ? L1_k
+                                : ((amount < L2) ? L2_k
+                                                 : (is_shared ? L3_k : mem_k)))
+            : ((amount < L2) ? L2_k : (is_shared ? L3_k : mem_k));
+    const auto cost = pk + k * (n - 1);
+    return cost / n;
+}
+
+float brg_blocking_t::io_k(const loop_t loop, const array_in_loop_t arr,
+        float pk, bool is_broadcast, bool is_shared) const {
+    return io_k(loop.src.itersize, loop.wei.itersize, loop.dst.itersize,
+            arr.repeatn * arr.overlap, pk, is_broadcast, is_shared);
+}
+
+void brg_blocking_t::select_ic_block() {
+    auto nb_simd = utils::div_up(ic, simd_w);
+    auto max_simd_blocks = nstl::min(5 * simd_w, nb_simd);
+    const auto nb_icb_eff_threshold = 0.5f;
+    const auto padded_ic = last_ic_block_size * (is_ic_padded ? acc_simd_w : 1);
+
+    const auto est_ur = sp_block > 0
+            ? nstl::min(sp_block, estimate_ur(oc_block))
+            : estimate_ur(oc_block);
+    const auto inp_ur = is_os_blocking ? est_ur : inp_w(est_ur, kw_block);
+
+    if (kw_block > 1) {
+        // try to fit src into L1
+        const auto inp_per_ic = static_cast<unsigned int>(inp_ur) * src_dsz;
+        max_simd_blocks = saturate(1, max_simd_blocks,
+                static_cast<int>(L1 / (inp_per_ic * simd_w)));
+    }
+    // try to fit all batch for ur into L2
+    const bool adjust = wei_plain && math::is_pow2(oc)
+            && utils::everyone_is(1, kd_block, kh_block, kw_block);
+    const int adj_oc_block = adjust ? oc : oc_block; // due to aliasing
+    const auto wei_per_ic = static_cast<unsigned int>(kd_block) * kh_block
+            * kw_block * adj_oc_block * wei_dsz;
+    const auto inp_per_ic
+            = static_cast<unsigned int>(kd_block) * kh_block * inp_ur * src_dsz;
+    const auto out_size = static_cast<unsigned int>(ur) * oc_block * dst_dsz;
+
+    max_simd_blocks = saturate(1, max_simd_blocks,
+            static_cast<int>(
+                    (L2 - out_size) / ((wei_per_ic + inp_per_ic) * simd_w)));
+
+    auto simd_blocks = 1;
+    for (int nb_icb = nstl::min(max_simd_blocks, nb_simd); nb_icb >= 1;
+            nb_icb--) {
+        auto nb_icb_eff = static_cast<float>(nb_simd) / rnd_up(nb_simd, nb_icb);
+        if (nb_icb_eff >= nb_icb_eff_threshold) {
+            simd_blocks = nb_icb;
+            break;
+        }
+    }
+
+    ic_block = nstl::min((exec_type == exec_trans) ? rnd_up(ic, padded_ic) : ic,
+            simd_blocks * simd_w);
+
+    nb_ic = utils::div_up(ic, ic_block);
+}
+
+status_t brg_blocking_t::estimate_brgemm_ur() {
+    // Simple simulation of brgemm_desc init
+    if (sp_block <= 0) return status::invalid_arguments;
+    LDA = is_rtus
+            ? (ic_block)
+            : (kh_sets > 1 ? kh_sets : 1) * (kw_sets > 1 ? kw_sets : stride_w)
+                    * (exec_type == exec_trans ? ic_block
+                                               : ngroups * ic_without_padding);
+    LDB = wei_plain ? oc_without_padding : oc_block;
+    LDC = use_buffer ? oc_block : oc_without_padding;
+
+    const auto padded_ic = last_ic_block_size * (is_ic_padded ? acc_simd_w : 1);
+
+    icp = rnd_up(ic, padded_ic);
+    M = brgM = sp >= sp_block ? sp_block : 0;
+    M_tail = brgM_tail = sp % sp_block;
+    if (is_os_blocking) {
+        if (!is_1x1) M_tail = (oh * ow) % sp_block;
+        oskip = ((ext_kw - 1) / stride_w) * stride_h + (stride_h - 1) * ow;
+
+        brgM = M + oskip * (div_up(M, ow) - 1);
+        brgM_tail = M_tail + oskip * div_up(M_tail, ow);
+    }
+
+    N = oc >= oc_block ? oc_block : 0;
+    N_tail = oc % oc_block;
+
+    K = kh_sets * kw_sets * (ic >= ic_block ? ic_block : 0);
+    K_tail = kh_sets * kw_sets
+            * (exec_type == exec_trans && (!is_bf32)
+                            ? ic_block
+                            : rnd_up(ic % ic_block, last_ic_block_size));
+
+    const auto vK = K > 0 ? K : K_tail;
+    const auto vM = M > 0 ? M : M_tail;
+    const auto vN = N > 0 ? N : N_tail;
+
+    const float alpha = 1.0;
+    const float beta = 0.0;
+    brgemm_t brg;
+    brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
+            brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
+            is_bf32);
+    CHECK(brgemm_utils::brgemm_blocking(&brg));
+    ur = brg.bd_block;
+    ur_block = brg.bd_block;
+    ur_block_tail = 0;
+
+    return status::success;
+}
+
+status_t brg_blocking_t::get_brgemm_ur(
+        const primitive_attr_t *attr, const memory_desc_t &dst_md) {
+    // Detailed simulation of brgemm convolution init
+    if (sp_block <= 0 || ic_block <= 0 || oc_block <= 0)
+        return status::invalid_arguments;
+    CHECK(estimate_brgemm_ur());
+
+    LDD = oc_without_padding;
+
+    const float alpha = 1.0;
+    const float beta = 1.0;
+    const float beta_init = 0.0;
+
+    for (int i = 0; i < M; i++) {
+        auto vM = i + 1;
+        // init only needed brgemm descriptors
+        if ((utils::one_of(exec_type, exec_trans, exec_vpad) || is_1x1)
+                && vM != M && vM != M_tail)
+            continue;
+        for (int i_init = 0; i_init < 2; i_init++) {
+            for_(int i_N = 0; i_N < 2; i_N++)
+            for (int i_K = 0; i_K < 2; i_K++) {
+                auto vbeta = (i_init) ? beta_init : beta;
+                auto vN = (i_N) ? N_tail : N;
+                auto vK = (i_K) ? K_tail : K;
+                if (vN == 0 || vK == 0) continue;
+                brgemm_t brg;
+                brgemm_strides_t brg_strides;
+                brg_strides.stride_a = ngroups * ic_without_padding
+                        * (dilate_w + 1) * src_dsz;
+                // weights are padded by oc_block and last_ic_block
+                brg_strides.stride_b = rnd_up(ic, last_ic_block_size)
+                        * rnd_up(oc, oc_block) * wei_dsz;
+                const auto strides_ptr
+                        = (brg_type == brgemm_strd) ? &brg_strides : nullptr;
+                brgemm_utils::init_brgemm_conf(&brg, isa, brg_type, src_dt,
+                        wei_dt, brgemm_row_major, alpha, vbeta, LDA, LDB, LDC,
+                        vM, vN, vK, strides_ptr, is_bf32);
+                CHECK(brgemm_utils::brgemm_blocking(&brg));
+
+                brgemm_attr_t brgattr;
+                brgattr.max_bs = max_batch;
+                max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
+                brgattr.max_top_vpad = max_vpad;
+                brgattr.max_bottom_vpad = max_vpad;
+                brgattr.fpmath_mode = attr->fpmath_.mode_;
+                CHECK(brgemm_desc_set_attr(&brg, brgattr));
+
+                brg.with_sum = with_sum;
+                CHECK(brgemm_desc_set_postops(
+                        &brg, attr, &dst_md, LDD, bia_dt));
+            }
+        }
+    }
+
+    return status::success;
+}
+
+void brg_blocking_t::update_blocks() {
+    if (sp_block <= 0
+            || utils::one_of(0, od_block, oh_block, ic_block, oc_block,
+                    kd_block, kh_block, kw_block, os_block, ow_block))
+        return;
+
+    nb_od = div_up(od, od_block);
+    nb_oh = div_up(oh, oh_block);
+    nb_ic = div_up(ic, ic_block);
+    nb_oc = div_up(oc, oc_block);
+    nb_kd = div_up(kd, kd_block);
+    nb_kh = div_up(kh, kh_block);
+    nb_kw = div_up(kw, kw_block);
+    nb_ow = div_up(ow, ow_block);
+    if (is_os_blocking) {
+        nb_os = div_up(os, os_block);
+        sp = os;
+        sp_block = os_block;
+        nb_sp = nb_os;
+    } else {
+        sp = ow;
+        sp_block = ow_block;
+        nb_sp = nb_ow;
+        iw_block = get_inp_size(iwp, ow_block, kw, stride_w, dilate_w);
+    }
+}
+
+bool brg_blocking_t::fast_check_oc_block() const {
+    // This function for reducing the number of blocking variants
+    // TODO: eliminate heuristic in this function
+    const auto rnd_oc = rnd_up(oc, acc_simd_w);
+    auto res = false;
+    if (oc_block == 64) {
+        res = (rnd_oc % oc_block == 0 && rnd_oc * wei_dsz < 192 * 4);
+    } else if (oc_block == 48) {
+        const bool big_spatial
+                = id * ih * iw > 81 * stride_d * stride_h * stride_w;
+        res = (rnd_oc % oc_block == 0 && rnd_oc * wei_dsz <= 384 * 4
+                && big_spatial);
+    } else
+        res = true;
+
+    return res;
+}
+
+float brg_blocking_t::est_eff() {
+    const auto ocblock = oc_block / acc_simd_w;
+
+    const auto brgemm_microkernel_eff
+            = (static_cast<float>(ocblock) * ur) / ((ur + ocblock) * max_regs);
+
+    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
+    const auto brgemm_eff = squeeze_val(ur
+                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+                    / 64,
+            0.5f);
+
+    const auto sp_amount = nb_od * nb_oh * nb_sp;
+    const auto work_amount = mb * ngroups * nb_oc * sp_amount;
+    const auto sp_eff = (static_cast<float>(sp) / rnd_up(sp, sp_block));
+
+    const auto thr_eff = static_cast<float>(work_amount)
+            / utils::rnd_up(work_amount, nthr);
+
+    const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+
+    const auto job = div_up(work_amount, nthr);
+
+    auto job_eff = 1.f;
+    if (job < nthr) {
+        std::vector<dim_t> thr_jobs(nthr);
+
+        for (int ithr = 0; ithr < nthr; ithr++) {
+            thr_jobs[ithr] = 0;
+            if (ithr >= work_amount) continue;
+            dim_t thr_job = 0;
+            int start {0}, end {0};
+            balance211(work_amount, nthr, ithr, start, end);
+            int n {0}, g {0}, ocb {0}, odp {0}, ohp {0}, spb {0};
+            if (loop_order == loop_ndhwgc)
+                nd_iterator_init(start, n, mb, odp, od, ohp, oh, spb, nb_sp, g,
+                        ngroups, ocb, nb_oc);
+            else if (loop_order == loop_ngcdhw)
+                nd_iterator_init(start, n, mb, g, ngroups, ocb, nb_oc, odp, od,
+                        ohp, oh, spb, nb_sp);
+
+            for (auto work = start; work < end; work++) {
+                const int ocp = ocb * oc_block;
+                const auto oc_sz = nstl::min(oc - ocp, oc_block);
+                int sp_sz = 0;
+                const int spp = spb * sp_block;
+                sp_sz = nstl::min(sp - spp, sp_block);
+                thr_job += sp_sz * oc_sz;
+
+                if (loop_order == loop_ndhwgc)
+                    nd_iterator_step(n, mb, odp, od, ohp, oh, spb, nb_sp, g,
+                            ngroups, ocb, nb_oc);
+                else if (loop_order == loop_ngcdhw)
+                    nd_iterator_step(n, mb, g, ngroups, ocb, nb_oc, odp, od,
+                            ohp, oh, spb, nb_sp);
+            }
+            thr_jobs[ithr] = thr_job;
+        }
+
+        dim_t max_job = 0;
+        dim_t sum_job = 0;
+        for (int ithr = 0; ithr < nthr; ithr++) {
+            if (thr_jobs[ithr] > max_job) max_job = thr_jobs[ithr];
+            sum_job += thr_jobs[ithr];
+        }
+        job_eff = max_job == 0 ? 1
+                               : static_cast<float>(sum_job) / (max_job * nthr);
+
+    } else {
+        job_eff = thr_eff;
+    }
+
+    const auto ic_blocking_size = ic_block * nb_ic_blocking;
+    const auto oc_blocking_size = oc_block * ic_blocking_size;
+
+    int l = -1;
+
+    // -- brgemm kernel: loop by simd_w  --
+    l++;
+    const auto inp_ur = inp_w(ur, kw_block);
+    loop[l].src.set(inp_ur * simd_w, 1, bcast_simd);
+    loop[l].dst.set(0, 1);
+    loop[l].wei.set(oc_block, 1);
+
+    // -- brgemm kernel: loop by kw in kw_block  --
+    l++;
+    auto src_is = rnd_inp_simd(ur, kw_block, ic_blocking_size);
+    loop[l].src.set(src_is, 1, kw_block);
+    loop[l].dst.set(0, 1);
+    loop[l].wei.set(oc_blocking_size, 1);
+
+    // -- brgemm kernel: loop by batch (grouped by kw_block) in ur  --
+    l++;
+    loop[l].src.set(src_is, 1);
+    loop[l].dst.set(0, 1);
+    auto wei_is = kw_block * oc_blocking_size;
+    loop[l].wei.set(wei_is, 1);
+    // -- brgemm kernel: loop by ur in sp_block --
+    l++;
+    const auto nb_ur = div_up(sp_block, ur);
+    loop[l].src.set(kd_block * kh_block * src_is, 1);
+    loop[l].dst.set(ur * oc_block, 1);
+    wei_is = kd_block * kh_block * kw_block * oc_blocking_size;
+    loop[l].wei.set(wei_is, nb_ur);
+
+    // -- harness: loop by k_blocks in ks --
+    l++;
+    loop[l].src.set(kd_block * kh_block
+                    * rnd_inp_simd(sp_block, kw_block, ic_blocking_size),
+            1);
+    loop[l].dst.set(sp_block * oc_block, nb_kd * nb_kh * nb_kw);
+    loop[l].wei.set(wei_is, 1);
+
+    // -- brgemm kernel: loop by ic_chunks --
+    l++;
+    const auto ic_chunks = div_up(nb_ic, nb_ic_blocking);
+    loop[l].src.set(kd * kh * rnd_inp_simd(sp_block, kw, ic_blocking_size), 1);
+    loop[l].dst.set(sp_block * oc_block, ic_chunks);
+    wei_is = kd * kh * kw * oc_blocking_size;
+    loop[l].wei.set(wei_is, 1);
+
+    const auto dim_oc = (loop_order == loop_ndhwgc) ? 1 : sp_amount;
+    const auto nb_oc_thr = nstl::min(nb_oc, div_up(job, dim_oc));
+    const auto oc_thr = nstl::min(oc, nb_oc_thr * oc_block);
+    const auto nsimd_oc_thr = div_up(oc_thr, simd_w);
+
+    const auto dim_sp = (loop_order == loop_ndhwgc) ? ngroups * nb_oc : 1;
+    const auto nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
+    const auto sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
+
+    int nb_oh_thr {1}, oh_thr {1}, nb_od_thr {1}, od_thr {1};
+    if (!is_os_blocking) {
+        const auto dim_oh = nb_sp * dim_sp;
+        nb_oh_thr = nstl::min(nb_oh, div_up(job, dim_oh));
+        oh_thr = nstl::min(oh, nb_oh_thr * oh_block);
+
+        const auto dim_od = nb_oh * dim_oh;
+        nb_od_thr = nstl::min(nb_od, div_up(job, dim_od));
+        od_thr = nstl::min(od, nb_od_thr * od_block);
+    }
+
+    src_is = kd * kh * rnd_inp_simd(sp_block, kw, ic);
+
+    auto wei_op = kd * kh * kw * ocblock * ic;
+    if (loop_order == loop_ndhwgc) {
+        // -- harness: loop by oc_block --
+        l++;
+        loop[l].src.set(src_is, nb_oc_thr);
+        loop[l].dst.set(sp_block * oc_block, 1);
+        wei_is = kd * kh * kw * oc_block * ic;
+        wei_op = kd * kh * kw * nsimd_oc_thr * ic;
+        loop[l].wei.set(wei_is, 1);
+    }
+
+    // -- harness: loop by sp_blocks --
+    l++;
+    loop[l].src.set(src_is, 1);
+    const auto rnd_oc_for_sp
+            = simd_w * ((loop_order == loop_ndhwgc) ? nsimd_oc_thr : ocblock);
+    loop[l].dst.set(sp_block * rnd_oc_for_sp, 1);
+    loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+    // oh_block almost all is 1. TODO: manage oh_block != 1
+    // -- harness: loop by oh_blocks --
+    l++;
+    src_is = kd * kh * rnd_inp_simd(sp_thr, kw, ic);
+    loop[l].src.set(oh_block * src_is, 1);
+    loop[l].dst.set(sp_thr * rnd_oc_for_sp, 1);
+    loop[l].wei.set(wei_op * simd_w, nb_oh_thr);
+    // od_block almost all is 1. TODO: manage oh_block != 1
+    // -- harness: loop by od_blocks --
+    l++;
+    loop[l].src.set(od_block * oh_thr * src_is, 1);
+    loop[l].dst.set(oh_thr * sp_thr * rnd_oc_for_sp, 1);
+    loop[l].wei.set(wei_op * simd_w, nb_od_thr);
+
+    if (loop_order != loop_ndhwgc) {
+        // -- harness: loop by oc_block --
+        l++;
+        loop[l].src.set(od_thr * oh_thr * src_is, nb_oc_thr);
+        loop[l].dst.set(oc_block * od_thr * oh_thr * sp_thr, 1);
+        loop[l].wei.set(kd * kh * kw * oc_block * ic, 1);
+    }
+
+    // -- harness: loop by mb --
+    l++;
+    const auto mb_thr = nstl::min(mb, div_up(job, sp_amount * ngroups * nb_oc));
+    loop[l].src.set(od_thr * oh_thr * src_is, 1);
+    loop[l].dst.set(od_thr * oh_thr * sp_thr * nsimd_oc_thr * simd_w, 1);
+    loop[l].wei.set(kd * kh * kw * nsimd_oc_thr * simd_w * ic, mb_thr);
+
+    const auto src_op = static_cast<dim_t>(mb_thr) * od_thr * oh_thr * sp_thr
+            * kd * kh * kw * ic;
+    const auto dst_op = static_cast<dim_t>(mb_thr) * od_thr * oh_thr * sp_thr
+            * nsimd_oc_thr;
+    wei_op = kd * kh * kw * nsimd_oc_thr * ic;
+
+    // for "real" application set bench_iterations to 1
+    const auto iterations = bench_iterations;
+    l++;
+    loop[l].src.set(src_op, iterations);
+    loop[l].dst.set(dst_op * simd_w, iterations);
+    loop[l].wei.set(wei_op * simd_w, iterations);
+
+    auto src_mem_k = mem_k;
+    auto dst_mem_k = mem_k;
+    auto wei_mem_k = mem_k;
+    float src_rp = 1;
+    float dst_rp = 1;
+    float wei_rp = 1;
+
+    for (auto il = l; il >= 0; il--) {
+        src_mem_k = io_k(loop[il], loop[il].src, src_mem_k, true,
+                loop_order == loop_ndhwgc ? false : true);
+        dst_mem_k = io_k(loop[il], loop[il].dst, dst_mem_k, false, false);
+        wei_mem_k = io_k(loop[il], loop[il].wei, wei_mem_k, false,
+                loop_order == loop_ndhwgc ? true : false);
+        src_rp *= loop[il].src.repeatn;
+        dst_rp *= loop[il].dst.repeatn;
+        wei_rp *= loop[il].wei.repeatn;
+    }
+    const auto src_ops = (src_op * src_rp) / iterations;
+    const auto dst_ops = (dst_op * dst_rp) / iterations;
+    const auto wei_ops = (wei_op * wei_rp) / iterations;
+
+    const auto src_cost = src_mem_k * src_ops;
+    const auto dst_cost = dst_mem_k * dst_ops;
+    const auto wei_cost = wei_mem_k * wei_ops;
+    const auto call_kernel_cost
+            = 1000.f * job * ic_chunks * nb_kd * nb_kh * nb_kw;
+
+    // Avoid huge batch sizes if possible (ie prefer to block on kd/kh/kw).
+    const float gemm_batch_bytes
+            = sizeof(brgemm_batch_element_t) * gemm_batch_size;
+    const float batch_eff = uses_batch_elements(brg_type, exec_type)
+            ? nstl::min(1.f, L2 / (gemm_batch_bytes))
+            : 1.f;
+
+    const auto cache_eff = (static_cast<dim_t>(mb) * od * oh * sp * ic * oc)
+            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto res_eff = oc_block_eff * brgemm_microkernel_eff * sp_eff
+            * job_eff * ur_eff * cache_eff * brgemm_eff * batch_eff;
+    return res_eff;
+}
+
+void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
+        int kh_block_, bool maybe_use_buffer, int max_ow_block_thr) {
+
+    unsigned est_k_amount = ic * oc_block * wei_dsz;
+
+    kd_block = kd_block_;
+    kh_block = kh_block_;
+    if (one_of(exec_type, exec_vpad, exec_trans)) {
+        kw_block = kw;
+        kd_block_pad = kd_block;
+        kh_block_pad = kh_block;
+        kw_block_pad = kw_block;
+    } else {
+        kw_block = (est_k_amount * kw < L2) ? kw : 1;
+        kd_block_pad = kh_block >= kd ? kd : 1;
+        kh_block_pad = kw_block >= kh ? kh : 1;
+        kw_block_pad = kw;
+    }
+    gemm_batch_size = nb_ic_blocking
+            * nstl::max(kd_block * kh_block * kw_block,
+                    kd_block_pad * kh_block_pad * kw_block_pad);
+
+    sp_block = -1;
+    select_ic_block();
+
+    if (exec_type == exec_vpad) {
+        od_block = 1;
+        oh_block = 1;
+    } else if (exec_type == exec_trans) {
+        const auto w_block_size
+                = 2 * src_dsz * ic_block * iwp + dst_dsz * ow * oc_block;
+        const auto other_size = wei_dsz * kd * kh * kw * ic_block * oc_block;
+        const auto L2_available = nstl::min(static_cast<size_t>(div_up(L2, 2)),
+                other_size > L2 ? 0 : L2 - other_size);
+        if (idp * ihp * w_block_size > L2_available) {
+            od_block = utils::saturate(
+                    1, od, int(L2_available / (ihp * w_block_size)));
+            if (od_block == 1)
+                oh_block = utils::saturate(
+                        1, oh, int(L2_available / (w_block_size)));
+            else
+                oh_block = oh;
+        } else {
+            od_block = 1;
+            oh_block = oh;
+        }
+
+        // limit oh_block to have good threading
+        const auto thr_oc_block = div_up(
+                nthr, mb * div_up((oc > 32 ? ngroups : 1) * oc, oc_block));
+        const auto thr_od_block = div_up(od, thr_oc_block);
+        const auto thr_oh_block
+                = div_up(oh, thr_oc_block * div_up(od, thr_od_block));
+        od_block = nstl::min(od_block, thr_od_block);
+        oh_block = nstl::min(oh_block, thr_oh_block);
+    } else {
+        od_block = 1;
+        oh_block = 1;
+    }
+
+    // --- Select ow_block ----
+    const auto max_ow_block_L2 = ow;
+    auto start_ow_block = nstl::min(max_ow_block_thr, max_ow_block_L2);
+
+    sp = ow;
+    const auto start_sp_block = is_os_blocking ? ow : start_ow_block;
+    auto prev_spb = 0;
+    for (auto ns = 1; ns <= sp; ns++) {
+        const auto spb = div_up(sp, ns);
+        if (spb == prev_spb || spb > start_sp_block) continue;
+        if (is_os_blocking && spb != ow) continue;
+        prev_spb = spb;
+        ow_block = spb;
+        sp_block = ow_block;
+
+        select_ic_block();
+
+        use_buffer = maybe_use_buffer
+                && (ic_block * nb_ic_blocking < ic || kd_block != kd
+                        || kh_block != kh || kw_block != kw
+                        || kd_block_pad != kd || kh_block_pad != kh
+                        || kw_block_pad != kw);
+        if (exec_type == exec_base)
+            use_buffer = use_buffer || (maybe_use_buffer && iwp != iw);
+
+        const status_t st = estimate_brgemm_ur();
+        if (st != status::success) continue;
+        os_block = sp_block = ow_block;
+        update_blocks();
+
+        eff = est_eff();
+
+        if (eff > best_brgb.eff || best_brgb.eff == 0) best_brgb = *this;
+    }
+}
+
+status_t brg_blocking_t::calc_blocks() {
+    sp = ow;
+
+    nb_ic_blocking = 1;
+    // --- Select kernel blocking ---
+    // if dst_dt != acc_dt and we need to store intermediate
+    // results then we need the out buffer
+    const auto maybe_use_buffer = (dst_dt != acc_dt || with_sum);
+
+    std::vector<int> kd_blocks(1), kh_blocks(1);
+    kd_blocks[0] = kd;
+    kh_blocks[0] = kh;
+    if (kd != 1) {
+        kd_blocks.resize(2);
+        kd_blocks[1] = 1;
+    }
+    if (kh != 1) {
+        kh_blocks.resize(2);
+        kh_blocks[1] = 1;
+    }
+
+    const auto thr_eff_threshold = 0.9f;
+    const auto max_ow_block_thr = utils::saturate(1, ow,
+            static_cast<int>(div_up(
+                    mb * ngroups * nb_oc * os, thr_eff_threshold * nthr)));
+
+    ow_block = os_block = sp_block = -1;
+    brg_blocking_t best_brgb = *this;
+    for (const auto &kd_block : kd_blocks) {
+        for (const auto &kh_block : kh_blocks) {
+            iterate_ker_block(best_brgb, kd_block, kh_block, maybe_use_buffer,
+                    max_ow_block_thr);
+        }
+    }
+    *this = best_brgb;
+    if (!IMPLICATION(!is_os_blocking, sp_block > 0))
+        return status::unimplemented;
+
+    if (is_os_blocking) {
+        ow_block = ow;
+        os_block = ow * oh_block;
+        sp_block = os_block;
+        ow_tail = 0;
+    } else {
+        ow_block = os_block = sp_block;
+        ow_tail = ow % ow_block;
+    }
+    update_blocks();
+    return status::success;
+}
+
+bool brg_blocking_t::fast_check_oc_block_1x1() const {
+    // This function for reducing the number of blocking variants
+    // TODO: eliminate heuristic in this function
+    const auto rnd_oc = rnd_up(oc, acc_simd_w);
+    auto res = false;
+    if (oc_block == 64) {
+        const auto big_spatial
+                = od * oh * ow >= 64 * stride_d * stride_h * stride_w;
+        res = (rnd_oc % oc_block == 0 && big_spatial);
+    } else if (oc_block == 48) {
+        const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+        res = (oc_block_eff >= 0.95f);
+    } else
+        res = true;
+
+    return res;
+}
+
+float brg_blocking_t::est_eff_1x1() {
+    const auto ocblock = oc_block / acc_simd_w;
+
+    // TODO: remove this condition
+
+    const auto brgemm_microkernel_eff
+            = (static_cast<float>(ocblock) * ur) / ((ur + ocblock) * max_regs);
+    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
+    const auto brgemm_eff = squeeze_val(ur
+                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+                    / 64,
+            0.5f);
+
+    const auto sp_amount = is_os_blocking ? div_up(nb_os, nb_os_blocking)
+                                          : nb_od * nb_oh * nb_sp;
+    const auto work_amount = mb * ngroups * nb_oc * sp_amount;
+
+    const auto sp_eff = static_cast<float>(sp) / rnd_up(sp, sp_block);
+    const auto thr_eff = static_cast<float>(work_amount)
+            / utils::rnd_up(work_amount, nthr);
+    const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+
+    const auto job = div_up(work_amount, nthr);
+
+    const auto dim_oc = (loop_order == loop_ndhwgc) ? 1 : sp_amount;
+    const auto nb_oc_thr = nstl::min(nb_oc, div_up(job, dim_oc));
+    const auto oc_thr = nstl::min(oc, nb_oc_thr * oc_block);
+    const auto nsimd_oc_thr = div_up(oc_thr, simd_w);
+
+    const auto dim_sp = (loop_order == loop_ndhwgc) ? ngroups * nb_oc : 1;
+    const auto nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
+    const auto sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
+
+    int nb_oh_thr {1}, oh_thr {1}, nb_od_thr {1}, od_thr {1};
+    if (!is_os_blocking) {
+        const auto dim_oh = nb_sp * dim_sp;
+        nb_oh_thr = nstl::min(nb_oh, div_up(job, dim_oh));
+        oh_thr = nstl::min(oh, nb_oh_thr * oh_block);
+
+        const auto dim_od = nb_oh * dim_oh;
+        nb_od_thr = nstl::min(nb_od, div_up(job, dim_od));
+        od_thr = nstl::min(od, nb_od_thr * od_block);
+    }
+
+    auto job_eff = 1.f;
+    if (job < nthr) {
+        std::vector<dim_t> thr_jobs(nthr);
+        for (int ithr = 0; ithr < nthr; ithr++) {
+            thr_jobs[ithr] = 0;
+            if (ithr >= work_amount) continue;
+            dim_t thr_job = 0;
+            int start {0}, end {0};
+            balance211(work_amount, nthr, ithr, start, end);
+            int n {0}, g {0}, ocb {0}, oss {0}, odp {0}, ohp {0}, spb {0};
+            if (loop_order == loop_ndhwgc) {
+                if (is_os_blocking)
+                    nd_iterator_init(start, n, mb, oss, sp_amount, g, ngroups,
+                            ocb, nb_oc);
+                else
+                    nd_iterator_init(start, n, mb, odp, od, ohp, oh, spb, nb_sp,
+                            g, ngroups, ocb, nb_oc);
+            } else if (loop_order == loop_ngcdhw) {
+                if (is_os_blocking)
+                    nd_iterator_init(start, n, mb, g, ngroups, ocb, nb_oc, oss,
+                            sp_amount);
+                else
+                    nd_iterator_init(start, n, mb, g, ngroups, ocb, nb_oc, odp,
+                            od, ohp, oh, spb, nb_sp);
+            }
+
+            for (auto work = start; work < end; work++) {
+                const int ocp = ocb * oc_block;
+                const auto oc_sz = nstl::min(oc - ocp, oc_block);
+                int sp_sz = 0;
+                if (is_os_blocking) {
+                    const auto osb_start = oss * nb_os_blocking;
+                    const auto osb_range
+                            = nstl::min(nb_os - osb_start, nb_os_blocking);
+                    for (int osb = 0; osb < osb_range; osb++) {
+                        const int osp = (osb_start + osb) * sp_block;
+                        sp_sz = nstl::min(os - osp, sp_block);
+                    }
+                } else {
+                    const int spp = spb * sp_block;
+                    sp_sz = nstl::min(sp - spp, sp_block);
+                }
+                thr_job += sp_sz * oc_sz;
+
+                if (loop_order == loop_ndhwgc) {
+                    if (is_os_blocking)
+                        nd_iterator_step(
+                                n, mb, oss, sp_amount, g, ngroups, ocb, nb_oc);
+                    else
+                        nd_iterator_step(n, mb, odp, od, ohp, oh, spb, nb_sp, g,
+                                ngroups, ocb, nb_oc);
+                } else if (loop_order == loop_ngcdhw) {
+                    if (is_os_blocking)
+                        nd_iterator_step(
+                                n, mb, g, ngroups, ocb, nb_oc, oss, sp_amount);
+                    else
+                        nd_iterator_step(n, mb, g, ngroups, ocb, nb_oc, odp, od,
+                                ohp, oh, spb, nb_sp);
+                }
+            }
+            thr_jobs[ithr] = thr_job;
+        }
+
+        dim_t max_job = 0;
+        dim_t sum_job = 0;
+        for (int ithr = 0; ithr < nthr; ithr++) {
+            if (thr_jobs[ithr] > max_job) max_job = thr_jobs[ithr];
+            sum_job += thr_jobs[ithr];
+        }
+
+        job_eff = max_job == 0 ? 1
+                               : static_cast<float>(sum_job) / (max_job * nthr);
+    } else {
+        job_eff = thr_eff;
+    }
+
+    const auto ic_blocking_size = ic_block * nb_ic_blocking;
+    const auto oc_blocking_size = oc_block * ic_blocking_size;
+
+    int l = -1;
+    // -- brgemm kernel: loop by simd_w  --
+    l++;
+    loop[l].src.set(ur * simd_w, 1, bcast_simd);
+    loop[l].dst.set(0, 1);
+    loop[l].wei.set(oc_block, 1);
+
+    // -- brgemm kernel: loop by ur in sp_block --
+    l++;
+    const auto nb_ur = div_up(sp_block, ur);
+    loop[l].src.set(ur * rnd_simd(ic_blocking_size), 1);
+    loop[l].dst.set(ur * oc_block, 1);
+    loop[l].wei.set(oc_blocking_size, nb_ur);
+    // -- brgemm kernel: loop by ic_chunks --
+    l++;
+    const auto ic_chunks = div_up(nb_ic, nb_ic_blocking);
+    loop[l].src.set(sp_block * ic_blocking_size, 1);
+    loop[l].dst.set(sp_block * oc_block, ic_chunks);
+    auto wei_is = oc_blocking_size;
+    auto wei_op = ocblock * ic;
+    loop[l].wei.set(wei_is, 1);
+
+    if (loop_order == loop_ndhwgc) {
+        // -- harness: loop by oc_block --
+        l++;
+        loop[l].src.set(sp_block * rnd_simd(ic), nb_oc_thr);
+        loop[l].dst.set(sp_block * oc_block, 1);
+        wei_is = oc_block * ic;
+        wei_op = nsimd_oc_thr * ic;
+        loop[l].wei.set(wei_is, 1);
+    }
+
+    const auto rnd_oc_for_sp
+            = simd_w * ((loop_order == loop_ndhwgc) ? nsimd_oc_thr : ocblock);
+    if (is_os_blocking) {
+        // -- harness: loop by os_blocks --
+        l++;
+        loop[l].src.set(sp_block * ic_blocking_size, 1);
+        loop[l].dst.set(sp_block * rnd_oc_for_sp, 1);
+        loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+    } else {
+        // -- harness: loop by sp_blocks --
+        l++;
+        loop[l].src.set(sp_block * ic_blocking_size, 1);
+        loop[l].dst.set(sp_block * rnd_oc_for_sp, 1);
+        loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+        // -- harness: loop by oh_blocks --
+        l++;
+        loop[l].src.set(oh_block * sp_thr * rnd_simd(ic_blocking_size), 1);
+        loop[l].dst.set(oh_block * sp_thr * rnd_oc_for_sp, 1);
+        loop[l].wei.set(wei_op * simd_w, nb_oh_thr);
+        // -- harness: loop by od_blocks --
+        l++;
+        loop[l].src.set(
+                od_block * oh_thr * sp_thr * rnd_simd(ic_blocking_size), 1);
+        loop[l].dst.set(od_block * oh_thr * sp_thr * rnd_oc_for_sp, 1);
+        loop[l].wei.set(wei_op * simd_w, nb_od_thr);
+    }
+
+    if (loop_order != loop_ndhwgc) {
+        // -- harness: loop by oc_block --
+        l++;
+        loop[l].src.set(od_thr * oh_thr * rnd_simd(sp_thr * ic_blocking_size),
+                nb_oc_thr);
+        loop[l].dst.set(oc_block * od_thr * oh_thr * sp_thr, 1);
+        loop[l].wei.set(oc_block * ic, 1);
+    }
+
+    // -- harness: loop by mb --
+    l++;
+    const auto mb_thr = nstl::min(mb, div_up(job, sp_amount * ngroups * nb_oc));
+    loop[l].src.set(od_thr * oh_thr * sp_thr * rnd_simd(ic_blocking_size), 1);
+    loop[l].dst.set(nsimd_oc_thr * simd_w * od_thr * oh_thr * sp_thr, 1);
+    loop[l].wei.set(nsimd_oc_thr * ic * simd_w, mb_thr);
+
+    const auto src_op = static_cast<dim_t>(mb_thr) * od_thr * oh_thr * sp_thr
+            * ic_blocking_size;
+    const auto dst_op = static_cast<dim_t>(mb_thr) * nsimd_oc_thr * od_thr
+            * oh_thr * sp_thr;
+    wei_op = nsimd_oc_thr * ic;
+
+    // for "real" application set bench_iterations to 1
+    const auto iterations = bench_iterations;
+    l++;
+    loop[l].src.set(src_op, iterations);
+    loop[l].dst.set(dst_op * simd_w, iterations);
+    loop[l].wei.set(wei_op * simd_w, iterations);
+
+    auto src_mem_k = mem_k;
+    auto dst_mem_k = mem_k;
+    auto wei_mem_k = mem_k;
+    float src_rp = 1;
+    float dst_rp = 1;
+    float wei_rp = 1;
+
+    for (auto il = l; il >= 0; il--) {
+        src_mem_k = io_k(loop[il], loop[il].src, src_mem_k, true, false);
+        dst_mem_k = io_k(loop[il], loop[il].dst, dst_mem_k, false, false);
+        wei_mem_k = io_k(loop[il], loop[il].wei, wei_mem_k, false, true);
+        src_rp *= loop[il].src.repeatn;
+        dst_rp *= loop[il].dst.repeatn;
+        wei_rp *= loop[il].wei.repeatn;
+    }
+    const auto src_ops = (src_op * src_rp) / iterations;
+    const auto dst_ops = (dst_op * dst_rp) / iterations;
+    const auto wei_ops = (wei_op * wei_rp) / iterations;
+
+    const auto src_cost = src_mem_k * src_ops;
+    const auto dst_cost = dst_mem_k * dst_ops;
+    const auto wei_cost = wei_mem_k * wei_ops;
+    const auto call_kernel_cost = 1000.f * job * ic_chunks;
+
+    const auto up_sp_size = is_os_blocking ? 1 : od * oh;
+
+    const auto cache_eff = (static_cast<dim_t>(mb) * up_sp_size * sp * ic * oc)
+            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+
+    const auto res_eff = oc_block_eff * brgemm_microkernel_eff * sp_eff
+            * job_eff * ur_eff * cache_eff * brgemm_eff;
+    return res_eff;
+}
+
+void brg_blocking_t::calc_blocks_1x1() {
+    const bool is_os_blocking_ok
+            = utils::everyone_is(1, stride_d, stride_h) && iw % stride_w == 0;
+    const bool is_ic_zero_padded = ic != ic_without_padding;
+    is_rtus = is_ic_zero_padded;
+    if (is_os_blocking_ok || is_rtus) {
+        sp = os;
+        is_os_blocking = true;
+    } else {
+        sp = ow;
+        is_os_blocking = false;
+    }
+
+    od_block = 1;
+    oh_block = 1;
+    kd_block = kh_block = kw_block = 1;
+    kd_block_pad = kh_block_pad = kw_block_pad = 1;
+    nb_ic_blocking = 1;
+
+    const auto thr_eff_threshold = 0.9f;
+
+    const auto max_sp_block_L2 = os;
+    // TODO: nb_os_blocking always is 1 for now. Update this code
+    nb_os_blocking = 1;
+    int start_sp_block = 0;
+
+    if (is_os_blocking) {
+        ow_block = 0;
+
+        const auto max_os_block_thr
+                = (src_dsz * ic >= 1024 && src_dsz * ic < 4096)
+                ? nstl::max(nstl::min(16, os),
+                        div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
+                : nstl::max(div_up(2048, oc_block),
+                        static_cast<int>(div_up(mb * ngroups * os, nthr)));
+        const auto max_os_block_L2 = max_sp_block_L2;
+
+        auto max_os_block_aliasing = 1000000 / nthr;
+        if ((oc_without_padding * os * dst_dsz) % P4K == 0) {
+            max_os_block_aliasing /= 1;
+            for (auto cur_oc = oc_without_padding;
+                    max_os_block_aliasing * dst_dsz > 400 && cur_oc % 2 == 0
+                    && cur_oc * os * dst_dsz >= P4K;
+                    cur_oc /= 2) {
+                max_os_block_aliasing /= 2;
+            }
+            max_os_block_aliasing += max_os_block_aliasing % 2 ? 0 : 1;
+        }
+        max_os_block_aliasing
+                = nstl::min(div_up(1001, dst_dsz), max_os_block_aliasing);
+
+        start_sp_block = utils::saturate(1, os,
+                nstl::min(nstl::min(max_os_block_thr, max_os_block_L2),
+                        max_os_block_aliasing));
+
+    } else {
+        os_block = 0;
+
+        const auto max_ow_block_thr = utils::saturate(1, ow,
+                static_cast<int>(div_up(
+                        mb * ngroups * nb_oc * os, thr_eff_threshold * nthr)));
+        const auto max_ow_block_L2 = max_sp_block_L2;
+
+        start_sp_block = utils::saturate(
+                1, ow, nstl::min(max_ow_block_thr, max_ow_block_L2));
+    }
+    os_block = ow_block = sp_block = -1;
+    brg_blocking_t best_brgb = *this;
+
+    auto prev_spb = 0;
+    for (auto ns = 1; ns <= sp; ns++) {
+        auto spb = div_up(sp, ns);
+        if (spb == prev_spb || spb > start_sp_block) continue;
+        prev_spb = spb;
+        os_block = ow_block = sp_block = spb;
+        select_ic_block();
+        const status_t st = estimate_brgemm_ur();
+        if (st != status::success) continue;
+        update_blocks();
+
+        use_buffer = (dst_dt != acc_dt || with_sum)
+                && (ic_block * nb_ic_blocking < ic);
+
+        eff = est_eff_1x1();
+        if (eff > best_brgb.eff || best_brgb.eff == 0) best_brgb = *this;
+    }
+    *this = best_brgb;
+    os_block = ow_block = sp_block;
+    update_blocks();
+}
+
+brgemm_broadcast_t get_zp_type(const primitive_attr_t &attr, int arg) {
+    return attr.zero_points_.has_default_values(arg)
+            ? brgemm_broadcast_t::none
+            : brgemm_broadcast_t::per_tensor;
+}
+status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
+    using namespace prop_kind;
+
+    brg_blocking_t::L1 = platform::get_per_core_cache_size(1);
+    brg_blocking_t::L2 = platform::get_per_core_cache_size(2);
+    brg_blocking_t::L3 = platform::get_per_core_cache_size(2);
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bias_d(&bias_md);
+
+    const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
+    int ndims = src_d.ndims();
+
+    jcp = zero<decltype(jcp)>();
+    jcp.isa = isa;
+
+    jcp.ndims = ndims;
+    jcp.prop_kind = cd.prop_kind;
+    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    jcp.mb = src_d.dims()[0];
+    jcp.oc_without_padding = dst_d.dims()[1];
+    jcp.oc = jcp.oc_without_padding / jcp.ngroups;
+    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = jcp.ic_without_padding;
+    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
+    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
+    jcp.iw = src_d.dims()[ndims - 1];
+    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
+    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
+    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
+    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
+    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
+    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
+    jcp.stride_w = cd.strides[ndims - 3];
+
+    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
+    jcp.dilate_w = cd.dilates[ndims - 3];
+
+    jcp.os = jcp.od * jcp.oh * jcp.ow;
+
+    jcp.ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    jcp.ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    jcp.ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+
+    jcp.back_pad = calculate_end_padding(
+            jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, jcp.ext_kd);
+    jcp.b_pad = calculate_end_padding(
+            jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, jcp.ext_kh);
+    jcp.r_pad = calculate_end_padding(
+            jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, jcp.ext_kw);
+
+    jcp.is_1x1 = jcp.f_pad <= 0 && jcp.back_pad <= 0 && jcp.t_pad <= 0
+            && jcp.b_pad <= 0 && jcp.l_pad <= 0 && jcp.r_pad <= 0
+            && utils::everyone_is(1, jcp.kd, jcp.kh, jcp.kw);
+
+    jcp.with_bias = bias_md.format_kind != format_kind::undef;
+
+    jcp.src_dt = src_md.data_type;
+    jcp.dst_dt = dst_md.data_type;
+    jcp.wei_dt = weights_md.data_type;
+    jcp.bia_dt = jcp.with_bias ? bias_md.data_type : data_type::undef;
+
+    if (one_of(jcp.src_dt, u8, s8)) {
+        jcp.acc_dt = s32;
+    } else if (one_of(jcp.src_dt, f32, bf16, f16)) {
+        jcp.acc_dt = f32;
+    } else
+        return status::unimplemented;
+
+    jcp.src_dsz = types::data_type_size(jcp.src_dt);
+    jcp.wei_dsz = types::data_type_size(jcp.wei_dt);
+    jcp.dst_dsz = types::data_type_size(jcp.dst_dt);
+    jcp.acc_dsz = types::data_type_size(jcp.acc_dt);
+    jcp.bia_dsz = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+
+    jcp.simd_w = isa_max_vlen(isa) / jcp.src_dsz;
+    jcp.acc_simd_w = isa_max_vlen(isa) / jcp.acc_dsz;
+    jcp.is_bf32 = false;
+    jcp.wei_plain = everyone_is(true, jcp.wei_dt == data_type::f32,
+            is_superset(isa, sve_512), weights_d.is_plain());
+    if (jcp.wei_plain)
+        CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
+
+    if (one_of(jcp.prop_kind, prop_kind::forward_training,
+                prop_kind::forward_inference)
+            && jcp.ngroups == 1 && jcp.dilate_w == 0 && jcp.kw > 1
+            && jcp.stride_w > 1 && jcp.l_pad <= 0 && jcp.r_pad <= 0) {
+        // such convolutions are equivalent to
+        // [iw / k][kw / k][stride_w / k][ic * k]
+        const bool pure_1d = (jcp.mb == 1 && jcp.id == 1 && jcp.ih == 1);
+        int w_koef = 1;
+        auto w_koef_max = nstl::min(jcp.kw, nstl::min(jcp.stride_w, jcp.iw));
+        for (int i = 1; i <= w_koef_max; i++) {
+            if (IMPLICATION(!pure_1d, jcp.iw % i == 0)
+                    && IMPLICATION(jcp.ic * i > jcp.simd_w,
+                            (jcp.ic * i) % jcp.simd_w == 0)
+                    && jcp.kw % i == 0 && jcp.stride_w % i == 0)
+                w_koef = i;
+        }
+        if (w_koef > 1) {
+            jcp.ic_without_padding *= w_koef;
+            jcp.ic *= w_koef;
+            jcp.iw /= w_koef;
+            jcp.kw /= w_koef;
+            jcp.stride_w /= w_koef;
+            jcp.ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+            jcp.r_pad = calculate_end_padding(
+                    jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, jcp.ext_kw);
+        }
+    }
+
+    brg_blocking_t::last_ic_block_size = data_type_vnni_granularity(jcp.wei_dt);
+
+    // TODO: optimize depthwise convolutions (for now direct approach is faster)
+    const bool is_depthwise
+            = with_groups && jcp.ngroups > 1 && everyone_is(1, jcp.ic, jcp.oc);
+    if (is_depthwise)
+        if (allow_perf_heuristics(jcp)) return status::unimplemented;
+
+    // TODO: optimize grouped convolutions with small ic
+    const bool is_grouped_small_ic
+            = jcp.prop_kind != prop_kind::backward_weights && with_groups
+            && jcp.ngroups > 1
+            && jcp.ic <= jcp.acc_simd_w
+            // Enable the shapes not supported in direct convs
+            && IMPLICATION(with_groups, is_groups_ok(jcp));
+    if (is_grouped_small_ic)
+        if (allow_perf_heuristics(jcp)) return status::unimplemented;
+
+    // TODO: optimize the perf of 3d shape with small ic and large spatial
+
+    const bool is_signed_input = jcp.src_dt == s8;
+    jcp.s8s8_compensation_required = is_signed_input && !isa_has_s8s8(jcp.isa);
+    jcp.has_int8_vnni
+            = is_superset(jcp.isa, sve_512) || is_superset(jcp.isa, sve_256);
+    if (!IMPLICATION(
+                jcp.wei_dt == s8, mayiuse(sve_512) || one_of(jcp.isa, sve_256)))
+        return status::unimplemented;
+    if (!IMPLICATION(jcp.wei_dt == bf16, mayiuse(sve_256)))
+        return status::unimplemented;
+    if (!IMPLICATION(jcp.wei_dt == f16, mayiuse(sve_256)))
+        return status::unimplemented;
+    const bool is_f32
+            = utils::everyone_is(f32, jcp.src_dt, jcp.wei_dt, jcp.dst_dt);
+    if (!IMPLICATION(is_f32, one_of(isa, sve_512, sve_256) || jcp.is_bf32))
+        return status::unimplemented;
+
+    if (!post_ops_ok(jcp, attr, dst_d)) return status::unimplemented;
+
+    const auto &p = attr.post_ops_;
+    jcp.with_sum = p.find(primitive_kind::sum) != -1;
+    const int eltwise_ind = p.find(primitive_kind::eltwise);
+    jcp.with_eltwise = eltwise_ind != -1;
+
+    const int binary_ind = p.find(primitive_kind::binary);
+    const int prelu_ind = p.find(primitive_kind::prelu);
+    jcp.with_binary = !everyone_is(-1, binary_ind, prelu_ind);
+
+    jcp.src_zero_point
+            = get_zp_type(attr, DNNL_ARG_SRC) != brgemm_broadcast_t::none;
+    jcp.dst_zero_point
+            = get_zp_type(attr, DNNL_ARG_DST) != brgemm_broadcast_t::none;
+
+    const bool has_zero_points = jcp.src_zero_point || jcp.dst_zero_point;
+    const bool params_ok
+            = IMPLICATION(has_zero_points, utils::one_of(jcp.src_dt, u8, s8))
+            && IMPLICATION(
+                    jcp.src_zero_point, attr.zero_points_.common(DNNL_ARG_SRC))
+            && IMPLICATION(
+                    jcp.dst_zero_point, attr.zero_points_.common(DNNL_ARG_DST));
+    if (!params_ok) return status::unimplemented;
+
+    jcp.nthr = nthreads;
+    jcp.kh_sets = 1;
+    jcp.kw_sets = 1;
+    jcp.copy_block_only = false;
+    jcp.use_M_mask = 0;
+    jcp.is_os_blocking = false;
+    jcp.oskip = 0;
+    jcp.use_uker = false;
+    jcp.use_interleave_stores = false;
+    jcp.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf_default;
+    jcp.brgemm_bd_loop_innermost = false;
+
+    if (!jcp.wei_plain && jcp.prop_kind != prop_kind::backward_weights) {
+        // fast check data layout before spending time for blocking selection
+        format_tag_t src_tag = pick(jcp.ndims - 3, nwc, nhwc, ndhwc);
+        CHECK(init_tag(
+                jcp.src_tag, src_md, src_d, src_tag, is_any_eligible(jcp)));
+    }
+    if (jcp.with_bias) {
+        if (bias_d.format_kind() == format_kind::any)
+            CHECK(memory_desc_init_by_tag(bias_md, x));
+    }
+
+    jcp.idp = jcp.id + jcp.f_pad + jcp.back_pad;
+    jcp.ihp = jcp.ih + jcp.t_pad + jcp.b_pad;
+    jcp.iwp = jcp.iw + jcp.l_pad + jcp.r_pad;
+
+    return status::success;
+}
+
+status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
+
+    using namespace prop_kind;
+    if (!mayiuse(isa)) return status::unimplemented;
+
+    CHECK(init_jcp(
+            jcp, isa, cd, src_md, weights_md, dst_md, bias_md, attr, nthreads));
+
+    if (jcp.is_1x1)
+        if (allow_perf_heuristics(jcp)) return status::unimplemented;
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bias_d(&bias_md);
+
+    const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
+
+    using namespace data_type;
+    // ======================= blocking =================================
+
+    auto bcast_amount
+            = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw * jcp.src_dsz;
+    auto wei_amount = static_cast<size_t>(jcp.oc) * jcp.kd * jcp.kh * jcp.kw
+            * jcp.wei_dsz;
+
+    jcp.loop_order = (bcast_amount < wei_amount) ? loop_ngcdhw : loop_ndhwgc;
+
+    const int min_oc_block = jcp.acc_simd_w;
+
+    int selected_ur = 0;
+    MAYBE_UNUSED(selected_ur);
+
+    auto try_exec_type = [&]() {
+        brg_blocking_t best_brgb = zero<decltype(best_brgb)>();
+        best_brgb.oc_block = min_oc_block;
+        auto start_ocb = 4;
+        start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
+
+        auto finish_ocb = 1;
+        for (auto ocb = start_ocb; ocb >= finish_ocb; ocb--) {
+            brg_blocking_t cur_brgb = zero<decltype(best_brgb)>();
+            cur_brgb.get_from_jcp(jcp);
+            cur_brgb.oc_block = ocb * jcp.acc_simd_w;
+            cur_brgb.nb_oc = utils::div_up(jcp.oc, cur_brgb.oc_block);
+            if (!cur_brgb.fast_check_oc_block()) continue;
+
+            const status_t blocking_ok = cur_brgb.calc_blocks();
+            if (blocking_ok != status::success) continue;
+
+            const status_t st = cur_brgb.get_brgemm_ur(&attr, dst_md);
+            if (st != status::success) continue;
+            cur_brgb.eff = cur_brgb.est_eff();
+            if (cur_brgb.eff > best_brgb.eff) best_brgb = cur_brgb;
+        }
+        if (best_brgb.oc_block == 0 || best_brgb.ic_block == 0
+                || best_brgb.ow_block == 0)
+            return false;
+        best_brgb.save_to_jcp(jcp);
+        selected_ur = best_brgb.ur;
+        return true;
+    };
+
+    //-----------------------------------------------------------------------
+
+    jcp.exec_type = exec_base;
+    bool try_exec_vpad = false;
+    bool try_exec_trans = false;
+    bool try_exec_base = true;
+
+    if (div_up(jcp.l_pad, jcp.stride_w) < jcp.kw
+            && div_up(jcp.r_pad, jcp.stride_w) < jcp.kw) {
+        try_exec_vpad = true;
+    }
+
+    const auto ic_padded_block
+            = jcp.acc_simd_w * brg_blocking_t::last_ic_block_size;
+
+    bool must_exec_vpad = false;
+
+    // TODO: in future use (kd/kh/kw) and (kd/kh/kw)_pad blocks for more
+    // precise calculation of jcp.max_batch
+    jcp.max_batch = jcp.kd * jcp.kh * jcp.kw;
+
+    bool try_exec_type_res = false;
+
+    if (try_exec_vpad) {
+        jcp.exec_type = exec_vpad;
+        try_exec_type_res = try_exec_type();
+        // to avoid case when both top and bottom virtual padding are non-zero
+        // TODO: remove this restriction
+        const auto iw_block = (jcp.ow_block - 1) * jcp.stride_w + 1;
+        if (!must_exec_vpad && (iw_block > jcp.iw)) try_exec_type_res = false;
+    }
+    if (try_exec_type_res == false && try_exec_trans) {
+        jcp.exec_type = exec_trans;
+
+        // try loop_ndhwgc always for exec_trans
+        jcp.loop_order = loop_ndhwgc;
+
+        // we read input block only once for loop_ndhwgc, so we don't need to
+        // keep it memory
+        if (jcp.loop_order == loop_ndhwgc) { jcp.copy_block_only = true; }
+
+        jcp.is_ic_padded = one_of(jcp.wei_dt, bf16, f16, s8)
+                && jcp.ic * jcp.kw_sets > ic_padded_block;
+
+        try_exec_type_res = try_exec_type();
+    }
+    if (try_exec_base && try_exec_type_res == false) {
+        jcp.exec_type = exec_base;
+        try_exec_type_res = try_exec_type();
+    }
+
+    if (try_exec_type_res == false) return status::unimplemented;
+
+    // ============ end blocking ===========================================
+
+    jcp.brg_type = (jcp.use_uker && jcp.exec_type == exec_trans)
+            ? brgemm_static_offs
+            : brgemm_addr; // TODO: Choose right type of BRGEMM
+
+    if (jcp.ow_block == 0 || jcp.ic_block == 0 || jcp.oc_block == 0)
+        return status::unimplemented;
+
+    // to avoid cache concurrent write access from different threads
+    size_t sc_size = sizeof(brgemm_batch_element_t);
+    jcp.adjusted_batch_size
+            = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
+
+    if (!jcp.wei_plain)
+        CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
+    CHECK(attr.set_default_formats(&dst_md));
+
+    jcp.buffer_size = jcp.LDC * jcp.M;
+
+    jcp.nb_od = div_up(jcp.od, jcp.od_block);
+    jcp.nb_oh = div_up(jcp.oh, jcp.oh_block);
+
+    if (jcp.exec_type == exec_trans) {
+        // TODO: this is rough estimation of buffer for transpose input
+        dim_t ds = jcp.copy_block_only
+                ? (brg_blocking_t::get_inp_size(jcp.idp, jcp.od_block, jcp.kd,
+                           jcp.stride_d, jcp.dilate_d)
+                        + nstl::max(0, jcp.f_pad) + nstl::max(0, jcp.back_pad))
+                : jcp.idp;
+        dim_t hs = jcp.copy_block_only
+                ? (brg_blocking_t::get_inp_size(jcp.ihp, jcp.oh_block, jcp.kh,
+                           jcp.stride_h, jcp.dilate_h)
+                        + nstl::max(0, jcp.t_pad) + nstl::max(0, jcp.b_pad))
+                : jcp.ihp;
+        if (jcp.is_os_blocking)
+            hs = div_up(rnd_up(hs * jcp.iwp, jcp.brgM), jcp.iwp);
+
+        jcp.inp_buffer_size = rnd_up(
+                ds * hs * jcp.iwp * jcp.ngroups * jcp.nb_ic * jcp.LDA, P4K);
+
+        jcp.inp_buffer_mask_size = rnd_up(static_cast<dim_t>(jcp.nb_od)
+                        * jcp.nb_oh * jcp.nb_ow * jcp.ngroups * jcp.nb_ic,
+                P4K);
+    }
+
+    const bool with_pad = jcp.f_pad > 0 || jcp.back_pad > 0 || jcp.t_pad > 0
+            || jcp.b_pad > 0;
+
+    if (jcp.s8s8_compensation_required) {
+        weights_md.extra.flags = 0 | memory_extra_flags::compensation_conv_s8s8;
+        weights_md.extra.compensation_mask = with_groups ? 0x3 : 0x1;
+        if (!jcp.has_int8_vnni) {
+            weights_md.extra.flags |= memory_extra_flags::scale_adjust;
+            weights_md.extra.scale_adjust = 0.5f;
+        }
+    }
+    jcp.scale_adjust_factor
+            = (jcp.s8s8_compensation_required && !jcp.has_int8_vnni)
+            ? 1 / weights_md.extra.scale_adjust
+            : 1.0f;
+    if (jcp.src_zero_point) {
+        weights_md.extra.flags
+                |= memory_extra_flags::compensation_conv_asymmetric_src;
+        weights_md.extra.asymm_compensation_mask = with_groups ? 0x3 : 0x1;
+    }
+
+    const auto &src_scales = attr.scales_.get(DNNL_ARG_SRC);
+    const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
+    jcp.with_scales = !src_scales.has_default_values()
+            || !wei_scales.has_default_values()
+            || jcp.scale_adjust_factor != 1.0f;
+    jcp.is_oc_scale = wei_scales.mask_ != 0;
+
+    // disables the shape with small ic but large spatial
+    // or specific large spatial shapes for int8 conv
+    const auto is_ok_large_spatial
+            = IMPLICATION(jcp.ic <= 128,
+                      jcp.od * jcp.oh < 100
+                              || jcp.ic * jcp.oc_block * jcp.ow_block > 8192)
+            && !(jcp.oc == 1024
+                    && utils::everyone_is(1, jcp.od, jcp.oh, jcp.kd, jcp.kh)
+                    && jcp.ow >= 595 && jcp.kw <= 5);
+    if (one_of(jcp.src_dt, u8, s8) && !is_ok_large_spatial)
+        if (allow_perf_heuristics(jcp)) return status::unimplemented;
+
+    // For padding shapes, we calculate the comp along with the computation
+    // inside brgemm kernel when output size is small to get optimal perf
+    // Or we calculate the comp using brgemm_coomp_pad kernel
+    const auto output_sz = static_cast<dim_t>(jcp.mb) * jcp.ngroups * jcp.oc
+            * jcp.od * jcp.oh * jcp.ow;
+    const auto comp_with_pads
+            = (jcp.src_zero_point || jcp.s8s8_compensation_required)
+            && IMPLICATION(jcp.exec_type == exec_vpad, with_pad);
+    jcp.req_brg_comp_pad = comp_with_pads && output_sz <= 8192 && jcp.oc < 512;
+    jcp.req_cal_comp_pad = comp_with_pads && !jcp.req_brg_comp_pad;
+
+    // estimate the number of kernel range combination for compensation
+    const auto kd_cnt = 1 + utils::div_up(abs(jcp.f_pad), jcp.dilate_d + 1)
+            + utils::div_up(abs(jcp.back_pad), jcp.dilate_d + 1);
+    const auto kh_cnt = 1 + utils::div_up(abs(jcp.t_pad), jcp.dilate_h + 1)
+            + utils::div_up(abs(jcp.b_pad), jcp.dilate_h + 1);
+    const auto kw_cnt
+            = (1
+                      + (utils::div_up(abs(jcp.l_pad), jcp.dilate_w + 1)
+                              + utils::div_up(
+                                      abs(jcp.r_pad), jcp.dilate_w + 1)))
+            * 2;
+
+    jcp.ker_ranges_size = jcp.exec_type == exec_base ? kd_cnt * kh_cnt * kw_cnt
+                                                     : kd_cnt * kh_cnt;
+    jcp.comp_a_buffer_size
+            = jcp.ngroups * jcp.nb_oc * jcp.ker_ranges_size * jcp.oc_block;
+    jcp.s8s8_comp_buffer_size = jcp.comp_a_buffer_size;
+
+    // enable ununroll_bd_loop for big shapes to reduce kernel sizes
+    jcp.ununroll_bd_loop
+            = static_cast<dim_t>(jcp.M) * jcp.N * (jcp.is_bf32 ? 1 : 2)
+            > 8 * 1024;
+
+    if (!IMPLICATION(jcp.is_bf32, jcp.use_uker)) return status::unimplemented;
+
+    return status::success;
+}
+
+status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
+
+    using namespace prop_kind;
+    if (!mayiuse(isa)) return status::unimplemented;
+
+    CHECK(init_jcp(
+            jcp, isa, cd, src_md, weights_md, dst_md, bias_md, attr, nthreads));
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper weights_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bias_d(&bias_md);
+
+    if (!jcp.is_1x1) return status::unimplemented;
+
+    using namespace data_type;
+    // ===================== blocking =================================
+
+    auto bcast_amount
+            = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw * jcp.src_dsz;
+    auto wei_amount = static_cast<size_t>(jcp.oc) * jcp.wei_dsz;
+
+    jcp.loop_order = (bcast_amount < wei_amount) ? loop_ngcdhw : loop_ndhwgc;
+
+    const auto min_oc_block = jcp.acc_simd_w;
+
+    jcp.brg_type = brgemm_addr; // TODO: Choose right type of BRGEMM
+
+    // max_batch is 1 for 1x1 convolutions
+    jcp.max_batch = 1;
+
+    brg_blocking_t best_brgb = zero<decltype(best_brgb)>();
+    best_brgb.oc_block = min_oc_block;
+    auto start_ocb = 4;
+    start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
+
+    auto finish_ocb = 1;
+
+    const bool is_os_blocking_ok
+            = utils::everyone_is(1, jcp.stride_d, jcp.stride_h)
+            && jcp.iw % jcp.stride_w == 0;
+    if (jcp.wei_plain && is_os_blocking_ok) {
+        start_ocb = div_up(jcp.oc, jcp.acc_simd_w);
+    }
+
+    for (auto ocb = start_ocb; ocb >= finish_ocb; ocb--) {
+        brg_blocking_t cur_brgb = zero<decltype(cur_brgb)>();
+        cur_brgb.get_from_jcp(jcp);
+        cur_brgb.oc_block = ocb * min_oc_block;
+        cur_brgb.nb_oc = utils::div_up(jcp.oc, cur_brgb.oc_block);
+
+        if (!cur_brgb.fast_check_oc_block_1x1()) continue;
+
+        cur_brgb.calc_blocks_1x1();
+        const status_t st = cur_brgb.get_brgemm_ur(&attr, dst_md);
+        if (st != status::success) continue;
+        cur_brgb.eff = cur_brgb.est_eff_1x1();
+        if (cur_brgb.eff > best_brgb.eff) best_brgb = cur_brgb;
+    }
+    best_brgb.save_to_jcp(jcp);
+
+    // =============== end blocking =================================
+    jcp.brg_stride_a = jcp.ic_block * jcp.src_dsz;
+    jcp.brg_stride_b = jcp.ic_block * jcp.oc_without_padding * jcp.wei_dsz;
+
+    if (jcp.ic_block == 0 || jcp.oc_block == 0) return status::unimplemented;
+
+    // Configure matrix sizes
+
+    if (best_brgb.is_os_blocking) {
+        if (jcp.os_block == 0) return status::unimplemented;
+        jcp.M = jcp.brgM = jcp.os_block;
+        jcp.M_tail = jcp.brgM_tail = jcp.os % jcp.os_block;
+    } else {
+        if (jcp.ow_block == 0) return status::unimplemented;
+        jcp.M = jcp.brgM = jcp.ow_block;
+        jcp.M_tail = jcp.brgM_tail = jcp.ow % jcp.ow_block;
+    }
+
+    jcp.K = jcp.ic >= jcp.ic_block ? jcp.ic_block : 0;
+    jcp.N = jcp.oc >= jcp.oc_block ? jcp.oc_block : 0;
+    jcp.N_tail = jcp.oc % jcp.oc_block;
+    jcp.K_tail = jcp.ic % jcp.ic_block;
+
+    jcp.gemm_batch_size = jcp.nb_ic_blocking;
+    // to avoid cache concurrent access from different threads
+    size_t sc_size = sizeof(brgemm_batch_element_t);
+    jcp.adjusted_batch_size
+            = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
+
+    // TODO: heuristic to dispatch BF32 BRGeMM
+    // The following condition checks for shapes where down-convert execution
+    // in brgemm fails
+    if (jcp.is_bf32 && jcp.ic < 64 && jcp.ic % 32 != 0)
+        return status::unimplemented;
+
+    if (jcp.use_uker)
+        jcp.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf1;
+    if (!jcp.wei_plain)
+        CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
+    CHECK(attr.set_default_formats(&dst_md));
+
+    const bool with_groups = weights_d.ndims() == src_d.ndims() + 1;
+
+    // no inp buffer or brgemm_vpad for 1x1
+    constexpr int align_size = platform::get_cache_line_size();
+    jcp.exec_type = jcp.is_rtus ? exec_trans : exec_base;
+    jcp.inp_buffer_size
+            = jcp.is_rtus ? rnd_up(jcp.LDA * jcp.os, align_size) : 0;
+    jcp.inp_buffer_mask_size = jcp.is_rtus
+            ? rnd_up(div_up(jcp.nb_ic, jcp.nb_ic_blocking) * jcp.nb_os,
+                    align_size)
+            : 0;
+    jcp.buffer_size = jcp.LDC * jcp.M;
+
+    if (jcp.s8s8_compensation_required) {
+        weights_md.extra.flags = 0 | memory_extra_flags::compensation_conv_s8s8;
+        weights_md.extra.compensation_mask = with_groups ? 0x3 : 0x1;
+        if (!jcp.has_int8_vnni) {
+            weights_md.extra.flags |= memory_extra_flags::scale_adjust;
+            weights_md.extra.scale_adjust = 0.5f;
+        }
+    }
+    jcp.scale_adjust_factor
+            = (jcp.s8s8_compensation_required && !jcp.has_int8_vnni)
+            ? 1 / weights_md.extra.scale_adjust
+            : 1.0f;
+    if (jcp.src_zero_point) {
+        weights_md.extra.flags
+                |= memory_extra_flags::compensation_conv_asymmetric_src;
+        weights_md.extra.asymm_compensation_mask = with_groups ? 0x3 : 0x1;
+    }
+    jcp.req_cal_comp_pad = false;
+    jcp.s8s8_comp_buffer_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    jcp.comp_a_buffer_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+
+    const auto &src_scales = attr.scales_.get(DNNL_ARG_SRC);
+    const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
+    jcp.with_scales = !src_scales.has_default_values()
+            || !wei_scales.has_default_values()
+            || jcp.scale_adjust_factor != 1.0f;
+    jcp.is_oc_scale = wei_scales.mask_ != 0;
+
+    // enable ununroll_bd_loop for big shapes to reduce kernel sizes
+    jcp.ununroll_bd_loop
+            = static_cast<dim_t>(jcp.M) * jcp.N * (jcp.is_bf32 ? 1 : 2)
+            > 8 * 1024;
+
+    return status::success;
+}
+
+void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+        const jit_brgemm_conv_conf_t &jcp) {
+    if (uses_batch_elements(jcp.brg_type, jcp.exec_type)) {
+        scratchpad.book(key_brgemm_primitive_batch,
+                static_cast<size_t>(jcp.nthr) * jcp.adjusted_batch_size,
+                sizeof(brgemm_batch_element_t), 64, P4K);
+    }
+    if (jcp.exec_type == exec_trans) {
+        size_t inp_buffer_size
+                = static_cast<size_t>(jcp.nthr) * jcp.inp_buffer_size;
+        scratchpad.book(key_conv_brgemm_inp_buffer, inp_buffer_size,
+                jcp.src_dsz, 0, P4K);
+        size_t inp_buffer_mask_size
+                = static_cast<size_t>(jcp.nthr) * jcp.inp_buffer_mask_size;
+        scratchpad.book(key_conv_brgemm_inp_buffer_mask, inp_buffer_mask_size,
+                sizeof(uint8_t), 0, P4K);
+    }
+    if (jcp.use_buffer) {
+        scratchpad.book(key_brgemm_primitive_buffer, jcp.nthr * jcp.buffer_size,
+                jcp.acc_dsz, 0, P4K);
+    }
+    if (jcp.s8s8_compensation_required && jcp.req_cal_comp_pad) {
+        scratchpad.book(key_brgemm_primitive_buffer_comp,
+                jcp.s8s8_comp_buffer_size, sizeof(int32_t), 0, P4K);
+    }
+    if (jcp.src_zero_point && jcp.req_cal_comp_pad) {
+        scratchpad.book(key_brgemm_primitive_zp_comp_a, jcp.comp_a_buffer_size,
+                sizeof(int32_t), 0, P4K);
+    }
+}
+
+void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
+
+    const auto os_chunks = jcp.nthr_mb_work;
+    const auto oc_chunks = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
+    const auto ic_chunks = div_up(jcp.nb_ic, jcp.nb_ic_blocking);
+
+    auto calc_mem_cost = [=](int nthr_mb, int nthr_g, int nthr_oc_b,
+                                 int nthr_ic_b) {
+        /* calculate per thread memory cost (read/write). high level
+            * optimizer tries to minimize memory consumption. few notes:
+            *  (n1) if weights tensor size is less than source and destination
+            *       tensors we apply the ratio of the source and destination
+            *       tensor sizes to weights one as compensation coefficient to
+            *       avoid parallelization across batch size only, otherwise we
+            *       apply additional coefficient to source component based on
+            *       performance measurements
+            *  (n2) use scales based on output vs input channels ratio for
+            *       source and destination components to improve threading
+            *       balance across input and output channels */
+
+        const dim_t src_type_size = 2;
+        const dim_t wei_type_size = 4;
+        const dim_t acc_type_size = wei_type_size;
+
+        const auto wei_ks = jcp.kh * jcp.kw * jcp.kd;
+
+        const auto src_spatial = (dim_t)jcp.mb * jcp.id * jcp.ih * jcp.tr_iw;
+        const auto dst_spatial = (dim_t)jcp.mb * jcp.od * jcp.oh * jcp.tr_ow;
+
+        dim_t src_size = src_spatial * jcp.ic * src_type_size;
+        dim_t dst_size = dst_spatial * jcp.oc * src_type_size;
+        dim_t wei_size = (dim_t)jcp.oc * jcp.ic * wei_ks * wei_type_size;
+
+        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
+        float oi_channels_ratio = (float)(oc_chunks) / ic_chunks;
+
+        auto get_src_coef = [=]() {
+            float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
+            if (wei_compensation_scale < 1.0f) src_coef *= 4.0f;
+            return src_coef;
+        };
+
+        auto get_dst_coef
+                = [=]() { return nstl::max(oi_channels_ratio, 1.0f); };
+
+        auto get_wei_coef
+                = [=]() { return nstl::max(wei_compensation_scale, 1.0f); };
+
+        const float src_coef = get_src_coef();
+        const float dst_coef = get_dst_coef();
+        const float wei_coef = get_wei_coef();
+
+        const auto thr_mb = div_up(os_chunks, nthr_mb);
+        const auto nb_oc_job = jcp.oc_block * jcp.nb_oc_blocking;
+        const auto nb_ic_job = jcp.ic_block * jcp.nb_ic_blocking;
+
+        const auto src_chunk = src_spatial / os_chunks;
+        const auto dst_chunk = dst_spatial / os_chunks;
+
+        const auto thr_g = div_up(jcp.ngroups, nthr_g);
+        const auto thr_ic_b = div_up(ic_chunks, nthr_ic_b);
+        const auto thr_src_sp = thr_mb * src_chunk / jcp.stride_d / jcp.stride_h
+                / jcp.stride_w;
+        const auto thr_dst_sp = thr_mb * dst_chunk;
+        const auto thr_ic_amount = thr_ic_b * nb_ic_job;
+
+        const auto thr_oc_b = div_up(oc_chunks, nb_oc_job * nthr_oc_b);
+
+        const auto thr_oc_amount = thr_oc_b * nb_oc_job;
+        float src_v
+                = src_type_size * src_coef * thr_g * thr_ic_amount * thr_src_sp;
+        float dst_v
+                = src_type_size * dst_coef * thr_g * thr_oc_amount * thr_dst_sp;
+        float wei_v = acc_type_size * wei_coef * thr_g * thr_oc_amount
+                * thr_ic_amount * wei_ks;
+
+        return src_v + dst_v + wei_v;
+    };
+
+    auto balance = [=](int &nthr_, int &nthr_mb_, int &nthr_g_, int &nthr_oc_b_,
+                           int &nthr_ic_b_) {
+        nthr_ = nthr_mb_ = nthr_g_ = nthr_oc_b_ = nthr_ic_b_ = 1;
+
+        if (jcp.nthr < jcp.ngroups) {
+            /* simplification... fortunately it doesn't hurt much */
+            nthr_ = nthr_g_ = jcp.nthr;
+            return;
+        }
+
+        nthr_g_ = jcp.ngroups;
+        const int nthr = jcp.nthr / nthr_g_;
+
+        float best_mem_cost
+                = calc_mem_cost(nthr_mb_, nthr_g_, nthr_oc_b_, nthr_ic_b_);
+
+        /* find the best thread distribution with lowest memory cost */
+
+        const int nthr_mb_max = nstl::min(nthr, jcp.nthr_mb_work);
+        for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
+            const int nthr_par = nthr / nthr_mb;
+            const int nthr_oc_b_max = nstl::min(nthr_par,
+                    oc_chunks); // Amount of nb_oc_blocks
+            for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
+                int nthr_ic_b = nstl::min(
+                        nthr_par / nthr_oc_b, (jcp.nb_ic / jcp.nb_ic_blocking));
+
+                float mem_cost
+                        = calc_mem_cost(nthr_mb, nthr_g_, nthr_oc_b, nthr_ic_b);
+                if (mem_cost <= best_mem_cost) {
+                    best_mem_cost = mem_cost;
+                    nthr_mb_ = nthr_mb;
+                    nthr_oc_b_ = nthr_oc_b;
+                    nthr_ic_b_ = nthr_ic_b;
+                }
+            }
+        }
+
+        if (nthr_mb_ > nthr / 2 && nthr_mb_ < nthr)
+            nthr_mb_ = nstl::min(jcp.nthr_mb_work, nthr);
+        nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
+
+        assert(nthr_ <= jcp.nthr);
+    };
+
+    int nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b;
+    balance(nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b);
+
+    // empiric balancing for some shapes
+    const auto sps = (jcp.ih * jcp.iw);
+    bool neat_1x1
+            = everyone_is(1, jcp.id, jcp.kh, jcp.kw, jcp.ngroups, jcp.stride_h);
+    if (neat_1x1 && jcp.nthr >= 28 && jcp.mb >= jcp.nthr) {
+        const bool more_oc = (jcp.ic < jcp.oc);
+        if (sps >= 56 * 56 && jcp.ic >= 64 && jcp.oc >= 64) {
+            nthr_mb = jcp.nthr;
+            nthr_oc_b = 1;
+        } else if (sps >= 28 * 28 && jcp.ic >= 128 && jcp.oc >= 128) {
+            nthr_mb = jcp.nthr / 4;
+            nthr_oc_b = more_oc ? jcp.nthr / nthr_mb : 1;
+        } else if (sps >= 14 * 14 && jcp.ic >= 256 && jcp.oc >= 256) {
+            nthr_mb = div_up(jcp.nthr, 8);
+            nthr_oc_b = more_oc ? jcp.nthr / nthr_mb : 1;
+        } else if (sps >= 7 * 7 && jcp.ic >= 512 && jcp.oc >= 512) {
+            nthr_mb = div_up(jcp.nthr, 14);
+            nthr_oc_b = more_oc ? jcp.nthr / nthr_mb : 1;
+        }
+        nthr_ic_b = jcp.nthr / (nthr_mb * nthr_oc_b);
+        nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
+    } else if (jcp.ngroups == 1 && (jcp.oc > 2048 || jcp.ic > 2048)) {
+        const bool more_oc = (jcp.ic < jcp.oc);
+        if (more_oc) {
+            nthr_oc_b = div_up(jcp.nthr, 8);
+            nthr_mb = div_up(jcp.nthr / nthr_oc_b, 2);
+            nthr_ic_b = jcp.nthr / (nthr_mb * nthr_oc_b);
+        } else {
+            nthr_ic_b = div_up(jcp.nthr, 8);
+            nthr_mb = div_up(jcp.nthr / nthr_ic_b, 2);
+            nthr_oc_b = jcp.nthr / (nthr_mb * nthr_ic_b);
+        }
+        nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
+    } else if (jcp.kw > 100 && jcp.id == 1 && jcp.ih == 1) {
+        nthr_g = nstl::min(jcp.nthr, jcp.ngroups);
+        nthr_oc_b = nstl::min(jcp.nthr / nthr_g, div_up(jcp.nb_oc, 2));
+        nthr_ic_b = nstl::min(
+                jcp.nthr / (nthr_g * nthr_oc_b), div_up(jcp.nb_ic, 2));
+        nthr_mb = jcp.nthr / (nthr_g * nthr_oc_b * nthr_ic_b);
+        nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
+    }
+
+    jcp.nthr = nthr;
+    jcp.nthr_mb = nthr_mb;
+    jcp.nthr_g = nthr_g;
+    jcp.nthr_oc_b = nthr_oc_b;
+    jcp.nthr_ic_b = nthr_ic_b;
+}
+
+status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &diff_weights_md, memory_desc_t &diff_bias_md,
+        memory_desc_t &diff_dst_md, primitive_attr_t &attr, int nthreads) {
+
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper diff_weights_d(&diff_weights_md);
+    const memory_desc_wrapper diff_dst_d(&diff_dst_md);
+    const memory_desc_wrapper diff_bias_d(&diff_bias_md);
+
+    return status::unimplemented;
+
+    return status::success;
+}
+
+status_t init_scratchpad_bwd_w(memory_tracking::registrar_t &scratchpad,
+        const jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
+        memory_desc_t &diff_weights_md, memory_desc_t &diff_dst_md) {
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper diff_weights_d(&diff_weights_md);
+    const memory_desc_wrapper diff_dst_d(&diff_dst_md);
+
+    const size_t tr_src_size = jcp.tr_src_buf_count * jcp.tr_src_buf_size
+            + jcp.tr_src_num_guard_elems;
+    scratchpad.book(key_conv_tr_src, tr_src_size, jcp.src_dsz);
+
+    /* prepare synchronization contexts */
+    if (jcp.global_transpose && jcp.nthr_oc_b > 1) {
+        const int tr_src_bctx_size = jcp.nthr / jcp.nthr_oc_b;
+        scratchpad.book<simple_barrier::ctx_t>(
+                key_conv_tr_src_bctx, tr_src_bctx_size);
+    }
+
+    // The tr_ow <= tr_iw, so we need some guarding at the end of diff_dst
+    // TODO: update this guarding:
+    // (jcp.tr_diff_dst_buf_size + jcp.tr_iw * jcp.oc_block)
+    const auto tr_diff_dst_size
+            = jcp.tr_diff_dst_buf_count * jcp.tr_diff_dst_buf_size
+            + jcp.tr_iw * jcp.oc_block;
+
+    const size_t min_align = 64;
+    scratchpad.book(
+            key_conv_tr_diff_dst, tr_diff_dst_size, jcp.src_dsz, min_align);
+
+    /* prepare synchronization contexts */
+    if (jcp.global_transpose && jcp.nthr_ic_b > 1) {
+        const size_t tr_diff_dst_bctx_size = jcp.nthr / jcp.nthr_ic_b;
+        scratchpad.book<simple_barrier::ctx_t>(
+                key_conv_tr_diff_dst_bctx, tr_diff_dst_bctx_size);
+    }
+
+    if (IMPLICATION(jcp.nthr_mb == 1,
+                (jcp.with_bias && jcp.bia_dt != data_type::f32)
+                        || jcp.wei_dt != data_type::f32)) {
+        const size_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block
+                * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
+        const size_t bia_size
+                = jcp.with_bias * jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+
+        const int num_wei_buffers
+                = jcp.wei_dt != data_type::f32 ? jcp.nthr_mb : jcp.nthr_mb - 1;
+        const int num_bia_buffers = jcp.with_bias
+                ? (jcp.bia_dt != data_type::f32 ? jcp.nthr_mb : jcp.nthr_mb - 1)
+                : 0;
+
+        const size_t wei_bia_reduction_size
+                = wei_size * num_wei_buffers + bia_size * num_bia_buffers;
+
+        scratchpad.book<float>(
+                key_conv_wei_bia_reduction, wei_bia_reduction_size);
+
+        scratchpad.book<simple_barrier::ctx_t>(
+                key_conv_wei_bia_reduction_bctx, 1);
+    }
+
+    if (jcp.with_bias
+            && ((jcp.oc % jcp.oc_block != 0) && jcp.bia_dt == data_type::f32)) {
+        scratchpad.book(key_conv_padded_bias,
+                jcp.ngroups * jcp.nb_oc * jcp.oc_block, jcp.bia_dsz);
+    }
+
+    constexpr size_t scratchpad_limit_by_absolute_value = (size_t)32
+            << 30; // 32Gb - TODO: may it's too large?
+    const size_t scratchpad_limit_by_tensor_sizes = (size_t)64 * jcp.nthr
+            * (src_d.size() + diff_weights_d.size() + diff_dst_d.size());
+    const size_t scratchpad_limit
+            = nstl::min(scratchpad_limit_by_absolute_value,
+                    scratchpad_limit_by_tensor_sizes);
+
+    scratchpad.book(key_brgemm_primitive_batch,
+            static_cast<size_t>(jcp.nthr) * jcp.adjusted_batch_size,
+            sizeof(brgemm_batch_element_t), 64, P4K);
+
+    if (scratchpad.size() > scratchpad_limit)
+        return status::unimplemented;
+    else
+        return status::success;
+}
+
+} // namespace brgemm_convolution_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.hpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+* Copyright 2021-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef CPU_AARCH64_JIT_BRGEMM_CONV_UTILS_HPP
+#define CPU_AARCH64_JIT_BRGEMM_CONV_UTILS_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_tracking.hpp"
+
+#include "cpu/aarch64/brgemm/brgemm.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+#include "cpu/cpu_convolution_pd.hpp"
+#include "cpu/cpu_engine.hpp"
+#include "cpu/platform.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace brgemm_convolution_utils {
+
+constexpr size_t P4K = 4096;
+
+bool uses_batch_elements(
+        brgemm_batch_kind_t brg_type, conv_brgemm_exec_type_t exec_type);
+
+status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads);
+
+status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads);
+
+void init_scratchpad(memory_tracking::registrar_t &scratchpad,
+        const jit_brgemm_conv_conf_t &jcp);
+
+status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &diff_weights_md, memory_desc_t &diff_bias_md,
+        memory_desc_t &diff_dst_md, primitive_attr_t &attr, int nthreads);
+
+status_t init_scratchpad_bwd_w(memory_tracking::registrar_t &scratchpad,
+        const jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
+        memory_desc_t &diff_weights_md, memory_desc_t &diff_dst_md);
+
+} // namespace brgemm_convolution_utils
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -1,0 +1,946 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef CPU_AARCH64_JIT_BRGEMM_POST_OPS_HPP
+#define CPU_AARCH64_JIT_BRGEMM_POST_OPS_HPP
+
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+
+#include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/aarch64/jit_brgemm_primitive_conf.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+#include "cpu/cpu_engine.hpp"
+
+using namespace Xbyak_aarch64;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct brgemm_kernel_diff_bias_t {
+    brgemm_kernel_diff_bias_t()
+        : ptr_diff_dst(nullptr)
+        , ptr_diff_bias_acc(nullptr)
+        , ptr_diff_bias(nullptr)
+        , flags(0) {};
+
+    void *ptr_diff_dst;
+    void *ptr_diff_bias_acc;
+    void *ptr_diff_bias;
+    int flags;
+};
+
+#define GET_OFF(field) offsetof(brgemm_kernel_diff_bias_t, field)
+
+struct jit_brgemm_kernel_diff_bias_t : public jit_generator {
+    jit_brgemm_kernel_diff_bias_t(
+            const jit_brgemm_primitive_conf_t &ajbgp, const brgemm_t &abrg)
+        : brg_(abrg)
+        , ddst_dt_(ajbgp.dst_dt)
+        , bia_dt_(ajbgp.bia_dt)
+        , acc_dt_(ajbgp.acc_dt)
+        , bia_typesize_(types::data_type_size(bia_dt_))
+        , acc_typesize_(types::data_type_size(acc_dt_)) {
+
+        ddst_dt_ = ajbgp.dst_dt;
+        ddst_typesize_ = types::data_type_size(ddst_dt_);
+        mult_ = data_type_vnni_granularity(ddst_dt_);
+    }
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_diff_bias_t)
+
+private:
+    brgemm_t brg_;
+    data_type_t ddst_dt_;
+    data_type_t bia_dt_;
+    data_type_t acc_dt_;
+
+    int ddst_typesize_;
+    int bia_typesize_;
+    int acc_typesize_;
+    int mult_;
+
+    // Register decomposition
+    const XReg param1 = x7; //abi_param1
+    const XReg reg_ddst = x15;
+    const XReg reg_bias = x14;
+    const XReg reg_bias_acc = x13;
+    const XReg aux_reg_ddst = x12;
+    const XReg reg_k_iter = x11;
+    const XReg reg_flag = x10;
+
+    PReg k_full_mask = PReg(2);
+    PReg k_tail_mask = PReg(3);
+    ZReg vreg_unit = ZReg(31);
+    ZReg vreg_perm = ZReg(30);
+
+    const int n_max_regs_ = 4;
+
+    ZReg get_bias_reg(int n) const { return ZReg(n); }
+    ZReg get_bias_reg_lower(int n) const { return ZReg(n); }
+    ZReg get_ddst_reg(int n) const { return ZReg(n + n_max_regs_); }
+
+    void accumulate_bias(int idx, bool mask_flag) {
+        auto vddst = get_ddst_reg(idx);
+        const auto k_mask = mask_flag ? k_tail_mask : k_full_mask;
+        auto vbias = get_bias_reg(idx);
+        if (ddst_dt_ == data_type::f16) {
+            assert(!"unsupported\n");
+        } else {
+            auto addr = ptr(
+                    aux_reg_ddst, ddst_typesize_ * mult_ * idx * brg_.ld_block);
+            ld1w(vddst.s, k_mask / T_z, addr);
+            if (ddst_dt_ == data_type::bf16)
+                assert(!"unsupported\n");
+            else
+                fadd(vbias.s, vbias.s, vddst.s);
+        }
+    }
+
+    void store(int idx, bool mask_flag) {
+        auto addr = ptr(reg_bias, bia_typesize_ * idx * brg_.ld_block);
+        const auto k_mask = mask_flag ? k_tail_mask : k_full_mask;
+        switch (bia_dt_) {
+            case data_type::bf16: assert(!"unsupported\n"); break;
+            case data_type::f16: assert(!"unsupported\n"); break;
+            case data_type::f32: st1w(get_bias_reg(idx).s, k_mask, addr); break;
+            default: assert("Unsupported bias data type");
+        }
+    }
+
+    void loop_by_N(int n_loop, int nb_tail) {
+
+        mov(aux_reg_ddst, reg_ddst);
+
+        int n_iters = n_loop;
+        if (nb_tail > 0) n_iters--;
+        Label k_loop, init_zero, init_done;
+        int n_ = 0;
+
+        tst(reg_flag, FLAG_REDUCE_FIRST);
+        b(NE, init_zero); // FLAG_REDUCE_FIRST is set
+
+        for (; n_ < n_iters; n_++) {
+            ldr(get_bias_reg(n_),
+                    ptr(reg_bias_acc, acc_typesize_ * n_ * brg_.ld_block));
+        }
+        if (nb_tail > 0) {
+            ld1w(get_bias_reg(n_).s, k_tail_mask / T_z,
+                    ptr(reg_bias_acc, acc_typesize_ * n_ * brg_.ld_block));
+        }
+        b(init_done);
+        L(init_zero);
+
+        for (int n_ = 0; n_ < n_loop; n_++) {
+            eor(get_bias_reg(n_).d, get_bias_reg(n_).d, get_bias_reg(n_).d);
+        }
+        L(init_done);
+
+        mov(reg_k_iter, utils::div_up(brg_.reduce_dim, mult_));
+        L(k_loop);
+        {
+            int n_ = 0;
+            for (; n_ < n_iters; n_++)
+                accumulate_bias(n_, false);
+
+            if (nb_tail > 0) accumulate_bias(n_, true);
+
+            add_imm(aux_reg_ddst, aux_reg_ddst,
+                    ddst_typesize_ * mult_ * brg_.LDB, X_TMP_0);
+
+            sub(reg_k_iter, reg_k_iter, 1);
+            b(NE, k_loop);
+        }
+
+        Label store_final, store_done;
+        tst(reg_flag, FLAG_REDUCE_LAST);
+        b(NE, store_final); // FLAG_REDUCE_LAST is set
+
+        n_ = 0;
+        for (; n_ < n_iters; n_++) {
+            str(get_bias_reg(n_),
+                    ptr(reg_bias_acc, acc_typesize_ * n_ * brg_.ld_block));
+        }
+        if (nb_tail > 0) {
+            st1w(get_bias_reg(n_).s, k_tail_mask,
+                    ptr(reg_bias_acc, acc_typesize_ * n_ * brg_.ld_block));
+        }
+        b(store_done);
+
+        L(store_final);
+        n_ = 0;
+
+        for (; n_ < n_iters; n_++)
+            store(n_, false);
+
+        if (nb_tail > 0) store(n_, true);
+
+        L(store_done);
+    }
+
+    void generate() override {
+        preamble();
+
+        int nb = utils::div_up(brg_.load_dim, brg_.ld_block);
+        int nb_tail = brg_.load_dim % brg_.ld_block;
+
+        int n_loop = nb / n_max_regs_;
+        int n_loop_tail = nb % n_max_regs_;
+        if (n_loop_tail == 0 && nb_tail > 0) {
+            n_loop--;
+            n_loop_tail = n_max_regs_;
+        }
+
+        ptrue(k_full_mask.b);
+        set_preg(k_tail_mask.s, nb_tail, X_TMP_0, X_TMP_1);
+        pfalse(P_TMP_0.b);
+        zip1(k_tail_mask.b, k_tail_mask.b, P_TMP_0.b);
+        zip1(k_tail_mask.h, k_tail_mask.h, P_TMP_0.h);
+
+        if (ddst_dt_ == data_type::bf16) { assert(!"unsupported data type\n"); }
+
+        if (ddst_dt_ == data_type::f16) { assert(!"unsupported data type\n"); }
+
+        add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_diff_dst), X_TMP_0);
+        ldr(reg_ddst, ptr(X_DEFAULT_ADDR));
+        add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_diff_bias_acc), X_TMP_0);
+        ldr(reg_bias_acc, ptr(X_DEFAULT_ADDR));
+        add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_diff_bias), X_TMP_0);
+        ldr(reg_bias, ptr(X_DEFAULT_ADDR));
+        add_imm(X_DEFAULT_ADDR, param1, GET_OFF(flags), X_TMP_0);
+        ldr(reg_flag, ptr(X_DEFAULT_ADDR));
+
+        for (int nb_ = 0; nb_ < n_loop; nb_++) {
+            loop_by_N(n_max_regs_, 0);
+
+            add_imm(reg_ddst, reg_ddst,
+                    ddst_typesize_ * mult_ * n_max_regs_ * brg_.ld_block,
+                    X_TMP_0);
+            add_imm(reg_bias, reg_bias,
+                    bia_typesize_ * n_max_regs_ * brg_.ld_block, X_TMP_0);
+            add_imm(reg_bias_acc, reg_bias_acc,
+                    acc_typesize_ * n_max_regs_ * brg_.ld_block, X_TMP_0);
+        }
+
+        if (n_loop_tail > 0) loop_by_N(n_loop_tail, nb_tail);
+        postamble();
+    }
+};
+
+#undef GET_OFF
+
+#define GET_OFF(field) offsetof(brgemm_kernel_post_ops_t, field)
+
+struct brgemm_kernel_post_ops_t {
+    void *ptr_in;
+    void *ptr_out;
+    void *ptr_bias;
+    void *ptr_scales;
+    const void *ptr_binary_post_ops_rhs;
+    size_t apply_comp = 0;
+    int32_t a_comp_val = 1;
+    int32_t *a_zp_compensation;
+    int32_t *c_zp_values;
+    int32_t *s8s8_compensation;
+    const void *dst_orig;
+    void *ptr_dst_scales;
+};
+
+struct jit_brgemm_kernel_post_ops : public jit_generator {
+
+    jit_brgemm_kernel_post_ops(const jit_brgemm_conv_conf_t &ajcp,
+            const brgemm_t &abrg, const primitive_attr_t &aattr)
+        : brg(abrg)
+        , jcp(ajcp)
+        , attr(aattr)
+        , postops_injector_(nullptr)
+        , with_binary_non_scalar_bcast_(brg.with_binary
+                  && binary_injector::
+                          any_binary_postop_rhs_non_scalar_broadcast(
+                                  brg.attr->post_ops_,
+                                  memory_desc_wrapper(brg.dst_md))) {
+
+        if (brg.beta != 0) {
+            static constexpr bool preserve_gpr = true;
+            static constexpr bool preserve_vmm = true;
+            static constexpr bool use_exact_tail_scalar_bcast = false;
+
+            const binary_injector::rhs_arg_static_params_t rhs_sp {
+                    static_cast<size_t>(vmm_tmp(4).getIdx()), XReg(14),
+                    XReg(15), XReg(13), preserve_gpr, preserve_vmm,
+                    GET_OFF(ptr_binary_post_ops_rhs), GET_OFF(dst_orig),
+                    memory_desc_wrapper(brg.dst_md),
+                    static_cast<size_t>(brg.load_dim % brg.ld_block),
+                    k_tail_mask, use_exact_tail_scalar_bcast};
+            const binary_injector::static_params_t bsp {this->param1, rhs_sp};
+
+            const bool save_state = jcp.with_eltwise;
+            const auto &reserved_eltwise_gpr = reg_reserved_eltwise;
+            const auto reserved_eltwise_maskr = PReg(1);
+
+            const eltwise_injector::static_params_t esp {
+                    save_state, reserved_eltwise_gpr, reserved_eltwise_maskr};
+
+            postops_injector_ = utils::make_unique<
+                    injector::jit_uni_postops_injector_t<sve_512>>(
+                    this, attr.post_ops_, bsp, esp);
+        }
+
+        const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
+        // per_oc: conv: 1 << 0, (1 << 1) + (1 << 0) (with groups)
+        // per_oc: ip: 1 << 0
+        is_oc_scale_
+                = utils::one_of(wei_scales.mask_, 1 << 0, (1 << 1) + (1 << 0));
+
+        LDD_ = brg.LDD;
+        inp_dt_ = brg.dt_c;
+        out_dt_ = brg.dt_d;
+        bia_dt_ = jcp.bia_dt;
+        inp_typesize_ = types::data_type_size(inp_dt_);
+        out_typesize_ = types::data_type_size(out_dt_);
+        bia_typesize_ = (jcp.with_bias) ? types::data_type_size(bia_dt_) : 0;
+    }
+
+    ~jit_brgemm_kernel_post_ops() = default;
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_post_ops)
+
+    brgemm_t brg;
+    jit_brgemm_conv_conf_t jcp;
+    const primitive_attr_t &attr;
+
+private:
+    int LDD_;
+
+    data_type_t inp_dt_;
+    data_type_t out_dt_;
+    data_type_t bia_dt_;
+    std::unique_ptr<injector::jit_uni_postops_injector_t<sve_512>>
+            postops_injector_;
+
+    const bool with_binary_non_scalar_bcast_;
+
+    int inp_typesize_;
+    int out_typesize_;
+    int bia_typesize_;
+
+    int is_oc_scale_;
+    constexpr static int max_vregs_ = 32;
+
+    // Register decomposition
+    const XReg reg_reserved_eltwise = x0;
+    ;
+    const XReg param1 = x7; //abi_param1=rdi
+    const XReg reg_in = x15;
+    const XReg reg_out = x14;
+    const XReg aux_reg_in = x13;
+    const XReg aux_reg_out = x12;
+
+    const XReg reg_bias = x11;
+    const XReg aux_reg_bias = x10;
+
+    const XReg reg_scales = x9;
+    const XReg aux_reg_scales = x8;
+
+    const XReg reg_ptr_sum_scale = x2;
+    ;
+    const XReg reg_ptr_sum_zp = x6;
+
+    const XReg reg_zp_c_values = x3;
+    const XReg aux_reg_zp_c_values = x3;
+    const XReg reg_zp_a_comp = x3;
+    const XReg aux_reg_zp_a_comp = x3;
+    const XReg reg_s8s8_comp = x3;
+    const XReg aux_reg_s8s8_comp = x3;
+    const XReg reg_zp_a_val = x3;
+    const XReg reg_apply_comp = x3;
+    const XReg reg_dst_scales = x3;
+    const XReg aux_reg_dst_scales = x3;
+    const XReg reg_tmp = abi_not_param1;
+
+    constexpr static int reg_zp_c_values_offs_ = 0;
+    constexpr static int aux_reg_zp_c_values_offs_ = 8;
+    constexpr static int reg_zp_a_comp_offs_ = 16;
+    constexpr static int aux_reg_zp_a_comp_offs_ = 24;
+    constexpr static int reg_s8s8_comp_offs_ = 32;
+    constexpr static int aux_reg_s8s8_comp_offs_ = 40;
+    constexpr static int reg_zp_a_val_offs_ = 48;
+    constexpr static int reg_apply_comp_offs_ = 56;
+    constexpr static int reg_dst_scales_offs_ = 64;
+    constexpr static int stack_space_needed_ = 72;
+
+    PReg k_full_mask = p2;
+    PReg k_tail_mask = p3;
+
+    const int n_block2_ = 4;
+
+    ZReg vmm_tmp(int i) const { return ZReg(max_vregs_ - 1 - i); }
+
+    int zp_c_values_offset(int n, bool is_tail = false) const noexcept {
+        if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
+            return (is_tail) ? sizeof(int32_t) * brg.ldb_tail
+                             : sizeof(int32_t) * n * brg.ld_block;
+        }
+
+        return 0;
+    }
+    int zp_comp_a_vpad_offset(
+            int n, int m, bool is_tail = false) const noexcept {
+        return (is_tail) ? sizeof(int32_t) * (brg.ldb_tail + m * brg.LDB)
+                         : sizeof(int32_t) * (n * brg.ld_block + m * brg.LDB);
+    }
+    int mb_zp_comp_a_offset(int m_block) const noexcept {
+        return sizeof(int32_t) * m_block * brg.LDB;
+    }
+    int compensation_vpad_offset(
+            int n, int m, bool is_tail = false) const noexcept {
+        return (is_tail) ? sizeof(int32_t) * (brg.ldb_tail + m * brg.LDB)
+                         : sizeof(int32_t) * (n * brg.ld_block + m * brg.LDB);
+    }
+    int mb_compensation_offset(int m_block) const noexcept {
+        return sizeof(int32_t) * m_block * brg.LDB;
+    }
+
+    void cvt2ps(data_type_t type_in, const ZReg zmm_in, const AdrNoOfs &op,
+            bool mask_flag, bool store, PReg ktail_mask) {
+        switch (type_in) {
+            case data_type::f32:
+            case data_type::s32:
+                if (mask_flag) {
+                    if (store) {
+                        st1w(zmm_in.s, ktail_mask / T_m, op);
+                    } else {
+                        ld1w(zmm_in.s, ktail_mask / T_z, op);
+                    }
+                } else {
+                    ld1w(zmm_in.s, k_full_mask / T_z, op);
+                }
+                break;
+            case data_type::s8: assert(!"unsupported data type\n"); break;
+            case data_type::u8: assert(!"unsupported data type\n"); break;
+            case data_type::bf16: assert(!"unsupported data type\n"); break;
+            default: assert(!"unsupported data type");
+        }
+        if (!utils::one_of(type_in, data_type::f32, data_type::bf16))
+            assert(!"unsupported data type\n");
+    }
+
+    ZReg vector(int m, int n, int n_block) { return ZReg(m * n_block + n); };
+
+    void inject_attr_postops(int m_block, int n_block, int tail = 0) {
+        const auto &p = attr.post_ops_;
+        const int sum_idx = p.find(primitive_kind::sum);
+        const auto k_mask = tail == 0 ? k_full_mask : k_tail_mask;
+        const auto sum_dt = p.get_sum_dt(out_dt_);
+
+        const auto sum_injector = [&] {
+            const float *p_sum_scale = &p.entry_[sum_idx].sum.scale;
+            const int32_t *p_sum_zp = &p.entry_[sum_idx].sum.zero_point;
+            if (*p_sum_scale != 1.f)
+                mov_imm(reg_ptr_sum_scale, (size_t)p_sum_scale);
+            auto vmm_sum_zp = vmm_tmp(1);
+            if (*p_sum_zp != 0) {
+                mov_imm(reg_ptr_sum_zp, (size_t)p_sum_zp);
+                ld1rw(vmm_sum_zp.s, k_full_mask / T_z, ptr(reg_ptr_sum_zp));
+                scvtf(vmm_sum_zp.s, k_full_mask / T_m, vmm_sum_zp.s);
+            }
+
+            for_(int m = 0; m < m_block; m++)
+            for (int n = 0; n < n_block; n++) {
+                const auto vmm = vector(m, n, n_block);
+
+                const auto vmm_prev_dst = vmm_tmp(0);
+                const auto vmm_tmp2 = vmm_tmp(2);
+                add_imm(X_DEFAULT_ADDR, aux_reg_out,
+                        out_typesize_ * (m * LDD_ + n * brg.ld_block), X_TMP_0);
+                cvt2ps(sum_dt, vmm_prev_dst, ptr(X_DEFAULT_ADDR), tail, false,
+                        k_mask);
+                if (*p_sum_zp != 0)
+                    fsub(vmm_prev_dst.s, vmm_prev_dst.s, vmm_sum_zp.s);
+                if (*p_sum_scale == 1.f)
+                    fadd(vmm.s, vmm.s, vmm_prev_dst.s);
+                else {
+                    ld1rw(vmm_tmp2.s, k_full_mask / T_z,
+                            ptr(reg_ptr_sum_scale));
+                    fmla(vmm.s, k_full_mask / T_m, vmm_prev_dst.s, vmm_tmp2.s);
+                }
+            }
+        };
+
+        if (jcp.with_sum) {
+            postops_injector_->set_lambda_injector(
+                    primitive_kind::sum, sum_injector);
+        }
+
+        binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
+
+        if (with_binary_non_scalar_bcast_) {
+            for_(int m = 0; m < m_block; m++)
+            for (int n = 0; n < n_block; n++) {
+                const auto vmm_idx = vector(m, n, n_block).getIdx();
+                const size_t aux_output_offset
+                        = out_typesize_ * (m * LDD_ + n * brg.ld_block);
+
+                rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, aux_reg_out);
+                rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
+                        vmm_idx, aux_output_offset);
+                if (tail) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
+            }
+        }
+
+        postops_injector_->compute_vector_range(
+                0, m_block * n_block, rhs_arg_params);
+    }
+    void apply_comp(int m_block, int n_block, int tail = 0) {
+        auto k_mask = (tail == 0) ? k_full_mask : k_tail_mask;
+
+        if (brg.zp_type_a != brgemm_broadcast_t::none) {
+            auto vmm_zp_a_val = vmm_tmp(1);
+            ldr(reg_zp_a_val, ptr(X_SP, reg_zp_a_val_offs_));
+            dup(vmm_zp_a_val.s, WReg(reg_zp_a_val.getIdx()));
+
+            ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+            for (int n = 0; n < n_block; n++) {
+                auto vmm_zp_comp_a = vmm_tmp(0);
+                const size_t zp_comp_offset
+                        = sizeof(int32_t) * (n * brg.ld_block);
+                add_imm(X_DEFAULT_ADDR, aux_reg_zp_a_comp, zp_comp_offset,
+                        X_TMP_0);
+                ldr(vmm_zp_comp_a, ptr(X_DEFAULT_ADDR));
+                mul(vmm_zp_comp_a.s, k_mask / T_m, vmm_zp_a_val.s);
+                for (int m = 0; m < m_block; m++) {
+                    auto vmm = vector(m, n, n_block);
+                    add(vmm.s, vmm.s, vmm_zp_comp_a.s);
+                }
+            }
+        }
+
+        if (brg.req_s8s8_compensation) {
+            ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+            for (int n = 0; n < n_block; n++) {
+                auto vmm_comp = vmm_tmp(0);
+                const size_t s8s8_comp_offset
+                        = sizeof(int32_t) * (n * brg.ld_block);
+                add_imm(X_DEFAULT_ADDR, aux_reg_s8s8_comp, s8s8_comp_offset,
+                        X_TMP_0);
+                ld1w(vmm_comp.s, k_mask / T_z, ptr(X_DEFAULT_ADDR));
+                for (int m = 0; m < m_block; m++) {
+                    auto vmm = vector(m, n, n_block);
+                    add(vmm.s, vmm.s, vmm_comp.s);
+                }
+            }
+        }
+    }
+    void maybe_apply_comp(int m_block, int n_block, int tail = 0) {
+        Label label_apply_without_comp;
+        ldr(reg_apply_comp, ptr(X_SP, reg_apply_comp_offs_));
+        cmp(reg_apply_comp, 0);
+        b(EQ, label_apply_without_comp);
+        apply_comp(m_block, n_block, tail);
+        L_aligned(label_apply_without_comp);
+
+        for_(int m = 0; m < m_block; m++)
+        for (int n = 0; n < n_block; n++) {
+            scvtf(vector(m, n, n_block).s, k_full_mask / T_m,
+                    vector(m, n, n_block).s);
+        }
+    }
+
+    void apply_post_ops(int m_block, int n_block, int tail = 0) {
+        const auto vector = [=](int m, int n) { return ZReg(m * n_block + n); };
+        auto k_mask = (tail == 0) ? k_full_mask : k_tail_mask;
+        const auto req_comp = brg.is_int8 && brg.beta != 0
+                && (brg.req_s8s8_compensation
+                        || brg.zp_type_a != brgemm_broadcast_t::none);
+
+        // brg.alpha == 0 means initialize registers, 1 means read from input
+        // brg.beta == 0 means skip postwork, 1 means do postwork
+        // req_comp == true -> convert accumulated values to f32 after applying
+        // compensation to avoid the loss of accuracy when converting s32 to f32
+        for_(int m = 0; m < m_block; m++)
+        for (int n = 0; n < n_block; n++) {
+            if (brg.alpha == 0 && brg.beta != 0) {
+                // if postwork then have to init zmm each time
+                eor(vector(m, n).d, vector(m, n).d, vector(m, n).d);
+            } else if (brg.alpha != 0) {
+                add_imm(X_DEFAULT_ADDR, aux_reg_in,
+                        inp_typesize_ * (m * brg.LDC + n * brg.ld_block),
+                        X_TMP_0);
+                cvt2ps(inp_dt_, vector(m, n), ptr(X_DEFAULT_ADDR), true, false,
+                        k_mask);
+            }
+        }
+
+        if (req_comp) maybe_apply_comp(m_block, n_block, tail);
+
+        if (brg.beta != 0) {
+            for_(int m = 0; m < m_block; m++)
+            for (int n = 0; n < n_block; n++) {
+                auto vmm = vector(m, n);
+                auto vmm_tmp0 = vmm_tmp(0);
+                const auto k_mask = tail > 0 ? k_tail_mask : k_full_mask;
+                add_imm(X_DEFAULT_ADDR, aux_reg_scales,
+                        is_oc_scale_ * sizeof(float) * (n * brg.ld_block),
+                        X_TMP_0);
+                ldr(vmm_tmp0, ptr(X_DEFAULT_ADDR));
+                fmul(vmm.s, vmm.s, vmm_tmp0.s);
+                if (tail > 0) mov(vmm.s, k_mask / T_m, vmm.s);
+            }
+        }
+
+        if (brg.beta != 0 && jcp.with_bias) {
+            for (int n = 0; n < n_block; n++) {
+                auto vmm_bias = vmm_tmp(0);
+                add_imm(X_DEFAULT_ADDR, aux_reg_bias,
+                        bia_typesize_ * (n * brg.ld_block), X_TMP_0);
+                cvt2ps(bia_dt_, vmm_bias, ptr(X_DEFAULT_ADDR), true, false,
+                        k_mask);
+                for (int m = 0; m < m_block; m++) {
+                    fadd(vector(m, n).s, vector(m, n).s, vmm_bias.s);
+                }
+            }
+        }
+
+        if (postops_injector_) inject_attr_postops(m_block, n_block, tail);
+
+        if (brg.beta != 0 && brg.with_dst_scales) {
+            ldr(aux_reg_dst_scales, ptr(X_SP, reg_dst_scales_offs_));
+            auto vmm_tmp1 = vmm_tmp(1);
+            ldr(vmm_tmp1, ptr(aux_reg_dst_scales));
+
+            for_(int m = 0; m < m_block; m++)
+            for (int n = 0; n < n_block; n++) {
+                auto vmm = vector(m, n);
+                fmul(vmm.s, vmm.s, vmm_tmp1.s);
+                if (tail > 0) mov(vmm.s, k_mask / T_m, vmm.s);
+            }
+        }
+
+        if (brg.beta != 0 && brg.zp_type_c != brgemm_broadcast_t::none) {
+            ldr(aux_reg_zp_c_values, ptr(X_SP, aux_reg_zp_c_values_offs_));
+            auto vmm_zp_c = vmm_tmp(0);
+            if (brg.zp_type_c == brgemm_broadcast_t::per_tensor) {
+                auto vmm_tmp1 = vmm_tmp(1);
+                ld1rw(vmm_tmp1.s, k_full_mask / T_z,
+                        ptr(aux_reg_zp_c_values, 0));
+                scvtf(vmm_zp_c.s, k_full_mask / T_m, vmm_tmp1.s);
+            }
+            for (int n = 0; n < n_block; n++) {
+                if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
+                    int zp_c_off = zp_c_values_offset(n);
+                    add_imm(X_DEFAULT_ADDR, aux_reg_zp_c_values, zp_c_off,
+                            X_TMP_0);
+                    cvt2ps(data_type::s32, vmm_zp_c, ptr(X_DEFAULT_ADDR), tail,
+                            false, k_mask);
+                }
+                for (int m = 0; m < m_block; m++) {
+                    const auto vmm = vector(m, n);
+                    fadd(vmm.s, vmm.s, vmm_zp_c.s);
+                }
+            }
+        }
+
+        const bool dt_requires_saturation = types::is_integral_dt(out_dt_);
+
+        const XReg reg_tmp_gpr = reg_tmp;
+        auto vmm_lbound = vmm_tmp(0);
+        auto vmm_ubound = vmm_tmp(1);
+        if (dt_requires_saturation) {
+            init_saturate_f32(vmm_lbound, vmm_ubound, reg_tmp_gpr,
+                    data_type::f32, out_dt_);
+        }
+
+        for_(int m = 0; m < m_block; m++)
+        for (int n = 0; n < n_block; n++) {
+            // incase of tail, stores are unconditionally masked, regardless
+            // of `n`, implying n_block must be equal to `1`.
+            assert(IMPLICATION(tail > 0, n_block == 1));
+            auto vmm = vector(m, n);
+
+            if (dt_requires_saturation) {
+                saturate_f32(vmm, vmm_lbound, vmm_ubound, out_dt_, k_full_mask);
+                frintn(vmm.s, k_full_mask, vmm.s);
+                fcvtzs(vmm.s, k_full_mask, vmm.s);
+            }
+
+            switch (out_dt_) {
+                case data_type::f32:
+                case data_type::s32:
+                    add_imm(X_DEFAULT_ADDR, aux_reg_out,
+                            out_typesize_ * (m * LDD_ + n * brg.ld_block),
+                            X_TMP_0); //addr
+                    st1w(vmm.s, k_mask / T_m, ptr(X_DEFAULT_ADDR));
+                    break;
+                case data_type::s8: assert(!"unsupported data type\n"); break;
+                case data_type::u8: assert(!"unsupported data type\n"); break;
+                default: assert(!"unknown dst_dt");
+            }
+        }
+    }
+
+    void loop_by_N(int m_block, int nb2, int nb2_tail, int nb_tail) {
+
+        if (brg.alpha) { mov(aux_reg_in, reg_in); }
+        if (brg.beta != 0) {
+            if (jcp.with_bias) mov(aux_reg_bias, reg_bias);
+            if (brg.zp_type_c != brgemm_broadcast_t::none) {
+                ldr(aux_reg_zp_c_values, ptr(X_SP, reg_zp_c_values_offs_));
+                str(aux_reg_zp_c_values, ptr(X_SP, aux_reg_zp_c_values_offs_));
+            }
+            if (brg.zp_type_a != brgemm_broadcast_t::none) {
+                ldr(aux_reg_zp_a_comp, ptr(X_SP, reg_zp_a_comp_offs_));
+                str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+            }
+            if (brg.req_s8s8_compensation) {
+                ldr(aux_reg_s8s8_comp, ptr(X_SP, reg_s8s8_comp_offs_));
+                str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+            }
+            mov(aux_reg_scales, reg_scales);
+        }
+        mov(aux_reg_out, reg_out);
+
+        for (int n_loop_ = 0; n_loop_ < nb2; n_loop_++) {
+            apply_post_ops(m_block, n_block2_);
+
+            const auto oc_l_offset = n_block2_ * brg.ld_block;
+
+            add_imm(aux_reg_out, aux_reg_out, out_typesize_ * oc_l_offset,
+                    X_TMP_0);
+            if (brg.alpha != 0) {
+                add_imm(aux_reg_in, aux_reg_in, inp_typesize_ * oc_l_offset,
+                        X_TMP_0);
+            }
+            if (brg.beta != 0) {
+                if (jcp.with_bias)
+                    add_imm(aux_reg_bias, aux_reg_bias,
+                            bia_typesize_ * oc_l_offset, X_TMP_0);
+                if (brg.zp_type_c != brgemm_broadcast_t::none) {
+                    ldr(aux_reg_zp_c_values,
+                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                    add_imm(aux_reg_zp_c_values, aux_reg_zp_c_values,
+                            zp_c_values_offset(n_block2_), X_TMP_0);
+                    str(aux_reg_zp_c_values,
+                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                }
+                if (brg.zp_type_a != brgemm_broadcast_t::none) {
+                    ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    add_imm(aux_reg_zp_a_comp, aux_reg_zp_a_comp,
+                            sizeof(int32_t) * oc_l_offset, X_TMP_0);
+                    str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                }
+                if (brg.req_s8s8_compensation) {
+                    ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    add_imm(aux_reg_s8s8_comp, aux_reg_s8s8_comp,
+                            sizeof(int32_t) * oc_l_offset, X_TMP_0);
+                    str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                }
+
+                add_imm(aux_reg_scales, aux_reg_scales,
+                        is_oc_scale_ * sizeof(float) * oc_l_offset, X_TMP_0);
+            }
+        }
+        if (nb2_tail > 0) {
+            apply_post_ops(m_block, nb2_tail);
+            const auto oc_l_offset = nb2_tail * brg.ld_block;
+
+            add_imm(aux_reg_out, aux_reg_out, out_typesize_ * oc_l_offset,
+                    X_TMP_0);
+            if (brg.alpha != 0) {
+                add_imm(aux_reg_in, aux_reg_in, inp_typesize_ * oc_l_offset,
+                        X_TMP_0);
+            }
+            if (brg.beta != 0) {
+                if (jcp.with_bias)
+                    add_imm(aux_reg_bias, aux_reg_bias,
+                            bia_typesize_ * oc_l_offset, X_TMP_0);
+                if (brg.zp_type_c != brgemm_broadcast_t::none) {
+                    ldr(aux_reg_zp_c_values,
+                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                    add_imm(aux_reg_zp_c_values, aux_reg_zp_c_values,
+                            zp_c_values_offset(nb2_tail), X_TMP_0);
+                    str(aux_reg_zp_c_values,
+                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                }
+                if (brg.zp_type_a != brgemm_broadcast_t::none) {
+                    ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    add_imm(aux_reg_zp_a_comp, aux_reg_zp_a_comp,
+                            sizeof(int32_t) * oc_l_offset, X_TMP_0);
+                    str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                }
+                if (brg.req_s8s8_compensation) {
+                    ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    add_imm(aux_reg_s8s8_comp, aux_reg_s8s8_comp,
+                            sizeof(int32_t) * oc_l_offset, X_TMP_0);
+                    str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                }
+
+                add_imm(aux_reg_scales, aux_reg_scales,
+                        is_oc_scale_ * sizeof(float) * oc_l_offset, X_TMP_0);
+            }
+        }
+        if (nb_tail > 0) {
+            apply_post_ops(m_block, 1, nb_tail);
+
+            if (brg.alpha != 0) {
+                add_imm(aux_reg_in, aux_reg_in, inp_typesize_ * (nb_tail),
+                        X_TMP_0);
+            }
+            if (brg.beta != 0) {
+                if (jcp.with_bias)
+                    add_imm(aux_reg_bias, aux_reg_bias,
+                            bia_typesize_ * (nb_tail), X_TMP_0);
+                if (brg.zp_type_c != brgemm_broadcast_t::none) {
+                    ldr(aux_reg_zp_c_values,
+                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                    add_imm(aux_reg_zp_c_values, aux_reg_zp_c_values,
+                            zp_c_values_offset(1, nb_tail), X_TMP_0);
+                    str(aux_reg_zp_c_values,
+                            ptr(X_SP, aux_reg_zp_c_values_offs_));
+                }
+                if (brg.zp_type_a != brgemm_broadcast_t::none) {
+                    ldr(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                    add_imm(aux_reg_zp_a_comp, aux_reg_zp_a_comp,
+                            sizeof(int32_t) * nb_tail, X_TMP_0);
+                    str(aux_reg_zp_a_comp, ptr(X_SP, aux_reg_zp_a_comp_offs_));
+                }
+                if (brg.req_s8s8_compensation) {
+                    ldr(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                    add_imm(aux_reg_s8s8_comp, aux_reg_s8s8_comp,
+                            sizeof(int32_t) * nb_tail, X_TMP_0);
+                    str(aux_reg_s8s8_comp, ptr(X_SP, aux_reg_s8s8_comp_offs_));
+                }
+                add_imm(aux_reg_scales, aux_reg_scales,
+                        is_oc_scale_ * bia_typesize_ * (nb_tail), X_TMP_0);
+            }
+            add_imm(aux_reg_out, aux_reg_out, out_typesize_ * (nb_tail),
+                    X_TMP_0);
+        }
+    }
+
+    void generate() override {
+        preamble();
+
+        mov(x7, x0);
+        mov(x6, x1);
+        mov(x2, x2);
+        mov(x1, x3);
+        mov(x8, x4);
+        mov(x9, x5);
+
+        mov(x4, X_SP);
+        int nb = brg.load_dim / brg.ld_block;
+        int nb_tail = brg.load_dim % brg.ld_block;
+
+        int nb2 = nb / n_block2_;
+        int nb2_tail = nb % n_block2_;
+        int n_block = (nb2 == 0) ? nstl::max(1, nb2_tail) : n_block2_;
+
+        int m_max_regs = (max_vregs_ - 4) / n_block;
+        int m_block = nstl::min(brg.bcast_dim, m_max_regs);
+
+        int mb = brg.bcast_dim / m_block;
+        int mb_tail = brg.bcast_dim % m_block;
+
+        ptrue(k_full_mask.b);
+        set_preg(k_tail_mask.s, nb_tail, X_TMP_0, X_TMP_1);
+
+        if (brg.alpha != 0) {
+            add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_in), X_TMP_0);
+            ldr(reg_in, ptr(X_DEFAULT_ADDR));
+        }
+        if (brg.beta != 0) {
+            add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_scales), X_TMP_0);
+            ldr(reg_scales, ptr(X_DEFAULT_ADDR));
+            add_imm(X_DEFAULT_ADDR, param1, GET_OFF(apply_comp), X_TMP_0);
+            ldr(reg_apply_comp, ptr(X_DEFAULT_ADDR));
+            str(reg_apply_comp, ptr(X_SP, reg_apply_comp_offs_));
+
+            if (jcp.with_bias) {
+                add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_bias), X_TMP_0);
+                ldr(reg_bias, ptr(X_DEFAULT_ADDR));
+            }
+            if (brg.zp_type_c != brgemm_broadcast_t::none) {
+                add_imm(X_DEFAULT_ADDR, param1, GET_OFF(c_zp_values), X_TMP_0);
+                ldr(reg_zp_c_values, ptr(X_DEFAULT_ADDR));
+                str(reg_zp_c_values, ptr(X_SP, reg_zp_c_values_offs_));
+            }
+            if (brg.zp_type_a != brgemm_broadcast_t::none) {
+                add_imm(X_DEFAULT_ADDR, param1, GET_OFF(a_zp_compensation),
+                        X_TMP_0);
+                ldr(reg_zp_a_comp, ptr(X_DEFAULT_ADDR));
+                str(reg_zp_a_comp, ptr(X_SP, reg_zp_a_comp_offs_));
+
+                add_imm(X_DEFAULT_ADDR, param1, GET_OFF(a_comp_val), X_TMP_0);
+                ldr(reg_zp_a_val, ptr(X_DEFAULT_ADDR));
+                str(reg_zp_a_val, ptr(X_SP, reg_zp_a_val_offs_));
+            }
+            if (brg.req_s8s8_compensation) {
+                add_imm(X_DEFAULT_ADDR, param1, GET_OFF(s8s8_compensation),
+                        X_TMP_0);
+                ldr(reg_s8s8_comp, ptr(X_DEFAULT_ADDR));
+                str(reg_s8s8_comp, ptr(X_SP, reg_s8s8_comp_offs_));
+            }
+            if (brg.with_dst_scales) {
+                add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_dst_scales),
+                        X_TMP_0);
+                ldr(reg_dst_scales, ptr(X_DEFAULT_ADDR));
+                str(reg_dst_scales, ptr(X_SP, reg_dst_scales_offs_));
+            }
+        }
+        add_imm(X_DEFAULT_ADDR, param1, GET_OFF(ptr_out), X_TMP_0);
+        ldr(reg_out, ptr(X_DEFAULT_ADDR));
+
+        // brg.alpha == 0 means initialize registers, 1 means read from input
+        // brg.beta == 0 means skip postwork, 1 means do postwork
+        if (brg.alpha == 0 && brg.beta == 0) {
+            for_(int m = 0; m < m_block; m++)
+            for (int n = 0; n < n_block; n++) {
+                auto zmm = ZReg(m * n_block + n);
+                eor(zmm.d, zmm.d, zmm.d);
+            }
+        }
+
+        for (int mb_ = 0; mb_ < mb; mb_++) {
+            loop_by_N(m_block, nb2, nb2_tail, nb_tail);
+
+            if (brg.alpha != 0)
+                add_imm(reg_in, reg_in, inp_typesize_ * (m_block * brg.LDC),
+                        X_TMP_0);
+            add_imm(reg_out, reg_out, out_typesize_ * (m_block * LDD_),
+                    X_TMP_0);
+        }
+        if (mb_tail > 0) loop_by_N(mb_tail, nb2, nb2_tail, nb_tail);
+
+        add_imm(X_SP, X_SP, stack_space_needed_, X_TMP_0);
+
+        postamble();
+
+        if (postops_injector_) postops_injector_->prepare_table();
+    }
+};
+
+#undef GET_OFF
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_brgemm_primitive_conf.hpp
@@ -1,0 +1,98 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef CPU_AARCH64_JIT_BRGEMM_PRIMITIVE_CONF_HPP
+#define CPU_AARCH64_JIT_BRGEMM_PRIMITIVE_CONF_HPP
+
+#include "cpu/aarch64/brgemm/brgemm_types.hpp"
+#include "cpu/aarch64/jit_primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct jit_brgemm_primitive_conf_t {
+    prop_kind_t prop_kind;
+    conv_version_t ver;
+    conv_loop_order_t loop_order;
+    conv_harness_t harness;
+    int simd_w;
+    int ndims;
+    int mb;
+    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    int id, ih, iw, od, oh, ow, os;
+    int f_pad, l_pad, t_pad;
+    int back_pad, r_pad, b_pad;
+    int kd, kh, kw;
+    int stride_d, stride_h, stride_w;
+    int dilate_d, dilate_h, dilate_w;
+    format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
+    bool is_wei_layout_any;
+    bool with_bias;
+    bool with_sum;
+    bool with_eltwise;
+    bool with_binary;
+    bool with_scales;
+    bool req_s8s8_compensation;
+    int nb_ic, ic_block, ic_block_ext;
+    int nb_oc, oc_block, oc_block_ext;
+    int nb_iw, iw_block;
+    int nb_ow, ow_block;
+    int nb_os, os_block;
+    int nb_oc_blocking;
+    int nb_ic_blocking;
+    int nb_os_blocking;
+
+    data_type_t src_dt;
+    data_type_t dst_dt;
+    data_type_t wei_dt;
+    data_type_t acc_dt;
+    data_type_t bia_dt;
+
+    bool use_buffer;
+    bool use_buffer_a;
+    bool use_buffer_b;
+    bool is_bf32;
+
+    int is_oc_scale;
+
+    int LDA, LDB, LDC, LDD;
+    int M, N, K, M_tail, N_tail, K_tail;
+    int gemm_batch_size, adjusted_batch_size;
+    brgemm_batch_kind_t brg_type;
+    int num_gemm_kernels;
+    int nthr, nthr_mb, nthr_oc_b, nthr_ic_b;
+
+    // Use kernels and blocking for small os that consume less bandwidth.
+    bool use_small_os_kernels = false;
+
+    cpu_isa_t isa;
+    bool ip_bwd_d_global_b_transpose;
+    bool use_uker;
+    bool use_interleave_stores;
+    brgemm_kernel_prefetching_t hint_prefetching
+            = brgemm_kernel_prefetching_t::brgemm_prf_default;
+    bool ip_bwd_w_local_buffers_for_input_tensors;
+    bool with_dst_scales;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.cpp
@@ -1,0 +1,825 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/c_types_map.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+
+#include "cpu/aarch64/jit_brgemm_transpose_utils.hpp"
+
+#define LD_MUL_VL(mn, op, mask, addr, off, size) \
+    { \
+        const int mul_vl_len = (cpu_sveLen / 4) * size; \
+        const int off_mod = off % mul_vl_len; \
+        const int off_mul_vl = off / mul_vl_len; \
+        if (off_mod == 0 && -8 <= off_mul_vl && off_mul_vl <= 7) \
+            mn(op, mask / T_z, ptr(addr, off_mul_vl, MUL_VL)); \
+        else \
+            mn(op, mask / T_z, \
+                    ptr(addr_off(addr, off, X_DEFAULT_ADDR, X_TMP_0))); \
+    }
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::format_tag;
+using namespace dnnl::impl::utils;
+using namespace Xbyak_aarch64;
+
+#define GET_OFF(x) offsetof(ctx_t, x)
+
+struct jit_brgemm_trans_m_k_f32_t : public jit_brgemm_trans_src_t,
+                                    public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_m_k_f32_t)
+
+    jit_brgemm_trans_m_k_f32_t(const jit_brgemm_primitive_conf_t *conf)
+        : jit_brgemm_trans_src_t(conf) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
+    status_t create_kernel() override { return jit_generator::create_kernel(); }
+
+private:
+    enum { typesize = sizeof(float), transpose_size = 16 };
+    dim_t src_stride = 0, tr_src_stride = 0;
+
+    const PReg k3333 = p1;
+    const PReg k5555 = p2;
+    const PReg kAAAA = p3;
+    const PReg kCCCC = p4;
+    const PReg k0F0F = p5;
+    const PReg kF0F0 = p6;
+    const PReg kTail = p7;
+
+    const XReg reg_src_base = x0;
+    const XReg reg_tr_src_base = x3;
+
+    const XReg reg_src = x8;
+    const XReg reg_tr_src = x9;
+    const XReg reg_loop_K = x10;
+    const XReg reg_loop_M = x11;
+    const XReg reg_loop_batch = x12;
+    const XReg reg_tr_src_tmp = x13;
+    const WReg regw_tmp = w14;
+
+    void transpose_16x16(int nrows, int ncolumns = transpose_size);
+    void generate() override;
+};
+
+void jit_brgemm_trans_m_k_f32_t::transpose_16x16(int nrows, int ncolumns) {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_trans_m_k_f32_t::generate() {
+    preamble();
+    assert(conf_->ic_block % transpose_size == 0);
+    const int os_block = conf_->os_block;
+    const int last_os_block_tail = conf_->K_tail % transpose_size;
+    const int ic_tail = conf_->M_tail % transpose_size;
+    src_stride = conf_->ic * typesize;
+    tr_src_stride = conf_->LDA * typesize;
+    const dim_t m_src_shift = transpose_size * typesize;
+    const dim_t m_tr_src_shift = tr_src_stride * transpose_size;
+
+    const dim_t batch_src_shift = src_stride * os_block;
+    const dim_t batch_tr_src_shift = tr_src_stride * conf_->M;
+
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(src), X_TMP_0);
+    ldr(reg_src_base, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(tr_src), X_TMP_0);
+    ldr(reg_tr_src_base, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_gemm_batch), X_TMP_0);
+    ldr(reg_loop_batch, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_K), X_TMP_0);
+    ldr(reg_loop_K, ptr(X_DEFAULT_ADDR));
+
+    auto kmovw = [=](PReg k, unsigned w) {
+        mov_imm(regw_tmp, w);
+        set_preg(k.h, w, X_TMP_0, X_TMP_1);
+    };
+
+    kmovw(k3333, 0x3333); // 0011001100110011
+    kmovw(k5555, 0x5555); // 0101010101010101
+    kmovw(kAAAA, 0xaaaa); // 1010101010101010
+    kmovw(kCCCC, 0xcccc); // 1100110011001100
+    kmovw(k0F0F, 0x0f0f); // 0000111100001111
+    kmovw(kF0F0, 0xf0f0); // 1111000011110000
+
+    auto compute_M = [=](bool is_os_tail) {
+        const auto nrows = is_os_tail ? last_os_block_tail : transpose_size;
+        add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_M), X_TMP_0);
+        ldr(reg_loop_M, ptr(X_DEFAULT_ADDR));
+        mov(reg_src, reg_src_base);
+        mov(reg_tr_src, reg_tr_src_base);
+        Label M_loop, M_tail_or_done, M_done;
+        if (ic_tail > 0) {
+            cmp_imm(reg_loop_M, transpose_size, X_TMP_0);
+            b(LT, M_tail_or_done);
+        }
+
+        L(M_loop);
+        transpose_16x16(nrows, transpose_size);
+        if (conf_->ic_block > transpose_size) {
+            add_imm(reg_src, reg_src, m_src_shift, X_TMP_0);
+            add_imm(reg_tr_src, reg_tr_src, m_tr_src_shift, X_TMP_1);
+            sub_imm(reg_loop_M, reg_loop_M, (int)transpose_size, X_TMP_0);
+            cmp_imm(reg_loop_M, transpose_size, X_TMP_1);
+            b(GE, M_loop);
+        } else {
+            b(M_done);
+        }
+
+        L(M_tail_or_done);
+        if (ic_tail > 0) {
+            cmp_imm(reg_loop_M, 0, X_TMP_0);
+            b(LE, M_done);
+            transpose_16x16(nrows, ic_tail);
+        }
+        L(M_done);
+    };
+
+    auto compute_batch = [=](bool is_os_tail) {
+        Label batch_loop;
+        L(batch_loop);
+
+        compute_M(is_os_tail);
+        add_imm(reg_src_base, reg_src_base, batch_src_shift, X_TMP_0);
+        add_imm(reg_tr_src_base, reg_tr_src_base, batch_tr_src_shift, X_TMP_1);
+
+        sub_imm(reg_loop_batch, reg_loop_batch, 1, X_TMP_0);
+        b(NE, batch_loop);
+    };
+
+    Label K_tail;
+    if (last_os_block_tail > 0) {
+        cmp_imm(reg_loop_K, transpose_size, X_TMP_0);
+        b(LT, K_tail);
+    }
+
+    compute_batch(false);
+
+    if (last_os_block_tail > 0) {
+        Label K_done;
+        b(K_done);
+
+        L(K_tail);
+        compute_batch(true);
+        L(K_done);
+    }
+
+    postamble();
+}
+
+struct jit_brgemm_trans_m_k_bf16_t : public jit_brgemm_trans_src_t,
+                                     public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_m_k_bf16_t)
+    jit_brgemm_trans_m_k_bf16_t(const jit_brgemm_primitive_conf_t *conf)
+        : jit_brgemm_trans_src_t(conf) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
+    status_t create_kernel() override { return jit_generator::create_kernel(); }
+
+private:
+    enum {
+        typesize = sizeof(int16_t),
+        transpose_size = 16,
+    };
+
+    const PReg kFFFF = p1;
+    const PReg k5555 = p2;
+    const PReg kAAAA = p3;
+    const PReg kAA = p4;
+    const PReg k55 = p5;
+    const PReg kCC = p6;
+    const PReg k33 = p7;
+    const PReg kTail = p1;
+
+    const WReg regw_tmp = w15;
+
+    const XReg reg_k_src = x14;
+    const XReg reg_k_tr_src = x13;
+
+    const XReg reg_m_src = x12;
+    const XReg reg_m_tr_src = x11;
+
+    const XReg reg_batch_src = x10;
+    const XReg reg_batch_tr_src = x9;
+
+    const XReg reg_loop_batch = x8;
+    const XReg reg_loop_K = x0;
+    const XReg reg_loop_M = x3;
+
+    const XReg reg_tr_src_tmp = x1; // lnx -> rcx
+    const XReg imm_addr64 = x2;
+
+    ZReg vidx1 = z31;
+    ZReg vidx2 = z30;
+    ZReg vidx3 = z29;
+    ZReg vidx4 = z28;
+    ZReg vidx5 = z27;
+    ZReg zmm_tmp = z26;
+
+    void transpose(const XReg dst, const XReg src, int nrows,
+            int ncolumns = transpose_size);
+    void generate() override;
+};
+
+void jit_brgemm_trans_m_k_bf16_t::transpose(
+        XReg dst, XReg src, int nrows, int ncolumns) {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_trans_m_k_bf16_t::generate() {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_copy_to_coarse_t::copy_row_blks(int num_row_blks) {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_copy_to_coarse_t::copy_row_tail(
+        bool is_last_iteration, int row_offset) {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_copy_to_coarse_t::zero_out_rows() {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_copy_to_coarse_t::copy_row_loop() {
+    Label label_row_tail, label_row_exit;
+
+    // Note: copying is done in chunks of size row_step_
+    const auto copy_row = [&](bool is_last_iteration) {
+        const int row_blk
+                = is_last_iteration ? (row_size_ % tr_row_size_) : tr_row_size_;
+        const int row_iters = row_blk / row_step_;
+        const int row_iters_tail = row_blk % row_step_;
+
+        copy_row_blks(row_iters);
+        if (row_iters_tail != 0)
+            copy_row_tail(is_last_iteration, /* row_offset = */ row_iters);
+
+        // For the last iteration, zero-out rows if needed
+        if (is_last_iteration) zero_out_rows();
+    };
+
+    const bool only_row_tail = row_size_ < tr_row_size_;
+
+    if (!only_row_tail) {
+        cmp_imm(reg_last_row_blk, 0, X_TMP_0);
+        b(NE, label_row_tail);
+
+        copy_row(/* is_last_iteration = */ false);
+        b(label_row_exit);
+    }
+
+    L(label_row_tail);
+    copy_row(/* is_last_iteration = */ true);
+
+    L(label_row_exit);
+}
+
+void jit_brgemm_copy_to_coarse_t::copy_os_loop() {
+
+    Label loop_os;
+    L(loop_os);
+
+    copy_row_loop();
+    add_imm(reg_data, reg_data, data_stride_, X_TMP_0);
+    add_imm(reg_tr_data, reg_tr_data, tr_data_stride_, X_TMP_1);
+
+    subs(reg_os_work, reg_os_work, 1);
+    cmp_imm(reg_os_work, 0, X_TMP_0);
+    b(NE, loop_os);
+}
+
+void jit_brgemm_copy_to_coarse_t::set_last_row_tail_masks() {
+    const int row_tail = (row_size_ % tr_row_size_) % row_step_;
+    assert(row_tail > 0 && "kernel is meant to be used with tail processing");
+
+    // Set load mask
+    set_preg(
+            reg_m_last_row_tail_load.d, typesize_ * row_tail, X_TMP_0, X_TMP_1);
+
+    // Caution: Since size of ZMM equals 64 bytes therefore we need
+    // different masks to store tails with smaller row_block_size_
+    constexpr auto full_mask = size_t {0xffffffffffffffff};
+    constexpr auto half_mask = size_t {0x00000000ffffffff};
+    constexpr auto quad_mask = size_t {0x000000000000ffff};
+
+    const auto num_bytes = [](size_t mask) -> int {
+        // Given by 1 + position of leftmost 1 bit
+        return 1 + math::ilog2q(mask);
+    };
+
+    const int row_tail_store_size
+            = utils::rnd_up(row_tail, row_block_size_) * typesize_;
+    if (row_tail_store_size >= num_bytes(full_mask)) {
+        ptrue(reg_m_last_row_tail_load.b);
+    } else if (row_tail_store_size >= num_bytes(half_mask))
+        set_preg(reg_m_last_row_tail_load.b, half_mask, X_TMP_0, X_TMP_1);
+    else {
+        assert(row_tail_store_size == num_bytes(quad_mask));
+        set_preg(reg_m_last_row_tail_load.b, quad_mask, X_TMP_0, X_TMP_1);
+    }
+}
+
+void jit_brgemm_copy_to_coarse_t::set_full_row_tail_masks() {
+    const auto full_row_tail = tr_row_size_ % row_step_;
+    assert(row_step_ == 2 * full_row_tail || row_step_ == 4 * full_row_tail);
+
+    const auto tail_mask = row_step_ == 2 * full_row_tail
+            ? size_t {0x00000000ffffffff}
+            : size_t {0x000000000000ffff};
+
+    set_preg(reg_m_full_row_tail_store.b, tail_mask, X_TMP_0, X_TMP_1);
+    set_preg(reg_m_full_row_tail_load.b, tail_mask, X_TMP_0, X_TMP_1);
+}
+
+void jit_brgemm_copy_to_coarse_t::generate() {
+    preamble();
+
+    // set up masks for tail processing
+    set_last_row_tail_masks();
+    const bool has_full_row_tail_ = tr_row_size_ % row_step_ != 0;
+    if (has_full_row_tail_) set_full_row_tail_masks();
+
+    // init zero vreg (zmm_zero) if it is needed
+    const int last_row_size
+            = utils::rnd_up(row_size_ % tr_row_size_, row_step_);
+    const bool zero_iters_needed
+            = last_row_size > 0 && last_row_size < tr_row_size_;
+    if (zero_iters_needed) eor(zmm_zero.d, zmm_zero.d, zmm_zero.d);
+
+    // load arguments to the jit kernel
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(data), X_TMP_0);
+    ldr(reg_data, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(tr_data), X_TMP_0);
+    ldr(reg_tr_data, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(os_work), X_TMP_0);
+    ldr(reg_os_work, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(last_row_blk), X_TMP_0);
+    ldr(reg_last_row_blk, ptr(X_DEFAULT_ADDR));
+
+    // enter the `main` loop
+    copy_os_loop();
+
+    postamble();
+}
+
+struct jit_trans_to_vnni_t : public jit_brgemm_trans_to_vnni_t,
+                             public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_trans_to_vnni_t)
+    jit_trans_to_vnni_t(const jit_brgemm_primitive_conf_t *conf,
+            jit_brgemm_trans_to_vnni_t::matrix_to_transform_t
+                    matrix_to_transform)
+        : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
+    status_t create_kernel() override { return jit_generator::create_kernel(); }
+
+private:
+    enum {
+        typesize_data = sizeof(int16_t),
+        typesize_acc = sizeof(float),
+        transpose_size = 16,
+    };
+
+    PReg kFFFF = p1;
+    PReg mask_tail = p2;
+
+    ZReg vidx1 = z31;
+
+    WReg regw_tmp = w15;
+
+    XReg reg_batch_src = x14;
+    XReg reg_batch_tr_src = x13;
+
+    XReg reg_row_src = x12;
+    XReg reg_row_tr_src = x11;
+
+    XReg reg_col_src = x10;
+    XReg reg_col_tr_src = x9;
+
+    XReg reg_loop_batch = x8;
+    XReg reg_loop_row = x0;
+    XReg reg_loop_col = x3;
+
+    XReg imm_addr64 = x1; // lnx -> rcx
+
+    void maybe_zero_pad_col(XReg dst);
+    void transpose(XReg dst, XReg src, int nrows, int ncolumns = transpose_size,
+            bool pad_by_zeroes = false);
+    void generate() override;
+};
+
+void jit_trans_to_vnni_t::maybe_zero_pad_col(XReg dst) {
+    assert(!"unsupported\n");
+}
+
+void jit_trans_to_vnni_t::transpose(
+        XReg dst, XReg src, int nrows, int ncolumns, bool pad_by_zeroes) {
+    assert(!"unsupported\n");
+}
+
+void jit_trans_to_vnni_t::generate() {
+    assert(!"unsupported\n");
+}
+
+struct jit_copy_f32_t : public jit_brgemm_trans_to_vnni_t,
+                        public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_copy_f32_t)
+    jit_copy_f32_t(const jit_brgemm_primitive_conf_t *conf,
+            jit_brgemm_trans_to_vnni_t::matrix_to_transform_t
+                    matrix_to_transform)
+        : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
+    status_t create_kernel() override { return jit_generator::create_kernel(); }
+
+private:
+    enum {
+        typesize_data = sizeof(float),
+        column_step = 16,
+        num_regs = 32,
+    };
+
+    dim_t src_stride = 0, tr_src_stride = 0;
+    dim_t src_batch_shift = 0, tr_src_batch_shift = 0;
+
+    PReg mask_tail = p2;
+
+    XReg reg_src = x8;
+    XReg reg_tr_src = x9;
+    XReg reg_loop_batch = x10;
+    XReg reg_loop_row = x11;
+    XReg reg_loop_col = x12;
+    WReg regw_tmp = w14;
+    XReg reg_long_offt = x15;
+
+    void copy_block(int nrows, int ncolumns);
+    void generate() override;
+};
+
+void jit_copy_f32_t::copy_block(int nrows, int ncolumns) {
+    assert(!"unsupported\n");
+}
+
+void jit_copy_f32_t::generate() {
+    preamble();
+
+    const int row_block = conf_->os_block;
+    const int row_tail = conf_->os % row_block;
+    const int col_block = conf_->oc_block * conf_->nb_oc_blocking;
+    const int col_tail = conf_->oc % col_block;
+    src_stride = conf_->oc * typesize_data;
+    tr_src_stride = conf_->LDB * typesize_data;
+    src_batch_shift = src_stride * row_block;
+    tr_src_batch_shift = tr_src_stride * row_block;
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(src), X_TMP_0);
+    ldr(reg_src, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(tr_src), X_TMP_0);
+    ldr(reg_tr_src, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_gemm_batch), X_TMP_0);
+    ldr(reg_loop_batch, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_row_size), X_TMP_0);
+    ldr(reg_loop_row, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_col_size), X_TMP_0);
+    ldr(reg_loop_col, ptr(X_DEFAULT_ADDR));
+
+    auto compute_batch = [=](int nrows, int ncolumns) {
+        Label batch_loop;
+        L(batch_loop);
+
+        copy_block(nrows, ncolumns);
+        add_imm(reg_src, reg_src, src_batch_shift, X_TMP_0);
+        add_imm(reg_tr_src, reg_tr_src, tr_src_batch_shift, X_TMP_1);
+
+        sub_imm(reg_loop_batch, reg_loop_batch, 1, X_TMP_0);
+        cmp_imm(reg_loop_batch, 0, X_TMP_0);
+        b(NE, batch_loop);
+    };
+
+    auto compute_rows = [=](int ncolumns) {
+        Label row_done;
+        if (row_tail > 0) {
+            Label row_common;
+            cmp_imm(reg_loop_row, row_block, X_TMP_0);
+            b(EQ, row_common);
+
+            compute_batch(row_tail, ncolumns);
+            b(row_done);
+
+            L(row_common);
+        }
+
+        compute_batch(row_block, ncolumns);
+        L(row_done);
+    };
+
+    Label col_done;
+    if (col_tail > 0) {
+        Label col_common;
+        cmp_imm(reg_loop_col, col_block, X_TMP_0);
+        b(EQ, col_common);
+
+        compute_rows(col_tail);
+        b(col_done);
+
+        L(col_common);
+    }
+
+    compute_rows(col_block);
+    L(col_done);
+
+    postamble();
+}
+
+struct jit_brgemm_trans_wei_f32_t : public jit_brgemm_trans_wei_t,
+                                    public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_wei_f32_t)
+
+    jit_brgemm_trans_wei_f32_t(const jit_brgemm_primitive_conf_t *conf)
+        : jit_brgemm_trans_wei_t(conf) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
+    status_t create_kernel() override { return jit_generator::create_kernel(); }
+
+private:
+    enum { typesize = sizeof(float), transpose_size = 16 };
+    dim_t src_stride = 0, tr_src_stride = 0;
+
+    PReg k3333 = p1;
+    PReg k5555 = p2;
+    PReg kAAAA = p3;
+    PReg kCCCC = p4;
+    PReg k0F0F = p5;
+    PReg kF0F0 = p6;
+    PReg kTail = p7;
+
+    XReg reg_src_base = x0;
+    XReg reg_tr_src_base = x3;
+
+    XReg reg_src = x8;
+    XReg reg_tr_src = x9;
+    XReg reg_loop_N = x10;
+    XReg reg_loop_K = x11;
+    XReg reg_loop_batch = x12;
+    XReg reg_tr_src_tmp = x13;
+    WReg regw_tmp = w14;
+
+    void transpose_16x16(int nrows, int ncolumns = transpose_size);
+    void generate() override;
+};
+
+void jit_brgemm_trans_wei_f32_t::transpose_16x16(int nrows, int ncolumns) {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_trans_wei_f32_t::generate() {
+    preamble();
+    assert(conf_->oc_block % transpose_size == 0);
+    int fwd_ic_block = conf_->simd_w;
+    int fwd_oc_block = 0;
+    switch (conf_->wei_tag) {
+        case OI16i64o:
+        case OIw16i64o:
+        case OIhw16i64o:
+        case OIdhw16i64o:
+        case OI8i64o2i:
+        case OIw8i64o2i:
+        case OIhw8i64o2i:
+        case OIdhw8i64o2i:
+        case OI16i64o2i:
+        case OIw16i64o2i:
+        case OIhw16i64o2i:
+        case OIdhw16i64o2i: fwd_oc_block = 4 * conf_->simd_w; break;
+        case OI16i32o:
+        case OIw16i32o:
+        case OIhw16i32o:
+        case OIdhw16i32o:
+        case OI8i32o2i:
+        case OIw8i32o2i:
+        case OIhw8i32o2i:
+        case OIdhw8i32o2i:
+        case OI16i32o2i:
+        case OIw16i32o2i:
+        case OIhw16i32o2i:
+        case OIdhw16i32o2i: fwd_oc_block = 2 * conf_->simd_w; break;
+        default: fwd_oc_block = conf_->simd_w;
+    };
+
+    int oc_tail = conf_->K_tail % transpose_size;
+    int ic_block = conf_->ic_block;
+    int ic_tail = conf_->N_tail % transpose_size;
+    src_stride = fwd_oc_block * typesize;
+    tr_src_stride = ic_block * typesize;
+    dim_t N_src_shift = conf_->kd * conf_->kh * conf_->kw * fwd_ic_block
+            * fwd_oc_block * typesize;
+    dim_t N_tr_src_shift = conf_->simd_w * typesize;
+    dim_t K_src_shift = conf_->simd_w * typesize;
+    dim_t K_tr_src_shift = conf_->ic_block * conf_->simd_w * typesize;
+
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(src), X_TMP_0);
+    ldr(reg_src_base, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(tr_src), X_TMP_0);
+    ldr(reg_tr_src_base, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_gemm_batch), X_TMP_0);
+    ldr(reg_loop_batch, ptr(X_DEFAULT_ADDR));
+    add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_K), X_TMP_0);
+    ldr(reg_loop_K, ptr(X_DEFAULT_ADDR));
+
+    auto kmovw
+            = [=](PReg k, unsigned w) { set_preg(k.h, w, X_TMP_0, X_TMP_1); };
+
+    kmovw(k3333, 0x3333); // 0011001100110011
+    kmovw(k5555, 0x5555); // 0101010101010101
+    kmovw(kAAAA, 0xaaaa); // 1010101010101010
+    kmovw(kCCCC, 0xcccc); // 1100110011001100
+    kmovw(k0F0F, 0x0f0f); // 0000111100001111
+    kmovw(kF0F0, 0xf0f0); // 1111000011110000
+
+    auto compute_N = [=](bool is_oc_tail) {
+        add_imm(X_DEFAULT_ADDR, param1, GET_OFF(current_N), X_TMP_0);
+        ldr(reg_loop_N, ptr(X_DEFAULT_ADDR));
+        mov(reg_src, reg_src_base);
+        mov(reg_tr_src, reg_tr_src_base);
+        Label N_loop, N_loop_tail;
+
+        cmp_imm(reg_loop_N, transpose_size, X_TMP_0);
+        b(LT, N_loop_tail);
+
+        L(N_loop);
+
+        transpose_16x16(transpose_size, is_oc_tail ? oc_tail : transpose_size);
+        add_imm(reg_src, reg_src, N_src_shift, X_TMP_0);
+        add_imm(reg_tr_src, reg_tr_src, N_tr_src_shift, X_TMP_1);
+
+        sub_imm(reg_loop_N, reg_loop_N, (int)transpose_size, X_TMP_0);
+        cmp_imm(reg_loop_N, transpose_size, X_TMP_1);
+        b(GE, N_loop);
+
+        L(N_loop_tail);
+        if (ic_tail > 0) {
+            Label N_loop_done;
+            cmp_imm(reg_loop_N, 0, X_TMP_0);
+            b(LE, N_loop_done);
+            transpose_16x16(ic_tail, is_oc_tail ? oc_tail : transpose_size);
+            L(N_loop_done);
+        }
+    };
+
+    Label K_loop, K_tail;
+    if (oc_tail > 0) {
+        cmp_imm(reg_loop_K, transpose_size, X_TMP_0);
+        b(LT, K_tail);
+    }
+
+    L(K_loop);
+    compute_N(false);
+    add_imm(reg_src_base, reg_src_base, K_src_shift, X_TMP_0);
+    add_imm(reg_tr_src_base, reg_tr_src_base, K_tr_src_shift, X_TMP_1);
+
+    sub_imm(reg_loop_K, reg_loop_K, (int)transpose_size, X_TMP_0);
+    cmp_imm(reg_loop_K, transpose_size, X_TMP_1);
+    b(GT, K_loop);
+
+    L(K_tail);
+    if (oc_tail > 0) {
+        Label K_loop_done;
+        cmp_imm(reg_loop_K, 0, X_TMP_0);
+        b(LE, K_loop_done);
+
+        compute_N(true);
+        L(K_loop_done);
+    }
+
+    postamble();
+}
+
+struct jit_brgemm_trans_wei_bf16_t : public jit_brgemm_trans_wei_t,
+                                     public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_wei_bf16_t)
+
+    jit_brgemm_trans_wei_bf16_t(const jit_brgemm_primitive_conf_t *conf)
+        : jit_brgemm_trans_wei_t(conf) {}
+
+    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
+    status_t create_kernel() override { return jit_generator::create_kernel(); }
+
+private:
+    enum { typesize = sizeof(int16_t), transpose_size = 16 };
+
+    PReg kTail = p7;
+
+    XReg reg_src_base = x0;
+    XReg reg_tr_src_base = x3;
+
+    XReg reg_src = x8;
+    XReg reg_tr_src = x9;
+    XReg reg_loop_N = x10;
+    XReg reg_loop_K = x11;
+    XReg reg_loop_batch = x12;
+    XReg reg_tr_src_tmp = x13;
+    WReg regw_tmp = w14;
+    XReg imm_addr64 = x15;
+
+    ZReg v_abcdefgh_to_abefcdgh = z31;
+
+    void transpose_16x16_vnni(int nrows, int ncolumns = transpose_size);
+    void generate() override;
+};
+
+void jit_brgemm_trans_wei_bf16_t::transpose_16x16_vnni(
+        int nrows, int ncolumns) {
+    assert(!"unsupported\n");
+}
+
+void jit_brgemm_trans_wei_bf16_t::generate() {
+    assert(!"unsupported\n");
+}
+
+#undef GET_OFF
+
+status_t create_brgemm_trans_src(
+        std::unique_ptr<jit_brgemm_trans_src_t> &trans_ker,
+        const jit_brgemm_primitive_conf_t *conf) {
+    if (conf->prop_kind == dnnl_backward_weights
+            && conf->src_dt == data_type::f32)
+        CHECK(safe_ptr_assign(trans_ker, new jit_brgemm_trans_m_k_f32_t(conf)));
+    else if (conf->prop_kind == dnnl_backward_weights
+            && conf->src_dt == data_type::bf16)
+        CHECK(safe_ptr_assign(
+                trans_ker, new jit_brgemm_trans_m_k_bf16_t(conf)));
+    else
+        return status::invalid_arguments;
+
+    return trans_ker->create_kernel();
+}
+
+status_t create_brgemm_copy_to_coarse(
+        std::unique_ptr<jit_brgemm_copy_to_coarse_t> &copy_ker,
+        const jit_brgemm_primitive_conf_t *conf) {
+    if (false)
+        CHECK(safe_ptr_assign(copy_ker, new jit_brgemm_copy_to_coarse_t(conf)));
+    else
+        return status::invalid_arguments;
+
+    return copy_ker->create_kernel();
+}
+
+status_t create_brgemm_trans_to_vnni(
+        std::unique_ptr<jit_brgemm_trans_to_vnni_t> &trans_ker,
+        const jit_brgemm_primitive_conf_t *conf,
+        jit_brgemm_trans_to_vnni_t::matrix_to_transform_t matrix_to_transform) {
+    if (conf->prop_kind == dnnl_backward_weights
+            && conf->dst_dt == data_type::bf16)
+        CHECK(safe_ptr_assign(
+                trans_ker, new jit_trans_to_vnni_t(conf, matrix_to_transform)));
+    else if (conf->prop_kind == dnnl_backward_weights
+            && conf->dst_dt == data_type::f32)
+        CHECK(safe_ptr_assign(
+                trans_ker, new jit_copy_f32_t(conf, matrix_to_transform)));
+    else
+        return status::invalid_arguments;
+
+    return trans_ker->create_kernel();
+}
+
+status_t create_brgemm_trans_wei(
+        std::unique_ptr<jit_brgemm_trans_wei_t> &trans_ker,
+        const jit_brgemm_primitive_conf_t *conf) {
+    if (conf->prop_kind == dnnl_backward_data && conf->wei_dt == data_type::f32)
+        CHECK(safe_ptr_assign(trans_ker, new jit_brgemm_trans_wei_f32_t(conf)));
+    else if (conf->prop_kind == dnnl_backward_data
+            && conf->wei_dt == data_type::bf16)
+        CHECK(safe_ptr_assign(
+                trans_ker, new jit_brgemm_trans_wei_bf16_t(conf)));
+    else
+        return status::invalid_arguments;
+
+    return trans_ker->create_kernel();
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
@@ -1,0 +1,197 @@
+/*******************************************************************************
+* Copyright 2020-2023 Intel Corporation
+* Copyright 2024 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_BRGEMM_TRANSPOSE_UTILS_HPP
+#define CPU_AARCH64_JIT_BRGEMM_TRANSPOSE_UTILS_HPP
+
+#include "cpu/aarch64/jit_brgemm_primitive_conf.hpp"
+#include "cpu/aarch64/jit_generator.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct jit_brgemm_trans_src_t {
+    struct ctx_t {
+        const void *src;
+        const void *tr_src;
+
+        dim_t current_gemm_batch;
+        dim_t current_M, current_K;
+    };
+
+    virtual void operator()(ctx_t *ctx) = 0;
+    virtual status_t create_kernel() = 0;
+
+    jit_brgemm_trans_src_t(const jit_brgemm_primitive_conf_t *conf)
+        : conf_(conf) {}
+    virtual ~jit_brgemm_trans_src_t() {}
+
+    const jit_brgemm_primitive_conf_t *conf_;
+};
+
+struct jit_brgemm_copy_to_coarse_t : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_copy_to_coarse_t)
+
+    struct ctx_t {
+        const void *data;
+        const void *tr_data;
+
+        dim_t os_work;
+        dim_t last_row_blk;
+    };
+
+    void operator()(ctx_t *ctx) { jit_generator::operator()(ctx); }
+    status_t create_kernel() override { return jit_generator::create_kernel(); }
+
+    jit_brgemm_copy_to_coarse_t(const jit_brgemm_primitive_conf_t *conf)
+        : conf_(conf)
+        , typesize_(sizeof(bfloat16_t))
+        , is_fwd_dir_(utils::one_of(conf_->prop_kind,
+                  prop_kind::forward_training, prop_kind::forward_inference))
+        , row_block_size_(is_fwd_dir_ ? conf_->ic_block : conf_->oc_block)
+        , row_size_(is_fwd_dir_ ? conf_->ic_without_padding
+                                : conf_->oc_without_padding)
+        , tr_row_size_(conf_->LDA)
+        , row_granularity_(granularity_in_bytes / typesize_)
+        , row_step_(zmm_size_in_bytes / typesize_)
+        , data_stride_(row_size_ * typesize_)
+        , tr_data_stride_(tr_row_size_ * typesize_) {
+
+        // Kernel is supposed to be called under the following constraints
+        assert(row_size_ % row_granularity_ != 0);
+
+        MAYBE_UNUSED(row_granularity_);
+    }
+    ~jit_brgemm_copy_to_coarse_t() {}
+
+private:
+    enum {
+        zmm_size_in_bytes = 64,
+        row_loop_unroll = 16,
+        granularity_in_bytes = 4,
+    };
+
+    const jit_brgemm_primitive_conf_t *conf_;
+    const int typesize_;
+    const bool is_fwd_dir_;
+    const int row_block_size_, row_size_, tr_row_size_, row_granularity_,
+            row_step_;
+    const dim_t data_stride_, tr_data_stride_;
+
+    inline size_t addr_offset(int row_idx) {
+        return row_idx * row_step_ * typesize_;
+    }
+    inline Xbyak_aarch64::ZReg get_zmm_copy(int row_idx) const {
+        assert(row_idx >= 0 && row_idx < row_loop_unroll);
+        return Xbyak_aarch64::ZReg(row_idx);
+    }
+
+    const Xbyak_aarch64::ZReg zmm_zero = Xbyak_aarch64::ZReg(row_loop_unroll);
+    const Xbyak_aarch64::ZReg zmm_row_tail
+            = Xbyak_aarch64::ZReg(row_loop_unroll + 1);
+
+    const Xbyak_aarch64::PReg reg_m_full_row_tail_load = p7;
+    const Xbyak_aarch64::PReg reg_m_full_row_tail_store = p6;
+    const Xbyak_aarch64::PReg reg_m_last_row_tail_load = p5;
+    const Xbyak_aarch64::PReg reg_m_last_row_tail_store = p4;
+
+    const Xbyak_aarch64::XReg reg_data = x0;
+    const Xbyak_aarch64::XReg reg_tr_data = x3;
+
+    const Xbyak_aarch64::XReg reg_os_work = x11;
+    const Xbyak_aarch64::XReg reg_last_row_blk = x12;
+    const Xbyak_aarch64::XReg reg_tail_mask = x13;
+
+    void copy_os_loop();
+    void copy_row_loop();
+
+    void copy_row_blks(int num_row_blks);
+    void copy_row_tail(bool is_last_iteration, int row_offset);
+    void zero_out_rows();
+
+    void set_full_row_tail_masks();
+    void set_last_row_tail_masks();
+
+    void generate() override;
+};
+
+struct jit_brgemm_trans_to_vnni_t {
+    struct ctx_t {
+        const void *src;
+        const void *tr_src;
+
+        dim_t current_gemm_batch;
+        dim_t current_col_size, current_row_size;
+    };
+
+    typedef enum matrix_to_transform {
+        matrix_B,
+        matrix_C
+    } matrix_to_transform_t;
+
+    virtual void operator()(ctx_t *ctx) = 0;
+    virtual status_t create_kernel() = 0;
+
+    jit_brgemm_trans_to_vnni_t(const jit_brgemm_primitive_conf_t *conf,
+            matrix_to_transform_t matrix_to_transform)
+        : conf_(conf), matrix_to_transform_(matrix_to_transform) {}
+    virtual ~jit_brgemm_trans_to_vnni_t() {}
+
+    const jit_brgemm_primitive_conf_t *conf_;
+    matrix_to_transform_t matrix_to_transform_;
+};
+
+struct jit_brgemm_trans_wei_t {
+    struct ctx_t {
+        const void *src;
+        const void *tr_src;
+
+        dim_t current_gemm_batch;
+        dim_t current_N, current_K;
+    };
+
+    virtual void operator()(ctx_t *ctx) = 0;
+    virtual status_t create_kernel() = 0;
+
+    jit_brgemm_trans_wei_t(const jit_brgemm_primitive_conf_t *conf)
+        : conf_(conf) {}
+    virtual ~jit_brgemm_trans_wei_t() {}
+
+    const jit_brgemm_primitive_conf_t *conf_;
+};
+
+status_t create_brgemm_trans_src(
+        std::unique_ptr<jit_brgemm_trans_src_t> &trans_ker,
+        const jit_brgemm_primitive_conf_t *conf);
+status_t create_brgemm_copy_to_coarse(
+        std::unique_ptr<jit_brgemm_copy_to_coarse_t> &copy_ker,
+        const jit_brgemm_primitive_conf_t *conf);
+status_t create_brgemm_trans_to_vnni(
+        std::unique_ptr<jit_brgemm_trans_to_vnni_t> &trans_ker,
+        const jit_brgemm_primitive_conf_t *conf,
+        jit_brgemm_trans_to_vnni_t::matrix_to_transform_t matrix_to_transform);
+status_t create_brgemm_trans_wei(
+        std::unique_ptr<jit_brgemm_trans_wei_t> &trans_ker,
+        const jit_brgemm_primitive_conf_t *conf);
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -56,6 +56,8 @@
 #include "cpu/x64/jit_uni_x8s8s32x_convolution.hpp"
 using namespace dnnl::impl::cpu::x64;
 #elif DNNL_AARCH64
+#include "cpu/aarch64/jit_brgemm_1x1_conv.hpp"
+#include "cpu/aarch64/jit_brgemm_conv.hpp"
 #include "cpu/aarch64/jit_sve_512_1x1_convolution.hpp"
 #include "cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp"
 #include "cpu/aarch64/jit_sve_convolution.hpp"
@@ -134,6 +136,8 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(jit_avx2_convolution_fwd_t)
             CPU_INSTANCE_SSE41(jit_sse41_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_wino_convolution_fwd_t)
+            CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_512>)
+            CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_512>)
             CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
             CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_fwd_t<f32,f32,f32,sve_512>)


### PR DESCRIPTION
# Description

This commit enables BRGEMM general and 1x1 forward convolution for the ARM SVE ISA.

**Major code changes:**

Added BRGEMM convolution files in src/aarch64 to support general and 1x1 forward convolution.
Added support for brgemm convolution in src/cpu/aarch64/brgemm/brgemm_containers.hpp, src/aarch64/cpu_isa_traits.hpp and src/cpu/aarch64/jit_primitive_conf.hpp.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
 Test output is same with and without this commit.

 1. make test output : 
  ```
   98% tests passed, 3 tests failed out of 194
    Total Test time (real) = 535.50 sec
    The following tests FAILED:
        148 - test_graph_unit_dnnl_conv_usm_cpu (Failed)
        153 - test_graph_unit_dnnl_large_partition_usm_cpu (Failed)
        175 - test_benchdnn_modeC_graph_ci_cpu (Failed)
   Errors while running CTest
   Output from these tests are in: 
   /home/deekshak/xybak/oss_pr/forked_oss/oneDNN_Fork/build/Testing/Temporary/LastTest.log
   Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
   make: *** [Makefile:71: test] Error 8
```

  
- [x] Have you formatted the code using clang-format? Yes
cc: @kawakami-k 



