### PR TITLE
gpu: intel: Optimize reusable layer normalization using work-group based reductions

### DIFF
--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
@@ -37,15 +37,15 @@ __attribute__((intel_reqd_sub_group_size(SG_SIZE))) __kernel void
 lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
         __global float *variance, dim_t reduce_size, __global DST_DATA_T *dst,
         __global WEI_DATA_T *scale, __global WEI_DATA_T *shift, float eps,
-        __global float *src_scale, __global float *dst_scale, int greads,
-        float rrs, dispatch_gws_rt_params_t gws_params) {
-    int sg_offset = get_sub_group_id() * SG_SIZE * VECT_DT_N;
-    src = (GWS_GET_BUFFER_POS(SRC, gws_params, src)) - get_local_id(0)
-            + sg_offset;
+        __global float *src_scale, __global float *dst_scale, float rrs,
+        dispatch_gws_rt_params_t gws_params) {
+    int sg_offset
+            = -(get_local_id(0)) + get_sub_group_id() * SG_SIZE * VECT_DT_N;
+    src = GWS_GET_BUFFER_POS(SRC, gws_params, src) + sg_offset;
 
     FLT_ACC_DATA_T local_variance = 0.f;
     FLT_ACC_DATA_T local_mean = 0.f;
-#if PVT_MEM_SIZE > 0
+#if PVT_MEM_SIZE > 1
     VECT_FLOAT_T val[PVT_MEM_SIZE];
 #else
     VECT_FLOAT_T val;
@@ -53,32 +53,30 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
     if (CALCULATE_STATS) {
         /// Read global memory and mean and variance
         VECT_FLOAT_T sum = 0;
-#if PVT_MEM_SIZE > 0
-        //unroll_for_by(N_UNROLL)(int sg_idx = 0, i = 0; i < greads; sg_idx += GROUP_STRIDE, i++) {
-        unroll_for_by(N_UNROLL)(int sg_idx = 0, i = 0; i < PVT_MEM_SIZE; sg_idx += GROUP_STRIDE, i++) {
-          val[i] = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
-                                                                       (const __global BLOCK_DATA_T *)(&src[sg_idx]))));
+#if PVT_MEM_SIZE > 1
+        unroll_for_by(N_UNROLL)(int sg_idx = 0, i = 0; i < PVT_MEM_SIZE;
+                                sg_idx += GROUP_STRIDE, i++) {
+            val[i] = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
+                    (const __global BLOCK_DATA_T *)(&src[sg_idx]))));
         }
         unroll_for_by(N_UNROLL)(int i = 0; i < PVT_MEM_SIZE; i++) {
-          sum += val[i];
+            sum += val[i];
         }
 #else
-        val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
-                                                                  (const __global BLOCK_DATA_T *)(src))));
+        val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)(src))));
         sum = val;
 #endif
 
         local_mean = GROUP_ADD(vec_sum(sum)) * rrs;
 
-
-#if PVT_MEM_SIZE > 0
+#if PVT_MEM_SIZE > 1
         sum = 0;
-        //unroll_for_by(N_UNROLL)(int i = 0; i < greads; i++) {
         unroll_for_by(N_UNROLL)(int i = 0; i < PVT_MEM_SIZE; i++) {
-          VECT_FLOAT_T var_val;
-          var_val = val[i] - local_mean;
-          var_val *= var_val;
-          sum += var_val;
+            VECT_FLOAT_T var_val;
+            var_val = val[i] - local_mean;
+            var_val *= var_val;
+            sum += var_val;
         }
 #else
         sum = val - local_mean;
@@ -87,43 +85,40 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
 #endif
         local_variance = GROUP_ADD(vec_sum(sum)) * rrs;
     } else {
-      mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);
-      variance = GWS_GET_BUFFER_POS(STAT, gws_params, variance);
-      local_mean = *mean;
+        mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);
+        variance = GWS_GET_BUFFER_POS(STAT, gws_params, variance);
+        local_mean = *mean;
         local_variance = *variance;
     }
 
     if (USE_SCALE)
-        scale = GWS_GET_BUFFER_POS(SS, gws_params, scale) - get_local_id(0)
-                + sg_offset;
+        scale = GWS_GET_BUFFER_POS(SS, gws_params, scale) + sg_offset;
     if (USE_SHIFT)
-        shift = GWS_GET_BUFFER_POS(SS, gws_params, shift) - get_local_id(0)
-                + sg_offset;
+        shift = GWS_GET_BUFFER_POS(SS, gws_params, shift) + sg_offset;
 
