### PR TITLE
Workflow for automatic RFC labeling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+#===============================================================================
+# Copyright 2019-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+# Default
+* @oneapi-src/onednn-arch

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,38 @@
+#===============================================================================
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+# This is configuration file for Labeler workflow. See documenation for syntax
+# reference: https://github.com/marketplace/actions/labeler
+
+# Labels based on area of responsibility
+# Process definition and code owners
+governance:
+- changed-files:
+  - any-glob-to-any-file: ['*', 'rfcs/template.md', '.github/CODEOWNERS']
+
+# Github automation
+devops:
+- all:
+  - changed-files:
+    - any-glob-to-any-file: '.github/**'
+    - all-globs-to-all-files: '!.github/CODEOWNERS'
+
+# RFC
+RFC:
+- all:
+  - changed-files:
+    - any-glob-to-any-file: 'rfcs/**'
+    - all-globs-to-all-files: '!rfcs/template.md'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,34 @@
+#===============================================================================
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+name: Labeler
+on: [pull_request_target]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v5.0.0
+        with:
+          sync-labels: true
+          configuration-path: '.github/labels.yml'


### PR DESCRIPTION
Follow up to #2055.

This PR introduces Labeler and CODEOWNERS to an orphan branch `rfcs`.
