### PR TITLE
cpu: {x64,aarch64}: fix debug verbose output

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -2726,9 +2726,10 @@ static void prb_thread_kernel_balance(
 
     if (want_borrow_ker_from_drv || want_borrow_drv_from_ker) {
         DEBUG({
-            printf("split: ");
-            prb_dump(prb);
-            printf("ndims_ker_max = %d\n", ndims_ker_max);
+            verbose_printf(
+                    verbose_t::debuginfo, "split: %s\n", prb_dump(prb).c_str());
+            verbose_printf(verbose_t::debuginfo, "ndims_ker_max = %d\n",
+                    ndims_ker_max);
         });
     }
 }
@@ -2793,8 +2794,8 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
 
     prb_block_for_cache(prb);
     DEBUG({
-        printf("cache: ");
-        prb_dump(prb);
+        verbose_printf(
+                verbose_t::debuginfo, "cache: %s\n", prb_dump(prb).c_str());
     });
 
     int ndims_ker_max {};
@@ -2813,8 +2814,8 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
         return status::unimplemented;
 
     DEBUG({
-        printf("ker  : ");
-        prb_dump(ker_desc.prb);
+        verbose_printf(verbose_t::debuginfo, "ker  : %s\n",
+                prb_dump(ker_desc.prb).c_str());
     });
 
     auto _pd = make_unique_pd<pd_t>(
@@ -3023,12 +3024,12 @@ void jit_uni_reorder_t::omp_driver(const char *in, char *out,
     out += pd()->prb_.ooff * data_type_size(pd()->prb_.otype);
 
     DEBUG({
-        printf("prb : ");
-        tr::prb_dump(pd()->prb_);
+        verbose_printf(verbose_t::debuginfo, "prb : %s\n",
+                tr::prb_dump(pd()->prb_).c_str());
     });
     DEBUG({
-        printf("ker : ");
-        tr::prb_dump(pd()->ker_desc_.prb);
+        verbose_printf(verbose_t::debuginfo, "ker : %s\n",
+                tr::prb_dump(pd()->ker_desc_.prb).c_str());
     });
 
     int ndims = pd()->prb_.ndims;
@@ -3232,8 +3233,8 @@ status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
 
     prb_tile_normalize(prb);
     DEBUG({
-        printf("tile : ");
-        prb_dump(prb);
+        verbose_printf(
+                verbose_t::debuginfo, "tile : %s\n", prb_dump(prb).c_str());
     });
 
     if (!tr::jit_single_blk_kernel_t::applicable(prb)) {

--- a/src/cpu/aarch64/jit_uni_reorder.hpp
+++ b/src/cpu/aarch64/jit_uni_reorder.hpp
@@ -149,8 +149,8 @@ void prb_node_swap(prb_t &p, int d0, int d1);
  * to the right if d0 > d1 */
 void prb_node_move(prb_t &p, int d0, int d1);
 
-/** dumps the problem to stdout */
-void prb_dump(const prb_t &p);
+/** dumps the problem to a string */
+std::string prb_dump(const prb_t &p);
 
 struct call_param_t {
     const void *in = nullptr;

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -2505,8 +2505,8 @@ static void prb_thread_kernel_balance(
 
     if (want_borrow_ker_from_drv || want_borrow_drv_from_ker) {
         DEBUG({
-            verbose_printf(verbose_t::debuginfo, "split: ");
-            prb_dump(prb);
+            verbose_printf(
+                    verbose_t::debuginfo, "split: %s\n", prb_dump(prb).c_str());
             verbose_printf(verbose_t::debuginfo, "ndims_ker_max = %d\n",
                     ndims_ker_max);
         });
@@ -2573,8 +2573,8 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
 
     prb_block_for_cache(prb);
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "cache: ");
-        prb_dump(prb);
+        verbose_printf(
+                verbose_t::debuginfo, "cache: %s\n", prb_dump(prb).c_str());
     });
 
     int ndims_ker_max {};
@@ -2593,8 +2593,8 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
             VERBOSE_BAD_NDIMS, "driver", ndims_driver);
 
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "ker  : ");
-        prb_dump(ker_desc.prb);
+        verbose_printf(verbose_t::debuginfo, "ker  : %s\n",
+                prb_dump(ker_desc.prb).c_str());
     });
 
     auto _pd = make_unique_pd<pd_t>(
@@ -2803,12 +2803,12 @@ void jit_uni_reorder_t::omp_driver(const char *in, char *out,
     out += pd()->prb_.ooff * data_type_size(pd()->prb_.otype);
 
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "prb  : ");
-        tr::prb_dump(pd()->prb_);
+        verbose_printf(verbose_t::debuginfo, "prb  : %s\n",
+                tr::prb_dump(pd()->prb_).c_str());
     });
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "ker  : ");
-        tr::prb_dump(pd()->ker_desc_.prb);
+        verbose_printf(verbose_t::debuginfo, "ker  : %s\n",
+                tr::prb_dump(pd()->ker_desc_.prb).c_str());
     });
 
     int ndims = pd()->prb_.ndims;
