### PR TITLE
cpu: x64: jit_avx512_common_conv_kernel.hpp: improve memory management safety

### DIFF
--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_AVX512_COMMON_CONV_KERNEL_HPP
 #define CPU_X64_JIT_AVX512_COMMON_CONV_KERNEL_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -180,15 +181,18 @@ struct jit_avx512_common_conv_fwd_kernel {
         : kernel_(nullptr) {
         switch (ajcp.oc_block) {
             case 16:
-                kernel_ = new _jit_avx512_common_conv_fwd_kernel<Xbyak::Zmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_common_conv_fwd_kernel<Xbyak::Zmm>>(
                         ajcp, attr, dst_md);
                 return;
             case 8:
-                kernel_ = new _jit_avx512_common_conv_fwd_kernel<Xbyak::Ymm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_common_conv_fwd_kernel<Xbyak::Ymm>>(
                         ajcp, attr, dst_md);
                 return;
             case 4:
-                kernel_ = new _jit_avx512_common_conv_fwd_kernel<Xbyak::Xmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_common_conv_fwd_kernel<Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -200,7 +204,7 @@ struct jit_avx512_common_conv_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_common_conv_fwd_kernel() { delete kernel_; }
+    ~jit_avx512_common_conv_fwd_kernel() {}
 
     enum { typesize = sizeof(float) };
 
@@ -217,7 +221,7 @@ struct jit_avx512_common_conv_fwd_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_common_conv_fwd_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 template <typename Vmm>
@@ -347,16 +351,19 @@ struct jit_avx512_common_conv_bwd_data_kernel_f32 {
         : kernel_(nullptr) {
         switch (ajcp.ic_block) {
             case 16:
-                kernel_ = new _jit_avx512_common_conv_bwd_data_kernel_f32<
-                        Xbyak::Zmm>(ajcp);
+                kernel_ = utils::make_unique<
+                        _jit_avx512_common_conv_bwd_data_kernel_f32<
+                                Xbyak::Zmm>>(ajcp);
                 return;
             case 8:
-                kernel_ = new _jit_avx512_common_conv_bwd_data_kernel_f32<
-                        Xbyak::Ymm>(ajcp);
+                kernel_ = utils::make_unique<
+                        _jit_avx512_common_conv_bwd_data_kernel_f32<
+                                Xbyak::Ymm>>(ajcp);
                 return;
             case 4:
-                kernel_ = new _jit_avx512_common_conv_bwd_data_kernel_f32<
-                        Xbyak::Xmm>(ajcp);
+                kernel_ = utils::make_unique<
+                        _jit_avx512_common_conv_bwd_data_kernel_f32<
+                                Xbyak::Xmm>>(ajcp);
                 return;
             default: assert(!"invalid channel blocking");
         }
@@ -367,7 +374,7 @@ struct jit_avx512_common_conv_bwd_data_kernel_f32 {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_common_conv_bwd_data_kernel_f32() { delete kernel_; }
+    ~jit_avx512_common_conv_bwd_data_kernel_f32() {}
 
     enum { typesize = sizeof(float) };
 
@@ -382,7 +389,7 @@ struct jit_avx512_common_conv_bwd_data_kernel_f32 {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_common_conv_bwd_data_kernel_f32);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 struct jit_avx512_common_conv_bwd_weights_kernel_f32 : public jit_generator {


### PR DESCRIPTION
# Description

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by myself. This PR updates memory allocation in `jit_avx512_common_conv_fwd_kernel` and `jit_avx512_common_conv_bwd_data_kernel_f32` by using `utils::make_unique` for object management of the private member `kernel_` instead of raw pointers. 

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

