### PR TITLE
gpu: generic: sycl: lnorm Intel GPU precision issues

### DIFF
--- a/src/gpu/generic/sycl/ref_batch_normalization.cpp
+++ b/src/gpu/generic/sycl/ref_batch_normalization.cpp
@@ -84,9 +84,13 @@ status_t ref_batch_normalization_fwd_t::init(impl::engine_t *engine) {
                 = ::sycl::get_kernel_id<batch_normalization_fwd_kernel_vec_t>();
         CHECK(create_kernel(engine, kid, &kernel_));
     } else {
+        // Enabling the IEEE div compliant implementation
+        setenv("SYCL_PROGRAM_COMPILE_OPTIONS",
+                "-cl-fp32-correctly-rounded-divide-sqrt", 1);
         const auto kid = ::sycl::get_kernel_id<
                 batch_normalization_fwd_kernel_vec_t1>();
         CHECK(create_kernel(engine, kid, &kernel_));
+        unsetenv("SYCL_PROGRAM_COMPILE_OPTIONS");
     }
     return status::success;
 }

--- a/src/gpu/generic/sycl/ref_layer_normalizations.cpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.cpp
@@ -82,9 +82,13 @@ status_t ref_layer_normalization_fwd_t::init(impl::engine_t *engine) {
                 = ::sycl::get_kernel_id<layer_normalization_fwd_kernel_vec_t>();
         CHECK(create_kernel(engine, kid, &kernel_));
     } else {
+        // Enabling the IEEE div compliant implementation
+        setenv("SYCL_PROGRAM_COMPILE_OPTIONS",
+                "-cl-fp32-correctly-rounded-divide-sqrt", 1);
         const auto kid = ::sycl::get_kernel_id<
                 layer_normalization_fwd_kernel_vec1_t>();
         CHECK(create_kernel(engine, kid, &kernel_));
+        unsetenv("SYCL_PROGRAM_COMPILE_OPTIONS");
     }
     return status::success;
 }


### PR DESCRIPTION
# Description

When used in Intel PVC, the layer normalization SYCL kernel implementation faces some precision issues in variance computation.

```bash
create: --lnorm --engine=gpu --inplace=true 30x300
run: --lnorm --engine=gpu --inplace=true 30x300
[   0][VAR][0] exp_f32:   0.0202823 exp:   0.0202823 got:   0.0202823 diff:1.86265e-09 rdiff:9.1836e-08
[   1][VAR][1] exp_f32:   0.0804944 exp:   0.0804944 got:   0.0804944 diff:7.45058e-09 rdiff:9.25603e-08
[   2][VAR][2] exp_f32:    0.327062 exp:    0.327062 got:    0.327062 diff:2.98023e-08 rdiff:9.11213e-08
[   6][VAR][6] exp_f32:     82.4779 exp:     82.4779 got:     82.4779 diff:7.62939e-06 rdiff:9.25023e-08
[  17][VAR][17] exp_f32:      1.3052 exp:      1.3052 got:      1.3052 diff:1.19209e-07 rdiff:9.1334e-08
[  22][VAR][22] exp_f32:   0.0829537 exp:   0.0829537 got:   0.0829537 diff:7.45058e-09 rdiff:8.98161e-08
[  23][VAR][23] exp_f32:    0.324289 exp:    0.324289 got:    0.324289 diff:2.98023e-08 rdiff:9.19006e-08
[  29][VAR][29] exp_f32:   0.0822034 exp:   0.0822034 got:   0.0822034 diff:7.45058e-09 rdiff:9.0636e-08
[COMPARE_STATS][VAR]: trh=0 err_max_diff:7.62939e-06 err_max_rdiff:9.25603e-08 all_max_diff:7.62939e-06 all_max_rdiff:9.25603e-08
0:FAILED (errors:8 total:9060) __REPRO: --lnorm --engine=gpu --inplace=true 30x300
```

```bash
[  14][VAR][14] exp_f32: 2.68618e-05 exp: 2.68618e-05 got: 2.68618e-05 diff:1.81899e-12 rdiff:6.77165e-08
[COMPARE_STATS][VAR]: trh=0 err_max_diff:1.81899e-12 err_max_rdiff:6.77165e-08 all_max_diff:1.81899e-12 all_max_rdiff:6.77165e-08
8471:FAILED (errors:1 total:75) __REPRO: --lnorm --engine=gpu --dt=f32:bf16 --tag=axb --stat_tag=abx --flags=CH 15x3_n"lnorm_ci_0d:0"
```

The previous are just a couple of failing examples.

As a proposal, the variance threshold is modified to pass the failing tests.