-    /// Normalize layer
     FLT_ACC_DATA_T sqrt_variance = rsqrt(local_variance + eps);
-    __global DST_DATA_T *dst_vect = (GWS_GET_BUFFER_POS(DST, gws_params, dst))
-            - get_local_id(0) + sg_offset;
+    __global DST_DATA_T *dst_vect
+            = (GWS_GET_BUFFER_POS(DST, gws_params, dst)) + sg_offset;
 
     float src_scale_val = src_scale ? *src_scale : 1.f;
     float dst_scale_val = dst_scale ? native_recip(*dst_scale) : 1.f;
 
-    //unroll_for_by(N_UNROLL)(int i = 0; i < greads; i++) {
-#if PVT_MEM_SIZE > 0
+#if PVT_MEM_SIZE > 1
     unroll_for_by(N_UNROLL)(int i = 0; i < PVT_MEM_SIZE; i++) {
 #endif
-      VECT_FLOAT_T res;
-#if PVT_MEM_SIZE > 0
-      res = val[i] - local_mean;
+        VECT_FLOAT_T res;
+#if PVT_MEM_SIZE > 1
+        res = val[i] - local_mean;
 #else
-      res = val - local_mean;
+    res = val - local_mean;
 #endif
-      VECT_FLOAT_T sc = (USE_SCALE) ? LOAD_VECT_WEI(scale) : 1.f;
-      VECT_FLOAT_T sh = (USE_SHIFT) ? LOAD_VECT_WEI(shift) : 0.f;
-      VECT_FLOAT_T out = (sc * res * sqrt_variance + sh) * src_scale_val * dst_scale_val;
+        VECT_FLOAT_T sc = (USE_SCALE) ? LOAD_VECT_WEI(scale) : 1.f;
+        VECT_FLOAT_T sh = (USE_SHIFT) ? LOAD_VECT_WEI(shift) : 0.f;
+        VECT_FLOAT_T out = (sc * res * sqrt_variance + sh) * src_scale_val
+                * dst_scale_val;
 
-      VECT_DST_BLOCK_WRITE(dst_vect, CONVERT_VECTOR_DST_DATA_T(out));
-#if PVT_MEM_SIZE > 0
+        VECT_DST_BLOCK_WRITE(dst_vect, CONVERT_VECTOR_DST_DATA_T(out));
+#if PVT_MEM_SIZE > 1
         dst_vect += GROUP_STRIDE;
         if (USE_SCALE) scale += GROUP_STRIDE;
         if (USE_SHIFT) shift += GROUP_STRIDE;

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
@@ -38,39 +38,50 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
         __global WEI_DATA_T *scale, __global WEI_DATA_T *shift, float eps,
         __global float *src_scale, __global float *dst_scale, int greads,
         float rrs, dispatch_gws_rt_params_t gws_params) {
-
     int sg_offset = get_sub_group_id() * SG_SIZE * VECT_DT_N;
     src = (GWS_GET_BUFFER_POS(SRC, gws_params, src)) - get_local_id(0)
             + sg_offset;
 
     FLT_ACC_DATA_T local_variance = 0.f;
     FLT_ACC_DATA_T local_mean = 0.f;
+#if PVT_MEM_SIZE > 0
+    VECT_FLOAT_T val[PVT_MEM_SIZE];
+#else
     VECT_FLOAT_T val;
+#endif
     if (CALCULATE_STATS) {
         /// Read global memory and mean and variance
-        FLT_ACC_DATA_T sum = 0;
-        int sg_idx = 0;
-        unroll_for_by(N_UNROLL)(int sg_idx = 0; sg_idx < reduce_size;
-                                sg_idx += GROUP_STRIDE) {
-            val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
-                    (const __global BLOCK_DATA_T *)(&src[sg_idx]))));
-            sum += vec_sum(val);
+        VECT_FLOAT_T sum = 0;
+#if PVT_MEM_SIZE > 0
+        unroll_for_by(N_UNROLL)(int sg_idx = 0, i = 0; sg_idx < reduce_size;
+                                sg_idx += GROUP_STRIDE, i++) {
+          val[i] = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
+                                                                       (const __global BLOCK_DATA_T *)(&src[sg_idx]))));
+          sum += val[i];
         }
