### PR TITLE
build: Fix the build failure on Power 10

### DIFF
--- a/src/cpu/ppc64/ppc64_gemm_s8x8s32.cpp
+++ b/src/cpu/ppc64/ppc64_gemm_s8x8s32.cpp
@@ -150,8 +150,9 @@ dnnl_status_t cblas_gemm_s8x8s32_ppc64(int ATflag, int BTflag,
                 }
             }
             for (int i = 0; i < m; ++i) {
-                comparray[i] = out_round<int32_t>(saturate<int32_t>(
-                        ((double)comparray[i]) * alpha * -128.0));
+                comparray[i] = cpu::q10n::out_round<int32_t>(
+                        cpu::q10n::saturate<int32_t>(
+                                ((double)comparray[i]) * alpha * -128.0));
             }
             for (int j = 0; j < n; ++j) {
                 int *ca = comparray;


### PR DESCRIPTION
# Description

This PR resolves the build failure on Power 10 by using qualified names `cpu::q10n::out_round` and `cpu::q10n::saturate`

Fixes [Build failure on Power10](https://github.com/oneapi-src/oneDNN/issues/2145). 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? - Ran 
```
100% tests passed, 0 tests failed out of 200
Total Test time (real) = 1439.56 sec
```
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

