### PR TITLE
gpu: generic: sycl: resampling and matmul sycl-post-ops issues

### DIFF
--- a/src/gpu/generic/sycl/ref_matmul.cpp
+++ b/src/gpu/generic/sycl/ref_matmul.cpp
@@ -118,7 +118,7 @@ status_t ref_matmul_t::pd_t::init_conf() {
 
     conf_.use_dropout = !attr()->dropout_.has_default_values();
 
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
 
     for (auto i = 0; i < conf_.post_ops.get_post_op(); ++i) {
         const auto &e = attr()->post_ops_.entry_[i];

--- a/src/gpu/generic/sycl/ref_resampling.cpp
+++ b/src/gpu/generic/sycl/ref_resampling.cpp
@@ -50,7 +50,7 @@ status_t ref_resampling_fwd_t::pd_t::init_conf() {
     }
     conf_.po_len = attr_po.len();
 
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
     return status::success;
 }
 


### PR DESCRIPTION
# Description

We found that the issue solved in #2096 was also happening for **matmul** and **resampling** operators. The data type initialization in the sycl_post_ops_t is needed.
