### PR TITLE
generic: sycl: sum: Issues with scales and conf_ struct on Intel

### DIFF
--- a/src/gpu/generic/sycl/ref_sum.cpp
+++ b/src/gpu/generic/sycl/ref_sum.cpp
@@ -68,30 +68,12 @@ status_t ref_sum_t::execute(const exec_ctx_t &ctx) const {
                 = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 6);
         auto src7_mem_arg
                 = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 7);
-        auto src8_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 8);
-        auto src9_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 9);
-        auto src10_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 10);
-        auto src11_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 11);
-        auto src12_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 12);
-        auto src13_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 13);
-        auto src14_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 14);
-        auto src15_mem_arg
-                = CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_MULTIPLE_SRC + 15);
 
         auto dst_mem_arg = CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST);
 
         sum_kernel_vec_t sum_kernel(pd()->conf_, src0_mem_arg, src1_mem_arg,
                 src2_mem_arg, src3_mem_arg, src4_mem_arg, src5_mem_arg,
-                src6_mem_arg, src7_mem_arg, src8_mem_arg, src9_mem_arg,
-                src10_mem_arg, src11_mem_arg, src12_mem_arg, src13_mem_arg,
-                src14_mem_arg, src15_mem_arg, dst_mem_arg);
+                src6_mem_arg, src7_mem_arg, dst_mem_arg);
 
         const int block_size = pd()->conf_.block_size;
         const int wg_size = pd()->conf_.wg_size;

--- a/src/gpu/generic/sycl/ref_sum_many_inputs.hpp
+++ b/src/gpu/generic/sycl/ref_sum_many_inputs.hpp
@@ -50,7 +50,7 @@ struct ref_sum_many_inputs_t : public gpu::generic::sycl::primitive_t {
                     && n > DNNL_REF_SUM_MAX_NUM_TENSORS; // prevent inf recursion
             if (!ok) return status::unimplemented;
 
-            // the first kernel handles up to 16 inputs and remaining ones up to 15
+            // the first kernel handles up to 8 inputs and remaining ones up to 7
             const int n_kernels = n == 1
                     ? 1
                     : utils::div_up(n - 1, DNNL_REF_SUM_MAX_NUM_TENSORS - 1);

--- a/src/gpu/generic/sycl/sum_kernels.hpp
+++ b/src/gpu/generic/sycl/sum_kernels.hpp
@@ -51,13 +51,7 @@ struct sum_kernel_vec_t {
             xpu::sycl::in_memory_arg_t &src2, xpu::sycl::in_memory_arg_t &src3,
             xpu::sycl::in_memory_arg_t &src4, xpu::sycl::in_memory_arg_t &src5,
             xpu::sycl::in_memory_arg_t &src6, xpu::sycl::in_memory_arg_t &src7,
-            xpu::sycl::in_memory_arg_t &src8, xpu::sycl::in_memory_arg_t &src9,
-            xpu::sycl::in_memory_arg_t &src10,
-            xpu::sycl::in_memory_arg_t &src11,
-            xpu::sycl::in_memory_arg_t &src12,
-            xpu::sycl::in_memory_arg_t &src13,
-            xpu::sycl::in_memory_arg_t &src14,
-            xpu::sycl::in_memory_arg_t &src15, xpu::sycl::out_memory_arg_t &dst)
+            xpu::sycl::out_memory_arg_t &dst)
         : conf_(conf)
         , src0_(src0)
         , src1_(src1)
