### PR TITLE
attributes: remove obsolete quantization internals

### DIFF
--- a/src/common/gemm.cpp
+++ b/src/common/gemm.cpp
@@ -85,7 +85,7 @@ std::string get_descriptor(dim_t M, dim_t N, dim_t K) {
         if (!is_src_ab && lda != M) ss << "lda:" << lda << " "; \
         if (is_wei_ab && ldb != N) ss << "ldb:" << ldb << " "; \
         if (!is_wei_ab && ldb != K) ss << "ldb:" << ldb << " "; \
-        if (alpha != 1.f) ss << "attr-oscale:common:" << alpha << " "; \
+        if (alpha != 1.f) ss << "attr-scales:src:common:" << alpha << " "; \
         if (beta != 0.f) ss << "attr-post-ops:sum:" << beta << " "; \
         ss << ",," << get_descriptor(M, N, K); \
         VPROF(start_ms, primitive, exec, VERBOSE_profile, ss.str().c_str(), \

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -40,7 +40,7 @@ const runtime_scales_t &default_runtime_scale() {
     return default_runtime_scale_instance;
 }
 
-void scales_t::set_single_scale(float scale) {
+void rnn_create_time_scales_t::set_single_scale(float scale) {
     count_ = 1;
     mask_ = 0;
     scales_ = scales_buf_;
@@ -51,7 +51,8 @@ void scales_t::set_single_scale(float scale) {
     }
 }
 
-status_t scales_t::set(dim_t count, int mask, const float *scales) {
+status_t rnn_create_time_scales_t::set(
+        dim_t count, int mask, const float *scales) {
     cleanup();
 
     count_ = count;

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -594,17 +594,23 @@ status_t dnnl_primitive_attr_set_zero_points_mask(
     return attr->zero_points_.set(arg, mask);
 }
 
-dnnl_status_t DNNL_API dnnl_primitive_attr_set_zero_points(
-        dnnl_primitive_attr_t attr, int arg, int mask, int ndims,
-        const dnnl_dims_t group_dims, dnnl_data_type_t data_type) {
+status_t dnnl_primitive_attr_set_zero_points(dnnl_primitive_attr_t attr,
+        int arg, int mask, int ndims, const dnnl_dims_t group_dims,
+        dnnl_data_type_t data_type) {
     using namespace data_type;
-    bool ok = attr && arg >= 0 && mask >= 0 && ndims >= 0
-            && utils::one_of(data_type, s32, s8, u8, s4, u4)
-            && IMPLICATION(
-                    arg != DNNL_ARG_WEIGHTS, data_type == s32 && ndims == 0)
-            && IMPLICATION(utils::one_of(data_type, s4, u4), mask > 0)
-            && IMPLICATION(ndims, validate_dims(ndims, group_dims));
-    if (!ok) return invalid_arguments;
+    VCHECK_ATTR(attr, VERBOSE_NULL_ARG);
+    VCHECK_ATTR(mask >= 0, VERBOSE_BAD_PARAM, "mask");
+    VCHECK_ATTR(arg >= 0, VERBOSE_BAD_PARAM, "arg");
+    VCHECK_ATTR(ndims >= 0, VERBOSE_BAD_PARAM, "ndims");
+    VCHECK_ATTR(utils::one_of(data_type, s32, s8, u8, s4, u4),
+            VERBOSE_INVALID_DATATYPE, "zero points");
+    VCHECK_ATTR(IMPLICATION(utils::one_of(data_type, s4, u4), mask > 0),
+            VERBOSE_BAD_PARAM, "mask with int4 data type");
+    VCHECK_ATTR(IMPLICATION(!utils::one_of(arg, DNNL_ARG_WEIGHTS),
+                        data_type == s32 && ndims == 0),
+            VERBOSE_INVALID_DATATYPE, "zero points");
+    VCHECK_ATTR(IMPLICATION(ndims, validate_dims(ndims, group_dims)),
+            VERBOSE_BAD_PARAM, "group_dims");
 
     return attr->zero_points_.set(arg, mask, ndims, group_dims, data_type);
 }

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -131,8 +131,6 @@ bool primitive_attr_t::has_default_values(dnnl_primitive_attr::skip_mask_t mask,
     using smask_t = skip_mask_t;
     // prepare mask for runtime-parameters check
     smask_t defined_mask = smask_t::none;
-    if ((mask & smask_t::oscale_runtime) == smask_t::oscale_runtime)
-        defined_mask |= smask_t::oscale;
     if ((mask & smask_t::scales_runtime) == smask_t::scales_runtime)
         defined_mask |= smask_t::scales;
     if ((mask & smask_t::zero_points_runtime) == smask_t::zero_points_runtime)
@@ -143,7 +141,6 @@ bool primitive_attr_t::has_default_values(dnnl_primitive_attr::skip_mask_t mask,
 #define CHECK_MASK(mask_name, mask_field) \
     CHECK_ARG(IMPLICATION( \
             (bool)(~mask & (mask_name)), (mask_field).has_default_values()))
-    CHECK_MASK(smask_t::oscale_runtime, output_scales_);
     CHECK_MASK(smask_t::scales, scales_);
     CHECK_ARG(IMPLICATION((bool)(~mask & smask_t::scales_runtime_groups),
             scales_.has_default_groups()));
@@ -189,7 +186,6 @@ bool primitive_attr_t::defined(dnnl_primitive_attr::skip_mask_t mask) const {
 #define CHECK_ARG(x) ok = ok && (x)
 #define CHECK_MASK(mask_name, mask_field) \
     CHECK_ARG(IMPLICATION((bool)(~mask & (mask_name)), (mask_field).defined()))
-    CHECK_MASK(smask_t::oscale, output_scales_);
     CHECK_MASK(smask_t::scales, scales_);
     CHECK_MASK(smask_t::zero_points, zero_points_);
     CHECK_MASK(smask_t::post_ops, post_ops_);

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -225,10 +225,6 @@ struct runtime_scales_t : public c_compatible {
     bool has_default_groups() const { return 0 == ndims_; }
     bool has_default_data_type() const { return data_type_ == data_type::f32; }
 
-    bool defined() const { return has_default_values(); }
-
-    void reset() { *this = default_runtime_scale(); }
-
     // TODO: replace with `-1` to remove `is_set_`.
     // Hide `mask_` under `private:` to force interface usage.
     int mask_ = 0;
@@ -318,8 +314,6 @@ struct arg_scales_t : public c_compatible {
         return status::success;
     }
 
-    bool defined() const { return has_default_values(); }
-
     status_t copy_from(const arg_scales_t &other) {
         for (auto it = other.scales_.begin(); it != other.scales_.end(); ++it) {
             // Find an entry that can match the arguments without constructing a
@@ -387,7 +381,6 @@ struct zero_points_t : public c_compatible {
 
     // arg-specific checks
     bool common(int arg) const { return get_mask(arg) == 0; }
-    bool defined(int arg) const { return has_default_values(arg); }
     bool has_default_values(int arg) const {
         return is_set(arg) == false && has_default_data_type(arg);
     }
@@ -399,7 +392,6 @@ struct zero_points_t : public c_compatible {
     }
     // same checks but for all supported arguments at once
     bool common() const { return check_all(&zero_points_t::common); }
-    bool defined() const { return has_default_values(); }
     bool has_default_values() const {
         return check_all(&zero_points_t::has_default_values);
     }
@@ -743,7 +735,6 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
         return dst_dt;
     }
 
-    bool defined() const;
     int len() const { return (int)entry_.size(); }
     bool has_default_values(
             const std::vector<dnnl::impl::primitive_kind_t> &skip_pk

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -129,14 +129,14 @@ private:
 };
 
 // Note: keep for RNN quantization
-struct scales_t : public c_compatible {
-    scales_t() : count_(1), mask_(0), scales_(scales_buf_) {
+struct rnn_create_time_scales_t : public c_compatible {
+    rnn_create_time_scales_t() : count_(1), mask_(0), scales_(scales_buf_) {
         set_single_scale(1.);
     }
 
-    ~scales_t() { cleanup(); }
+    ~rnn_create_time_scales_t() { cleanup(); }
 
-    bool operator==(const scales_t &rhs) const {
+    bool operator==(const rnn_create_time_scales_t &rhs) const {
         bool ret = count_ == rhs.count_ && mask_ == rhs.mask_
                 && !utils::any_null(scales_, rhs.scales_)
                 && defined() == rhs.defined()
@@ -162,7 +162,7 @@ struct scales_t : public c_compatible {
         return status::success;
     }
 
-    status_t copy_from(const scales_t &other) {
+    status_t copy_from(const rnn_create_time_scales_t &other) {
         return set(other.count_, other.mask_, other.scales_);
     }
 
@@ -182,7 +182,7 @@ private:
         scales_ = scales_buf_;
     }
 
-    DNNL_DISALLOW_COPY_AND_ASSIGN(scales_t);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(rnn_create_time_scales_t);
 };
 
 struct runtime_scales_t : public c_compatible {
@@ -973,8 +973,8 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
     bool deterministic_;
     dnnl::impl::post_ops_t post_ops_;
     dnnl::impl::rnn_data_qparams_t rnn_data_qparams_;
-    dnnl::impl::scales_t rnn_weights_qparams_;
-    dnnl::impl::scales_t rnn_weights_projection_qparams_;
+    dnnl::impl::rnn_create_time_scales_t rnn_weights_qparams_;
+    dnnl::impl::rnn_create_time_scales_t rnn_weights_projection_qparams_;
     dnnl::impl::rnn_tparams_t rnn_tparams_;
     dnnl::impl::dropout_t dropout_;
     dnnl::impl::rnd_mode_t rounding_mode_;

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -828,7 +828,6 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
     dnnl::impl::status_t copy_from(const dnnl_primitive_attr &other) {
         using namespace dnnl::impl;
 
-        output_scales_ = other.output_scales_;
         scales_ = other.scales_;
         zero_points_ = other.zero_points_;
         rounding_mode_ = other.rounding_mode_;
@@ -852,8 +851,6 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
 
     enum class skip_mask_t : unsigned {
         none = 0,
-        oscale = 1u << 0,
-        oscale_runtime = 1u << 1,
         scales = 1u << 2,
         scales_runtime = (unsigned)scales | (1u << 3),
         zero_points = 1u << 4,
@@ -889,7 +886,6 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
         bool ret = scratchpad_mode_ == rhs.scratchpad_mode_
                 && fpmath_ == rhs.fpmath_ && acc_mode_ == rhs.acc_mode_
                 && deterministic_ == rhs.deterministic_
-                && output_scales_ == rhs.output_scales_
                 && scales_ == rhs.scales_ && zero_points_ == rhs.zero_points_
                 && post_ops_ == rhs.post_ops_
                 && rnn_data_qparams_ == rhs.rnn_data_qparams_
@@ -964,7 +960,6 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
     }
 
     // NOTE: make sure that the types below have overloaded comparison operator
-    dnnl::impl::runtime_scales_t output_scales_;
     dnnl::impl::arg_scales_t scales_;
     dnnl::impl::zero_points_t zero_points_;
     dnnl::impl::scratchpad_mode_t scratchpad_mode_;

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -150,9 +150,6 @@ struct primitive_desc_t : public c_compatible {
     enum class arg_usage_t { unused, input, output };
     virtual arg_usage_t arg_usage(int arg) const {
         using types::is_zero_md;
-        if (arg == DNNL_ARG_ATTR_OUTPUT_SCALES
-                && !attr()->output_scales_.defined())
-            return arg_usage_t::input;
         if (arg & DNNL_ARG_ATTR_ZERO_POINTS) {
             int zp_arg = arg & ~DNNL_ARG_ATTR_ZERO_POINTS;
             if (!attr()->zero_points_.defined(zp_arg))

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -152,19 +152,19 @@ struct primitive_desc_t : public c_compatible {
         using types::is_zero_md;
         if (arg & DNNL_ARG_ATTR_ZERO_POINTS) {
             int zp_arg = arg & ~DNNL_ARG_ATTR_ZERO_POINTS;
-            if (!attr()->zero_points_.defined(zp_arg))
+            if (!attr()->zero_points_.has_default_values(zp_arg))
                 return arg_usage_t::input;
         }
         if (arg & DNNL_ARG_ATTR_SCALES) {
             int scale_arg = arg & ~DNNL_ARG_ATTR_SCALES;
-            if (!attr()->scales_.get(scale_arg).defined())
+            if (!attr()->scales_.get(scale_arg).has_default_values())
                 return arg_usage_t::input;
         }
         if ((arg == (DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0))
-                && !attr()->scales_.get(DNNL_ARG_SRC_0).defined())
+                && !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values())
             return arg_usage_t::input;
         if ((arg == (DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_1))
-                && !attr()->scales_.get(DNNL_ARG_SRC_1).defined())
+                && !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values())
             return arg_usage_t::input;
         if (arg == DNNL_ARG_SCRATCHPAD && !is_zero_md(scratchpad_md()))
             return arg_usage_t::output;

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -223,10 +223,7 @@ size_t get_attr_hash(const primitive_attr_t &attr) {
         }
     }
 
-    if (!attr.output_scales_.has_default_values()) {
-        // output_scales: mask
-        seed = hash_combine(seed, attr.output_scales_.mask_);
-    } else if (!attr.scales_.has_default_values()) {
+    if (!attr.scales_.has_default_values()) {
         // go through scales for all arguments
         for (const auto &p : attr.scales_.scales_) {
             // scales: arg

--- a/src/common/serialization.cpp
+++ b/src/common/serialization.cpp
@@ -186,10 +186,7 @@ void serialize_attr(
     // acc_mode
     sstream.write(&attr.acc_mode_);
 
-    if (!attr.output_scales_.has_default_values()) {
-        // output_scales: mask
-        sstream.write(&attr.output_scales_.mask_);
-    } else if (!attr.scales_.has_default_values()) {
+    if (!attr.scales_.has_default_values()) {
         sstream.write("scale:");
         // go through scales for all arguments
         for (const auto &p : attr.scales_.scales_) {

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -715,11 +715,6 @@ std::ostream &operator<<(std::ostream &ss, const primitive_attr_t *attr) {
     }
     if (attr->has_default_values()) return ss;
 
-    const runtime_scales_t &os = attr->output_scales_;
-    if (!os.has_default_values()) {
-        ss << field_delim() << "attr-oscale:" << os;
-    }
-
     const arg_scales_t &as = attr->scales_;
     if (!as.has_default_values()) {
         std::string delim = empty_delim;

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -602,12 +602,13 @@ std::ostream &operator<<(std::ostream &ss, const runtime_scales_t &scale) {
     return ss;
 }
 
-std::ostream &operator<<(std::ostream &ss, const scales_t &oscale) {
-    ss << oscale.mask_;
-    const float val = oscale.scales_[0];
+std::ostream &operator<<(
+        std::ostream &ss, const rnn_create_time_scales_t &rnn_scales) {
+    ss << rnn_scales.mask_;
+    const float val = rnn_scales.scales_[0];
     // Can't use scientific flags since it breaks parsing on converter and
     // benchdnn side.
-    if (oscale.mask_ == 0 || is_runtime_value(val))
+    if (rnn_scales.mask_ == 0 || is_runtime_value(val))
         ss << ":" << get_val_str(val);
     return ss;
 }

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
@@ -274,12 +274,8 @@ status_t _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel::init_conf(
     //save post_ops desc for further usage
     jcp.post_ops = p;
 
-    const auto &oscales = attr.output_scales_;
-    jcp.is_oc_scale = oscales.mask_ == 1 << 1;
-
-    // only common and per-oc-channel scales are supported
-    const bool oscales_ok = one_of(oscales.mask_, 0, 1 << 1);
-    if (!oscales_ok) return status::unimplemented;
+    // TODO: add proper scaling support.
+    jcp.is_oc_scale = false;
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
@@ -1416,7 +1416,8 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
     const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     const int nb_groups = jcp.nb_ch;
 
-    DEFINE_SCALES_BUFFER(oscales);
+    // TODO: add support for scaling based on latest programming model.
+    DEFINE_ARG_SCALES_BUFFER(oscales, DNNL_ARG_WEIGHTS);
     const size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<int8_t *>(weights);
     int32_t *compensation = (!jcp.signed_input)
@@ -1514,7 +1515,8 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
     size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
     size_t wht_kh_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-    DEFINE_SCALES_BUFFER(oscales);
+    // TODO: add support for scaling based on latest programming model.
+    DEFINE_ARG_SCALES_BUFFER(oscales, DNNL_ARG_WEIGHTS);
     const size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<int8_t *>(weights);
     int32_t *compensation = (!jcp.signed_input)
@@ -1675,7 +1677,8 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
     size_t wht_kd_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
     size_t wht_kh_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-    DEFINE_SCALES_BUFFER(oscales);
+    // TODO: add support for scaling based on latest programming model.
+    DEFINE_ARG_SCALES_BUFFER(oscales, DNNL_ARG_WEIGHTS);
     size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<int8_t *>(weights);
     int32_t *compensation = (!jcp.signed_input)

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
@@ -286,8 +286,7 @@ struct jit_sve_512_core_x8s8s32x_deconvolution_fwd_t : public primitive_t {
                                     weights_md(1)->data_type, f32, s32, s8, u8))
                     && utils::one_of(dst_md(0)->data_type, f32, s32, s8, u8)
                     && desc()->accum_data_type == s32
-                    && attr()->has_default_values(skip_mask_t::oscale_runtime
-                            | skip_mask_t::post_ops
+                    && attr()->has_default_values(skip_mask_t::post_ops
                             | skip_mask_t::zero_points_runtime);
             if (!ok) return status::unimplemented;
 

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
@@ -1426,12 +1426,8 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
 
     pick_loop_order(jcp, jcp.nthr);
 
-    const auto &oscales = attr.output_scales_;
-    jcp.is_oc_scale = oscales.mask_ == 1 << 1;
-
-    // only common and per-oc-channel scales are supported
-    const bool oscales_ok = one_of(oscales.mask_, 0, 1 << 1);
-    if (!oscales_ok) return status::unimplemented;
+    // TODO: enable quantization.
+    jcp.is_oc_scale = false;
 
     jcp.wei_adj_scale
             = (weights_d.extra().flags & memory_extra_flags::scale_adjust)

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.cpp
@@ -61,7 +61,8 @@ jit_sve_512_x8s8s32x_convolution_fwd_t<src_type, dst_type>::execute_forward_1d(
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
     assert(jcp.nb_ch % jcp.nb_ch_blocking == 0);
 
-    DEFINE_SCALES_BUFFER(oscales);
+    // TODO: add support for scaling based on latest programming model.
+    DEFINE_ARG_SCALES_BUFFER(oscales, DNNL_ARG_WEIGHTS);
 
     size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<wei_data_t *>(weights);
@@ -174,7 +175,8 @@ jit_sve_512_x8s8s32x_convolution_fwd_t<src_type, dst_type>::execute_forward_2d(
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
     assert(jcp.nb_ch % jcp.nb_ch_blocking == 0);
 
-    DEFINE_SCALES_BUFFER(oscales);
+    // TODO: add support for scaling based on latest programming model.
+    DEFINE_ARG_SCALES_BUFFER(oscales, DNNL_ARG_WEIGHTS);
 
     size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<wei_data_t *>(weights);
@@ -319,7 +321,8 @@ status_t jit_sve_512_x8s8s32x_convolution_fwd_t<src_type,
     assert(jcp.nb_oc_blocking == 1);
     assert(jcp.nb_ch % jcp.nb_ch_blocking == 0);
 
-    DEFINE_SCALES_BUFFER(oscales);
+    // TODO: add support for scaling based on latest programming model.
+    DEFINE_ARG_SCALES_BUFFER(oscales, DNNL_ARG_WEIGHTS);
 
     size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<wei_data_t *>(weights);
@@ -408,7 +411,8 @@ jit_sve_512_x8s8s32x_convolution_fwd_t<src_type, dst_type>::execute_forward_3d(
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
     assert(jcp.nb_ch % jcp.nb_ch_blocking == 0);
 
-    DEFINE_SCALES_BUFFER(oscales);
+    // TODO: add support for scaling based on latest programming model.
+    DEFINE_ARG_SCALES_BUFFER(oscales, DNNL_ARG_WEIGHTS);
 
     size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<wei_data_t *>(weights);

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
@@ -53,9 +53,7 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
                             utils::one_of(bias_md_.data_type, data_type::f32,
                                     data_type::s32, data_type::s8,
                                     data_type::u8))
-                    && attr()->has_default_values(
-                            smask_t::oscale_runtime | smask_t::post_ops,
-                            dst_type)
+                    && attr()->has_default_values(smask_t::post_ops, dst_type)
                     && !has_zero_dim_memory();
             if (!ok) return status::unimplemented;
 

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -140,10 +140,10 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
                     po, src0_md_, get_supported_postops_bcast_strategies());
     conf_.op_type = get_op_type(src0_md_);
     assert(conf_.op_type != op_t::none);
-    conf_.do_scale_src0 = !attr()->scales_.get(DNNL_ARG_SRC_0).defined()
-            || !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
-    conf_.do_scale_src1 = !attr()->scales_.get(DNNL_ARG_SRC_1).defined()
-            || !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
+    conf_.do_scale_src0
+            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_src1
+            = !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
     const auto sum_idx = po.find(primitive_kind::sum);
     conf_.do_sum = sum_idx != -1 && po.entry_[sum_idx].sum.scale != 0.f;
     conf_.with_eltwise = po.find(primitive_kind::eltwise) != -1;

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -85,10 +85,9 @@ status_t acl_matmul_t::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_DT_CFG);
     VDISPATCH_MATMUL(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
     VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
-    VDISPATCH_MATMUL(attr()->has_default_values(smask_t::oscale
-                             | smask_t::post_ops | smask_t::fpmath_mode),
+    VDISPATCH_MATMUL(attr()->has_default_values(
+                             smask_t::post_ops | smask_t::fpmath_mode),
             VERBOSE_UNSUPPORTED_ATTR);
-    VDISPATCH_MATMUL(attr_oscale_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
     VDISPATCH_MATMUL(
             !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
 

--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
@@ -43,12 +43,6 @@ struct acl_matmul_t : public primitive_t {
         acl_matmul_conf_t amp_;
         acl_post_ops_t acl_post_ops;
         dnnl::impl::format_kind_t weights_format_kind_;
-
-    protected:
-        bool attr_oscale_ok() const {
-            const auto &oscale = attr()->output_scales_;
-            return oscale.mask_ == 0;
-        }
     };
 
     acl_matmul_t(const pd_t *apd)

--- a/src/cpu/cpu_primitive.hpp
+++ b/src/cpu/cpu_primitive.hpp
@@ -66,7 +66,7 @@
 #define DEFINE_ZERO_POINTS_BUFFER(zero_points_ptr, mem_arg) \
     int32_t CONCAT2(default_zero_point_, mem_arg) = 0; \
     const int32_t *zero_points_ptr \
-            = pd()->attr()->zero_points_.defined(mem_arg) \
+            = pd()->attr()->zero_points_.has_default_values(mem_arg) \
             ? &CONCAT2(default_zero_point_, mem_arg) \
             : CTX_IN_MEM( \
                     const int32_t *, DNNL_ARG_ATTR_ZERO_POINTS | mem_arg); \

--- a/src/cpu/cpu_primitive.hpp
+++ b/src/cpu/cpu_primitive.hpp
@@ -29,35 +29,6 @@
 
 #include "cpu/ref_io_helper.hpp"
 
-#define DEFINE_SCALES_BUFFER_ATTR_ARG(attr, scales, arg) \
-    alignas(16) float CONCAT2(scales, _buf16)[16] = {0}; \
-    const float *scales {nullptr}; \
-    if ((attr)) { \
-        if ((attr)->output_scales_.has_default_values()) { \
-            utils::array_set(CONCAT2(scales, _buf16), 1.0f, 16); \
-            scales = CONCAT2(scales, _buf16); \
-        } else { \
-            scales = CTX_IN_MEM(const float *, arg); \
-            VCHECK_ATTR(scales != nullptr, \
-                    "Scales buffer for arg %d is missing", arg); \
-            const auto scales_d = ctx.memory_mdw(arg); \
-            VCHECK_ATTR(scales_d.data_type() == data_type::f32, \
-                    "Scales data type is not f32"); \
-            VCHECK_ATTR(scales_d.ndims() == 1, "Scales ndims is not 1"); \
-            if (scales_d.dims()[0] == 1) { \
-                utils::array_set(CONCAT2(scales, _buf16), scales[0], 16); \
-                scales = CONCAT2(scales, _buf16); \
-            } \
-        } \
-    } \
-    MAYBE_UNUSED(scales);
-
-#define DEFINE_SCALES_BUFFER_ATTR(attr, scales) \
-    DEFINE_SCALES_BUFFER_ATTR_ARG(attr, scales, DNNL_ARG_ATTR_OUTPUT_SCALES);
-
-#define DEFINE_SCALES_BUFFER(scales) \
-    DEFINE_SCALES_BUFFER_ATTR(pd()->attr(), scales)
-
 #define DEFINE_ARG_SCALES_BUFFER_ATTR(attr, scales, arg) \
     alignas(16) float CONCAT2(scales, _buf16)[16] = {0}; \
     const float *scales {nullptr}; \

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -172,10 +172,10 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     conf_.is_f16 = conf_.dst_type == f16;
     conf_.op_type = get_op_type(src0_md_);
     assert(conf_.op_type != op_t::none);
-    conf_.do_scale_src0 = !attr()->scales_.get(DNNL_ARG_SRC_0).defined()
-            || !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
-    conf_.do_scale_src1 = !attr()->scales_.get(DNNL_ARG_SRC_1).defined()
-            || !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
+    conf_.do_scale_src0
+            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_src1
+            = !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
     const auto sum_idx = po.find(primitive_kind::sum);
     conf_.do_sum = sum_idx != -1 && po.entry_[sum_idx].sum.scale != 0.f;
     conf_.with_eltwise = po.find(primitive_kind::eltwise) != -1;

--- a/src/gpu/amd/miopen_convolution.hpp
+++ b/src/gpu/amd/miopen_convolution.hpp
@@ -50,7 +50,7 @@ struct miopen_convolution_fwd_t : public gpu::primitive_t {
             using namespace data_type;
 
             using sm_t = primitive_attr_t::skip_mask_t;
-            const auto attr_skip_mask = sm_t::oscale_runtime | sm_t::post_ops;
+            const auto attr_skip_mask = sm_t::post_ops;
 
             bool ok = utils::one_of(desc()->prop_kind,
                     prop_kind::forward_training, prop_kind::forward_inference);
@@ -81,10 +81,6 @@ struct miopen_convolution_fwd_t : public gpu::primitive_t {
                     && IMPLICATION(
                             desc()->alg_kind == dnnl_convolution_winograd,
                             ndims() < 5 && src_md_.data_type != s8);
-            ok = ok
-                    && IMPLICATION(!attr()->output_scales_.has_default_values(),
-                            src_md_.data_type == s8
-                                    && attr()->output_scales_.mask_ == 0);
             ok = ok
                     && IMPLICATION(
                             src_md_.data_type == s8, check_s8_configuration())

--- a/src/gpu/amd/miopen_convolution_impl.hpp
+++ b/src/gpu/amd/miopen_convolution_impl.hpp
@@ -154,8 +154,8 @@ public:
         with_bias = pd->with_bias();
         alpha = 1.0f;
         beta = 0.0f;
-        do_scaling = !pd->attr()->output_scales_.has_default_values();
-        output_scaling = !pd->attr()->output_scales_.defined();
+        do_scaling = false;
+        output_scaling = false;
 
         dnnl_descs[x] = *pd->invariant_src_md();
         dnnl_descs[weights] = *pd->invariant_wei_md();

--- a/src/gpu/amd/miopen_gemm_inner_product.hpp
+++ b/src/gpu/amd/miopen_gemm_inner_product.hpp
@@ -182,7 +182,7 @@ struct miopen_gemm_inner_product_fwd_t : public miopen_inner_product_fwd_t {
                     : reorder_check(src_md(), weights_md(), dst_md());
 
             using sm_t = primitive_attr_t::skip_mask_t;
-            const auto attr_skip_mask = sm_t::oscale_runtime | sm_t::post_ops;
+            const auto attr_skip_mask = sm_t::post_ops;
 
             bool with_eltwise
                     = attr()->post_ops_.find(primitive_kind::eltwise) != -1;
@@ -212,9 +212,6 @@ struct miopen_gemm_inner_product_fwd_t : public miopen_inner_product_fwd_t {
             ok = ok && memory_format_ok(src_md())
                     && memory_format_ok(weights_md(0))
                     && memory_format_ok(dst_md())
-                    && IMPLICATION(!attr()->output_scales_.has_default_values(),
-                            utils::one_of(src_md_.data_type, s8)
-                                    && attr()->output_scales_.mask_ == 0)
                     && attr()->has_default_values(attr_skip_mask)
                     && attr_post_ops_ok(attr(), s8_case)
                     && dense_check(src_md(), weights_md(), dst_md())

--- a/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
+++ b/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
@@ -248,9 +248,9 @@ struct miopen_gemm_inner_product_fwd_impl_t
         with_eltwise_ = with_eltwise || with_relu;
         with_relu_ = with_eltwise;
 
-        output_scales_ = 1.0f;
-        alpha_s32 = output_scales_;
-        alpha_f32 = output_scales_;
+        alpha_ = 1.0f;
+        alpha_s32 = alpha_;
+        alpha_f32 = alpha_;
 
         with_sum_ = with_sum;
         sum_scale_ = sum_scale(pd);
@@ -324,9 +324,8 @@ struct miopen_gemm_inner_product_fwd_impl_t
 
         if (with_bias_) {
             MIOPEN_EXECUTE_FUNC(miopenOpTensor, miopen_handle,
-                    miopenTensorOpAdd, &alpha_, y_acc_desc_, y_dst,
-                    &output_scales_, tensor_descs_[io::bia], b, &alpha2,
-                    y_acc_desc_, y_dst);
+                    miopenTensorOpAdd, &alpha_, y_acc_desc_, y_dst, &alpha_,
+                    tensor_descs_[io::bia], b, &alpha2, y_acc_desc_, y_dst);
         }
 
         if (with_eltwise_) {

--- a/src/gpu/amd/miopen_inner_product_impl.hpp
+++ b/src/gpu/amd/miopen_inner_product_impl.hpp
@@ -155,7 +155,7 @@ struct miopen_inner_product_impl_base_t {
 
 struct miopen_inner_product_fwd_base_t
     : public miopen_inner_product_impl_base_t {
-    float output_scales_; // alpha in gemm
+    float alpha_; // alpha in gemm
     bool do_scaling_ {false}, runtime_scaling_ {false};
     float sum_scale_; // beta in gemm
     float eltwise_alpha(const inner_product_pd_t *pd) const {

--- a/src/gpu/amd/miopen_matmul.hpp
+++ b/src/gpu/amd/miopen_matmul.hpp
@@ -62,8 +62,7 @@ struct miopen_matmul_t : public gpu::primitive_t {
 
             bool ok = blocking_ok()
                     && attr()->has_default_values(smask_t::post_ops)
-                    && attr_oscale_ok() && attr_post_ops_ok(s8_case)
-                    && set_default_formats()
+                    && attr_post_ops_ok(s8_case) && set_default_formats()
                     && (f32_case || f16_case || s8_case || bf16_case)
                     && IMPLICATION(with_bias(),
                             (IMPLICATION(f32_case, (bia_dt == f32))
@@ -80,11 +79,6 @@ struct miopen_matmul_t : public gpu::primitive_t {
         }
 
     private:
-        bool attr_oscale_ok() const {
-            const auto &oscale = attr()->output_scales_;
-            return oscale.mask_ == 0;
-        }
-
         bool attr_post_ops_ok(bool s8_case) const {
             using namespace primitive_kind;
             const auto &p = attr()->post_ops_;

--- a/src/gpu/generic/sycl/ref_layer_normalizations.cpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.cpp
@@ -40,7 +40,7 @@ status_t ref_layer_normalization_fwd_t::pd_t::init_conf() {
     conf_.wk_size = memory_desc_wrapper(src_md(0)).nelems();
     conf_.block_size = 16;
 
-    conf_.rt_scaling = !attr()->scales_.defined();
+    conf_.rt_scaling = !attr()->scales_.has_default_values();
     conf_.src_def = attr()->scales_.get(DNNL_ARG_SRC).has_default_values();
     conf_.dst_def = attr()->scales_.get(DNNL_ARG_DST).has_default_values();
 

--- a/src/gpu/intel/jit/gemm/gen_gemm.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.hpp
@@ -188,8 +188,6 @@ struct gen_gemm_t : public gpu_gemm_t {
                     VERBOSE_UNSUPPORTED_DEVICE_FEATURE, "ngen_kernels");
             VDISPATCH_GEMM(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_GEMM(attr()->output_scales_.mask_ == 0,
-                    VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_GEMM(IMPLICATION(with_sum_ab(),
                                    !with_bias()
                                            && (attr_zps.has_default_values(

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -62,12 +62,13 @@ public:
                           DNNL_ARG_WEIGHTS))
         , do_dst_compensation(pd
                   && !pd->attr()->zero_points_.has_default_values(DNNL_ARG_DST))
-        , is_runtime_src_zero_points(
-                  pd && !pd->attr()->zero_points_.defined(DNNL_ARG_SRC))
-        , is_runtime_wei_zero_points(
-                  pd && !pd->attr()->zero_points_.defined(DNNL_ARG_WEIGHTS))
-        , is_runtime_dst_zero_points(
-                  pd && !pd->attr()->zero_points_.defined(DNNL_ARG_DST))
+        , is_runtime_src_zero_points(pd
+                  && !pd->attr()->zero_points_.has_default_values(DNNL_ARG_SRC))
+        , is_runtime_wei_zero_points(pd
+                  && !pd->attr()->zero_points_.has_default_values(
+                          DNNL_ARG_WEIGHTS))
+        , is_runtime_dst_zero_points(pd
+                  && !pd->attr()->zero_points_.has_default_values(DNNL_ARG_DST))
         , is_common_src_zero_point(
                   pd && pd->attr()->zero_points_.common(DNNL_ARG_SRC))
         , is_common_wei_zero_point(

--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
@@ -89,7 +89,6 @@ status_t gemm_with_post_ops_t::pd_t::init(impl::engine_t *engine) {
     primitive_attr_t attributes_without_po = *attr();
     attributes_without_po.set_post_ops(post_ops_t());
     attributes_without_po.scales_ = arg_scales_t();
-    attributes_without_po.output_scales_ = runtime_scales_t();
     attributes_without_po.zero_points_ = zero_points_t();
     int src_mask, wei_mask;
     auto zp = attributes_with_po->zero_points_;

--- a/src/gpu/intel/ocl/gemm_post_ops_inner_product.cpp
+++ b/src/gpu/intel/ocl/gemm_post_ops_inner_product.cpp
@@ -62,10 +62,8 @@ status_t gemm_post_ops_inner_product_fwd_t::execute_forward(
         arg_list.set(arg_idx++,
                 pd()->use_scratchpad() ? *acc
                                        : memory_storage_t::empty_storage());
-        arg_list.set(arg_idx,
-                pd()->attr_info_.with_runtime_oscales
-                        ? CTX_IN_STORAGE(DNNL_ARG_ATTR_OUTPUT_SCALES)
-                        : memory_storage_t::empty_storage());
+        // TODO: remove me?
+        arg_list.set(arg_idx, memory_storage_t::empty_storage());
 
         size_t mb = pd()->MB();
         size_t oc = pd()->OC();

--- a/src/gpu/intel/ocl/gemm_post_ops_inner_product.hpp
+++ b/src/gpu/intel/ocl/gemm_post_ops_inner_product.hpp
@@ -53,9 +53,9 @@ struct gemm_post_ops_inner_product_fwd_t : public gpu_primitive_t {
             using namespace primitive_kind;
             assert(engine->kind() == engine_kind::gpu);
 
+            // TODO: add proper quantization support
             const primitive_attr_t::skip_mask_t attr_skip_mask
-                    = primitive_attr_t::skip_mask_t::oscale_runtime
-                    | primitive_attr_t::skip_mask_t::post_ops;
+                    = primitive_attr_t::skip_mask_t::post_ops;
 
             VDISPATCH_INNER_PRODUCT(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_INNER_PRODUCT_SC(
@@ -73,10 +73,6 @@ struct gemm_post_ops_inner_product_fwd_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_INNER_PRODUCT_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_INNER_PRODUCT(
-                    IMPLICATION(!attr()->output_scales_.has_default_values(),
-                            one_of(attr()->output_scales_.mask_, 0, 1 << 1)),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
 
             attr_info_ = attr_info_t::create(attr());
 

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -150,8 +150,6 @@ struct attr_info_t {
         attr_info.with_per_oc_oscales
                 = attr_info.with_oscales && (scales_mask == (1 << 1));
 
-        attr_info.with_runtime_oscales = !attr->output_scales_.defined();
-
         const auto &src_scales = attr->scales_.get(DNNL_ARG_SRC);
         attr_info.with_src_scales = !src_scales.has_default_values();
         attr_info.with_src0_scale = !src_scales.has_default_values();
@@ -207,7 +205,6 @@ struct attr_info_t {
     bool with_oscales;
     bool with_common_oscales;
     bool with_per_oc_oscales;
-    bool with_runtime_oscales;
 
     bool with_src0_scale;
     bool with_src1_scale;
@@ -1440,8 +1437,6 @@ inline status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("WITH_SRC1_SCALE", attr_info.with_src1_scale);
 
     kernel_ctx.define_int("WITH_SCALES", attr_info.with_oscales);
-    kernel_ctx.define_int(
-            "WITH_RUNTIME_SCALES", attr_info.with_runtime_oscales);
     kernel_ctx.define_int("SCALES_PER_OC", attr_info.with_per_oc_oscales);
     kernel_ctx.define_int("SCALES_COMMON", attr_info.with_common_oscales);
 

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -177,10 +177,12 @@ struct attr_info_t {
         attr_info.dst_zpoints_data_type = zp.get_data_type(DNNL_ARG_DST);
 
         attr_info.with_per_ic_src_zpoints = attr_info.with_src_zpoints
-                && !zp.defined(DNNL_ARG_SRC) && !zp.common(DNNL_ARG_SRC);
+                && !zp.has_default_values(DNNL_ARG_SRC)
+                && !zp.common(DNNL_ARG_SRC);
 
         attr_info.with_per_oc_dst_zpoints = attr_info.with_dst_zpoints
-                && !zp.defined(DNNL_ARG_DST) && !zp.common(DNNL_ARG_DST);
+                && !zp.has_default_values(DNNL_ARG_DST)
+                && !zp.common(DNNL_ARG_DST);
 
         attr_info.initialized = true;
         return attr_info;

--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -35,11 +35,11 @@ status_t cudnn_binary_t::execute(const exec_ctx_t &ctx) const {
     nvidia::stream_t *cuda_stream
             = utils::downcast<nvidia::stream_t *>(ctx.stream());
 
-    if (!pd()->attr()->scales_.get(DNNL_ARG_SRC_0).defined())
+    if (!pd()->attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values())
         CHECK(stream_utils::copy_input_arg_to_host(ctx, cuda_stream,
                 &host_scales_[0], DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0,
                 sizeof(float)));
-    if (!pd()->attr()->scales_.get(DNNL_ARG_SRC_1).defined())
+    if (!pd()->attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values())
         CHECK(stream_utils::copy_input_arg_to_host(ctx, cuda_stream,
                 &host_scales_[1], DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_1,
                 sizeof(float)));

--- a/src/graph/backend/graph_compiler/core/src/runtime/microkernel/cpu/brgemm_onednn.cpp
+++ b/src/graph/backend/graph_compiler/core/src/runtime/microkernel/cpu/brgemm_onednn.cpp
@@ -196,7 +196,7 @@ static dnnl::impl::post_ops_t get_dnnl_postops_setting(
         if (alg == alg_kind_t::bias_add) {
             bias_dt = convert_dnnl_dtype(static_cast<int>(op.bias_op_.dtype_));
         } else if (alg == alg_kind_t::out_scales) {
-            status = pattr.output_scales_.set(op.scale_op_.scale_);
+            assert(!"unsupported quantization");
         } else if (alg == alg_kind_t::a_zp) {
             status = pattr.zero_points_.set(DNNL_ARG_SRC, op.zp_op_.zp_);
         } else if (alg == alg_kind_t::b_zp) {


### PR DESCRIPTION
I'd like to start the process of improving attributes internals responsible for quantization.
There were two major changes affected that piece of functionality:
* v3.0 moved from static to dynamic quantization.
* v3.4 introduced data types and groups for quantization parameters.

Both changes left a pile of technical debt towards a better solution, and it start biting in attempts to extends groups and data type support further.

To succeed with refactor, some obsolete entries required to be removed, and later to be replaced with modern analogue of that functionality in affected implementations.

This PR removes `oscale` abstraction and everything related to it as there's no way to invoke it through a public API. It also removes `defined()` method as unneeded. The change touches all teams as there are old pieces of code laying there. Please confirm you are fine with the change and will update quantized support in the correspondent backend as and if needed.