### PR TITLE
generic sycl: refactor kernel mainloops

### DIFF
--- a/src/gpu/generic/sycl/eltwise_kernels.hpp
+++ b/src/gpu/generic/sycl/eltwise_kernels.hpp
@@ -43,14 +43,6 @@ struct eltwise_fwd_kernel_vec_t {
         memory_tensor_t src_mem(src_, conf_.src_md);
         memory_tensor_t dst_mem(dst_, conf_.dst_md);
 
-        auto sg = item.get_sub_group();
-        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
-        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
-        size_t wi_offset_t = sg.get_local_id();
-        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
-
-        size_t base_idx = offset_t * conf_.block_size;
-
         auto operation = [&](dim_t &idx, dim_t &n, dim_t &c, dim_t &d, dim_t &h,
                                  dim_t &w) {
             dim_t src_offset = data_offset(src_mem.md(), n, c, d, h, w);
@@ -72,22 +64,20 @@ struct eltwise_fwd_kernel_vec_t {
             dst_mem.store(acc, src_offset);
         };
 
-        for (dim_t blk_idx = 0; blk_idx < conf_.block_size; blk_idx++) {
-            dim_t idx = base_idx + blk_idx;
-            if (idx < conf_.wk_size) {
-                dim_t N = conf_.mb;
-                dim_t C = conf_.c;
-                dim_t D = conf_.d;
-                dim_t H = conf_.h;
-                dim_t W = conf_.w;
+        for (dim_t idx = item.get_global_id(0); idx < conf_.wk_size;
+                idx += item.get_global_range(0)) {
+            dim_t N = conf_.mb;
+            dim_t C = conf_.c;
+            dim_t D = conf_.d;
+            dim_t H = conf_.h;
+            dim_t W = conf_.w;
 
-                dim_t n = (idx / (C * D * H * W)) % N;
-                dim_t c = (idx / (D * H * W)) % C;
-                dim_t d = (idx / (H * W)) % D;
-                dim_t h = (idx / (W)) % H;
-                dim_t w = (idx / (1)) % W;
-                operation(idx, n, c, d, h, w);
-            }
+            dim_t n = (idx / (C * D * H * W)) % N;
+            dim_t c = (idx / (D * H * W)) % C;
+            dim_t d = (idx / (H * W)) % D;
+            dim_t h = (idx / (W)) % H;
+            dim_t w = (idx / (1)) % W;
+            operation(idx, n, c, d, h, w);
         }
     }
 
@@ -221,23 +211,14 @@ struct eltwise_bwd_kernel_vec_t {
         memory_tensor_t diff_src_mem(diff_src_, conf_.diff_src_md);
         memory_tensor_t diff_dst_mem(diff_dst_, conf_.diff_dst_md);
 
-        auto sg = item.get_sub_group();
-        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
-        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
-        size_t wi_offset_t = sg.get_local_id();
-        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
-        size_t base_idx = offset_t * conf_.block_size;
+        for (dim_t idx = item.get_global_id(0); idx < conf_.wk_size;
+                idx += item.get_global_range(0)) {
+            auto diff_src = diff_src_mem.load(idx);
+            auto src = src_mem.load(idx);
 
-        for (dim_t i = 0; i < conf_.block_size; i++) {
-            dim_t idx = base_idx + i;
-            if (idx < conf_.wk_size) {
-                auto diff_src = diff_src_mem.load(idx);
-                auto src = src_mem.load(idx);
-
-                auto dst = compute_alg_n(
-                        diff_src, src, conf_.alpha, conf_.beta, conf_.alg_kind);
-                diff_dst_mem.store(dst, idx);
-            }
+            auto dst = compute_alg_n(
+                    diff_src, src, conf_.alpha, conf_.beta, conf_.alg_kind);
+            diff_dst_mem.store(dst, idx);
         }
     }
 

--- a/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
+++ b/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
@@ -47,14 +47,8 @@ struct layer_normalization_fwd_kernel_vec_t {
                   DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)) {}
 
     void operator()(::sycl::nd_item<1> item) const {
-        auto sg = item.get_sub_group();
-        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
-        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
-        size_t wi_offset_t = sg.get_local_id();
-        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
-        size_t base_idx = offset_t * conf_.block_size;
-        for (int i = 0; i < conf_.block_size; i++) {
-            dim_t idx = base_idx + i;
+        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+                idx += item.get_global_range(0)) {
             if (idx < conf_.N) { compute_alg_n(idx); }
         }
     }
@@ -146,15 +140,8 @@ struct layer_normalization_fwd_kernel_vec1_t {
                   DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)) {}
 
     void operator()(::sycl::nd_item<1> item) const {
-        auto sg = item.get_sub_group();
-        size_t wg_offset_t = item.get_group(0) * conf_.wg_size;
-        size_t sg_offset_t = sg.get_group_id()[0] * sg.get_local_range()[0];
-        size_t wi_offset_t = sg.get_local_id();
-        size_t offset_t = wg_offset_t + sg_offset_t + wi_offset_t;
-
-        size_t base_idx = offset_t * conf_.block_size;
-        for (int i = 0; i < conf_.block_size; i++) {
-            dim_t idx = base_idx + i;
+        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
+                idx += item.get_global_range(0)) {
             if (idx < conf_.N) { compute_alg_n(idx); }
         }
     }

--- a/src/gpu/generic/sycl/pooling_kernels.hpp
+++ b/src/gpu/generic/sycl/pooling_kernels.hpp
@@ -48,7 +48,7 @@ struct pooling_fwd_kernel_vec_t {
         memory_tensor_t src_mem(src_, conf_.src_md);
         memory_tensor_t dst_mem(dst_, conf_.dst_md);
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
         const bool is_max_pool = conf_.alg == alg_kind::pooling_max;
         float base_res = is_max_pool ? data_conv() : 0.f;
         dim_t MB = conf_.MB;
@@ -254,7 +254,7 @@ struct pooling_bwd_kernel_vec_t {
         memory_tensor_t diff_src_mem(diff_src_, conf_.diff_src_md);
         memory_tensor_t diff_dst_mem(diff_dst_, conf_.diff_dst_md);
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
         int denom = 1;
 
         const bool is_max_pool = conf_.alg == alg_kind::pooling_max;

--- a/src/gpu/generic/sycl/prelu_kernels.hpp
+++ b/src/gpu/generic/sycl/prelu_kernels.hpp
@@ -50,7 +50,7 @@ struct prelu_fwd_kernel_vec_t {
         memory_tensor_t weights_mem(weights_, conf_.weights_md);
         memory_tensor_t dst_mem(dst_, conf_.dst_md);
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
 
         const int mask = conf_.mask;
         const dim_t work_amount = conf_.work_amount;
@@ -172,7 +172,7 @@ struct prelu_bwd_kernel_vec_t {
         memory_plain_t scratchpad_mem(
                 scratchpad_, conf_.weights_md.data_type());
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
         switch (conf_.bcast_type) {
             case broadcasting_strategy_t::scalar:
                 calculate_scalar(data_mem, weights_mem, scratchpad_mem,
@@ -393,7 +393,7 @@ private:
             out_memory_tensor_t &diff_src_mem, size_t ith,
             ::sycl::nd_item<1> item) const {
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
         dims_t dims_d, dims_w;
         for (int i = 0; i < max_supported_ndims; i++) {
             dim_t data_dim_i = data_md().dims()[i];

--- a/src/gpu/generic/sycl/ref_binary.cpp
+++ b/src/gpu/generic/sycl/ref_binary.cpp
@@ -16,6 +16,7 @@
 
 #include "gpu/generic/sycl/ref_binary.hpp"
 #include "gpu/generic/sycl/binary_kernels.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -30,10 +31,6 @@ status_t ref_binary_t::pd_t::init_conf() {
     conf_.src1_md = xpu::sycl::md_t(src_md(1));
     conf_.dst_md = xpu::sycl::md_t(dst_md());
     conf_.ndims = ndims();
-
-    // XXX: should probably be tuned.
-    conf_.block_size = 16;
-    conf_.wg_size = 32;
 
     conf_.wk_size = memory_desc_wrapper(dst_md()).nelems();
 
@@ -70,15 +67,7 @@ status_t ref_binary_t::execute(const exec_ctx_t &ctx) const {
     parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         binary_kernel_vec_t binary_kernel(pd()->conf_, cgh, ctx);
 
-        const int block_size = pd()->conf_.block_size;
-        const int wg_size = pd()->conf_.wg_size;
-
-        const int t_work = pd()->conf_.wk_size;
-        const int wg_work = wg_size * block_size;
-        const int wg_cnt = utils::div_up(t_work, wg_work);
-
-        cgh.parallel_for(
-                ::sycl::nd_range<1>(wg_cnt * wg_size, wg_size), binary_kernel);
+        cgh.parallel_for(get_range(ctx, pd()->conf_.wk_size), binary_kernel);
     });
 
     return status::success;

--- a/src/gpu/generic/sycl/ref_deconvolution.cpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.cpp
@@ -16,6 +16,7 @@
 
 #include "gpu/generic/sycl/ref_deconvolution.hpp"
 #include "gpu/generic/sycl/convolution_kernels.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -63,10 +64,6 @@ status_t ref_deconvolution_bwd_weights_t::pd_t::init_conf() {
 
     conf_.diff_weights_md = xpu::sycl::md_t(&diff_weights_md_copy);
 
-    // XXX: should probably be tuned.
-    conf_.block_size = 16;
-    conf_.wg_size = 32;
-
     conf_.wk_size = memory_desc_wrapper(diff_weights_md()).nelems();
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
@@ -96,13 +93,8 @@ status_t ref_deconvolution_bwd_weights_t::execute(const exec_ctx_t &ctx) const {
         convolution_kernel_bwd_weights_t convolution_kernel(
                 pd()->conf_, cgh, ctx, DNNL_ARG_DIFF_DST, DNNL_ARG_SRC);
 
-        const int wg_size = pd()->conf_.wg_size;
-
-        const int t_work = pd()->conf_.wk_size;
-        const int wg_cnt = utils::div_up(t_work, wg_size);
-
-        cgh.parallel_for(::sycl::nd_range<1>(wg_cnt * wg_size, wg_size),
-                convolution_kernel);
+        cgh.parallel_for(
+                get_range(ctx, pd()->conf_.wk_size), convolution_kernel);
     });
 
     return status::success;

--- a/src/gpu/generic/sycl/ref_eltwise.hpp
+++ b/src/gpu/generic/sycl/ref_eltwise.hpp
@@ -59,7 +59,6 @@ struct ref_sycl_eltwise_fwd_t : public gpu::generic::sycl::primitive_t {
         }
 
         sycl_eltwise_conf_t conf_;
-        dim_t wg_thr;
 
     private:
         status_t init_conf();
@@ -114,7 +113,6 @@ struct ref_sycl_eltwise_bwd_t : public gpu::generic::sycl::primitive_t {
         }
 
         sycl_eltwise_conf_t conf_;
-        dim_t wg_thr;
 
     private:
         status_t init_conf();

--- a/src/gpu/generic/sycl/ref_softmax.cpp
+++ b/src/gpu/generic/sycl/ref_softmax.cpp
@@ -16,6 +16,7 @@
 
 #include "gpu/generic/sycl/ref_softmax.hpp"
 #include "gpu/generic/sycl/softmax_kernels.hpp"
+#include "gpu/generic/sycl/sycl_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -28,8 +29,6 @@ status_t ref_sycl_softmax_fwd_t::pd_t::init_conf() {
     conf_.src_md = xpu::sycl::md_t(src_md());
     conf_.dst_md = xpu::sycl::md_t(dst_md());
     conf_.alg_kind = desc()->alg_kind;
-    conf_.block_size = 16;
-    conf_.wg_size = 32;
     conf_.axis = axis();
     conf_.axis_size = axis_size(true);
     conf_.inner_size = inner_size();
@@ -55,18 +54,10 @@ status_t ref_sycl_softmax_fwd_t::init(impl::engine_t *engine) {
 
 status_t ref_sycl_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
-        const auto block_size = pd()->conf_.block_size;
-        const auto wg_size = pd()->conf_.wg_size;
-        const auto t_work = pd()->conf_.wk_size;
-        const auto wg_work = wg_size * block_size;
-        const auto wg_cnt = (t_work + wg_work - 1) / wg_work;
-        auto n_thr = wg_cnt * wg_size;
-        n_thr = n_thr < 1 ? 1 : n_thr;
-
         softmax_fwd_kernel_vec_t softmax_fwd_kernel_(pd()->conf_, cgh, ctx);
 
         cgh.parallel_for(
-                ::sycl::nd_range<1>(n_thr, wg_size), softmax_fwd_kernel_);
+                get_range(ctx, pd()->conf_.wk_size), softmax_fwd_kernel_);
     });
 }
 
@@ -76,8 +67,6 @@ status_t ref_sycl_softmax_bwd_t::pd_t::init_conf() {
     conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md());
     conf_.diff_src_md = xpu::sycl::md_t(diff_src_md());
     conf_.alg_kind = desc()->alg_kind;
-    conf_.block_size = 16;
-    conf_.wg_size = 32;
     conf_.axis = axis();
     conf_.axis_size = axis_size(true);
     conf_.inner_size = inner_size();
@@ -97,16 +86,8 @@ status_t ref_sycl_softmax_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
     return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         softmax_bwd_kernel_vec_t softmax_bwd_kernel(pd()->conf_, cgh, ctx);
 
-        const auto block_size = pd()->conf_.block_size;
-        const auto wg_size = pd()->conf_.wg_size;
-        const auto t_work = pd()->conf_.wk_size;
-        const auto wg_work = wg_size * block_size;
-        const auto wg_cnt = (t_work + wg_work - 1) / wg_work;
-        auto n_thr = wg_cnt * wg_size;
-        n_thr = n_thr < 1 ? 1 : n_thr;
-
         cgh.parallel_for(
-                ::sycl::nd_range<1>(n_thr, wg_size), softmax_bwd_kernel);
+                get_range(ctx, pd()->conf_.wk_size), softmax_bwd_kernel);
     });
 }
 

