### PR TITLE
cpu: aarch64: Enable stateless ACL depthwise convolution

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -283,25 +283,6 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
 
     return status::success;
 }
-
-status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
-        memory_desc_t &weights_md, memory_desc_t &dst_md,
-        memory_desc_t &bias_md, const convolution_desc_t &cd,
-        const primitive_attr_t &attr) {
-    if (weights_md.ndims != 5) return status::unimplemented;
-
-    CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
-
-    ACL_CHECK_VALID(arm_compute::NEDepthwiseConvolutionLayer::validate(
-            &acp.src_tensor_info, &acp.wei_tensor_info,
-            acp.with_bias ? &acp.bia_tensor_info : nullptr,
-            &acp.dst_tensor_info, acp.padstride_info,
-            1, // depth multiplier default value
-            acp.act_info, acp.dilation_info));
-
-    return status::success;
-}
-
 } // namespace acl_convolution_utils
 
 } // namespace aarch64

--- a/src/cpu/aarch64/acl_depthwise_convolution.cpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,21 +21,76 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
+namespace {
+// Keys are anonymous. So deduce the type automagically.
+using conv_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);
+
+// Map: [slot , key]
+const std::map<int, conv_key_t> depthwise_conv_keys
+        = {{0, conv_key_t::key_gemm_tmp_buffer},
+                {1, conv_key_t::key_conv_permuted_weights}};
+} // namespace
+
 status_t acl_depthwise_convolution_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
-    std::lock_guard<std::mutex> _lock {this->mtx};
-
-    auto *acl_resource
-            = ctx.get_resource_mapper()
-                      ->get<acl_depthwise_convolution_resource_t>(this);
-    acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer> &acl_depthwise_obj
-            = acl_resource->get_acl_obj();
-
-    return execute_forward_conv_acl<
-            acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer>, pd_t, data_t>(
-            ctx, acl_depthwise_obj, pd());
+    return execute_forward_conv_acl<acl_obj_t<Op>, pd_t, data_t>(
+            ctx, acl_obj_.get(), pd(), depthwise_conv_keys);
 }
 
+status_t acl_depthwise_convolution_fwd_t::pd_t::init(engine_t *engine) {
+    using namespace data_type;
+
+    const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
+            && attr()->has_default_values(
+                    primitive_attr_t::skip_mask_t::post_ops, f16);
+    const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
+            && attr()->has_default_values(
+                    primitive_attr_t::skip_mask_t::post_ops, f32);
+    bool ok = is_fwd() && set_default_alg_kind(alg_kind::convolution_direct)
+            && utils::one_of(true, is_fp16_ok, is_fp32_ok)
+            && !has_zero_dim_memory();
+    if (!ok) return status::unimplemented;
+
+    if (weights_md_.ndims != 5) return status::unimplemented;
+
+    CHECK(acl_convolution_utils::acl_init_conf(
+            acp_, src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr()));
+
+    ACL_CHECK_VALID(Op::validate(&acp_.src_tensor_info, &acp_.wei_tensor_info,
+            acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
+            &acp_.dst_tensor_info, acp_.padstride_info,
+            1, // depth multiplier default value
+            acp_.act_info, acp_.dilation_info));
+
+    Op conv;
+    conv.configure(&acp_.src_tensor_info, &acp_.wei_tensor_info,
+            acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
+            &acp_.dst_tensor_info, acp_.padstride_info,
+            1, // depth multiplier default value
+            acp_.act_info, acp_.dilation_info);
+
+    auto scratchpad = scratchpad_registry().registrar();
+    return init_scratchpad(conv, scratchpad, depthwise_conv_keys, engine,
+            post_ops, attr_.post_ops_, acp_.act_info, acp_.use_dst_acc_for_sum,
+            dst_md_);
+}
+
+status_t acl_depthwise_convolution_fwd_t::create_resource(
+        engine_t *engine, resource_mapper_t &mapper) const {
+    CHECK(pd()->post_ops.create_resource(engine, mapper));
+    return status::success;
+}
+
+status_t acl_depthwise_convolution_fwd_t::init(engine_t *engine) {
+    auto acp_ = pd()->acp_;
+    acl_obj_->conv.configure(&acp_.src_tensor_info, &acp_.wei_tensor_info,
+            acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
+            &acp_.dst_tensor_info, acp_.padstride_info,
+            1, // depth multiplier default value
+            acp_.act_info, acp_.dilation_info);
+    acl_obj_->aux_mem_req = acl_obj_->conv.workspace();
+    return status::success;
+}
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/acl_depthwise_convolution.hpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
@@ -17,7 +17,8 @@
 #ifndef CPU_AARCH64_ACL_DEPTHWISE_CONVOLUTION_HPP
 #define CPU_AARCH64_ACL_DEPTHWISE_CONVOLUTION_HPP
 
