### PR TITLE
generic: sycl: refactor how post op arguments are loaded

### DIFF
--- a/src/gpu/generic/sycl/convolution_kernels.hpp
+++ b/src/gpu/generic/sycl/convolution_kernels.hpp
@@ -208,12 +208,7 @@ struct convolution_kernel_fwd_t {
                     accumulator += bias;
                 }
 
-                auto dst = load_float_value(
-                        conf_.post_ops.sum_dt_ == dnnl_data_type_undef
-                                ? dst_md().data_type()
-                                : conf_.post_ops.sum_dt_,
-                        dst_ptr(), idx);
-                accumulator = conf_.post_ops.apply(accumulator, dst);
+                accumulator = conf_.post_ops.apply(accumulator, dst_, idx);
 
                 if (conf_.do_scale_dst) { accumulator /= sm_dst; }
                 if (conf_.use_dst_zeropoints) {
@@ -446,12 +441,7 @@ struct convolution_kernel_bwd_data_t {
                 accumulator += bias;
             }
 
-            auto diff_data = load_float_value(
-                    conf_.post_ops.sum_dt_ == dnnl_data_type_undef
-                            ? diff_data_md().data_type()
-                            : conf_.post_ops.sum_dt_,
-                    diff_data_ptr(), idx);
-            accumulator = conf_.post_ops.apply(accumulator, diff_data);
+            accumulator = conf_.post_ops.apply(accumulator, diff_data_, idx);
 
             if (conf_.do_scale_dst) { accumulator /= sm_dst; }
             if (conf_.use_dst_zeropoints) {

--- a/src/gpu/generic/sycl/ref_binary.cpp
+++ b/src/gpu/generic/sycl/ref_binary.cpp
@@ -52,15 +52,8 @@ status_t ref_binary_t::pd_t::init_conf() {
                 = conf_.src0_md.dims()[i] != 1 && conf_.src1_md.dims()[i] == 1;
     }
 
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
 
-    for (auto i = 0; i < conf_.post_ops.get_post_op(); ++i) {
-        const auto &e = attr()->post_ops_.entry_[i];
-        if (e.is_binary() || e.is_prelu()) {
-            conf_.binary_src_arr[i] = xpu::sycl::md_t(
-                    arg_md(DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-        }
-    }
     return status::success;
 }
 

--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -54,7 +54,7 @@ status_t ref_convolution_fwd_t::pd_t::init_conf() {
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
     conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
 
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
     conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
@@ -125,7 +125,7 @@ status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
     conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
 
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
     conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);

--- a/src/gpu/generic/sycl/ref_eltwise.cpp
+++ b/src/gpu/generic/sycl/ref_eltwise.cpp
@@ -43,11 +43,7 @@ status_t ref_sycl_eltwise_fwd_t::pd_t::init_conf() {
         return status::unimplemented;
     }
     conf_.post_po_len = attr()->post_ops_.len();
-    conf_.post_ops = sycl_post_ops_t(attr());
-
-    for (auto i = 0; i < conf_.post_po_len; ++i)
-        conf_.binary_src_arr[i] = xpu::sycl::md_t(
-                arg_md(DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
 
     const int block_size = conf_.block_size;
     const int wg_size = conf_.wg_size;

--- a/src/gpu/generic/sycl/ref_pooling.cpp
+++ b/src/gpu/generic/sycl/ref_pooling.cpp
@@ -70,13 +70,7 @@ status_t ref_pooling_fwd_t::pd_t::init_conf() {
         return dnnl_unimplemented;
     }
     conf_.po_len = attr_po.len();
-    for (auto i = 0; i < attr_po.len(); ++i) {
-        if (attr_po.contain(binary, i)) {
-            dnnl::impl::memory_desc_t mem = attr_po.entry_[i].binary.src1_desc;
-            conf_.src1_md[i] = xpu::sycl::md_t(&mem);
-        }
-    }
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
     return status::success;
 }
 

--- a/src/gpu/generic/sycl/ref_resampling.cpp
+++ b/src/gpu/generic/sycl/ref_resampling.cpp
@@ -50,12 +50,6 @@ status_t ref_resampling_fwd_t::pd_t::init_conf() {
     }
     conf_.po_len = attr_po.len();
 
-    for (auto i = 0; i < attr_po.len(); ++i) {
-        if (attr_po.contain(primitive_kind::binary, i)) {
-            dnnl::impl::memory_desc_t mem = attr_po.entry_[i].binary.src1_desc;
-            conf_.src1_md[i] = xpu::sycl::md_t(&mem);
-        }
-    }
     conf_.post_ops = sycl_post_ops_t(attr());
     return status::success;
 }

--- a/src/gpu/generic/sycl/ref_softmax.cpp
+++ b/src/gpu/generic/sycl/ref_softmax.cpp
@@ -42,16 +42,9 @@ status_t ref_sycl_softmax_fwd_t::pd_t::init_conf() {
     conf_.do_scale_dst
             = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
 
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
     conf_.po_len = attr()->post_ops_.len();
 
-    for (auto i = 0; i < conf_.post_ops.get_post_op(); ++i) {
-        const auto &e = attr()->post_ops_.entry_[i];
-        if (e.is_binary()) {
-            conf_.src1_md[i] = xpu::sycl::md_t(
-                    arg_md(DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-        }
-    }
     return status::success;
 }
 

--- a/src/gpu/generic/sycl/reorder_kernels.hpp
+++ b/src/gpu/generic/sycl/reorder_kernels.hpp
@@ -104,7 +104,6 @@ struct reorder_kernel_t {
 
                 int dst_idx = dst_md().off_v(off);
                 auto src = src_mem.load(idx);
-                auto dst = dst_mem.load(dst_idx);
 
                 if (conf_.do_scale_src) {
                     if (conf_.scale_src_mask != 0) {
@@ -124,7 +123,7 @@ struct reorder_kernel_t {
                 }
 
                 auto acc = src;
-                acc = conf_.post_ops.apply(acc, dst);
+                acc = conf_.post_ops.apply(acc, dst_, dst_idx);
                 if (conf_.do_scale_dst) {
                     if (conf_.scale_dst_mask != 0) {
                         int scale_idx = 0;

--- a/src/gpu/generic/sycl/sycl_io_helper.hpp
+++ b/src/gpu/generic/sycl/sycl_io_helper.hpp
@@ -235,6 +235,14 @@ struct memory_tensor_t {
         return load(md_.off_v(offsets));
     }
 
+    inline float load_md_bc(dims_t offsets) const {
+        dims_t offsets_masked;
+        for (int i = 0; i < xpu::sycl::md_t::max_dims; i++) {
+            offsets_masked[i] = md_.dims()[i] == 1 ? 0 : offsets[i];
+        }
+        return load(md_.off_v(offsets_masked));
+    }
+
     inline void store_md(float val, dims_t offsets) {
         store(val, md_.off_v(offsets));
     }

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -46,8 +46,6 @@ struct sycl_binary_conf_t {
     int wg_size;
     int wk_size;
 
-    xpu::sycl::md_t binary_src_arr[sycl_post_ops_t::max_post_ops];
-
     sycl_post_ops_t post_ops;
 };
 
@@ -105,7 +103,6 @@ struct sycl_eltwise_conf_t {
     dim_t wg_size;
     dim_t wk_size;
     dim_t post_po_len;
-    xpu::sycl::md_t binary_src_arr[sycl::sycl_post_ops_t::max_post_ops];
     sycl_post_ops_t post_ops;
 };
 
@@ -190,7 +187,6 @@ struct sycl_resampling_conf_t {
     size_t work_amount;
 
     xpu::sycl::md_t src_md;
-    xpu::sycl::md_t src1_md[sycl_post_ops_t::max_post_ops];
     xpu::sycl::md_t dst_md;
     xpu::sycl::md_t diff_src_md;
     xpu::sycl::md_t diff_dst_md;
@@ -293,7 +289,6 @@ struct sycl_batch_normalization_conf_t {
 struct sycl_softmax_conf_t {
     prop_kind_t prop_kind;
     xpu::sycl::md_t src_md;
-    xpu::sycl::md_t src1_md[sycl_post_ops_t::max_post_ops];
     xpu::sycl::md_t dst_md;
 
     xpu::sycl::md_t diff_md;
@@ -375,7 +370,6 @@ struct sycl_pooling_base_conf_t {
 
 struct sycl_pooling_fwd_conf_t : public sycl_pooling_base_conf_t {
     xpu::sycl::md_t src_md;
-    xpu::sycl::md_t src1_md[sycl_post_ops_t::max_post_ops];
     xpu::sycl::md_t dst_md;
     sycl_post_ops_t post_ops;
 };


### PR DESCRIPTION
Refactor where data for post ops is loaded. Instead of the kernel that supports post ops now post ops load any data they need. This has two benefits:
 - data is only loaded if actually used by post ops
 - code is simplified.