### PR TITLE
generic: sycl: deconvolution: implemented

### DIFF
--- a/src/gpu/generic/sycl/ref_batch_normalization.cpp
+++ b/src/gpu/generic/sycl/ref_batch_normalization.cpp
@@ -18,8 +18,9 @@
 #include "common/dnnl_traits.hpp"
 #include "xpu/sycl/types.hpp"
 
-#include "gpu/generic/sycl/batch_normalizations_kernels.hpp"
 #include "gpu/generic/sycl/ref_batch_normalization.hpp"
+
+#include "gpu/generic/sycl/batch_normalizations_kernels.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -222,7 +222,7 @@ status_t ref_convolution_bwd_weights_t::execute(const exec_ctx_t &ctx) const {
 
     parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         convolution_kernel_bwd_weights_t convolution_kernel(
-                pd()->conf_, cgh, ctx);
+                pd()->conf_, cgh, ctx, DNNL_ARG_SRC, DNNL_ARG_DIFF_DST);
 
         const int wg_size = pd()->conf_.wg_size;
 

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -22,6 +22,7 @@
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 #include "gpu/gpu_convolution_pd.hpp"
 #include "xpu/sycl/types.hpp"
 
@@ -83,7 +84,7 @@ struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
 
             const bool ok = is_fwd()
                     && check_convolution_work_amount(weights_d, OC())
-                    && set_default_formats()
+                    && set_default_formats() && md_dims_in_range(src_md())
                     && attr_.set_default_formats(dst_md()) == status::success
                     && check_convolution_data_types(data_d, weights_d, dst_d)
                     && check_convolution_formats(data_d, weights_d, dst_d)
@@ -157,7 +158,7 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
 
             const bool ok = is_bwd_d()
                     && check_convolution_work_amount(weights_d, OC())
