### PR TITLE
gpu: nvidia: Updating pointers to memory_t

### DIFF
--- a/src/gpu/nvidia/cudnn_matmul.cpp
+++ b/src/gpu/nvidia/cudnn_matmul.cpp
@@ -126,7 +126,7 @@ status_t cudnn_matmul_lt_t::execute(const exec_ctx_t &ctx) const {
         src_scale_binary_args[DNNL_ARG_SRC_1] = memory_arg_t {
                 ctx.args().at(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC).mem, true};
 
-        std::unique_ptr<memory_t> scratch_mem;
+        std::unique_ptr<memory_t, memory_deleter_t> scratch_mem;
         auto scratchpad_storage
                 = ctx.get_scratchpad_grantor().get_memory_storage(
                         memory_tracking::names::key_matmul_lt_src_scale);
@@ -151,7 +151,7 @@ status_t cudnn_matmul_lt_t::execute(const exec_ctx_t &ctx) const {
                 ctx.args().at(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS).mem,
                 true};
 
-        std::unique_ptr<memory_t> scratch_mem;
+        std::unique_ptr<memory_t, memory_deleter_t> scratch_mem;
         auto scratchpad_storage
                 = ctx.get_scratchpad_grantor().get_memory_storage(
                         memory_tracking::names::key_matmul_lt_wei_scale);
@@ -174,7 +174,7 @@ status_t cudnn_matmul_lt_t::execute(const exec_ctx_t &ctx) const {
     if (matmul_impl_->with_bias()) {
         // bias sycl binary
         exec_args_t binary_args;
-        std::unique_ptr<memory_t> scratch_mem;
+        std::unique_ptr<memory_t, memory_deleter_t> scratch_mem;
         if (dst_d.data_type() == dnnl_s8) {
             auto scratchpad_storage
                     = ctx.get_scratchpad_grantor().get_memory_storage(

--- a/src/gpu/nvidia/cudnn_reorder_lt.cpp
+++ b/src/gpu/nvidia/cudnn_reorder_lt.cpp
@@ -68,7 +68,7 @@ status_t cudnn_reorder_lt_t::execute(const exec_ctx_t &ctx) const {
         dst_scales = &arg_dst_scale_md->second;
     }
     if (pd()->src_float_) {
-        std::unique_ptr<memory_t> scratch_mem;
+        std::unique_ptr<memory_t, memory_deleter_t> scratch_mem;
         auto scratchpad_storage
                 = ctx.get_scratchpad_grantor().get_memory_storage(
                         memory_tracking::names::key_reorder_cublaslt_src_float);
@@ -118,7 +118,7 @@ status_t cudnn_reorder_lt_t::execute(const exec_ctx_t &ctx) const {
         });
 
         if (pd()->dst_float_) {
-            std::unique_ptr<memory_t> scratch_mem;
+            std::unique_ptr<memory_t, memory_deleter_t> scratch_mem;
             auto scratchpad_storage
                     = ctx.get_scratchpad_grantor().get_memory_storage(
                             memory_tracking::names::


### PR DESCRIPTION
# Description
Commit 28ec30dd80dea203949ec175996122b81b9d825e introduces changes to `memory_t`. Adding the required changes to enable building nvidia backend, as it currently does not compile.
