### PR TITLE
Enable macos build in ci

### DIFF
--- a/.github/automation/get_acl.sh
+++ b/.github/automation/get_acl.sh
@@ -1,0 +1,95 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+set -o errexit -o pipefail -o noclobber
+
+WORKSPACE=${GITHUB_WORKSPACE:-$(pwd)}
+echo "github workspace $GITHUB_WORKSPACE"
+
+os_type=$(uname)
+
+ACL_WITH_ASSERTS=${ACL_WITH_ASSERTS:-0}
+ACL_VERSION=${ACL_VERSION:-v24.08.1}
+
+if [[ "$os_type" == "Linux" ]]; then
+  echo "This machine is running Linux"
+  ARCHIVE="arm_compute-${ACL_VERSION}-linux-aarch64-cpu-bin.tar.gz"
+elif [[ "$os_type" == "Darwin" ]]; then
+  echo "This machine is running macOS"
+  ARCHIVE="arm_compute-${ACL_VERSION}-macos-aarch64-cpu-bin.tar.gz"
+else
+  echo "Unknown OS: $os_type"
+  exit 1
+fi
+
+# Set version and root directory
+export ACL_ROOT_DIR="${WORKSPACE}/ComputeLibrary"
+
+echo "ACL_VERSION: ${ACL_VERSION}"
+echo "ACL_DIR_NAME: ${ACL_DIR_NAME}"
+echo "ACL_ROOT_DIR: ${ACL_ROOT_DIR}"
+echo "ACL_WITH_ASSERTS: ${ACL_WITH_ASSERTS}"
+
+# Download the specified Compute Library version
+if [[ ! -f $ARCHIVE ]]; then
+  ACL_URL="https://github.com/ARM-software/ComputeLibrary/releases/download/${ACL_VERSION}/${ARCHIVE}"
+  echo "Downloading ACL from ${ACL_URL}"
+  wget ${ACL_URL}
+else
+  echo "$ARCHIVE already exists, skipping download."
+fi
+
+# Function to find the appropriate lib directory
+find_acl_lib_dir() {
+  local dirs=("$ACL_ROOT_DIR"/lib/*/)
+  local selected_dir=""
+
+  # Select directory based on build type
+  for dir in "${dirs[@]}"; do
+    if [[ $ACL_WITH_ASSERTS == 1 ]]; then
+      [[ "$dir" == *"-asserts/" ]] && selected_dir="$dir" && break
+    else
+      [[ "$dir" != *"-asserts/" ]] && selected_dir="$dir" && break
+    fi
+  done
+
+  # Return result or exit if not found
+  if [[ -z "$selected_dir" ]]; then
+    echo "No matching ACL lib directory found."
+    exit 1
+  else
+    echo "$selected_dir"
+  fi
+}
+
+# Extract the tarball if not already extracted
+if [[ ! -d $ACL_ROOT_DIR ]]; then
+  mkdir -p $ACL_ROOT_DIR
+  tar -xzvf "${ARCHIVE}" -C $ACL_ROOT_DIR --strip-components=1 >/dev/null 2>&1
+else
+  echo "$ACL_ROOT_DIR directory already exists, skipping extraction."
+fi
+
+# Find the ACL library directory
+ACL_LIB_DIR=$(find_acl_lib_dir)
+echo "Using ACL lib from ${ACL_LIB_DIR}"
+echo "cp contents from ${ACL_LIB_DIR} to ${ACL_ROOT_DIR}/lib"
+cp -rf "$ACL_LIB_DIR"* "$ACL_ROOT_DIR/lib/"
+
+echo "${ACL_VERSION}" >"${ACL_ROOT_DIR}/arm_compute/arm_compute_version.embed"

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -1,0 +1,100 @@
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+name: "CI AArch64"
+
+#* To avoid duplicate jobs running when both push and PR is satisfied, we use this:
+#* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+#* Stop stale workflows when pull requests are updated: https://stackoverflow.com/a/70972844
+#* Does not apply to the main branch.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  macos:
+    name: macOS
+    runs-on: macos-14
+    strategy:
+      matrix:
+        compiler: [
+          {CC: clang, CXX: clang++},
+          {CC: gcc-14, CXX: g++-14}
+        ]
+        config: [
+          {CMAKE_BUILD_TYPE: Debug, ACL_WITH_ASSERTS: '1'},
+          {CMAKE_BUILD_TYPE: Release, ACL_WITH_ASSERTS: '0'}
+        ]
+    steps:
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v2
+        id: cpu-cores
+      - name: Checkout oneDNN
+        uses: actions/checkout@v4
+        with:
+          path: oneDNN
+      # ACL is built with clang, so we can link with it directly if we are using
+      # clang as well.
+      - if: matrix.compiler.CC == 'clang'
+        name: Download and Extract ACL
+        run: ${{ github.workspace }}/oneDNN/.github/automation/get_acl.sh
+        env:
+          ACL_WITH_ASSERTS: ${{ matrix.config.ACL_WITH_ASSERTS }}
+          ACL_VERSION: ${{ github.event.inputs.ACL_VERSION || 'v24.08.1' }}
+      # If we are building with gcc, we need to clone and build ACL ourselves to
+      # link properly.
+      - if: contains( matrix.compiler.CC , 'gcc' )
+        name: Install Scons
+        uses: threeal/pipx-install-action@v1.0.0
+        with:
+          packages: scons
+      - if: contains( matrix.compiler.CC , 'gcc' )
+        name: Checkout ACL
+        uses: actions/checkout@v4
+        with:
+          repository: ARM-software/ComputeLibrary
+          ref: 'v24.08.1'
+          path: ComputeLibrary
+      - if: contains( matrix.compiler.CC , 'gcc' )
+        name: Build ACL
+        working-directory: ${{ github.workspace }}/ComputeLibrary
+        run: scons Werror=1 -j${{ steps.cpu-cores.outputs.count }} neon=1 opencl=0 os=macos arch=armv8.2-a build=native cppthreads=0 openmp=0 examples=0 validation_tests=0
+        env:
+          CC: ${{ matrix.compiler.CC }}
+          CXX: ${{ matrix.compiler.CXX }}
+      - name: Configure oneDNN
+        run: cmake -B${{ github.workspace }}/oneDNN/build -S${{ github.workspace }}/oneDNN -DDNNL_AARCH64_USE_ACL=ON -DONEDNN_BUILD_GRAPH=0 -DONEDNN_WERROR=OFF -DDNNL_BUILD_FOR_CI=ON -DCMAKE_BUILD_TYPE=${{ matrix.config.CMAKE_BUILD_TYPE }}
+        working-directory: ${{ github.workspace }}/oneDNN
+        env:
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/lib
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          CC: ${{ matrix.compiler.CC }}
+          CXX: ${{ matrix.compiler.CXX }}
+      - name: Build oneDNN
+        run: cmake --build ${{ github.workspace }}/oneDNN/build -j${{ steps.cpu-cores.outputs.count }}
+        working-directory: ${{ github.workspace }}/oneDNN
+        env:
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/lib
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -109,7 +109,8 @@ status_t acl_wino_convolution_fwd_t::pd_t::init_conf() {
 
     const bool shape_ok
             // only unit strides allowed
-            = (acp_.padstride_info.stride() == std::pair<uint, uint> {1, 1})
+            = (acp_.padstride_info.stride()
+                      == std::pair<unsigned int, unsigned int> {1, 1})
             // Note: Compute Library supports arbitrary padding for wino kernels
             // but we only allow small padding to be consistent with oneDNN
             && (acp_.padstride_info.pad().first <= 1) // padding left/right


### PR DESCRIPTION
This change enables a basic ci pipeline for macos using github actions. At this moment, it only performs a build, and uses the provided free macos runners, which are sufficient for the use case.

The logic is:

- When compiling with clang, we just pull ACL from its github releases and link oneDNN with it. This is because macos ACL releases are built with clang. The script to do this is added.
- When compiling with gcc, we build ACL and link with it.

I had to make a trivial code change in one file to get the code to compile with gcc.

For now, the yaml file is quite crude (for example, the fact that I have to specify the ACL_VERSION twice is not elegant), but I would like to submit it so that we can start ci. There are plans to improve on it later and then also at some point I would like to add smoke tests.

Note that I was unable to turn on WERROR, and I would like to fix this ASAP so I can turn on the switch.

Some admin might be required with @vpirogov's help to enable and enforce this workflow for the repo.

It would be helpful to get this in soon so that we can at least start protecting against build failures.