### PR TITLE
gpu: sycl: binary: Reduce number of binary postops

### DIFF
--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -46,7 +46,7 @@ struct sycl_binary_conf_t {
     int wg_size;
     int wk_size;
 
-    xpu::sycl::md_t binary_src_arr[8];
+    xpu::sycl::md_t binary_src_arr[sycl_post_ops_t::max_post_ops];
 
     sycl_post_ops_t post_ops;
 };


### PR DESCRIPTION
# Description

The binary SYCL kernel currently only supports up to 5 postops, but the conf struct for binary had an array of 8 postops.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?