### PR TITLE
gpu: sycl: prelu: Fix backward pass

### DIFF
--- a/src/gpu/generic/sycl/prelu_kernels.hpp
+++ b/src/gpu/generic/sycl/prelu_kernels.hpp
@@ -174,7 +174,6 @@ struct prelu_bwd_kernel_vec_t {
             case broadcasting_strategy_t::scalar:
                 calculate_scalar(data_ptr(), weights_ptr(), diff_weights_ptr(),
                         diff_dst_ptr(), diff_data_ptr(), ithr);
-                reduce_scalar(diff_weights_ptr(), ithr);
                 break;
             case broadcasting_strategy_t::no_broadcast:
                 calculate_no_broadcast(data_ptr(), weights_ptr(),
@@ -205,28 +204,6 @@ struct prelu_bwd_kernel_vec_t {
         store_float_value(
                 data_md().data_type(), diff_src_res, diff_src, data_off);
         return diff_weight_res;
-    }
-
-    void reduce_scalar(float *diff_weights, size_t i) const {
-        const size_t nthr = conf_.n_thr;
-        const dim_t work_amount = conf_.work_amount_src;
-        const int thread_count = nstl::min((dim_t)nthr, work_amount);
-        double s = 0;
-        int c = 0;
-        for (dim_t a = 0; a < thread_count; a++) {
-            auto la = load_float_value(
-                    weights_md().data_type(), scratchpad_ptr(), i);
-            if (!std::isnan(la)) c = c + 1;
-        }
-        if (c == (thread_count)) {
-            for (dim_t j = 0; j < thread_count; j++) {
-                auto la = load_float_value(
-                        weights_md().data_type(), scratchpad_ptr(), j);
-                s = s + la;
-            }
-            store_float_value(
-                    weights_md().data_type(), s, diff_weights_ptr(), 0);
-        }
     }
 
     void set_reduction_buffers(
@@ -295,7 +272,6 @@ private:
         }
 
         balance211(work_amount, nthr, ithr, start, end);
-        const dim_t workload = end - start;
 
         if (conf_.ndims == 1) {
             utils::nd_iterator_init(start, off[0], dims_d[0]);
@@ -317,11 +293,6 @@ private:
                     off[2], dims_d[2], off[3], dims_d[3], off[4], dims_d[4]);
         }
 
-        dim_t group_size, buf_size;
-        set_reduction_buffers(workload, group_size, buf_size);
-        dim_t offset_buf {0}, group_off {0}, data_size {buf_size};
-        float s = 0;
-        float r = 0;
         for (dim_t iwork = start; iwork < end; ++iwork) {
             const auto data_off = offset(data_md(), off);
             const auto weight_off = 0;
@@ -336,17 +307,9 @@ private:
             float diff_weight_res = src_val > 0 ? 0 : (diff_dst_val * src_val);
             store_float_value(
                     data_md().data_type(), diff_src_res, diff_src, data_off);
+            store_float_value(diff_weights_md().data_type(), diff_weight_res,
+                    scratchpad_ptr(), data_off);
 
-            s = s + diff_weight_res;
-            if (++offset_buf == data_size) {
-                r = r + s;
-                offset_buf = 0;
-                group_off++;
-                s = 0;
-                data_size = ((group_off + 1) * buf_size <= workload)
-                        ? buf_size
-                        : workload - (group_off * buf_size);
-            }
             if (conf_.ndims == 1) {
                 utils::nd_iterator_step(off[0], dims_d[0]);
             }
@@ -367,7 +330,6 @@ private:
                         dims_d[4]);
             }
         }
-        store_float_value(weights_md().data_type(), r, scratchpad_ptr(), ithr);
     }
 
     void calculate_no_broadcast(const float *src, const float *weights,

--- a/src/gpu/generic/sycl/ref_prelu.cpp
+++ b/src/gpu/generic/sycl/ref_prelu.cpp
@@ -15,8 +15,11 @@
 *******************************************************************************/
 
 #include "gpu/generic/sycl/ref_prelu.hpp"
+#include "common/primitive_exec_types.hpp"
+#include "common/stream.hpp"
 #include "common/utils.hpp"
 #include "gpu/generic/sycl/prelu_kernels.hpp"
+#include "xpu/sycl/stream_impl.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -73,6 +76,43 @@ status_t ref_prelu_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     });
 }
 