@@ -3004,8 +3004,8 @@ status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
 
     prb_tile_normalize(prb);
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "tile : ");
-        prb_dump(prb);
+        verbose_printf(
+                verbose_t::debuginfo, "tile : %s\n", prb_dump(prb).c_str());
     });
 
     if (!tr::jit_single_blk_kernel_t::applicable(prb)) {

--- a/src/cpu/x64/jit_uni_reorder.hpp
+++ b/src/cpu/x64/jit_uni_reorder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2023 Intel Corporation
+* Copyright 2018-2024 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -147,8 +147,8 @@ void prb_node_swap(prb_t &p, int d0, int d1);
  * to the right if d0 > d1 */
 void prb_node_move(prb_t &p, int d0, int d1);
 
-/** dumps the problem to stdout */
-void prb_dump(const prb_t &p);
+/** dumps the problem to a string */
+std::string prb_dump(const prb_t &p);
 
 struct call_param_t {
     const void *in = nullptr;

--- a/src/cpu/x64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/x64/jit_uni_reorder_utils.cpp
@@ -428,14 +428,14 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
     p.beta = sum_idx == -1 ? 0.f : attr->post_ops_.entry_[sum_idx].sum.scale;
 
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "init : ");
-        prb_dump(p);
+        verbose_printf(
+                verbose_t::debuginfo, "init : %s\n", prb_dump(p).c_str());
     });
 
     prb_normalize(p);
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "norm : ");
-        prb_dump(p);
+        verbose_printf(
+                verbose_t::debuginfo, "norm : %s\n", prb_dump(p).c_str());
     });
 
     // compensation strides require prb_normalized
@@ -443,8 +443,8 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
     prb_simplify(p);
     DEBUG({
-        verbose_printf(verbose_t::debuginfo, "smpl : ");
-        prb_dump(p);
+        verbose_printf(
+                verbose_t::debuginfo, "smpl : %s\n", prb_dump(p).c_str());
     });
 
     return success;
@@ -596,19 +596,20 @@ void prb_node_move(prb_t &p, int d0, int d1) {
     p.nodes[d1] = node;
 }
 
-void prb_dump(const prb_t &p) {
-    verbose_printf(verbose_t::debuginfo, "@@@ type:%s:%s ndims:%d ",
-            dnnl_dt2str(p.itype), dnnl_dt2str(p.otype), p.ndims);
+std::string prb_dump(const prb_t &p) {
+    std::stringstream ss;
+    ss << "@@@ type:" << dnnl_dt2str(p.itype) << ':' << dnnl_dt2str(p.otype)
+       << " ndims:" << p.ndims;
     for (int d = 0; d < p.ndims; ++d) {
-        if (d != 0) verbose_printf(verbose_t::debuginfo, "x");
-        verbose_printf(verbose_t::debuginfo,
-                "[%zu:%zu:%d:%d:%s:%td:%td:%td:%td]", p.nodes[d].n,
-                p.nodes[d].tail_size, p.nodes[d].dim_id,
-                p.nodes[d].parent_node_id,
-                p.nodes[d].is_zero_pad_needed ? "true" : "false", p.nodes[d].is,
-                p.nodes[d].os, p.nodes[d].ss, p.nodes[d].cs);
+        if (d != 0) ss << 'x';
+        const auto &node = p.nodes[d];
+        ss << '[' << node.n << ':' << node.tail_size << ':' << node.dim_id
+           << ':' << node.parent_node_id << ':'
+           << (node.is_zero_pad_needed ? "true" : "false") << ':' << node.is
+           << ':' << node.os << ':' << node.ss << ':' << node.cs << ']';
     }
-    verbose_printf(verbose_t::debuginfo, " off:%zu:%zu\n", p.ioff, p.ooff);
+    ss << " off:" << p.ioff << ':' << p.ooff;
+    return ss.str();
 }
 
 } // namespace tr


### PR DESCRIPTION
Overuse of `verbose_printf` has led to verbose output like
```
onednn_verbose,v1,init : onednn_verbose,v1,@@@ type:f32:f32 ndims:3 onednn_verbose,v1,[1:0:0:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:1:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:2:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
onednn_verbose,v1,norm : onednn_verbose,v1,@@@ type:f32:f32 ndims:3 onednn_verbose,v1,[1:0:0:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:1:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:2:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
onednn_verbose,v1,smpl : onednn_verbose,v1,@@@ type:f32:f32 ndims:1 onednn_verbose,v1,[1:0:-1:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
onednn_verbose,v1,tile : onednn_verbose,v1,@@@ type:f32:f32 ndims:1 onednn_verbose,v1,[1:0:-1:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
onednn_verbose,v1,init : onednn_verbose,v1,@@@ type:f32:f32 ndims:3 onednn_verbose,v1,[1:0:0:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:1:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:2:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
onednn_verbose,v1,norm : onednn_verbose,v1,@@@ type:f32:f32 ndims:3 onednn_verbose,v1,[1:0:0:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:1:-1:false:1:1:0:0]onednn_verbose,v1,xonednn_verbose,v1,[1:0:2:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
onednn_verbose,v1,smpl : onednn_verbose,v1,@@@ type:f32:f32 ndims:1 onednn_verbose,v1,[1:0:-1:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
onednn_verbose,v1,cache: onednn_verbose,v1,@@@ type:f32:f32 ndims:1 onednn_verbose,v1,[1:0:-1:-1:false:1:1:0:0]onednn_verbose,v1, off:0:0
```
with a lot of extraneous `onednn_verbose,v1,`s. This PR corrects this and updates the aarch64 debug output to match.

- [x] Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally for each commit?
- [x] Have you formatted the code using clang-format?