### PR TITLE
generic: sycl: fix sum with many inputs

### DIFF
--- a/src/gpu/generic/sycl/ref_sum_many_inputs.cpp
+++ b/src/gpu/generic/sycl/ref_sum_many_inputs.cpp
@@ -62,12 +62,13 @@ status_t ref_sum_many_inputs_t::execute(const exec_ctx_t &ctx) const {
             r_args[DNNL_ARG_MULTIPLE_SRC + j + pass_in_dst]
                     = ctx.args().at(DNNL_ARG_MULTIPLE_SRC + j + in_arg_offset);
         }
-        n_remaining -= args_handled;
-        in_arg_offset += args_handled;
-        i++;
 
         exec_ctx_t r_ctx(ctx, std::move(r_args));
         CHECK(base_prims_[i]->execute(r_ctx));
+
+        n_remaining -= args_handled;
+        in_arg_offset += args_handled;
+        i++;
     }
     return status::success;
 }


### PR DESCRIPTION
# Description

This PR fixes an issue in the generic SYCL sum where the `base_prims_` vector was accessed out of bounds because the index variable `i` was incremented before the access.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