-
-        local_mean = GROUP_ADD(sum) * rrs;
-        FLT_ACC_DATA_T sumsq = 0;
-        unroll_for_by(N_UNROLL)(int i = 0; i < greads; i++) {
-            VECT_FLOAT_T var_val;
-#if REUSE
-            var_val = val;
 #else
-            var_val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
-                    (const __global BLOCK_DATA_T *)(&src[i * GROUP_STRIDE]))));
+          val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
+                                                                    (const __global BLOCK_DATA_T *)(src))));
+          sum = val;
 #endif
-            var_val *= var_val - local_mean;
-            sumsq += vec_sum(var_val);
+
+        local_mean = GROUP_ADD(vec_sum(sum)) * rrs;
+
+
+#if PVT_MEM_SIZE > 0
+        sum = 0;
+        unroll_for_by(N_UNROLL)(int i = greads - 1; i >= 0; i--) {
+          VECT_FLOAT_T var_val;
+          var_val = val[i] - local_mean;
+          var_val *= var_val;
+          sum += var_val;
         }
-        local_variance = GROUP_ADD(sumsq) * rrs;
+#else
+        sum = val - local_mean;
+        sum *= sum;
+        sum = sum;
+#endif
+        local_variance = GROUP_ADD(vec_sum(sum)) * rrs;
     } else {
         mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);
         variance = GWS_GET_BUFFER_POS(STAT, gws_params, variance);
@@ -80,38 +91,35 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
 
     if (USE_SCALE)
         scale = GWS_GET_BUFFER_POS(SS, gws_params, scale) - get_local_id(0)
-                + ((greads - 1) * GROUP_STRIDE) + sg_offset;
+                + sg_offset;
     if (USE_SHIFT)
         shift = GWS_GET_BUFFER_POS(SS, gws_params, shift) - get_local_id(0)
-                + ((greads - 1) * GROUP_STRIDE) + sg_offset;
+                + sg_offset;
 
     /// Normalize layer
     FLT_ACC_DATA_T sqrt_variance = rsqrt(local_variance + eps);
     __global DST_DATA_T *dst_vect = (GWS_GET_BUFFER_POS(DST, gws_params, dst))
-            - get_local_id(0) + ((greads - 1) * GROUP_STRIDE) + sg_offset;
+            - get_local_id(0) + sg_offset;
 
     float src_scale_val = src_scale ? *src_scale : 1.f;
     float dst_scale_val = dst_scale ? native_recip(*dst_scale) : 1.f;
 
-    unroll_for_by(N_UNROLL)(int i = greads - 1; i >= 0; i--) {
-#if REUSE
-        VECT_FLOAT_T res = val;
+    unroll_for_by(N_UNROLL)(int i = 0; i < greads; i++) {
+        VECT_FLOAT_T res;
+#if PVT_MEM_SIZE > 0
+        res = val[i] - local_mean;
 #else
-        VECT_FLOAT_T res = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
-                (const __global BLOCK_DATA_T *)(&src[i * GROUP_STRIDE]))));
+        res = val - local_mean;
 #endif
-        res -= local_mean;
-        res *= sqrt_variance;
-        if (USE_SCALE) res *= LOAD_VECT_WEI(scale);
-        if (USE_SHIFT) res += LOAD_VECT_WEI(shift);
+        VECT_FLOAT_T sc = (USE_SCALE) ? LOAD_VECT_WEI(scale) : 1.f;
+        VECT_FLOAT_T sh = (USE_SHIFT) ? LOAD_VECT_WEI(shift) : 0.f;
+        VECT_FLOAT_T out = (sc * res * sqrt_variance + sh) * src_scale_val
+                * dst_scale_val;
 
