### PR TITLE
@snadampal as codeowner for AArch64

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -161,6 +161,7 @@ Team: @oneapi-src/onednn-cpu-aarch64
 | Crefeda Rodrigues  | @cfrod                | Arm Ltd           | Code Owner |
 | David Svantesson   | @davsva01             | Arm Ltd           | Code Owner |
 | Johnatan Deakin    | @jondea               | Arm Ltd           | Code Owner |
+| Sunita Nadampalli  | @snadampal            | Amazon.com, Inc.  | Code Owner |
 
 ### OpenPOWER (PPC64)
 


### PR DESCRIPTION
I would like to nominate Sunita Nadampalli @snadampal for the role of code owner of AArch64 component. Sunita has [history of contributions](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+author%3Asnadampal) to oneDNN and vested interest in quality of oneDNN support for AWS Graviton processors in Pytorch.
