### PR TITLE
cpu: aarch64: Fix C_graph_fusions_cpu test

### DIFF
--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -129,9 +129,8 @@ bool post_ops_ok(brgemm_matmul_conf_t &bgmmc, const primitive_attr_t &attr,
                     true /*sum_requires_same_params*/, bcast_set));
 }
 
-status_t check_isa_with_datatype(
-        const brgemm_matmul_conf_utils_t &bm_conf_utils) {
-    if (bm_conf_utils.is_f32() && !bm_conf_utils.is_int8()
+status_t check_datatype(const brgemm_matmul_conf_utils_t &bm_conf_utils) {
+    if (bm_conf_utils.is_f32() && !bm_conf_utils.is_bf32()
             && !bm_conf_utils.is_bf16() && !bm_conf_utils.is_f16()
             && !bm_conf_utils.is_int8())
         return status::success;
@@ -320,10 +319,6 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
             case 16: return bgmmc.ndims == 3 ? aCB16b16c4b : BA16a16b4a;
             default: return format_tag::undef;
         }
-
-    assert(!this->is_bf16());
-    assert(!this->is_f16());
-    assert(!this->is_bf32());
 
     // Note: bf32 assumes f32 blocking
     if (this->is_f32() || this->is_bf32() || this->is_f16()) switch (n_blk) {
@@ -733,7 +728,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             dst_d.format_kind() == format_kind::any,
             bias_md.format_kind == format_kind::any);
 
-    VCHECK_BG(check_isa_with_datatype(bm_conf_utils), VERBOSE_ISA_DT_MISMATCH);
+    VCHECK_BG(check_datatype(bm_conf_utils), VERBOSE_UNSUPPORTED_DT);
 
     bgmmc.a_dt_sz = bgmmc.tr_a_dt_sz = types::data_type_size(bgmmc.src_dt);
     bgmmc.b_dt_sz = bgmmc.tr_b_dt_sz = types::data_type_size(bgmmc.wei_dt);


### PR DESCRIPTION
Remove asserts in brgemm_matmul_utils.cpp to make
test_benchdnn_modeC_graph_fusions_cpu fail or pass. The datatype support should be checked in
check_datatype. This has been renamed as well from check_isa_with_datatype to check_datatype.

# Description

By enabling all graph API tests on AArch64 as a follow-up of this change (https://github.com/oneapi-src/oneDNN/pull/2099#issuecomment-2379967176) unveiled that `ctest -R "test_benchdnn_modeC_graph_fusions_cpu"` failed due to the assets on lines 323, 324 and 325 in `src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp`.  

The test segfaulted because `pick_blocked_B_layout` is called before the init, when the object is constructed. These datatypes are checked in the init and return status unimplemented. 

This behaviour should be changed to calling `pick_blocked_B_layout` in configure after init has passed.

# Checklist
## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
