### PR TITLE
gpu: sycl: Ensure dimensions are <= INT32_MAX

### DIFF
--- a/src/gpu/generic/sycl/ref_batch_normalization.hpp
+++ b/src/gpu/generic/sycl/ref_batch_normalization.hpp
@@ -24,6 +24,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_batch_normalization_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -62,7 +63,8 @@ struct ref_batch_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
                             || with_relu_post_op(is_training()))
                     && set_default_formats_common()
                     && memory_desc_wrapper(src_md(0))
-                            == memory_desc_wrapper(dst_md(0));
+                            == memory_desc_wrapper(dst_md(0))
+                    && md_dims_in_range(src_md());
             if (!ok) return status::unimplemented;
             if (src_md(0)->data_type == s8 && !stats_is_src())
                 return status::unimplemented;
@@ -121,7 +123,8 @@ struct ref_batch_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
                     && attr()->has_default_values()
                     && set_default_formats_common()
                     && memory_desc_wrapper(diff_src_md())
-                            == memory_desc_wrapper(diff_dst_md());
+                            == memory_desc_wrapper(diff_dst_md())
+                    && md_dims_in_range(diff_src_md());
 
             if (!ok) return status::unimplemented;
             if (fuse_norm_relu() || fuse_norm_add_relu()) {

--- a/src/gpu/generic/sycl/ref_binary.hpp
+++ b/src/gpu/generic/sycl/ref_binary.hpp
@@ -22,6 +22,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_binary_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -55,7 +56,9 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
                             sm::scales_runtime | sm::post_ops)
                     && IMPLICATION(!attr()->scales_.has_default_values(),
                             check_scales_mask())
-                    && post_ops_ok();
+                    && post_ops_ok() && md_dims_in_range(src_md(0))
+                    && md_dims_in_range(src_md(1))
+                    && md_dims_in_range(dst_md());
             if (!ok) return status::unimplemented;
 
             return init_conf();

--- a/src/gpu/generic/sycl/ref_eltwise.hpp
+++ b/src/gpu/generic/sycl/ref_eltwise.hpp
@@ -20,6 +20,7 @@
 #include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_eltwise_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -50,7 +51,7 @@ struct ref_sycl_eltwise_fwd_t : public gpu::generic::sycl::primitive_t {
                     && attr()->has_default_values(sm::post_ops)
                     && set_default_formats_common() && src_d == dst_d
                     && attr_.set_default_formats(dst_md(0)) == status::success
-                    && post_ops_ok();
+                    && post_ops_ok() && md_dims_in_range(src_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();

--- a/src/gpu/generic/sycl/ref_layer_normalizations.hpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.hpp
@@ -23,6 +23,7 @@
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_layer_normalization_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -60,7 +61,8 @@ struct ref_layer_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
                     && stat_md()->data_type == f32
                     && check_scale_shift_data_type({f32, bf16, f16})
                     && attr()->has_default_values(sm::scales_runtime)
-                    && attr_scales_ok() && set_default_formats_common();
+                    && attr_scales_ok() && set_default_formats_common()
+                    && md_dims_in_range(src_md());
             if (!ok) return status::unimplemented;
             return init_conf();
         }
@@ -109,7 +111,8 @@ struct ref_layer_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
                     && stat_md()->data_type == f32
                     && check_scale_shift_data_type({f32, bf16, f16})
                     && attr()->has_default_values()
-                    && set_default_formats_common();
+                    && set_default_formats_common()
+                    && md_dims_in_range(diff_dst_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();

--- a/src/gpu/generic/sycl/ref_lrn.hpp
+++ b/src/gpu/generic/sycl/ref_lrn.hpp
@@ -18,6 +18,7 @@
 
 #include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_lrn_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -48,7 +49,8 @@ struct ref_sycl_lrn_fwd_t : public gpu::generic::sycl::primitive_t {
                             src_md()->data_type, dst_md()->data_type)
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && attr()->has_default_values()
-                    && set_default_formats_common() && src_d == dst_d;
+                    && set_default_formats_common() && src_d == dst_d
+                    && md_dims_in_range(src_md());
 
             if (!ok) return status::unimplemented;
             dat_tag_ = memory_desc_matches_one_of_tag(*src_md(), nchw, nhwc);
