### PR TITLE
[ARM] Enable fp16 direct copy reorder implementation

### DIFF
--- a/src/cpu/reorder/cpu_reorder_regular_f16.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f16.cpp
@@ -26,6 +26,8 @@ const impl_list_map_t &regular_f16_impl_list_map() {
     static const impl_list_map_t the_map = REG_REORDER_P({
         // f16 ->
         {{f16, data_type::undef, 0}, {
+            DNNL_AARCH64_ONLY(REG_SR_DIRECT_COPY(f16, f16))
+
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_matrix_B_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))


### PR DESCRIPTION
# Description

This patch enables fp16 direct copy reorder implementation. Aarch64 implementation of jit_reorder lacks fp16 support, so direct copy instance provides better performance

This change is upstreamed from [oneDNN fork repo](https://github.com/openvinotoolkit/oneDNN) maintained by [OpenVINO organization](https://github.com/openvinotoolkit).

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
```
100% tests passed, 0 tests failed out of 197
Total Test time (real) = 1701.15 sec
```
- [x] Have you formatted the code using clang-format?
