### PR TITLE
cmake: skip DEPENDENTLOADFLAG for mingw

### DIFF
--- a/cmake/SDL.cmake
+++ b/cmake/SDL.cmake
@@ -96,7 +96,7 @@ elseif(MSVC AND ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 # Windows setting. The following cmake flags change the search order so that 
 # DLLs are loaded from the current working directory only if it is under a path 
 # in the Safe Load List.
-if(WIN32)
+if(WIN32 AND NOT MINGW)
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         # add Clang++ specific flags
         append(CMAKE_EXE_LINKER_FLAGS "-Xlinker /DEPENDENTLOADFLAG:0x2000")


### PR DESCRIPTION
Adds a CMAKE code check for GNU on Windows systems, which should mean mingw, and then does not apply the non-existent /DEPENDENTLOADFLAG:0x2000 flag that fails on mingw

Added as part of the fix for  #2092