### PR TITLE
@theComputeKid as codeowner for devops

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -238,6 +238,7 @@ Team: @oneapi-src/onednn-devops
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Sergey Razumovskiy | @srazumov             | Intel Corporation | Maintainer |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
+| Hamza Butt         | @theComputeKid        | Arm Ltd           | Code Owner |
 
 ### Release management
 


### PR DESCRIPTION
I would like to nominate Hamza Butt @theComputeKid for the role of code owner of devops component. Hamza contributed initial CI support for Arm processors and working on extending this functionality with Arm Hosted GHA Runners.
