### PR TITLE
cpu: aarch64: fix jit_brgemm warnings

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1876,7 +1877,7 @@ void jit_brgemm_kernel_t::bdb_loop() {
 }
 
 void jit_brgemm_kernel_t::generate() {
-    size_t simd_w_;
+    size_t simd_w_ = 0;
     switch (brg.isa_impl) {
         case sve_512:
             simd_w_ = cpu_isa_traits<sve_512>::vlen / sizeof(float);
@@ -1884,7 +1885,10 @@ void jit_brgemm_kernel_t::generate() {
         case sve_256:
             simd_w_ = cpu_isa_traits<sve_256>::vlen / sizeof(float);
             break;
-        default: assert(!"unsupported isa");
+        default: {
+            assert(!"unsupported isa");
+            return;
+        }
     }
     preamble();
     if (simd_w_ != cpu_sveLen / sizeof(float)) {

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2022-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,8 +44,7 @@ struct jit_uni_brgemm_conv_comp_pad_kernel_t : public jit_generator {
 
     using XReg = const Xbyak_aarch64::XReg;
 
-    jit_uni_brgemm_conv_comp_pad_kernel_t<isa>(
-            const jit_brgemm_conv_conf_t &ajcp);
+    jit_uni_brgemm_conv_comp_pad_kernel_t(const jit_brgemm_conv_conf_t &ajcp);
 
     ~jit_uni_brgemm_conv_comp_pad_kernel_t() = default;
 

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -196,7 +197,7 @@ private:
     }
 
     void generate() override {
-        size_t simd_w_;
+        size_t simd_w_ = 0;
         switch (brg_.isa_impl) {
             case sve_512:
                 simd_w_ = cpu_isa_traits<sve_512>::vlen / sizeof(float);
@@ -204,7 +205,10 @@ private:
             case sve_256:
                 simd_w_ = cpu_isa_traits<sve_256>::vlen / sizeof(float);
                 break;
-            default: assert(!"unsupported isa");
+            default: {
+                assert(!"unsupported isa");
+                return;
+            }
         }
         preamble();
         if (simd_w_ != cpu_sveLen / sizeof(float)) {
@@ -850,7 +854,7 @@ private:
     }
 
     void generate() override {
-        size_t simd_w_;
+        size_t simd_w_ = 0;
         switch (brg.isa_impl) {
             case sve_512:
                 simd_w_ = cpu_isa_traits<sve_512>::vlen / sizeof(float);
@@ -858,7 +862,10 @@ private:
             case sve_256:
                 simd_w_ = cpu_isa_traits<sve_256>::vlen / sizeof(float);
                 break;
-            default: assert(!"unsupported isa");
+            default: {
+                assert(!"unsupported isa");
+                return;
+            }
         }
         preamble();
         if (simd_w_ != cpu_sveLen / sizeof(float)) {

--- a/src/cpu/cpu_deconvolution_list.cpp
+++ b/src/cpu/cpu_deconvolution_list.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2023 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022, 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "common/compiler_workarounds.hpp"
 #include "cpu/cpu_engine.hpp"
-
 #include "cpu/ref_deconvolution.hpp"
-
 #if DNNL_X64
 #include "cpu/x64/jit_avx512_core_amx_deconvolution.hpp"
 #include "cpu/x64/jit_avx512_core_x8s8s32x_1x1_deconvolution.hpp"


### PR DESCRIPTION
# Description

this change is to fix aarch64 compile warning so that we can enable Werror for aarch64 in the ci.

So far, we've fix t warnings inside oneDNN/src/cpu/aarch64/ folder and the following out-of-bound warning

```
In file included from /Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/memory_desc_wrapper.hpp:27,
                 from /Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/memory.hpp:26,
                 from /Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/engine.hpp:26,
                 from /Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/cpu_engine.hpp:26,
                 from /Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/cpu_deconvolution_list.cpp:19:
In function 'void dnnl::impl::copy_c_op_desc(op_desc_t*, const op_desc_t*)',
    inlined from 'dnnl::impl::primitive_desc_iterator_t::primitive_desc_iterator_t(dnnl::impl::engine_t*, const dnnl::impl::op_desc_t*, const dnnl::impl::primitive_attr_t*, const dnnl::impl::primitive_desc_t*, int)' at /Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/primitive_desc_iterator.hpp:50:23,
    inlined from 'dnnl::impl::status_t dnnl::impl::cpu::ref_deconvolution_bwd_data_t::pd_t::init_convolution(dnnl::impl::engine_t*)' at /Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/ref_deconvolution.hpp:338:[66](https://github.com/oneapi-src/oneDNN/actions/runs/11017022556/job/30593938494?pr=2118#step:9:67):
/Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/type_helpers.hpp:1225:23: warning: array subscript 'const dnnl::impl::op_desc_t[0]' is partly outside array bounds of 'dnnl::impl::convolution_desc_t [1]' [-Warray-bounds=]
 1225 |     switch ((int)src->kind) {
      |                  ~~~~~^~~~
In file included from /Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/cpu_deconvolution_list.cpp:21:
/Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/ref_deconvolution.hpp: In member function 'dnnl::impl::status_t dnnl::impl::cpu::ref_deconvolution_bwd_data_t::pd_t::init_convolution(dnnl::impl::engine_t*)':
/Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/ref_deconvolution.hpp:331:32: note: object 'cd' of size 5720
  331 |             convolution_desc_t cd;
      |                                ^~
In function 'void dnnl::impl::copy_c_op_desc(op_desc_t*, const op_desc_t*)',
    inlined from 'dnnl::impl::primitive_desc_iterator_t::primitive_desc_iterator_t(dnnl::impl::engine_t*, const dnnl::impl::op_desc_t*, const dnnl::impl::primitive_attr_t*, const dnnl::impl::primitive_desc_t*, int)' at /Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/primitive_desc_iterator.hpp:50:23,
    inlined from 'dnnl::impl::status_t dnnl::impl::cpu::ref_deconvolution_bwd_data_t::pd_t::init_convolution(dnnl::impl::engine_t*)' at /Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/ref_deconvolution.hpp:338:66:
/Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/type_helpers.hpp:1223:44: warning: array subscript 'const dnnl::impl::op_desc_t[0]' is partly outside array bounds of 'dnnl::impl::convolution_desc_t [1]' [-Warray-bounds=]
 1223 |     case primitive_kind::pkind: dst->pkind = src->pkind; break;
      |                                            ^
/Users/runner/work/oneDNN/oneDNN/oneDNN/src/common/type_helpers.hpp:1242:9: note: in expansion of macro 'CASE_OP_DESC'
 1242 |         CASE_OP_DESC(sdpa);
      |         ^~~~~~~~~~~~
/Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/ref_deconvolution.hpp: In member function 'dnnl::impl::status_t dnnl::impl::cpu::ref_deconvolution_bwd_data_t::pd_t::init_convolution(dnnl::impl::engine_t*)':
/Users/runner/work/oneDNN/oneDNN/oneDNN/src/cpu/ref_deconvolution.hpp:331:32: note: object 'cd' of size 5720
  331 |             convolution_desc_t cd;
```
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
