### PR TITLE
tests: Run convolution_format_any on GPU

### DIFF
--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -129,5 +129,7 @@ TEST_P(conv_any_fmt_test_float, TestsConvolutionAnyFmt) {}
 
 CPU_INSTANTIATE_TEST_SUITE_P(TestConvolutionAlexnetAnyFmtForward,
         conv_any_fmt_test_float, ::testing::Values(ALEXNET_SUITE(BLK)));
+GPU_INSTANTIATE_TEST_SUITE_P(TestConvolutionAlexnetAnyFmtForward,
+        conv_any_fmt_test_float, ::testing::Values(ALEXNET_SUITE(BLK)));
 #endif
 } // namespace dnnl


### PR DESCRIPTION
Prevents a spurious Success result when GPU support is not available.

---

I'm not terribly familiar with gtest, if there's a more idiomatic way to run the test on both engine types I'm happy to do that instead. One way to reproduce the issue is to set `OCL_ICD_VENDORS=/dev/null` and verify that `clinfo -l` shows no platforms or devices before running the test.