### PR TITLE
cpu: x64: improve memory safety for additional x64 JIT objects

### DIFF
--- a/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
@@ -18,6 +18,7 @@
 #define CPU_X64_JIT_AVX512_CORE_BF16CVT_HPP
 
 #include <assert.h>
+#include <memory>
 
 #include "common/c_types_map.hpp"
 #include "common/nstl.hpp"
@@ -179,13 +180,14 @@ struct jit_avx512_core_add_cvt_ps_to_bf16_t : public jit_generator {
 
     jit_avx512_core_add_cvt_ps_to_bf16_t()
         : jit_generator(jit_name()), simd_w_(16) {
-        bf16_emu_ = new bf16_emulation_t(
+        bf16_emu_ = utils::make_unique<bf16_emulation_t>(
                 this, one, even, selector, scratch, fp32_tmp, fp32_tmp);
 
         UNUSED_STATUS(create_kernel());
     }
 
-    ~jit_avx512_core_add_cvt_ps_to_bf16_t() { delete bf16_emu_; }
+    ~jit_avx512_core_add_cvt_ps_to_bf16_t() = default;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_add_cvt_ps_to_bf16_t)
 
     void generate() override {
         preamble();
@@ -258,7 +260,7 @@ struct jit_avx512_core_add_cvt_ps_to_bf16_t : public jit_generator {
 private:
     int simd_w_;
 
-    bf16_emulation_t *bf16_emu_;
+    std::unique_ptr<bf16_emulation_t> bf16_emu_;
 
     Xbyak::Opmask ktail_mask = k2;
     Xbyak::Zmm fp32_inp = Xbyak::Zmm(0);

--- a/src/cpu/x64/jit_uni_xf16_sum.hpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_UNI_XF16_SUM_HPP
 #define CPU_X64_JIT_UNI_XF16_SUM_HPP
 
+#include <memory>
 #include "common/c_types_map.hpp"
 #include "common/primitive.hpp"
 
@@ -106,12 +107,13 @@ struct jit_avx512_core_bf16_sum_kernel_t
                   - (isa_has_bf16(jsp.isa) ? 1 : 6))
         , bf16_emu_(nullptr) {
         if (!mayiuse(avx512_core_bf16))
-            bf16_emu_ = new bf16_emulation_t(this, bf16_emu_reserved_1,
-                    bf16_emu_reserved_2, bf16_emu_reserved_3, bf16_emu_scratch,
-                    bf16_emu_reserved_4, bf16_emu_reserved_5);
+            bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,
+                    bf16_emu_reserved_1, bf16_emu_reserved_2,
+                    bf16_emu_reserved_3, bf16_emu_scratch, bf16_emu_reserved_4,
+                    bf16_emu_reserved_5);
     }
 
-    ~jit_avx512_core_bf16_sum_kernel_t() { delete bf16_emu_; }
+    ~jit_avx512_core_bf16_sum_kernel_t() = default;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_bf16_sum_kernel_t)
 
@@ -173,7 +175,7 @@ protected:
         return num_regs;
     }
 
-    bf16_emulation_t *bf16_emu_;
+    std::unique_ptr<bf16_emulation_t> bf16_emu_;
 
     Xbyak::Zmm bf16_emu_reserved_1 = Xbyak::Zmm(26);
     Xbyak::Zmm bf16_emu_reserved_2 = Xbyak::Zmm(27);


### PR DESCRIPTION
# Description

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by @fwph & @jweese. This PR updates memory allocation for additional JIT-related objects for cpu/x64. Note that in the case of `jit_avx512_core_add_cvt_ps_to_bf16_t` the macro `DNNL_DISALLOW_COPY_AND_ASSIGN` was missing and was added. This PR is effectively applying the update from https://github.com/oneapi-src/oneDNN/pull/2017 to additional files.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?