### PR TITLE
doc: Add status icon for CI pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ oneAPI Deep Neural Network Library (oneDNN)
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8762/badge)](https://www.bestpractices.dev/projects/8762)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/oneapi-src/oneDNN/badge)](https://securityscorecards.dev/viewer/?uri=github.com/oneapi-src/oneDNN)
+![AArch64 Build Status](https://github.com/oneapi-src/oneDNN/actions/workflows/ci-aarch64.yml/badge.svg?branch=main)
 
 oneAPI Deep Neural Network Library (oneDNN) is an open-source cross-platform
 performance library of basic building blocks for deep learning applications.


### PR DESCRIPTION
It can be beneficial for users to know whether to expect the main branch to build as expected, especially for AArch64, as our current way of pushing directly to main can break AArch64 CI. Users can look to see the current CI status in the latest git commit, but for better visibility, we can add a badge. This also gives us the status of the last full CI run instead of the current CI run that the git commit status will give us (which may not be complete at the time of viewing, and can hide the current CI status). Also recall that AArch64 CI does not fully complete on forks and so they will never show the correct CI status on the git commits, and instead will need to rely on the badge.

We added status badges in the README here: https://github.com/oneapi-src/oneDNN/commit/4d82471cf15e721a69a0e5a63f5996ec0b9ddda4

This change adds another badge for CI. An example view of badge can be seen from my fork's README: https://github.com/theComputeKid/oneDNN/tree/badges

I don't have the privileges to get the x86 CI badges from Azure, so will wait for @vpirogov or @mgouicem, in case they want to add x86 badges.