### PR TITLE
generic: SYCL: convolution/deconvolution/softmax: add missing checks

### DIFF
--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -100,7 +100,8 @@ struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
                     && IMPLICATION(!attr()->scales_.has_default_values(),
                             attr_scales_ok()
                                     && check_convolution_scales_types(attr()))
-                    && sycl_post_ops_t::post_ops_ok(attr(), false);
+                    && sycl_post_ops_t::post_ops_ok(attr(), false)
+                    && set_default_alg_kind(alg_kind::convolution_direct);
             if (!ok) return status::unimplemented;
 
             return init_conf();
@@ -156,7 +157,8 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
                             | sm::zero_points_runtime | sm::sum_dt)
                     && IMPLICATION(!attr()->scales_.has_default_values(),
                             attr_scales_ok()
-                                    && check_convolution_scales_types(attr()));
+                                    && check_convolution_scales_types(attr()))
+                    && set_default_alg_kind(alg_kind::convolution_direct);
             if (!ok) return status::unimplemented;
 
             return init_conf();
@@ -195,7 +197,6 @@ struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
-            using sm = primitive_attr_t::skip_mask_t;
 
             const memory_desc_wrapper data_d(src_md());
             const memory_desc_wrapper diff_weights_d(diff_weights_md());
@@ -208,11 +209,8 @@ struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
                             data_d, diff_weights_d, diff_dst_d)
                     && check_convolution_formats(
                             data_d, diff_weights_d, diff_dst_d)
-                    && attr()->has_default_values(sm::scales_runtime
-                            | sm::zero_points_runtime | sm::sum_dt)
-                    && IMPLICATION(!attr()->scales_.has_default_values(),
-                            attr_scales_ok()
-                                    && check_convolution_scales_types(attr()));
+                    && attr()->has_default_values()
+                    && set_default_alg_kind(alg_kind::convolution_direct);
             if (!ok) return status::unimplemented;
 
             return init_conf();

--- a/src/gpu/generic/sycl/ref_deconvolution.hpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.hpp
@@ -44,7 +44,6 @@ struct ref_deconvolution_bwd_weights_t
 
         status_t init(impl::engine_t *engine) {
             using namespace data_type;
-            using sm = primitive_attr_t::skip_mask_t;
 
             const memory_desc_wrapper data_d(src_md());
             const memory_desc_wrapper diff_weights_d(diff_weights_md());
@@ -57,9 +56,8 @@ struct ref_deconvolution_bwd_weights_t
                             data_d, diff_weights_d, diff_dst_d)
                     && check_convolution_formats(
                             data_d, diff_weights_d, diff_dst_d)
-                    && attr()->has_default_values(sm::scales_runtime
-                            | sm::zero_points_runtime | sm::post_ops
-                            | sm::sum_dt);
+                    && attr()->has_default_values()
+                    && desc()->alg_kind == alg_kind::deconvolution_direct;
             if (!ok) return status::unimplemented;
 
             return init_conf();

--- a/src/gpu/generic/sycl/ref_softmax.hpp
+++ b/src/gpu/generic/sycl/ref_softmax.hpp
@@ -48,6 +48,7 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
                     && sycl_post_ops_t::post_ops_ok(attr(), true, false)
                     && set_default_formats() == status::success
                     && attr_.set_default_formats(dst_md()) == status::success
+                    && check_formats(diff_src_md(), diff_dst_md())
                     && md_dims_in_range(src_md());
 
             if (!ok) return status::unimplemented;
@@ -69,6 +70,15 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
         bool check_data_types(data_type_t src) {
             return utils::one_of(src, data_type::f32, data_type::bf16,
                     data_type::f16, data_type::s8, data_type::u8);
+        }
+
+        static bool check_formats(const memory_desc_wrapper &src,
+                const memory_desc_wrapper &dst) {
+            for (const auto &mdw : {src, dst}) {
+                if (!mdw.is_plain()) return false;
+            }
+
+            return true;
         }
     };
 
@@ -101,10 +111,20 @@ struct ref_sycl_softmax_bwd_t : public gpu::generic::sycl::primitive_t {
                     && dst_md()->data_type == diff_dst_md()->data_type
                     && attr()->has_default_values()
                     && set_default_formats() == status::success
+                    && check_formats(src_md(), dst_md())
                     && md_dims_in_range(diff_dst_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();
+        }
+
+        static bool check_formats(const memory_desc_wrapper &src,
+                const memory_desc_wrapper &dst) {
+            for (const auto &mdw : {src, dst}) {
+                if (!mdw.is_plain()) return false;
+            }
+
+            return true;
         }
 
         sycl_softmax_conf_t conf_;


### PR DESCRIPTION
Adds some previously missing checks on the SYCL implementations of convolution, deconvolution and softmax.