### PR TITLE
gpu: sycl: convolution: implemented

### DIFF
--- a/src/gpu/generic/sycl/convolution_kernels.hpp
+++ b/src/gpu/generic/sycl/convolution_kernels.hpp
@@ -1,0 +1,634 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_CONVOLUTION_KERNELS_HPP
+#define GPU_SYCL_CONVOLUTION_KERNELS_HPP
+
+#include "gpu/generic/sycl/sycl_io_helper.hpp"
+#include "gpu/generic/sycl/sycl_post_ops.hpp"
+#include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+struct convolution_kernel_fwd_t {
+    static constexpr int max_supported_ndims = 6;
+
+    convolution_kernel_fwd_t(const sycl_convolution_conf_t &conf,
+            xpu::sycl::in_memory_arg_t &data,
+            xpu::sycl::in_memory_arg_t &weights,
+            xpu::sycl::in_memory_arg_t &bias, xpu::sycl::out_memory_arg_t &dst,
+            xpu::sycl::in_memory_arg_t &data_scale,
+            xpu::sycl::in_memory_arg_t &weights_scale,
+            xpu::sycl::in_memory_arg_t &dst_scale,
+            xpu::sycl::in_memory_arg_t &data_zeropoints,
+            xpu::sycl::in_memory_arg_t &dst_zeropoints,
+            data_type_t scales_data_dt, data_type_t scales_weights_dt,
+            data_type_t zeropoints_data_dt, data_type_t zeropoints_dst_dt)
+        : conf_(conf)
+        , data_(data)
+        , weights_(weights)
+        , bias_(bias)
+        , dst_(dst)
+        , data_scale_(data_scale)
+        , weights_scale_(weights_scale)
+        , dst_scale_(dst_scale)
+        , data_zeropoints_(data_zeropoints)
+        , dst_zeropoints_(dst_zeropoints)
+        , scales_data_dt_(scales_data_dt)
+        , scales_weights_dt_(scales_weights_dt)
+        , zeropoints_data_dt_(zeropoints_data_dt)
+        , zeropoints_dst_dt_(zeropoints_dst_dt) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        auto sg = item.get_sub_group();
+        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
+        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
+        size_t wi_offset_t = sg.get_local_id();
+        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
+
+        size_t base_idx = offset_t * conf_.block_size;
+
+        const float sm_data = (conf_.do_scale_data
+                        ? load_float_value(scales_data_dt_, data_scale_ptr(), 0)
+                        : 1.f);
+
+        float sm_weights = (conf_.do_scale_weights && conf_.single_weight_scale
+                        ? load_float_value(
+                                scales_weights_dt_, weights_scale_ptr(), 0)
+                        : 1.f);
+
+        const float sm_dst = (conf_.do_scale_dst
+                        ? load_float_value(data_type::f32, dst_scale_ptr(), 0)
+                        : 1.f);
+
+        dims_t data_dims, weights_dims, dst_dims, dst_strides, off;
+        for (int i = 0; i < max_supported_ndims; i++) {
+            data_dims[i] = (i < data_md().ndims()) ? data_md().dims()[i] : 1;
+            weights_dims[i]
+                    = (i < weights_md().ndims()) ? weights_md().dims()[i] : 1;
+            dst_dims[i] = (i < dst_md().ndims()) ? dst_md().dims()[i] : 1;
+            dst_strides[i]
+                    = (i < dst_md().ndims()) ? dst_md().strides()[i] : INT_MAX;
+        }
+
+        bool no_groups = weights_md().ndims() == data_md().ndims();
+
+        const int SD = conf_.strides[0];
+        const int SH = conf_.strides[1];
+        const int SW = conf_.strides[2];
+
+        //per group
+        int OC = weights_dims[1];
+        int IC = weights_dims[2];
+
+        int KD = weights_dims[3];
+        int KH = weights_dims[4];
+        int KW = weights_dims[5];
+        if (no_groups) {
+            OC = weights_dims[0];
+            IC = weights_dims[1];
+            KD = weights_dims[2];
+            KH = weights_dims[3];
+            KW = weights_dims[4];
+        }
+
+        const int PD = conf_.padding[0];
+        const int PH = conf_.padding[1];
+        const int PW = conf_.padding[2];
+
+        const int DD = conf_.dilation[0];
+        const int DH = conf_.dilation[1];
+        const int DW = conf_.dilation[2];
+
+        for (int i = 0; i < conf_.block_size; i++) {
+            int idx = base_idx + i;
+            if (idx < conf_.wk_size) {
+                for (int i = 0; i < max_supported_ndims; i++) {
+                    off[i] = idx / dst_strides[i] % dst_dims[i];
+                }
+
+                const int n = off[0];
+                const int oc_tot = off[1];
+                const int oc = oc_tot % OC;
+                const int g = oc_tot / OC;
+
+                const int od = off[2];
+                const int oh = off[3];
+                const int ow = off[4];
+
+                float accumulator = 0;
+                for (int ic = 0; ic < IC; ++ic) {
+                    for (int kd = 0; kd < KD; ++kd) {
+                        for (int kh = 0; kh < KH; ++kh) {
+                            for (int kw = 0; kw < KW; ++kw) {
+                                const int id = od * SD - PD + kd * (1 + DD);
+                                const int ih = oh * SH - PH + kh * (1 + DH);
+                                const int iw = ow * SW - PW + kw * (1 + DW);
+
+                                if (id < 0 || id >= data_dims[2] || ih < 0
+                                        || ih >= data_dims[3] || iw < 0
+                                        || iw >= data_dims[4]) {
+                                    continue;
+                                }
+
+                                dims_t off_data {n, g * IC + ic, id, ih, iw};
+                                const int data_idx = data_md().off_v(off_data);
+                                dims_t off_weights {g, oc, ic, kd, kh, kw};
+                                dims_t off_weights_no_groups {
+                                        oc, ic, kd, kh, kw};
+                                const int weights_idx = weights_md().off_v(
+                                        no_groups ? off_weights_no_groups
+                                                  : off_weights);
+
+                                auto data = load_float_value(
+                                        data_md().data_type(), data_ptr(),
+                                        data_idx);
+                                auto weight = load_float_value(
+                                        weights_md().data_type(), weights_ptr(),
+                                        weights_idx);
+
+                                if (conf_.use_data_zeropoints) {
+                                    int zpoint_idx = conf_.single_data_zeropoint
+                                            ? 0
+                                            : g * IC + ic;
+                                    auto data_zeropoint = load_float_value(
+                                            zeropoints_data_dt_,
+                                            data_zeropoint_ptr(), zpoint_idx);
+                                    data -= data_zeropoint;
+                                }
+                                accumulator += data * weight;
+                            }
+                        }
+                    }
+                }
+                if (conf_.do_scale_data) { accumulator *= sm_data; }
+                if (conf_.do_scale_weights) {
+                    if (!conf_.single_weight_scale) {
+                        sm_weights = load_float_value(scales_weights_dt_,
+                                weights_scale_ptr(), oc_tot);
+                    }
+                    accumulator *= sm_weights;
+                }
+
+                if (bias_md().ndims() != 0) {
+                    auto bias = load_float_value(
+                            bias_md().data_type(), bias_ptr(), oc_tot);
+                    accumulator += bias;
+                }
+
+                auto dst = load_float_value(
+                        conf_.post_ops.sum_dt_ == dnnl_data_type_undef
+                                ? dst_md().data_type()
+                                : conf_.post_ops.sum_dt_,
+                        dst_ptr(), idx);
+                accumulator = conf_.post_ops.apply(accumulator, dst);
+
+                if (conf_.do_scale_dst) { accumulator /= sm_dst; }
+                if (conf_.use_dst_zeropoints) {
+                    int zpoint_idx = conf_.single_dst_zeropoint ? 0 : oc_tot;
+                    auto dst_zeropoint = load_float_value(zeropoints_dst_dt_,
+                            dst_zeropoint_ptr(), zpoint_idx);
+                    accumulator += dst_zeropoint;
+                }
+                store_float_value(
+                        dst_md().data_type(), accumulator, dst_ptr(), idx);
+            }
+        }
+    }
+
+private:
+    const xpu::sycl::md_t &data_md() const { return conf_.data_md; }
+    const xpu::sycl::md_t &weights_md() const { return conf_.weights_md; }
+    const xpu::sycl::md_t &bias_md() const { return conf_.bias_md; }
+    const xpu::sycl::md_t &dst_md() const { return conf_.dst_md; }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *weights_ptr() const { return weights_.get_pointer(); }
+    void *bias_ptr() const { return bias_.get_pointer(); }
+    void *dst_ptr() const { return dst_.get_pointer(); }
+    void *data_scale_ptr() const { return data_scale_.get_pointer(); }
+    void *weights_scale_ptr() const { return weights_scale_.get_pointer(); }
+    void *dst_scale_ptr() const { return dst_scale_.get_pointer(); }
+    void *data_zeropoint_ptr() const { return data_zeropoints_.get_pointer(); }
+    void *dst_zeropoint_ptr() const { return dst_zeropoints_.get_pointer(); }
+
+    sycl_convolution_conf_t conf_;
+
+    xpu::sycl::in_memory_arg_t data_;
+    xpu::sycl::in_memory_arg_t weights_;
+    xpu::sycl::in_memory_arg_t bias_;
+    xpu::sycl::out_memory_arg_t dst_;
+    xpu::sycl::in_memory_arg_t data_scale_;
+    xpu::sycl::in_memory_arg_t weights_scale_;
+    xpu::sycl::in_memory_arg_t dst_scale_;
+    xpu::sycl::in_memory_arg_t data_zeropoints_;
+    xpu::sycl::in_memory_arg_t dst_zeropoints_;
+    data_type_t scales_data_dt_;
+    data_type_t scales_weights_dt_;
+    data_type_t zeropoints_data_dt_;
+    data_type_t zeropoints_dst_dt_;
+};
+
+struct convolution_kernel_bwd_data_t {
+    static constexpr int max_supported_ndims = 6;
+
+    convolution_kernel_bwd_data_t(const sycl_convolution_conf_t &conf,
+            xpu::sycl::out_memory_arg_t &diff_data,
+            xpu::sycl::in_memory_arg_t &weights,
+            xpu::sycl::in_memory_arg_t &bias,
+            xpu::sycl::in_memory_arg_t &diff_dst,
+            xpu::sycl::in_memory_arg_t &data_scale,
+            xpu::sycl::in_memory_arg_t &weights_scale,
+            xpu::sycl::in_memory_arg_t &dst_scale,
+            xpu::sycl::in_memory_arg_t &data_zeropoints,
+            xpu::sycl::in_memory_arg_t &dst_zeropoints,
+            data_type_t scales_data_dt, data_type_t scales_weights_dt,
+            data_type_t zeropoints_data_dt, data_type_t zeropoints_dst_dt)
+        : conf_(conf)
+        , diff_data_(diff_data)
+        , weights_(weights)
+        , bias_(bias)
+        , diff_dst_(diff_dst)
+        , data_scale_(data_scale)
+        , weights_scale_(weights_scale)
+        , dst_scale_(dst_scale)
+        , data_zeropoints_(data_zeropoints)
+        , dst_zeropoints_(dst_zeropoints)
+        , scales_data_dt_(scales_data_dt)
+        , scales_weights_dt_(scales_weights_dt)
+        , zeropoints_data_dt_(zeropoints_data_dt)
+        , zeropoints_dst_dt_(zeropoints_dst_dt) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        const float sm_data = (conf_.do_scale_data
+                        ? load_float_value(scales_data_dt_, data_scale_ptr(), 0)
+                        : 1.f);
+
+        float sm_weights = (conf_.do_scale_weights && conf_.single_weight_scale
+                        ? load_float_value(
+                                scales_weights_dt_, weights_scale_ptr(), 0)
+                        : 1.f);
+
+        const float sm_dst = (conf_.do_scale_dst
+                        ? load_float_value(data_type::f32, dst_scale_ptr(), 0)
+                        : 1.f);
+
+        dims_t data_dims, weights_dims, dst_dims, data_strides, off;
+        for (int i = 0; i < max_supported_ndims; i++) {
+            data_dims[i] = (i < diff_data_md().ndims())
+                    ? diff_data_md().dims()[i]
+                    : 1;
+            weights_dims[i]
+                    = (i < weights_md().ndims()) ? weights_md().dims()[i] : 1;
+            dst_dims[i]
+                    = (i < diff_dst_md().ndims()) ? diff_dst_md().dims()[i] : 1;
+            data_strides[i] = (i < diff_data_md().ndims())
+                    ? diff_data_md().strides()[i]
+                    : INT_MAX;
+        }
+
+        bool no_groups = weights_md().ndims() == diff_data_md().ndims();
+
+        const int SD = ::sycl::max(conf_.strides[0], 1);
+        const int SH = ::sycl::max(conf_.strides[1], 1);
+        const int SW = ::sycl::max(conf_.strides[2], 1);
+
+        //per group
+        int OC = weights_dims[1];
+        int IC = weights_dims[2];
+
+        int KD = weights_dims[3];
+        int KH = weights_dims[4];
+        int KW = weights_dims[5];
+        if (no_groups) {
+            OC = weights_dims[0];
+            IC = weights_dims[1];
+            KD = weights_dims[2];
+            KH = weights_dims[3];
+            KW = weights_dims[4];
+        }
+
+        const int PD = conf_.padding[0];
+        const int PH = conf_.padding[1];
+        const int PW = conf_.padding[2];
+
+        const int DD = conf_.dilation[0];
+        const int DH = conf_.dilation[1];
+        const int DW = conf_.dilation[2];
+
+        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+                idx += item.get_global_range(0)) {
+            for (int i = 0; i < max_supported_ndims; i++) {
+                off[i] = idx / data_strides[i] % data_dims[i];
+            }
+
+            const int n = off[0];
+            const int ic_tot = off[1];
+            const int ic = ic_tot % IC;
+            const int g = ic_tot / IC;
+
+            const int id = off[2];
+            const int ih = off[3];
+            const int iw = off[4];
+
+            float accumulator = 0;
+            for (int oc = 0; oc < OC; ++oc) {
+                for (int kd = 0; kd < KD; ++kd) {
+                    for (int kh = 0; kh < KH; ++kh) {
+                        for (int kw = 0; kw < KW; ++kw) {
+                            int ow = iw - kw * (1 + DW) + PW;
+                            int oh = ih - kh * (1 + DH) + PH;
+                            int od = id - kd * (1 + DD) + PD;
+
+                            if (od < 0 || oh < 0 || ow < 0) { continue; }
+
+                            if (ow % SW != 0 || oh % SH != 0 || od % SD != 0) {
+                                continue;
+                            }
+                            ow /= SW;
+                            oh /= SH;
+                            od /= SD;
+
+                            if (od >= dst_dims[2] || oh >= dst_dims[3]
+                                    || ow >= dst_dims[4]) {
+                                continue;
+                            }
+
+                            dims_t off_dst {n, g * OC + oc, od, oh, ow};
+                            const int dst_idx = diff_dst_md().off_v(off_dst);
+                            dims_t off_weights {g, oc, ic, kd, kh, kw};
+                            dims_t off_weights_no_groups {oc, ic, kd, kh, kw};
+                            const int weights_idx = weights_md().off_v(no_groups
+                                            ? off_weights_no_groups
+                                            : off_weights);
+
+                            auto diff_dst = load_float_value(
+                                    diff_dst_md().data_type(), diff_dst_ptr(),
+                                    dst_idx);
+                            auto weight
+                                    = load_float_value(weights_md().data_type(),
+                                            weights_ptr(), weights_idx);
+
+                            if (conf_.use_dst_zeropoints) {
+                                int zpoint_idx = conf_.single_dst_zeropoint
+                                        ? 0
+                                        : ic_tot;
+                                auto dst_zeropoint = load_float_value(
+                                        zeropoints_dst_dt_, dst_zeropoint_ptr(),
+                                        zpoint_idx);
+                                diff_dst -= dst_zeropoint;
+                            }
+                            accumulator += diff_dst * weight;
+                        }
+                    }
+                }
+            }
+            if (conf_.do_scale_data) { accumulator *= sm_data; }
+            if (conf_.do_scale_weights) {
+                if (!conf_.single_weight_scale) {
+                    sm_weights = load_float_value(
+                            scales_weights_dt_, weights_scale_ptr(), ic_tot);
+                }
+                accumulator *= sm_weights;
+            }
+
+            if (bias_md().ndims() != 0) {
+                auto bias = load_float_value(
+                        bias_md().data_type(), bias_ptr(), ic_tot);
+                accumulator += bias;
+            }
+
+            auto diff_data = load_float_value(
+                    conf_.post_ops.sum_dt_ == dnnl_data_type_undef
+                            ? diff_data_md().data_type()
+                            : conf_.post_ops.sum_dt_,
+                    diff_data_ptr(), idx);
+            accumulator = conf_.post_ops.apply(accumulator, diff_data);
+
+            if (conf_.do_scale_dst) { accumulator /= sm_dst; }
+            if (conf_.use_data_zeropoints) {
+                int zpoint_idx = conf_.single_data_zeropoint ? 0 : g * IC + ic;
+                auto data_zeropoint = load_float_value(
+                        zeropoints_data_dt_, data_zeropoint_ptr(), zpoint_idx);
+                accumulator += data_zeropoint;
+            }
+            store_float_value(diff_data_md().data_type(), accumulator,
+                    diff_data_ptr(), idx);
+        }
+    }
+
+private:
+    const xpu::sycl::md_t &diff_data_md() const { return conf_.diff_data_md; }
+    const xpu::sycl::md_t &weights_md() const { return conf_.weights_md; }
+    const xpu::sycl::md_t &bias_md() const { return conf_.bias_md; }
+    const xpu::sycl::md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+
+    void *diff_data_ptr() const { return diff_data_.get_pointer(); }
+    void *weights_ptr() const { return weights_.get_pointer(); }
+    void *bias_ptr() const { return bias_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+    void *data_scale_ptr() const { return data_scale_.get_pointer(); }
+    void *weights_scale_ptr() const { return weights_scale_.get_pointer(); }
+    void *dst_scale_ptr() const { return dst_scale_.get_pointer(); }
+    void *data_zeropoint_ptr() const { return data_zeropoints_.get_pointer(); }
+    void *dst_zeropoint_ptr() const { return dst_zeropoints_.get_pointer(); }
+
+    sycl_convolution_conf_t conf_;
+
+    xpu::sycl::out_memory_arg_t diff_data_;
+    xpu::sycl::in_memory_arg_t weights_;
+    xpu::sycl::in_memory_arg_t bias_;
+    xpu::sycl::in_memory_arg_t diff_dst_;
+    xpu::sycl::in_memory_arg_t data_scale_;
+    xpu::sycl::in_memory_arg_t weights_scale_;
+    xpu::sycl::in_memory_arg_t dst_scale_;
+    xpu::sycl::in_memory_arg_t data_zeropoints_;
+    xpu::sycl::in_memory_arg_t dst_zeropoints_;
+    data_type_t scales_data_dt_;
+    data_type_t scales_weights_dt_;
+    data_type_t zeropoints_data_dt_;
+    data_type_t zeropoints_dst_dt_;
+};
+
+struct convolution_kernel_bwd_weights_t {
+    static constexpr int max_supported_ndims = 6;
+
+    convolution_kernel_bwd_weights_t(const sycl_convolution_conf_t &conf,
+            xpu::sycl::in_memory_arg_t &data,
+            xpu::sycl::out_memory_arg_t &diff_weights,
+            xpu::sycl::out_memory_arg_t &diff_bias,
+            xpu::sycl::in_memory_arg_t &diff_dst)
+        : conf_(conf)
+        , data_(data)
+        , diff_weights_(diff_weights)
+        , diff_bias_(diff_bias)
+        , diff_dst_(diff_dst) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        dims_t data_dims, weights_dims, dst_dims, weights_strides, off;
+        for (int i = 0; i < max_supported_ndims; i++) {
+            data_dims[i] = (i < data_md().ndims()) ? data_md().dims()[i] : 1;
+            weights_dims[i] = (i < diff_weights_md().ndims())
+                    ? diff_weights_md().dims()[i]
+                    : 1;
+            dst_dims[i]
+                    = (i < diff_dst_md().ndims()) ? diff_dst_md().dims()[i] : 1;
+            weights_strides[i] = (i < diff_weights_md().ndims())
+                    ? diff_weights_md().strides()[i]
+                    : INT_MAX;
+        }
+
+        bool no_groups = diff_weights_md().ndims() == data_md().ndims();
+
+        const int SD = ::sycl::max(conf_.strides[0], 1);
+        const int SH = ::sycl::max(conf_.strides[1], 1);
+        const int SW = ::sycl::max(conf_.strides[2], 1);
+
+        //per group
+        int OC = weights_dims[1];
+        int IC = weights_dims[2];
+        if (no_groups) {
+            OC = weights_dims[0];
+            IC = weights_dims[1];
+        }
+
+        int MB = data_dims[0];
+        int ID = data_dims[2];
+        int IH = data_dims[3];
+        int IW = data_dims[4];
+        int OD = dst_dims[2];
+        int OH = dst_dims[3];
+        int OW = dst_dims[4];
+
+        const int PD = conf_.padding[0];
+        const int PH = conf_.padding[1];
+        const int PW = conf_.padding[2];
+
+        const int DD = conf_.dilation[0];
+        const int DH = conf_.dilation[1];
+        const int DW = conf_.dilation[2];
+
+        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+                idx += item.get_global_range(0)) {
+            for (int i = 0; i < max_supported_ndims; i++) {
+                off[i] = idx / weights_strides[i] % weights_dims[i];
+            }
+
+            int g = off[0];
+            int oc = off[1];
+            int ic = off[2];
+            int kd = off[3];
+            int kh = off[4];
+            int kw = off[5];
+            if (no_groups) {
+                g = 0;
+                oc = off[0];
+                ic = off[1];
+                kd = off[2];
+                kh = off[3];
+                kw = off[4];
+            }
+
+            if (ic == 0 && kh == 0 && kw == 0 & kd == 0) {
+                float accumulator_bias = 0;
+                for (int n = 0; n < MB; ++n) {
+                    for (int od = 0; od < OD; ++od) {
+                        for (int oh = 0; oh < OH; ++oh) {
+                            for (int ow = 0; ow < OW; ++ow) {
+                                dims_t off_dst {n, g * OC + oc, od, oh, ow};
+                                const int dst_idx
+                                        = diff_dst_md().off_v(off_dst);
+                                auto diff_dst = load_float_value(
+                                        diff_dst_md().data_type(),
+                                        diff_dst_ptr(), dst_idx);
+                                accumulator_bias += diff_dst;
+                            }
+                        }
+                    }
+                }
+                store_float_value(diff_bias_md().data_type(), accumulator_bias,
+                        diff_bias_ptr(), g * OC + oc);
+            }
+
+            float accumulator_weights = 0;
+            for (int n = 0; n < MB; ++n) {
+                for (int od = 0; od < OD; ++od) {
+                    for (int oh = 0; oh < OH; ++oh) {
+                        for (int ow = 0; ow < OW; ++ow) {
+                            int id = od * SD - PD + kd * (1 + DD);
+                            int ih = oh * SH - PH + kh * (1 + DH);
+                            int iw = ow * SW - PW + kw * (1 + DW);
+
+                            if (id >= ID || ih >= IH || iw >= IW || id < 0
+                                    || ih < 0 || iw < 0) {
+                                continue;
+                            }
+
+                            dims_t off_dst {n, g * OC + oc, od, oh, ow};
+                            const int dst_idx = diff_dst_md().off_v(off_dst);
+                            dims_t off_data {n, g * IC + ic, id, ih, iw};
+                            const int data_idx = data_md().off_v(off_data);
+
+                            auto diff_dst = load_float_value(
+                                    diff_dst_md().data_type(), diff_dst_ptr(),
+                                    dst_idx);
+                            auto data = load_float_value(data_md().data_type(),
+                                    data_ptr(), data_idx);
+
+                            accumulator_weights += diff_dst * data;
+                        }
+                    }
+                }
+            }
+            store_float_value(diff_weights_md().data_type(),
+                    accumulator_weights, diff_weights_ptr(), idx);
+        }
+    }
+
+private:
+    const xpu::sycl::md_t &data_md() const { return conf_.data_md; }
+    const xpu::sycl::md_t &diff_weights_md() const {
+        return conf_.diff_weights_md;
+    }
+    const xpu::sycl::md_t &diff_bias_md() const { return conf_.diff_bias_md; }
+    const xpu::sycl::md_t &diff_dst_md() const { return conf_.diff_dst_md; }
+
+    void *data_ptr() const { return data_.get_pointer(); }
+    void *diff_weights_ptr() const { return diff_weights_.get_pointer(); }
+    void *diff_bias_ptr() const { return diff_bias_.get_pointer(); }
+    void *diff_dst_ptr() const { return diff_dst_.get_pointer(); }
+
+    sycl_convolution_conf_t conf_;
+
+    xpu::sycl::in_memory_arg_t data_;
+    xpu::sycl::out_memory_arg_t diff_weights_;
+    xpu::sycl::out_memory_arg_t diff_bias_;
+    xpu::sycl::in_memory_arg_t diff_dst_;
+};
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -1,0 +1,329 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/generic/sycl/ref_convolution.hpp"
+#include "gpu/generic/sycl/convolution_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+status_t ref_convolution_fwd_t::pd_t::init_conf() {
+    conf_ = sycl_convolution_conf_t();
+
+    conf_.data_md = xpu::sycl::md_t(src_md());
+    conf_.weights_md = xpu::sycl::md_t(weights_md(0));
+    if (with_bias()) { conf_.bias_md = xpu::sycl::md_t(weights_md(1)); }
+    conf_.dst_md = xpu::sycl::md_t(dst_md());
+    conf_.ndims = ndims();
+
+    // XXX: should probably be tuned.
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+
+    conf_.wk_size = memory_desc_wrapper(dst_md()).nelems();
+
+    conf_.do_scale_data
+            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_weights
+            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
+    conf_.do_scale_dst
+            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
+    conf_.single_weight_scale
+            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+
+    conf_.use_data_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.use_dst_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
+    conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
+    conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
+
+    conf_.post_ops = sycl_post_ops_t(attr());
+
+    conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
+    conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
+    conf_.padding[2] = static_cast<int>(desc()->padding[0][2]);
+
+    conf_.strides[0] = static_cast<int>(desc()->strides[0]);
+    conf_.strides[1] = static_cast<int>(desc()->strides[1]);
+    conf_.strides[2] = static_cast<int>(desc()->strides[2]);
+
+    conf_.dilation[0] = static_cast<int>(desc()->dilates[0]);
+    conf_.dilation[1] = static_cast<int>(desc()->dilates[1]);
+    conf_.dilation[2] = static_cast<int>(desc()->dilates[2]);
+    return status::success;
+}
+
+status_t ref_convolution_fwd_t::init(impl::engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<convolution_kernel_fwd_t>();
+    CHECK(create_kernel(engine, kid, &kernel_));
+    return status::success;
+}
+
+status_t ref_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
+
+    parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto data_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC_0);
+        auto weights_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_WEIGHTS);
+        auto bias_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_BIAS);
+        auto dst_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
+        auto data_scale_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0);
+        auto weights_scale_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS);
+        auto dst_scale_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+
+        auto scales_data_dt = (pd()->conf_.do_scale_data)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+        auto scales_weights_dt = (pd()->conf_.do_scale_weights)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+
+        auto data_zeropoints = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC_0);
+        auto dst_zeropoints = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST);
+
+        auto zeropoints_data_dt = (pd()->conf_.use_data_zeropoints)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC_0)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+        auto zeropoints_dst_dt = (pd()->conf_.use_dst_zeropoints)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+
+        convolution_kernel_fwd_t convolution_kernel(pd()->conf_, data_mem_arg,
+                weights_mem_arg, bias_mem_arg, dst_mem_arg, data_scale_mem_arg,
+                weights_scale_mem_arg, dst_scale_mem_arg, data_zeropoints,
+                dst_zeropoints, scales_data_dt, scales_weights_dt,
+                zeropoints_data_dt, zeropoints_dst_dt);
+
+        const int block_size = pd()->conf_.block_size;
+        const int wg_size = pd()->conf_.wg_size;
+
+        const int t_work = pd()->conf_.wk_size;
+        const int wg_work = wg_size * block_size;
+        const int wg_cnt = utils::div_up(t_work, wg_work);
+
+        cgh.parallel_for(::sycl::nd_range<1>(wg_cnt * wg_size, wg_size),
+                convolution_kernel);
+    });
+
+    return status::success;
+}
+
+status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
+    conf_ = sycl_convolution_conf_t();
+
+    conf_.diff_data_md = xpu::sycl::md_t(diff_src_md());
+    conf_.weights_md = xpu::sycl::md_t(weights_md(0));
+    if (with_bias()) { conf_.bias_md = xpu::sycl::md_t(weights_md(1)); }
+    conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md());
+    conf_.ndims = ndims();
+
+    // XXX: should probably be tuned.
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+
+    conf_.wk_size = memory_desc_wrapper(diff_src_md()).nelems();
+
+    conf_.do_scale_data
+            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_weights
+            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
+    conf_.do_scale_dst
+            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
+    conf_.single_weight_scale
+            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+
+    conf_.use_data_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.use_dst_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
+    conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
+    conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
+
+    conf_.post_ops = sycl_post_ops_t(attr());
+
+    conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
+    conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
+    conf_.padding[2] = static_cast<int>(desc()->padding[0][2]);
+
+    conf_.strides[0] = static_cast<int>(desc()->strides[0]);
+    conf_.strides[1] = static_cast<int>(desc()->strides[1]);
+    conf_.strides[2] = static_cast<int>(desc()->strides[2]);
+
+    conf_.dilation[0] = static_cast<int>(desc()->dilates[0]);
+    conf_.dilation[1] = static_cast<int>(desc()->dilates[1]);
+    conf_.dilation[2] = static_cast<int>(desc()->dilates[2]);
+    return status::success;
+}
+
+status_t ref_convolution_bwd_data_t::init(impl::engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<convolution_kernel_bwd_data_t>();
+    CHECK(create_kernel(engine, kid, &kernel_));
+    return status::success;
+}
+
+status_t ref_convolution_bwd_data_t::execute(const exec_ctx_t &ctx) const {
+
+    parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto diff_data_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
+        auto weights_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_WEIGHTS);
+        auto bias_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_BIAS);
+        auto diff_dst_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+        auto data_scale_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0);
+        auto weights_scale_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS);
+        auto dst_scale_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+
+        auto scales_data_dt = (pd()->conf_.do_scale_data)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+        auto scales_weights_dt = (pd()->conf_.do_scale_weights)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+
+        auto data_zeropoints = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC_0);
+        auto dst_zeropoints = CTX_IN_SYCL_KERNEL_MEMORY(
+                DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST);
+
+        auto zeropoints_data_dt = (pd()->conf_.use_data_zeropoints)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC_0)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+        auto zeropoints_dst_dt = (pd()->conf_.use_dst_zeropoints)
+                ? ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST)
+                          .data_type()
+                : data_type_t::dnnl_f32;
+
+        convolution_kernel_bwd_data_t convolution_kernel(pd()->conf_,
+                diff_data_mem_arg, weights_mem_arg, bias_mem_arg,
+                diff_dst_mem_arg, data_scale_mem_arg, weights_scale_mem_arg,
+                dst_scale_mem_arg, data_zeropoints, dst_zeropoints,
+                scales_data_dt, scales_weights_dt, zeropoints_data_dt,
+                zeropoints_dst_dt);
+
+        const int wg_size = pd()->conf_.wg_size;
+
+        const int t_work = pd()->conf_.wk_size;
+        const int wg_cnt = utils::div_up(t_work, wg_size);
+
+        cgh.parallel_for(::sycl::nd_range<1>(wg_cnt * wg_size, wg_size),
+                convolution_kernel);
+    });
+
+    return status::success;
+}
+
+status_t ref_convolution_bwd_weights_t::pd_t::init_conf() {
+    conf_ = sycl_convolution_conf_t();
+
+    conf_.data_md = xpu::sycl::md_t(src_md());
+    conf_.diff_weights_md = xpu::sycl::md_t(diff_weights_md(0));
+    if (with_bias()) {
+        conf_.diff_bias_md = xpu::sycl::md_t(diff_weights_md(1));
+    }
+    conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md());
+    conf_.ndims = ndims();
+
+    // XXX: should probably be tuned.
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+
+    conf_.wk_size = memory_desc_wrapper(diff_weights_md()).nelems();
+
+    conf_.do_scale_data
+            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_weights
+            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
+    conf_.do_scale_dst
+            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
+    conf_.single_weight_scale
+            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+
+    conf_.use_data_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.use_dst_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
+    conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
+    conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
+
+    conf_.post_ops = sycl_post_ops_t(attr());
+
+    conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
+    conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
+    conf_.padding[2] = static_cast<int>(desc()->padding[0][2]);
+
+    conf_.strides[0] = static_cast<int>(desc()->strides[0]);
+    conf_.strides[1] = static_cast<int>(desc()->strides[1]);
+    conf_.strides[2] = static_cast<int>(desc()->strides[2]);
+
+    conf_.dilation[0] = static_cast<int>(desc()->dilates[0]);
+    conf_.dilation[1] = static_cast<int>(desc()->dilates[1]);
+    conf_.dilation[2] = static_cast<int>(desc()->dilates[2]);
+    return status::success;
+}
+
+status_t ref_convolution_bwd_weights_t::init(impl::engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<convolution_kernel_bwd_weights_t>();
+    CHECK(create_kernel(engine, kid, &kernel_));
+    return status::success;
+}
+
+status_t ref_convolution_bwd_weights_t::execute(const exec_ctx_t &ctx) const {
+
+    parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        auto data_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
+        auto diff_weights_mem_arg
+                = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_WEIGHTS);
+        auto diff_bias_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_BIAS);
+        auto diff_dst_mem_arg = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
+
+        convolution_kernel_bwd_weights_t convolution_kernel(pd()->conf_,
+                data_mem_arg, diff_weights_mem_arg, diff_bias_mem_arg,
+                diff_dst_mem_arg);
+
+        const int wg_size = pd()->conf_.wg_size;
+
+        const int t_work = pd()->conf_.wk_size;
+        const int wg_cnt = utils::div_up(t_work, wg_size);
+
+        cgh.parallel_for(::sycl::nd_range<1>(wg_cnt * wg_size, wg_size),
+                convolution_kernel);
+    });
+
+    return status::success;
+}
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -1,0 +1,258 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_REF_CONVOLUTION_HPP
+#define GPU_SYCL_REF_CONVOLUTION_HPP
+
+#include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/generic/sycl/sycl_io_helper.hpp"
+#include "gpu/generic/sycl/sycl_post_ops.hpp"
+#include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/gpu_convolution_pd.hpp"
+#include "xpu/sycl/types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+static bool check_convolution_data_types(const memory_desc_wrapper &src0,
+        const memory_desc_wrapper &src1, const memory_desc_wrapper &dst) {
+    using namespace data_type;
+
+    const auto src0_dt = src0.data_type();
+    const auto src1_dt = src1.data_type();
+    const auto dst_dt = dst.data_type();
+
+    for (auto t : {src0_dt, src1_dt, dst_dt}) {
+        if (!utils::one_of(t, f32, bf16, f16, s32, s8, u8)) return false;
+    }
+
+    return true;
+}
+
+static bool check_convolution_formats(const memory_desc_wrapper &src0,
+        const memory_desc_wrapper &src1, const memory_desc_wrapper &dst) {
+    using namespace format_tag;
+
+    for (const auto &mdw : {src0, src1, dst}) {
+        if (!mdw.is_plain()) { return false; }
+    }
+    return true;
+}
+
+static bool check_convolution_work_amount(
+        const memory_desc_wrapper &weights, dim_t OC) {
+    auto elems = weights.nelems();
+    auto work_per_output = elems / OC;
+    // arbitrarily chosen threshold to avoid unreasonably long runtimes
+    // such cases should use a different implementation
+    return work_per_output < 200000;
+}
+
+struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
+    using gpu::generic::sycl::primitive_t::primitive_t;
+
+    struct pd_t : public convolution_fwd_pd_t {
+        using convolution_fwd_pd_t::convolution_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_convolution_fwd_t);
+
+        status_t init(impl::engine_t *engine) {
+            using namespace data_type;
+            using sm = primitive_attr_t::skip_mask_t;
+
+            const memory_desc_wrapper data_d(src_md());
+            const memory_desc_wrapper weights_d(weights_md());
+            const memory_desc_wrapper dst_d(dst_md());
+
+            const bool ok = is_fwd()
+                    && check_convolution_work_amount(weights_d, OC())
+                    && set_default_formats()
+                    && attr_.set_default_formats(dst_md()) == status::success
+                    && check_convolution_data_types(data_d, weights_d, dst_d)
+                    && check_convolution_formats(data_d, weights_d, dst_d)
+                    && attr()->has_default_values(sm::scales_runtime
+                            | sm::zero_points_runtime | sm::post_ops
+                            | sm::sum_dt)
+                    && IMPLICATION(!attr()->scales_.has_default_values(),
+                            attr_scales_ok())
+                    && post_ops_ok();
+            if (!ok) return status::unimplemented;
+
+            return init_conf();
+        }
+
+        sycl_convolution_conf_t conf_;
+
+    private:
+        status_t init_conf();
+
+        bool set_default_formats() {
+            using namespace format_tag;
+            auto dat_tag = utils::pick(ndims() - 3, nwc, nhwc, ndhwc);
+            auto wei_tag = with_groups()
+                    ? utils::pick(ndims() - 3, goiw, goihw, goidhw)
+                    : utils::pick(ndims() - 3, oiw, oihw, oidhw);
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+
+        bool post_ops_ok() const {
+            for (int i = 0; i < attr()->post_ops_.len(); i++) {
+                const auto &e = attr()->post_ops_.entry_[i];
+                if (!IMPLICATION(e.is_eltwise(),
+                            utils::one_of(e.eltwise.alg, alg_kind::eltwise_relu,
+                                    alg_kind::eltwise_linear,
+                                    alg_kind::eltwise_clip,
+                                    alg_kind::eltwise_clip_v2,
+                                    alg_kind::eltwise_hardswish))) {
+                    return false;
+                }
+            }
+            return attr()->post_ops_.len() <= sycl_post_ops_t::max_post_ops
+                    && attr()->post_ops_.has_default_values(
+                            {primitive_kind::eltwise, primitive_kind::prelu,
+                                    primitive_kind::sum});
+        }
+    };
+
+    status_t init(impl::engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    kernel_t kernel_;
+};
+
+struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
+    using gpu::generic::sycl::primitive_t::primitive_t;
+
+    struct pd_t : public convolution_bwd_data_pd_t {
+        using convolution_bwd_data_pd_t::convolution_bwd_data_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_convolution_bwd_data_t);
+
+        status_t init(impl::engine_t *engine) {
+            using namespace data_type;
+            using sm = primitive_attr_t::skip_mask_t;
+
+            const memory_desc_wrapper diff_data_d(diff_src_md());
+            const memory_desc_wrapper weights_d(weights_md());
+            const memory_desc_wrapper diff_dst_d(diff_dst_md());
+
+            const bool ok = is_bwd_d()
+                    && check_convolution_work_amount(weights_d, OC())
+                    && set_default_formats()
+                    && check_convolution_data_types(
+                            diff_data_d, weights_d, diff_dst_d)
+                    && check_convolution_formats(
+                            diff_data_d, weights_d, diff_dst_d)
+                    && attr()->has_default_values(sm::scales_runtime
+                            | sm::zero_points_runtime | sm::sum_dt)
+                    && IMPLICATION(!attr()->scales_.has_default_values(),
+                            attr_scales_ok());
+            if (!ok) return status::unimplemented;
+
+            return init_conf();
+        }
+
+        sycl_convolution_conf_t conf_;
+
+    private:
+        status_t init_conf();
+
+        bool set_default_formats() {
+            using namespace format_tag;
+            auto dat_tag = utils::pick(ndims() - 3, nwc, nhwc, ndhwc);
+            auto wei_tag = with_groups()
+                    ? utils::pick(ndims() - 3, goiw, goihw, goidhw)
+                    : utils::pick(ndims() - 3, oiw, oihw, oidhw);
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+    };
+
+    status_t init(impl::engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    kernel_t kernel_;
+};
+
+struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
+    using gpu::generic::sycl::primitive_t::primitive_t;
+
+    struct pd_t : public convolution_bwd_weights_pd_t {
+        using convolution_bwd_weights_pd_t::convolution_bwd_weights_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_convolution_bwd_weights_t);
+
+        status_t init(impl::engine_t *engine) {
+            using namespace data_type;
+            using sm = primitive_attr_t::skip_mask_t;
+
+            const memory_desc_wrapper data_d(src_md());
+            const memory_desc_wrapper diff_weights_d(diff_weights_md());
+            const memory_desc_wrapper diff_dst_d(diff_dst_md());
+
+            const bool ok = is_bwd_w()
+                    && check_convolution_work_amount(diff_weights_d, OC())
+                    && set_default_formats()
+                    && check_convolution_data_types(
+                            data_d, diff_weights_d, diff_dst_d)
+                    && check_convolution_formats(
+                            data_d, diff_weights_d, diff_dst_d)
+                    && attr()->has_default_values(sm::scales_runtime
+                            | sm::zero_points_runtime | sm::sum_dt)
+                    && IMPLICATION(!attr()->scales_.has_default_values(),
+                            attr_scales_ok());
+            if (!ok) return status::unimplemented;
+
+            return init_conf();
+        }
+
+        sycl_convolution_conf_t conf_;
+
+    private:
+        status_t init_conf();
+
+        bool set_default_formats() {
+            using namespace format_tag;
+            auto dat_tag = utils::pick(ndims() - 3, nwc, nhwc, ndhwc);
+            auto wei_tag = with_groups()
+                    ? utils::pick(ndims() - 3, goiw, goihw, goidhw)
+                    : utils::pick(ndims() - 3, oiw, oihw, oidhw);
+            return set_default_formats_common(dat_tag, wei_tag, dat_tag);
+        }
+    };
+
+    status_t init(impl::engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -51,6 +51,40 @@ struct sycl_binary_conf_t {
     sycl_post_ops_t post_ops;
 };
 
+struct sycl_convolution_conf_t {
+    xpu::sycl::md_t data_md;
+    xpu::sycl::md_t dst_md;
+    xpu::sycl::md_t weights_md;
+    xpu::sycl::md_t bias_md;
+    xpu::sycl::md_t diff_data_md;
+    xpu::sycl::md_t diff_dst_md;
+    xpu::sycl::md_t diff_weights_md;
+    xpu::sycl::md_t diff_bias_md;
+
+    int padding[3];
+    int strides[3];
+    int dilation[3];
+
+    bool do_scale_data;
+    bool do_scale_weights;
+    bool do_scale_dst;
+    bool single_weight_scale;
+
+    bool use_data_zeropoints;
+    bool use_dst_zeropoints;
+    bool single_data_zeropoint;
+    bool single_dst_zeropoint;
+
+    int ndims;
+
+    int block_size;
+    int wg_size;
+    int wk_size;
+    bool has_groups;
+
+    sycl_post_ops_t post_ops;
+};
+
 struct sycl_eltwise_conf_t {
     prop_kind_t prop_kind;
     xpu::sycl::md_t src_md;

--- a/src/gpu/gpu_convolution_list.cpp
+++ b/src/gpu/gpu_convolution_list.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
+#include "gpu/generic/sycl/ref_convolution.hpp"
 #include "gpu/nvidia/cudnn_convolution.hpp"
 #endif
 
@@ -53,6 +54,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>>
         GPU_INSTANCE_INTEL(intel::ocl::ref_convolution_fwd_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_convolution_fwd_t)
         GPU_INSTANCE_AMD(amd::miopen_convolution_fwd_t)
+        GPU_INSTANCE_GENERIC_SYCL(generic::sycl::ref_convolution_fwd_t)
         nullptr,
     }},
     {{backward_data}, REG_BWD_D_PK({
@@ -61,6 +63,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>>
         GPU_INSTANCE_INTEL(intel::ocl::ref_convolution_bwd_data_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_convolution_bwd_data_t)
         GPU_INSTANCE_AMD(amd::miopen_convolution_bwd_data_t)
+        GPU_INSTANCE_GENERIC_SYCL(generic::sycl::ref_convolution_bwd_data_t)
         nullptr,
     })},
     {{backward_weights}, REG_BWD_PK({
@@ -69,6 +72,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>>
         GPU_INSTANCE_INTEL(intel::ocl::ref_convolution_bwd_weights_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_convolution_bwd_weights_t)
         GPU_INSTANCE_AMD(amd::miopen_convolution_bwd_weights_t)
+        GPU_INSTANCE_GENERIC_SYCL(generic::sycl::ref_convolution_bwd_weights_t)
         nullptr,
     })},
 });


### PR DESCRIPTION
Implemented SYCL convolution, including FWD, BWD_DATA and BWD_WEIGHTS. 

Also adds support for hardswish and sum zeropoints to post ops, as these are used in convolution tests.