### PR TITLE
cpu: aarch64: ci turn on DONEDNN_WERROR

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -91,7 +91,7 @@ jobs:
           CC: ${{ matrix.compiler.CC }}
           CXX: ${{ matrix.compiler.CXX }}
       - name: Configure oneDNN
-        run: cmake -B${{ github.workspace }}/oneDNN/build -S${{ github.workspace }}/oneDNN -DDNNL_AARCH64_USE_ACL=ON -DONEDNN_BUILD_GRAPH=0 -DONEDNN_WERROR=OFF -DDNNL_BUILD_FOR_CI=ON -DONEDNN_TEST_SET=SMOKE -DCMAKE_BUILD_TYPE=${{ matrix.config.CMAKE_BUILD_TYPE }}
+        run: cmake -B${{ github.workspace }}/oneDNN/build -S${{ github.workspace }}/oneDNN -DDNNL_AARCH64_USE_ACL=ON -DONEDNN_BUILD_GRAPH=0 -DONEDNN_WERROR=ON -DDNNL_BUILD_FOR_CI=ON -DONEDNN_TEST_SET=SMOKE -DCMAKE_BUILD_TYPE=${{ matrix.config.CMAKE_BUILD_TYPE }}
         working-directory: ${{ github.workspace }}/oneDNN
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/lib


### PR DESCRIPTION
# Description

having fix all existing warnings for aarch64 in https://github.com/oneapi-src/oneDNN/pull/2118, we'd like to turn on DONEDNN_WERROR option in ci.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?