-                    && set_default_formats()
+                    && md_dims_in_range(src_md()) && set_default_formats()
                     && check_convolution_data_types(
                             diff_data_d, weights_d, diff_dst_d)
                     && check_convolution_formats(
@@ -212,7 +213,7 @@ struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
 
             const bool ok = is_bwd_w()
                     && check_convolution_work_amount(diff_weights_d, OC())
-                    && set_default_formats()
+                    && md_dims_in_range(src_md()) && set_default_formats()
                     && check_convolution_data_types(
                             data_d, diff_weights_d, diff_dst_d)
                     && check_convolution_formats(

--- a/src/gpu/generic/sycl/ref_deconvolution.cpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.cpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/generic/sycl/ref_deconvolution.hpp"
+#include "gpu/generic/sycl/convolution_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+status_t ref_deconvolution_bwd_weights_t::pd_t::init_conf() {
+    conf_ = sycl_convolution_conf_t();
+
+    conf_.diff_dst_md = xpu::sycl::md_t(src_md());
+    if (with_bias()) {
+        conf_.diff_bias_md = xpu::sycl::md_t(diff_weights_md(1));
+    }
+    conf_.data_md = xpu::sycl::md_t(diff_dst_md());
+    conf_.ndims = ndims();
+
+    memory_desc_t diff_weights_md_copy = *diff_weights_md(0);
+
+    //IC and OC are the other way around compared to convolution
+    bool no_groups = diff_weights_md(0)->ndims == diff_dst_md()->ndims;
+    auto &strides = diff_weights_md_copy.format_desc.blocking.strides;
+
+    auto recalc_strides_swap_dims = [&](int dim0, int dim1) {
+        int bigger_stride_idx = strides[dim0] > strides[dim1] ? dim0 : dim1;
+        int smaller_stride_idx = strides[dim0] > strides[dim1] ? dim1 : dim0;
+        for (int i = 0; i < diff_weights_md(0)->ndims; i++) {
+            if (strides[smaller_stride_idx] < strides[i]
+                    && strides[i] < strides[bigger_stride_idx]) {
+                strides[i] /= diff_weights_md_copy.dims[bigger_stride_idx];
+                strides[i] *= diff_weights_md_copy.dims[smaller_stride_idx];
+            }
+        }
+    };
+
+    if (no_groups) {
+        std::swap(strides[0], strides[1]);
+        recalc_strides_swap_dims(0, 1);
+        std::swap(diff_weights_md_copy.dims[0], diff_weights_md_copy.dims[1]);
+    } else {
+        std::swap(diff_weights_md_copy.dims[1], diff_weights_md_copy.dims[2]);
+        recalc_strides_swap_dims(1, 2);
+        std::swap(strides[1], strides[2]);
+    }
+
+    conf_.diff_weights_md = xpu::sycl::md_t(&diff_weights_md_copy);
+
+    // XXX: should probably be tuned.
+    conf_.block_size = 16;
+    conf_.wg_size = 32;
+
+    conf_.wk_size = memory_desc_wrapper(diff_weights_md()).nelems();
+
+    conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
+    conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
+    conf_.padding[2] = static_cast<int>(desc()->padding[0][2]);
+
+    conf_.strides[0] = static_cast<int>(desc()->strides[0]);
+    conf_.strides[1] = static_cast<int>(desc()->strides[1]);
+    conf_.strides[2] = static_cast<int>(desc()->strides[2]);
+
+    conf_.dilation[0] = static_cast<int>(desc()->dilates[0]);
+    conf_.dilation[1] = static_cast<int>(desc()->dilates[1]);
+    conf_.dilation[2] = static_cast<int>(desc()->dilates[2]);
+    conf_.is_deconvolution = true;
+    return status::success;
+}
+
+status_t ref_deconvolution_bwd_weights_t::init(impl::engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<convolution_kernel_bwd_weights_t>();
+    CHECK(create_kernel(engine, kid, &kernel_));
+    return status::success;
+}
+
+status_t ref_deconvolution_bwd_weights_t::execute(const exec_ctx_t &ctx) const {
+
+    parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        convolution_kernel_bwd_weights_t convolution_kernel(
+                pd()->conf_, cgh, ctx, DNNL_ARG_DIFF_DST, DNNL_ARG_SRC);
+
+        const int wg_size = pd()->conf_.wg_size;
+
+        const int t_work = pd()->conf_.wk_size;
+        const int wg_cnt = utils::div_up(t_work, wg_size);
+
+        cgh.parallel_for(::sycl::nd_range<1>(wg_cnt * wg_size, wg_size),
+                convolution_kernel);
+    });
+
+    return status::success;
+}
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/generic/sycl/ref_deconvolution.hpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.hpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_SYCL_REF_DECONVOLUTION_HPP
+#define GPU_SYCL_REF_DECONVOLUTION_HPP
+
+#include "gpu/generic/sycl/ref_convolution.hpp"
+#include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/generic/sycl/sycl_io_helper.hpp"
+#include "gpu/generic/sycl/sycl_post_ops.hpp"
+#include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
+#include "gpu/gpu_deconvolution_pd.hpp"
+#include "xpu/sycl/types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+struct ref_deconvolution_bwd_weights_t
+    : public gpu::generic::sycl::primitive_t {
+    using gpu::generic::sycl::primitive_t::primitive_t;
+
+    struct pd_t : public deconvolution_bwd_weights_pd_t {
+        using deconvolution_bwd_weights_pd_t::deconvolution_bwd_weights_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_deconvolution_bwd_weights_t);
+
+        status_t init(impl::engine_t *engine) {
+            using namespace data_type;
+            using sm = primitive_attr_t::skip_mask_t;
+
+            const memory_desc_wrapper data_d(src_md());
+            const memory_desc_wrapper diff_weights_d(diff_weights_md());
+            const memory_desc_wrapper diff_dst_d(diff_dst_md());
+
+            const bool ok = desc()->prop_kind == prop_kind::backward_weights
+                    && check_convolution_work_amount(diff_weights_d, OC())
+                    && md_dims_in_range(src_md()) && set_default_formats()
+                    && check_convolution_data_types(
+                            data_d, diff_weights_d, diff_dst_d)
+                    && check_convolution_formats(
+                            data_d, diff_weights_d, diff_dst_d)
+                    && attr()->has_default_values(sm::scales_runtime
+                            | sm::zero_points_runtime | sm::post_ops
+                            | sm::sum_dt);
+            if (!ok) return status::unimplemented;
+
+            return init_conf();
+        }
+
+        sycl_convolution_conf_t conf_;
+
+    private:
+        status_t init_conf();
+
+        bool set_default_formats_common_template(memory_desc_t &src_md,
+                format_tag_t src_tag, memory_desc_t &wei_md,
+                format_tag_t wei_tag, memory_desc_t &dst_md,
+                format_tag_t dst_tag, memory_desc_t &bia_md) {
+            using namespace format_tag;
+
+#define IS_OK(f) \
+    do { \
+        if ((f) != status::success) return false; \
+    } while (0)
+
+            if (src_md.format_kind == format_kind::any
+                    && !utils::one_of(src_tag, any, undef))
+                IS_OK(memory_desc_init_by_tag(src_md, src_tag));
+            if (dst_md.format_kind == format_kind::any
+                    && !utils::one_of(dst_tag, any, undef))
+                IS_OK(memory_desc_init_by_tag(dst_md, dst_tag));
+            if (wei_md.format_kind == format_kind::any
+                    && !utils::one_of(wei_tag, any, undef))
+                IS_OK(memory_desc_init_by_tag(wei_md, wei_tag));
+            if (with_bias() && bia_md.format_kind == format_kind::any)
+                IS_OK(memory_desc_init_by_tag(bia_md, x));
+#undef IS_OK
+
+            return true;
+        }
+
+        bool set_default_formats() {
+            using namespace format_tag;
+            auto dat_tag = utils::pick(ndims() - 3, nwc, nhwc, ndhwc);
+            auto wei_tag = with_groups()
+                    ? utils::pick(ndims() - 3, goiw, goihw, goidhw)
+                    : utils::pick(ndims() - 3, oiw, oihw, oidhw);
+            return set_default_formats_common_template(src_md_, dat_tag,
+                    diff_weights_md_, wei_tag, diff_dst_md_, dat_tag,
+                    diff_bias_md_);
+        }
+    };
+
+    status_t init(impl::engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -82,6 +82,8 @@ struct sycl_convolution_conf_t {
     int wk_size;
     bool has_groups;
 
+    bool is_deconvolution;
+
     sycl_post_ops_t post_ops;
 };
 

--- a/src/gpu/gpu_deconvolution_list.cpp
+++ b/src/gpu/gpu_deconvolution_list.cpp
@@ -21,6 +21,9 @@
 #endif
 
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
+#include "gpu/generic/sycl/ref_convolution.hpp"
+#include "gpu/generic/sycl/ref_deconvolution.hpp"
+#include "gpu/intel/ocl/convolution_deconvolution.hpp"
 #include "gpu/nvidia/cudnn_deconvolution.hpp"
 #endif
 
@@ -39,18 +42,19 @@ using namespace dnnl::impl::prop_kind;
 const std::map<pk_impl_key_t, std::vector<impl_list_item_t>>
         impl_list_map REG_DECONV_P({
     {{forward}, {
-        GPU_INSTANCE_INTEL(intel::ocl::convolution_deconvolution_fwd_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_deconvolution_fwd_t)
         GPU_INSTANCE_AMD(amd::miopen_deconvolution_fwd_t)
+        GPU_INSTANCE_GENERIC(intel::ocl::convolution_deconvolution_fwd_t)
         nullptr,
     }},
     {{backward}, REG_BWD_PK({
-        GPU_INSTANCE_INTEL(intel::ocl::convolution_deconvolution_bwd_data_t)
         GPU_INSTANCE_INTEL(intel::ocl::convolution_deconvolution_bwd_weights_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_deconvolution_bwd_data_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_deconvolution_bwd_weights_t)
         GPU_INSTANCE_AMD(amd::miopen_deconvolution_bwd_data_t)
         GPU_INSTANCE_AMD(amd::miopen_deconvolution_bwd_weights_t)
+        GPU_INSTANCE_GENERIC(intel::ocl::convolution_deconvolution_bwd_data_t)
+        GPU_INSTANCE_GENERIC_SYCL(generic::sycl::ref_deconvolution_bwd_weights_t)
         nullptr,
     })},
 });


### PR DESCRIPTION
Implemented SYCL deconvolution. For fwd and bwd data it uses existing implementations. For bwd_weights it uses existing convolution kernel, which is modified a bit.