### PR TITLE
cpu: aarch64: Upgrade matmul to use ACL stateless API

### DIFF
--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -24,6 +24,146 @@ namespace matmul {
 
 using namespace data_type;
 
+status_t acl_matmul_t::init(engine_t *engine) {
+    auto amp_ = pd()->amp_;
+    // Configure transpose kernel for src and wei
+    if (amp_.is_transA && !amp_.do_transC) {
+        acl_obj_->transA.configure(&amp_.src_acc_info, &amp_.src_tensor_info);
+    }
+    if (amp_.is_transB && !amp_.do_transC) {
+        acl_obj_->transB.configure(&amp_.wei_acc_info, &amp_.wei_tensor_info);
+    }
+    if (amp_.do_transC) {
+        acl_obj_->transC.configure(&amp_.dst_acc_info, &amp_.dst_tensor_info);
+    }
+    // Configure GEMM
+    if (amp_.do_transC) {
+        acl_obj_->asm_gemm.configure(&amp_.wei_tensor_info,
+                &amp_.src_tensor_info, nullptr, &amp_.dst_acc_info,
+                amp_.gemm_info);
+    } else {
+        acl_obj_->asm_gemm.configure(&amp_.src_tensor_info,
+                &amp_.wei_tensor_info, nullptr, &amp_.dst_tensor_info,
+                amp_.gemm_info);
+    }
+    acl_obj_->aux_mem_req = acl_obj_->asm_gemm.workspace();
+    if (amp_.do_act) {
+        auto dst_info_to_use
+                = amp_.do_transC ? &amp_.dst_acc_info : &amp_.dst_tensor_info;
+        acl_obj_->act.configure(dst_info_to_use, dst_info_to_use,
+                amp_.gemm_info.activation_info());
+    }
+
+    return status::success;
+}
+
+status_t acl_matmul_t::pd_t::init(engine_t *engine) {
+    using smask_t = primitive_attr_t::skip_mask_t;
+    const bool is_fp32_ok
+            = utils::everyone_is(data_type::f32, src_md()->data_type,
+                      weights_md()->data_type, dst_md()->data_type,
+                      desc()->accum_data_type)
+            && platform::has_data_type_support(data_type::f32);
+    const bool is_fp16_ok
+            = utils::everyone_is(data_type::f16, src_md()->data_type,
+                      weights_md()->data_type, dst_md()->data_type)
+            && platform::has_data_type_support(data_type::f16);
+    const bool is_bf16_ok
+            = utils::everyone_is(data_type::bf16, src_md()->data_type,
+                      weights_md()->data_type, dst_md()->data_type)
+            && platform::has_data_type_support(data_type::bf16);
+
+    // we need to save this state as it can change inside set_default_formats()
+    weights_format_kind_ = weights_md_.format_kind;
+
+    VDISPATCH_MATMUL(is_dense_format_kind(), VERBOSE_UNSUPPORTED_SPARSE_CFG);
+    VDISPATCH_MATMUL(utils::one_of(true, is_fp32_ok, is_fp16_ok, is_bf16_ok),
+            VERBOSE_UNSUPPORTED_DT_CFG);
+    VDISPATCH_MATMUL(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+    VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_MATMUL(attr()->has_default_values(smask_t::oscale
+                             | smask_t::post_ops | smask_t::fpmath_mode),
+            VERBOSE_UNSUPPORTED_ATTR);
+    VDISPATCH_MATMUL(attr_oscale_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VDISPATCH_MATMUL(
+            !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+
+    if (weights_format_kind_ == format_kind::any) {
+        CHECK(acl_matmul_utils::init_conf_matmul<true>(
+                amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
+    } else {
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        // to avoid seg. fault in case threadpool is enabled and its pointer is null
+        if (threadpool_utils::get_active_threadpool() == nullptr)
+            return status::unimplemented;
+#endif
+        CHECK(acl_matmul_utils::init_conf_matmul<false>(
+                amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
+    }
+
+    // We can only fuse sum if it is the first post op and we aren't
+    // transposing dst after
+    if (attr_.post_ops_.contain(primitive_kind::sum, 0) && !amp_.do_transC) {
+        // Check there isn't another sum after the first
+        VDISPATCH_MATMUL(attr_.post_ops_.find(primitive_kind::sum, 1, -1) < 0,
+                "cannot contain multiple sum post-ops");
+        VDISPATCH_MATMUL(attr_.post_ops_.entry_[0].sum.scale == 1.0f,
+                "sum post op scale must be 1 (no scale)");
+        VDISPATCH_MATMUL(attr_.post_ops_.entry_[0].sum.zero_point == 0,
+                "sum post op zero point must be 0 (no shift)");
+        amp_.gemm_info.set_accumulate(true);
+    }
+
+    amp_.do_act = false;
+    arm_compute::ActivationLayerInfo act_info;
+    CHECK(acl_post_ops.init(engine, attr_.post_ops_, dst_md_, act_info,
+            amp_.gemm_info.accumulate() ? 1 : 0));
+    amp_.gemm_info.set_activation_info(act_info);
+    if (act_info.enabled()
+            && !arm_compute::experimental::op::ll::CpuGemmAssemblyDispatch::
+                       is_activation_supported(act_info)) {
+        auto dst_info_to_use
+                = amp_.do_transC ? &amp_.dst_acc_info : &amp_.dst_tensor_info;
+        ACL_CHECK_VALID(arm_compute::experimental::op::CpuActivation::validate(
+                dst_info_to_use, dst_info_to_use, act_info));
+        amp_.do_act = true;
+    }
+    amp_.use_dst_acc_for_sum = acl_post_ops.has_sum();
+
+    // Validate ACL GEMM
+    if (amp_.do_transC) {
+        ACL_CHECK_VALID(
+                arm_compute::experimental::op::ll::CpuGemmAssemblyDispatch::
+                        validate(&amp_.wei_tensor_info, &amp_.src_tensor_info,
+                                nullptr, &amp_.dst_acc_info, amp_.gemm_info));
+    } else {
+        ACL_CHECK_VALID(arm_compute::experimental::op::ll::
+                        CpuGemmAssemblyDispatch::validate(&amp_.src_tensor_info,
+                                &amp_.wei_tensor_info, nullptr,
+                                &amp_.dst_tensor_info, amp_.gemm_info));
+    }
+
+    auto scratchpad = scratchpad_registry().registrar();
+    arm_compute::experimental::MemoryRequirements aux_mem_req;
+
+    // Query buffer memory requirement, if not using fixed-format kernel
+    if (weights_format_kind_ != format_kind::any) {
+        arm_compute::experimental::op::ll::CpuGemmAssemblyDispatch asm_gemm;
+        if (amp_.do_transC) {
+            asm_gemm.configure(&amp_.wei_tensor_info, &amp_.src_tensor_info,
+                    nullptr, &amp_.dst_acc_info, amp_.gemm_info);
+        } else {
+            asm_gemm.configure(&amp_.src_tensor_info, &amp_.wei_tensor_info,
+                    nullptr, &amp_.dst_tensor_info, amp_.gemm_info);
+        }
+        aux_mem_req = asm_gemm.workspace();
+    }
+    CHECK(acl_matmul_utils::init_scratchpad(
+            scratchpad, amp_, src_md_, weights_md_, dst_md_, aux_mem_req));
+
+    return status::success;
+}
+
 template <bool IsFixedFormat>
 status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
 
@@ -31,82 +171,163 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
     auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
     auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
 
-    bool is_transA = pd()->amp_.is_transA;
-    bool is_transB = pd()->amp_.is_transB;
-    bool do_transC = pd()->amp_.do_transC;
-    bool use_dst_acc_for_sum = pd()->amp_.use_dst_acc_for_sum;
-
-    std::lock_guard<std::mutex> _lock {this->mtx};
-    auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
-    acl_matmul_obj_t &acl_obj = acl_resource->get_acl_obj();
+    auto amp = pd()->amp_;
+    bool is_transA = amp.is_transA;
+    bool is_transB = amp.is_transB;
+    bool do_transC = amp.do_transC;
+    bool do_act = amp.do_act;
+    bool use_dst_acc_for_sum = amp.use_dst_acc_for_sum;
 
     const auto scratchpad = ctx.get_scratchpad_grantor();
 
-    // Run transpose kernel
-    if (is_transA && !is_transB) {
-        auto transA_scratch = scratchpad.get<void>(
-                memory_tracking::names::key_matmul_src_trans);
-        acl_obj.src_tensor.allocator()->import_memory(transA_scratch);
-        acl_obj.src_acc_tensor.allocator()->import_memory(
-                const_cast<data_t *>(src_base));
-        acl_obj.transA.run();
-        acl_obj.wei_tensor.allocator()->import_memory(
-                const_cast<data_t *>(wei_base));
-    } else if (is_transB && !is_transA) {
-        auto transB_scratch = scratchpad.get<void>(
-                memory_tracking::names::key_matmul_wei_trans);
-        acl_obj.wei_tensor.allocator()->import_memory(transB_scratch);
-        acl_obj.wei_acc_tensor.allocator()->import_memory(
-                const_cast<data_t *>(wei_base));
-        acl_obj.transB.run();
-        acl_obj.src_tensor.allocator()->import_memory(
-                const_cast<data_t *>(src_base));
-    } else if (is_transA && is_transB && !do_transC) {
-        auto transA_scratch = scratchpad.get<void>(
-                memory_tracking::names::key_matmul_src_trans);
-        auto transB_scratch = scratchpad.get<void>(
-                memory_tracking::names::key_matmul_wei_trans);
-        acl_obj.src_tensor.allocator()->import_memory(transA_scratch);
-        acl_obj.src_acc_tensor.allocator()->import_memory(
-                const_cast<data_t *>(src_base));
-        acl_obj.wei_tensor.allocator()->import_memory(transB_scratch);
-        acl_obj.wei_acc_tensor.allocator()->import_memory(
-                const_cast<data_t *>(wei_base));
-        acl_obj.transA.run();
-        acl_obj.transB.run();
-    } else {
-        acl_obj.src_tensor.allocator()->import_memory(
-                const_cast<data_t *>(src_base));
-        acl_obj.wei_tensor.allocator()->import_memory(
-                const_cast<data_t *>(wei_base));
-        if (do_transC) {
-            auto transC_scratch = scratchpad.get<void>(
-                    memory_tracking::names::key_matmul_dst_trans);
-            acl_obj.dst_acc_tensor.allocator()->import_memory(transC_scratch);
-        }
-    }
+    arm_compute::Tensor src_tensor;
+    arm_compute::Tensor wei_tensor;
+    arm_compute::Tensor bia_tensor = nullptr;
+    arm_compute::Tensor dst_tensor;
+    arm_compute::Tensor dst_acc_tensor;
+    src_tensor.allocator()->init(amp.src_tensor_info);
+    wei_tensor.allocator()->init(amp.wei_tensor_info);
+    dst_tensor.allocator()->init(amp.dst_tensor_info);
 
     // If we have an unfused sum post op, put the result in a scratchpad tensor.
     // Result will be summed to the dst during acl_post_ops.execute
     auto dst_base = use_dst_acc_for_sum ? scratchpad.get<void>(
                             memory_tracking::names::key_matmul_dst_in_acc_dt)
                                         : CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
-    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+    dst_tensor.allocator()->import_memory(dst_base);
 
-    acl_obj.gemm.run();
+    // Run transpose kernel
+    if (is_transA && !is_transB) {
+        arm_compute::Tensor src_acc_tensor;
+        src_acc_tensor.allocator()->init(amp.src_acc_info);
+        src_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(src_base));
+        auto transA_scratch = scratchpad.get<void>(
+                memory_tracking::names::key_matmul_src_trans);
+        src_tensor.allocator()->import_memory(transA_scratch);
+        arm_compute::ITensorPack transpose_pack;
+        transpose_pack.add_tensor(
+                arm_compute::TensorType::ACL_SRC, &src_acc_tensor);
+        transpose_pack.add_tensor(
+                arm_compute::TensorType::ACL_DST, &src_tensor);
+        acl_obj_->transA.run(transpose_pack);
+        wei_tensor.allocator()->import_memory(const_cast<data_t *>(wei_base));
+        src_acc_tensor.allocator()->free();
+    } else if (is_transB && !is_transA) {
+        arm_compute::Tensor wei_acc_tensor;
+        wei_acc_tensor.allocator()->init(amp.wei_acc_info);
+        wei_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(wei_base));
+        auto transB_scratch = scratchpad.get<void>(
+                memory_tracking::names::key_matmul_wei_trans);
+        wei_tensor.allocator()->import_memory(transB_scratch);
+        arm_compute::ITensorPack transpose_pack;
+        transpose_pack.add_tensor(
+                arm_compute::TensorType::ACL_SRC, &wei_acc_tensor);
+        transpose_pack.add_tensor(
+                arm_compute::TensorType::ACL_DST, &wei_tensor);
+        acl_obj_->transB.run(transpose_pack);
+        src_tensor.allocator()->import_memory(const_cast<data_t *>(src_base));
+        wei_acc_tensor.allocator()->free();
+    } else if (is_transA && is_transB && !do_transC) {
+        arm_compute::Tensor src_acc_tensor;
+        arm_compute::Tensor wei_acc_tensor;
+        src_acc_tensor.allocator()->init(amp.src_acc_info);
+        src_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(src_base));
+        wei_acc_tensor.allocator()->init(amp.wei_acc_info);
+        wei_acc_tensor.allocator()->import_memory(
+                const_cast<data_t *>(wei_base));
+        auto transA_scratch = scratchpad.get<void>(
+                memory_tracking::names::key_matmul_src_trans);
+        auto transB_scratch = scratchpad.get<void>(
+                memory_tracking::names::key_matmul_wei_trans);
+        src_tensor.allocator()->import_memory(transA_scratch);
+        wei_tensor.allocator()->import_memory(transB_scratch);
+        arm_compute::ITensorPack transpose_packA;
+        transpose_packA.add_tensor(
+                arm_compute::TensorType::ACL_SRC, &src_acc_tensor);
+        transpose_packA.add_tensor(
+                arm_compute::TensorType::ACL_DST, &src_tensor);
+        arm_compute::ITensorPack transpose_packB;
+        transpose_packB.add_tensor(
+                arm_compute::TensorType::ACL_SRC, &wei_acc_tensor);
+        transpose_packB.add_tensor(
+                arm_compute::TensorType::ACL_DST, &wei_tensor);
+        acl_obj_->transA.run(transpose_packA);
+        acl_obj_->transB.run(transpose_packB);
+        src_acc_tensor.allocator()->free();
+        wei_acc_tensor.allocator()->free();
+    } else {
+        src_tensor.allocator()->import_memory(const_cast<data_t *>(src_base));
+        wei_tensor.allocator()->import_memory(const_cast<data_t *>(wei_base));
+        if (do_transC) {
+            auto transC_scratch = scratchpad.get<void>(
+                    memory_tracking::names::key_matmul_dst_trans);
+            dst_acc_tensor.allocator()->init(amp.dst_acc_info);
+            dst_acc_tensor.allocator()->import_memory(transC_scratch);
+        }
+    }
 
-    if (do_transC) { acl_obj.transC.run(); }
+    arm_compute::ITensorPack matmul_pack;
+    if (do_transC) {
+        matmul_pack.add_const_tensor(
+                arm_compute::TensorType::ACL_SRC_0, &wei_tensor);
+        matmul_pack.add_const_tensor(
+                arm_compute::TensorType::ACL_SRC_1, &src_tensor);
+        matmul_pack.add_tensor(arm_compute::TensorType::ACL_SRC_2, &bia_tensor);
+        matmul_pack.add_tensor(
+                arm_compute::TensorType::ACL_DST, &dst_acc_tensor);
+    } else {
+        matmul_pack.add_const_tensor(
+                arm_compute::TensorType::ACL_SRC_0, &src_tensor);
+        matmul_pack.add_const_tensor(
+                arm_compute::TensorType::ACL_SRC_1, &wei_tensor);
+        matmul_pack.add_tensor(arm_compute::TensorType::ACL_SRC_2, &bia_tensor);
+        matmul_pack.add_tensor(arm_compute::TensorType::ACL_DST, &dst_tensor);
+    }
 
-    acl_obj.src_tensor.allocator()->free();
-    acl_obj.wei_tensor.allocator()->free();
-    if (is_transA) acl_obj.src_acc_tensor.allocator()->free();
-    if (is_transB) acl_obj.wei_acc_tensor.allocator()->free();
+    // Get pointer to scratchpad memory and create a workspace tensor for
+    // CpuGemm. Fixed-format kernel does not need this workspace tensor.
+    std::vector<arm_compute::Tensor> tmp_tensors(acl_obj_->aux_mem_req.size());
+    if (!IsFixedFormat) {
+        for (const auto &key : matmul_keys) {
+            const auto id = key.first;
+            if (acl_obj_->aux_mem_req[id].size > 0) {
+                const auto info = arm_compute::TensorInfo(
+                        arm_compute::TensorShape(
+                                acl_obj_->aux_mem_req[id].size),
+                        1, arm_compute::DataType::U8);
+                auto buffer = scratchpad.get<void>(key.second);
+                tmp_tensors[id].allocator()->init(
+                        info, acl_obj_->aux_mem_req[id].alignment);
+                tmp_tensors[id].allocator()->import_memory(buffer);
+                matmul_pack.add_tensor(
+                        acl_obj_->aux_mem_req[id].slot, &tmp_tensors[id]);
+            }
+        }
+    }
 
-    void *dst = acl_obj.dst_tensor.buffer();
+    acl_obj_->asm_gemm.run(matmul_pack);
+    if (do_act) {
+        auto dst_to_use = do_transC ? &dst_acc_tensor : &dst_tensor;
+        arm_compute::ITensorPack act_pack;
+        act_pack.add_tensor(arm_compute::TensorType::ACL_SRC, dst_to_use);
+        act_pack.add_tensor(arm_compute::TensorType::ACL_DST, dst_to_use);
+        acl_obj_->act.run(act_pack);
+    }
+
+    if (do_transC) {
+        arm_compute::ITensorPack transpose_packC;
+        transpose_packC.add_tensor(
+                arm_compute::TensorType::ACL_SRC, &dst_acc_tensor);
+        transpose_packC.add_tensor(
+                arm_compute::TensorType::ACL_DST, &dst_tensor);
+        acl_obj_->transC.run(transpose_packC);
+    }
+
+    void *dst = dst_tensor.buffer();
     pd()->acl_post_ops.execute(ctx, dst);
-
-    acl_obj.dst_tensor.allocator()->free();
-    if (do_transC) acl_obj.dst_acc_tensor.allocator()->free();
 
     return status;
 }

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -27,56 +27,6 @@ namespace cpu {
 namespace aarch64 {
 namespace matmul {
 
-struct acl_resource_t : public resource_t {
-    acl_resource_t() : acl_obj_(utils::make_unique<acl_matmul_obj_t>()) {}
-
-    status_t configure(const acl_matmul_conf_t &amp,
-            const dnnl::impl::format_kind_t weights_format_kind_) {
-        if (!acl_obj_) return status::out_of_memory;
-        acl_obj_->src_tensor.allocator()->init(amp.src_tensor_info);
-        acl_obj_->wei_tensor.allocator()->init(amp.wei_tensor_info);
-        acl_obj_->dst_tensor.allocator()->init(amp.dst_tensor_info);
-
-        // Configure transpose kernel for src, wei, or dst
-        if (amp.is_transA && !amp.do_transC) {
-            acl_obj_->src_acc_tensor.allocator()->init(amp.src_acc_info);
-            acl_obj_->transA.configure(
-                    &acl_obj_->src_acc_tensor, &acl_obj_->src_tensor);
-        }
-
-        if (amp.is_transB && !amp.do_transC) {
-            acl_obj_->wei_acc_tensor.allocator()->init(amp.wei_acc_info);
-            acl_obj_->transB.configure(
-                    &acl_obj_->wei_acc_tensor, &acl_obj_->wei_tensor);
-        }
-
-        if (amp.do_transC) {
-            acl_obj_->dst_acc_tensor.allocator()->init(amp.dst_acc_info);
-            acl_obj_->transC.configure(
-                    &acl_obj_->dst_acc_tensor, &acl_obj_->dst_tensor);
-        }
-
-        // Configure GEMM
-        if (amp.do_transC) {
-            acl_obj_->gemm.configure(&acl_obj_->wei_tensor,
-                    &acl_obj_->src_tensor, nullptr, &acl_obj_->dst_acc_tensor,
-                    1.0f, 0.0f, amp.gemm_info);
-        } else {
-            acl_obj_->gemm.configure(&acl_obj_->src_tensor,
-                    &acl_obj_->wei_tensor, nullptr, &acl_obj_->dst_tensor, 1.0f,
-                    0.0f, amp.gemm_info);
-        }
-
-        return status::success;
-    }
-    acl_matmul_obj_t &get_acl_obj() const { return *acl_obj_; }
-
-    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_resource_t);
-
-private:
-    std::unique_ptr<acl_matmul_obj_t> acl_obj_;
-};
-
 struct acl_matmul_t : public primitive_t {
     struct pd_t : public dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
 
@@ -90,91 +40,7 @@ struct acl_matmul_t : public primitive_t {
 
         DECLARE_COMMON_PD_T("gemm:acl", acl_matmul_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
-            using smask_t = primitive_attr_t::skip_mask_t;
-            const bool is_fp32_ok
-                    = utils::everyone_is(data_type::f32, src_md()->data_type,
-                              weights_md()->data_type, dst_md()->data_type,
-                              desc()->accum_data_type)
-                    && platform::has_data_type_support(data_type::f32);
-            const bool is_fp16_ok
-                    = utils::everyone_is(data_type::f16, src_md()->data_type,
-                              weights_md()->data_type, dst_md()->data_type)
-                    && platform::has_data_type_support(data_type::f16);
-            const bool is_bf16_ok
-                    = utils::everyone_is(data_type::bf16, src_md()->data_type,
-                              weights_md()->data_type, dst_md()->data_type)
-                    && platform::has_data_type_support(data_type::bf16);
-
-            // we need to save this state as it can change inside set_default_formats()
-            weights_format_kind_ = weights_md_.format_kind;
-
-            VDISPATCH_MATMUL(
-                    is_dense_format_kind(), VERBOSE_UNSUPPORTED_SPARSE_CFG);
-            VDISPATCH_MATMUL(
-                    utils::one_of(true, is_fp32_ok, is_fp16_ok, is_bf16_ok),
-                    VERBOSE_UNSUPPORTED_DT_CFG);
-            VDISPATCH_MATMUL(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
-            VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_MATMUL(
-                    attr()->has_default_values(smask_t::oscale
-                            | smask_t::post_ops | smask_t::fpmath_mode),
-                    VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_MATMUL(attr_oscale_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
-            VDISPATCH_MATMUL(!has_runtime_dims_or_strides(),
-                    VERBOSE_RUNTIMEDIM_UNSUPPORTED);
-
-            if (weights_format_kind_ == format_kind::any) {
-                CHECK(acl_matmul_utils::init_conf_matmul<true>(
-                        amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
-            } else {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-                // to avoid seg. fault in case threadpool is enabled and its pointer is null
-                if (threadpool_utils::get_active_threadpool() == nullptr)
-                    return status::unimplemented;
-#endif
-                CHECK(acl_matmul_utils::init_conf_matmul<false>(
-                        amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
-            }
-
-            // We can only fuse sum if it is the first post op and we aren't
-            // transposing dst after
-            if (attr_.post_ops_.contain(primitive_kind::sum, 0)
-                    && !amp_.do_transC) {
-                // Check there isn't another sum after the first
-                VDISPATCH_MATMUL(
-                        attr_.post_ops_.find(primitive_kind::sum, 1, -1) < 0,
-                        "cannot contain multiple sum post-ops");
-                VDISPATCH_MATMUL(attr_.post_ops_.entry_[0].sum.scale == 1.0f,
-                        "sum post op scale must be 1 (no scale)");
-                VDISPATCH_MATMUL(attr_.post_ops_.entry_[0].sum.zero_point == 0,
-                        "sum post op zero point must be 0 (no shift)");
-                amp_.gemm_info.set_accumulate(true);
-            }
-
-            arm_compute::ActivationLayerInfo act_info;
-            CHECK(acl_post_ops.init(engine, attr_.post_ops_, dst_md_, act_info,
-                    amp_.gemm_info.accumulate() ? 1 : 0));
-            amp_.gemm_info.set_activation_info(act_info);
-            amp_.use_dst_acc_for_sum = acl_post_ops.has_sum();
-
-            // Validate ACL GEMM
-            if (amp_.do_transC) {
-                ACL_CHECK_VALID(arm_compute::NEGEMM::validate(
-                        &amp_.wei_tensor_info, &amp_.src_tensor_info, nullptr,
-                        &amp_.dst_acc_info, 1.0f, 0.0f, amp_.gemm_info));
-            } else {
-                ACL_CHECK_VALID(arm_compute::NEGEMM::validate(
-                        &amp_.src_tensor_info, &amp_.wei_tensor_info, nullptr,
-                        &amp_.dst_tensor_info, 1.0f, 0.0f, amp_.gemm_info));
-            }
-
-            auto scratchpad = scratchpad_registry().registrar();
-            CHECK(acl_matmul_utils::init_scratchpad(
-                    scratchpad, amp_, src_md_, weights_md_, dst_md_));
-
-            return status::success;
-        }
+        status_t init(engine_t *engine);
 
         acl_matmul_conf_t amp_;
         acl_post_ops_t acl_post_ops;
@@ -187,22 +53,18 @@ struct acl_matmul_t : public primitive_t {
         }
     };
 
-    acl_matmul_t(const pd_t *apd) : primitive_t(apd) {}
+    acl_matmul_t(const pd_t *apd)
+        : primitive_t(apd), acl_obj_(std::make_unique<acl_matmul_obj_t>()) {}
 
     status_t create_resource(
             engine_t *engine, resource_mapper_t &mapper) const override {
-        if (mapper.has_resource(this)) return status::success;
-        auto r = utils::make_unique<acl_resource_t>();
-        if (!r) return status::out_of_memory;
-
-        // Configure the resource based on information from primitive descriptor
-        CHECK(r->configure(pd()->amp_, pd()->weights_format_kind_));
-        mapper.add(this, std::move(r));
 
         CHECK(pd()->acl_post_ops.create_resource(engine, mapper));
 
         return status::success;
     }
+
+    status_t init(engine_t *engine) override;
 
     typedef typename prec_traits<data_type::f32>::type data_t;
 
@@ -215,12 +77,12 @@ struct acl_matmul_t : public primitive_t {
     }
 
 private:
-    // To guard the const execute_forward(), the mutex must be 'mutable'
-    mutable std::mutex mtx;
     template <bool IsFixedFormat>
     status_t execute_forward(const exec_ctx_t &ctx) const;
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+
+    std::unique_ptr<acl_matmul_obj_t> acl_obj_;
 }; // acl_matmul_t
 
 } // namespace matmul

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -104,6 +104,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
                 acl_dst_data_t);
         amp.src_tensor_info = arm_compute::TensorInfo(
                 arm_compute::TensorShape(M, K, src_batch), 1, acl_src_data_t);
+        amp.src_tensor_info.set_are_values_constant(false);
         amp.wei_tensor_info = arm_compute::TensorInfo(
                 arm_compute::TensorShape(K, N, 1, wei_batch), 1,
                 acl_wei_data_t);
@@ -113,6 +114,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
                 acl_src_data_t);
         amp.wei_tensor_info = arm_compute::TensorInfo(
                 arm_compute::TensorShape(N, K, wei_batch), 1, acl_wei_data_t);
+        amp.wei_tensor_info.set_are_values_constant(false);
     }
 
     amp.dst_tensor_info = arm_compute::TensorInfo(
@@ -120,13 +122,13 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
 
     // Validate ACL transpose
     if (amp.is_transA && !amp.do_transC)
-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+        ACL_CHECK_VALID(arm_compute::experimental::op::CpuTranspose::validate(
                 &amp.src_acc_info, &amp.src_tensor_info));
     if (amp.is_transB && !amp.do_transC)
-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+        ACL_CHECK_VALID(arm_compute::experimental::op::CpuTranspose::validate(
                 &amp.wei_acc_info, &amp.wei_tensor_info));
     if (amp.do_transC)
-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+        ACL_CHECK_VALID(arm_compute::experimental::op::CpuTranspose::validate(
                 &amp.dst_acc_info, &amp.dst_tensor_info));
 
     bool is_fastmath_enabled = utils::one_of(
@@ -144,9 +146,10 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
         // kernels, because they require one specific weights format
         arm_compute::WeightFormat expected_weight_format;
         ACL_CHECK_VALID(
-                arm_compute::NEGEMM::has_opt_impl(expected_weight_format,
-                        &amp.src_tensor_info, &amp.wei_tensor_info, nullptr,
-                        &amp.dst_tensor_info, 1.0f, 0.0f, amp.gemm_info));
+                arm_compute::experimental::op::ll::CpuGemmAssemblyDispatch::
+                        has_opt_impl(expected_weight_format,
+                                &amp.src_tensor_info, &amp.wei_tensor_info,
+                                nullptr, &amp.dst_tensor_info, amp.gemm_info));
 
         // Set gemm weights info to the one returned by has_opt_impl
         amp.gemm_info.set_weight_format(expected_weight_format);
@@ -175,11 +178,21 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
 
 status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
         const acl_matmul_conf_t &amp, const memory_desc_t &src_md,
-        const memory_desc_t &weights_md, const memory_desc_t &dst_md) {
+        const memory_desc_t &weights_md, const memory_desc_t &dst_md,
+        const arm_compute::experimental::MemoryRequirements &aux_mem_req) {
     if (amp.use_dst_acc_for_sum) {
         const memory_desc_wrapper dst_d(&dst_md);
         scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
                 dst_d.nelems(), dst_d.data_type_size());
+    }
+    if (aux_mem_req.size() != 0) {
+        for (const auto &key : matmul_keys) {
+            const auto id = key.first;
+            if (aux_mem_req[id].size > 0) {
+                scratchpad.book(key.second, aux_mem_req[id].size, 1,
+                        aux_mem_req[id].alignment, aux_mem_req[id].alignment);
+            }
+        }
     }
     if (amp.is_transA) {
         const memory_desc_wrapper src_d(&src_md);

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
@@ -17,6 +17,10 @@
 #ifndef CPU_AARCH64_ACL_MATMUL_UTILS_HPP
 #define CPU_AARCH64_ACL_MATMUL_UTILS_HPP
 
+#include "arm_compute/runtime/experimental/low_level/CpuGemmAssemblyDispatch.h"
+#include "arm_compute/runtime/experimental/operators/CpuActivation.h"
+#include "arm_compute/runtime/experimental/operators/CpuTranspose.h"
+
 #include "cpu/matmul/cpu_matmul_pd.hpp"
 
 #include "cpu/aarch64/acl_utils.hpp"
@@ -26,23 +30,30 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
+namespace {
+// Keys are anonymous. So deduce the type automagically.
+using matmul_key_t = decltype(memory_tracking::names::key_gemm_asm_tmp_buffer);
+
+// Map: [slot , key]
+const std::map<int, matmul_key_t> matmul_keys
+        = {{0, matmul_key_t::key_gemm_asm_tmp_buffer},
+                {2, matmul_key_t::key_gemm_pretranspose}};
+} // namespace
+
 struct acl_matmul_obj_t {
-    arm_compute::NEGEMM gemm;
-    arm_compute::NETranspose transA;
-    arm_compute::NETranspose transB;
-    arm_compute::NETranspose transC;
-    arm_compute::Tensor src_tensor;
-    arm_compute::Tensor src_acc_tensor;
-    arm_compute::Tensor wei_acc_tensor;
-    arm_compute::Tensor dst_acc_tensor;
-    arm_compute::Tensor wei_tensor;
-    arm_compute::Tensor dst_tensor;
+    arm_compute::experimental::op::ll::CpuGemmAssemblyDispatch asm_gemm;
+    arm_compute::experimental::op::CpuActivation act;
+    arm_compute::experimental::op::CpuTranspose transA;
+    arm_compute::experimental::op::CpuTranspose transB;
+    arm_compute::experimental::op::CpuTranspose transC;
+    arm_compute::experimental::MemoryRequirements aux_mem_req;
 };
 
 struct acl_matmul_conf_t {
     bool is_transA;
     bool is_transB;
     bool do_transC;
+    bool do_act;
     // If this is true, the result of the matmul goes into a temporarily
     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
     bool use_dst_acc_for_sum;
@@ -64,7 +75,8 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
 
 status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
         const acl_matmul_conf_t &amp, const memory_desc_t &src_md,
-        const memory_desc_t &weights_md, const memory_desc_t &dst_md);
+        const memory_desc_t &weights_md, const memory_desc_t &dst_md,
+        const arm_compute::experimental::MemoryRequirements &aux_mem_req);
 
 } // namespace acl_matmul_utils
 


### PR DESCRIPTION
Following on from #2027, #2032, #2043 et al, this patch upgrades matmul to use the new stateless ACL API.

However, this patch needs to go in after #2043 is merged, as it needs the minimum version of ACL to be bumped up. Please take care to merge in order.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?