### PR TITLE
generic: fix several gtest issues

### DIFF
--- a/src/gpu/generic/ref_concat.hpp
+++ b/src/gpu/generic/ref_concat.hpp
@@ -129,6 +129,9 @@ struct ref_concat_t : public gpu::primitive_t {
     }
 
     status_t execute(const exec_ctx_t &ctx) const override {
+        if (memory_desc_wrapper(pd()->dst_md()).size() == 0)
+            return status::success;
+
         using namespace memory_tracking::names;
         impl::engine_t *engine = ctx.stream()->engine();
         const auto n = pd()->n_inputs();

--- a/src/gpu/generic/sycl/ref_binary.cpp
+++ b/src/gpu/generic/sycl/ref_binary.cpp
@@ -55,12 +55,15 @@ status_t ref_binary_t::pd_t::init_conf() {
 }
 
 status_t ref_binary_t::init(impl::engine_t *engine) {
+    if (memory_desc_wrapper(pd()->dst_md()).size() == 0) return status::success;
+
     const auto kid = ::sycl::get_kernel_id<binary_kernel_vec_t>();
     CHECK(create_kernel(engine, kid, &kernel_));
     return status::success;
 }
 
 status_t ref_binary_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->dst_md()).size() == 0) return status::success;
 
     ctx.zero_pad_output(DNNL_ARG_TO);
 

--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -74,6 +74,8 @@ status_t ref_convolution_fwd_t::init(impl::engine_t *engine) {
 }
 
 status_t ref_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->dst_md()).size() == 0) return status::success;
+
     parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         convolution_kernel_fwd_t convolution_kernel(pd()->conf_, cgh, ctx);
 
@@ -111,7 +113,7 @@ status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
     conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
 
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
+    conf_.post_ops = sycl_post_ops_t(attr(), diff_src_md());
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
     conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);
@@ -134,6 +136,9 @@ status_t ref_convolution_bwd_data_t::init(impl::engine_t *engine) {
 }
 
 status_t ref_convolution_bwd_data_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->diff_src_md()).size() == 0)
+        return status::success;
+
     parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         convolution_kernel_bwd_data_t convolution_kernel(pd()->conf_, cgh, ctx);
 

--- a/src/gpu/generic/sycl/ref_layer_normalizations.cpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.cpp
@@ -91,6 +91,8 @@ status_t ref_layer_normalization_fwd_t::init(impl::engine_t *engine) {
 
 status_t ref_layer_normalization_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->dst_md()).size() == 0) return status::success;
