### PR TITLE
cpu: aarch64: optimising memory/thread utilization in BRGEMM Matmul

### DIFF
--- a/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
@@ -85,7 +85,8 @@ status_t brgemm_matmul_matrix_B_reorder_t::pd_t::init(
     matmul_conf_for_reorder_.K = dims[ndims - 2];
     matmul_conf_for_reorder_.N = dims[ndims - 1];
     matmul_conf_for_reorder_.wei_n_blk = matmul_conf_for_reorder_.N_blk
-            = matmul_conf_for_reorder_.LDB = matmul::get_default_n_block(otag);
+            = matmul_conf_for_reorder_.LDB
+            = matmul::get_default_n_block(otag, matmul_conf_for_reorder_);
     matmul_conf_for_reorder_.N_tail
             = matmul_conf_for_reorder_.N % matmul_conf_for_reorder_.N_blk;
     matmul_conf_for_reorder_.K_blk = 16 * vnni_granularity;

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
+* Copyright 2023-2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -312,7 +313,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 void init_scratchpad(memory_tracking::registrar_t &scratchpad,
         const brgemm_matmul_conf_t &bgmmc);
 
-int get_default_n_block(format_tag_t matrix_b_tag);
+int get_default_n_block(format_tag_t, brgemm_matmul_conf_t &bgmmc);
 
 } // namespace matmul
 } // namespace aarch64


### PR DESCRIPTION
# Description

This PR brings some optimizations to brgemm matmul operator by improving memory utilization and multithreading capabilities.

This PR contains the following changes:

- Modification of blocking parameters for M,K,N based on some heuristics obtained by testing matmul on shapes of majority of language models.
- Assembly level optimization which removes the necessity of the `fadd() `instruction before storing the accumulator results in destination matrix.

## General

- [y] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
```
make test

99% tests passed, 2 tests failed out of 200

Total Test time (real) = 2142.22 sec

The following tests FAILED:
	159 - test_graph_unit_dnnl_large_partition_usm_cpu (Failed)
	181 - test_benchdnn_modeC_graph_ci_cpu (Failed)
Errors while running CTest
Output from these tests are in: /home/shreyas/G/shr-fuj/oneDNN_open_source/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8

```
- [y] Have you formatted the code using clang-format?