### PR TITLE
gpu: nvidia: Added support for native host task extension

### DIFF
--- a/src/gpu/nvidia/sycl_cuda_compat.hpp
+++ b/src/gpu/nvidia/sycl_cuda_compat.hpp
@@ -35,9 +35,13 @@ T get_native_mem(const interop_handle &ih, U acc) {
             ih.get_native_mem<::sycl::backend::ext_oneapi_cuda>(acc));
 }
 
-template <typename T>
-void host_task(::sycl::handler &cgh, const T &task) {
+template <typename HandlerT, typename FnT>
+void host_task(HandlerT &cgh, const FnT &task) {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+    cgh.ext_codeplay_enqueue_native_command(task);
+#else
     cgh.host_task(task);
+#endif
 }
 
 template <typename native_object_t, typename sycl_object_t,

--- a/src/gpu/nvidia/sycl_cuda_utils.hpp
+++ b/src/gpu/nvidia/sycl_cuda_utils.hpp
@@ -70,6 +70,12 @@ inline status_t check_device(dnnl::impl::engine_kind_t eng_kind) {
                     : status::invalid_arguments);
 }
 
+static void sync_device() {
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+    cudaDeviceSynchronize();
+#endif
+}
+
 static void convert_dnnl_dims_array(
         const dnnl_dim_t *dims, int *new_dims, int n_dims) {
     for (size_t i = 0; i < n_dims; i++) {


### PR DESCRIPTION

# Description

Adding support for the extension `ext_codeplay_enqueue_native_command` [LINK](https://github.com/intel/llvm/blob/2f0abc61d551b773e0497276c61fbcc576475a23/sycl/doc/extensions/experimental/sycl_ext_codeplay_enqueue_native_command.asciidoc#L2) to documentation.

Apart from improved dependencies for native commands, the native command provides less execution overhead, improving performance.

Example:
```
# old host task
    total perf: min(ms):38.256 avg(ms):97.7698
# native host task
    total perf: min(ms):33.4952 avg(ms):33.7441
```

Results generated running on A100 with command
`--eltwise --engine=gpu --mode=P --skip-impl=dpcpp:ref:any --batch=tests/benchdnn/inputs/eltwise/test_eltwise_gpu`

# Checklist

## General

- [ x ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ x ] Have you formatted the code using clang-format?

## Performance improvements

- [ x ] Have you submitted performance data that demonstrates performance improvements?