### PR TITLE
github: workflows: Enable Arm Hosted GitHub Runners

### DIFF
--- a/.github/automation/build_aarch64.sh
+++ b/.github/automation/build_aarch64.sh
@@ -1,0 +1,51 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Build oneDNN for aarch64.
+
+set -o errexit -o pipefail -o noclobber
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Defines MP, CC, CXX and OS.
+source ${SCRIPT_DIR}/common_aarch64.sh
+
+export ACL_ROOT_DIR=${ACL_ROOT_DIR:-"${PWD}/ComputeLibrary"}
+
+CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
+ONEDNN_TEST_SET=SMOKE
+
+# ACL is not built with OMP on macOS.
+if [[ "$OS" == "Darwin" ]]; then
+    ONEDNN_THREADING=SEQ
+fi
+
+set -x
+cmake \
+    -Bbuild -S. \
+    -DDNNL_AARCH64_USE_ACL=ON \
+    -DONEDNN_BUILD_GRAPH=0 \
+    -DDNNL_CPU_RUNTIME=$ONEDNN_THREADING \
+    -DONEDNN_WERROR=ON \
+    -DDNNL_BUILD_FOR_CI=ON \
+    -DONEDNN_TEST_SET=$ONEDNN_TEST_SET \
+    -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+
+cmake --build build $MP
+set +x

--- a/.github/automation/common_aarch64.sh
+++ b/.github/automation/common_aarch64.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Common variables for aarch64 ci. Exports: 
+# CC, CXX, OS, MP
+
+set -o errexit -o pipefail -o noclobber
+
+export OS=$(uname)
+
+# Num threads on system.
+if [[ "$OS" == "Darwin" ]]; then
+    export MP="-j$(sysctl -n hw.ncpu)"
+elif [[ "$OS" == "Linux" ]]; then
+    export MP="-j$(nproc)"
+fi
+
+if [[ "$BUILD_TOOLSET" == "gcc" ]]; then
+    export CC=gcc-${GCC_VERSION}
+    export CXX=g++-${GCC_VERSION}
+elif [[ "$BUILD_TOOLSET" == "clang" ]]; then
+    export CC=clang
+    export CXX=clang++
+fi
+
+# Print every exported variable.
+echo "OS: $OS"
+echo "Toolset: $BUILD_TOOLSET"
+echo "CC: $CC"
+echo "CXX: $CXX"
+echo "MP: $MP"

--- a/.github/automation/test_aarch64.sh
+++ b/.github/automation/test_aarch64.sh
@@ -1,0 +1,96 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Test oneDNN for aarch64.
+
+set -o errexit -o pipefail -o noclobber
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Defines MP, CC, CXX and OS.
+source ${SCRIPT_DIR}/common_aarch64.sh
+
+# Skip tests for certain config to preserve resources, while maintaining 
+# coverage. Skip: 
+# (SEQ,CLANG)
+# (OMP,CLANG,DEBUG)
+SKIP_TESTS=0
+if [[ "$OS" == "Linux" ]]; then
+    if [[ "$ONEDNN_THREADING" == "SEQ" ]]; then
+        if [[ "$BUILD_TOOLSET" == "clang" ]]; then
+            SKIP_TESTS=1
+        fi
+    elif [[ "$ONEDNN_THREADING" == "OMP" ]]; then 
+        if [[ "$BUILD_TOOLSET" == "clang" ]]; then
+            if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+                SKIP_TESTS=1
+            fi
+        fi
+    fi
+fi
+
+if [[ $SKIP_TESTS == 1 ]]; then
+    echo "Skipping tests for this configuration: $OS $ONEDNN_THREADING $BUILD_TOOLSET".
+    exit 0
+fi
+
+#  We currently have some OS and config specific test failures.
+if [[ "$OS" == "Linux" ]]; then
+    if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|cpu-primitives-matmul-cpp"
+        SKIPPED_TEST_FAILURES+="|test_convolution_backward_weights_f32"
+        SKIPPED_TEST_FAILURES+="|test_matmul"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_conv_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_deconv_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_matmul_smoke_cpu"
+    elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+    fi
+elif [[ "$OS" == "Darwin" ]]; then
+    if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_ci_cpu"
+    elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_ci_cpu"
+    fi
+fi
+
+if [[ "$OS" == "Darwin" ]]; then
+    # Since macos does not build with OMP, we can use multiple ctest threads.
+    CTEST_MP=$MP
+elif [[ "$OS" == "Linux" ]]; then
+    if [[ "$ONEDNN_THREADING" == "OMP" ]]; then
+        # OMP is already multi-threaded. Let's not oversubscribe.
+        CTEST_MP=-j2
+    elif [[ "$ONEDNN_THREADING" == "SEQ" ]]; then
+        CTEST_MP=$MP
+    fi
+fi
+
+set -x
+ctest $CTEST_MP --no-tests=error --verbose --output-on-failure -E "$SKIPPED_TEST_FAILURES"
+set +x

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -35,80 +35,117 @@ permissions: read-all
 
 jobs:
   macos:
