### PR TITLE
cpu: aarch64: improve memory management safety for aarch64 kernels

### DIFF
--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
@@ -19,6 +19,7 @@
 #define CPU_AARCH64_JIT_SVE_512_CORE_X8S8S32X_DECONVOLUTION_HPP
 
 #include <functional>
+#include <memory>
 #include <vector>
 
 #include "common/c_types_map.hpp"
@@ -227,16 +228,19 @@ struct _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel {
         int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
-                kernel_ = new jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
-                        sve_512>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<sve_512>>(
+                        ajcp, attr, dst_md);
                 return;
             case 8:
-                kernel_ = new jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
-                        sve_256>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<sve_256>>(
+                        ajcp, attr, dst_md);
                 return;
             case 4:
-                kernel_ = new jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
-                        sve_128>(ajcp, attr, dst_md);
+                kernel_ = utils::make_unique<
+                        jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<sve_128>>(
+                        ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
         }
@@ -244,7 +248,7 @@ struct _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel {
 
     status_t create_kernel() { return kernel_->create_kernel(); }
 
-    ~_jit_sve_512_core_x8s8s32x_deconv_fwd_kernel() { delete kernel_; }
+    ~_jit_sve_512_core_x8s8s32x_deconv_fwd_kernel() = default;
 
     void operator()(const jit_deconv_call_s *p) const { (*kernel_)(p); }
 
@@ -259,7 +263,7 @@ struct _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel {
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(_jit_sve_512_core_x8s8s32x_deconv_fwd_kernel);
-    jit_generator *kernel_;
+    std::unique_ptr<jit_generator> kernel_;
 };
 
 struct jit_sve_512_core_x8s8s32x_deconvolution_fwd_t : public primitive_t {

--- a/src/cpu/aarch64/jit_sve_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.hpp
@@ -18,6 +18,7 @@
 #ifndef CPU_AARCH64_JIT_SVE_CONV_KERNEL_HPP
 #define CPU_AARCH64_JIT_SVE_CONV_KERNEL_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -42,17 +43,16 @@ namespace aarch64 {
 
 template <cpu_isa_t isa = isa_undef>
 struct jit_sve_conv_fwd_kernel : public jit_generator {
-
     jit_sve_conv_fwd_kernel(
             const jit_conv_conf_t &ajcp, const primitive_attr_t &attr)
         : jcp(ajcp), attr_(attr), eltwise_injector_(nullptr) {
-
         if (jcp.with_eltwise)
             eltwise_injector_
-                    = new jit_uni_eltwise_injector_f32<isa>(this, jcp.eltwise);
+                    = utils::make_unique<jit_uni_eltwise_injector_f32<isa>>(
+                            this, jcp.eltwise);
     }
 
-    ~jit_sve_conv_fwd_kernel() { delete eltwise_injector_; }
+    ~jit_sve_conv_fwd_kernel() = default;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_conv_fwd_kernel)
 
@@ -162,7 +162,7 @@ private:
         }
     }
 
-    jit_uni_eltwise_injector_f32<isa> *eltwise_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_f32<isa>> eltwise_injector_;
 
     inline void prepare_output(int ur_w);
     inline void store_output(int ur_w);

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -18,6 +18,7 @@
 #ifndef CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_F32_HPP
 #define CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_F32_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
 
@@ -41,10 +42,11 @@ struct jit_uni_dw_conv_fwd_kernel_f32 : public jit_generator {
         : jcp(ajcp), eltwise_injector_(nullptr) {
         if (jcp.with_eltwise)
             eltwise_injector_
-                    = new jit_uni_eltwise_injector_f32<isa>(this, jcp.eltwise);
+                    = utils::make_unique<jit_uni_eltwise_injector_f32<isa>>(
+                            this, jcp.eltwise);
     }
 
-    ~jit_uni_dw_conv_fwd_kernel_f32() { delete eltwise_injector_; }
+    ~jit_uni_dw_conv_fwd_kernel_f32() = default;
 
     jit_conv_conf_t jcp;
 
@@ -133,7 +135,8 @@ private:
                 format_tag::nwc);
     }
 
-    jit_uni_eltwise_injector_f32<isa> *eltwise_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_f32<isa>> eltwise_injector_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel_f32)
     void generate() override;
 };
 

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -18,6 +18,7 @@
 #ifndef CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_UTILS_HPP
 #define CPU_AARCH64_JIT_UNI_DW_CONV_KERNEL_UTILS_HPP
 
+#include <memory>
 #include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
