### PR TITLE
@Radu2k and @Sqvid as codeowners for AArch64

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -163,6 +163,8 @@ Team: @oneapi-src/onednn-cpu-aarch64
 | David Svantesson   | @davsva01             | Arm Ltd           | Code Owner |
 | Jonathan Deakin    | @jondea               | Arm Ltd           | Code Owner |
 | Hamza Butt         | @theComputeKid        | Arm Ltd           | Code Owner |
+| Radu Salavat       | @Radu2k               | Arm Ltd           | Code Owner |
+| Siddhartha Menon   | @Sqvid                | Arm Ltd           | Code Owner |
 | Sunita Nadampalli  | @snadampal            | Amazon.com, Inc.  | Code Owner |
 
 ### OpenPOWER (PPC64)


### PR DESCRIPTION
I would like to nominate Radu Salavat @Radu2k and Siddhartha Menon @Sqvid for the roles of code owner of AArch64 component. Radu and Siddhartha are members of oneDNN team at Arm and have a history of contributions to oneDNN.