+status_t ref_prelu_bwd_t::pd_t::init_reduction(impl::engine_t *engine) {
+    if (reduce_diff_weights_) {
+        reduction_desc_t rdesc;
+        scratch_md_ = memory_desc_t(*src_md(0));
+        scratch_md_.data_type = diff_weights_md()->data_type;
+        CHECK(reduction_desc_init(&rdesc, dnnl_alg_kind_t::dnnl_reduction_sum,
+                &scratch_md_, diff_weights_md(0), 0, 0));
+        primitive_attr_t reduction_attr(*attr());
+        if (!reduction_attr.is_initialized()) return status::out_of_memory;
+
+        primitive_desc_iterator_t it(
+                engine, (op_desc_t *)&rdesc, &reduction_attr, nullptr);
+        if (!it.is_initialized()) return status::invalid_arguments;
+        while (++it != it.end()) {
+            reduction_pd_ = *it;
+            if (reduction_pd_) break;
+        }
+
+        if (!reduction_pd_) { return status::invalid_arguments; }
+    }
+
+    return status::success;
+}
+
+void ref_prelu_bwd_t::pd_t::init_scratchpad() {
+    if (reduce_diff_weights_) {
+        auto scratchpad = scratchpad_registry().registrar();
+        size_t size
+                = utils::array_product(src_md()->padded_dims, src_md()->ndims);
+        scratchpad.book(memory_tracking::names::key_prelu_reduction, size,
+                types::data_type_size(scratch_md_.data_type));
+
+        scratchpad.book(memory_tracking::names::key_nested,
+                reduction_pd_->scratchpad_registry());
+    }
+}
+
 status_t ref_prelu_bwd_t::pd_t::init_conf() {
     if (has_zero_dim_memory()) return status::success;
     conf_ = sycl_prelu_conf_t();
@@ -87,6 +127,8 @@ status_t ref_prelu_bwd_t::pd_t::init_conf() {
     const memory_desc_wrapper data_d(src_md(0));
     conf_.bcast_type = dnnl::impl::get_rhs_arg_broadcasting_strategy(
             *weights_d.md_, data_d);
+    reduce_diff_weights_
+            = (conf_.bcast_type == broadcasting_strategy_t::scalar);
     conf_.mask = utils::get_dims_mask(data_d.dims(), weights_d.dims(), ndims());
     conf_.block_size = 16;
     conf_.wg_size = 32;
@@ -101,6 +143,12 @@ status_t ref_prelu_bwd_t::pd_t::init_conf() {
 }
 
 status_t ref_prelu_bwd_t::init(impl::engine_t *engine) {
+    if (pd()->reduce_diff_weights_) {
+        std::pair<std::shared_ptr<impl::primitive_t>, cache_state_t> p;
+        CHECK(pd()->reduction_pd_->create_primitive_nested(p, engine));
+        reduction_p_ = p.first;
+    }
+
     const auto kid = ::sycl::get_kernel_id<prelu_bwd_kernel_vec_t>();
     return create_kernel(engine, kid, &kernel_);
 }
@@ -108,15 +156,31 @@ status_t ref_prelu_bwd_t::init(impl::engine_t *engine) {
 status_t ref_prelu_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
     if (pd()->has_zero_dim_memory()) return status::success;
 
-    return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+    std::unique_ptr<memory_t> scratch_mem;
+    if (pd()->reduce_diff_weights_) {
+        auto scratchpad_storage
+                = ctx.get_scratchpad_grantor().get_memory_storage(
+                        memory_tracking::names::key_prelu_reduction);
+        CHECK(safe_ptr_assign(scratch_mem,
+                new memory_t(ctx.stream()->engine(), &pd()->scratch_md_,
+                        std::move(scratchpad_storage))));
+    }
+
+    auto status = parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         auto data = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC);
         auto weights = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_WEIGHTS);
         auto diff_data = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_SRC);
         auto diff_weights = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_WEIGHTS);
         auto diff_dst = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST);
-        auto scratchpad = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_SCRATCHPAD);
         auto nelems_A = memory_desc_wrapper(pd()->src_md(0)).nelems();
         int tot_work = nelems_A;
+
+        auto scratchpad = pd()->reduce_diff_weights_
+                ? utils::downcast<const xpu::sycl::memory_storage_base_t *>(
+                        scratch_mem->memory_storage())
+                          ->get_out_memory_arg(ctx.stream(), cgh)
+                : xpu::sycl::memory_storage_base_t::empty_out_memory_arg(
+                        ctx.stream(), cgh);
 
         prelu_bwd_kernel_vec_t prelu_bwd_kernel(pd()->conf_, data, diff_data,
                 weights, diff_weights, diff_dst, scratchpad);
@@ -127,6 +191,22 @@ status_t ref_prelu_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
         int n_thr = n_wgs * wg_size;
         cgh.parallel_for(::sycl::nd_range<1>(n_thr, wg_size), prelu_bwd_kernel);
     });
+
+    CHECK(status);
+
+    if (pd()->reduce_diff_weights_) {
+        exec_args_t reduction_args;
+        reduction_args[DNNL_ARG_SRC] = memory_arg_t {scratch_mem.get(), true};
+        reduction_args[DNNL_ARG_DST] = ctx.args().at(DNNL_ARG_DIFF_WEIGHTS);
+        exec_ctx_t reduction_ctx(ctx, std::move(reduction_args));
+
+        nested_scratchpad_t ns(
+                ctx, memory_tracking::names::key_nested, reduction_p_);
+        reduction_ctx.set_scratchpad_grantor(ns.grantor());
+        return reduction_p_->execute(reduction_ctx);
+    }
+
+    return status::success;
 }
 
 } // namespace sycl

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -85,7 +85,6 @@ struct sycl_prelu_conf_t {
     dim_t work_amount_wei;
     dim_t work_amount_src;
     dim_t work_load;
-    bool reduce_diff_weights = 0;
     int mask;
     float sum;
     broadcasting_strategy_t bcast_type;


### PR DESCRIPTION
# Description

This PR fixes the backward pass of the SYCL PRELU implementation for scalar broadcast cases. The changes made are:
- Allocate scratchpad in `init()`
- Use the reduction primitive to reduce diff_weights. Since the scratchpad is stored in global memory and the PRELU kernel first stores data in it which is later reduced in the same kernel, there was a race condition as there is no way to guarantee that all threads have finished writing to it before it is being read from. Launching a separate kernel (reduction) guarantees correct synchronisation.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
