### PR TITLE
github: workflows: disable testcase for graph on macos aarch64 CI

### DIFF
--- a/.github/automation/test_aarch64.sh
+++ b/.github/automation/test_aarch64.sh
@@ -84,10 +84,12 @@ elif [[ "$OS" == "Darwin" ]]; then
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_ci_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
     elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_ci_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
     fi
 fi
 

--- a/.github/automation/test_aarch64.sh
+++ b/.github/automation/test_aarch64.sh
@@ -68,6 +68,7 @@ if [[ "$OS" == "Linux" ]]; then
         SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_usm_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_usm_cpu"
     elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
@@ -77,6 +78,7 @@ if [[ "$OS" == "Linux" ]]; then
         SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_usm_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_usm_cpu"
     fi
 elif [[ "$OS" == "Darwin" ]]; then
     if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
@@ -85,11 +87,13 @@ elif [[ "$OS" == "Darwin" ]]; then
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_ci_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_usm_cpu"
     elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_ci_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_usm_cpu"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_usm_cpu"
     fi
 fi
 


### PR DESCRIPTION


# Description

temporary skip unit test `test_graph_unit_dnnl_sdp_decomp_usm_cpu` on aarch64 ci. This's a known bug which causes segfault. aarch64 doesn't support graph until this one is fixed. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

