### PR TITLE
generic: deconvolution: bugfix includes

### DIFF
--- a/src/gpu/generic/convolution_deconvolution.hpp
+++ b/src/gpu/generic/convolution_deconvolution.hpp
@@ -19,9 +19,11 @@
 
 #include "common/c_types_map.hpp"
 #include "common/primitive.hpp"
+#include "common/primitive_desc_iterator.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 #include "gpu/gpu_deconvolution_pd.hpp"
+#include "gpu/gpu_primitive.hpp"
 
 namespace dnnl {
 namespace impl {


### PR DESCRIPTION
Fixes missing includes in generic convolution deconvolution that pop up when compiling without non-generic implementations.