### PR TITLE
github: apply commit msg check to all commits

### DIFF
--- a/.github/automation/commit-msg-check.py
+++ b/.github/automation/commit-msg-check.py
@@ -2,6 +2,7 @@
 
 # *******************************************************************************
 # Copyright 2024 Arm Limited and affiliates.
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +19,7 @@
 # *******************************************************************************
 
 import argparse
-
+import subprocess
 
 # * Ensuring the scopes end in colon and same level scopes are comma delimited.
 # TODO: Limit scopes to an acceptable list of tags.
@@ -61,12 +62,20 @@ def __numCharacterCheck(msg: str):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("msg", help="Commit message to check.")
+    parser.add_argument("head", help="Head commit of PR branch")
+    parser.add_argument("base", help="Base commit of PR branch")
     args = parser.parse_args()
-    msg: str = args.msg
-    print(f"msg: {msg}")
-    __numCharacterCheck(msg)
-    __scopeCheck(msg)
+    base: str = args.base
+    head: str = args.head
+
+    commit_range = base + ".." + head
+    messages = subprocess.run(["git", "rev-list", "--ancestry-path", commit_range, "--format=oneline"], capture_output=True, text=True).stdout
+
+    for i in messages.splitlines():
+      commit_msg=i.split(' ', 1)[1]
+      print(f"msg: {commit_msg}")
+      __numCharacterCheck(commit_msg)
+      __scopeCheck(commit_msg)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/commit-msg-check.yml
+++ b/.github/workflows/commit-msg-check.yml
@@ -1,5 +1,6 @@
 # *******************************************************************************
 # Copyright 2024 Arm Limited and affiliates.
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,10 +25,16 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# Kill stale checks
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   title:
+    if: github.repository == 'oneapi-src/oneDNN'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Pass pull request title through script.
-        run: python3 ./.github/automation/pr-title-check.py "${{ github.event.pull_request.title }}"
+      - name: Pass pull request commit messages through script.
+        run: python3 ./.github/automation/commit-msg-check.py "${{ github.event.pull_request.head.sha }}" "${{ github.event.pull_request.base.sha }}"


### PR DESCRIPTION
Current code checks the PR title and not the commit messages.
This PR:
- renames the check from PR_check to commit_msg_check for more clarity
- checks all commit messages in the PR instead of the PR title.