### PR TITLE
cpu: aarch64: Fix Threadpool not initializing issue causing test to fail.

### DIFF
--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -92,11 +92,6 @@ status_t acl_matmul_t::pd_t::init(engine_t *engine) {
         CHECK(acl_matmul_utils::init_conf_matmul<true>(
                 amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
     } else {
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-        // to avoid seg. fault in case threadpool is enabled and its pointer is null
-        if (threadpool_utils::get_active_threadpool() == nullptr)
-            return status::unimplemented;
-#endif
         CHECK(acl_matmul_utils::init_conf_matmul<false>(
                 amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
     }


### PR DESCRIPTION
# Description

Test cpu-tutorials-matmul-matmul-quantization-cpp is failing due to Threadpool not being initialised. This patch fixes the issue by executing the task on a single thread when Threadpool is unavailable. It is a response to the comment made by @mgouicem [here](https://github.com/oneapi-src/oneDNN/pull/2047#discussion_r1724733775).

The error can be reproduced executing:

`DNNL_VERBOSE=1 ./examples/cpu-tutorials-matmul-matmul-quantization-cpp`

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?