### PR TITLE
cpu: aarch64: use stateless ACL CpuActivation interface for eltwise

### DIFF
--- a/src/cpu/aarch64/acl_eltwise.cpp
+++ b/src/cpu/aarch64/acl_eltwise.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2022, 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,35 +14,27 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "cpu/aarch64/acl_eltwise.hpp"
+#include "acl_eltwise.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-status_t acl_eltwise_fwd_t::execute_forward(
-        const exec_ctx_t &ctx, const void *src, void *dst) const {
-    // Lock here is needed because resource_mapper does not support
-    // concurrent access.
-    std::lock_guard<std::mutex> _lock {this->mtx};
+status_t acl_eltwise_fwd_t::execute(const exec_ctx_t &ctx) const {
+    return execute_forward(ctx);
+}
 
-    // Retrieve primitive resource and configured Compute Library objects
-    auto *acl_resource
-            = ctx.get_resource_mapper()->get<acl_eltwise_resource_t>(this);
-    acl_eltwise_obj_t &acl_obj = acl_resource->get_acl_obj();
+status_t acl_eltwise_fwd_t::init(engine_t *engine) {
+    auto aep = pd()->aep;
 
-    // import_memory() and free() methods do not allocate/free any additional
-    // memory, only acquire/release pointers.
-    acl_obj.src_tensor.allocator()->import_memory(const_cast<void *>(src));
-    acl_obj.dst_tensor.allocator()->import_memory(dst);
-
-    acl_obj.act.run();
-
-    acl_obj.src_tensor.allocator()->free();
-    acl_obj.dst_tensor.allocator()->free();
+    act_->configure(&aep.data_info, &aep.data_info, aep.act_info);
 
     return status::success;
+}
+
+const acl_eltwise_fwd_t::pd_t *acl_eltwise_fwd_t::pd() const {
+    return static_cast<const pd_t *>(primitive_t::pd().get());
 }
 
 status_t acl_eltwise_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
@@ -53,6 +45,69 @@ status_t acl_eltwise_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return execute_forward(ctx, src, dst);
 }
 
+status_t acl_eltwise_fwd_t::execute_forward(
+        const exec_ctx_t &ctx, const void *src, void *dst) const {
+
+    auto aep = pd()->aep;
+    arm_compute::Tensor src_tensor;
+    arm_compute::Tensor dst_tensor;
+
+    src_tensor.allocator()->init(aep.data_info);
+    src_tensor.allocator()->import_memory(const_cast<void *>(src));
+    dst_tensor.allocator()->init(aep.data_info);
+    dst_tensor.allocator()->import_memory(dst);
+
+    arm_compute::ITensorPack act_pack;
+    act_pack.add_tensor(arm_compute::TensorType::ACL_SRC, &src_tensor);
+    act_pack.add_tensor(arm_compute::TensorType::ACL_DST, &dst_tensor);
+
+    act_->run(act_pack);
+
+    return status::success;
+}
+
+status_t acl_eltwise_fwd_t::pd_t::init(engine_t *engine) {
+    using namespace utils;
+    using namespace data_type;
+    const memory_desc_wrapper src_d(src_md());
+
+    bool ok = is_fwd() && one_of(src_d.data_type(), f32, f16, s32, s8)
+            && !has_zero_dim_memory() && attr()->has_default_values()
+            && set_default_formats_common() && src_d.is_dense()
+            && src_d == memory_desc_wrapper(dst_md());
+    if (!ok) return status::unimplemented;
+
+    // Workaround for the inaccuracies caused by
+    // logistic/soft_relu/elu/gelu_erf of ACL for fp16.
+    // TODO: Relax the error bounds in eltwise checks, or rework these
+    // fp16 operations in ACL for better accuracy.
+    using namespace dnnl::impl::alg_kind;
+    if (src_d.data_type() == f16
+            && utils::one_of(desc_.alg_kind, eltwise_logistic,
+                    eltwise_soft_relu, eltwise_elu, eltwise_gelu_erf)) {
+        return status::unimplemented;
+    }
+
+    auto acl_data_t = acl_utils::get_acl_data_t(src_d.data_type());
+
+    // Operator acts elementwise, so we only require that the product of
+    // all the dimensions equals the total number of elements. We are
+    // free to swap/combine dimensions. ACL performs SIMD parallelism
+    // over the first dimension and thread parallelism over the second.
+    // We pick a single dimension to thread over (taking the max of 2 to
+    // reduce the chance of it being 1), with the remaining dimensions
+    // to SIMD over.
+    dim_t thread_dim = std::max(W(), ndims() >= 2 ? C() : 1);
+    auto shape
+            = arm_compute::TensorShape(src_d.nelems() / thread_dim, thread_dim);
+    aep.data_info = arm_compute::TensorInfo(shape, 1, acl_data_t);
+
+    CHECK(acl_utils::convert_to_acl_act(desc_, aep.act_info));
+
+    ACL_CHECK_VALID(Op::validate(&aep.data_info, &aep.data_info, aep.act_info));
+
+    return status::success;
+}
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/acl_eltwise.hpp
+++ b/src/cpu/aarch64/acl_eltwise.hpp
@@ -17,20 +17,17 @@
 #ifndef CPU_AARCH64_ACL_ELTWISE_HPP
 #define CPU_AARCH64_ACL_ELTWISE_HPP
 
+#include <memory>
 #include "cpu/cpu_eltwise_pd.hpp"
 
