### PR TITLE
cpu: aarch64: allow sbgemm config for matmul primitive

### DIFF
--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -82,13 +82,20 @@ status_t acl_matmul_t::pd_t::init(engine_t *engine) {
                       weights_md()->data_type)
             && utils::everyone_is(data_type::f32, dst_md()->data_type)
             && platform::has_data_type_support(data_type::bf16);
+    const bool is_fp32bf16fp32_ok
+            = (utils::everyone_is(data_type::f32, src_md()->data_type,
+                       dst_md()->data_type, desc()->accum_data_type)
+                    && platform::has_data_type_support(data_type::f32)
+                    && utils::everyone_is(
+                            data_type::bf16, weights_md()->data_type)
+                    && platform::has_data_type_support(data_type::bf16));
 
     // we need to save this state as it can change inside set_default_formats()
     weights_format_kind_ = weights_md_.format_kind;
 
     VDISPATCH_MATMUL(is_dense_format_kind(), VERBOSE_UNSUPPORTED_SPARSE_CFG);
     VDISPATCH_MATMUL(utils::one_of(true, is_fp32_ok, is_fp16_ok, is_bf16_ok,
-                             is_bf16f32_ok),
+                             is_bf16f32_ok, is_fp32bf16fp32_ok),
             VERBOSE_UNSUPPORTED_DT_CFG);
     VDISPATCH_MATMUL(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
     VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -84,11 +84,8 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
     } else {
         auto src_tag = memory_desc_matches_one_of_tag(
                 src_md, acdb, abcd, abdc, abc, acb, ab, ba);
-        auto wei_tag = memory_desc_matches_one_of_tag(
-                wei_md, acdb, abcd, abdc, abc, acb, ab, ba);
         auto dst_tag = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab);
-        ACL_CHECK_SUPPORT(
-                utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
+        ACL_CHECK_SUPPORT(utils::one_of(format_tag::undef, src_tag, dst_tag),
                 "Format tag is undefined");
     }
 

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -211,3 +211,10 @@
 
 # fp4
 --batch=test_matmul_fp4
+
+# Tests for external blocked weights layout.
+--reset
+--dt=f32
+--stag=ab --wtag=Ab8a --dtag=ab
+--attr-post-ops=mul:f32,relu,sum
+ 3x20:20x4n"postops+runtime_dims_2d"

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -218,3 +218,19 @@
 --stag=ab --wtag=Ab8a --dtag=ab
 --attr-post-ops=mul:f32,relu,sum
  3x20:20x4n"postops+runtime_dims_2d"
+
+# Tests for sbgemm scenario with any format
+--reset
+--dt=f32:bf16:f32
+--stag=ab --wtag=any --dtag=ab
+--attr-fpmath=bf16
+--attr-post-ops=mul:f32,relu,sum
+ 3x20:20x4n"postops+runtime_dims_2d"
+
+# Tests for sbgemm scenario with external blocked layout
+--reset
+--dt=f32:bf16:f32
+--stag=ab --wtag=Ba4b --dtag=ab
+--attr-fpmath=bf16
+--attr-post-ops=mul:f32,relu,sum
+ 3x20:20x4n"postops+runtime_dims_2d"


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

This is required to support precompiled graphs where the primitive gets created with the reordered (already reordered) weight tensors, so their formats are blocked and more custom.

1. allow additional blocked layout formats. 
2. use bfloat16 fast math kernels from openxla. 

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
ran `make test` and 
`./benchdnn --matmul --mode=P --engine=cpu --allow-enum-tags-only=0 --batch=inputs/matmul/test_matmul_ci`
- [ x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
