### PR TITLE
build: fix int/size_t implicit cast

### DIFF
--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -209,6 +209,13 @@ constexpr bool any_null(Args... ptrs) {
     return one_of(nullptr, ptrs...);
 }
 
+// Workaround on macos/gcc14.2 build error for static arrays
+template <typename T, size_t ndims>
+inline void array_copy(T dst[ndims], const T src[ndims], size_t size) {
+    assert(size < ndims);
+    for (size_t i = 0; i < size; ++i)
+        dst[i] = src[i];
+}
 template <typename T>
 inline void array_copy(T *dst, const T *src, size_t size) {
     for (size_t i = 0; i < size; ++i)

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -195,7 +195,7 @@ inline dim_t get_quant_off(const dims_t &input_idx, const int ndims,
         const int quant_mask, const dim_t g0, const dim_t g1,
         const memory_desc_t &quant_md) {
     dims_t quant_idx {};
-    utils::array_copy(quant_idx, input_idx, ndims);
+    utils::array_copy<dim_t, DNNL_MAX_NDIMS>(quant_idx, input_idx, ndims);
     utils::apply_mask_on_dims(quant_idx, ndims, quant_mask);
     // Note: an `idx` must divide by a group value as grouped quantization
     // applies to consecutive points.


### PR DESCRIPTION
SHould fix newly introduced build failure on aarch64.
https://github.com/oneapi-src/oneDNN/actions/runs/11267787655/job/31333497703