### PR TITLE
cpu: aarch64: injectors: Improve performance of tanh for block size 16

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -476,8 +476,86 @@ void jit_uni_eltwise_injector_f32<isa>::elu_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
+void jit_uni_eltwise_injector_f32<
+        isa>::tanh_polynomial_approx_compute_vector_fwd(const TRegS &vmm_src) {
+
+    if (!utils::one_of(isa, sve_512)) return;
+
+    using namespace Xbyak_aarch64::util;
+
+    const int tanh_n_polynomials = 32;
+
+    // Register mapping
+    TRegS vmm_dst = vmm_aux1, vmm_src_shift = vmm_aux1, vmm_coeff = vmm_aux1,
+          vmm_pol = vmm_aux2, vmm_indices = vmm_aux3, vmm_tmp = vmm_aux3,
+          vmm_src_pos = vmm_aux4, vmm_sign = vmm_aux4;
+
+    const auto &mask = PReg(6); // avoid pred regs used in *conv_kernel*
+
+    // Helper function to gather polynomial coefficients
+    auto gather_coefficient = [&](TRegS vmm_coeff, int coeff_idx,
+                                      TRegS vmm_pol_idx) {
+        h->add_imm(h->X_TMP_1, x_table,
+                table_off(tanh_pol_table, coeff_idx * tanh_n_polynomials),
+                h->X_TMP_0);
+        h->ld1w(ZRegS(IDX(vmm_coeff)), p_all,
+                ptr(h->X_TMP_1, ZRegS(IDX(vmm_pol_idx)), SXTW));
+    };
+
+    // because tanh(x) = -tanh(-x), we extract sign to make x postive
+    // and reapply sign at the end
+    h->fabs(vmm_src_pos, p_all / T_z, vmm_src);
+
+    // Compute indices for the table lookup
+    h->sub(ZRegS(IDX(vmm_indices)), ZRegS(IDX(vmm_src_pos)),
+            ZRegS(IDX(table_val(tanh_idx_bias, z_tmp))));
+    h->and_(ZRegD(IDX(vmm_indices)), ZRegD(IDX(vmm_indices)),
+            ZRegD(IDX(table_val(tanh_idx_mask, z_tmp))));
+    h->lsr(ZRegD(IDX(vmm_indices)), ZRegD(IDX(vmm_indices)), 20);
+
+    // Argument reduction
+    h->and_(ZRegD(IDX(vmm_src_shift)), ZRegD(IDX(vmm_src_pos)),
+            ZRegD(IDX(table_val(tanh_idx_mask, z_tmp))));
+    h->fsub(vmm_src_pos, vmm_src_pos, ZRegS(IDX(vmm_src_shift)));
+
+    gather_coefficient(vmm_pol, 6, vmm_indices);
+    for (int deg = 5; deg >= 0; --deg) {
+        gather_coefficient(vmm_coeff, deg, vmm_indices);
+        h->fmad(vmm_pol, p_all / T_m, vmm_src_pos, vmm_coeff);
+    }
+
+    // Restore src_pos
+    h->fabs(vmm_src_pos, p_all / T_z, vmm_src);
+
+    // Now Blend the results
+    // [saturation_ubound; +inf] : return +/- 1
+    table_val(one, vmm_dst);
+
+    // [linear_ubound; saturation_lbound] :  return +/- P(x)
+    table_val(tanh_saturation_lbound, vmm_tmp);
+    h->fcmgt(PRegS(IDX(mask)), p_all / T_z, vmm_tmp, vmm_src_pos);
+    h->sel(vmm_dst, mask / T_m, vmm_pol, vmm_dst);
+
+    // [0; linear_ubound]  :  return x
+    table_val(tanh_linear_ubound, vmm_tmp);
+    h->fcmgt(PRegS(IDX(mask)), p_all / T_z, vmm_tmp, vmm_src_pos);
+    h->sel(vmm_dst, mask / T_m, vmm_src_pos, vmm_dst);
+
+    // Reapply sign and return
+    h->and_(ZRegD(IDX(vmm_sign)), ZRegD(IDX(vmm_src)),
+            ZRegD(IDX(table_val(sign_mask, z_tmp))));
+    h->eor(ZRegD(IDX(vmm_src)), ZRegD(IDX(vmm_dst)), ZRegD(IDX(vmm_sign)));
+}
+
+template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_f32<isa>::tanh_compute_vector_fwd(
         const TRegS &vmm_src) {
+
+    if (utils::one_of(isa, sve_512)) {
+        tanh_polynomial_approx_compute_vector_fwd(vmm_src);
+        return;
+    }
+
     // tanh(x) = x(1 + (-1/3)x^2) for |x| < tanh_range
     // tanh(x) = 1 - 2/(1 + exp(2 x)) for otherwise
 
@@ -1734,9 +1812,248 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
             {bwd_mish_max_x_for_equation_f, {0x41b17217, true}}};
 
     // tanh(x) constants for four interval approximation