@@ -39,11 +40,11 @@ namespace aarch64 {
 template <cpu_isa_t isa, data_type_t kernel_dt>
 struct jit_uni_dw_conv_fwd_kernel {
 
-    jit_uni_dw_conv_fwd_kernel(jit_conv_conf_t ajcp) : ker_(nullptr) {
-        ker_ = new jit_uni_dw_conv_fwd_kernel_f32<isa>(ajcp);
-    }
+    jit_uni_dw_conv_fwd_kernel(jit_conv_conf_t ajcp)
+        : ker_(utils::make_unique<jit_uni_dw_conv_fwd_kernel_f32<isa>>(ajcp)) {}
+
     status_t create_kernel() { return ker_->create_kernel(); }
-    ~jit_uni_dw_conv_fwd_kernel() { delete ker_; }
+    ~jit_uni_dw_conv_fwd_kernel() = default;
 
     static bool post_ops_ok(jit_conv_conf_t &jcp, const primitive_attr_t &attr);
 
@@ -55,11 +56,12 @@ struct jit_uni_dw_conv_fwd_kernel {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    jit_generator *ker() const { return ker_; }
+    jit_generator *ker() const { return ker_.get(); }
     void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
 
 private:
-    jit_uni_dw_conv_fwd_kernel_f32<isa> *ker_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel)
+    std::unique_ptr<jit_uni_dw_conv_fwd_kernel_f32<isa>> ker_;
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
@@ -287,12 +289,12 @@ template struct jit_uni_dw_conv_fwd_kernel<sve_256, data_type::f32>;
 template <cpu_isa_t isa, data_type_t kernel_dt>
 struct jit_uni_dw_conv_bwd_data_kernel {
 
-    jit_uni_dw_conv_bwd_data_kernel(jit_conv_conf_t ajcp) : ker_(nullptr) {
-        ker_ = new jit_uni_dw_conv_bwd_data_kernel_f32<isa>(ajcp);
-    }
+    jit_uni_dw_conv_bwd_data_kernel(jit_conv_conf_t ajcp)
+        : ker_(utils::make_unique<jit_uni_dw_conv_bwd_data_kernel_f32<isa>>(
+                ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
-    ~jit_uni_dw_conv_bwd_data_kernel() { delete ker_; }
+    ~jit_uni_dw_conv_bwd_data_kernel() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &diff_src_d,
@@ -305,9 +307,8 @@ struct jit_uni_dw_conv_bwd_data_kernel {
     void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
 
 private:
-    jit_uni_dw_conv_bwd_data_kernel_f32<isa> *ker_;
-
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel)
+    std::unique_ptr<jit_uni_dw_conv_bwd_data_kernel_f32<isa>> ker_;
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
@@ -420,12 +421,12 @@ template struct jit_uni_dw_conv_bwd_data_kernel<sve_256, data_type::f32>;
 template <cpu_isa_t isa, data_type_t kernel_dt>
 struct jit_uni_dw_conv_bwd_weights_kernel {
 
-    jit_uni_dw_conv_bwd_weights_kernel(jit_conv_conf_t ajcp) : ker_(nullptr) {
-        ker_ = new jit_uni_dw_conv_bwd_weights_kernel_f32<isa>(ajcp);
-    }
+    jit_uni_dw_conv_bwd_weights_kernel(jit_conv_conf_t ajcp)
+        : ker_(utils::make_unique<jit_uni_dw_conv_bwd_weights_kernel_f32<isa>>(
+                ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
-    ~jit_uni_dw_conv_bwd_weights_kernel() { delete ker_; }
+    ~jit_uni_dw_conv_bwd_weights_kernel() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
@@ -440,7 +441,8 @@ struct jit_uni_dw_conv_bwd_weights_kernel {
     void operator()(const jit_dw_conv_call_s *p) const { (*ker_)(p); }
 
 private:
-    jit_uni_dw_conv_bwd_weights_kernel_f32<isa> *ker_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_weights_kernel)
+    std::unique_ptr<jit_uni_dw_conv_bwd_weights_kernel_f32<isa>> ker_;
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>


### PR DESCRIPTION
# Description

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by @fwph & @jweese. This PR updates memory allocation across several objects in the aarch64 implementation. Note that the bot is configured to add the `DNNL_DISALLOW_COPY_AND_ASSIGN` where it is missing; while this is redundant with the use of unique_ptr, it provides more consistency with existing code.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?*
- [X] Have you formatted the code using clang-format?

* note that on our build system (AWS graviton instance) the test `172 - test_benchdnn_modeC_brgemm_ci_cpu (Subprocess aborted)` is failing both on this branch AND on the main branch.
