### PR TITLE
build: aarch64: skip -fcf-protection=full on arm64

### DIFF
--- a/cmake/SDL.cmake
+++ b/cmake/SDL.cmake
@@ -1,6 +1,7 @@
 #===============================================================================
 # Copyright 2017-2024 Intel Corporation
 # Copyright 2021 FUJITSU LIMITED
+# Copyright 2024 Arm Ltd. and affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +42,10 @@ macro(sdl_gnu_common_ccxx_flags var)
             append(${var} "-fstack-protector-strong")
         endif()
     endif()
-    if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0))
+    # -fcf-protection=full is an x86 specific option and needs to skipped for
+    # other configurations.
+    if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0) AND
+        (CMAKE_SYSTEM_PROCESSOR MATCHES "i686|x86_64"))
         append(${var} "-fcf-protection=full")
     endif()
 endmacro()


### PR DESCRIPTION
The `-fcf-protection=full` option fails to compile on aarch64 with the error: `'-fcf-protection=full' is not supported for this target`. This patch skips this option for this configuration.

# Description

The recent change implemented by 07765d3a3986b68cf7adaca38f4a221e0bc95935 has broken GCC builds on aarch64 with the previously mentioned error. This patch sidesteps this flag on aarch64.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?