+
     if (pd()->stats_are_src()) {
         return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
             layer_normalization_fwd_kernel_vec_t layer_normalization_fwd_kernel(
@@ -163,6 +165,9 @@ status_t ref_layer_normalization_bwd_t::init(impl::engine_t *engine) {
 
 status_t ref_layer_normalization_bwd_t::execute_backward(
         const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->diff_src_md()).size() == 0)
+        return status::success;
+
     if (pd()->conf_.use_scale || pd()->conf_.use_shift) {
         auto status = parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
             auto nelems_A = memory_desc_wrapper(pd()->src_md(0)).nelems();

--- a/src/gpu/generic/sycl/ref_matmul.cpp
+++ b/src/gpu/generic/sycl/ref_matmul.cpp
@@ -142,6 +142,8 @@ status_t ref_matmul_t::init(impl::engine_t *engine) {
 }
 
 status_t ref_matmul_t::execute(const exec_ctx_t &ctx) const {
+    if (memory_desc_wrapper(pd()->dst_md()).size() == 0) return status::success;
+
     sycl_matmul_conf_t conf = pd()->conf_;
     if (pd()->any_runtime_params_) {
         const auto src_d = ctx.memory_mdw(DNNL_ARG_SRC, pd()->src_md());

--- a/src/gpu/generic/sycl/ref_pooling.cpp
+++ b/src/gpu/generic/sycl/ref_pooling.cpp
@@ -74,6 +74,11 @@ status_t ref_pooling_fwd_t::init(impl::engine_t *engine) {
 }
 
 status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
+    // XXX: Add support for 0-dim src
+    for (auto &md : {pd()->src_md(), pd()->dst_md()}) {
+        if (memory_desc_wrapper(md).size() == 0) return status::success;
+    }
+
     return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         auto nelems_A = memory_desc_wrapper(pd()->src_md(0)).nelems();
         pooling_fwd_kernel_vec_t pooling_fwd_kernel(pd()->conf_, cgh, ctx);
@@ -135,6 +140,10 @@ status_t ref_pooling_bwd_t::init(impl::engine_t *engine) {
 }
 
 status_t ref_pooling_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
+    for (auto &md : {pd()->diff_src_md(), pd()->diff_dst_md()}) {
+        if (memory_desc_wrapper(md).size() == 0) return status::success;
+    }
+
     return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         auto nelems_A = memory_desc_wrapper(pd()->diff_src_md(0)).nelems();
         pooling_bwd_kernel_vec_t pooling_bwd_kernel(pd()->conf_, cgh, ctx);

--- a/src/gpu/generic/sycl/ref_prelu.hpp
+++ b/src/gpu/generic/sycl/ref_prelu.hpp
@@ -56,7 +56,8 @@ struct ref_prelu_fwd_t : public gpu::generic::sycl::primitive_t {
                     && (weights_md(0)->format_desc.blocking.inner_nblks == 0)
                     && check_data_types(data_d, weights_d, dst_d)
                     && md_dims_in_range(src_md())
-                    && md_dims_in_range(weights_md());
+                    && md_dims_in_range(weights_md())
+                    && attr()->has_default_values();
 
             if (!ok) return status::unimplemented;
             return init_conf();
@@ -109,7 +110,8 @@ struct ref_prelu_bwd_t : public gpu::generic::sycl::primitive_t {
                     && diff_weights_md(0)->data_type == weights_md(0)->data_type
                     && check_data_types(data_d, weights_d, diff_dst_d)
                     && md_dims_in_range(diff_src_md())
-                    && md_dims_in_range(weights_md());
+                    && md_dims_in_range(weights_md())
+                    && attr()->has_default_values();
 
             if (!ok) return status::unimplemented;
 

--- a/src/gpu/generic/sycl/ref_shuffle.hpp
+++ b/src/gpu/generic/sycl/ref_shuffle.hpp
@@ -55,6 +55,8 @@ struct ref_shuffle_t : public gpu::generic::sycl::primitive_t {
                     && IMPLICATION(is_fwd(),
                             src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && attr()->has_default_values()
+                    && memory_desc_wrapper(src_data_md)
+                            == memory_desc_wrapper(dst_data_md)
                     && md_dims_in_range(src_md());
             if (!ok) return status::unimplemented;
             return init_conf();

--- a/src/gpu/generic/sycl/ref_softmax.cpp
+++ b/src/gpu/generic/sycl/ref_softmax.cpp
@@ -52,6 +52,8 @@ status_t ref_sycl_softmax_fwd_t::init(impl::engine_t *engine) {
 }
 
 status_t ref_sycl_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
+    if (pd()->has_zero_dim_memory()) return status::success;
+
     return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         softmax_fwd_kernel_vec_t softmax_fwd_kernel_(pd()->conf_, cgh, ctx);
 
@@ -82,6 +84,8 @@ status_t ref_sycl_softmax_bwd_t::init(impl::engine_t *engine) {
 }
 
 status_t ref_sycl_softmax_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
+    if (pd()->has_zero_dim_memory()) return status::success;
+
     return parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         softmax_bwd_kernel_vec_t softmax_bwd_kernel(pd()->conf_, cgh, ctx);
 

--- a/src/gpu/generic/sycl/ref_softmax.hpp
+++ b/src/gpu/generic/sycl/ref_softmax.hpp
@@ -111,20 +111,13 @@ struct ref_sycl_softmax_bwd_t : public gpu::generic::sycl::primitive_t {
                     && dst_md()->data_type == diff_dst_md()->data_type
                     && attr()->has_default_values()
                     && set_default_formats() == status::success
-                    && check_formats(diff_src_md(), diff_dst_md())
+                    && memory_desc_wrapper(diff_src_md()).is_plain()
+                    && memory_desc_wrapper(diff_dst_md()).is_plain()
+                    && memory_desc_wrapper(dst_md()).is_plain()
                     && md_dims_in_range(diff_dst_md());
 
             if (!ok) return status::unimplemented;
             return init_conf();
-        }
-
-        static bool check_formats(const memory_desc_wrapper &src,
-                const memory_desc_wrapper &dst) {
-            for (const auto &mdw : {src, dst}) {
-                if (!mdw.is_plain()) return false;
-            }
-
-            return true;
         }
 
         sycl_softmax_conf_t conf_;

--- a/tests/gtests/dnnl_test_macros.hpp
+++ b/tests/gtests/dnnl_test_macros.hpp
@@ -69,6 +69,21 @@
 #define SKIP_FOR_LOOP_HIP(cond, message)
 #endif
 
+#ifdef DNNL_SYCL_GENERIC
+#define SKIP_IF_GENERIC(cond, message) \
+    do { \
+        SKIP_IF(get_test_engine_kind() == engine::kind::gpu && (cond), \
+                (message)); \
+    } while (0)
+
+#define SKIP_FOR_LOOP_GENERIC(cond, message) \
+    SKIP_FOR_LOOP( \
+            get_test_engine_kind() == engine::kind::gpu && (cond), (message));
+#else
+#define SKIP_IF_GENERIC(cond, message)
+#define SKIP_FOR_LOOP_GENERIC(cond, message)
+#endif
+
 #define TEST_F_(test_fixture, test_name) TEST_F(test_fixture, test_name)
 
 #define CPU_TEST_F(test_fixture, test_name) \

--- a/tests/gtests/sycl/api/CMakeLists.txt
+++ b/tests/gtests/sycl/api/CMakeLists.txt
@@ -20,3 +20,20 @@ file(GLOB TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp)
 list(APPEND TEST_SOURCES ${MAIN_SRC_GTEST})
 
 register_exe(${TEST_EXE} "${TEST_SOURCES}" "test" "dnnl_gtest")
+# InteropReorderAndUserKernel & EltwiseWithUserKernel tests run SYCL kernels
+# so they need to be compiled with the correct device triple
+if(DNNL_WITH_SYCL)
+    if(DNNL_SYCL_GENERIC)
+        CHECK_CXX_COMPILER_FLAG("-fsycl -fsycl-targets=nvptx64-nvidia-cuda" NVIDIA_TARGET_SUPPORTED)
+    endif()
+
+    # Enable linking SYCL kernels.
+    if(DNNL_SYCL_CUDA OR (DNNL_SYCL_GENERIC AND NVIDIA_TARGET_SUPPORTED))
+        append(CMAKE_CXX_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda")
+        append(CMAKE_CXX_FLAGS "-Wno-linker-warnings")
+    endif()
+
+    if(DNNL_AMD_ENABLE_SYCL_KERNELS)
+        append(CMAKE_CXX_FLAGS "-fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=${DNNL_AMD_SYCL_KERNELS_TARGET_ARCH}")
+    endif()
+endif()

--- a/tests/gtests/test_batch_normalization.cpp
+++ b/tests/gtests/test_batch_normalization.cpp
@@ -59,6 +59,11 @@ bool hip_check_format_tag(tag first_tag, Rest... rest_tags) {
     return hip_check_format_tag(rest_tags...);
 }
 
+bool generic_check_format_tag(tag atag) {
+    return impl::utils::one_of(atag, tag::ncw, tag::nchw, tag::ncdhw, tag::nwc,
+            tag::nhwc, tag::ndhwc, tag::any);
+}
+
 class batch_normalization_test_t
     : public ::testing::TestWithParam<batch_normalization_test_params_t> {
 private:
@@ -79,6 +84,11 @@ protected:
 
         SKIP_IF_HIP(!hip_check_format_tag(p.src_tag, p.dst_tag),
                 "Unsupported format tag");
+
+        SKIP_IF_GENERIC(
+                !generic_check_format_tag(p.src_tag), "Unsupported format tag");
+        SKIP_IF_GENERIC(
+                !generic_check_format_tag(p.dst_tag), "Unsupported format tag");
 
         SKIP_IF_CUDA(p.src_dt != p.dst_dt && p.src_dt != dt::undef
                         && p.dst_dt != dt::undef,

--- a/tests/gtests/test_binary.cpp
+++ b/tests/gtests/test_binary.cpp
@@ -69,6 +69,8 @@ protected:
                     "Unsupported source format tag");
             SKIP_IF_HIP(!hip_check_format_tag(tag),
                     "Unsupported source format tag");
+            SKIP_IF_GENERIC(!generic_check_format_tag(tag),
+                    "Unsupported source format tag");
         }
         SKIP_IF_CUDA(!cuda_check_format_tag(p.dst_format),
                 "Unsupported destination format tag");
@@ -101,6 +103,14 @@ protected:
         return atag == tag::abcd || atag == tag::acdb;
     }
     bool hip_check_format_tag(tag atag) { return atag == tag::abcd; }
+    bool generic_check_format_tag(tag atag) {
+        return impl::utils::one_of(atag, tag::a, tag::ab, tag::abc, tag::abcd,
+                tag::abcde, tag::abcdef, tag::abdec, tag::acb, tag::acbde,
+                tag::acbdef, tag::acdb, tag::acdeb, tag::ba, tag::bac,
+                tag::bacd, tag::bca, tag::bcda, tag::bcdea, tag::cba, tag::cdba,
+                tag::cdeba, tag::decab, tag::defcab, tag::Ab32a, tag::aBc32b,
+                tag::any);
+    }
 
     void Test() {
         auto eng = get_test_engine();

--- a/tests/gtests/test_concat.cpp
+++ b/tests/gtests/test_concat.cpp
@@ -99,6 +99,14 @@ protected:
                 dnnl_aBcde4b);
     }
 
+    bool generic_supported_format_tag(memory::format_tag tag) {
+        return impl::utils::one_of(tag, dnnl_a, dnnl_ab, dnnl_abc, dnnl_abcd,
+                dnnl_abcde, dnnl_abcdef, dnnl_abdec, dnnl_acb, dnnl_acbde,
+                dnnl_acbdef, dnnl_acdb, dnnl_acdeb, dnnl_ba, dnnl_bac,
+                dnnl_bacd, dnnl_bca, dnnl_bcda, dnnl_bcdea, dnnl_cba, dnnl_cdba,
+                dnnl_cdeba, dnnl_decab, dnnl_defcab);
+    }
+
     void SetUp() override {
         auto data_type = data_traits<data_t>::data_type;
         SKIP_IF_HIP(true, "Concat operator is not supported");
@@ -109,9 +117,13 @@ protected:
         for (size_t i = 0; i < p.srcs_cds.size(); i++) {
             SKIP_IF_CUDA(!cuda_supported_format_tag(p.srcs_format[i]),
                     "Unsupported format tag");
+            SKIP_IF_GENERIC(!generic_supported_format_tag(p.srcs_format[i]),
+                    "Unsupported format tag");
         }
 
         SKIP_IF_CUDA(!cuda_supported_format_tag(p.dst_format),
+                "Unsupported format tag");
+        SKIP_IF_GENERIC(!generic_supported_format_tag(p.dst_format),
                 "Unsupported format tag");
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status, false);

--- a/tests/gtests/test_convolution_backward_data_common.hpp
+++ b/tests/gtests/test_convolution_backward_data_common.hpp
@@ -138,6 +138,23 @@ protected:
                                     p.formats.weights_format, p.aalgorithm)),
                 "Format is not supported.");
 
+        SKIP_IF_GENERIC(
+                !(generic_check_format_tags(p.formats.src_format)
+                        && generic_check_format_tags(p.formats.dst_format)
+                        && (generic_check_format_tags(p.formats.weights_format)
+                                || (impl::utils::one_of(
+                                        p.formats.weights_format,
+                                        memory::format_tag::goiw,
+                                        memory::format_tag::goihw,
+                                        memory::format_tag::goidhw,
+                                        memory::format_tag::oiw,
+                                        memory::format_tag::oihw,
+                                        memory::format_tag::oidhw)))
+                        && check_generic_dt<data_t_diff_src>()
+                        && check_generic_dt<data_t_diff_dst>()
+                        && check_generic_dt<data_t_wei>()),
+                "Format is not supported.");
+
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }
@@ -154,6 +171,14 @@ protected:
                 memory::format_tag::abcde, memory::format_tag::abcdef,
                 memory::format_tag::acb, memory::format_tag::acdb,
                 memory::format_tag::acdeb);
+    }
+
+    bool generic_check_format_tags(memory::format_tag tag) {
+        return impl::utils::one_of(tag, memory::format_tag::ab,
+                memory::format_tag::abc, memory::format_tag::abcd,
+                memory::format_tag::abcde, memory::format_tag::abcdef,
+                memory::format_tag::acb, memory::format_tag::acdb,
+                memory::format_tag::acdeb, memory::format_tag::any);
     }
 
     bool check_cuda_alg_format(memory::format_tag dst_fmt,
@@ -180,6 +205,14 @@ protected:
                             memory::format_tag::abcdef);
         }
         return res;
+    }
+
+    template <typename dt>
+    bool check_generic_dt() {
+        return impl::utils::one_of(data_traits<dt>::data_type,
+                memory::data_type::f32, memory::data_type::bf16,
+                memory::data_type::f16, memory::data_type::s32,
+                memory::data_type::s8, memory::data_type::u8);
     }
 
     void Test() {

--- a/tests/gtests/test_convolution_backward_weights_common.hpp
+++ b/tests/gtests/test_convolution_backward_weights_common.hpp
@@ -170,6 +170,28 @@ protected:
                                     p.formats.weights_format, p.aalgorithm)),
                 "Format is not supported.");
 