-    static const table_t tanh_consts {
-            {tanh_range, {0x3d4ccccd, true}},
+    // and for polynomial approximation
+    static const table_t tanh_consts {{tanh_range, {0x3d4ccccd, true}},
             {tanh_m1d3, {0xbeaaaaab, true}},
+            {tanh_idx_bias, {0x39800000, true}},
+            {tanh_idx_mask, {0xffc00000, true}},
+            {tanh_linear_ubound, {0x39ddb3d7, true}},
+            {tanh_saturation_lbound, {0x41102cb3, true}}};
+
+    // tanh(x) polynomial approximation
+    // For each coefficient, there is 32 entries
+    static const table_t tanh_polynomial_table {
+            // coefficients of degree 0
+            {tanh_pol_table, {0x00000000, false}},
+            {tanh_pol_table, {0x39bfffff, false}},
+            {tanh_pol_table, {0x39ffffff, false}},
+            {tanh_pol_table, {0x3a3ffffe, false}},
+            {tanh_pol_table, {0x3a7ffffb, false}},
+            {tanh_pol_table, {0x3abffff7, false}},
+            {tanh_pol_table, {0x3affffeb, false}},
+            {tanh_pol_table, {0x3b3fffdc, false}},
+            {tanh_pol_table, {0x3b7fffab, false}},
+            {tanh_pol_table, {0x3bbfff70, false}},
+            {tanh_pol_table, {0x3bfffeab, false}},
+            {tanh_pol_table, {0x3c3ffdc0, false}},
+            {tanh_pol_table, {0x3c7ffaab, false}},
+            {tanh_pol_table, {0x3cbff701, false}},
+            {tanh_pol_table, {0x3cffeaad, false}},
+            {tanh_pol_table, {0x3d3fdc08, false}},
+            {tanh_pol_table, {0x3d7faacd, false}},
+            {tanh_pol_table, {0x3dbf7081, false}},
+            {tanh_pol_table, {0x3dfeacc9, false}},
+            {tanh_pol_table, {0x3e3dc7fd, false}},
+            {tanh_pol_table, {0x3e7acbf5, false}},
+            {tanh_pol_table, {0x3eb77a9f, false}},
+            {tanh_pol_table, {0x3eec9a9f, false}},
+            {tanh_pol_table, {0x3f22991f, false}},
+            {tanh_pol_table, {0x3f42f7d6, false}},
+            {tanh_pol_table, {0x3f67b7cc, false}},
+            {tanh_pol_table, {0x3f76ca83, false}},
+            {tanh_pol_table, {0x3f7ebbe9, false}},
+            {tanh_pol_table, {0x3f7fd40c, false}},
+            {tanh_pol_table, {0x3f7fff32, false}},
+            {tanh_pol_table, {0x3f7ffffc, false}},
+            {tanh_pol_table, {0x3f800000, false}},
+            // coefficients of degree 1
+            {tanh_pol_table, {0x3f800000, false}},
+            {tanh_pol_table, {0x3f800018, false}},
+            {tanh_pol_table, {0x3f7fffe8, false}},
+            {tanh_pol_table, {0x3f7fffda, false}},
+            {tanh_pol_table, {0x3f7fffdc, false}},
+            {tanh_pol_table, {0x3f7fffdc, false}},
+            {tanh_pol_table, {0x3f7fffac, false}},
+            {tanh_pol_table, {0x3f7fff70, false}},
+            {tanh_pol_table, {0x3f7ffeec, false}},
+            {tanh_pol_table, {0x3f7ffdc0, false}},
+            {tanh_pol_table, {0x3f7ffbed, false}},
+            {tanh_pol_table, {0x3f7ff704, false}},
+            {tanh_pol_table, {0x3f7feff5, false}},
+            {tanh_pol_table, {0x3f7fdbca, false}},
+            {tanh_pol_table, {0x3f7fbfff, false}},
+            {tanh_pol_table, {0x3f7f7041, false}},
+            {tanh_pol_table, {0x3f7f009b, false}},
+            {tanh_pol_table, {0x3f7dc36c, false}},
+            {tanh_pol_table, {0x3f7c0aa8, false}},
+            {tanh_pol_table, {0x3f7734b8, false}},
+            {tanh_pol_table, {0x3f70a4de, false}},
+            {tanh_pol_table, {0x3f5f1fd8, false}},
+            {tanh_pol_table, {0x3f495493, false}},
+            {tanh_pol_table, {0x3f18b9ec, false}},
+            {tanh_pol_table, {0x3ed706cb, false}},
+            {tanh_pol_table, {0x3e390b06, false}},
+            {tanh_pol_table, {0x3d90b11f, false}},
+            {tanh_pol_table, {0x3c21a053, false}},
+            {tanh_pol_table, {0x3aaf7fdb, false}},
+            {tanh_pol_table, {0x37ccc1a3, false}},
+            {tanh_pol_table, {0x355c6733, false}},
+            {tanh_pol_table, {0x00000000, false}},
+            // coefficients of degree 2
+            {tanh_pol_table, {0x00000000, false}},
+            {tanh_pol_table, {0xbe4e0ff1, false}},
+            {tanh_pol_table, {0x3d25b1b1, false}},
+            {tanh_pol_table, {0x3d6b6dab, false}},
+            {tanh_pol_table, {0x3c9fb1d5, false}},
+            {tanh_pol_table, {0xbabff06f, false}},
+            {tanh_pol_table, {0x3c07b3f6, false}},
+            {tanh_pol_table, {0xbb3fc1bc, false}},
+            {tanh_pol_table, {0x3a9f5921, false}},
+            {tanh_pol_table, {0xbbbf06f2, false}},
+            {tanh_pol_table, {0xbbb0f402, false}},
+            {tanh_pol_table, {0xbc47db9e, false}},
+            {tanh_pol_table, {0xbc73d5e7, false}},
+            {tanh_pol_table, {0xbca25bda, false}},
+            {tanh_pol_table, {0xbcfca780, false}},
+            {tanh_pol_table, {0xbd40e07c, false}},
+            {tanh_pol_table, {0xbd7dab03, false}},
+            {tanh_pol_table, {0xbdbe4a0f, false}},
+            {tanh_pol_table, {0xbdfb14a5, false}},
+            {tanh_pol_table, {0xbe36cc8d, false}},
+            {tanh_pol_table, {0xbe6bd102, false}},
+            {tanh_pol_table, {0xbe9fe7c5, false}},
+            {tanh_pol_table, {0xbeba0f10, false}},
+            {tanh_pol_table, {0xbec206a8, false}},
+            {tanh_pol_table, {0xbea3c388, false}},
+            {tanh_pol_table, {0xbe277d62, false}},
+            {tanh_pol_table, {0xbd8b7960, false}},
+            {tanh_pol_table, {0xbc209f49, false}},
+            {tanh_pol_table, {0xbaad44ca, false}},
+            {tanh_pol_table, {0xb7c6eeac, false}},
+            {tanh_pol_table, {0xb663aa41, false}},
+            {tanh_pol_table, {0x00000000, false}},
+            // coefficients of degree 3
+            {tanh_pol_table, {0x00000000, false}},
+            {tanh_pol_table, {0x45b3ae96, false}},
+            {tanh_pol_table, {0xc414eb20, false}},
+            {tanh_pol_table, {0xc450e02e, false}},
+            {tanh_pol_table, {0xc3152b4e, false}},
+            {tanh_pol_table, {0xbead2f56, false}},
+            {tanh_pol_table, {0xc2162e02, false}},
+            {tanh_pol_table, {0xbeb4bd5a, false}},
+            {tanh_pol_table, {0xc11a59a4, false}},
+            {tanh_pol_table, {0xbed2f507, false}},
+            {tanh_pol_table, {0xc020d32c, false}},
+            {tanh_pol_table, {0x3dd0f506, false}},
+            {tanh_pol_table, {0xbf2a75e2, false}},
+            {tanh_pol_table, {0xbff950e3, false}},
+            {tanh_pol_table, {0xbed47334, false}},
+            {tanh_pol_table, {0xbe809b8c, false}},
+            {tanh_pol_table, {0xbeb64532, false}},
+            {tanh_pol_table, {0xbe961a5b, false}},
+            {tanh_pol_table, {0xbe9b63ac, false}},
+            {tanh_pol_table, {0xbea0d4b2, false}},
+            {tanh_pol_table, {0xbe828a77, false}},
+            {tanh_pol_table, {0xbe378612, false}},
+            {tanh_pol_table, {0xbdc20908, false}},
+            {tanh_pol_table, {0x3d2d3957, false}},
+            {tanh_pol_table, {0x3dd46e89, false}},
+            {tanh_pol_table, {0x3db3f629, false}},
+            {tanh_pol_table, {0x3d2c5e7b, false}},
+            {tanh_pol_table, {0x3bd20403, false}},
+            {tanh_pol_table, {0x3a59dfae, false}},
+            {tanh_pol_table, {0x3770af45, false}},
+            {tanh_pol_table, {0x372cc014, false}},
+            {tanh_pol_table, {0x00000000, false}},
+            // coefficients of degree 4
+            {tanh_pol_table, {0x00000000, false}},
+            {tanh_pol_table, {0xcc981a1b, false}},
+            {tanh_pol_table, {0x4a7edd3d, false}},
+            {tanh_pol_table, {0x4ab1007c, false}},
+            {tanh_pol_table, {0x48fedd9c, false}},
+            {tanh_pol_table, {0x41a557b5, false}},
+            {tanh_pol_table, {0x477ee32a, false}},
+            {tanh_pol_table, {0x422557f5, false}},
+            {tanh_pol_table, {0x45ff3ce4, false}},
+            {tanh_pol_table, {0x42a55641, false}},
+            {tanh_pol_table, {0x446e0867, false}},
+            {tanh_pol_table, {0xc33dc19a, false}},
+            {tanh_pol_table, {0x42915214, false}},
+            {tanh_pol_table, {0x43af4fad, false}},
+            {tanh_pol_table, {0x4110fe88, false}},
+            {tanh_pol_table, {0xc1099b75, false}},
+            {tanh_pol_table, {0x3fc8a8dc, false}},
+            {tanh_pol_table, {0xbfbeaef5, false}},
+            {tanh_pol_table, {0xbe365aad, false}},
+            {tanh_pol_table, {0x3f4d9652, false}},
+            {tanh_pol_table, {0x3ddfa08f, false}},
+            {tanh_pol_table, {0x3e34e9b8, false}},
+            {tanh_pol_table, {0x3e2d07a6, false}},
+            {tanh_pol_table, {0x3dc63567, false}},
+            {tanh_pol_table, {0x3cdaeb78, false}},
+            {tanh_pol_table, {0xbcd17537, false}},
+            {tanh_pol_table, {0xbc92829c, false}},
+            {tanh_pol_table, {0xbb43ab99, false}},
+            {tanh_pol_table, {0xb9b471dd, false}},
+            {tanh_pol_table, {0xb6baad5a, false}},
+            {tanh_pol_table, {0xb78bafc7, false}},
+            {tanh_pol_table, {0x00000000, false}},
+            // coefficients of degree 5
+            {tanh_pol_table, {0x00000000, false}},
+            {tanh_pol_table, {0x52f688d5, false}},
+            {tanh_pol_table, {0xd0505c72, false}},
+            {tanh_pol_table, {0xd08f98e3, false}},
+            {tanh_pol_table, {0xce505cc9, false}},
+            {tanh_pol_table, {0xc7162b8a, false}},
+            {tanh_pol_table, {0xcc5061d6, false}},
+            {tanh_pol_table, {0xc7162bdf, false}},
+            {tanh_pol_table, {0xca50b37f, false}},
+            {tanh_pol_table, {0xc7162a3a, false}},
+            {tanh_pol_table, {0xc8422086, false}},
+            {tanh_pol_table, {0x471a714e, false}},
+            {tanh_pol_table, {0xc5ece1f1, false}},
+            {tanh_pol_table, {0xc70e3d90, false}},
+            {tanh_pol_table, {0xc3eba94a, false}},
+            {tanh_pol_table, {0x43e0c424, false}},
+            {tanh_pol_table, {0xc21f4552, false}},
+            {tanh_pol_table, {0x42217cc8, false}},
+            {tanh_pol_table, {0x405e7dc4, false}},
+            {tanh_pol_table, {0xc10dd401, false}},
+            {tanh_pol_table, {0x3e96b602, false}},
+            {tanh_pol_table, {0xbd1a6d2f, false}},
+            {tanh_pol_table, {0xbd393883, false}},
+            {tanh_pol_table, {0xbd674682, false}},
+            {tanh_pol_table, {0xbd310016, false}},
+            {tanh_pol_table, {0xb961e269, false}},
+            {tanh_pol_table, {0x3ba32495, false}},
+            {tanh_pol_table, {0x3a7680d5, false}},
+            {tanh_pol_table, {0x38b3173c, false}},
+            {tanh_pol_table, {0x35a9deea, false}},
+            {tanh_pol_table, {0x375c3f2a, false}},
+            {tanh_pol_table, {0x00000000, false}},
+            // coefficients of degree 6
+            {tanh_pol_table, {0x00000000, false}},
+            {tanh_pol_table, {0xd8995ed1, false}},
+            {tanh_pol_table, {0x558285ea, false}},
+            {tanh_pol_table, {0x55b2cd69, false}},
+            {tanh_pol_table, {0x53028625, false}},
+            {tanh_pol_table, {0x4bc9991f, false}},
+            {tanh_pol_table, {0x5082898a, false}},
+            {tanh_pol_table, {0x4b4999b3, false}},
+            {tanh_pol_table, {0x4e02c07c, false}},
+            {tanh_pol_table, {0x4ac99764, false}},
+            {tanh_pol_table, {0x4b72c822, false}},
+            {tanh_pol_table, {0xca40c0e1, false}},
+            {tanh_pol_table, {0x489413e4, false}},
+            {tanh_pol_table, {0x49b12224, false}},
+            {tanh_pol_table, {0x46134c4e, false}},
+            {tanh_pol_table, {0xc60c2d57, false}},
+            {tanh_pol_table, {0x43c83910, false}},
+            {tanh_pol_table, {0xc3c872d1, false}},
+            {tanh_pol_table, {0xc186bc9e, false}},
+            {tanh_pol_table, {0x42325bc3, false}},
+            {tanh_pol_table, {0xbf2ffa4a, false}},
+            {tanh_pol_table, {0x3d9a203c, false}},
+            {tanh_pol_table, {0xbc545a43, false}},
+            {tanh_pol_table, {0xbae08fee, false}},
+            {tanh_pol_table, {0x3c80225d, false}},
+            {tanh_pol_table, {0x3b1fd1df, false}},
+            {tanh_pol_table, {0xba36b9d1, false}},
+            {tanh_pol_table, {0xb91de544, false}},
+            {tanh_pol_table, {0xb71f100f, false}},
+            {tanh_pol_table, {0xb408e2ed, false}},
+            {tanh_pol_table, {0xb685fec8, false}},
+            {tanh_pol_table, {0x00000000, false}},
     };
 
     // soft_relu(x) constants
@@ -2061,6 +2378,7 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
     if (need.exp()) push_entries_of(exp_consts2);
     if (need.mish()) push_entries_of(mish_consts);
     if (need.tanh()) push_entries_of(tanh_consts);
+    if (need.tanh()) push_entries_of(tanh_polynomial_table);
     if (need.soft_relu()) push_entries_of(soft_relu_consts);
     if (need.soft_relu()) push_entries_of(soft_relu_polynomial);
     if (need.gelu_tanh()) push_entries_of(gelu_tanh_consts);

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -215,6 +215,7 @@ private:
     void relu_zero_ns_compute_vector_fwd(const TRegS &vmm_src);
     void elu_compute_vector_fwd(const TRegS &vmm_src);
     void tanh_compute_vector_fwd(const TRegS &vmm_src);
+    void tanh_polynomial_approx_compute_vector_fwd(const TRegS &vmm_src);
     void square_compute_vector_fwd(const TRegS &vmm_src);
     void abs_compute_vector_fwd(const TRegS &vmm_src);
     void sqrt_compute_vector_fwd(const TRegS &vmm_src);
@@ -277,6 +278,11 @@ private:
         bwd_mish_max_x_for_equation_f,
         tanh_range, // tanh(x) = x - x^3/3 for |x| < tanh_range
         tanh_m1d3, // -1/3
+        tanh_idx_bias, // bias applied during index computation
+        tanh_idx_mask, // mask applied to extract index
+        tanh_linear_ubound, // arg below which tanh(x) = x
+        tanh_saturation_lbound, // arg after which tanh(x) = 1.f
+        tanh_pol_table, // table of polynomial coefficients
         soft_relu_one_twenty_six, // 126.f
         soft_relu_mantissa_sign_mask, // mask for mantissa bits and sign
         soft_relu_pol, // see correspondent table for float values


### PR DESCRIPTION
# Description
Performance Improvement:  Eltwise Tanh performance improvement for block size 16

Major Code changes:
• Added a new function tanh_polynomial_approx_compute_vector_fwd(const TRegS &vmm_src) for
computing tanh.
• Added new tanh constants and polynomial constants table.

# Checklist

## General
All the tests are carried on A64FX machine which has block size 16:
- [✓] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? 
1. `make test`
```
95% tests passed, 11 tests failed out of 200
Total Test time (real) = 3790.05 sec
The following tests FAILED:
	 55 - test_convolution_backward_data_f32 (Subprocess aborted)
	123 - test_graph_c_api_compile_parametrized_usm_cpu (Failed)
	153 - test_graph_unit_dnnl_conv_usm_cpu (Failed)
	157 - test_graph_unit_dnnl_group_norm_usm_cpu (Failed)
	159 - test_graph_unit_dnnl_large_partition_usm_cpu (Failed)
	160 - test_graph_unit_dnnl_layer_norm_usm_cpu (Failed)
	161 - test_graph_unit_dnnl_matmul_usm_cpu (Failed)
	162 - test_graph_unit_dnnl_mqa_decomp_usm_cpu (Failed)
	163 - test_graph_unit_dnnl_pool_usm_cpu (Failed)
	168 - test_graph_unit_dnnl_sdp_decomp_usm_cpu (Failed)
	169 - test_graph_unit_dnnl_softmax_usm_cpu (Failed)
Errors while running CTest
Output from these tests are in: /home/vishwas/oneDNN/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8
```
2. `./benchdnn --eltwise --batch=inputs/eltwise/test_eltwise_all`
```
tests:75713 passed:6771 skipped:68907 mistrusted:35 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 125.07s; fill: 29.31s (23%); compute_ref: 15.50s (12%); compare: 27.88s (22%);
```
3. `make test_benchdnn_*`
 ```
make: *** No rule to make target 'test_benchdnn_*'.  Stop.
``` 
 ### gtests
4. `./test_eltwise` 
 ```
----------] Global test environment tear-down
[==========] 44 tests from 5 test suites ran. (2752 ms total)
[  PASSED  ] 24 tests.
[  SKIPPED ] 20 tests, listed below:
[  SKIPPED ] Test_Eltwise_EF/eltwise_test_t.TestsEltwise/4
[  SKIPPED ] Test_Eltwise_EF/eltwise_test_t.TestsEltwise/5
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/0
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/1
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/2
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/3
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/4
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/5
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/6
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/7
[  SKIPPED ] EltwiseSimpleBF16/eltwise_test_t.TestsEltwise/8
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/0
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/1
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/2
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/3
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/4
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/5
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/6
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/7
[  SKIPPED ] EltwiseSimpleF16/eltwise_test_t.TestsEltwise/8

 ```
   **Note:** All above results are same with and without the code changes.
- [✓] Have you formatted the code using clang-format? - Yes

## Performance improvements
- [✓ ] Have you submitted performance data that demonstrates performance improvements?
![image](https://github.com/user-attachments/assets/59c32fce-405d-4309-aca9-acb6c737d6f1)
![image](https://github.com/user-attachments/assets/087b4114-0b2a-4b65-a920-de8a1e3878a4)
