### PR TITLE
github: workflows: Enable aarch64 CI

### DIFF
--- a/.github/automation/build_aarch64.sh
+++ b/.github/automation/build_aarch64.sh
@@ -1,0 +1,51 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Build oneDNN for aarch64.
+
+set -o errexit -o pipefail -o noclobber
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Defines MP, CC, CXX and OS.
+source ${SCRIPT_DIR}/common_aarch64.sh
+
+export ACL_ROOT_DIR=${ACL_ROOT_DIR:-"${PWD}/ComputeLibrary"}
+
+CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
+ONEDNN_TEST_SET=SMOKE
+
+# ACL is not built with OMP on macOS.
+if [[ "$OS" == "Darwin" ]]; then
+    ONEDNN_THREADING=SEQ
+fi
+
+set -x
+cmake \
+    -Bbuild -S. \
+    -DDNNL_AARCH64_USE_ACL=ON \
+    -DONEDNN_BUILD_GRAPH=0 \
+    -DDNNL_CPU_RUNTIME=$ONEDNN_THREADING \
+    -DONEDNN_WERROR=OFF \
+    -DDNNL_BUILD_FOR_CI=ON \
+    -DONEDNN_TEST_SET=$ONEDNN_TEST_SET \
+    -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+
+cmake --build build $MP
+set +x

--- a/.github/automation/common_aarch64.sh
+++ b/.github/automation/common_aarch64.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Common variables for aarch64 ci. Exports: 
+# CC, CXX, OS, MP
+
+set -o errexit -o pipefail -o noclobber
+
+export OS=$(uname)
+
+# Num threads on system.
+if [[ "$OS" == "Darwin" ]]; then
+    export MP="-j$(sysctl -n hw.ncpu)"
+elif [[ "$OS" == "Linux" ]]; then
+    export MP="-j$(nproc)"
+fi
+
+if [[ "$BUILD_TOOLSET" == "gcc" ]]; then
+    export CC=gcc-${GCC_VERSION}
+    export CXX=g++-${GCC_VERSION}
+elif [[ "$BUILD_TOOLSET" == "clang" ]]; then
+    export CC=clang
+    export CXX=clang++
+fi
+
+# Print every exported variable.
+echo "OS: $OS"
+echo "Toolset: $BUILD_TOOLSET"
+echo "CC: $CC"
+echo "CXX: $CXX"
+echo "MP: $MP"

