### PR TITLE
cpu: aarch64: fix wino conv test failure

### DIFF
--- a/tests/gtests/test_iface_wino_convolution.cpp
+++ b/tests/gtests/test_iface_wino_convolution.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -68,7 +68,9 @@ TEST_F(wino_conv_test_t, TestSmallPadding) {
         if (unsupported_data_type(input.dat_dt)
                 || unsupported_data_type(input.wei_dt))
             continue;
-
+#if defined(DNNL_AARCH64) && defined(DNNL_AARCH64_USE_ACL)
+        if (input.dat_dt == data_type::f16) continue;
+#endif
         memory::desc src_md {{1, 16, 7, 7}, input.dat_dt, tag::any};
         memory::desc wei_md {{32, 16, 3, 3}, input.wei_dt, tag::any};
         memory::desc dst_md {{1, 32, 7, 7}, input.dat_dt, tag::any};


### PR DESCRIPTION
# Description

The benchDNN wino_conv_test_t.TestSmallPadding test now fails on AArch64 due to the absence of an FP16 Winograd convolution kernel implementation in ACL. This PR modifies the test suite to skip FP16 test cases when compiled with the DNNL_AARCH64_USE_ACL option.

Fixes #2109

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
