### PR TITLE
generic: sycl: matmul: implemented

### DIFF
--- a/src/gpu/generic/sycl/matmul_kernels.hpp
+++ b/src/gpu/generic/sycl/matmul_kernels.hpp
@@ -1,0 +1,731 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_GENERIC_SYCL_MATMUL_KERNELS_HPP
+#define GPU_GENERIC_SYCL_MATMUL_KERNELS_HPP
+
+#include "common/primitive_exec_types.hpp"
+#include "gpu/generic/sycl/sycl_io_helper.hpp"
+#include "gpu/generic/sycl/sycl_math_utils.hpp"
+#include "gpu/generic/sycl/sycl_post_ops.hpp"
+#include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
+#include "xpu/sycl/memory_storage_base.hpp"
+#include "xpu/sycl/types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+struct matmul_kernel_fwd_t {
+    static constexpr int max_supported_ndims = 6;
+
+    static constexpr int vec_len = 2;
+
+    // block sizes must be a multiple of vec_len
+    static constexpr int register_block_M = 4;
+    static constexpr int register_block_N = 2;
+    static constexpr int register_block_K = 2;
+
+    static int transpose_mask(int mask, int ndims) {
+        return (mask & ~(3 << (ndims - 2))) | ((mask & (1 << (ndims - 2))) << 1)
+                | ((mask >> 1) & (1 << (ndims - 2)));
+    }
+
+    static uint get_dropout_threshold(float p) {
+        if (p >= 1.f) return 0xFFFFFFFFu;
+        char exponent = 126 - ((reinterpret_cast<uint &>(p) >> 23) & 0x7F);
+        if ((p <= 0.f) || (exponent > 31)) return 0u;
+        uint mantissa = (reinterpret_cast<uint &>(p) << 8) | 0x80000000u;
+        if (!exponent) return (ulong(mantissa) * 0xFFFFFFFFuL) >> 32;
+        return ((ulong(mantissa >> exponent) * 0xFFFFFFFFuL) >> 32)
+                + !!(mantissa & ((1u << exponent) - 1u));
+    }
+
+    template <int Rows, int Cols>
+    struct register_block {
+        using Vec = ::sycl::vec<float, vec_len>;
+        using Transposed = register_block<Cols, Rows>;
+        static constexpr int size = Rows * Cols;
+        Vec data[Rows][Cols / vec_len];
+
+        void transpose_from(register_block<Cols, Rows> input) {
+            for (int row = 0; row < Rows; row++) {
+                for (int col = 0; col < Cols; col++) {
+                    data[row][col / vec_len][col % vec_len]
+                            = input.data[col][row / vec_len][row % vec_len];
+                }
+            }
+        }
+
+        template <::sycl::access_mode mode>
+        static Vec load_vec_helper(
+                const memory_tensor_t<mode> &input, int offset) {
+            data_type_t type = input.md().data_type();
+            char *offset_ptr = static_cast<char *>(input.ptr())
+                    + data_type_size(type) * offset;
+            return load_float_vec<vec_len>(type, offset_ptr, 0);
+        }
+
+        static void store_vec_helper(
+                out_memory_tensor_t &output, Vec data, int offset) {
+            data_type_t type = output.md().data_type();
+            char *offset_ptr = static_cast<char *>(output.ptr())
+                    + data_type_size(type) * offset;
+            return store_float_vec<vec_len>(type, data, offset_ptr, 0);
+        }
+
+        // offset and row_stride are in scalars
+        template <::sycl::access_mode mode>
+        void load(const memory_tensor_t<mode> &input, int offset,
+                int row_stride) {
+            for (int row = 0; row < Rows; row++) {
+                for (int col = 0; col < Cols / vec_len; col++) {
+                    data[row][col] = load_vec_helper(
+                            input, offset + row * row_stride + col * vec_len);
+                }
+            }
+        }
+
+        template <::sycl::access_mode mode>
+        void load_masked(const memory_tensor_t<mode> &input, int offset,
+                int row_stride, int mask) {
+            switch ((mask >> (input.md().ndims() - 2)) & 3) {
+                default:
+                case 3: load(input, offset, row_stride); break;
+                case 2: load(input, offset, 0); break;
+                case 1: {
+                    register_block<Cols, Rows> tmp;
+                    tmp.load(input, offset, 0);
+                    transpose_from(tmp);
+                    break;
+                }
+                case 0: {
+                    float val = load_float_value(
+                            input.md().data_type(), input.ptr(), offset);
+                    eltwise([=](float &el) { el = val; });
+                    break;
+                }
+            }
+        }
+
+        template <::sycl::access_mode mode>
+        void load_edge(const memory_tensor_t<mode> &input, int offset,
+                int row_stride, int rows, int cols) {
+            for (int row = 0; row < rows; row++) {
+                int col;
+                for (col = 0; col < cols / vec_len; col++) {
+                    data[row][col] = load_vec_helper(
+                            input, offset + row * row_stride + col * vec_len);
+                }
+                int n_remaining = cols - col * vec_len;
+                for (int vec_el = 0; vec_el < n_remaining; vec_el++) {
+                    data[row][col][vec_el] = load_float_value(
+                            input.md().data_type(), input.ptr(),
+                            offset + row * row_stride + col * vec_len + vec_el);
+                }
+            }
+        }
+
+        template <::sycl::access_mode mode>
+        void load_edge_masked(const memory_tensor_t<mode> &input, int offset,
+                int row_stride, int rows, int cols, int mask) {
+            switch ((mask >> (input.md().ndims() - 2)) & 3) {
+                case 3: load_edge(input, offset, row_stride, rows, cols); break;
+                case 2: load_edge(input, offset, 0, rows, cols); break;
+                case 1: {
+                    register_block<Cols, Rows> tmp;
+                    tmp.load_edge(input, offset, 0, cols, rows);
+                    transpose_from(tmp);
+                    break;
+                }
+                case 0: {
+                    float val = load_float_value(
+                            input.md().data_type(), input.ptr(), offset);
+                    eltwise([=](float &el) { el = val; });
+                    break;
+                }
+            }
+        }
+
+        template <::sycl::access_mode mode>
+        void load_generic(const memory_tensor_t<mode> &input, int offset,
+                int row_stride, bool transpose, bool is_edge_block, int rows,
+                int cols, int mask = ~0) {
+            if (is_edge_block) {
+                if (transpose) {
+                    Transposed tmp;
+                    tmp.load_edge_masked(input, offset, row_stride, cols, rows,
+                            transpose_mask(mask, input.md().ndims()));
+                    transpose_from(tmp);
+                } else {
+                    load_edge_masked(
+                            input, offset, row_stride, rows, cols, mask);
+                }
+            } else {
+                if (transpose) {
+                    Transposed tmp;
+                    tmp.load_masked(input, offset, row_stride,
+                            transpose_mask(mask, input.md().ndims()));
+                    transpose_from(tmp);
+                } else {
+                    load_masked(input, offset, row_stride, mask);
+                }
+            }
+        }
+
+        void store(out_memory_tensor_t &output, int offset, int row_stride) {
+            for (int row = 0; row < Rows; row++) {
+                for (int col = 0; col < Cols / vec_len; col++) {
+                    store_vec_helper(output, data[row][col],
+                            offset + row * row_stride + col * vec_len);
+                }
+            }
+        }
+
+        void store_edge(out_memory_tensor_t &output, int offset, int row_stride,
+                int rows, int cols) {
+            for (int row = 0; row < rows; row++) {
+                int col;
+                for (col = 0; col < cols / vec_len; col++) {
+                    store_vec_helper(output, data[row][col],
+                            offset + row * row_stride + col * vec_len);
+                }
+                int n_remaining = cols - col * vec_len;
+                for (int vec_el = 0; vec_el < n_remaining; vec_el++) {
+                    store_float_value(output.md().data_type(),
+                            data[row][col][vec_el], output.ptr(),
+                            offset + row * row_stride + col * vec_len + vec_el);
+                }
+            }
+        }
+
+        void store_generic(out_memory_tensor_t &output, int offset,
+                int row_stride, bool transpose, bool is_edge_block, int rows,
+                int cols) {
+            if (is_edge_block) {
+                if (transpose) {
+                    Transposed dst_tmp;
+                    dst_tmp.transpose_from(*this);
+                    dst_tmp.store_edge(output, offset, row_stride, cols, rows);
+                } else {
+                    store_edge(output, offset, row_stride, rows, cols);
+                }
+            } else {
+                if (transpose) {
+                    Transposed dst_tmp;
+                    dst_tmp.transpose_from(*this);
+                    dst_tmp.store(output, offset, row_stride);
+                } else {
+                    store(output, offset, row_stride);
+                }
+            }
+        }
+
+        template <typename F>
+        void eltwise(F funct) {
+            for (int row = 0; row < Rows; row++) {
+                for (int col = 0; col < Cols / vec_len; col++) {
+                    for (int v_el = 0; v_el < vec_len; v_el++) {
+                        funct(data[row][col][v_el]);
+                    }
+                }
+            }
+        }
+
+        template <int K>
+        void matmul_accumulate(
+                register_block<Rows, K> lhs, register_block<K, Cols> rhs) {
+            for (int row = 0; row < Rows; row++) {
+                for (int k = 0; k < K / vec_len; k++) {
+                    for (int k_el = 0; k_el < vec_len; k_el++) {
+                        for (int col = 0; col < Cols / vec_len; col++) {
+                            data[row][col] += Vec(lhs.data[row][k][k_el])
+                                    * rhs.data[k * vec_len + k_el][col];
+                        }
+                    }
+                }
+            }
+        }
+
+        template <int K>
+        void matmul_accumulate_edge_k(register_block<Rows, K> lhs,
+                register_block<K, Cols> rhs, int k_max) {
+            for (int row = 0; row < Rows; row++) {
+                int k;
+                for (k = 0; k < k_max / vec_len; k++) {
+                    for (int k_el = 0; k_el < vec_len; k_el++) {
+                        for (int col = 0; col < Cols / vec_len; col++) {
+                            data[row][col] += Vec(lhs.data[row][k][k_el])
+                                    * rhs.data[k * vec_len + k_el][col];
+                        }
+                    }
+                }
+                int last_vec_len = k_max - k * vec_len;
+                for (int k_el = 0; k_el < last_vec_len; k_el++) {
+                    for (int col = 0; col < Cols / vec_len; col++) {
+                        data[row][col] += Vec(lhs.data[row][k][k_el])
+                                * rhs.data[k * vec_len + k_el][col];
+                    }
+                }
+            }
+        }
+
+        void dropout(xpu::sycl::out_memory_arg_t dropout_mask, int threshold,
+                int seed, int inv_q, int offset, int row_stride) {
+            for (int row = 0; row < Rows; row++) {
+                for (int col = 0; col < Cols / vec_len; col++) {
+                    for (int vec_el = 0; vec_el < vec_len; vec_el++) {
+                        int dst_off = offset + row * row_stride + col * vec_len
+                                + vec_el;
+                        uint random
+                                = ::dnnl::impl::math::philox4x32(dst_off, seed);
+                        char dropout = random > threshold;
+                        data[row][col][vec_el]
+                                = dropout ? data[row][col][vec_el] * inv_q : 0;
+                        static_cast<char *>(dropout_mask.get_pointer())[dst_off]
+                                = dropout;
+                    }
+                }
+            }
+        }
+
+        void apply_post_ops(sycl_post_ops_t post_ops,
+                register_block<Rows, Cols> prev_dst, dims_t off_po, int dim1,
+                const matmul_kernel_fwd_t *kernel) {
+            for (int row = 0; row < Rows; row++) {
+                for (int col = 0; col < Cols / vec_len; col++) {
+                    for (int v_el = 0; v_el < vec_len; v_el++) {
+                        off_po[dim1] += row;
+                        off_po[dim1 + 1] += col * vec_len + v_el;
+                        ::sycl::vec<float, 16> binary_src_vals
+                                = kernel->post_op_src_val(off_po);
+                        off_po[dim1] -= row;
+                        off_po[dim1 + 1] -= col * vec_len + v_el;
+                        data[row][col][v_el] = post_ops.apply(
+                                data[row][col][v_el],
+                                prev_dst.data[row][col][v_el], binary_src_vals);
+                    }
+                }
+            }
+        }
+    };
+
+    matmul_kernel_fwd_t(const sycl_matmul_conf_t &conf, ::sycl::handler &cgh,
+            const exec_ctx_t &ctx)
+        : conf_(conf)
+        , data_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC_0))
+        , weights_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_WEIGHTS))
+        , bias_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_BIAS))
+        , dst_(CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST))
+        , data_scale_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0))
+        , data_scales_dt_((conf_.do_scale_data)
+                          ? ctx.memory_mdw(
+                                       DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0)
+                                    .data_type()
+                          : data_type_t::dnnl_f32)
+        , weights_scale_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS))
+        , weights_scales_dt_((conf_.do_scale_weights)
+                          ? ctx.memory_mdw(
+                                       DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS)
+                                    .data_type()
+                          : data_type_t::dnnl_f32)
+        , dst_scale_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST))
+        , dst_scales_dt_((conf_.do_scale_dst)
+                          ? ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)
+                                    .data_type()
+                          : data_type_t::dnnl_f32)
+        , data_zeropoints_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC_0))
+        , data_zeropoints_dt_((conf_.use_data_zeropoints)
+                          ? ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS
+                                       | DNNL_ARG_SRC_0)
+                                    .data_type()
+                          : data_type_t::dnnl_f32)
+        , weights_zeropoints_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS))
+        , weights_zeropoints_dt_((conf_.use_weights_zeropoints)
+                          ? ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS
+                                       | DNNL_ARG_WEIGHTS)
+                                    .data_type()
+                          : data_type_t::dnnl_f32)
+        , dst_zeropoints_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST))
+        , dst_zeropoints_dt_((conf_.use_dst_zeropoints)
+                          ? ctx.memory_mdw(
+                                       DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST)
+                                    .data_type()
+                          : data_type_t::dnnl_f32)
+        , dropout_mask_(CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_ATTR_DROPOUT_MASK))
+        , dropout_seed_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_ATTR_DROPOUT_SEED))
+        , dropout_probability_(
+                  CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_ATTR_DROPOUT_PROBABILITY))
+        , po1_src_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  (DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1)))
+        , po2_src_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  (DNNL_ARG_ATTR_MULTIPLE_POST_OP(1) | DNNL_ARG_SRC_1)))
+        , po3_src_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  (DNNL_ARG_ATTR_MULTIPLE_POST_OP(2) | DNNL_ARG_SRC_1)))
+        , po4_src_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  (DNNL_ARG_ATTR_MULTIPLE_POST_OP(3) | DNNL_ARG_SRC_1)))
+        , po5_src_(CTX_IN_SYCL_KERNEL_MEMORY(
+                  (DNNL_ARG_ATTR_MULTIPLE_POST_OP(4) | DNNL_ARG_SRC_1))) {}
+
+    void operator()(::sycl::nd_item<1> item) const {
+        using data_block_t = register_block<register_block_M, register_block_K>;
+        using weights_block_t
+                = register_block<register_block_K, register_block_N>;
+        using dst_block_t = register_block<register_block_M, register_block_N>;
+
+        memory_tensor_t data_mem(data_, conf_.data_md);
+        memory_tensor_t weights_mem(weights_, conf_.weights_md);
+        memory_tensor_t bias_mem(bias_, conf_.bias_md);
+        memory_tensor_t dst_mem(dst_, conf_.dst_md);
+        memory_plain_t data_scale_mem(data_scale_, data_scales_dt_);
+        memory_plain_t weights_scale_mem(weights_scale_, weights_scales_dt_);
+        memory_plain_t dst_scale_mem(dst_scale_, dst_scales_dt_);
+        memory_plain_t data_zeropoints_mem(
+                data_zeropoints_, data_zeropoints_dt_);
+        memory_plain_t weights_zeropoints_mem(
+                weights_zeropoints_, weights_zeropoints_dt_);
+        memory_plain_t dst_zeropoints_mem(dst_zeropoints_, dst_zeropoints_dt_);
+
+        bool has_bias = bias_mem.md().ndims() != 0;
+
+        float data_scale, weights_scale, dst_scale, data_zeropoint,
+                weights_zeropoint, dst_zeropoint;
+        if (conf_.do_scale_data) { data_scale = data_scale_mem.load(0); }
+        if (conf_.do_scale_weights && conf_.single_weights_scale) {
+            weights_scale = weights_scale_mem.load(0);
+        }
+        if (conf_.do_scale_dst) { dst_scale = dst_scale_mem.load(0); }
+
+        if (conf_.use_data_zeropoints) {
+            data_zeropoint = data_zeropoints_mem.load(0);
+        }
+        if (conf_.use_weights_zeropoints) {
+            weights_zeropoint = weights_zeropoints_mem.load(0);
+        }
+        if (conf_.use_dst_zeropoints) {
+            dst_zeropoint = dst_zeropoints_mem.load(0);
+        }
+
+        uint dropout_seed;
+        float dropout_p;
+        uint dropout_threshold;
+        float dropout_inv_q;
+        if (conf_.use_dropout) {
+            dropout_seed = reinterpret_cast<const uint *>(
+                    dropout_seed_.get_pointer())[0];
+            dropout_p = reinterpret_cast<const float *>(
+                    dropout_probability_.get_pointer())[0];
+            dropout_threshold = get_dropout_threshold(dropout_p);
+            dropout_inv_q = (dropout_p != 1.f) ? 1.f / (1.f - dropout_p) : 0.f;
+        }
+
+        // dimensions N/M/K depending on the tensor
+        const int matmul_dim_1 = dst_mem.md().ndims() - 2;
+        const int matmul_dim_2 = dst_mem.md().ndims() - 1;
+
+        int M = dst_mem.md().dims()[matmul_dim_1];
+        int N = dst_mem.md().dims()[matmul_dim_2];
+        if (conf_.transpose_dst) { std::swap(M, N); }
+        int K = data_mem.md().dims()[conf_.transpose_data ? matmul_dim_1
+                                                          : matmul_dim_2];
+
+        dims_t dst_dims, dst_blocks, dst_strides, off_dst_blocks, off_dst;
+        for (int i = 0; i < max_supported_ndims; i++) {
+            if (i < dst_mem.md().ndims()) {
+                dst_dims[i] = dst_mem.md().dims()[i];
+                dst_blocks[i] = dst_mem.md().dims()[i];
+                dst_strides[i] = dst_mem.md().strides()[i];
+            } else {
+                dst_dims[i] = 1;
+                dst_blocks[i] = 1;
+                dst_strides[i] = INT_MAX;
+            }
+        }
+        dst_blocks[matmul_dim_1] = math::div_up(dst_blocks[matmul_dim_1],
+                conf_.transpose_dst ? register_block_N : register_block_M);
+        dst_blocks[matmul_dim_2] = math::div_up(dst_blocks[matmul_dim_2],
+                conf_.transpose_dst ? register_block_M : register_block_N);
+        int n_blocks = 1;
+        for (int i = 0; i < max_supported_ndims; i++) {
+            n_blocks *= dst_blocks[i];
+        }
+
+        int dst_block_row_stride = dst_mem.md().strides()[matmul_dim_1];
+        int bias_block_row_stride = bias_mem.md().strides()[matmul_dim_1];
+        int data_block_row_stride = data_mem.md().strides()[matmul_dim_1];
+        int weights_block_row_stride = weights_mem.md().strides()[matmul_dim_1];
+
+        for (int block_idx = item.get_global_id(0); block_idx < n_blocks;
+                block_idx += item.get_global_range(0)) {
+            int idx_tmp = block_idx;
+            for (int i = max_supported_ndims - 1; i >= 0; i--) {
+                off_dst_blocks[i] = idx_tmp % dst_blocks[i];
+                idx_tmp /= dst_blocks[i];
+                off_dst[i] = off_dst_blocks[i];
+            }
+            bool is_dst_edge_block
+                    = off_dst[matmul_dim_1] == dst_blocks[matmul_dim_1] - 1
+                    || off_dst[matmul_dim_2] == dst_blocks[matmul_dim_2] - 1;
+            off_dst[matmul_dim_1] *= conf_.transpose_dst ? register_block_N
+                                                         : register_block_M;
+            off_dst[matmul_dim_2] *= conf_.transpose_dst ? register_block_M
+                                                         : register_block_N;
+            int m = off_dst[conf_.transpose_dst ? matmul_dim_2 : matmul_dim_1];
+            int n = off_dst[conf_.transpose_dst ? matmul_dim_1 : matmul_dim_2];
+
+            dims_t off_src, off_weights, off_bias;
+            for (int i = max_supported_ndims - 1; i >= 0; i--) {
+                off_src[i] = off_dst[i];
+                off_weights[i] = off_dst[i];
+                off_bias[i] = off_dst[i];
+            }
+
+            int bias_mask = conf_.bias_mask;
+            if (conf_.transpose_dst ^ conf_.transpose_bias) {
+                std::swap(off_bias[matmul_dim_1], off_bias[matmul_dim_2]);
+            }
+            if (conf_.transpose_bias) {
+                bias_mask = transpose_mask(bias_mask, data_mem.md().ndims());
+            }
+
+            int dst_block_start = dst_mem.md().off_v(off_dst);
+            int bias_block_start
+                    = bias_mem.md().off_v_masked(off_bias, bias_mask);
+
+            int remaining_m = ::sycl::min(M - m, register_block_M);
+            int remaining_n = ::sycl::min(N - n, register_block_N);
+
+            dst_block_t dst_block;
+            if (!has_bias) {
+                dst_block.eltwise([=](float &el) { el = 0; });
+            } else {
+                // load bias
+                dst_block.load_generic(bias_mem, bias_block_start,
+                        bias_block_row_stride, conf_.transpose_bias,
+                        is_dst_edge_block, remaining_m, remaining_n,
+                        conf_.bias_mask);
+            }
+
+            for (int k = 0; k < K; k += register_block_K) {
+                bool is_edge_k = k + register_block_K >= K;
+                bool is_edge_block
+                        = is_dst_edge_block || k + register_block_K >= K;
+                off_src[matmul_dim_1] = conf_.transpose_data ? k : m;
+                off_src[matmul_dim_2] = conf_.transpose_data ? m : k;
+                off_weights[matmul_dim_1] = conf_.transpose_weights ? n : k;
+                off_weights[matmul_dim_2] = conf_.transpose_weights ? k : n;
+
+                int data_block_start
+                        = data_mem.md().off_v_masked(off_src, conf_.data_mask);
+                int weights_block_start = weights_mem.md().off_v_masked(
+                        off_weights, conf_.weights_mask);
+
+                data_block_t data_block;
+                weights_block_t weights_block;
+
+                int remaining_k = ::sycl::min(K - k, register_block_K);
+
+                data_block.load_generic(data_mem, data_block_start,
+                        data_block_row_stride, conf_.transpose_data,
+                        is_edge_block, remaining_m, remaining_k,
+                        conf_.data_mask);
+                if (conf_.use_data_zeropoints) {
+                    data_block.eltwise(
+                            [=](float &el) { el -= data_zeropoint; });
+                }
+                if (conf_.do_scale_data) {
+                    data_block.eltwise([=](float &el) { el *= data_scale; });
+                }
+
+                weights_block.load_generic(weights_mem, weights_block_start,
+                        weights_block_row_stride, conf_.transpose_weights,
+                        is_edge_block, remaining_k, remaining_n,
+                        conf_.weights_mask);
+                if (conf_.use_weights_zeropoints) {
+                    weights_block.eltwise(
+                            [=](float &el) { el -= weights_zeropoint; });
+                }
+                if (conf_.do_scale_weights) {
+                    if (conf_.single_weights_scale) {
+                        weights_block.eltwise(
+                                [=](float &el) { el *= weights_scale; });
+                    } else {
+                        for (int n1 = 0; n1 < remaining_n; n1++) {
+                            float scale_n = weights_scale_mem.load(n + n1);
+                            for (int k1 = 0; k1 < remaining_k; k1++) {
+                                weights_block
+                                        .data[k1][n1 / vec_len][n1 % vec_len]
+                                        *= scale_n;
+                            }
+                        }
+                    }
+                }
+
+                if (is_edge_k) {
+                    dst_block.matmul_accumulate_edge_k(
+                            data_block, weights_block, remaining_k);
+                } else {
+                    dst_block.matmul_accumulate(data_block, weights_block);
+                }
+            }
+            if (conf_.use_dropout) {
+                dst_block.dropout(dropout_mask_, dropout_threshold,
+                        dropout_seed, dropout_inv_q, dst_block_start,
+                        dst_block_row_stride);
+            }
+
+            dst_block_t prev_dst;
+            prev_dst.load_generic(dst_mem, dst_block_start,
+                    dst_block_row_stride, conf_.transpose_dst,
+                    is_dst_edge_block, remaining_m, remaining_n);
+            dims_t off_po;
+            for (int i = 0; i < max_supported_ndims; i++) {
+                off_po[i] = off_dst[i];
+            }
+            if (conf_.transpose_dst) {
+                std::swap(off_po[matmul_dim_1], off_po[matmul_dim_2]);
+            }
+            dst_block.apply_post_ops(
+                    conf_.post_ops, prev_dst, off_po, matmul_dim_1, this);
+
+            if (conf_.do_scale_dst) {
+                dst_block.eltwise([=](float &el) { el /= dst_scale; });
+            }
+            if (conf_.use_dst_zeropoints) {
+                dst_block.eltwise([=](float &el) { el += dst_zeropoint; });
+            }
+            dst_block.store_generic(dst_mem, dst_block_start,
+                    dst_block_row_stride, conf_.transpose_dst,
+                    is_dst_edge_block, remaining_m, remaining_n);
+        }
+    }
+
+private:
+    inline ::sycl::vec<float, 16> post_op_src_val(dims_t data_off) const {
+        ::sycl::vec<float, 16> post_po_sr;
+        const auto maxPostPo = conf_.post_ops.get_post_op();
+
+        for (dim_t po_idx = 0; po_idx < maxPostPo; po_idx++) {
+            float res = 0.0f;
+            if (po_idx == 0)
+                res = get_post_op_val(po1_src_, po_idx, data_off);
+            else if (po_idx == 1)
+                res = get_post_op_val(po2_src_, po_idx, data_off);
+            else if (po_idx == 2)
+                res = get_post_op_val(po3_src_, po_idx, data_off);
+            else if (po_idx == 3)
+                res = get_post_op_val(po4_src_, po_idx, data_off);
+            else if (po_idx == 4)
+                res = get_post_op_val(po5_src_, po_idx, data_off);
+
+            post_po_sr[po_idx] = res;
+        }
+        return post_po_sr;
+    }
+
+    float get_post_op_val(const xpu::sycl::in_memory_arg_t &bin_src_op,
+            dim_t &idx, dims_t offset) const {
+        auto src1_desc = conf_.binary_src_arr[idx];
+
+        xpu::sycl::md_t::dim32_t ndims = conf_.dst_md.ndims();
+        xpu::sycl::md_t::dims32_t dst_dims;
+        for (int i = 0; i < ndims; i++) {
+            dst_dims[i] = conf_.dst_md.dims()[i];
+        }
+        if (conf_.transpose_dst) {
+            std::swap(dst_dims[ndims - 1], dst_dims[ndims - 2]);
+        }
+        const auto off
+                = get_matmul_src1_off(src1_desc, offset, dst_dims, ndims);
+
+        auto dst = load_float_value(
+                src1_desc.data_type(), bin_src_op.get_pointer(), off);
+        return dst;
+    }
+
+    dim_t get_matmul_src1_off(const xpu::sycl::md_t &src1_md, dims_t offset,
+            const xpu::sycl::md_t::dims32_t &dst_dims,
+            const xpu::sycl::md_t::dim32_t &dst_ndims) const {
+        const dim_t mask_matmul_po
+                = get_dims_mask(dst_dims, src1_md.dims(), dst_ndims);
+        return get_po_tensor_off(
+                src1_md, offset, dst_dims, dst_ndims, mask_matmul_po);
+    }
+
+    inline dim_t get_dims_mask(const xpu::sycl::md_t::dims32_t &dims1,
+            const xpu::sycl::md_t::dims32_t &dims2, const dim_t &ndims,
+            bool skip_dim_of_one = false) const {
+        dim_t mask = 0;
+        for (dim_t d = 0; d < ndims; ++d) {
+            // Disable mask_bit for dimensions of `1` by request.
+            dim_t mask_bit = skip_dim_of_one && dims1[d] == 1 ? 0 : (1 << d);
+            mask += dims1[d] == dims2[d] ? mask_bit : 0;
+        }
+        return mask;
+    }
+
+    inline dim_t get_po_tensor_off(const xpu::sycl::md_t &tensor_md,
+            dims_t offset, const xpu::sycl::md_t::dims32_t &dst_dims,
+            const dim_t &dst_ndims, const dim_t &mask) const {
+        dims_t offset_po {};
+        utils::copy_dims_with_mask(offset_po, offset, dst_ndims, mask);
+        return tensor_md.off_v(offset_po);
+    }
+
+    sycl_matmul_conf_t conf_;
+
+    xpu::sycl::in_memory_arg_t data_;
+    xpu::sycl::in_memory_arg_t weights_;
+    xpu::sycl::in_memory_arg_t bias_;
+    xpu::sycl::out_memory_arg_t dst_;
+    xpu::sycl::in_memory_arg_t data_scale_;
+    data_type_t data_scales_dt_;
+    xpu::sycl::in_memory_arg_t weights_scale_;
+    data_type_t weights_scales_dt_;
+    xpu::sycl::in_memory_arg_t dst_scale_;
+    data_type_t dst_scales_dt_;
+    xpu::sycl::in_memory_arg_t data_zeropoints_;
+    data_type_t data_zeropoints_dt_;
+    xpu::sycl::in_memory_arg_t weights_zeropoints_;
+    data_type_t weights_zeropoints_dt_;
+    xpu::sycl::in_memory_arg_t dst_zeropoints_;
+    data_type_t dst_zeropoints_dt_;
+    xpu::sycl::out_memory_arg_t dropout_mask_;
+    xpu::sycl::in_memory_arg_t dropout_seed_;
+    xpu::sycl::in_memory_arg_t dropout_probability_;
+    xpu::sycl::in_memory_arg_t po1_src_;
+    xpu::sycl::in_memory_arg_t po2_src_;
+    xpu::sycl::in_memory_arg_t po3_src_;
+    xpu::sycl::in_memory_arg_t po4_src_;
+    xpu::sycl::in_memory_arg_t po5_src_;
+};
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/generic/sycl/ref_matmul.cpp
+++ b/src/gpu/generic/sycl/ref_matmul.cpp
@@ -1,0 +1,162 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/generic/sycl/ref_matmul.hpp"
+#include "gpu/generic/sycl/matmul_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+status_t ref_matmul_t::pd_t::init_conf() {
+    conf_ = sycl_matmul_conf_t();
+
+    int matmul_dim_1 = ndims() - 2;
+    int matmul_dim_2 = ndims() - 1;
+
+    memory_desc_t data_md_copy = *src_md();
+    auto &data_strides = data_md_copy.format_desc.blocking.strides;
+    if (data_strides[matmul_dim_1] < data_strides[matmul_dim_2]) {
+        std::swap(data_strides[matmul_dim_1], data_strides[matmul_dim_2]);
+        std::swap(data_md_copy.dims[matmul_dim_1],
+                data_md_copy.dims[matmul_dim_2]);
+        conf_.transpose_data = true;
+    }
+    conf_.data_md = xpu::sycl::md_t(&data_md_copy);
+
+    memory_desc_t weights_md_copy = *weights_md();
+    auto &weights_strides = weights_md_copy.format_desc.blocking.strides;
+    if (weights_strides[matmul_dim_1] < weights_strides[matmul_dim_2]) {
+        std::swap(weights_strides[matmul_dim_1], weights_strides[matmul_dim_2]);
+        std::swap(weights_md_copy.dims[matmul_dim_1],
+                weights_md_copy.dims[matmul_dim_2]);
+        conf_.transpose_weights = true;
+    }
+    conf_.weights_md = xpu::sycl::md_t(&weights_md_copy);
+
+    memory_desc_t dst_md_copy = *dst_md();
+    auto &dst_strides = dst_md_copy.format_desc.blocking.strides;
+    if (dst_strides[matmul_dim_1] < dst_strides[matmul_dim_2]) {
+        std::swap(dst_strides[matmul_dim_1], dst_strides[matmul_dim_2]);
+        std::swap(
+                dst_md_copy.dims[matmul_dim_1], dst_md_copy.dims[matmul_dim_2]);
+        conf_.transpose_dst = true;
+    }
+    conf_.dst_md = xpu::sycl::md_t(&dst_md_copy);
+
+    if (with_bias()) {
+        memory_desc_t bias_md_copy = *weights_md(1);
+        auto &bias_strides = bias_md_copy.format_desc.blocking.strides;
+        if (bias_strides[matmul_dim_1] < bias_strides[matmul_dim_2]) {
+            std::swap(bias_strides[matmul_dim_1], bias_strides[matmul_dim_2]);
+            std::swap(bias_md_copy.dims[matmul_dim_1],
+                    bias_md_copy.dims[matmul_dim_2]);
+            conf_.transpose_bias = true;
+        }
+        conf_.bias_md = xpu::sycl::md_t(&bias_md_copy);
+    }
+
+    dims_t dst_blocks;
+    for (int i = 0; i < matmul_kernel_fwd_t::max_supported_ndims; i++) {
+        if (i < conf_.dst_md.ndims()) {
+            dst_blocks[i] = conf_.dst_md.dims()[i];
+        } else {
+            dst_blocks[i] = 1;
+        }
+    }
+    dst_blocks[matmul_dim_1] = math::div_up(
+            dst_blocks[matmul_dim_1], matmul_kernel_fwd_t::register_block_N);
+    dst_blocks[matmul_dim_2] = math::div_up(
+            dst_blocks[matmul_dim_2], matmul_kernel_fwd_t::register_block_M);
+    int n_blocks = 1;
+    for (int i = 0; i < matmul_kernel_fwd_t::max_supported_ndims; i++) {
+        n_blocks *= dst_blocks[i];
+    }
+    conf_.wk_size = n_blocks;
+
+    int high_two_bits = 3 << (ndims() - 2);
+    // last two dimensions of data and weights are never broadcast
+    conf_.data_mask
+            = utils::get_dims_mask(dst_md()->dims, src_md()->dims, ndims())
+            | high_two_bits;
+    conf_.weights_mask
+            = utils::get_dims_mask(dst_md()->dims, weights_md(0)->dims, ndims())
+            | high_two_bits;
+    conf_.bias_mask = utils::get_dims_mask(
+            dst_md()->dims, weights_md(1)->dims, ndims());
+
+    conf_.do_scale_data
+            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_weights
+            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
+    conf_.do_scale_dst
+            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
+    conf_.single_weights_scale
+            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+
+    conf_.use_data_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.use_weights_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS_0);
+    conf_.use_dst_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
+
+    conf_.use_dropout = !attr()->dropout_.has_default_values();
+
+    conf_.post_ops = sycl_post_ops_t(attr());
+
+    for (auto i = 0; i < conf_.post_ops.get_post_op(); ++i) {
+        const auto &e = attr()->post_ops_.entry_[i];
+        if (e.is_binary() || e.is_prelu()) {
+            conf_.binary_src_arr[i] = xpu::sycl::md_t(
+                    arg_md(DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
+        }
+    }
+    return status::success;
+}
+
+status_t ref_matmul_t::init(impl::engine_t *engine) {
+    const auto kid = ::sycl::get_kernel_id<matmul_kernel_fwd_t>();
+    CHECK(create_kernel(engine, kid, &kernel_));
+    return status::success;
+}
+
+status_t ref_matmul_t::execute(const exec_ctx_t &ctx) const {
+
+    parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
+        matmul_kernel_fwd_t matmul_kernel(pd()->conf_, cgh, ctx);
+
+        const int block_size = 32;
+        const int wg_size = 32;
+
+        const int t_work = pd()->conf_.wk_size;
+        const int wg_work = wg_size * block_size;
+        const int wg_cnt = utils::div_up(t_work, wg_work);
+
+        cgh.parallel_for(
+                ::sycl::nd_range<1>(wg_cnt * wg_size, wg_size), matmul_kernel);
+    });
+
+    return status::success;
+}
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/generic/sycl/ref_matmul.hpp
+++ b/src/gpu/generic/sycl/ref_matmul.hpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_GENERIC_SYCL_REF_MATMUL_HPP
+#define GPU_GENERIC_SYCL_REF_MATMUL_HPP
+
+#include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
+#include "gpu/generic/sycl/sycl_io_helper.hpp"
+#include "gpu/generic/sycl/sycl_post_ops.hpp"
+#include "gpu/generic/sycl/sycl_primitive_conf.hpp"
+#include "gpu/generic/sycl/sycl_q10n.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
+#include "gpu/gpu_matmul_pd.hpp"
+#include "xpu/sycl/types.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace generic {
+namespace sycl {
+
+struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
+    using gpu::generic::sycl::primitive_t::primitive_t;
+
+    struct pd_t : public gpu_matmul_pd_t {
+        using gpu_matmul_pd_t::gpu_matmul_pd_t;
+
+        DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_matmul_t);
+
+        status_t init(impl::engine_t *engine) {
+            using namespace data_type;
+            using sm = primitive_attr_t::skip_mask_t;
+
+            const memory_desc_wrapper src_d(src_md());
+            const memory_desc_wrapper weights_d(weights_md(0));
+            const memory_desc_wrapper bias_d(weights_md(1));
+            const memory_desc_wrapper dst_d(dst_md());
+
+            const bool ok = set_default_params() == status::success
+                    && attr_.set_default_formats(dst_md()) == status::success
+                    && check_data_types(src_d, weights_d, dst_d)
+                    && check_formats(src_d, weights_d, dst_d)
+                    && attr()->has_default_values(sm::scales_runtime
+                            | sm::zero_points_runtime | sm::post_ops
+                            | sm::dropout | sm::scales_runtime_data_type
+                            | sm::zero_points_runtime_data_type)
+                    && IMPLICATION(!attr()->scales_.has_default_values(),
+                            check_scales_mask())
+                    && post_ops_ok() && md_dims_in_range(src_md())
+                    && md_dims_in_range(weights_md());
+            if (!ok) return status::unimplemented;
+
+            return init_conf();
+        }
+
+        sycl_matmul_conf_t conf_;
+
+    private:
+        status_t init_conf();
+
+        status_t set_default_params() {
+            if (src_md_.format_kind == format_kind::any) {
+                auto src_tag = utils::pick(ndims() - 2, format_tag::ab,
+                        format_tag::abc, format_tag::abcd);
+                CHECK(memory_desc_init_by_tag(src_md_, src_tag));
+            }
+            const memory_desc_wrapper src_d(src_md());
+            if (src_d.is_blocking_desc()) {
+                if (weights_md_.format_kind == format_kind::any) {
+                    CHECK(memory_desc_init_by_blocking_desc(
+                            weights_md_, src_d.blocking_desc()));
+                }
+                if (dst_md_.format_kind == format_kind::any) {
+                    CHECK(memory_desc_init_by_blocking_desc(
+                            dst_md_, src_d.blocking_desc()));
+                }
+            }
+            const memory_desc_wrapper dst_d(dst_md());
+            if (dst_d.is_blocking_desc()) {
+                if (bias_md_.format_kind == format_kind::any) {
+                    CHECK(memory_desc_init_by_blocking_desc(
+                            bias_md_, dst_d.blocking_desc()));
+                }
+            }
+            return status::success;
+        }
+
+        bool check_scales_mask() const {
+            const std::vector<int> supported_args
+                    = {DNNL_ARG_SRC_0, DNNL_ARG_WEIGHTS_0, DNNL_ARG_DST};
+            return attr_scales_ok(supported_args);
+        }
+
+        bool post_ops_ok() const {
+            // Dw conv post-ops are not supported.
+            return attr()->post_ops_.len() <= sycl_post_ops_t::max_post_ops
+                    && attr()->post_ops_.has_default_values(
+                            {primitive_kind::eltwise, primitive_kind::binary,
+                                    primitive_kind::sum});
+        }
+
+        static bool check_data_types(const memory_desc_wrapper &src,
+                const memory_desc_wrapper &weights,
+                const memory_desc_wrapper &dst) {
+            using namespace data_type;
+
+            const auto src_dt = src.data_type();
+            const auto weights_dt = weights.data_type();
+            const auto dst_dt = dst.data_type();
+
+            for (auto t : {src_dt, weights_dt, dst_dt}) {
+                if (!utils::one_of(t, f32, bf16, f16, s8, u8, s32))
+                    return false;
+            }
+
+            return true;
+        }
+
+        static bool check_formats(const memory_desc_wrapper &src,
+                const memory_desc_wrapper &weights,
+                const memory_desc_wrapper &dst) {
+            using namespace format_tag;
+
+            for (const auto &mdw : {src, weights, dst}) {
+                if (!mdw.is_plain() || mdw.has_runtime_dims()) { return false; }
+            }
+            return true;
+        }
+    };
+
+    status_t init(impl::engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    kernel_t kernel_;
+};
+
+} // namespace sycl
+} // namespace generic
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/generic/sycl/sycl_io_helper.hpp
+++ b/src/gpu/generic/sycl/sycl_io_helper.hpp
@@ -239,6 +239,8 @@ struct memory_tensor_t {
         store(val, md_.off_v(offsets));
     }
 
