### PR TITLE
gpu: sycl: bugfix kernel includes

### DIFF
--- a/src/gpu/generic/sycl/batch_normalizations_kernels.hpp
+++ b/src/gpu/generic/sycl/batch_normalizations_kernels.hpp
@@ -17,13 +17,13 @@
 #ifndef GPU_GENERIC_SYCL_BATCH_NORMALIZATION_KERNELS_HPP
 #define GPU_GENERIC_SYCL_BATCH_NORMALIZATION_KERNELS_HPP
 
-#include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/dnnl_traits.hpp"
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
-#include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/binary_kernels.hpp
+++ b/src/gpu/generic/sycl/binary_kernels.hpp
@@ -17,10 +17,11 @@
 #ifndef GPU_GENERIC_SYCL_BINARY_KERNELS_HPP
 #define GPU_GENERIC_SYCL_BINARY_KERNELS_HPP
 
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/convolution_kernels.hpp
+++ b/src/gpu/generic/sycl/convolution_kernels.hpp
@@ -17,10 +17,11 @@
 #ifndef GPU_SYCL_CONVOLUTION_KERNELS_HPP
 #define GPU_SYCL_CONVOLUTION_KERNELS_HPP
 
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/eltwise_kernels.hpp
+++ b/src/gpu/generic/sycl/eltwise_kernels.hpp
@@ -17,10 +17,13 @@
 #ifndef GPU_GENERIC_SYCL_ELTWISE_KERNELS_HPP
 #define GPU_GENERIC_SYCL_ELTWISE_KERNELS_HPP
 
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_math_utils.hpp"
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
+#include "xpu/sycl/types.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
+++ b/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
@@ -17,12 +17,11 @@
 #ifndef GPU_GENERIC_SYCL_LAYER_NORMALIZATION_KERNELS_HPP
 #define GPU_GENERIC_SYCL_LAYER_NORMALIZATION_KERNELS_HPP
 
-#include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
-#include "common/dnnl_traits.hpp"
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/lrn_kernels.hpp
+++ b/src/gpu/generic/sycl/lrn_kernels.hpp
@@ -17,8 +17,11 @@
 #ifndef GPU_GENERIC_SYCL_LRN_KERNELS_HPP
 #define GPU_GENERIC_SYCL_LRN_KERNELS_HPP
 
+#include "common/c_types_map.hpp"
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/pooling_kernels.hpp
+++ b/src/gpu/generic/sycl/pooling_kernels.hpp
@@ -20,11 +20,12 @@
 #include "common/dnnl_thread.hpp"
 #include "common/dnnl_traits.hpp"
 #include "common/nstl.hpp"
-#include "common/primitive_attr.hpp"
+#include "common/primitive_exec_types.hpp"
+#include "common/utils.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/prelu_kernels.hpp
+++ b/src/gpu/generic/sycl/prelu_kernels.hpp
@@ -19,17 +19,11 @@
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
-#include "common/dnnl_traits.hpp"
-#include "common/math_utils.hpp"
-#include "common/memory_storage.hpp"
 #include "common/primitive_exec_types.hpp"
 #include "common/utils.hpp"
-
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_math_utils.hpp"
-#include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
 #include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 

--- a/src/gpu/generic/sycl/reorder_kernels.hpp
+++ b/src/gpu/generic/sycl/reorder_kernels.hpp
@@ -17,10 +17,12 @@
 #ifndef GPU_GENERIC_SYCL_REORDER_KERNELS_HPP
 #define GPU_GENERIC_SYCL_REORDER_KERNELS_HPP
 
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
+#include "xpu/sycl/types.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/generic/sycl/resampling_kernels.hpp
+++ b/src/gpu/generic/sycl/resampling_kernels.hpp
@@ -18,12 +18,13 @@
 #define GPU_GENERIC_SYCL_RESAMPLING_KERNELS_HPP
 
 #include "common/dnnl_thread.hpp"
-#include "common/dnnl_traits.hpp"
+#include "common/primitive_exec_types.hpp"
+#include "common/utils.hpp"
 #include "gpu/generic/sycl/resampling_utils.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
 #include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/shuffle_kernels.hpp
+++ b/src/gpu/generic/sycl/shuffle_kernels.hpp
@@ -18,11 +18,10 @@
 #define GPU_GENERIC_SYCL_SHUFFLE_KERNELS_HPP
 
 #include "common/dnnl_thread.hpp"
-#include "common/dnnl_traits.hpp"
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
-#include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
 #include "xpu/sycl/types.hpp"
 
 namespace dnnl {

--- a/src/gpu/generic/sycl/softmax_kernels.hpp
+++ b/src/gpu/generic/sycl/softmax_kernels.hpp
@@ -19,8 +19,12 @@
 
 #include "common/compiler_workarounds.hpp"
 
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
+#include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
+#include "xpu/sycl/types.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/generic/sycl/sum_kernels.hpp
+++ b/src/gpu/generic/sycl/sum_kernels.hpp
@@ -17,10 +17,11 @@
 #ifndef GPU_SYCL_SUM_KERNELS_HPP
 #define GPU_SYCL_SUM_KERNELS_HPP
 
+#include "common/primitive_exec_types.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
-#include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
-#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
+#include "xpu/sycl/types.hpp"
 
 namespace dnnl {
 namespace impl {


### PR DESCRIPTION
Fixes includes in headers containing sycl kernels, so that they include what they use and nothing else. This has been a bit of a mess, making header include order matter.

Fixes a bug introduced in https://github.com/oneapi-src/oneDNN/pull/2004 where clang-format reordering includes caused a build failure.