--- a/src/gpu/generic/sycl/resampling_kernels.hpp
+++ b/src/gpu/generic/sycl/resampling_kernels.hpp
@@ -45,7 +45,7 @@ struct resampling_kernel_fwd_vec_t {
         memory_tensor_t src_mem(src_, conf_.src_md);
         memory_tensor_t dst_mem(dst_, conf_.dst_md);
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
 
         const auto &src_ndims = conf_.src_md.ndims();
         const auto &src_dims = conf_.src_md.dims();
@@ -156,7 +156,7 @@ struct resampling_kernel_bwd_vec_t {
         memory_tensor_t diff_src_mem(diff_src_, conf_.diff_src_md);
         memory_tensor_t diff_dst_mem(diff_dst_, conf_.diff_dst_md);
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
 
         const auto &diff_src_ndims = conf_.diff_src_md.ndims();
         const auto &diff_src_dims = conf_.diff_src_md.dims();

--- a/src/gpu/generic/sycl/shuffle_kernels.hpp
+++ b/src/gpu/generic/sycl/shuffle_kernels.hpp
@@ -84,7 +84,7 @@ struct shuffle_kernel_vec2_t {
 
         const dim_t stride_mb = conf_.stride_m;
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
         dim_t sp_start {0}, sp_end {0};
         balance211(conf_.SP, conf_.nthr, ithr, sp_start, sp_end);
 
@@ -121,7 +121,7 @@ struct shuffle_kernel_vec3_t {
         memory_tensor_t data_mem(data_, conf_.src_md);
         memory_tensor_t dst_mem(dst_, conf_.dst_md);
 
-        size_t ithr = item.get_group(0) * conf_.wg_size + item.get_local_id();
+        size_t ithr = item.get_global_id(0);
         const dim_t outer_size = conf_.outer_size;
         const dim_t inner_size = conf_.inner_size;
         const dim_t dim = conf_.axis_size * inner_size;

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -42,8 +42,6 @@ struct sycl_binary_conf_t {
     int ndims;
     bool is_tensor_op;
 
-    int block_size;
-    int wg_size;
     int wk_size;
 
     sycl_post_ops_t post_ops;
@@ -75,8 +73,6 @@ struct sycl_convolution_conf_t {
 
     int ndims;
 
-    int block_size;
-    int wg_size;
     int wk_size;
     bool has_groups;
 
@@ -99,8 +95,6 @@ struct sycl_eltwise_conf_t {
     dim_t d;
     dim_t h;
     dim_t w;
-    dim_t block_size;
-    dim_t wg_size;
     dim_t wk_size;
     dim_t post_po_len;
     sycl_post_ops_t post_ops;
@@ -204,8 +198,6 @@ struct sycl_reorder_conf_t {
 
     int ndims;
 
-    int block_size;
-    int wg_size;
     int wk_size;
 
     sycl_post_ops_t post_ops;
@@ -326,8 +318,6 @@ struct sycl_softmax_conf_t {
     xpu::sycl::md_t diff_src_md;
     xpu::sycl::md_t diff_dst_md;
     alg_kind_t alg_kind;
-    dim_t block_size;
-    dim_t wg_size;
     dim_t wk_size;
 
     int po_len;
@@ -363,8 +353,6 @@ struct sycl_lrn_conf_t {
     float beta;
     float k;
 
-    int block_size;
-    int wg_size;
     int wk_size;
 };
 
@@ -413,8 +401,6 @@ struct sycl_sum_conf_t {
     xpu::sycl::md_t dst_md;
     float src_scales[DNNL_REF_SUM_MAX_NUM_TENSORS];
     int n;
-    int block_size;
-    int wg_size;
     int wk_size;
 };
 


### PR DESCRIPTION
Refactors mainloops in many sycl kernels so that consecutive workitems work on consecutive calculations. This should improve performace on Nvidia and AMD GPUs, as coalesced memory transfers can be used in more cases. The amount of duplicated code is also reduced.

This PR should be easier to review with hiding of whitespace changes, as in many places there is difference only in indentation levels.