+        SKIP_IF_GENERIC(
+                !(generic_check_format_tags(p.formats.src_format)
+                        && generic_check_format_tags(p.formats.dst_format)
+                        && (generic_check_format_tags(p.formats.weights_format)
+                                || (impl::utils::one_of(
+                                        p.formats.weights_format,
+                                        memory::format_tag::goiw,
+                                        memory::format_tag::goihw,
+                                        memory::format_tag::goidhw,
+                                        memory::format_tag::oiw,
+                                        memory::format_tag::oihw,
+                                        memory::format_tag::oidhw,
+                                        memory::format_tag::bacd,
+                                        memory::format_tag::bcda,
+                                        memory::format_tag::acbde,
+                                        memory::format_tag::iohw,
+                                        memory::format_tag::hwigo)))
+                        && check_generic_dt<data_t_src>()
+                        && check_generic_dt<data_t_diff_dst>()
+                        && check_generic_dt<data_t_diff_weights>()),
+                "Format is not supported.");
+
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }
@@ -212,6 +234,22 @@ protected:
                             memory::format_tag::abcdef);
         }
         return res;
+    }
+
+    bool generic_check_format_tags(memory::format_tag tag) {
+        return impl::utils::one_of(tag, memory::format_tag::ab,
+                memory::format_tag::abc, memory::format_tag::abcd,
+                memory::format_tag::abcde, memory::format_tag::abcdef,
+                memory::format_tag::acb, memory::format_tag::acdb,
+                memory::format_tag::acdeb, memory::format_tag::any);
+    }
+
+    template <typename dt>
+    bool check_generic_dt() {
+        return impl::utils::one_of(data_traits<dt>::data_type,
+                memory::data_type::f32, memory::data_type::bf16,
+                memory::data_type::f16, memory::data_type::s32,
+                memory::data_type::s8, memory::data_type::u8);
     }
 
     void Test() {

--- a/tests/gtests/test_convolution_eltwise_forward_common.hpp
+++ b/tests/gtests/test_convolution_eltwise_forward_common.hpp
@@ -161,6 +161,24 @@ protected:
                                         memory::format_tag::odhwi))),
                 "Format is not supported.");
 