@@ -93,7 +95,8 @@ struct ref_sycl_lrn_bwd_t : public gpu::generic::sycl::primitive_t {
                     && utils::everyone_is(src_md()->data_type,
                             diff_src_md()->data_type, diff_dst_md()->data_type)
                     && attr()->has_default_values()
-                    && set_default_formats_common() && diff_dst_d == diff_src_d;
+                    && set_default_formats_common() && diff_dst_d == diff_src_d
+                    && md_dims_in_range(diff_dst_md());
 
             if (!ok) return status::unimplemented;
 

--- a/src/gpu/generic/sycl/ref_pooling.hpp
+++ b/src/gpu/generic/sycl/ref_pooling.hpp
@@ -24,6 +24,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_pooling_pd.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 #include "xpu/sycl/types.hpp"
@@ -66,7 +67,8 @@ struct ref_pooling_fwd_t : public gpu::generic::sycl::primitive_t {
                             || utils::everyone_is(s32, src_md(0)->data_type,
                                     dst_md(0)->data_type))
                     && attr()->has_default_values(sm::post_ops)
-                    && attr_.set_default_formats(dst_md(0)) == status::success;
+                    && attr_.set_default_formats(dst_md(0)) == status::success
+                    && md_dims_in_range(src_md());
             if (!ok) return status::unimplemented;
             bool is_training = desc_.prop_kind == prop_kind::forward_training;
             if (desc()->alg_kind == alg_kind::pooling_max && is_training)
@@ -114,7 +116,8 @@ struct ref_pooling_bwd_t : public gpu::generic::sycl::primitive_t {
                                     diff_src_md(0)->data_type,
                                     diff_dst_md(0)->data_type))
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
-                    && attr()->has_default_values();
+                    && attr()->has_default_values()
+                    && md_dims_in_range(diff_dst_md());
 
             if (!ok) return status::unimplemented;
             if (desc()->alg_kind == alg_kind::pooling_max) {

--- a/src/gpu/generic/sycl/ref_prelu.hpp
+++ b/src/gpu/generic/sycl/ref_prelu.hpp
@@ -24,6 +24,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_prelu_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -50,7 +51,9 @@ struct ref_prelu_fwd_t : public gpu::generic::sycl::primitive_t {
 
             const bool ok = is_fwd() && set_default_formats()
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
-                    && (weights_md(0)->format_desc.blocking.inner_nblks == 0);
+                    && (weights_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && md_dims_in_range(src_md())
+                    && md_dims_in_range(weights_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();
@@ -91,8 +94,9 @@ struct ref_prelu_bwd_t : public gpu::generic::sycl::primitive_t {
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && (weights_md(0)->format_desc.blocking.inner_nblks == 0)
                     && diff_src_md(0)->data_type == src_md(0)->data_type
-                    && diff_weights_md(0)->data_type
-                            == weights_md(0)->data_type;
+                    && diff_weights_md(0)->data_type == weights_md(0)->data_type
+                    && md_dims_in_range(diff_src_md())
+                    && md_dims_in_range(weights_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();

--- a/src/gpu/generic/sycl/ref_reorder.hpp
+++ b/src/gpu/generic/sycl/ref_reorder.hpp
@@ -22,6 +22,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_reorder_pd.hpp"
 
 namespace dnnl {
@@ -50,12 +51,8 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
                     && check_formats(src_d, dst_d)
                     && attr()->has_default_values(
                             sm::scales_runtime | sm::post_ops)
-                    && post_ops_ok();
+                    && post_ops_ok() && md_dims_in_range(dst_md());
             if (!ok) return status::unimplemented;
-
-            for (int i = 0; i < dst_d.ndims(); i++) {
-                if (dst_d.dims()[i] > INT_MAX) { return status::unimplemented; }
-            }
 
             return init_conf();
         }

--- a/src/gpu/generic/sycl/ref_resampling.hpp
+++ b/src/gpu/generic/sycl/ref_resampling.hpp
@@ -22,6 +22,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_resampling_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -63,7 +64,8 @@ struct ref_resampling_fwd_t : public gpu::generic::sycl::primitive_t {
                             || utils::everyone_is(s32, src_md(0)->data_type,
                                     dst_md(0)->data_type))
                     && attr()->has_default_values(sm::post_ops)
-                    && attr_.set_default_formats(dst_md(0)) == status::success;
+                    && attr_.set_default_formats(dst_md(0)) == status::success
+                    && md_dims_in_range(src_md());
 
             if (!ok) { return status::unimplemented; }
             return init_conf();
@@ -101,7 +103,8 @@ struct ref_resampling_bwd_t : public gpu::generic::sycl::primitive_t {
             bool ok = !is_fwd() && set_default_params() == status::success
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && (diff_dst_md(0)->format_desc.blocking.inner_nblks == 0)
-                    && attr()->has_default_values();
+                    && attr()->has_default_values()
+                    && md_dims_in_range(diff_dst_md());
             if (!ok) return status::unimplemented;
             return init_conf();
         }

--- a/src/gpu/generic/sycl/ref_shuffle.hpp
+++ b/src/gpu/generic/sycl/ref_shuffle.hpp
@@ -22,6 +22,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_shuffle_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -53,7 +54,8 @@ struct ref_shuffle_t : public gpu::generic::sycl::primitive_t {
                     && set_default_formats_common()
                     && IMPLICATION(is_fwd(),
                             src_md(0)->format_desc.blocking.inner_nblks == 0)
-                    && attr()->has_default_values();
+                    && attr()->has_default_values()
+                    && md_dims_in_range(src_md());
             if (!ok) return status::unimplemented;
             return init_conf();
         }

--- a/src/gpu/generic/sycl/ref_softmax.hpp
+++ b/src/gpu/generic/sycl/ref_softmax.hpp
@@ -18,6 +18,7 @@
 
 #include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_softmax_pd.hpp"
 
 namespace dnnl {
@@ -42,7 +43,8 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && attr()->has_default_values(sm::scales_runtime)
                     && attr_oscale_ok()
-                    && set_default_formats() == status::success;
+                    && set_default_formats() == status::success
+                    && md_dims_in_range(src_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();
@@ -94,7 +96,8 @@ struct ref_sycl_softmax_bwd_t : public gpu::generic::sycl::primitive_t {
                     && (dst_md(0)->format_desc.blocking.inner_nblks == 0)
                     && dst_md()->data_type == diff_dst_md()->data_type
                     && attr()->has_default_values()
-                    && set_default_formats() == status::success;
+                    && set_default_formats() == status::success
+                    && md_dims_in_range(diff_dst_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();

--- a/src/gpu/generic/sycl/sycl_utils.hpp
+++ b/src/gpu/generic/sycl/sycl_utils.hpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright 2022-2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_GENERIC_SYCL_SYCL_UTILS_HPP
+#define GPU_GENERIC_SYCL_SYCL_UTILS_HPP
+
+#include "common/memory_desc.hpp"
+#include "common/memory_desc_wrapper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+inline bool md_dims_in_range(const dnnl::impl::memory_desc_t *desc) {
+    auto wrap = dnnl::impl::memory_desc_wrapper(desc);
+    for (int i = 0; i < wrap.ndims(); i++) {
+        if (wrap.dims()[i] > INT_MAX) { return false; }
+    }
+
+    return true;
+}
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
# Description

Currently dimensions in `xpu::sycl::md_t` are stored as 32-bit integers and the constructor has an assertion that the size of each dimension is <= `INT32_MAX`. This PR adds a check to all SYCL primitives to ensure they return unimplemented if they are created with inputs with dimensions > `INT32_MAX`. Some primitives (e.g. eltwise) have tests with very large tensors, which was triggering this assert in Debug mode.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
