### PR TITLE
cpu: x64: brgemm: use range-based loop

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -1007,8 +1007,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
 
             align(64);
             L(jmp_table_base);
-            for (int m_i = 0; m_i < m_blocks; ++m_i) {
-                putL(jmp_table_labels[m_i]);
+            for (const auto &label : jmp_table_labels) {
+                putL(label);
             }
         }
 


### PR DESCRIPTION
The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by @eelenberg and @jweese. This PR replaces an iteration-based for loop over `jmp_table_labels` with a range-based for loop, which removes an unnecessary indexing variable, improves readability, and reduces potential off-by-one errors.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

