### PR TITLE
generic: sycl: deconvolution: bugfix post-ops

### DIFF
--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -111,7 +111,7 @@ status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
     conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
 
-    conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
+    conf_.post_ops = sycl_post_ops_t(attr(), diff_src_md());
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
     conf_.padding[1] = static_cast<int>(desc()->padding[0][1]);

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -154,7 +154,9 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
                     && check_convolution_formats(
                             diff_data_d, weights_d, diff_dst_d)
                     && attr()->has_default_values(sm::scales_runtime
-                            | sm::zero_points_runtime | sm::sum_dt)
+                            | sm::zero_points_runtime | sm::sum_dt
+                            | sm::post_ops)
+                    && sycl_post_ops_t::post_ops_ok(attr(), false)
                     && IMPLICATION(!attr()->scales_.has_default_values(),
                             attr_scales_ok()
                                     && check_convolution_scales_types(attr()))


### PR DESCRIPTION
Fixes a bug with deconvolution post ops not being supported and with sum post op outputting nan.