### PR TITLE
[RV64] Add missing include `common/primitive.hpp` required for riscv64 platforms

### DIFF
--- a/src/cpu/rv64/rvv_nchw_pooling.hpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.hpp
@@ -18,6 +18,7 @@
 #ifndef RV64_NCHW_POOLING_HPP
 #define RV64_NCHW_POOLING_HPP
 
+#include "common/primitive.hpp"
 #include "cpu/cpu_pooling_pd.hpp"
 
 namespace dnnl {


### PR DESCRIPTION
# Description

The patch fixes build on riscv64 platforms: adds missing include `common/primitive.hpp` where the base class `primitive_t` of `riscv_nchw_pooling_fwd_t` is defined.

This change is upstreamed from [oneDNN fork repo](https://github.com/openvinotoolkit/oneDNN) maintained by [OpenVINO organization](https://github.com/openvinotoolkit).

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?