### PR TITLE
github: workflows: Enable graph builds for aarch64 CI

### DIFF
--- a/.github/automation/build_aarch64.sh
+++ b/.github/automation/build_aarch64.sh
@@ -30,17 +30,24 @@ export ACL_ROOT_DIR=${ACL_ROOT_DIR:-"${PWD}/ComputeLibrary"}
 
 CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
 ONEDNN_TEST_SET=SMOKE
+ONEDNN_BUILD_GRAPH=1
 
 # ACL is not built with OMP on macOS.
 if [[ "$OS" == "Darwin" ]]; then
     ONEDNN_THREADING=SEQ
+    if [[ "$BUILD_TOOLSET" == "clang" ]]; then
+        if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+            # Darwin graph tests take a lot of time in debug mode.
+            ONEDNN_BUILD_GRAPH=0
+        fi
+    fi
 fi
 
 set -x
 cmake \
     -Bbuild -S. \
     -DDNNL_AARCH64_USE_ACL=ON \
-    -DONEDNN_BUILD_GRAPH=0 \
+    -DONEDNN_BUILD_GRAPH=$ONEDNN_BUILD_GRAPH \
     -DDNNL_CPU_RUNTIME=$ONEDNN_THREADING \
     -DONEDNN_WERROR=ON \
     -DDNNL_BUILD_FOR_CI=ON \

--- a/.github/automation/test_aarch64.sh
+++ b/.github/automation/test_aarch64.sh
@@ -62,9 +62,21 @@ if [[ "$OS" == "Linux" ]]; then
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_conv_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_deconv_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_matmul_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-gqa-cpp"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-mqa-cpp"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_usm_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
     elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-gqa-cpp"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-mqa-cpp"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_usm_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
     fi
 elif [[ "$OS" == "Darwin" ]]; then
     if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
@@ -85,7 +97,7 @@ if [[ "$OS" == "Darwin" ]]; then
 elif [[ "$OS" == "Linux" ]]; then
     if [[ "$ONEDNN_THREADING" == "OMP" ]]; then
         # OMP is already multi-threaded. Let's not oversubscribe.
-        CTEST_MP=-j2
+        CTEST_MP=-j3
     elif [[ "$ONEDNN_THREADING" == "SEQ" ]]; then
         CTEST_MP=$MP
     fi

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "graph/backend/dnnl/kernels/sdp_primitive_config.hpp"
+#include "common/compiler_workarounds.hpp"
 
 namespace dnnl {
 namespace impl {


### PR DESCRIPTION
Enabling graph builds in the CI so we can monitor breakages for aarch64. To do this, I had to deal with solving some aarch64 compiler warnings, same as those that appeared in #2118. So I adopted the same resolution as [suggested](https://github.com/oneapi-src/oneDNN/pull/2118#issuecomment-2372124064) for that PR.

For MacOS we only test graph for release mode with clang as the smoke tests take too long in debug mode (1 hour+).

Fixes #2137.