+    inline void *ptr() const { return mem_.get_pointer(); }
+
 private:
     xpu::sycl::memory_arg_t<mode> mem_;
     xpu::sycl::md_t md_;

--- a/src/gpu/generic/sycl/sycl_post_ops.hpp
+++ b/src/gpu/generic/sycl/sycl_post_ops.hpp
@@ -34,7 +34,9 @@ struct ref_eltwise_fwd_t {
         : alg_(alg), alpha_(alpha), beta_(beta), scale_(scale) {
         using namespace alg_kind;
         assert(utils::one_of(alg_, eltwise_relu, eltwise_linear, eltwise_clip,
-                eltwise_clip_v2, eltwise_hardswish));
+                eltwise_clip_v2, eltwise_hardswish, eltwise_gelu_tanh,
+                eltwise_gelu_erf, eltwise_tanh, eltwise_logistic, eltwise_swish,
+                eltwise_elu));
     }
 
     ref_eltwise_fwd_t(const post_ops_t::entry_t::eltwise_t &eltwise)
@@ -81,6 +83,14 @@ struct ref_eltwise_fwd_t {
             case eltwise_hardswish:
                 d = dnnl::impl::math::hardswish_fwd(s, alpha, beta);
                 break;
+            case eltwise_gelu_tanh: d = gelu_tanh_fwd(s); break;
+            case eltwise_gelu_erf: d = gelu_erf_fwd(s); break;
+            case eltwise_tanh: d = tanh_fwd(s); break;
+            case eltwise_logistic: d = logistic_fwd(s); break;
+            case eltwise_swish:
+                d = dnnl::impl::math::swish_fwd(s, alpha);
+                break;
+            case eltwise_elu: d = dnnl::impl::math::elu_fwd(s, alpha); break;
             default: d = ::sycl::nan(0u);
         }
         return d;

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -109,6 +109,37 @@ struct sycl_eltwise_conf_t {
     sycl_post_ops_t post_ops;
 };
 
