### PR TITLE
cpu: x64: improve memory management safety for additional kernels

### DIFF
--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_AVX512_CORE_BF16_CONV_KERNEL_HPP
 #define CPU_X64_JIT_AVX512_CORE_BF16_CONV_KERNEL_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -218,15 +219,18 @@ struct jit_avx512_core_bf16_fwd_kernel {
         : kernel_(nullptr) {
         switch (ajcp.oc_block) {
             case 16:
-                kernel_ = new _jit_avx512_core_bf16_fwd_kernel<Xbyak::Zmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_bf16_fwd_kernel<Xbyak::Zmm>>(
                         ajcp, attr, dst_md);
                 return;
             case 8:
-                kernel_ = new _jit_avx512_core_bf16_fwd_kernel<Xbyak::Ymm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_bf16_fwd_kernel<Xbyak::Ymm>>(
                         ajcp, attr, dst_md);
                 return;
             case 4:
-                kernel_ = new _jit_avx512_core_bf16_fwd_kernel<Xbyak::Xmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_bf16_fwd_kernel<Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -238,7 +242,7 @@ struct jit_avx512_core_bf16_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_bf16_fwd_kernel() { delete kernel_; }
+    ~jit_avx512_core_bf16_fwd_kernel() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_pd,
@@ -252,7 +256,7 @@ struct jit_avx512_core_bf16_fwd_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_bf16_fwd_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 template <typename Vmm>
@@ -431,15 +435,18 @@ struct jit_avx512_core_bf16_bwd_data_kernel {
         : kernel_(nullptr) {
         switch (ajcp.ic_block) {
             case 16:
-                kernel_ = new _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Zmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Zmm>>(
                         ajcp);
                 return;
             case 8:
-                kernel_ = new _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Ymm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Ymm>>(
                         ajcp);
                 return;
             case 4:
-                kernel_ = new _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Xmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Xmm>>(
                         ajcp);
                 return;
             default: assert(!"invalid channel blocking");
@@ -451,7 +458,7 @@ struct jit_avx512_core_bf16_bwd_data_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_bf16_bwd_data_kernel() { delete kernel_; }
+    ~jit_avx512_core_bf16_bwd_data_kernel() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &diff_src_md,
@@ -462,7 +469,7 @@ struct jit_avx512_core_bf16_bwd_data_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_bf16_bwd_data_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 struct jit_avx512_core_bf16_conv_bwd_weights_kernel_f32 : public jit_generator {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_AVX512_CORE_X8S8S32X_1X1_CONV_KERNEL_HPP
 #define CPU_X64_JIT_AVX512_CORE_X8S8S32X_1X1_CONV_KERNEL_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -154,16 +155,19 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel {
         int ch_block = ajcp.ic_block;
         switch (ch_block) {
             case 16:
-                kernel_ = new _jit_avx512_core_x8s8s32x_1x1_conv_kernel<
-                        Xbyak::Zmm>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Xbyak::Zmm>>(
+                        ajcp, attr, dst_md);
                 return;
             case 8:
-                kernel_ = new _jit_avx512_core_x8s8s32x_1x1_conv_kernel<
-                        Xbyak::Ymm>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Xbyak::Ymm>>(
+                        ajcp, attr, dst_md);
                 return;
             case 4:
-                kernel_ = new _jit_avx512_core_x8s8s32x_1x1_conv_kernel<
-                        Xbyak::Xmm>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Xbyak::Xmm>>(
+                        ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
         }
@@ -174,7 +178,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_x8s8s32x_1x1_conv_kernel() { delete kernel_; }
+    ~jit_avx512_core_x8s8s32x_1x1_conv_kernel() = default;
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_t *&src_md,
@@ -190,7 +194,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_x8s8s32x_1x1_conv_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_AVX512_CORE_X8S8S32X_CONV_KERNEL_HPP
 #define CPU_X64_JIT_AVX512_CORE_X8S8S32X_CONV_KERNEL_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -246,15 +247,18 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel {
         int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
-                kernel_ = new _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Zmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Zmm>>(
                         ajcp, attr, dst_md);
                 return;
             case 8:
-                kernel_ = new _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Ymm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Ymm>>(
                         ajcp, attr, dst_md);
                 return;
             case 4:
-                kernel_ = new _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Xmm>(
+                kernel_ = utils::make_unique<
+                        _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -266,7 +270,7 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_x8s8s32x_fwd_kernel() { delete kernel_; }
+    ~jit_avx512_core_x8s8s32x_fwd_kernel() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_pd,
@@ -278,7 +282,8 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel {
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
-    jit_generator *kernel_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_x8s8s32x_fwd_kernel)
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -18,6 +18,7 @@
 #define CPU_X64_JIT_AVX512_CORE_X8S8S32X_DECONVOLUTION_HPP
 
 #include <functional>
+#include <memory>
 #include <vector>
 
 #include "common/c_types_map.hpp"
@@ -198,16 +199,19 @@ struct _jit_avx512_core_x8s8s32x_deconv_fwd_kernel {
         int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
-                kernel_ = new jit_avx512_core_x8s8s32x_deconv_fwd_kernel<
-                        Xbyak::Zmm>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        jit_avx512_core_x8s8s32x_deconv_fwd_kernel<Xbyak::Zmm>>(
+                        ajcp, attr, dst_md);
                 return;
             case 8:
-                kernel_ = new jit_avx512_core_x8s8s32x_deconv_fwd_kernel<
-                        Xbyak::Ymm>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        jit_avx512_core_x8s8s32x_deconv_fwd_kernel<Xbyak::Ymm>>(
+                        ajcp, attr, dst_md);
                 return;
             case 4:
-                kernel_ = new jit_avx512_core_x8s8s32x_deconv_fwd_kernel<
-                        Xbyak::Xmm>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        jit_avx512_core_x8s8s32x_deconv_fwd_kernel<Xbyak::Xmm>>(
+                        ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
         }
@@ -218,7 +222,7 @@ struct _jit_avx512_core_x8s8s32x_deconv_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~_jit_avx512_core_x8s8s32x_deconv_fwd_kernel() { delete kernel_; }
+    ~_jit_avx512_core_x8s8s32x_deconv_fwd_kernel() = default;
 
     void operator()(const jit_deconv_call_s *p) const { (*kernel_)(p); }
 
@@ -236,7 +240,7 @@ struct _jit_avx512_core_x8s8s32x_deconv_fwd_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(_jit_avx512_core_x8s8s32x_deconv_fwd_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 struct jit_avx512_core_x8s8s32x_deconvolution_fwd_t : public primitive_t {

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_UNI_X8S8S32X_1X1_CONV_KERNEL_HPP
 #define CPU_X64_JIT_UNI_X8S8S32X_1X1_CONV_KERNEL_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -135,12 +136,12 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel {
 
         switch (isa) {
             case avx2:
-                kernel_ = new jit_avx2_x8s8s32x_1x1_conv_kernel(
+                kernel_ = utils::make_unique<jit_avx2_x8s8s32x_1x1_conv_kernel>(
                         ajcp, attr, dst_md);
                 return;
             case sse41:
-                kernel_ = new jit_sse41_x8s8s32x_1x1_conv_kernel(
-                        ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        jit_sse41_x8s8s32x_1x1_conv_kernel>(ajcp, attr, dst_md);
                 return;
             default: assert(!"Current ISA is not supported!");
         }
@@ -151,7 +152,7 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_uni_x8s8s32x_1x1_conv_kernel() { delete kernel_; }
+    ~jit_uni_x8s8s32x_1x1_conv_kernel() = default;
 
     void operator()(const jit_1x1_conv_call_s *p) const { (*kernel_)(p); }
 
@@ -173,7 +174,7 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_1x1_conv_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_UNI_X8S8S32X_CONV_KERNEL_HPP
 #define CPU_X64_JIT_UNI_X8S8S32X_CONV_KERNEL_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -196,13 +197,15 @@ struct jit_uni_x8s8s32x_fwd_kernel {
         switch (ch_block) {
             case 8:
                 if (utils::one_of(isa, avx2)) {
-                    kernel_ = new _jit_uni_x8s8s32x_fwd_kernel<isa, Xbyak::Ymm>(
+                    kernel_ = utils::make_unique<
+                            _jit_uni_x8s8s32x_fwd_kernel<isa, Xbyak::Ymm>>(
                             ajcp, attr, dst_md);
                 } else
                     assert(!"invalid channel blocking for current ISA");
                 return;
             case 4:
-                kernel_ = new _jit_uni_x8s8s32x_fwd_kernel<isa, Xbyak::Xmm>(
+                kernel_ = utils::make_unique<
+                        _jit_uni_x8s8s32x_fwd_kernel<isa, Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -214,7 +217,7 @@ struct jit_uni_x8s8s32x_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_uni_x8s8s32x_fwd_kernel() { delete kernel_; }
+    ~jit_uni_x8s8s32x_fwd_kernel() = default;
 
     void operator()(const jit_conv_call_s *p) const { (*kernel_)(p); }
 
@@ -229,7 +232,7 @@ struct jit_uni_x8s8s32x_fwd_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 } // namespace x64


### PR DESCRIPTION
# Description

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by @fwph & @jweese. This PR updates memory allocation for `jit_generator` objects across several structs. Note that in the case of `jit_avx512_core_x8s8s32x_fwd_kernel` the macro `DNNL_DISALLOW_COPY_AND_ASSIGN` was missing; and was added. This PR is effectively applying the update from https://github.com/oneapi-src/oneDNN/pull/2017 to additional files.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