+    name: macOS
     runs-on: macos-14
     strategy:
       matrix:
-        compiler: [{ CC: clang, CXX: clang++ }, { CC: gcc-14, CXX: g++-14 }]
-        config:
-          [
-            {
-              CMAKE_BUILD_TYPE: Debug,
-              ACL_WITH_ASSERTS: '1',
-              IGNORED_TEST_FAILS: 'cpu-primitives-deconvolution-cpp|test_benchdnn_modeC_lnorm_smoke_cpu|test_benchdnn_modeC_brgemm_smoke_cpu'
-            },
-            {
-              CMAKE_BUILD_TYPE: Release,
-              ACL_WITH_ASSERTS: '0',
-              IGNORED_TEST_FAILS: 'cpu-primitives-deconvolution-cpp|test_benchdnn_modeC_lnorm_smoke_cpu'
-            }
-          ]
-    name: macOS (${{ matrix.compiler.CC }}, ${{ matrix.config.CMAKE_BUILD_TYPE }})
+        toolset: [clang, gcc]
+        config: [Debug, Release]
+
     steps:
-      - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
-        id: cpu-cores
+      - name: Checkout oneDNN
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          path: oneDNN
+
+      - name: Install Scons
+        uses: threeal/pipx-install-action@b0bf0add7d5aefda03a3d4e47d651df807889e10 # v1.0.0
+        with:
+          packages: scons
+
+      - name: Build ACL
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        env:
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          ACL_CONFIG: ${{ matrix.config }}
+          GCC_VERSION: 14
+
+      - name: Build oneDNN
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
+        working-directory: ${{ github.workspace }}/oneDNN
+        env:
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          GCC_VERSION: 14
+
+      - if: matrix.toolset == 'clang'
+        name: Run oneDNN smoke tests
+        run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
+        working-directory: ${{ github.workspace }}/oneDNN/build
+        env:
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
+
+  # We only run the linux aarch64 runners if macos smoke tests pass.
+  linux:
+    needs: macos
+    strategy:
+      matrix:
+        threading: [OMP]
+        toolset: [clang, gcc]
+        config: [Debug, Release]
+        host: [
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50 }, 
+          { name: c7g, label: ah-ubuntu_22_04-c7g_2x-50 }
+        ]
+
+    name: ${{ matrix.host.name }}, ${{ matrix.toolset }}, ${{ matrix.threading }}, ${{ matrix.config }}
+    runs-on: ${{ matrix.host.label }}
+    steps:
       - name: Checkout oneDNN
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           path: oneDNN
-      # ACL is built with clang, so we can link with it directly if we are using
-      # clang as well.
-      - if: matrix.compiler.CC == 'clang'
-        name: Download and Extract ACL
-        run: ${{ github.workspace }}/oneDNN/.github/automation/get_acl.sh
-        env:
-          ACL_WITH_ASSERTS: ${{ matrix.config.ACL_WITH_ASSERTS }}
-          ACL_VERSION: ${{ github.event.inputs.ACL_VERSION || 'v24.08.1' }}
-      # If we are building with gcc, we need to clone and build ACL ourselves to
-      # link properly.
-      - if: contains( matrix.compiler.CC , 'gcc' )
-        name: Install Scons
-        uses: threeal/pipx-install-action@b0bf0add7d5aefda03a3d4e47d651df807889e10 # v1.0.0
+
+      - name: Install dev tools
+        run: |
+          sudo apt update -y
+          sudo apt install -y scons cmake make
+
+      - if: matrix.threading == 'OMP'
+        name: Install openmp
+        run: |
+          sudo apt install -y libomp-dev
+
+      - if: matrix.toolset == 'gcc'
+        name: Install gcc
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt update -y
+          sudo apt install -y g++-13
+
+      - if: matrix.toolset == 'clang'
+        name: Install clang
+        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
         with:
