### PR TITLE
cpu: aarch64: fix jit_brgemm warnings

### DIFF
--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -43,8 +43,7 @@ struct jit_uni_brgemm_conv_comp_pad_kernel_t : public jit_generator {
 
     using XReg = const Xbyak_aarch64::XReg;
 
-    jit_uni_brgemm_conv_comp_pad_kernel_t<isa>(
-            const jit_brgemm_conv_conf_t &ajcp);
+    jit_uni_brgemm_conv_comp_pad_kernel_t(const jit_brgemm_conv_conf_t &ajcp);
 
     ~jit_uni_brgemm_conv_comp_pad_kernel_t() = default;
 

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -196,7 +196,7 @@ private:
     }
 
     void generate() override {
-        size_t simd_w_;
+        size_t simd_w_ = 0;
         switch (brg_.isa_impl) {
             case sve_512:
                 simd_w_ = cpu_isa_traits<sve_512>::vlen / sizeof(float);
@@ -204,7 +204,10 @@ private:
             case sve_256:
                 simd_w_ = cpu_isa_traits<sve_256>::vlen / sizeof(float);
                 break;
-            default: assert(!"unsupported isa");
+            default: {
+                assert(!"unsupported isa");
+                return;
+            }
         }
         preamble();
         if (simd_w_ != cpu_sveLen / sizeof(float)) {
@@ -850,7 +853,7 @@ private:
     }
 
     void generate() override {
-        size_t simd_w_;
+        size_t simd_w_ = 0;
         switch (brg.isa_impl) {
             case sve_512:
                 simd_w_ = cpu_isa_traits<sve_512>::vlen / sizeof(float);
@@ -858,7 +861,10 @@ private:
             case sve_256:
                 simd_w_ = cpu_isa_traits<sve_256>::vlen / sizeof(float);
                 break;
-            default: assert(!"unsupported isa");
+            default: {
+                assert(!"unsupported isa");
+                return;
+            }
         }
         preamble();
         if (simd_w_ != cpu_sveLen / sizeof(float)) {


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