+        SKIP_IF_GENERIC(
+                !(generic_check_format_tags(p.formats.src_format)
+                        && generic_check_format_tags(p.formats.dst_format)
+                        && impl::utils::one_of(p.formats.weights_format,
+                                /* weights formats */
+                                memory::format_tag::goiw,
+                                memory::format_tag::goihw,
+                                memory::format_tag::goidhw,
+                                memory::format_tag::oiw,
+                                memory::format_tag::oihw,
+                                memory::format_tag::oidhw,
+                                memory::format_tag::bacd,
+                                memory::format_tag::bcda,
+                                memory::format_tag::acbde,
+                                memory::format_tag::iohw,
+                                memory::format_tag::hwigo)),
+                "Format is not supported.");
+
         SKIP_IF_CUDA(p.alg != algorithm::eltwise_relu
                         && p.alg != algorithm::eltwise_tanh
                         && p.alg != algorithm::eltwise_elu
@@ -176,6 +194,17 @@ protected:
                 "Unsupported algorithm type for HIP");
         SKIP_IF_HIP(p.alg == algorithm::eltwise_relu || p.eltwise_alpha != 0.0,
                 "DNNL only supports relu w/ slope=0 for integers");
+
+        SKIP_IF_GENERIC(
+                !impl::utils::one_of(p.alg, algorithm::eltwise_relu,
+                        algorithm::eltwise_linear, algorithm::eltwise_clip,
+                        algorithm::eltwise_clip_v2,
+                        algorithm::eltwise_hardswish,
+                        algorithm::eltwise_gelu_tanh,
+                        algorithm::eltwise_gelu_erf, algorithm::eltwise_tanh,
+                        algorithm::eltwise_logistic, algorithm::eltwise_swish,
+                        algorithm::eltwise_elu),
+                "Unsupported algorithm");
 
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
@@ -199,6 +228,14 @@ protected:
                 || (dt == memory::data_type::s8
                         && impl::utils::one_of(tag, memory::format_tag::aBcd4b,
                                 memory::format_tag::aBcde4b)));
