### PR TITLE
generic: sycl: implement prelu post-op

### DIFF
--- a/src/gpu/generic/sycl/binary_kernels.hpp
+++ b/src/gpu/generic/sycl/binary_kernels.hpp
@@ -48,7 +48,7 @@ struct binary_kernel_vec_t {
                                                         | DNNL_ARG_SRC_0)
                                                      .data_type()
                                            : data_type_t::dnnl_f32)
-        , po_args_(cgh, ctx) {}
+        , po_args_(cgh, ctx, conf_.post_ops) {}
 
     void operator()(::sycl::nd_item<1> item) const {
         memory_tensor_t src0_mem(src0_, conf_.src0_md);

--- a/src/gpu/generic/sycl/eltwise_kernels.hpp
+++ b/src/gpu/generic/sycl/eltwise_kernels.hpp
@@ -36,7 +36,7 @@ struct eltwise_fwd_kernel_vec_t {
             ::sycl::handler &cgh, const exec_ctx_t &ctx)
         : conf_(conf)
         , src_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC))
-        , po_args_(cgh, ctx)
+        , po_args_(cgh, ctx, conf_.post_ops)
         , dst_(CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST)) {}
 
     void operator()(::sycl::nd_item<1> item) const {

--- a/src/gpu/generic/sycl/pooling_kernels.hpp
+++ b/src/gpu/generic/sycl/pooling_kernels.hpp
@@ -42,7 +42,7 @@ struct pooling_fwd_kernel_vec_t {
         , src_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC))
         , dst_(CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST))
         , ws_(CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_WORKSPACE))
-        , po_args_(cgh, ctx) {}
+        , po_args_(cgh, ctx, conf_.post_ops) {}
 
     void operator()(::sycl::nd_item<1> item) const {
         memory_tensor_t src_mem(src_, conf_.src_md);

--- a/src/gpu/generic/sycl/ref_binary.cpp
+++ b/src/gpu/generic/sycl/ref_binary.cpp
@@ -49,7 +49,7 @@ status_t ref_binary_t::pd_t::init_conf() {
                 = conf_.src0_md.dims()[i] != 1 && conf_.src1_md.dims()[i] == 1;
     }
 
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     return status::success;
 }

--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -51,7 +51,7 @@ status_t ref_convolution_fwd_t::pd_t::init_conf() {
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
     conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
 
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
     conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
@@ -111,7 +111,7 @@ status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
     conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
 
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
     conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
@@ -173,7 +173,7 @@ status_t ref_convolution_bwd_weights_t::pd_t::init_conf() {
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
     conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
 
-    conf_.post_ops = sycl_post_ops_t(attr());
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
     conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);

--- a/src/gpu/generic/sycl/ref_eltwise.cpp
+++ b/src/gpu/generic/sycl/ref_eltwise.cpp
@@ -38,11 +38,7 @@ status_t ref_sycl_eltwise_fwd_t::pd_t::init_conf() {
     conf_.h = H();
     conf_.w = W();
 
-    if (attr()->post_ops_.len() > sycl_post_ops_t::max_post_ops) {
-        return status::unimplemented;
-    }
-    conf_.post_po_len = attr()->post_ops_.len();
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     return status::success;
 }

--- a/src/gpu/generic/sycl/ref_matmul.cpp
+++ b/src/gpu/generic/sycl/ref_matmul.cpp
@@ -43,8 +43,7 @@ void ref_matmul_t::pd_t::init_conf() {
             = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
 
     conf_.use_dropout = !attr()->dropout_.has_default_values();
-
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     memory_desc_wrapper src_d = src_md();
     memory_desc_wrapper weights_d = weights_md();

--- a/src/gpu/generic/sycl/ref_matmul.hpp
+++ b/src/gpu/generic/sycl/ref_matmul.hpp
@@ -59,7 +59,8 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
                             | sm::zero_points_runtime_data_type)
                     && IMPLICATION(
                             !attr()->scales_.has_default_values(), scales_ok())
-                    && post_ops_ok() && md_dims_in_range(src_md())
+                    && sycl_post_ops_t::post_ops_ok(attr())
+                    && md_dims_in_range(src_md())
                     && md_dims_in_range(weights_md());
             if (!ok) return status::unimplemented;
 
@@ -119,14 +120,6 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
                         && utils::one_of(s.data_type_, s8, s32, f32, f16, bf16);
             }
             return dt_ok && attr_scales_ok(supported_args);
