### PR TITLE
cpu: aarch64: remove unnecessary workaround for f16 eltwise_tanh

### DIFF
--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -80,16 +80,14 @@ struct acl_eltwise_fwd_t : public primitive_t {
                     && src_d == memory_desc_wrapper(dst_md());
             if (!ok) return status::unimplemented;
 
-            // Workaround for the nan-value caused by tanh of ACL for fp16
-            // ARM-software/ComputeLibrary#998. Workaround for the inaccuracies
-            // caused by logistic/soft_relu/elu of ACL for fp16.
+            // Workaround for the inaccuracies caused by
+            // logistic/soft_relu/elu/gelu_erf of ACL for fp16.
             // TODO: Relax the error bounds in eltwise checks, or rework these
             // fp16 operations in ACL for better accuracy.
             using namespace dnnl::impl::alg_kind;
             if (src_d.data_type() == f16
-                    && utils::one_of(desc_.alg_kind, eltwise_tanh,
-                            eltwise_logistic, eltwise_soft_relu, eltwise_elu,
-                            eltwise_gelu_erf)) {
+                    && utils::one_of(desc_.alg_kind, eltwise_logistic,
+                            eltwise_soft_relu, eltwise_elu, eltwise_gelu_erf)) {
                 return status::unimplemented;
             }
 


### PR DESCRIPTION
This patch removes a previously implemented workaround that falls back to the reference implementation of eltwise when the algorithm is tanh in f16. The original bug (ARM-software/ComputeLibrary#998) that the workaround addressed has been fixed.

# Description
This patch removes a previously implemented workaround that falls back to the reference implementation of eltwise when the algorithm is tanh in f16. The original bug (ARM-software/ComputeLibrary#998) that the workaround addressed has been fixed.

# Checklist

## General

- [Y] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ Y] Have you formatted the code using clang-format?

## Performance improvements

- [Y ] Have you submitted performance data that demonstrates performance improvements?
The direct performance benefits are marginal (refer to attached verbose logs) but since the ACL implementation is used it allows oneDNN to benefit from future targeted optimisations.

###Before:
```
onednn_verbose,info,oneDNN v3.6.0 (commit e88463601057ecdee0f67906e75a44759bce79da)
onednn_verbose,info,cpu,runtime:OpenMP,nthr:32
onednn_verbose,info,cpu,isa:AArch64 SVE (256 bits)
onednn_verbose,info,gpu,runtime:none
onednn_verbose,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,primitive,create:dispatch,eltwise,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,unsupported datatype,src/cpu/ref_eltwise.hpp:51
onednn_verbose,primitive,create:dispatch,eltwise,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,unsupported datatype,src/cpu/ref_eltwise.hpp:51
onednn_verbose,primitive,create:cache_miss,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,0.0170898
onednn_verbose,primitive,create:cache_hit,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,0.00195312
onednn_verbose,primitive,create:cache_miss,cpu,reorder,simple:any,undef,src_f32::blocked:abcd::f0 dst_f16::blocked:abcd::f0,,,500x192x55x55,0.0158691
onednn_verbose,primitive,exec,cpu,reorder,simple:any,undef,src_f32::blocked:abcd::f0 dst_f16::blocked:abcd::f0,,,500x192x55x55,433.831
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,218.724
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.358
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.757
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.313
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.449
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.365
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.956
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.279
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,218.101
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.43
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.997
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.275
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.505
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.997
onednn_verbose,primitive,exec,cpu,eltwise,ref:any,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,217.333
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,ref:any,,--mode=P --eltwise --dt=f16 --tag=nchw --alg=tanh --alpha=0 --beta=0 500x192x55x55,0,0.682373,217.337,0,217.655,0
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):217.337 avg(ms):217.655
total: 5.08s; fill: 1.40s (28%);
```
###After:
```
onednn_verbose,info,cpu,isa:AArch64 SVE (256 bits)
onednn_verbose,info,gpu,runtime:none
onednn_verbose,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,primitive,create:cache_miss,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,0.27417
onednn_verbose,primitive,create:cache_hit,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,0.0490723
onednn_verbose,primitive,create:cache_miss,cpu,reorder,simple:any,undef,src_f32::blocked:abcd::f0 dst_f16::blocked:abcd::f0,,,500x192x55x55,0.0151367
onednn_verbose,primitive,exec,cpu,reorder,simple:any,undef,src_f32::blocked:abcd::f0 dst_f16::blocked:abcd::f0,,,500x192x55x55,432.868
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.335
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.684
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.805
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.9
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.544
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.626
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.575
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.654
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.698
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.756
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.498
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.57
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.535
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.59
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.723
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.81
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.562
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.617
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.68
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.734
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.747
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.826
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.613
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.703
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.594
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.683
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.527
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.61
onednn_verbose,primitive,exec:external,CpuActivationKernel/neon_fp16_activation,215.679
onednn_verbose,primitive,exec,cpu,eltwise,acl,forward_training,data_f16::blocked:abcd::f0 diff_undef::undef:::,,alg:eltwise_tanh alpha:0 beta:0,500x192x55x55,215.757
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,acl,,--mode=P --eltwise --dt=f16 --tag=nchw --alg=tanh --alpha=0 --beta=0 500x192x55x55,0,1.21045,215.58,0,215.713,0
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):215.58 avg(ms):215.713
total: 5.04s; fill: 1.39s (28%);
```