+    }
+
+    bool generic_check_format_tags(memory::format_tag tag) {
+        return (impl::utils::one_of(tag, memory::format_tag::ab,
+                memory::format_tag::abc, memory::format_tag::abcd,
+                memory::format_tag::abcde, memory::format_tag::abcdef,
+                memory::format_tag::acb, memory::format_tag::acdb,
+                memory::format_tag::acdeb));
     }
 
     virtual void Test() {

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -63,6 +63,9 @@ protected:
                 "unsupported format");
         SKIP_IF_HIP((p.expected_src_fmt == BLK || p.expected_dst_fmt == BLK),
                 "unsupported format");
+        SKIP_IF_GENERIC(
+                (p.expected_src_fmt == BLK || p.expected_dst_fmt == BLK),
+                "unsupported format");
         ASSERT_EQ(data_type, dnnl::memory::data_type::f32);
 
         test_convolution_sizes_t cd = p.test_cd;

--- a/tests/gtests/test_convolution_forward_common.hpp
+++ b/tests/gtests/test_convolution_forward_common.hpp
@@ -162,6 +162,25 @@ protected:
                                         memory::format_tag::odhwi))),
                 "Format is not supported.");
 
+        SKIP_IF_GENERIC(
+                !(generic_check_format_tags(p.formats.src_format)
+                        && generic_check_format_tags(p.formats.dst_format)
+                        && (generic_check_format_tags(p.formats.weights_format)
+                                || (impl::utils::one_of(
+                                        p.formats.weights_format,
+                                        memory::format_tag::goiw,
+                                        memory::format_tag::goihw,
+                                        memory::format_tag::goidhw,
+                                        memory::format_tag::oiw,
+                                        memory::format_tag::oihw,
+                                        memory::format_tag::oidhw,
+                                        memory::format_tag::bacd,
+                                        memory::format_tag::bcda,
+                                        memory::format_tag::acbde,
+                                        memory::format_tag::iohw,
+                                        memory::format_tag::hwigo)))),
+                "Format is not supported.");
+
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }
@@ -184,6 +203,14 @@ protected:
                 || (dt == memory::data_type::s8
                         && impl::utils::one_of(tag, memory::format_tag::aBcd4b,
                                 memory::format_tag::aBcde4b)));
+    }
+
+    bool generic_check_format_tags(memory::format_tag tag) {
+        return impl::utils::one_of(tag, memory::format_tag::ab,
+                memory::format_tag::abc, memory::format_tag::abcd,
+                memory::format_tag::abcde, memory::format_tag::abcdef,
+                memory::format_tag::acb, memory::format_tag::acdb,
+                memory::format_tag::acdeb, memory::format_tag::any);
     }
 
     void Test() {

--- a/tests/gtests/test_deconvolution.cpp
+++ b/tests/gtests/test_deconvolution.cpp
@@ -158,6 +158,11 @@ protected:
                                 p.formats.dst_format, p.sizes.ng > 1)),
                 "Format is not supported.");
 
+        SKIP_IF_GENERIC(
+                !(generic_check_format_tags(p.formats.src_format)
+                        && generic_check_format_tags(p.formats.dst_format)),
+                "Format is not supported.");
+
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }
@@ -202,6 +207,13 @@ protected:
                                    : (wei == memory::format_tag::bcda));
         }
         return false;
