### PR TITLE
gpu: sycl: shuffle: Enabling u8 datatype support

### DIFF
--- a/src/gpu/generic/sycl/ref_shuffle.cpp
+++ b/src/gpu/generic/sycl/ref_shuffle.cpp
@@ -132,7 +132,6 @@ status_t ref_shuffle_t::execute(const exec_ctx_t &ctx) const {
         const int t_work
                 = (pd()->conf_.MB) * ((pd()->conf_.C / d2)) * pd()->conf_.SP;
 
-        std::cout << std::endl;
         const int wg_work = wg_size * block_size;
         const int wg_cnt = (t_work + wg_work - 1) / wg_work;
         const int n_thr = wg_cnt * wg_size;

--- a/src/gpu/generic/sycl/ref_shuffle.hpp
+++ b/src/gpu/generic/sycl/ref_shuffle.hpp
@@ -47,12 +47,12 @@ struct ref_shuffle_t : public gpu::generic::sycl::primitive_t {
 
             const bool ok = src_md()->data_type == dst_md()->data_type
                     && (src_md()->data_type == bf16 || src_md()->data_type == s8
+                            || src_md()->data_type == u8
                             || src_md()->data_type == f16
                             || src_md()->data_type == f32)
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && attr()->has_default_values()
                     && set_default_formats_common()
-
                     && IMPLICATION(!is_fwd(), set_default_formats_common());
             if (!ok) return status::unimplemented;
             return init_conf();


### PR DESCRIPTION
# Description

The sycl shuffle implementation is not supporting u8 datatype for the forward pass as suggested in [shuffle doc](https://oneapi-src.github.io/oneDNN/dev_guide_shuffle.html#data-types). This PR enables this feature.
