### PR TITLE
gpu: generic: sycl: reorder: sum post-ops issues

### DIFF
--- a/src/gpu/generic/sycl/ref_reorder.cpp
+++ b/src/gpu/generic/sycl/ref_reorder.cpp
@@ -41,7 +41,7 @@ status_t ref_reorder_t::pd_t::init_conf() {
     conf_.do_scale_dst
             = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
     conf_.scale_dst_mask = attr()->scales_.get(DNNL_ARG_DST).mask_;
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
 
     return status::success;
 }


### PR DESCRIPTION
# Description

Some benchdnn cases were failing.

```bash
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,2x16x3x4,0.158936
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,2x16x3x4,0.166992
onednn_verbose,v1,primitive,exec,gpu,reorder,dpcpp:ref:any,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,attr-scales:src0:2:f32 attr-post-ops:sum:0.5,,2x16x3x4,0.233887
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,2x16x3x4,0.216064
[   0][DST][0:0:0:0] exp_f32: 1.25829e+07 exp: 1.25829e+07 got:         nan diff:     nan rdiff:     nan
[   1][DST][0:0:0:1] exp_f32:-1.25829e+07 exp:-1.25829e+07 got:         nan diff:     nan rdiff:     nan
[   2][DST][0:0:0:2] exp_f32:           0 exp:           0 got:         nan diff:     nan rdiff:     nan
[   3][DST][0:0:0:3] exp_f32:      0.1875 exp:      0.1875 got:         nan diff:     nan rdiff:     nan
[   4][DST][0:0:1:0] exp_f32:       0.375 exp:       0.375 got:         nan diff:     nan rdiff:     nan
[   5][DST][0:0:1:1] exp_f32:        0.75 exp:        0.75 got:         nan diff:     nan rdiff:     nan
[   6][DST][0:0:1:2] exp_f32:       1.125 exp:       1.125 got:         nan diff:     nan rdiff:     nan
[   7][DST][0:0:1:3] exp_f32:         1.5 exp:         1.5 got:         nan diff:     nan rdiff:     nan
[   8][DST][0:0:2:0] exp_f32:          12 exp:          12 got:         nan diff:     nan rdiff:     nan
[   9][DST][0:0:2:1] exp_f32:          48 exp:          48 got:         nan diff:     nan rdiff:     nan
[COMPARE_STATS][DST]: trh=0 err_max_diff:     nan err_max_rdiff:     nan all_max_diff:     nan all_max_rdiff:     nan
1555:FAILED (errors:384 total:384) __REPRO: --reorder --engine=gpu --allow-enum-tags-only=false --sdt=f32 --ddt=f32 --stag=abx --dtag=abx --attr-scales=src:per_dim_1 --attr-post-ops=sum:0.5 2x16x3x4
```
The issue was because the destination datatype was not correctly set. This PR fixes the problem.