+    }
+
+    bool generic_check_format_tags(memory::format_tag tag) {
+        return impl::utils::one_of(tag, memory::format_tag::ab,
+                memory::format_tag::abc, memory::format_tag::abcd,
+                memory::format_tag::abcde, memory::format_tag::abcdef,
+                memory::format_tag::any);
     }
 
     void Test() {

--- a/tests/gtests/test_eltwise.cpp
+++ b/tests/gtests/test_eltwise.cpp
@@ -62,6 +62,13 @@ bool hip_check_format_tag(tag first_tag, Rest... rest_tags) {
     return hip_check_format_tag(rest_tags...);
 }
 
+template <typename... Rest>
+bool generic_check_format_tag(tag first_tag, Rest... rest_tags) {
+    const bool ok = hip_check_format_tag(first_tag);
+    if (!ok) return ok;
+    return hip_check_format_tag(rest_tags...);
+}
+
 class eltwise_test_t : public ::testing::TestWithParam<eltwise_test_params_t> {
 private:
     eltwise_test_params_t p;
@@ -82,6 +89,8 @@ protected:
         SKIP_IF_CUDA(!cuda_check_format_tag(p.src_tag, p.dst_tag),
                 "Unsupported format tag");
         SKIP_IF_HIP(!hip_check_format_tag(p.src_tag, p.dst_tag),
+                "Unsupported format tag");
+        SKIP_IF_GENERIC(!generic_check_format_tag(p.src_tag, p.dst_tag),
                 "Unsupported format tag");
         SKIP_IF_CUDA(p.src_dt != p.dst_dt && p.src_dt != dt::undef
                         && p.dst_dt != dt::undef,

--- a/tests/gtests/test_group_normalization.cpp
+++ b/tests/gtests/test_group_normalization.cpp
@@ -48,6 +48,8 @@ protected:
     void SetUp() override {
         SKIP_IF_HIP(
                 true, "Group Normalization operator is not supported in HIP");
+        SKIP_IF_GENERIC(true,
+                "Group Normalization operator is not supported in generic");
         p = ::testing::TestWithParam<
                 group_normalization_test_params_t>::GetParam();
 

--- a/tests/gtests/test_iface_attr_quantization.cpp
+++ b/tests/gtests/test_iface_attr_quantization.cpp
@@ -374,6 +374,7 @@ TEST_F(attr_quantization_test_t, TestInnerProduct) {
     SKIP_IF_CUDA(true, "Unsupported datatype for CUDA");
     // src, wei needs to be s8 and dst be s32.
     SKIP_IF_HIP(true, "Unsupported datatype for HIP");
+    SKIP_IF_GENERIC(true, "InnerProduct is not supported for Generic");
     memory::desc src_md {{1, 16, 7, 7}, data_type::u8, tag::any};
     memory::desc wei_md {{32, 16, 7, 7}, data_type::s8, tag::any};
     memory::desc dst_md {{1, 32}, data_type::s32, tag::any};
@@ -640,6 +641,7 @@ CPU_TEST_F(attr_quantization_test_t, TestReorder) {
 TEST_F(attr_quantization_test_t, TestRNN) {
     SKIP_IF_CUDA(true, "RNN primitive not supported for CUDA");
     SKIP_IF_HIP(true, "RNN primitive not supported for HIP");
+    SKIP_IF_GENERIC(true, "RNN primitive not supported for Generic");
     // Int8 RNN relies on packed API solely which is available only for X64.
 #if !DNNL_X64
     return;

--- a/tests/gtests/test_iface_pd_iter.cpp
+++ b/tests/gtests/test_iface_pd_iter.cpp
@@ -114,6 +114,7 @@ TEST_F(pd_iter_test_t, UnsupportedPrimitives) {
 TEST(pd_next_impl, TestEltwiseImpl) {
     SKIP_IF_CUDA(true, "Unsupported memory format for CUDA");
     SKIP_IF_HIP(true, "Unsupported memory format for HIP");
+    SKIP_IF_GENERIC(true, "Unsupported memory format for Generic");
     auto eng = get_test_engine();
     memory::desc md(
             {8, 32, 4, 4}, memory::data_type::f32, memory::format_tag::nChw8c);

--- a/tests/gtests/test_iface_runtime_dims.cpp
+++ b/tests/gtests/test_iface_runtime_dims.cpp
@@ -162,6 +162,8 @@ TEST_F(runtime_dim_test_t, TestEltwise) {
 }
 
 TEST_F(runtime_dim_test_t, TestInnerProduct) {
+    SKIP_IF_GENERIC(true, "InnerProduct is not implemented in Generic");
+
     memory::desc src_md {
             {DNNL_RUNTIME_DIM_VAL, 16, 7, 7}, data_type::f32, tag::abcd};
     memory::desc wei_md {{32, 16, 7, 7}, data_type::f32, tag::abcd};

--- a/tests/gtests/test_iface_wino_convolution.cpp
+++ b/tests/gtests/test_iface_wino_convolution.cpp
@@ -64,6 +64,7 @@ protected:
 };
 
 TEST_F(wino_conv_test_t, TestSmallPadding) {
+    SKIP_IF_GENERIC(true, "Unsupported test case.");
     for (const auto &input : {input_f32, input_f16, input_int8}) {
         if (unsupported_data_type(input.dat_dt)
                 || unsupported_data_type(input.wei_dt))
@@ -100,6 +101,7 @@ TEST_F(wino_conv_test_t, TestSmallPadding) {
 }
 
 TEST_F(wino_conv_test_t, TestLargePadding) {
+    SKIP_IF_GENERIC(true, "Unsupported test case.");
     for (const auto &input : {input_f32, input_f16, input_int8}) {
         if (unsupported_data_type(input.dat_dt)
                 || unsupported_data_type(input.wei_dt))
@@ -125,6 +127,7 @@ TEST_F(wino_conv_test_t, TestLargePadding) {
 
 TEST_F(wino_conv_test_t, TestUnsupportedKernel) {
     SKIP_IF_HIP(true, "Unsupported test case.");
+    SKIP_IF_GENERIC(true, "Unsupported test case.");
     for (const auto &input : {input_f32, input_f16, input_int8}) {
         if (unsupported_data_type(input.dat_dt)
                 || unsupported_data_type(input.wei_dt))

--- a/tests/gtests/test_inner_product_backward_data.cpp
+++ b/tests/gtests/test_inner_product_backward_data.cpp
@@ -100,6 +100,7 @@ protected:
                              p.weights_format, p.diff_dst_format),
                 "Unsupported format tag");
         SKIP_IF_CUDA(p.ndims > 5, "Unsupported number of dimensions");
+        SKIP_IF_GENERIC(true, "Primitive not implemented");
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }

--- a/tests/gtests/test_inner_product_backward_weights.cpp
+++ b/tests/gtests/test_inner_product_backward_weights.cpp
@@ -129,6 +129,7 @@ protected:
                         p.diff_bias_format, p.diff_dst_format),
                 "Unsupported format tag");
         SKIP_IF_CUDA(p.ndims > 5, "Unsupported number of dimensions");
+        SKIP_IF_GENERIC(true, "Primitive not implemented");
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }

--- a/tests/gtests/test_inner_product_forward.cpp
+++ b/tests/gtests/test_inner_product_forward.cpp
@@ -92,6 +92,7 @@ protected:
                              p.bias_format, p.dst_format),
                 "Unsupported format tag");
         SKIP_IF_CUDA(p.ndims > 5, "Unsupported number of dimensions");
+        SKIP_IF_GENERIC(true, "Primitive not implemented");
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }

--- a/tests/gtests/test_lrn.cpp
+++ b/tests/gtests/test_lrn.cpp
@@ -61,6 +61,13 @@ bool hip_check_format_tag(tag first_tag, Rest... rest_tags) {
     return hip_check_format_tag(rest_tags...);
 }
 
+template <typename... Rest>
+bool generic_check_format_tag(tag first_tag, Rest... rest_tags) {
+    const bool ok = cuda_check_format_tag(first_tag);
+    if (!ok) return ok;
+    return cuda_check_format_tag(rest_tags...);
+}
+
 class lrn_test_t : public ::testing::TestWithParam<lrn_test_params_t> {
 private:
     lrn_test_params_t p;
@@ -82,6 +89,8 @@ protected:
         SKIP_IF_CUDA(!cuda_check_format_tag(p.src_tag, p.dst_tag),
                 "Unsupported format tag");
         SKIP_IF_HIP(!hip_check_format_tag(p.src_tag, p.dst_tag),
+                "Unsupported format tag");
+        SKIP_IF_GENERIC(!generic_check_format_tag(p.src_tag, p.dst_tag),
                 "Unsupported format tag");
 
         SKIP_IF_CUDA(p.src_dt != p.dst_dt && p.src_dt != dt::undef

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -270,6 +270,11 @@ protected:
                 memory::data_type::s8, memory::data_type::u8);
         if (is_int8) aa.zp = true;
 
+#ifdef DNNL_SYCL_GENERIC
+        aa.po_prelu = true;
+        aa.po_binary = true;
+#endif
+
         test_fwd_pd_constructors<pd_t>(
                 matmul_pd, aa, src_md, weights_md, bia_md, dst_md);
 

--- a/tests/gtests/test_pooling_backward.cpp
+++ b/tests/gtests/test_pooling_backward.cpp
@@ -60,6 +60,13 @@ bool hip_check_format_tags(memory::format_tag format) {
     return format_ok;
 }
 
+bool generic_check_format_tags(memory::format_tag format) {
+    return impl::utils::one_of(format, memory::format_tag::a,
+            memory::format_tag::nchw, memory::format_tag::ncdhw,
+            memory::format_tag::nhwc, memory::format_tag::ndhwc,
+            memory::format_tag::any);
+}
+
 template <typename data_t>
 class pooling_bwd_test_t
     : public ::testing::TestWithParam<pool_bwd_test_params_t> {
@@ -96,6 +103,11 @@ protected:
         SKIP_IF_HIP(p.aalgorithm == algorithm::pooling_max,
                 "Test is not designed to test non-intel implementations of max "
                 "algorithm");
+
+        SKIP_IF_GENERIC(!generic_check_format_tags(p.diff_src_format),
+                "Unsupported format tag");
+        SKIP_IF_GENERIC(!generic_check_format_tags(p.diff_dst_format),
+                "Unsupported format tag");
 
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);

--- a/tests/gtests/test_reorder_common.hpp
+++ b/tests/gtests/test_reorder_common.hpp
@@ -87,6 +87,9 @@ protected:
                             && (supported_format(p.fmt_o)
                                     || supported_blocking(prec_o, p.fmt_o))),
                 "Unsupported cuda format tag/ data type");
+        SKIP_IF_GENERIC(
+                !(supported_format(p.fmt_i) && supported_format(p.fmt_o)),
+                "Unsupported generic format tag");
 
         catch_expected_failures(
                 [&]() {
@@ -137,6 +140,10 @@ protected:
                         && (supported_format(p.fmt_o)
                                 || supported_blocking(prec_o, p.fmt_o))),
                 "Unsupported hip format tag/ data type");
+#endif
+#ifdef DNNL_SYCL_GENERIC
+        SKIP_IF(!(supported_format(p.fmt_i) && supported_format(p.fmt_o)),
+                "Unsupported generic format tag");
 #endif
 
         catch_expected_failures([&]() { RunTest(eng_i, eng_o); },

--- a/tests/gtests/test_resampling.cpp
+++ b/tests/gtests/test_resampling.cpp
@@ -222,6 +222,10 @@ protected:
         return impl::utils::one_of(
                 tag, dnnl_abc, dnnl_abcd, dnnl_acb, dnnl_acdb);
     }
+    bool generic_supported_format_tag(memory::format_tag tag) {
+        return impl::utils::one_of(tag, dnnl_abc, dnnl_abcd, dnnl_acb,
+                dnnl_acdb, dnnl_format_tag_any);
+    }
     void SetUp() override {
         SKIP_IF_HIP(
                 true, "Resampling operator is not supported by hip backend");
@@ -231,6 +235,8 @@ protected:
         SKIP_IF_CUDA(p.ndims == 5,
                 "cudnn resampling backend does not support 5d tensor");
         SKIP_IF_CUDA(!cuda_supported_format_tag(p.src_format),
+                "Unsupported format tag");
+        SKIP_IF_GENERIC(!generic_supported_format_tag(p.src_format),
                 "Unsupported format tag");
 
         catch_expected_failures(

--- a/tests/gtests/test_shuffle.cpp
+++ b/tests/gtests/test_shuffle.cpp
@@ -36,6 +36,11 @@ struct shuffle_test_params_t {
     dnnl_status_t expected_status;
 };
 
+bool generic_check_format(memory::format_tag tag) {
+    return impl::utils::one_of(
+            tag, dnnl_abc, dnnl_abcd, dnnl_acbde, dnnl_acb, dnnl_acdb);
+}
+
 class shuffle_test_t : public ::testing::TestWithParam<shuffle_test_params_t> {
 private:
     shuffle_test_params_t p;
@@ -50,6 +55,8 @@ protected:
 
         SKIP_IF(unsupported_data_type(p.src_dt, p.dst_dt),
                 "Engine does not support this data type.");
+        SKIP_IF_GENERIC(!generic_check_format(p.src_tag), "Unsupported format");
+        SKIP_IF_GENERIC(!generic_check_format(p.dst_tag), "Unsupported format");
 
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -50,6 +50,7 @@ TEST_F(iface_sum_test_t, SumTestDstDataTypeCompliance) {
     for (dt dst_dt : {dt::undef, dt::s8, dt::s32, dt::f32}) {
         sum::primitive_desc sum_pd;
         SKIP_FOR_LOOP_CUDA(dst_dt == dt::s32, "Unsupported data_type");
+        SKIP_FOR_LOOP_GENERIC(dst_dt == dt::s32, "Unsupported data_type");
         if (dst_dt != dt::undef) {
             memory::desc dst_md(shape, dst_dt, dst_tag);
             sum_pd = sum::primitive_desc(
@@ -142,6 +143,17 @@ protected:
                 dnnl_cdeba, dnnl_decab, dnnl_defcab, dnnl_aBc4b, dnnl_aBcd4b,
                 dnnl_aBcde4b);
     }
+    bool generic_supported_format_tag(memory::format_tag tag) {
+        return impl::utils::one_of(tag, dnnl_a, dnnl_ab, dnnl_abc, dnnl_abcd,
+                dnnl_abcde, dnnl_abcdef, dnnl_abdec, dnnl_acb, dnnl_acbde,
+                dnnl_acbdef, dnnl_acdb, dnnl_acdeb, dnnl_ba, dnnl_bac,
+                dnnl_bacd, dnnl_bca, dnnl_bcda, dnnl_bcdea, dnnl_cba, dnnl_cdba,
+                dnnl_cdeba, dnnl_decab, dnnl_defcab, dnnl_format_tag_any);
+    }
+    bool generic_supported_dt(memory::data_type dt) {
+        return impl::utils::one_of(
+                dt, dnnl_f32, dnnl_bf16, dnnl_f16, dnnl_s8, dnnl_u8);
+    }
     void SetUp() override {
         SKIP_IF_HIP(true, "Sum operator is not supported by HIP");
         src_data_type = data_traits<src_data_t>::data_type;
@@ -162,6 +174,18 @@ protected:
             SKIP_IF_CUDA(!cuda_supported_format_tag(p.srcs_format[i]),
                     "Unsupported format tag");
         }
+
+        SKIP_IF_GENERIC(
+                !generic_supported_dt(src_data_type), "Unsupported data type");
+        SKIP_IF_GENERIC(
+                !generic_supported_dt(dst_data_type), "Unsupported data type");
+        SKIP_IF_GENERIC(!generic_supported_format_tag(p.dst_format),
+                "Unsupported format tag");
+        for (size_t i = 0; i < p.srcs_format.size(); i++) {
+            SKIP_IF_GENERIC(!generic_supported_format_tag(p.srcs_format[i]),
+                    "Unsupported format tag");
+        }
+
         catch_expected_failures(
                 [&]() { Test(); }, p.expect_to_fail, p.expected_status);
     }


### PR DESCRIPTION
# Description

This PR fixes several gtest issues on generic vendor:
- `NDR.LocalSize[0]==0` assertion was being thrown due to problems with 0-dim input/outputs not handled correctly
- Several unsupported cases were not skipped
- PRELU was missing a check for post-ops in `init()`
- InnerProduct & RNN tests were not skipped (IP & RNN are not implemented on generic vendor yet)
- There are some examples that are still failing due to unimplemented features which will be fixed in a separate PR
- ~~There are some convolution backward data & deconvolution tests that are still failing which will be fixed in a separate PR (as the issue doesn't seem to be caused by missing skips)~~