-        res *= src_scale_val;
-        res *= dst_scale_val;
-
-        VECT_DST_BLOCK_WRITE(dst_vect, CONVERT_VECTOR_DST_DATA_T(res));
-        dst_vect -= GROUP_STRIDE;
-        if (USE_SCALE) scale -= GROUP_STRIDE;
-        if (USE_SHIFT) shift -= GROUP_STRIDE;
+        VECT_DST_BLOCK_WRITE(dst_vect, CONVERT_VECTOR_DST_DATA_T(out));
+        dst_vect += GROUP_STRIDE;
+        if (USE_SCALE) scale += GROUP_STRIDE;
+        if (USE_SHIFT) shift += GROUP_STRIDE;
     }
     if (SAVE_STATS && get_local_id(0) == 0) {
         mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
@@ -38,32 +38,39 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
         __global WEI_DATA_T *scale, __global WEI_DATA_T *shift, float eps,
         __global float *src_scale, __global float *dst_scale, int greads,
         float rrs, dispatch_gws_rt_params_t gws_params) {
-    src = (GWS_GET_BUFFER_POS(SRC, gws_params, src)) - get_sub_group_local_id();
+
+    int sg_offset = get_sub_group_id() * SG_SIZE * VECT_DT_N;
+    src = (GWS_GET_BUFFER_POS(SRC, gws_params, src)) - get_local_id(0)
+            + sg_offset;
 
     FLT_ACC_DATA_T local_variance = 0.f;
     FLT_ACC_DATA_T local_mean = 0.f;
+    VECT_FLOAT_T val;
     if (CALCULATE_STATS) {
         /// Read global memory and mean and variance
         FLT_ACC_DATA_T sum = 0;
+        int sg_idx = 0;
         unroll_for_by(N_UNROLL)(int sg_idx = 0; sg_idx < reduce_size;
-                                sg_idx += SG_STRIDE) {
-            VECT_FLOAT_T val
-                    = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
-                            (const __global BLOCK_DATA_T *)(&src[sg_idx]))));
+                                sg_idx += GROUP_STRIDE) {
+            val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
+                    (const __global BLOCK_DATA_T *)(&src[sg_idx]))));
             sum += vec_sum(val);
         }
 
-        local_mean = sub_group_reduce_add(sum) * rrs;
+        local_mean = GROUP_ADD(sum) * rrs;
         FLT_ACC_DATA_T sumsq = 0;
         unroll_for_by(N_UNROLL)(int i = 0; i < greads; i++) {
-            VECT_FLOAT_T val;
-            val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ((
-                          const __global BLOCK_DATA_T *)(&src[i * SG_STRIDE]))))
-                    - local_mean;
-            val *= val;
-            sumsq += vec_sum(val);
+            VECT_FLOAT_T var_val;
+#if REUSE
+            var_val = val;
+#else
+            var_val = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
+                    (const __global BLOCK_DATA_T *)(&src[i * GROUP_STRIDE]))));
+#endif
+            var_val *= var_val - local_mean;
+            sumsq += vec_sum(var_val);
         }
-        local_variance = sub_group_reduce_add(sumsq) * rrs;
+        local_variance = GROUP_ADD(sumsq) * rrs;
     } else {
         mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);
         variance = GWS_GET_BUFFER_POS(STAT, gws_params, variance);
@@ -72,25 +79,28 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
     }
 
     if (USE_SCALE)
-        scale = GWS_GET_BUFFER_POS(SS, gws_params, scale)
-                + ((greads - 1) * SG_STRIDE);
+        scale = GWS_GET_BUFFER_POS(SS, gws_params, scale) - get_local_id(0)
+                + ((greads - 1) * GROUP_STRIDE) + sg_offset;
     if (USE_SHIFT)
-        shift = GWS_GET_BUFFER_POS(SS, gws_params, shift)
-                + ((greads - 1) * SG_STRIDE);
+        shift = GWS_GET_BUFFER_POS(SS, gws_params, shift) - get_local_id(0)
+                + ((greads - 1) * GROUP_STRIDE) + sg_offset;
 
     /// Normalize layer
     FLT_ACC_DATA_T sqrt_variance = rsqrt(local_variance + eps);
     __global DST_DATA_T *dst_vect = (GWS_GET_BUFFER_POS(DST, gws_params, dst))
-            - get_sub_group_local_id() + ((greads - 1) * SG_STRIDE);
+            - get_local_id(0) + ((greads - 1) * GROUP_STRIDE) + sg_offset;
 
     float src_scale_val = src_scale ? *src_scale : 1.f;
     float dst_scale_val = dst_scale ? native_recip(*dst_scale) : 1.f;
 
     unroll_for_by(N_UNROLL)(int i = greads - 1; i >= 0; i--) {
-        VECT_FLOAT_T res
-                = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ((
-                          const __global BLOCK_DATA_T *)(&src[i * SG_STRIDE]))))
-                - local_mean;
+#if REUSE
+        VECT_FLOAT_T res = val;
+#else
+        VECT_FLOAT_T res = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
+                (const __global BLOCK_DATA_T *)(&src[i * GROUP_STRIDE]))));
+#endif
+        res -= local_mean;
         res *= sqrt_variance;
         if (USE_SCALE) res *= LOAD_VECT_WEI(scale);
         if (USE_SHIFT) res += LOAD_VECT_WEI(shift);
@@ -99,11 +109,11 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
         res *= dst_scale_val;
 
         VECT_DST_BLOCK_WRITE(dst_vect, CONVERT_VECTOR_DST_DATA_T(res));