-#include "cpu/aarch64/acl_utils.hpp"
+#include "acl_utils.hpp"
+
+#include "arm_compute/runtime/experimental/operators/CpuActivation.h"
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
-
-struct acl_eltwise_obj_t {
-    arm_compute::NEActivationLayer act;
-    arm_compute::Tensor src_tensor;
-    arm_compute::Tensor dst_tensor;
-};
 
 struct acl_eltwise_conf_t {
     arm_compute::ActivationLayerInfo act_info;
@@ -38,117 +35,38 @@ struct acl_eltwise_conf_t {
     arm_compute::TensorInfo data_info;
 };
 
-struct acl_eltwise_resource_t : public resource_t {
-    acl_eltwise_resource_t()
-        : acl_eltwise_obj_(utils::make_unique<acl_eltwise_obj_t>()) {}
-
-    status_t configure(const acl_eltwise_conf_t &aep) {
-        if (!acl_eltwise_obj_) return status::out_of_memory;
-
-        // Init Compute Library tensors based on info from descriptor
-        acl_eltwise_obj_->src_tensor.allocator()->init(aep.data_info);
-        acl_eltwise_obj_->dst_tensor.allocator()->init(aep.data_info);
-
-        acl_eltwise_obj_->act.configure(&acl_eltwise_obj_->src_tensor,
-                &acl_eltwise_obj_->dst_tensor, aep.act_info);
-
-        return status::success;
-    }
-
-    acl_eltwise_obj_t &get_acl_obj() const { return *acl_eltwise_obj_; }
-
-    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_eltwise_resource_t);
-
-private:
-    std::unique_ptr<acl_eltwise_obj_t> acl_eltwise_obj_;
-}; // acl_eltwise_resource_t
-
 struct acl_eltwise_fwd_t : public primitive_t {
+    using Op = arm_compute::experimental::op::CpuActivation;
+
     struct pd_t : public cpu_eltwise_fwd_pd_t {
         using cpu_eltwise_fwd_pd_t::cpu_eltwise_fwd_pd_t;
 
         DECLARE_COMMON_PD_T("acl", acl_eltwise_fwd_t);
 
-        status_t init(engine_t *engine) {
-            using namespace utils;
-            using namespace data_type;
-            const memory_desc_wrapper src_d(src_md());
-
-            bool ok = is_fwd() && one_of(src_d.data_type(), f32, f16, s32, s8)
-                    && !has_zero_dim_memory() && attr()->has_default_values()
-                    && set_default_formats_common() && src_d.is_dense()
-                    && src_d == memory_desc_wrapper(dst_md());
-            if (!ok) return status::unimplemented;
-
-            // Workaround for the inaccuracies caused by
-            // logistic/soft_relu/elu/gelu_erf of ACL for fp16.
-            // TODO: Relax the error bounds in eltwise checks, or rework these
-            // fp16 operations in ACL for better accuracy.
-            using namespace dnnl::impl::alg_kind;
-            if (src_d.data_type() == f16
-                    && utils::one_of(desc_.alg_kind, eltwise_logistic,
-                            eltwise_soft_relu, eltwise_elu, eltwise_gelu_erf)) {
-                return status::unimplemented;
-            }
-
-            auto acl_data_t = acl_utils::get_acl_data_t(src_d.data_type());
-
-            // Operator acts elementwise, so we only require that the product of
-            // all the dimensions equals the total number of elements. We are
-            // free to swap/combine dimensions. ACL performs SIMD parallelism
-            // over the first dimension and thread parallelism over the second.
-            // We pick a single dimension to thread over (taking the max of 2 to
-            // reduce the chance of it being 1), with the remaining dimensions
-            // to SIMD over.
-            dim_t thread_dim = std::max(W(), ndims() >= 2 ? C() : 1);
-            auto shape = arm_compute::TensorShape(
-                    src_d.nelems() / thread_dim, thread_dim);
-            aep.data_info = arm_compute::TensorInfo(shape, 1, acl_data_t);
-
-            CHECK(acl_utils::convert_to_acl_act(desc_, aep.act_info));
-
-            ACL_CHECK_VALID(arm_compute::NEActivationLayer::validate(
-                    &aep.data_info, &aep.data_info, aep.act_info));
-
-            return status::success;
-        }
+        status_t init(engine_t *engine);
 
         acl_eltwise_conf_t aep;
 
         friend struct acl_post_ops_t;
     };
 
-    acl_eltwise_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+    acl_eltwise_fwd_t(const pd_t *apd)
+        : primitive_t(apd), act_(std::make_unique<Op>()) {}
 
-    status_t execute(const exec_ctx_t &ctx) const override {
-        return execute_forward(ctx);
-    }
+    status_t execute(const exec_ctx_t &ctx) const override;
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override {
-        if (mapper.has_resource(this)) return status::success;
-
-        auto r = utils::make_unique<acl_eltwise_resource_t>();
-        if (!r) return status::out_of_memory;
-
-        // Configure the resource based on information from primitive descriptor
-        CHECK(r->configure(pd()->aep));
-        mapper.add(this, std::move(r));
-
-        return status::success;
-    }
+    status_t init(engine_t *engine) override;
 
 private:
-    // execute_forward has to be const thus mutability of mtx
-    mutable std::mutex mtx;
-
     status_t execute_forward(const exec_ctx_t &ctx) const;
 
     // Execute forward with arbitrary src and dst, used by acl_post_ops_t
     status_t execute_forward(
             const exec_ctx_t &ctx, const void *src, void *dst) const;
 
-    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    const pd_t *pd() const;
+
+    std::unique_ptr<Op> act_;
 
     friend struct acl_post_ops_t;
 }; // acl_eltwise_fwd_t


### PR DESCRIPTION
# Description
Switch out NEActivationLayer for the stateless CpuActivation interface from ACL. acl_eltwise_obj_t does not store any tensors now; instead we pass a ITensorPack to CpuActivation::run().

The acl_eltwise_obj_t struct has also been replaced with a unique_ptr to CpuActivation.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

Follows the pattern of #2022 
