### PR TITLE
cpu: x64: injectors: fix segmentation fault when binary_injector_ is not created

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -298,7 +298,7 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_postops_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
     for (auto &alg_elt_inject : alg_to_eltwise_injector_)
         alg_elt_inject.second.prepare_table(gen_table);
-    binary_injector_->prepare_table();
+    if (binary_injector_) { binary_injector_->prepare_table(); }
 }
 
 template <cpu_isa_t isa, typename Vmm>


### PR DESCRIPTION
# Description

Several tests have been segfaulting; we tracked it down to cases when `binary_injector_` is not created but `prepare_table` is still called on it.

To reproduce the issue, run tests on x86 architecture. Note that many tests are still failing; some tests which previously failed with a segfault are now passing, and some are failing rather than erroring.

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

