### PR TITLE
cpu: aarch64: remove calls to acl_post_ops_t::create_resource

### DIFF
--- a/src/cpu/aarch64/acl_batch_normalization.hpp
+++ b/src/cpu/aarch64/acl_batch_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022, 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -257,8 +257,6 @@ struct acl_batch_normalization_fwd_t : public primitive_t {
         // Configure the resource based on information from primitive descriptor
         CHECK(r->configure(pd()->abp, pd()));
         mapper.add(this, std::move(r));
-
-        CHECK(pd()->post_ops.create_resource(engine, mapper));
 
         return status::success;
     }

--- a/src/cpu/aarch64/acl_deconvolution.hpp
+++ b/src/cpu/aarch64/acl_deconvolution.hpp
@@ -85,8 +85,7 @@ struct acl_deconvolution_fwd_t : public primitive_t {
         pd_t(const deconvolution_desc_t *adesc, const primitive_attr_t *attr,
                 const deconvolution_fwd_pd_t *hint_fwd_pd)
             : cpu_deconvolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
-            , acl_pd_conf()
-            , post_ops() {}
+            , acl_pd_conf() {}
 
         DECLARE_COMMON_PD_T(
                 "acl", acl_deconvolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
@@ -328,8 +327,6 @@ struct acl_deconvolution_fwd_t : public primitive_t {
         // Configure the resource based on information from primitive descriptor
         auto st = r->configure(pd()->acl_pd_conf);
         if (st == status::success) { mapper.add(this, std::move(r)); }
-
-        CHECK(pd()->post_ops.create_resource(engine, mapper));
 
         return st;
     }

--- a/src/cpu/aarch64/acl_depthwise_convolution.cpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.cpp
@@ -22,6 +22,8 @@ namespace cpu {
 namespace aarch64 {
 
 namespace {
+using data_t = prec_traits<data_type::f32>::type;
+
 // Keys are anonymous. So deduce the type automagically.
 using conv_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);
 
@@ -73,12 +75,6 @@ status_t acl_depthwise_convolution_fwd_t::pd_t::init(engine_t *engine) {
     return init_scratchpad(conv, scratchpad, depthwise_conv_keys, engine,
             post_ops, attr_.post_ops_, acp_.act_info, acp_.use_dst_acc_for_sum,
             dst_md_);
-}
-
-status_t acl_depthwise_convolution_fwd_t::create_resource(
-        engine_t *engine, resource_mapper_t &mapper) const {
-    CHECK(pd()->post_ops.create_resource(engine, mapper));
-    return status::success;
 }
 
 status_t acl_depthwise_convolution_fwd_t::init(engine_t *engine) {

--- a/src/cpu/aarch64/acl_depthwise_convolution.hpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
@@ -47,11 +47,6 @@ struct acl_depthwise_convolution_fwd_t : public primitive_t {
     acl_depthwise_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd), acl_obj_(std::make_unique<acl_obj_t<Op>>()) {}
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override;
-
-    typedef typename prec_traits<data_type::f32>::type data_t;
-
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
     }

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -49,15 +49,6 @@ const std::map<int, conv_key_t> gemm_conv_keys
 
 template <data_type_t src_t, data_type_t wei_t, data_type_t dst_t,
         data_type_t bia_t>
-status_t
-acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::create_resource(
-        engine_t *engine, resource_mapper_t &mapper) const {
-    CHECK(pd()->post_ops.create_resource(engine, mapper));
-    return status::success;
-}
-
-template <data_type_t src_t, data_type_t wei_t, data_type_t dst_t,
-        data_type_t bia_t>
 status_t acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::pd_t::init(
         engine_t *engine) {
     using namespace data_type;

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -54,13 +54,10 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override;
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override;
-
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
-    typedef typename prec_traits<bia_type>::type bia_data_t;
+    using src_data_t = typename prec_traits<src_type>::type;
+    using wei_data_t = typename prec_traits<wei_type>::type;
+    using dst_data_t = typename prec_traits<dst_type>::type;
+    using bia_data_t = typename prec_traits<bia_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -25,6 +25,8 @@ namespace cpu {
 namespace aarch64 {
 
 namespace {
+using data_t = typename prec_traits<data_type::f32>::type;
+
 // Keys are anonymous. So deduce the type automagically.
 using conv_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);
 
@@ -50,13 +52,6 @@ status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
     return execute_forward_conv_acl<acl_obj_t<Op>, pd_t, data_t>(
             ctx, acl_obj_.get(), pd(), indirect_conv_keys);
-}
-
-status_t acl_indirect_gemm_convolution_fwd_t::create_resource(
-        engine_t *engine, resource_mapper_t &mapper) const {
-
-    CHECK(pd()->post_ops.create_resource(engine, mapper));
-    return status::success;
 }
 
 status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init_conf() {

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
@@ -52,12 +52,7 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
     acl_indirect_gemm_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd), acl_obj_(std::make_unique<acl_obj_t<Op>>()) {}
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override;
-
     status_t init(engine_t *engine) override;
-
-    using data_t = typename prec_traits<data_type::f32>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);

--- a/src/cpu/aarch64/acl_inner_product.hpp
+++ b/src/cpu/aarch64/acl_inner_product.hpp
@@ -317,8 +317,6 @@ struct acl_inner_product_fwd_t : public primitive_t {
         CHECK(r->configure(pd()->aip));
         mapper.add(this, std::move(r));
 
-        CHECK(pd()->post_ops.create_resource(engine, mapper));
-
         return status::success;
     }
 

--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -162,14 +162,6 @@ struct acl_post_ops_t {
 
     bool has_sum() const { return sum_index >= 0; }
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const {
-        for (const auto &post_op : post_op_primitives) {
-            CHECK(post_op->create_resource(engine, mapper));
-        }
-        return status::success;
-    }
-
     status_t execute(
             const exec_ctx_t &ctx, void *src, void *dst = nullptr) const;
 

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -24,6 +24,8 @@ namespace cpu {
 namespace aarch64 {
 
 namespace {
+using data_t = prec_traits<data_type::f32>::type;
+
 // Keys are anonymous. So deduce the type automagically.
 using conv_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);
 
@@ -74,12 +76,6 @@ status_t acl_wino_convolution_fwd_t::pd_t::init(engine_t *engine) {
     const auto aux_mem = conv.workspace();
     return init_scratchpad(conv, scratchpad, wino_conv_keys, engine, post_ops,
             attr_.post_ops_, acp_.act_info, acp_.use_dst_acc_for_sum, dst_md_);
-}
-
-status_t acl_wino_convolution_fwd_t::create_resource(
-        engine_t *engine, resource_mapper_t &mapper) const {
-    CHECK(pd()->post_ops.create_resource(engine, mapper));
-    return status::success;
 }
 
 status_t acl_wino_convolution_fwd_t::init(engine_t *engine) {

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -33,9 +33,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
     struct pd_t : public cpu_convolution_fwd_pd_t {
         pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
                 const typename pd_t::base_class *hint_fwd_pd)
-            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
-            , acp_()
-            , post_ops() {}
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), acp_() {}
 
         DECLARE_COMMON_PD_T(
                 "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
@@ -52,12 +50,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
     acl_wino_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd), acl_obj_(std::make_unique<acl_obj_t<Op>>()) {}
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override;
-
     status_t init(engine_t *engine) override;
-
-    typedef typename prec_traits<data_type::f32>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -224,8 +224,6 @@ status_t acl_lowp_matmul_t::create_resource(
 
     mapper.add(this, std::move(r));
 
-    CHECK(pd()->acl_post_ops.create_resource(engine, mapper));
-
     return status::success;
 }
 

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -24,6 +24,10 @@ namespace matmul {
 
 using namespace data_type;
 
+namespace {
+using data_t = prec_traits<data_type::f32>::type;
+} // namespace
+
 status_t acl_matmul_t::init(engine_t *engine) {
     auto amp_ = pd()->amp_;
     // Configure transpose kernel for src and wei

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -32,9 +32,7 @@ struct acl_matmul_t : public primitive_t {
 
         pd_t(const matmul_desc_t *adesc, const primitive_attr_t *attr,
                 const cpu_matmul_pd_t *hint_fwd_pd)
-            : cpu_matmul_pd_t(adesc, attr, hint_fwd_pd)
-            , amp_()
-            , acl_post_ops() {}
+            : cpu_matmul_pd_t(adesc, attr, hint_fwd_pd), amp_() {}
 
         using cpu_matmul_pd_t::cpu_matmul_pd_t;
 
@@ -56,17 +54,7 @@ struct acl_matmul_t : public primitive_t {
     acl_matmul_t(const pd_t *apd)
         : primitive_t(apd), acl_obj_(std::make_unique<acl_matmul_obj_t>()) {}
 
-    status_t create_resource(
-            engine_t *engine, resource_mapper_t &mapper) const override {
-
-        CHECK(pd()->acl_post_ops.create_resource(engine, mapper));
-
-        return status::success;
-    }
-
     status_t init(engine_t *engine) override;
-
-    typedef typename prec_traits<data_type::f32>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         if (pd()->weights_format_kind_ == format_kind::any) {


### PR DESCRIPTION
# Description
Elementwise and binary post-ops have been made stateless by previous patches to oneDNN and ACL. This patch removes the now redundant calls to create_resource for these operators.

Fixes: [this comment](https://github.com/oneapi-src/oneDNN/pull/2043#discussion_r1723733268) by @dzarukin 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?