### PR TITLE
generic: conv: deconv: reduce kernel argument size

### DIFF
--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -25,11 +25,14 @@ namespace generic {
 namespace sycl {
 
 status_t ref_convolution_fwd_t::pd_t::init_conf() {
-    conf_ = sycl_convolution_conf_t();
+    conf_ = sycl_convolution_fwd_conf_t();
 
     conf_.data_md = xpu::sycl::md_t(src_md());
     conf_.weights_md = xpu::sycl::md_t(weights_md(0));
-    if (with_bias()) { conf_.bias_md = xpu::sycl::md_t(weights_md(1)); }
+    if (with_bias()) {
+        conf_.bias_dt = weights_md(1)->data_type;
+        conf_.has_bias = true;
+    }
     conf_.dst_md = xpu::sycl::md_t(dst_md());
     conf_.ndims = ndims();
 
@@ -85,11 +88,14 @@ status_t ref_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
 }
 
 status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
-    conf_ = sycl_convolution_conf_t();
+    conf_ = sycl_convolution_bwd_data_conf_t();
 
     conf_.diff_data_md = xpu::sycl::md_t(diff_src_md());
     conf_.weights_md = xpu::sycl::md_t(weights_md(0));
-    if (with_bias()) { conf_.bias_md = xpu::sycl::md_t(weights_md(1)); }
+    if (with_bias()) {
+        conf_.bias_dt = weights_md(1)->data_type;
+        conf_.has_bias = true;
+    }
     conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md());
     conf_.ndims = ndims();
 
@@ -145,12 +151,13 @@ status_t ref_convolution_bwd_data_t::execute(const exec_ctx_t &ctx) const {
 }
 
 status_t ref_convolution_bwd_weights_t::pd_t::init_conf() {
-    conf_ = sycl_convolution_conf_t();
+    conf_ = sycl_convolution_bwd_weights_conf_t();
 
     conf_.data_md = xpu::sycl::md_t(src_md());
     conf_.diff_weights_md = xpu::sycl::md_t(diff_weights_md(0));
     if (with_bias()) {
-        conf_.diff_bias_md = xpu::sycl::md_t(diff_weights_md(1));
+        conf_.bias_dt = diff_weights_md(1)->data_type;
+        conf_.has_bias = true;
     }
     conf_.diff_dst_md = xpu::sycl::md_t(diff_dst_md());
     conf_.ndims = ndims();

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -107,7 +107,7 @@ struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
             return init_conf();
         }
 
-        sycl_convolution_conf_t conf_;
+        sycl_convolution_fwd_conf_t conf_;
 
     private:
         status_t init_conf();
@@ -164,7 +164,7 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
             return init_conf();
         }
 
-        sycl_convolution_conf_t conf_;
+        sycl_convolution_bwd_data_conf_t conf_;
 
     private:
         status_t init_conf();
@@ -216,7 +216,7 @@ struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
             return init_conf();
         }
 
-        sycl_convolution_conf_t conf_;
+        sycl_convolution_bwd_weights_conf_t conf_;
 
     private:
         status_t init_conf();

--- a/src/gpu/generic/sycl/ref_deconvolution.cpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.cpp
@@ -25,11 +25,12 @@ namespace generic {
 namespace sycl {
 
 status_t ref_deconvolution_bwd_weights_t::pd_t::init_conf() {
-    conf_ = sycl_convolution_conf_t();
+    conf_ = sycl_convolution_bwd_weights_conf_t();
 
     conf_.diff_dst_md = xpu::sycl::md_t(src_md());
     if (with_bias()) {
-        conf_.diff_bias_md = xpu::sycl::md_t(diff_weights_md(1));
+        conf_.bias_dt = diff_weights_md(1)->data_type;
+        conf_.has_bias = true;
     }
     conf_.data_md = xpu::sycl::md_t(diff_dst_md());
     conf_.ndims = ndims();

--- a/src/gpu/generic/sycl/ref_deconvolution.hpp
+++ b/src/gpu/generic/sycl/ref_deconvolution.hpp
@@ -63,7 +63,7 @@ struct ref_deconvolution_bwd_weights_t
             return init_conf();
         }
 
-        sycl_convolution_conf_t conf_;
+        sycl_convolution_bwd_weights_conf_t conf_;
 
     private:
         status_t init_conf();

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -47,15 +47,9 @@ struct sycl_binary_conf_t {
     sycl_post_ops_t post_ops;
 };
 
-struct sycl_convolution_conf_t {
-    xpu::sycl::md_t data_md;
-    xpu::sycl::md_t dst_md;
-    xpu::sycl::md_t weights_md;
-    xpu::sycl::md_t bias_md;
-    xpu::sycl::md_t diff_data_md;
-    xpu::sycl::md_t diff_dst_md;
-    xpu::sycl::md_t diff_weights_md;
-    xpu::sycl::md_t diff_bias_md;
+struct sycl_convolution_common_conf_t {
+    bool has_bias = false;
+    data_type_t bias_dt;
 
     int padding[3];
     int strides[3];
@@ -79,6 +73,24 @@ struct sycl_convolution_conf_t {
     bool is_deconvolution;
 
     sycl_post_ops_t post_ops;
+};
+
+struct sycl_convolution_fwd_conf_t : sycl_convolution_common_conf_t {
+    xpu::sycl::md_t data_md;
+    xpu::sycl::md_t dst_md;
+    xpu::sycl::md_t weights_md;
+};
+
+struct sycl_convolution_bwd_data_conf_t : sycl_convolution_common_conf_t {
+    xpu::sycl::md_t weights_md;
+    xpu::sycl::md_t diff_data_md;
+    xpu::sycl::md_t diff_dst_md;
+};
+
+struct sycl_convolution_bwd_weights_conf_t : sycl_convolution_common_conf_t {
+    xpu::sycl::md_t data_md;
+    xpu::sycl::md_t diff_dst_md;
+    xpu::sycl::md_t diff_weights_md;
 };
 
 struct sycl_eltwise_conf_t {
@@ -416,6 +428,9 @@ CHECK_SYCL_KERNEL_ARG_TYPE(sycl_sum_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_pooling_base_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_pooling_fwd_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_pooling_bwd_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_convolution_fwd_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_convolution_bwd_data_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_convolution_bwd_weights_conf_t);
 
 } // namespace sycl
 } // namespace generic


### PR DESCRIPTION
# Description

This PR splits the conf struct for Convolution primitives into 3 separate structs, reducing the argument size passed to the kernel and enabling them to run on intel devices.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
