### PR TITLE
cpu: aarch64: gtests: Loose abs error check on AArch64

### DIFF
--- a/tests/gtests/graph/unit/backend/dnnl/test_conv.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_conv.cpp
@@ -2548,6 +2548,9 @@ TEST(test_conv_execute, ConvBiasAddEltwise) {
             // We noticed mish test has slight accuracy issue on GPU or AArch64
             // CPU or SNB.
             dst = eltwise_dst_ts.as_vec_type<float>();
+#ifdef DNNL_AARCH64
+            ASSERT_NEAR(dst[i], param.ref_dst[i], 1e-6);
+#else
             if (eng->kind() == graph::engine_kind::gpu
                     || (eng->kind() == graph::engine_kind::cpu
                             && dnnl_get_effective_cpu_isa()
@@ -2556,6 +2559,7 @@ TEST(test_conv_execute, ConvBiasAddEltwise) {
             } else {
                 ASSERT_FLOAT_EQ(dst[i], param.ref_dst[i]);
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
Loose the absolute error threshold for ConvBiasAddEltwise graph gtest to 1e-6.

# Description

Currently running `ctest -R test_graph_unit_dnnl_conv_usm_cpu` returns:
```
/build/oneDNN/tests/gtests/graph/unit/backend/dnnl/test_conv.cpp:2557: Failure
Expected equality of these values:
  dst[i]
    Which is: -0.072591752
  param.ref_dst[i]
    Which is: -0.072591871
```

This PR solves the issue by lowering the absolute error.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?