### PR TITLE
gpu: sycl: lnorm: bugfix scales datatypes

### DIFF
--- a/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
+++ b/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
@@ -242,14 +242,12 @@ private:
                         data_md().data_type(), data_ptr(), src_off);
                 float d = sm * (s - v_mean) + sv;
 
-                float sr = conf_.src_def
-                        ? 1.f
-                        : load_float_value(data_scaleshift_md().data_type(),
-                                rt_oscale_ptr(), 0);
-                float ds = conf_.dst_def
-                        ? 1.f
-                        : load_float_value(data_scaleshift_md().data_type(),
-                                dst_oscale_ptr(), 0);
+                float sr = conf_.src_def ? 1.f
+                                         : load_float_value(conf_.scales_src_dt,
+                                                 rt_oscale_ptr(), 0);
+                float ds = conf_.dst_def ? 1.f
+                                         : load_float_value(conf_.scales_dst_dt,
+                                                 dst_oscale_ptr(), 0);
                 d = (d * sr * (1.f / ds));
 
                 store_float_value(dst_md().data_type(), d, dst_ptr(), d_off);

--- a/src/gpu/generic/sycl/ref_layer_normalizations.cpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.cpp
@@ -44,6 +44,13 @@ status_t ref_layer_normalization_fwd_t::pd_t::init_conf() {
     conf_.src_def = attr()->scales_.get(DNNL_ARG_SRC).has_default_values();
     conf_.dst_def = attr()->scales_.get(DNNL_ARG_DST).has_default_values();
 
+    conf_.scales_src_dt = conf_.src_def
+            ? data_type_t::dnnl_f32
+            : attr()->scales_.get(DNNL_ARG_SRC).data_type_;
+    conf_.scales_dst_dt = conf_.dst_def
+            ? data_type_t::dnnl_f32
+            : attr()->scales_.get(DNNL_ARG_DST).data_type_;
+
     conf_.use_scale = use_scale();
     conf_.use_shift = use_shift();
     conf_.use_ss = conf_.use_scale || conf_.use_shift;

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -183,6 +183,8 @@ struct sycl_layer_normalization_conf_t {
     xpu::sycl::md_t shift;
     xpu::sycl::md_t stat_md;
     data_type_t var_dt;
+    data_type_t scales_src_dt;
+    data_type_t scales_dst_dt;
     xpu::sycl::md_t dst_md;
     xpu::sycl::md_t diff_dst_md;
     dim_t wk_size;


### PR DESCRIPTION
Fixes a bug in SYCL implementation of layer normalization, where source and destination scales could have wrong or even uninitialized types.