-        }
-
-        bool post_ops_ok() const {
-            // Dw conv post-ops are not supported.
-            return attr()->post_ops_.len() <= sycl_post_ops_t::max_post_ops
-                    && attr()->post_ops_.has_default_values(
-                            {primitive_kind::eltwise, primitive_kind::binary,
-                                    primitive_kind::sum});
         }
 
         static bool check_data_types(const memory_desc_wrapper &src,

--- a/src/gpu/generic/sycl/ref_pooling.cpp
+++ b/src/gpu/generic/sycl/ref_pooling.cpp
@@ -64,13 +64,7 @@ status_t ref_pooling_fwd_t::pd_t::init_conf() {
     conf_.DH = KDH(); //K:kernel D:Dilation H:Height
     conf_.DW = KDW(); //K:kernel D:Dilation W:Weight
 
-    const auto *att = attr();
-    const auto &attr_po = att->post_ops_;
-    if (attr_po.len() > sycl_post_ops_t::max_post_ops) {
-        return dnnl_unimplemented;
-    }
-    conf_.po_len = attr_po.len();
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
     return status::success;
 }
 

--- a/src/gpu/generic/sycl/ref_reorder.cpp
+++ b/src/gpu/generic/sycl/ref_reorder.cpp
@@ -38,7 +38,7 @@ status_t ref_reorder_t::pd_t::init_conf() {
     conf_.do_scale_dst
             = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
     conf_.scale_dst_mask = attr()->scales_.get(DNNL_ARG_DST).mask_;
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     return status::success;
 }

--- a/src/gpu/generic/sycl/ref_resampling.cpp
+++ b/src/gpu/generic/sycl/ref_resampling.cpp
@@ -43,14 +43,8 @@ status_t ref_resampling_fwd_t::pd_t::init_conf() {
     conf_.dst_md = xpu::sycl::md_t(dst_md());
 
     conf_.alg = desc()->alg_kind;
-    const auto *att = attr();
-    const auto &attr_po = att->post_ops_;
-    if (attr_po.len() > sycl_post_ops_t::max_post_ops) {
-        return dnnl_unimplemented;
-    }
-    conf_.po_len = attr_po.len();
 
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
     return status::success;
 }
 

--- a/src/gpu/generic/sycl/ref_softmax.cpp
+++ b/src/gpu/generic/sycl/ref_softmax.cpp
@@ -41,8 +41,7 @@ status_t ref_sycl_softmax_fwd_t::pd_t::init_conf() {
     conf_.do_scale_dst
             = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
 
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md()->data_type);
-    conf_.po_len = attr()->post_ops_.len();
+    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     return status::success;
 }

--- a/src/gpu/generic/sycl/resampling_kernels.hpp
+++ b/src/gpu/generic/sycl/resampling_kernels.hpp
@@ -39,7 +39,7 @@ struct resampling_kernel_fwd_vec_t {
         : conf_(conf)
         , src_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC))
         , dst_(CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST))
-        , po_args_(cgh, ctx) {}
+        , po_args_(cgh, ctx, conf_.post_ops) {}
 
     void operator()(::sycl::nd_item<1> item) const {
         memory_tensor_t src_mem(src_, conf_.src_md);

--- a/src/gpu/generic/sycl/softmax_kernels.hpp
+++ b/src/gpu/generic/sycl/softmax_kernels.hpp
@@ -42,7 +42,7 @@ struct softmax_fwd_kernel_vec_t {
         , scale_dst_(CTX_IN_SYCL_KERNEL_MEMORY(
                   DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST))
         , dst_(CTX_OUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST))
-        , po_args_(cgh, ctx) {}
+        , po_args_(cgh, ctx, conf_.post_ops) {}
 
     void operator()(::sycl::nd_item<1> item) const {
         memory_tensor_t src_mem(src_, conf_.src_md);

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -96,7 +96,6 @@ struct sycl_eltwise_conf_t {
     dim_t h;
     dim_t w;
     dim_t wk_size;
-    dim_t post_po_len;
     sycl_post_ops_t post_ops;
 };
 
@@ -110,8 +109,6 @@ struct sycl_matmul_conf_t {
     bool transpose_dst;
     bool transpose_weights;
     bool transpose_bias;
-    dim_t post_po_len;
-    xpu::sycl::md_t binary_src_arr[sycl::sycl_post_ops_t::max_post_ops];
     sycl_post_ops_t post_ops;
     int wk_size;
 
@@ -206,7 +203,6 @@ struct sycl_reorder_conf_t {
 struct sycl_resampling_conf_t {
     dims_t dst_dims;
     int dst_ndims;
-    int po_len;
     size_t work_amount;
 
     xpu::sycl::md_t src_md;
@@ -320,7 +316,6 @@ struct sycl_softmax_conf_t {
     alg_kind_t alg_kind;
     dim_t wk_size;
 
-    int po_len;
     dim_t axis;
     dim_t axis_size;
     dim_t inner_size;
@@ -359,7 +354,6 @@ struct sycl_lrn_conf_t {
 struct sycl_pooling_base_conf_t {
     xpu::sycl::md_t ws_md;
     int ndims;
-    int po_len;
     bool zero_dims;
     int block_size;
     int wg_size;


### PR DESCRIPTION
Implements PReLu as a post op, which can be used in any SYCL kernels that use post-ops.

This PR also includes some post-ops related cleanup (removing of now redundant members from conf structs) from previous refactors.