### PR TITLE
brgemm_assertion_fix

### DIFF
--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -130,11 +130,12 @@ bool post_ops_ok(brgemm_matmul_conf_t &bgmmc, const primitive_attr_t &attr,
 
 status_t check_isa_with_datatype(
         const cpu_isa_t isa, const brgemm_matmul_conf_utils_t &bm_conf_utils) {
-    assert(bm_conf_utils.is_f32());
-    assert(!bm_conf_utils.is_int8());
-    assert(!bm_conf_utils.is_bf16());
-    assert(!bm_conf_utils.is_f16());
-    assert(!bm_conf_utils.is_int8());
+    if (bm_conf_utils.is_f32() && !bm_conf_utils.is_int8()
+            && !bm_conf_utils.is_bf16() && !bm_conf_utils.is_f16()
+            && !bm_conf_utils.is_int8())
+        return status::success;
+    else
+        return status::unimplemented;
     return status::success;
 }
 

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -136,7 +136,6 @@ status_t check_isa_with_datatype(
         return status::success;
     else
         return status::unimplemented;
-    return status::success;
 }
 
 brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(


### PR DESCRIPTION
# Description

There was an issue raised on the brgemm matmul PR stating there was an assertion error when running this test : ctest -R cpu-tutorials-matmul-matmul-quantization-cpp in OneDNN debug mode. (https://github.com/oneapi-src/oneDNN/issues/1920)
We had intentionally added this statement but on discussion in the community it was decided that it had to be removed. This PR contains the required changes for the same.

## General

- [y] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
```
make test

98% tests passed, 3 tests failed out of 195

Total Test time (real) = 918.81 sec

The following tests FAILED:
        149 - test_graph_unit_dnnl_conv_usm_cpu (Failed)
        154 - test_graph_unit_dnnl_large_partition_usm_cpu (Failed)
        176 - test_benchdnn_modeC_graph_ci_cpu (Failed)
Errors while running CTest
Output from these tests are in: /home/shreyas/G/shr-fuj/oneDNN_open_source/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8
```
- [y] Have you formatted the code using clang-format?

