### PR TITLE
generic: sycl: pooling: Enabling different src/dst dt for AMD

### DIFF
--- a/tests/benchdnn/pool/ref_pool.cpp
+++ b/tests/benchdnn/pool/ref_pool.cpp
@@ -38,7 +38,8 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
         // XXX: this is a hack to let tests with padded area to pass for bf16
         // dt due to the library initialize values with -max_dt, but not -INF.
         float max_value = lowest_dt(prb->dst_dt());
-        if (is_nvidia_gpu()) max_value = lowest_dt(prb->src_dt());
+        if (is_nvidia_gpu() || is_amd_gpu())
+            max_value = lowest_dt(prb->src_dt());
         float avg_value = 0.;
         // Set initial value based on ws data type
         int ws_off = prb->kernel_size() <= UINT8_MAX ? UINT8_MAX : INT_MAX;


### PR DESCRIPTION
# Description

When enabling src/dst datatypes for nVidia a bug was introduced that makes the different datatypes unsuccessful on AMD. This PR fixes that situation.
