### PR TITLE
generic: sycl: pooling: bug fixes when running on Intel GPU

### DIFF
--- a/tests/benchdnn/pool/ref_pool.cpp
+++ b/tests/benchdnn/pool/ref_pool.cpp
@@ -38,8 +38,6 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
         // XXX: this is a hack to let tests with padded area to pass for bf16
         // dt due to the library initialize values with -max_dt, but not -INF.
         float max_value = lowest_dt(prb->dst_dt());
-        if (is_nvidia_gpu() || is_amd_gpu())
-            max_value = lowest_dt(prb->src_dt());
         float avg_value = 0.;
         // Set initial value based on ws data type
         int ws_off = prb->kernel_size() <= UINT8_MAX ? UINT8_MAX : INT_MAX;


### PR DESCRIPTION
# Description

There were some cases causing issues like the following when running on Intel PVC devices:
```bash
[3214][SRC][1:2:0:3] exp_f32:          64 exp:          64 got:          76 diff:      12 rdiff:  0.1875
[COMPARE_STATS][SRC]: trh=0.078125 err_max_diff:      12 err_max_rdiff:  0.1875 all_max_diff:      28 all_max_rdiff:  0.1875
3627:FAILED (errors:1 total:5746) __REPRO: --pool --engine=gpu --dir=BWD_D --dt=bf16:bf16 ic17ih13oh37kh17ph20
```
And also some unimplemented ones that were not caught in the implementation:
```bash
create: --pool --engine=gpu --tag=aBx16b ic64iw32ow16kw3sw2pw0
Error: Function 'check_dnnl_status' at (/home/svet/oneDNN-intel/tests/benchdnn/dnnl_common.hpp:324) returned 'unimplemented'
Error: Function 'create_primitive' at (/home/svet/oneDNN-intel/tests/benchdnn/dnnl_common.hpp:398) returned '1'
Error: Function 'init_prim' at (/home/svet/oneDNN-intel/tests/benchdnn/dnnl_common.hpp:465) returned '1'
Error: Function 'createit' at (/home/svet/oneDNN-intel/tests/benchdnn/pool/pool.cpp:324) returned '1'
Error: Function 'create' at (/home/svet/oneDNN-intel/tests/benchdnn/utils/task.hpp:49) returned '1'
run: --pool --engine=gpu --tag=aBx16b ic64iw32ow16kw3sw2pw0
3:UNIMPLEMENTED __REPRO: --pool --engine=gpu --tag=aBx16b ic64iw32ow16kw3sw2pw0
create: --pool --engine=gpu --tag=aBx16b --alg=avg_np ic64iw32ow16kw3sw2pw0
Error: Function 'check_dnnl_status' at (/home/svet/oneDNN-intel/tests/benchdnn/dnnl_common.hpp:324) returned 'unimplemented'
Error: Function 'create_primitive' at (/home/svet/oneDNN-intel/tests/benchdnn/dnnl_common.hpp:398) returned '1'
Error: Function 'init_prim' at (/home/svet/oneDNN-intel/tests/benchdnn/dnnl_common.hpp:465) returned '1'
Error: Function 'createit' at (/home/svet/oneDNN-intel/tests/benchdnn/pool/pool.cpp:324) returned '1'
Error: Function 'create' at (/home/svet/oneDNN-intel/tests/benchdnn/utils/task.hpp:49) returned '1'
run: --pool --engine=gpu --tag=aBx16b --alg=avg_np ic64iw32ow16kw3sw2pw0
4:UNIMPLEMENTED __REPRO: --pool --engine=gpu --tag=aBx16b --alg=avg_np ic64iw32ow16kw3sw2pw0
```

This PR solves the previous bugs.
