### PR TITLE
xpu/ocl: Minor generic-vendor fixes

### DIFF
--- a/src/xpu/ocl/engine_factory.hpp
+++ b/src/xpu/ocl/engine_factory.hpp
@@ -46,7 +46,7 @@ public:
         std::vector<cl_device_id> ocl_devices;
         status_t status
                 = xpu::ocl::get_devices(&ocl_devices, CL_DEVICE_TYPE_GPU);
-        if (status != status::success) return status;
+        if (status != status::success) return 0;
         return ocl_devices.size();
     }
 

--- a/src/xpu/ocl/utils.cpp
+++ b/src/xpu/ocl/utils.cpp
@@ -190,7 +190,7 @@ static bool is_intel_platform(cl_platform_id platform) {
 }
 
 status_t get_devices(std::vector<cl_device_id> *devices,
-        cl_device_type device_type, cl_uint vendor_id /* = 0x8086 */) {
+        cl_device_type device_type) {
     cl_uint num_platforms = 0;
 
     cl_int err = clGetPlatformIDs(0, nullptr, &num_platforms);
@@ -218,12 +218,8 @@ status_t get_devices(std::vector<cl_device_id> *devices,
             OCL_CHECK(clGetDeviceIDs(platforms[i], device_type, num_devices,
                     &plat_devices[0], nullptr));
 
-            // Use the devices for the requested vendor only.
             for (size_t j = 0; j < plat_devices.size(); ++j) {
-                cl_uint v_id;
-                OCL_CHECK(clGetDeviceInfo(plat_devices[j], CL_DEVICE_VENDOR_ID,
-                        sizeof(cl_uint), &v_id, nullptr));
-                if (v_id == vendor_id) { devices->push_back(plat_devices[j]); }
+                devices->push_back(plat_devices[j]);
             }
         }
     }

--- a/src/xpu/ocl/utils.cpp
+++ b/src/xpu/ocl/utils.cpp
@@ -202,8 +202,6 @@ status_t get_devices(std::vector<cl_device_id> *devices,
     OCL_CHECK(clGetPlatformIDs(num_platforms, &platforms[0], nullptr));
 
     for (size_t i = 0; i < platforms.size(); ++i) {
-        if (!is_intel_platform(platforms[i])) continue;
-
         cl_uint num_devices = 0;
         cl_int err = clGetDeviceIDs(
                 platforms[i], device_type, 0, nullptr, &num_devices);

--- a/src/xpu/ocl/utils.cpp
+++ b/src/xpu/ocl/utils.cpp
@@ -194,8 +194,7 @@ status_t get_devices(std::vector<cl_device_id> *devices,
     cl_uint num_platforms = 0;
 
     cl_int err = clGetPlatformIDs(0, nullptr, &num_platforms);
-    // No platforms - a valid scenario
-    if (err == CL_PLATFORM_NOT_FOUND_KHR) return status::success;
+    if (err == CL_PLATFORM_NOT_FOUND_KHR) return status::runtime_error;
 
     OCL_CHECK(err);
 
@@ -228,8 +227,11 @@ status_t get_devices(std::vector<cl_device_id> *devices,
             }
         }
     }
-    // No devices found but still return success
-    return status::success;
+
+    if (devices->size() != 0)
+        return status::success;
+
+    return status::runtime_error;
 }
 
 status_t get_devices(std::vector<cl_device_id> *devices,

--- a/src/xpu/ocl/utils.hpp
+++ b/src/xpu/ocl/utils.hpp
@@ -273,7 +273,7 @@ private:
 std::string get_kernel_name(cl_kernel kernel);
 
 status_t get_devices(std::vector<cl_device_id> *devices,
-        cl_device_type device_type, cl_uint vendor_id = 0x8086);
+        cl_device_type device_type);
 
 status_t get_devices(std::vector<cl_device_id> *devices,
         std::vector<wrapper_t<cl_device_id>> *sub_devices,


### PR DESCRIPTION
First one was found by inspection. Second one is still a bugfix but also a bikeshed: do you want to bake the error cases into the return code or not? I went for treating errors as errors, which means if the OpenCL runtime produces zero devices then that's an empty success. In practice I don't think this is much different but the existing thing was hard to justify.

The last two are arguably behavior changes but they remove vendor invariants from generic code and should not change behavior for the `DNNL_VENDOR_INTEL` build. The `DNNL_VENDOR_GENERIC` build will get closer to initializing though, and since it already doesn't work that seems like progress.