### PR TITLE
cpu: aarch64 make binary ops use stateless ACL interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ On a CPU based on Arm AArch64 architecture, oneDNN CPU engine can be built with
 machine learning applications and provides AArch64 optimized implementations
 of core functions. This functionality currently requires that ACL is downloaded
 and built separately. See [Build from Source] section of the Developer Guide for
-details. oneDNN only supports Compute Library versions 24.08 or later.
+details. oneDNN only supports Compute Library versions 24.08.1 or later.
 
 [Arm Compute Library (ACL)]: https://github.com/arm-software/ComputeLibrary
 

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -31,7 +31,7 @@ endif()
 
 find_package(ACL REQUIRED)
 
-set(ACL_MINIMUM_VERSION "24.08")
+set(ACL_MINIMUM_VERSION "24.08.1")
 
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE ${ACL_INCLUDE_DIR}/*/arm_compute_version.embed)

--- a/src/cpu/aarch64/acl_binary.cpp
+++ b/src/cpu/aarch64/acl_binary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022, 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,34 +14,200 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "cpu/aarch64/acl_binary.hpp"
+#include "acl_binary.hpp"
+
+#include "arm_compute/core/ITensorPack.h"
+#include "arm_compute/core/experimental/Types.h"
+#include "arm_compute/runtime/Tensor.h"
+#include "arm_compute/runtime/experimental/operators/CpuAdd.h"
+#include "arm_compute/runtime/experimental/operators/CpuElementwise.h"
+#include "arm_compute/runtime/experimental/operators/CpuMul.h"
+#include "arm_compute/runtime/experimental/operators/CpuSub.h"
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
 
+status_t acl_binary_t::pd_t::init(engine_t *engine) {
+    using namespace acl_utils;
+
+    // Only support f16/f32/s32 for now
+    data_type_t ddt = dst_md(0)->data_type;
+    if (!utils::one_of(ddt, data_type::f16, data_type::f32, data_type::s32))
+        return status::unimplemented;
+
+    // Only support src and dst all matching for now
+    if (ddt != src_md(0)->data_type || src_md(1)->data_type != ddt)
+        return status::unimplemented;
+
+    // Sets the memory format of dst from any to src_md(0) blocking desc
+    CHECK(set_default_params());
+
+    if (!attr()->has_default_values()) return status::unimplemented;
+
+    asp_.alg = desc()->alg_kind;
+
+    // All the algorithms we support
+    if (!utils::one_of(asp_.alg, alg_kind::binary_add, alg_kind::binary_sub,
+                alg_kind::binary_mul, alg_kind::binary_div,
+                alg_kind::binary_max, alg_kind::binary_min))
+        return status::unimplemented;
+
+    // s32 div in ACL does not round as oneDNN expects
+    if (ddt == data_type::s32 && asp_.alg == alg_kind::binary_div)
+        return status::unimplemented;
+
+    // ACL pointwise arithmetic operators assume that the innermost
+    // dimensions are dense for src0, src1 and dst. Reordering the
+    // logical dimensions by stride does this (if reordered_dims >= 1 )
+    // and also makes memory accesses contiguous in ACL (without any
+    // data reordering).
+    memory_desc_t src_d0_permed, src_d1_permed, dst_d_permed;
+    int reordered_dims = reorder_dimensions_by_stride(
+            {&src_d0_permed, &src_d1_permed, &dst_d_permed},
+            {src_md(0), src_md(1), dst_md()});
+    if (reordered_dims < 1) return status::unimplemented;
+
+    // Create ACL tensor infos with permuted descs
+    CHECK(tensor_info(asp_.src0_info, src_d0_permed));
+    CHECK(tensor_info(asp_.src1_info, src_d1_permed));
+    CHECK(tensor_info(asp_.dst_info, dst_d_permed));
+
+    // In this case ACL tries to treat src0 and src1 as a 1D array, but
+    // fails because the strides aren't equal. TODO: remove when fixed
+    // in ACL
+    if (asp_.alg == alg_kind::binary_add
+            && asp_.src0_info.tensor_shape() == asp_.src1_info.tensor_shape()
+            && asp_.src0_info.strides_in_bytes()
+                    != asp_.src1_info.strides_in_bytes()) {
+        return status::unimplemented;
+    }
+
+    // This forces ACL not to parallelise with small workloads, this is
+    // a temporary fix and should be removed in future versions (TODO)
+    memory_desc_wrapper dst_d(dst_md());
+    if (dst_d.nelems() < 40000) {
+        size_t acl_y_axis_i = 1;
+        CHECK(insert_singleton_dimension(asp_.src0_info, acl_y_axis_i));
+        CHECK(insert_singleton_dimension(asp_.src1_info, acl_y_axis_i));
+        CHECK(insert_singleton_dimension(asp_.dst_info, acl_y_axis_i));
+    }
+
+    // Call operator specific validate function to check support
+    ACL_CHECK_VALID(validate(asp_));
+
+    return status::success;
+}
+
+arm_compute::Status acl_binary_t::pd_t::validate(const acl_binary_conf_t &asp) {
+    switch (asp.alg) {
+        case alg_kind::binary_add:
+            return arm_compute::experimental::op::CpuAdd::validate(
+                    &asp.src0_info, &asp.src1_info, &asp.dst_info,
+                    arm_compute::ConvertPolicy::SATURATE);
+        case alg_kind::binary_sub:
+            return arm_compute::experimental::op::CpuSub::validate(
+                    &asp.src0_info, &asp.src1_info, &asp.dst_info,
+                    arm_compute::ConvertPolicy::SATURATE);
+        case alg_kind::binary_div:
+            return arm_compute::experimental::op::CpuElementwiseDivision::
+                    validate(&asp.src0_info, &asp.src1_info, &asp.dst_info);
+        case alg_kind::binary_mul:
+            return arm_compute::experimental::op::CpuMul::validate(
+                    &asp.src0_info, &asp.src1_info, &asp.dst_info, 1.0f,
+                    arm_compute::ConvertPolicy::SATURATE,
+                    arm_compute::RoundingPolicy::TO_ZERO);
+        case alg_kind::binary_min:
+            return arm_compute::experimental::op::CpuElementwiseMin::validate(
+                    &asp.src0_info, &asp.src1_info, &asp.dst_info);
+        case alg_kind::binary_max:
+            return arm_compute::experimental::op::CpuElementwiseMax::validate(
+                    &asp.src0_info, &asp.src1_info, &asp.dst_info);
+        default:
+            return arm_compute::Status(arm_compute::ErrorCode::RUNTIME_ERROR,
+                    "unsupported alg_kind");
+    }
+}
+
+status_t acl_binary_t::init(engine_t *engine) {
+    auto asp = pd()->asp_;
+
+    switch (asp.alg) {
+        case alg_kind::binary_add: {
+            auto add_op
+                    = std::make_unique<arm_compute::experimental::op::CpuAdd>();
+            add_op->configure(&asp.src0_info, &asp.src1_info, &asp.dst_info,
+                    arm_compute::ConvertPolicy::SATURATE);
+            binary_op_ = std::move(add_op);
+            break;
+        }
+        case alg_kind::binary_sub: {
+            auto sub_op
+                    = std::make_unique<arm_compute::experimental::op::CpuSub>();
+            sub_op->configure(&asp.src0_info, &asp.src1_info, &asp.dst_info,
+                    arm_compute::ConvertPolicy::SATURATE);
+            binary_op_ = std::move(sub_op);
+            break;
+        }
+        case alg_kind::binary_div: {
+            auto div_op = std::make_unique<
+                    arm_compute::experimental::op::CpuElementwiseDivision>();
+            div_op->configure(&asp.src0_info, &asp.src1_info, &asp.dst_info);
+            binary_op_ = std::move(div_op);
+            break;
+        }
+        case alg_kind::binary_mul: {
+            auto mul_op
+                    = std::make_unique<arm_compute::experimental::op::CpuMul>();
+            mul_op->configure(&asp.src0_info, &asp.src1_info, &asp.dst_info,
+                    1.0f, arm_compute::ConvertPolicy::SATURATE,
+                    arm_compute::RoundingPolicy::TO_ZERO);
+            binary_op_ = std::move(mul_op);
+            break;
+        }
+        case alg_kind::binary_min: {
+            auto min_op = std::make_unique<
+                    arm_compute::experimental::op::CpuElementwiseMin>();
+            min_op->configure(&asp.src0_info, &asp.src1_info, &asp.dst_info);
+            binary_op_ = std::move(min_op);
+            break;
+        }
+        case alg_kind::binary_max: {
+            auto max_op = std::make_unique<
+                    arm_compute::experimental::op::CpuElementwiseMax>();
+            max_op->configure(&asp.src0_info, &asp.src1_info, &asp.dst_info);
+            binary_op_ = std::move(max_op);
+            break;
+        }
+        default: return status::runtime_error;
+    }
+
+    return status::success;
+}
+
 status_t acl_binary_t::execute_forward(const exec_ctx_t &ctx, const void *src0,
         const void *src1, void *dst) const {
 
-    // Lock here is needed because resource_mapper does not support
-    // concurrent multithreaded access.
-    std::lock_guard<std::mutex> _lock {this->mtx};
+    auto asp = pd()->asp_;
 
-    // Retrieve primitive resource and configured Compute Library objects
-    acl_binary_obj_t &acl_obj = ctx.get_resource_mapper()
-                                        ->get<acl_binary_resource_t>(this)
-                                        ->get_acl_obj();
+    arm_compute::Tensor src0_tensor;
+    arm_compute::Tensor src1_tensor;
+    arm_compute::Tensor dst_tensor;
 
-    acl_obj.src0_tensor.allocator()->import_memory(const_cast<void *>(src0));
-    acl_obj.src1_tensor.allocator()->import_memory(const_cast<void *>(src1));
-    acl_obj.dst_tensor.allocator()->import_memory(dst);
+    src0_tensor.allocator()->init(asp.src0_info);
+    src0_tensor.allocator()->import_memory(const_cast<void *>(src0));
+    src1_tensor.allocator()->init(asp.src1_info);
+    src1_tensor.allocator()->import_memory(const_cast<void *>(src1));
+    dst_tensor.allocator()->init(asp.dst_info);
+    dst_tensor.allocator()->import_memory(dst);
 
-    acl_obj.binary_op->run();
+    arm_compute::ITensorPack run_pack {
+            {arm_compute::TensorType::ACL_SRC_0, &src0_tensor},
+            {arm_compute::TensorType::ACL_SRC_1, &src1_tensor},
+            {arm_compute::TensorType::ACL_DST, &dst_tensor}};
 
-    acl_obj.src0_tensor.allocator()->free();
-    acl_obj.src1_tensor.allocator()->free();
-    acl_obj.dst_tensor.allocator()->free();
+    binary_op_->run(run_pack);
 
     return status::success;
 }
@@ -53,6 +219,14 @@ status_t acl_binary_t::execute_forward(const exec_ctx_t &ctx) const {
     auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
 
     return execute_forward(ctx, src0, src1, dst);
+}
+
+status_t acl_binary_t::execute(const exec_ctx_t &ctx) const {
+    return execute_forward(ctx);
+}
+
+const acl_binary_t::pd_t *acl_binary_t::pd() const {
+    return static_cast<const pd_t *>(primitive_t::pd().get());
 }
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_binary.hpp
+++ b/src/cpu/aarch64/acl_binary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022, 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,21 +17,18 @@
 #ifndef CPU_AARCH64_ACL_BINARY_HPP
 #define CPU_AARCH64_ACL_BINARY_HPP
 
+#include "acl_utils.hpp"
 #include "cpu/cpu_binary_pd.hpp"
 
-#include "cpu/aarch64/acl_utils.hpp"
+#include "arm_compute/core/TensorInfo.h"
+#include "arm_compute/runtime/NEON/INEOperator.h"
+
+#include <memory>
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
-
-struct acl_binary_obj_t {
-    std::unique_ptr<arm_compute::IFunction> binary_op;
-    arm_compute::Tensor src0_tensor;
-    arm_compute::Tensor src1_tensor;
-    arm_compute::Tensor dst_tensor;
-};
 
 struct acl_binary_conf_t {
     arm_compute::TensorInfo src0_info;
@@ -40,233 +37,39 @@ struct acl_binary_conf_t {
     alg_kind_t alg;
 };
 
-struct acl_binary_resource_t : public resource_t {
-    acl_binary_resource_t()
-        : acl_obj_(utils::make_unique<acl_binary_obj_t>()) {}
-
-    status_t configure(const acl_binary_conf_t &asp) {
-        if (!acl_obj_) return status::out_of_memory;
-
-        // Init Compute Library tensors based on info from descriptor
-        acl_obj_->src0_tensor.allocator()->init(asp.src0_info);
-        acl_obj_->src1_tensor.allocator()->init(asp.src1_info);
-        acl_obj_->dst_tensor.allocator()->init(asp.dst_info);
-
-        switch (asp.alg) {
-            case alg_kind::binary_add: {
-                auto add_op
-                        = std::make_unique<arm_compute::NEArithmeticAddition>();
-                add_op->configure(&acl_obj_->src0_tensor,
-                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor,
-                        arm_compute::ConvertPolicy::SATURATE);
-                acl_obj_->binary_op = std::move(add_op);
-                break;
-            }
-            case alg_kind::binary_sub: {
-                auto sub_op = std::make_unique<
-                        arm_compute::NEArithmeticSubtraction>();
-                sub_op->configure(&acl_obj_->src0_tensor,
-                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor,
-                        arm_compute::ConvertPolicy::SATURATE);
-                acl_obj_->binary_op = std::move(sub_op);
-                break;
-            }
-            case alg_kind::binary_div: {
-                auto div_op = std::make_unique<
-                        arm_compute::NEElementwiseDivision>();
-                div_op->configure(&acl_obj_->src0_tensor,
-                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor);
-                acl_obj_->binary_op = std::move(div_op);
-                break;
-            }
-            case alg_kind::binary_mul: {
-                auto mul_op = std::make_unique<
-                        arm_compute::NEPixelWiseMultiplication>();
-                mul_op->configure(&acl_obj_->src0_tensor,
-                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor, 1.0f,
-                        arm_compute::ConvertPolicy::SATURATE,
-                        arm_compute::RoundingPolicy::TO_ZERO);
-                acl_obj_->binary_op = std::move(mul_op);
-                break;
-            }
-            case alg_kind::binary_min: {
-                auto min_op = std::make_unique<arm_compute::NEElementwiseMin>();
-                min_op->configure(&acl_obj_->src0_tensor,
-                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor);
-                acl_obj_->binary_op = std::move(min_op);
-                break;
-            }
-            case alg_kind::binary_max: {
-                auto max_op = std::make_unique<arm_compute::NEElementwiseMax>();
-                max_op->configure(&acl_obj_->src0_tensor,
-                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor);
-                acl_obj_->binary_op = std::move(max_op);
-                break;
-            }
-            default: return status::runtime_error;
-        }
-
-        return status::success;
-    }
-
-    acl_binary_obj_t &get_acl_obj() const { return *acl_obj_; }
-
-    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_binary_resource_t);
-
-private:
-    std::unique_ptr<acl_binary_obj_t> acl_obj_;
-}; // acl_binary_resource_t
-
 struct acl_binary_t : public primitive_t {
     struct pd_t : public cpu_binary_pd_t {
         using cpu_binary_pd_t::cpu_binary_pd_t;
 
         DECLARE_COMMON_PD_T("acl", acl_binary_t);
 
-        status_t init(engine_t *engine) {
-
-            using namespace acl_utils;
-
-            // Only support f16/f32/s32 for now
-            data_type_t ddt = dst_md(0)->data_type;
-            if (!utils::one_of(
-                        ddt, data_type::f16, data_type::f32, data_type::s32))
-                return status::unimplemented;
-
-            // Only support src and dst all matching for now
-            if (ddt != src_md(0)->data_type || src_md(1)->data_type != ddt)
-                return status::unimplemented;
-
-            // Sets the memory format of dst from any to src_md(0) blocking desc
-            CHECK(set_default_params());
-
-            if (!attr()->has_default_values()) return status::unimplemented;
-
-            asp_.alg = desc()->alg_kind;
-
-            // All the algorithms we support
-            if (!utils::one_of(asp_.alg, alg_kind::binary_add,
-                        alg_kind::binary_sub, alg_kind::binary_mul,
-                        alg_kind::binary_div, alg_kind::binary_max,
-                        alg_kind::binary_min))
-                return status::unimplemented;
-
-            // s32 div in ACL does not round as oneDNN expects
-            if (ddt == data_type::s32 && asp_.alg == alg_kind::binary_div)
-                return status::unimplemented;
-
-            // ACL pointwise arithmetic operators assume that the innermost
-            // dimensions are dense for src0, src1 and dst. Reordering the
-            // logical dimensions by stride does this (if reordered_dims >= 1 )
-            // and also makes memory accesses contiguous in ACL (without any
-            // data reordering).
-            memory_desc_t src_d0_permed, src_d1_permed, dst_d_permed;
-            int reordered_dims = reorder_dimensions_by_stride(
-                    {&src_d0_permed, &src_d1_permed, &dst_d_permed},
-                    {src_md(0), src_md(1), dst_md()});
-            if (reordered_dims < 1) return status::unimplemented;
-
-            // Create ACL tensor infos with permuted descs
-            CHECK(tensor_info(asp_.src0_info, src_d0_permed));
-            CHECK(tensor_info(asp_.src1_info, src_d1_permed));
-            CHECK(tensor_info(asp_.dst_info, dst_d_permed));
-
-            // In this case ACL tries to treat src0 and src1 as a 1D array, but
-            // fails because the strides aren't equal. TODO: remove when fixed
-            // in ACL
-            if (asp_.alg == alg_kind::binary_add
-                    && asp_.src0_info.tensor_shape()
-                            == asp_.src1_info.tensor_shape()
-                    && asp_.src0_info.strides_in_bytes()
-                            != asp_.src1_info.strides_in_bytes()) {
-                return status::unimplemented;
-            }
-
-            // This forces ACL not to parallelise with small workloads, this is
-            // a temporary fix and should be removed in future versions (TODO)
-            memory_desc_wrapper dst_d(dst_md());
-            if (dst_d.nelems() < 40000) {
-                size_t acl_y_axis_i = 1;
-                CHECK(insert_singleton_dimension(asp_.src0_info, acl_y_axis_i));
-                CHECK(insert_singleton_dimension(asp_.src1_info, acl_y_axis_i));
-                CHECK(insert_singleton_dimension(asp_.dst_info, acl_y_axis_i));
-            }
-
-            // Call operator specific validate function to check support
-            ACL_CHECK_VALID(validate(asp_));
-
-            return status::success;
-        }
+        status_t init(engine_t *engine);
 
         acl_binary_conf_t asp_;
 
     private:
-        arm_compute::Status validate(const acl_binary_conf_t &asp) {
-            switch (asp.alg) {
-                case alg_kind::binary_add:
-                    return arm_compute::NEArithmeticAddition::validate(
-                            &asp.src0_info, &asp.src1_info, &asp.dst_info,
-                            arm_compute::ConvertPolicy::SATURATE);
-                case alg_kind::binary_sub:
-                    return arm_compute::NEArithmeticSubtraction::validate(
-                            &asp.src0_info, &asp.src1_info, &asp.dst_info,
-                            arm_compute::ConvertPolicy::SATURATE);
-                case alg_kind::binary_div:
-                    return arm_compute::NEElementwiseDivision::validate(
-                            &asp.src0_info, &asp.src1_info, &asp.dst_info);
-                case alg_kind::binary_mul:
-                    return arm_compute::NEPixelWiseMultiplication::validate(
-                            &asp.src0_info, &asp.src1_info, &asp.dst_info, 1.0f,
-                            arm_compute::ConvertPolicy::SATURATE,
-                            arm_compute::RoundingPolicy::TO_ZERO);
-                case alg_kind::binary_min:
-                    return arm_compute::NEElementwiseMin::validate(
-                            &asp.src0_info, &asp.src1_info, &asp.dst_info);
-                case alg_kind::binary_max:
-                    return arm_compute::NEElementwiseMax::validate(
-                            &asp.src0_info, &asp.src1_info, &asp.dst_info);
-                default:
-                    return arm_compute::Status(
-                            arm_compute::ErrorCode::RUNTIME_ERROR,
-                            "unsupported alg_kind");
-            }
-        }
+        arm_compute::Status validate(const acl_binary_conf_t &asp);
 
         friend struct acl_post_ops_t;
     }; // pd_t
 
     acl_binary_t(const pd_t *apd) : primitive_t(apd) {}
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override {
-        if (mapper.has_resource(this)) return status::success;
-
-        auto r = utils::make_unique<acl_binary_resource_t>();
-        if (!r) return status::out_of_memory;
-
-        // Configure the resource based on information from primitive descriptor
-        auto st = r->configure(pd()->asp_);
-        if (st == status::success) { mapper.add(this, std::move(r)); }
-
-        return st;
-    }
-
-    status_t execute(const exec_ctx_t &ctx) const override {
-        return execute_forward(ctx);
-    }
+    status_t execute(const exec_ctx_t &ctx) const override;
 
 private:
-    // To guard the const execute_forward, the mutex must be 'mutable'
-    mutable std::mutex mtx;
+    status_t init(engine_t *engine) override;
 
     status_t execute_forward(const exec_ctx_t &ctx) const;
     // Execute forward with arbitrary src0, src1 and dst, used by acl_post_ops_t
     status_t execute_forward(const exec_ctx_t &ctx, const void *src0,
             const void *src1, void *dst) const;
 
-    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    const pd_t *pd() const;
 
     friend struct acl_post_ops_t;
+
+    std::unique_ptr<arm_compute::experimental::INEOperator> binary_op_;
 
 }; // acl_binary_t
 


### PR DESCRIPTION
# Description
make binary ops use stateless ACL interface
> [!NOTE]
> This patch depends on ACL v23.08.1. Please add it to the 3.6 milestone but kindly wait for the ACL v23.08.1 release before merging.

Will allow all post-ops to be made stateless, as pointed out by @dzarukin in [this comment](https://github.com/oneapi-src/oneDNN/pull/2043#discussion_r1723733268).

# Checklist
## General
- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?