### PR TITLE
gpu: sycl: binary: Enabling some skipped tests

### DIFF
--- a/src/gpu/generic/sycl/ref_binary.hpp
+++ b/src/gpu/generic/sycl/ref_binary.hpp
@@ -94,8 +94,7 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
                 if (!utils::one_of(t, f32, bf16, f16, s8, u8)) return false;
             }
 
-            return IMPLICATION(utils::one_of(bf16, src0_dt, src1_dt, dst_dt),
-                    src0_dt == dst_dt && src1_dt == dst_dt);
+            return true;
         }
 
         static bool check_formats(const memory_desc_wrapper &src0,


### PR DESCRIPTION
# Description

The binary primitive SYCL kernel implementation skipped some tests that must be computed. This PR solves that problem.

As an example, the following test needs to be passed:
```bash
./tests/benchdnn/benchdnn --binary --engine=gpu --skip-impl=cuda --sdt=bf16:bf16 --ddt=u8 --stag=abx:axb 3x5x6x9:3x5x6x9
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?