-        dst_vect -= SG_STRIDE;
-        if (USE_SCALE) scale -= SG_STRIDE;
-        if (USE_SHIFT) shift -= SG_STRIDE;
+        dst_vect -= GROUP_STRIDE;
+        if (USE_SCALE) scale -= GROUP_STRIDE;
+        if (USE_SHIFT) shift -= GROUP_STRIDE;
     }
-    if (SAVE_STATS && get_sub_group_local_id() == 0) {
+    if (SAVE_STATS && get_local_id(0) == 0) {
         mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);
         variance = GWS_GET_BUFFER_POS(STAT, gws_params, variance);
         *mean = local_mean;

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.cpp
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.cpp
@@ -26,7 +26,6 @@
 #include "gpu/intel/compute/kernel_arg_list.hpp"
 #include "gpu/intel/compute/utils.hpp"
 #include "gpu/intel/ocl/lnorm_utils.hpp"
-#include "gpu/intel/ocl/ocl_engine.hpp"
 #include "gpu/intel/ocl/ocl_utils.hpp"
 #include "gpu/intel/ocl/reusable_lnorm.hpp"
 #include "gpu/intel/primitive_conf.hpp"
@@ -90,6 +89,15 @@ static status_t init_conf_common(const layer_normalization_pd_t *pd,
         const compute::named_buffer_t &output_buf,
         const compute::named_buffer_t &stat_buf,
         const compute::named_buffer_t &ss_buf) {
+
+    int select_work_group_kernel = gpu_utils::dev_getenv("work_group", -1);
+    select_work_group_kernel
+            = select_work_group_kernel != -1 && select_work_group_kernel;
+    int max_unroll = gpu_utils::dev_getenv("unroll", -1);
+    if (max_unroll == -1) { max_unroll = 8; }
+    int reuse = gpu_utils::dev_getenv("reuse", -1);
+    int reuse_private_mem = gpu_utils::dev_getenv("reuse_private_mem", 999);
+
     conf->use_scale = pd->use_scale();
     conf->use_shift = pd->use_shift();
     conf->input_dt = input_buf.data_type;
@@ -126,23 +134,30 @@ static status_t init_conf_common(const layer_normalization_pd_t *pd,
         return status::unimplemented;
     }
 
+    const auto *compute_engine
+            = utils::downcast<const compute::compute_engine_t *>(engine);
     const auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
             pd->attr()->gpu_attr_.get());
 
-    const auto *compute_engine
-            = utils::downcast<const compute::compute_engine_t *>(engine);
+    size_t lnorm_bytes
+            = pd->norm_axis() * types::data_type_size(input_buf.data_type);
+    size_t tensor_size
+            = src_mdw.nelems() * types::data_type_size(input_buf.data_type);
+    size_t cache_size = compute_engine->device_info()->l3_cache_size();
 
+    std::unique_ptr<lws_strategy_t> lws_strategy;
     conf->sg_size = 0;
     conf->vector_size = 0;
     bool found_compatible_sg_and_vector_size = false;
+
     for (int sg_size : {32, 16}) {
         for (int vector_size : {8, 4, 2, 1}) {
             bool sg_and_vector_size_ok = is_sg_and_vector_size_compatible(
                     compute_engine, sg_size, vector_size);
-            bool sg_stride_ok = is_sg_stride_compatible(
+            bool group_stride_ok = is_sg_stride_compatible(
                     pd->norm_axis(), sg_size * vector_size);
 
-            if (sg_and_vector_size_ok && sg_stride_ok) {
+            if (sg_and_vector_size_ok && group_stride_ok) {
                 conf->sg_size = sg_size;
                 conf->vector_size = vector_size;
                 found_compatible_sg_and_vector_size = true;
@@ -160,39 +175,73 @@ static status_t init_conf_common(const layer_normalization_pd_t *pd,
         return status::unimplemented;
     }
 
-    conf->unroll = std::min<int>(
-            4, (int)pd->norm_axis() / (conf->sg_size * conf->vector_size));
 
+    float threads_launched_for_wg_kernel = (float)pd->norm_axis() / conf->vector_size * (src_mdw.nelems()/ pd->norm_axis()) / conf->sg_size;
+    float threads_launched_for_sg_kernel = (src_mdw.nelems()/ pd->norm_axis());
+    auto di = compute_engine->device_info();
 
+  //printf("sg: %f wg: %f ", threads_launched_for_sg_kernel, threads_launched_for_wg_kernel);
+    //printf("sg waves: %f wg waves:%f \n", di->eu_count()*8/threads_launched_for_sg_kernel, di->eu_count()*8/threads_launched_for_wg_kernel);
 
-    size_t lnorm_bytes = pd->norm_axis()
-            * types::data_type_size(input_buf.data_type);
-    size_t tensor_size = src_mdw.nelems()
-      * types::data_type_size(input_buf.data_type);
+    float sg_waves = threads_launched_for_sg_kernel/di->hw_threads();
+    float wg_waves = threads_launched_for_wg_kernel/di->hw_threads();
+    float sg_full_waves, wg_full_waves;
+    float sg_partial_waves = modf(sg_waves,&sg_full_waves);
+    float wg_partial_waves = modf(wg_waves,&wg_full_waves);
 
-    auto *ocl_engine = utils::downcast<const ocl_gpu_engine_t *>(compute_engine);
-    const cl_device_id &ocl_dev = ocl_engine->device();
-    size_t cache_size;
-    cl_int err = clGetDeviceInfo(ocl_dev, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, sizeof(size_t), &cache_size, nullptr);
-
-    //auto gpu_arch = compute_engine->device_info()->gpu_arch();
-
-
-    std::unique_ptr<lws_strategy_t> lws_strategy;
-    int userval = gpu_utils::dev_getenv("reuse", 0);
-    //printf("userval: %d\n", userval);
-    //if (!userval) {// && (lnorm_bytes <= 256 || (lnorm_bytes < 1024 && tensor_size < cache_size * 0.33))) {
-    if (lnorm_bytes > 768 || (lnorm_bytes > 512 && tensor_size > cache_size * 0.33)) {
-        conf->reuse = true;
-        conf->unroll = 1;
-        lws_strategy.reset(
-                new default_lws_strategy_t(compute_engine, gpu_attr));
+    //printf("hw_threads(): %d\n", di->hw_threads());
+    //printf("sg full: %f partial: %f wg full:%f partial: %f| ", sg_full_waves, sg_partial_waves, wg_full_waves, wg_partial_waves);
+    if(sg_waves < 1 && wg_waves < 1) {
+        select_work_group_kernel = wg_waves >= sg_waves;
+    } else if ( sg_waves == 1 || wg_waves == 1) {
+        select_work_group_kernel = wg_waves == 1;
+    } else if ( sg_waves < 1 ^ wg_waves < 1) {
+      // prefer 1 wave over multiple if the utilization is high
+      select_work_group_kernel = (wg_waves > 1 && sg_waves < 0.8);
     } else {
+        select_work_group_kernel = wg_full_waves > sg_full_waves;
+    }
+
+    int num_sg_per_wg = (int)pd->norm_axis() / (conf->sg_size * conf->vector_size);
+    
+    if (( (select_work_group_kernel || (tensor_size / cache_size >= 0.75)) || num_sg_per_wg > 4 ) && !(num_sg_per_wg == 1)) { // || !(lnorm_bytes <= 256)) {
+      //printf("wg: ");
+      conf->unroll = 1;
+      conf->private_mem_size = 0;
+      lws_strategy.reset(
+                         new default_lws_strategy_t(compute_engine, gpu_attr));
+
+      if ((pd->norm_axis() / conf->sg_size * conf->vector_size)
+          > compute_engine->device_info()->max_wg_size(false)) {
+        VDEBUGINFO(15, primitive, lnorm,
+                   "Reusable Vectorized LNorm not used because launch "
+                    "configuration exceeds device limits");
+            return status::unimplemented;
+        }
+        conf->reuse = true;
+    } else {
+
+      //printf("sg: ");
+        conf->unroll = std::min<int>(max_unroll,
+                (int)pd->norm_axis() / (conf->sg_size * conf->vector_size));
+
+        conf->private_mem_size = std::min<uint8_t>((uint8_t)reuse_private_mem,
+                pd->norm_axis() / (conf->sg_size * conf->vector_size));
         lws_strategy.reset(new single_subgroup_lws_strategy_t(
                 compute_engine, gpu_attr, conf->sg_size));
     }
 
-    //printf("lnorm_size: %zu tensor_size: %zu err: %d cache_size: %zu reuse: %d\n", lnorm_bytes, tensor_size, err, cache_size, conf->reuse);
+    //if(reuse != -1) {
+    //  conf->reuse = reuse;
+    //  if (reuse) {
+    //    conf->private_mem_size
+    //      = std::min<uint8_t>(reuse_private_mem, pd->norm_axis() / (conf->sg_size * conf->vector_size));
+    //  } else {
+    //      conf->private_mem_size = 0;
+    //  }
+    //}
+
+    //printf("lnorm_size: %zu tensor_size: %zu cache_size: %zu reuse: %d\n", lnorm_bytes, tensor_size, cache_size, conf->reuse);
     // Norm dispatch: all dimensions
 
     compute::reusable_dispatch_config_t dispatch_config(compute_engine, dims);
@@ -237,6 +286,8 @@ reusable_vectorized_lnorm_params_t::get_kernel_ctx() const {
     compute::kernel_ctx_t kernel_ctx;
     kernel_ctx.set_data_type(input_dt);
     kernel_ctx.add_option("-cl-std=CL3.0");
+    //kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
+
     def_data_type(kernel_ctx, input_dt, "SRC");
     def_data_type(kernel_ctx, ss_dt, "WEI");
     def_data_type(kernel_ctx, output_dt, "DST");
@@ -251,6 +302,8 @@ reusable_vectorized_lnorm_params_t::get_kernel_ctx() const {
     kernel_ctx.define_int("VECT_DT_N", vector_size);
     kernel_ctx.define_int("N_UNROLL", unroll);
     kernel_ctx.define_int("REUSE", reuse);
+    kernel_ctx.define_int("PVT_MEM_SIZE", private_mem_size);
+
     if (reuse) {
         kernel_ctx.add_option("-DGROUP_ADD=work_group_reduce_add");
         kernel_ctx.define_int("GROUP_STRIDE", INT32_MAX);
@@ -311,7 +364,8 @@ status_t reusable_vectorized_layer_normalization_fwd_t::execute_forward(
                 {static_cast<size_t>(pd()->norm_axis() / conf.vector_size),
                         rt_conf.gws_params.nd_range.global_range().data()[1],
                         rt_conf.gws_params.nd_range.global_range().data()[2]},
-                {static_cast<size_t>(pd()->norm_axis() / conf.vector_size), 1, 1});
+                {static_cast<size_t>(pd()->norm_axis() / conf.vector_size), 1,
+                        1});
 
         //std::cout << "rt_conf.gws_params.nd_range.str():  "
         //<< rt_conf.gws_params.nd_range.str() << "\n";
@@ -322,10 +376,12 @@ status_t reusable_vectorized_layer_normalization_fwd_t::execute_forward(
     } else {
         compute::nd_range_t gws_nd_range_calc(
                 {static_cast<size_t>(conf.sg_size),
+                        //std::max<size_t>((size_t)3587, rt_conf.gws_params.nd_range.global_range().data()[1]),
                         rt_conf.gws_params.nd_range.global_range().data()[1],
                         rt_conf.gws_params.nd_range.global_range().data()[2]},
                 {static_cast<size_t>(conf.sg_size), 1, 1});
 
+        //std::cout << "gws_nd_range_calc: " << gws_nd_range_calc.str() << " vector size: " << conf.vector_size <<  "\n";
         return parallel_for(ctx, gws_nd_range_calc, calculate_lnorm_kernel_,
                 lnorm_arg_list);
     }

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
@@ -81,7 +81,10 @@ struct reusable_vectorized_lnorm_params_t
     bool reuse = false;
 
     uint8_t private_mem_size = 0;
-    uint8_t padding[2] = {false};
+    bool large_grf = false;
+    uint32_t wg_size = 0;
+
+    //uint8_t padding[1] = {false};
 };
 
 struct reusable_vectorized_lnorm_runtime_params_t {

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
@@ -80,7 +80,8 @@ struct reusable_vectorized_lnorm_params_t
 
     bool reuse = false;
 
-    uint8_t padding[3] = {false};
+    uint8_t private_mem_size = 0;
+    uint8_t padding[2] = {false};
 };
 
 struct reusable_vectorized_lnorm_runtime_params_t {

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
@@ -56,11 +56,15 @@ struct reusable_vectorized_lnorm_params_t
     compute::kernel_ctx_t get_kernel_ctx() const;
 
     compute::dispatch_compile_params_t gws_params;
+
     /// Number of work items in a sub-group
-    int sg_size;
+    uint32_t sg_size;
+
+    /// The number of work-items in the work group
+    uint32_t wg_size = 0;
 
     /// Number of elements to process in each work-item
-    int vector_size;
+    uint32_t vector_size;
 
     /// The number of times the loops need to unroll
     int unroll;
@@ -78,13 +82,16 @@ struct reusable_vectorized_lnorm_params_t
     /// Saves the mean and variance to memory
     bool save_stats = false;
 
-    bool reuse = false;
+    /// Select the work_group based reduction kernel
+    bool select_work_group_kernel = false;
 
-    uint8_t private_mem_size = 0;
+    /// Use the cl-intel-256-GRF-per-thread flag
     bool large_grf = false;
-    uint32_t wg_size = 0;
 
-    //uint8_t padding[1] = {false};
+    /// The number of elements to allocate in the val array in the kernel
+    uint8_t private_mem_size = 0;
+
+    uint8_t padding[5] = {false};
 };
 
 struct reusable_vectorized_lnorm_runtime_params_t {

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
@@ -78,7 +78,9 @@ struct reusable_vectorized_lnorm_params_t
     /// Saves the mean and variance to memory
     bool save_stats = false;
 
-    uint8_t padding[4] = {false};
+    bool reuse = false;
+
+    uint8_t padding[3] = {false};
 };
 
 struct reusable_vectorized_lnorm_runtime_params_t {


### PR DESCRIPTION
# Description

This pull request adds an alternative kernel that performs better under certain conditions compared to the sub-group reduction kernel previously implemented. The new kernel uses the work_group_reduce_add function to perform the mean an variance reductions instead of using the sub_group based reductions. One benefit of this kernel is that it performs better for sizes that do not fully utilize the device when sub-group based reductions are used.

## Optimizations

### work-group based reductions vs sub-group based reductions

There are two kernels implemented for the reusable layer normalization layer. These kernels differ in the way the summation operation is performed in the variance and mean calculation. The work-group kernel will launch a work-item for each element in the lnorm axis and the sub-group kernel will launch one SIMD worth of work-items in the lnorm axis. The work group kernel will use work_group_reduction_add function and sub-group version will use the sub_group_reduction_add function to perform the summation. Here is a heatmap of the two kernel and how they perform over the different shapes of the input tensor.

![image](https://github.com/intel-innersource/libraries.performance.math.onednn/assets/457510/15b91cbb-e956-424f-8d32-448ec9ece47f)

### Use of fixed sized loops vs variable sized loops

Example: https://github.com/oneapi-src/oneDNN/compare/main...umar456:oneDNN:uarshad/reusable_vectorized_lnorm?expand=1#diff-399297f4e437e8a12e0e654089b8af8c938a7a8430c6efab4ea61a029a683f8cR53

There is a significant penalty when a runtime variable is used to exit the loop condition. Here are heatmaps between a runtime condition vs a compile time condition for the for loop:

![image](https://github.com/intel-innersource/libraries.performance.math.onednn/assets/457510/9400a7f8-a0d5-4bd8-840c-309afb810089)

### Use macro to avoid loops in work-group kernel

The ifdef here: https://github.com/oneapi-src/oneDNN/compare/main...umar456:oneDNN:uarshad/reusable_vectorized_lnorm?expand=1#diff-399297f4e437e8a12e0e654089b8af8c938a7a8430c6efab4ea61a029a683f8cR51

is used to avoid adding loop in the work-group kernel. I had originally assumed that if the compiler knew that we were only iterating the loop one time it would be able to remove the overhead of adding the loop but it seems its not the case. Here is a heatmap of using the macro to remove the loop in the work-group kernel.

![image](https://github.com/intel-innersource/libraries.performance.math.onednn/assets/457510/8c483071-bbbf-449b-9975-097017de1a27)


### Use large GRF for certain shapes in the sub-group based kernel

Large GRF flag can significantly improve the speed of the kernel under certain situation. You see the greatest speedup in situations where the tensor is small enough to fit in the device cache and there is the lnorm axis is larger than 768. I suspect this is because it allows the device to queue more load transactions than without the flag. Additionally there is a significant slowdown where the lnorm axis is small and the number of subgroups launched is greater than one wave. I suspect his is because fewer sub-groups are active when the large GRF flag is used. Here is the heatmap of the sub-group kernel with and without the GRF flag.

![image](https://github.com/intel-innersource/libraries.performance.math.onednn/assets/457510/abf0fbd1-efc7-4c70-8122-8d7198ac6d3b)

## Overall Speedup

### 512 EU PVC

Heatmap vs. Original Vectorized:
![reusable_pvc512](https://github.com/intel-innersource/libraries.performance.math.onednn/assets/457510/5cef6eb9-e275-485c-acda-6ce7fd4a9480)

![image](https://github.com/intel-innersource/libraries.performance.math.onednn/assets/457510/8d02e75f-d896-4316-8c19-65c1f9c8468b)