@@ -67,14 +61,6 @@ struct sum_kernel_vec_t {
         , src5_(src5)
         , src6_(src6)
         , src7_(src7)
-        , src8_(src8)
-        , src9_(src9)
-        , src10_(src10)
-        , src11_(src11)
-        , src12_(src12)
-        , src13_(src13)
-        , src14_(src14)
-        , src15_(src15)
         , dst_(dst) {}
 
     void operator()(::sycl::nd_item<1> item) const {
@@ -99,7 +85,8 @@ struct sum_kernel_vec_t {
                 for (int i = 0; i < max_supported_ndims; i++) {
                     off[i] = idx / strides[i] % dims[i];
                 }
-                auto result = load_float_val(src0_ptr(), conf_.src_md[0], off);
+                auto result = conf_.src_scales[0]
+                        * load_float_val(src0_ptr(), conf_.src_md[0], off);
 
 #define ONEDNN_SYCL_SUM_ADD_ARG(ARG_N) \
     if (conf_.n > ARG_N) \
@@ -114,14 +101,6 @@ struct sum_kernel_vec_t {
                 ONEDNN_SYCL_SUM_ADD_ARG(5)
                 ONEDNN_SYCL_SUM_ADD_ARG(6)
                 ONEDNN_SYCL_SUM_ADD_ARG(7)
-                ONEDNN_SYCL_SUM_ADD_ARG(8)
-                ONEDNN_SYCL_SUM_ADD_ARG(9)
-                ONEDNN_SYCL_SUM_ADD_ARG(11)
-                ONEDNN_SYCL_SUM_ADD_ARG(11)
-                ONEDNN_SYCL_SUM_ADD_ARG(12)
-                ONEDNN_SYCL_SUM_ADD_ARG(13)
-                ONEDNN_SYCL_SUM_ADD_ARG(14)
-                ONEDNN_SYCL_SUM_ADD_ARG(15)
 #undef ONEDNN_SYCL_SUM_ADD_ARG
 
                 store_float_value(
@@ -144,14 +123,6 @@ private:
     void *src5_ptr() const { return src5_.get_pointer(); }
     void *src6_ptr() const { return src6_.get_pointer(); }
     void *src7_ptr() const { return src7_.get_pointer(); }
-    void *src8_ptr() const { return src8_.get_pointer(); }
-    void *src9_ptr() const { return src9_.get_pointer(); }
-    void *src10_ptr() const { return src10_.get_pointer(); }
-    void *src11_ptr() const { return src11_.get_pointer(); }
-    void *src12_ptr() const { return src12_.get_pointer(); }
-    void *src13_ptr() const { return src13_.get_pointer(); }
-    void *src14_ptr() const { return src14_.get_pointer(); }
-    void *src15_ptr() const { return src15_.get_pointer(); }
     void *dst_ptr() const { return dst_.get_pointer(); }
 
     sycl_sum_conf_t conf_;
@@ -164,14 +135,6 @@ private:
     xpu::sycl::in_memory_arg_t src5_;
     xpu::sycl::in_memory_arg_t src6_;
     xpu::sycl::in_memory_arg_t src7_;
-    xpu::sycl::in_memory_arg_t src8_;
-    xpu::sycl::in_memory_arg_t src9_;
-    xpu::sycl::in_memory_arg_t src10_;
-    xpu::sycl::in_memory_arg_t src11_;
-    xpu::sycl::in_memory_arg_t src12_;
-    xpu::sycl::in_memory_arg_t src13_;
-    xpu::sycl::in_memory_arg_t src14_;
-    xpu::sycl::in_memory_arg_t src15_;
     xpu::sycl::out_memory_arg_t dst_;
 };
 

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -380,7 +380,8 @@ struct sycl_pooling_fwd_conf_t : public sycl_pooling_base_conf_t {
     sycl_post_ops_t post_ops;
 };
 
-#define DNNL_REF_SUM_MAX_NUM_TENSORS 16
+// Intel GPU kernel fails to run with more than 8 tensors.
+#define DNNL_REF_SUM_MAX_NUM_TENSORS 8
 
 struct sycl_sum_conf_t {
     xpu::sycl::md_t src_md[DNNL_REF_SUM_MAX_NUM_TENSORS];


### PR DESCRIPTION
# Description

We were having some issues on Intel when running the benchdnn tests on Intel PVC:

```bash
create: --sum --engine=gpu --dtag=abx --scales=0.25 --inplace=true 3x3x16x4
terminate called after throwing an instance of 'sycl::_V1::compile_program_error'
  what():  The program was built for 1 devices
Build program log for 'Intel(R) Data Center GPU Max 1100':
 -11 (PI_ERROR_BUILD_PROGRAM_FAILURE)
```
The previous issue is solved by reducing the size of the conf_ struct.

Additionally, we were having issues because the scaling factor was not being applied to the first tensor in the sum SYCL kernel. This was also fixed in the current PR.

