### PR TITLE
[cmake] fix condition for apple clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ if(POLICY CMP0022)
     cmake_policy(SET CMP0022 NEW)
 endif()
 
+# Compiler id for Apple Clang is now AppleClang
+if(POLICY CMP0025)
+    cmake_policy(SET CMP0025 NEW)
+endif()
+
 # Foo::Bar always refers to an IMPORTED target
 if(POLICY CMP0028)
     cmake_policy(SET CMP0028 NEW)

--- a/cmake/OpenMP.cmake
+++ b/cmake/OpenMP.cmake
@@ -23,7 +23,7 @@ endif()
 set(OpenMP_cmake_included true)
 include("cmake/Threading.cmake")
 
-if (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     # OSX Clang doesn't have OpenMP by default.
     # But we still want to build the library.
     set(_omp_severity "WARNING")


### PR DESCRIPTION
# Description

Cmake identifies Apple clang as "AppleClang"

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