+struct sycl_matmul_conf_t {
+    xpu::sycl::md_t data_md;
+    xpu::sycl::md_t dst_md;
+    xpu::sycl::md_t weights_md;
+    xpu::sycl::md_t bias_md;
+    alg_kind_t alg_kind;
+    bool transpose_data; //TODO can we remove?
+    bool transpose_dst;
+    bool transpose_weights;
+    bool transpose_bias;
+    dim_t post_po_len;
+    xpu::sycl::md_t binary_src_arr[sycl::sycl_post_ops_t::max_post_ops];
+    sycl_post_ops_t post_ops;
+    int wk_size;
+
+    int data_mask;
+    int weights_mask;
+    int bias_mask;
+
+    bool do_scale_data;
+    bool do_scale_weights;
+    bool do_scale_dst;
+    bool single_weights_scale;
+
+    bool use_data_zeropoints;
+    bool use_weights_zeropoints;
+    bool use_dst_zeropoints;
+
+    bool use_dropout;
+};
+
 struct sycl_prelu_conf_t {
     prop_kind_t prop_kind;
     xpu::sycl::md_t data_md;

--- a/src/gpu/generic/sycl/sycl_utils.hpp
+++ b/src/gpu/generic/sycl/sycl_utils.hpp
@@ -35,6 +35,27 @@ inline bool md_dims_in_range(const dnnl::impl::memory_desc_t *desc) {
     return true;
 }
 
+// copy from type_helpers.hpp, just without the assert
+inline size_t data_type_size(data_type_t data_type) {
+    using namespace data_type;
+    switch ((int)data_type) {
+        case f8_e5m2: return sizeof(prec_traits<f8_e5m2>::type);
+        case f8_e4m3: return sizeof(prec_traits<f8_e4m3>::type);
+        case f16: return sizeof(prec_traits<f16>::type);
+        case bf16: return sizeof(prec_traits<bf16>::type);
+        case tf32: // the tf32 type is an f32
+        case f32: return sizeof(prec_traits<f32>::type);
+        case f64: return sizeof(prec_traits<f64>::type);
+        case s32: return sizeof(prec_traits<s32>::type);
+        case s8: return sizeof(prec_traits<s8>::type);
+        case u8: return sizeof(prec_traits<u8>::type);
+        case s4: return sizeof(prec_traits<s4>::type);
+        case u4: return sizeof(prec_traits<u4>::type);
+        case boolean: return sizeof(prec_traits<boolean>::type);
+    }
+    return (size_t)-1; /* not supposed to be reachable */
+}
+
 } // namespace sycl
 } // namespace generic
 } // namespace gpu