-          packages: scons
-      - if: contains( matrix.compiler.CC , 'gcc' )
-        name: Checkout ACL
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-        with:
-          repository: ARM-software/ComputeLibrary
-          ref: 'v24.08.1'
-          path: ComputeLibrary
-      - if: contains( matrix.compiler.CC , 'gcc' )
-        name: Build ACL
-        working-directory: ${{ github.workspace }}/ComputeLibrary
-        run: scons Werror=1 -j${{ steps.cpu-cores.outputs.count }} neon=1 opencl=0 os=macos arch=armv8.2-a build=native cppthreads=0 openmp=0 examples=0 validation_tests=0
+          version: "17"
+
+      - name: Build ACL
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
         env:
-          CC: ${{ matrix.compiler.CC }}
-          CXX: ${{ matrix.compiler.CXX }}
-      - name: Configure oneDNN
-        run: cmake -B${{ github.workspace }}/oneDNN/build -S${{ github.workspace }}/oneDNN -DDNNL_AARCH64_USE_ACL=ON -DONEDNN_BUILD_GRAPH=0 -DONEDNN_WERROR=ON -DDNNL_BUILD_FOR_CI=ON -DONEDNN_TEST_SET=SMOKE -DCMAKE_BUILD_TYPE=${{ matrix.config.CMAKE_BUILD_TYPE }}
-        working-directory: ${{ github.workspace }}/oneDNN
-        env:
-          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/lib
+          ACL_CONFIG: ${{ matrix.config }}
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          CC: ${{ matrix.compiler.CC }}
-          CXX: ${{ matrix.compiler.CXX }}
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          GCC_VERSION: 13
+          ACL_THREADING: ${{ matrix.threading }}
+
       - name: Build oneDNN
-        run: cmake --build ${{ github.workspace }}/oneDNN/build -j${{ steps.cpu-cores.outputs.count }}
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
         working-directory: ${{ github.workspace }}/oneDNN
         env:
-          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/lib
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-      # Only run smoke tests for clang. We only test gcc for build.
-      # Failure list currently depends on config. Exclude current failures.
-      - if: matrix.compiler.CC == 'clang'
-        name: Run oneDNN smoke tests
-        run: ctest --test-dir ${{ github.workspace }}/oneDNN/build -j${{ steps.cpu-cores.outputs.count }} -E '${{ matrix.config.IGNORED_TEST_FAILS }}'
-        working-directory: ${{ github.workspace }}/oneDNN
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          GCC_VERSION: 13
+          ONEDNN_THREADING: ${{ matrix.threading }}
+
+      - name: Run oneDNN tests
+        run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
+        working-directory: ${{ github.workspace }}/oneDNN/build
         env:
-          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/lib
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
+          ONEDNN_THREADING: ${{ matrix.threading }}     


### PR DESCRIPTION
The oneDNN repo has now been enabled with Arm hosted GitHub runners. They have been activated for PRs opened against the repo.

This is an initial version of AArch64 CI for Linux, on c6g and c7g. We build for gcc-13 and clang-17, in debug and release, for openmp builds. For now, we enable smoke tests for most, but not all, configurations (in order to preserve runner resources). We have logic in the test scripts to skip tests on certain configs. As per suggestions from @vpirogov (and I agree), CI logic has been moved into cross-platform scripts.

The CI is dependent on MacOS pipelines passing. Total run time seems to be in line with x86:
- MacOS: 45 minutes
- Linux: 20-30 minutes

Overall time for a run: 1:15 (reasonable).

A few notes:

1. I have renamed the GitHub jobs generically so that they do not need to be updated when we upgrade compilers (e.g. gcc vs gcc-13). This means we can set them as required checks once then and forget.
2. I would like to rethink the CI scripts after initial work on CI is finished, to clean them up. Ideally, the scripts should allow developers to reproduce builds when debugging.
3. Threadpool builds still need to be added.
4. Full extensive CI testing needs to be added.
5. We should consider whether we should test multiple compiler versions in the future.
6. I believe we should be able to cache ACL builds in the future. We should explore this to save resources (approx 30% of compute time), instead of building every time. This can allow us to use smaller runners, of which more are available concurrently.

Unfortunately for oneDNN repo admins (@mgouicem, @vpirogov), you will need to tediously add all combinations of checks as "required", e.g.:

1. CI AArch64 / c7g, clang, OMP, Debug 
2. CI AArch64 / c6g, clang, OMP, Release
etc etc

Apologies for the inconvenience. However, this is a one-time effort as we don't need to update them later as those tags will rarely change. You will also need to remove the previous MacOS checks, e.g.: `macOS (gcc-14, Debug)` and replace with the current version-less MacOS checks, e.g.: `macOS (gcc, Debug)`.

For more info: 
1. https://github.com/apps/arm-hosted-gha-runners
2. https://gitlab.arm.com/tooling/gha-runner-docs/