### PR TITLE
generic: sycl: move check on post ops to a single location

### DIFF
--- a/src/gpu/generic/sycl/ref_binary.hpp
+++ b/src/gpu/generic/sycl/ref_binary.hpp
@@ -56,7 +56,8 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
                             sm::scales_runtime | sm::post_ops)
                     && IMPLICATION(!attr()->scales_.has_default_values(),
                             check_scales_mask())
-                    && post_ops_ok() && md_dims_in_range(src_md(0))
+                    && sycl_post_ops_t::post_ops_ok(attr())
+                    && md_dims_in_range(src_md(0))
                     && md_dims_in_range(src_md(1))
                     && md_dims_in_range(dst_md());
             if (!ok) return status::unimplemented;
@@ -73,15 +74,6 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
             const std::vector<int> supported_args
                     = {DNNL_ARG_SRC_0, DNNL_ARG_SRC_1};
             return attr_scales_ok(supported_args);
-        }
-
-        bool post_ops_ok() const {
-            // Dw conv post-ops are not supported.
-            return attr()->post_ops_.len() <= sycl_post_ops_t::max_post_ops
-                    && attr()->post_ops_.has_default_values(
-                            {primitive_kind::eltwise, primitive_kind::binary,
-                                    primitive_kind::prelu,
-                                    primitive_kind::sum});
         }
 
         static bool check_data_types(const memory_desc_wrapper &src0,

--- a/src/gpu/generic/sycl/ref_eltwise.hpp
+++ b/src/gpu/generic/sycl/ref_eltwise.hpp
@@ -51,7 +51,8 @@ struct ref_sycl_eltwise_fwd_t : public gpu::generic::sycl::primitive_t {
                     && attr()->has_default_values(sm::post_ops)
                     && set_default_formats_common() && src_d == dst_d
                     && attr_.set_default_formats(dst_md(0)) == status::success
-                    && post_ops_ok() && md_dims_in_range(src_md());
+                    && sycl_post_ops_t::post_ops_ok(attr())
+                    && md_dims_in_range(src_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();
@@ -73,27 +74,6 @@ struct ref_sycl_eltwise_fwd_t : public gpu::generic::sycl::primitive_t {
             }
 
             return true;
-        }
-
-        bool post_ops_ok() const {
-            for (int i = 0; i < attr()->post_ops_.len(); i++) {
-                const auto &e = attr()->post_ops_.entry_[i];
-                if (!IMPLICATION(e.is_binary(),
-                            utils::one_of(e.binary.alg, alg_kind::binary_add,
-                                    alg_kind::binary_div, alg_kind::binary_mul,
-                                    alg_kind::binary_sub, alg_kind::binary_max,
-                                    alg_kind::binary_min, alg_kind::binary_ge,
-                                    alg_kind::binary_gt, alg_kind::binary_le,
-                                    alg_kind::binary_lt, alg_kind::binary_eq,
-                                    alg_kind::binary_ne))) {
-
-                    return false;
-                }
-            }
-            return attr()->post_ops_.len() <= sycl_post_ops_t::max_post_ops
-                    && attr()->post_ops_.has_default_values(
-                            {primitive_kind::eltwise, primitive_kind::binary,
-                                    primitive_kind::sum});
         }
     };
 

--- a/src/gpu/generic/sycl/ref_reorder.hpp
+++ b/src/gpu/generic/sycl/ref_reorder.hpp
@@ -54,7 +54,8 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
                     && check_formats(src_d, dst_d)
                     && attr()->has_default_values(
                             sm::scales_runtime | sm::post_ops)
-                    && post_ops_ok() && md_dims_in_range(dst_md());
+                    && sycl_post_ops_t::post_ops_ok(attr())
+                    && md_dims_in_range(dst_md());
             if (!ok) return status::unimplemented;
 
             return init_conf();
@@ -66,15 +67,6 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
         DECLARE_GPU_REORDER_CREATE();
 
         status_t init_conf();
-
-        bool post_ops_ok() const {
-            for (int i = 0; i < attr()->post_ops_.len(); i++) {
-                if (!attr()->post_ops_.entry_[i].is_sum()) { return false; }
-            }
-            return attr()->post_ops_.len() <= sycl_post_ops_t::max_post_ops
-                    && attr()->post_ops_.has_default_values(
-                            {primitive_kind::sum});
-        }
 
         static bool check_data_types(const memory_desc_wrapper &src,
                 const memory_desc_wrapper &dst) {

--- a/src/gpu/generic/sycl/ref_softmax.hpp
+++ b/src/gpu/generic/sycl/ref_softmax.hpp
@@ -44,7 +44,8 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && attr()->has_default_values(
                             sm::scales_runtime | sm::post_ops)
-                    && attr_oscale_ok() && post_ops_ok()
+                    && attr_oscale_ok()
+                    && sycl_post_ops_t::post_ops_ok(attr(), true, false)
                     && set_default_formats() == status::success
                     && attr_.set_default_formats(dst_md()) == status::success
                     && md_dims_in_range(src_md());
@@ -63,12 +64,6 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
                 ok = ok && e.second.mask_ == 0;
             }
             return ok;
-        }
-
-        bool post_ops_ok() const {
-            return attr()->post_ops_.len() <= sycl_post_ops_t::max_post_ops
-                    && attr()->post_ops_.has_default_values(
-                            {primitive_kind::eltwise, primitive_kind::binary});
         }
 
         bool check_data_types(data_type_t src) {

--- a/src/gpu/generic/sycl/ref_sum.hpp
+++ b/src/gpu/generic/sycl/ref_sum.hpp
@@ -21,7 +21,6 @@
 #include "common/stream.hpp"
 #include "gpu/generic/sycl/sycl_gpu_primitive.hpp"
 #include "gpu/generic/sycl/sycl_io_helper.hpp"
-#include "gpu/generic/sycl/sycl_post_ops.hpp"
 #include "gpu/generic/sycl/sycl_primitive_conf.hpp"
 #include "gpu/generic/sycl/sycl_q10n.hpp"
 #include "gpu/gpu_sum_pd.hpp"


### PR DESCRIPTION
Move check on whether post ops are supported from each individual operation to a common location. The check itself is also improved to more accurately check what is actually supported.

Also fixes a bug introduced in https://github.com/oneapi-src/oneDNN/pull/2005 that `sum_dt_` was not set.