-#include "cpu/aarch64/acl_convolution_utils.hpp"
+#include "acl_convolution_utils.hpp"
+#include "arm_compute/runtime/experimental/operators/CpuDepthwiseConv2d.h"
 #include "cpu/cpu_convolution_pd.hpp"
 
 namespace dnnl {
@@ -25,46 +26,9 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-struct acl_depthwise_convolution_resource_t : public resource_t {
-    acl_depthwise_convolution_resource_t()
-        : acl_obj_(utils::make_unique<
-                acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer>>()) {}
-
-    status_t configure(const acl_conv_conf_t &acp) {
-        if (!acl_obj_) return status::out_of_memory;
-
-        acl_obj_->src_tensor.allocator()->init(acp.src_tensor_info);
-        acl_obj_->wei_tensor.allocator()->init(acp.wei_tensor_info);
-        acl_obj_->dst_tensor.allocator()->init(acp.dst_tensor_info);
-        acl_obj_->bia_tensor.allocator()->init(acp.bia_tensor_info);
-
-        // clang-format off
-        acl_obj_->conv.configure(
-            &acl_obj_->src_tensor,
-            &acl_obj_->wei_tensor,
-            acp.with_bias ? &acl_obj_->bia_tensor : nullptr,
-            &acl_obj_->dst_tensor,
-            acp.padstride_info,
-            1, // depth multiplier default value
-            acp.act_info,
-            acp.dilation_info);
-
-        // clang-format on
-        return status::success;
-    }
-
-    acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer> &get_acl_obj() const {
-        return *acl_obj_;
-    }
-
-    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_depthwise_convolution_resource_t);
-
-private:
-    std::unique_ptr<acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer>>
-            acl_obj_;
-};
-
 struct acl_depthwise_convolution_fwd_t : public primitive_t {
+
+    using Op = arm_compute::experimental::op::CpuDepthwiseConv2d;
 
     struct pd_t : public cpu_convolution_fwd_pd_t {
         pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
@@ -74,59 +38,17 @@ struct acl_depthwise_convolution_fwd_t : public primitive_t {
         DECLARE_COMMON_PD_T("depthwise_convolution:acl",
                 acl_depthwise_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
 
-        status_t init(engine_t *engine) {
-            using namespace data_type;
-
-            const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
-                    && attr()->has_default_values(
-                            primitive_attr_t::skip_mask_t::post_ops, f16);
-            const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
-                    && attr()->has_default_values(
-                            primitive_attr_t::skip_mask_t::post_ops, f32);
-            bool ok = is_fwd()
-                    && set_default_alg_kind(alg_kind::convolution_direct)
-                    && utils::one_of(true, is_fp16_ok, is_fp32_ok)
-                    && !has_zero_dim_memory();
-            if (!ok) return status::unimplemented;
-
-            CHECK(acl_convolution_utils::init_conf_depthwise(acp_, src_md_,
-                    weights_md_, dst_md_, bias_md_, *desc(), *attr()));
-
-            CHECK(post_ops.init(
-                    engine, attr_.post_ops_, dst_md_, acp_.act_info));
-            acp_.use_dst_acc_for_sum = post_ops.has_sum();
-
-            if (acp_.use_dst_acc_for_sum) {
-                const memory_desc_wrapper dst_d(&dst_md_);
-                auto scratchpad = scratchpad_registry().registrar();
-                scratchpad.book(memory_tracking::names::key_generic_acc,
-                        dst_d.nelems(), dst_d.data_type_size());
-            }
-
-            return status::success;
-        }
+        status_t init(engine_t *engine);
 
         acl_conv_conf_t acp_;
-
         acl_post_ops_t post_ops;
     };
 
-    acl_depthwise_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+    acl_depthwise_convolution_fwd_t(const pd_t *apd)
+        : primitive_t(apd), acl_obj_(std::make_unique<acl_obj_t<Op>>()) {}
 
     status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override {
-        if (mapper.has_resource(this)) return status::success;
-
-        auto r = utils::make_unique<acl_depthwise_convolution_resource_t>();
-        if (!r) return status::out_of_memory;
-
-        CHECK(r->configure(pd()->acp_));
-        mapper.add(this, std::move(r));
-
-        CHECK(pd()->post_ops.create_resource(engine, mapper));
-
-        return status::success;
-    }
+            engine_t *engine, resource_mapper_t &mapper) const override;
 
     typedef typename prec_traits<data_type::f32>::type data_t;
 
@@ -134,11 +56,12 @@ struct acl_depthwise_convolution_fwd_t : public primitive_t {
         return execute_forward(ctx);
     }
 
-private:
-    mutable std::mutex mtx;
-    status_t execute_forward(const exec_ctx_t &ctx) const;
+    status_t init(engine_t *engine) override;
 
+private:
+    status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::unique_ptr<acl_obj_t<Op>> acl_obj_;
 };
 
 } // namespace aarch64


### PR DESCRIPTION
- All common conv code is now stateless, so we can delete all legacy code.
- Coincidentally fixes #2033 by making the weights constant.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?