--- a/.github/automation/test_aarch64.sh
+++ b/.github/automation/test_aarch64.sh
@@ -1,0 +1,96 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Test oneDNN for aarch64.
+
+set -o errexit -o pipefail -o noclobber
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Defines MP, CC, CXX and OS.
+source ${SCRIPT_DIR}/common_aarch64.sh
+
+# Skip tests for certain config to preserve resources, while maintaining 
+# coverage. Skip: 
+# (SEQ,CLANG)
+# (OMP,CLANG,DEBUG)
+SKIP_TESTS=0
+if [[ "$OS" == "Linux" ]]; then
+    if [[ "$ONEDNN_THREADING" == "SEQ" ]]; then
+        if [[ "$BUILD_TOOLSET" == "clang" ]]; then
+            SKIP_TESTS=1
+        fi
+    elif [[ "$ONEDNN_THREADING" == "OMP" ]]; then 
+        if [[ "$BUILD_TOOLSET" == "clang" ]]; then
+            if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+                SKIP_TESTS=1
+            fi
+        fi
+    fi
+fi
+
+if [[ $SKIP_TESTS == 1 ]]; then
+    echo "Skipping tests for this configuration: $OS $ONEDNN_THREADING $BUILD_TOOLSET".
+    exit 0
+fi
+
+#  We currently have some OS and config specific test failures.
+if [[ "$OS" == "Linux" ]]; then
+    if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|cpu-primitives-matmul-cpp"
+        SKIPPED_TEST_FAILURES+="|test_convolution_backward_weights_f32"
+        SKIPPED_TEST_FAILURES+="|test_matmul"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_conv_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_deconv_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_matmul_smoke_cpu"
+    elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+    fi
+elif [[ "$OS" == "Darwin" ]]; then
+    if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_ci_cpu"
+    elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
+        SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_ci_cpu"
+    fi
+fi
+
+if [[ "$OS" == "Darwin" ]]; then
+    # Since macos does not build with OMP, we can use multiple ctest threads.
+    CTEST_MP=$MP
+elif [[ "$OS" == "Linux" ]]; then
+    if [[ "$ONEDNN_THREADING" == "OMP" ]]; then
+        # OMP is already multi-threaded. Let's not oversubscribe.
+        CTEST_MP=-j2
+    elif [[ "$ONEDNN_THREADING" == "SEQ" ]]; then
+        CTEST_MP=$MP
+    fi
+fi
+
+set -x
+ctest $CTEST_MP --no-tests=error --verbose --output-on-failure -E "$SKIPPED_TEST_FAILURES"
+set +x

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -1,0 +1,151 @@
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+name: "CI AArch64"
+
+#* To avoid duplicate jobs running when both push and PR is satisfied, we use this:
+#* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+#* Stop stale workflows when pull requests are updated: https://stackoverflow.com/a/70972844
+#* Does not apply to the main branch.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  macos:
+    name: macOS
+    runs-on: macos-14
+    strategy:
+      matrix:
+        toolset: [clang, gcc]
+        config: [Debug, Release]
+
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          path: oneDNN
+
+      - name: Install Scons
+        uses: threeal/pipx-install-action@b0bf0add7d5aefda03a3d4e47d651df807889e10 # v1.0.0
+        with:
+          packages: scons
+
+      - name: Build ACL
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        env:
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          ACL_CONFIG: ${{ matrix.config }}
+          GCC_VERSION: 14
+
+      - name: Build oneDNN
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
+        working-directory: ${{ github.workspace }}/oneDNN
+        env:
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          GCC_VERSION: 14
+
+      - if: matrix.toolset == 'clang'
+        name: Run oneDNN smoke tests
+        run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
+        working-directory: ${{ github.workspace }}/oneDNN/build
+        env:
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
+
+  # We only run the linux aarch64 runners if macos smoke tests pass.
+  linux:
+    needs: macos
+    strategy:
+      matrix:
+        threading: [OMP]
+        toolset: [clang, gcc]
+        config: [Debug, Release]
+        host: [
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50 }, 
+          { name: c7g, label: ah-ubuntu_22_04-c7g_2x-50 }
+        ]
+
+    name: ${{ matrix.host.name }}, ${{ matrix.toolset }}, ${{ matrix.threading }}, ${{ matrix.config }}
+    runs-on: ${{ matrix.host.label }}
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          path: oneDNN
+
+      - name: Install dev tools
+        run: |
+          sudo apt update -y
+          sudo apt install -y scons cmake make
+
+      - if: matrix.threading == 'OMP'
+        name: Install openmp
+        run: |
+          sudo apt install -y libomp-dev
+
+      - if: matrix.toolset == 'gcc'
+        name: Install gcc
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt update -y
+          sudo apt install -y g++-13
+
+      - if: matrix.toolset == 'clang'
+        name: Install clang
+        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
+        with:
+          version: "17"
+
+      - name: Build ACL
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        env:
+          ACL_CONFIG: ${{ matrix.config }}
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          GCC_VERSION: 13
+          ACL_THREADING: ${{ matrix.threading }}
+
+      - name: Build oneDNN
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
+        working-directory: ${{ github.workspace }}/oneDNN
+        env:
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          GCC_VERSION: 13
+          ONEDNN_THREADING: ${{ matrix.threading }}
+
+      - name: Run oneDNN tests
+        run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
+        working-directory: ${{ github.workspace }}/oneDNN/build
+        env:
+          BUILD_TOOLSET: ${{ matrix.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
+          ONEDNN_THREADING: ${{ matrix.threading }}     

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -109,7 +109,8 @@ status_t acl_wino_convolution_fwd_t::pd_t::init_conf() {
 
     const bool shape_ok
             // only unit strides allowed
-            = (acp_.padstride_info.stride() == std::pair<uint, uint> {1, 1})
+            = (acp_.padstride_info.stride()
+                      == std::pair<unsigned int, unsigned int> {1, 1})
             // Note: Compute Library supports arbitrary padding for wino kernels
             // but we only allow small padding to be consistent with oneDNN
             && (acp_.padstride_info.pad().first <= 1) // padding left/right


### PR DESCRIPTION
- Backport for v3.6 for #2130
- Plus backporting a small change to successfully compile with gcc.