--- a/src/gpu/gpu_matmul_list.cpp
+++ b/src/gpu/gpu_matmul_list.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
+#include "gpu/generic/sycl/ref_matmul.hpp"
 #include "gpu/nvidia/cudnn_matmul.hpp"
 #endif
 
@@ -41,6 +42,7 @@ constexpr impl_list_item_t impl_list[] = REG_MATMUL_P({
         GPU_INSTANCE_INTEL_REF(intel::ocl::ref_matmul_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_matmul_t)
         GPU_INSTANCE_AMD(amd::miopen_matmul_t)
+        GPU_INSTANCE_GENERIC_SYCL(generic::sycl::ref_matmul_t)
         nullptr,
 });
 // clang-format on

--- a/src/xpu/sycl/types.hpp
+++ b/src/xpu/sycl/types.hpp
@@ -178,6 +178,12 @@ struct md_t {
         return phys_offset;
     }
 
+    dim_t off_v_masked(const dims_t pos, int mask, bool is_pos_padded = false) {
+        dims_t pos_masked;
+        utils::copy_dims_with_mask(pos_masked, pos, ndims(), mask);
+        return off_v(pos_masked, is_pos_padded);
+    }
+
     dim_t off_l(dim_t l_offset, bool is_pos_padded = false) const {
         dims_t pos;
         for (int rd = 0; rd < ndims(); ++rd) {


### PR DESCRIPTION
Implemented SYCL matmul. Rruntime dimensions and prelu post op are not yet supported - will be added in future. 

As they are used in the benchdnn tests a number of post ops options have also been added.