### PR TITLE
gpu: nvidia: convolution: bugfix sum post op with int8

### DIFF
--- a/src/gpu/nvidia/cudnn_convolution.cpp
+++ b/src/gpu/nvidia/cudnn_convolution.cpp
@@ -54,11 +54,8 @@ status_t cudnn_convolution_fwd_t::execute_convolution(
 
         if (pd()->use_temp_dst()) {
             memory_storage_t *temp_dst_mem = scratch_storage.get();
-            memory_storage_t *temp_reorder_mem = scratch_storage_2.get();
             temp_dst = xpu::sycl::interop_memory_arg_t<
                     ::sycl::access::mode::read_write>(temp_dst_mem, cgh);
-            temp_reorder = xpu::sycl::interop_memory_arg_t<
-                    ::sycl::access::mode::read_write>(temp_reorder_mem, cgh);
         }
 
         xpu::sycl::interop_memory_arg_t<::sycl::access::mode::read_write>
@@ -85,7 +82,6 @@ status_t cudnn_convolution_fwd_t::execute_convolution(
             args.push_back(arg_scratch.get_native_pointer(ih));
             args.push_back(arg_filter_scratch.get_native_pointer(ih));
             args.push_back(temp_dst.get_native_pointer(ih));
-            args.push_back(temp_reorder.get_native_pointer(ih));
             args.push_back(arg_src_scale.get_native_pointer(ih));
             args.push_back(arg_wei_scale.get_native_pointer(ih));
             args.push_back(arg_dst_scale.get_native_pointer(ih));

--- a/src/gpu/nvidia/cudnn_convolution.hpp
+++ b/src/gpu/nvidia/cudnn_convolution.hpp
@@ -176,10 +176,6 @@ struct cudnn_convolution_fwd_t : public gpu::primitive_t {
             CHECK(sycl_engine->create_memory_storage(
                     &scratch_ptr, memory_flags_t::alloc, wrap.size(), nullptr));
             scratch_storage.reset(scratch_ptr);
-
-            CHECK(sycl_engine->create_memory_storage(
-                    &scratch_ptr, memory_flags_t::alloc, wrap.size(), nullptr));
-            scratch_storage_2.reset(scratch_ptr);
         }
         if (impl && impl->use_scales_dst()) {
             CHECK(sycl_engine->create_memory_storage(


### PR DESCRIPTION
Fixes a bug with sum post-op and int8 in nvidia convolution implementation. Also removes now redundant temporary memory alocation.