### PR TITLE
generic: sycl: add missing type checks on scales

### DIFF
--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -32,22 +32,16 @@ namespace gpu {
 namespace generic {
 namespace sycl {
 
-static bool check_convolution_data_types(const memory_desc_wrapper &src0,
+inline bool check_convolution_data_types(const memory_desc_wrapper &src0,
         const memory_desc_wrapper &src1, const memory_desc_wrapper &dst) {
-    using namespace data_type;
-
-    const auto src0_dt = src0.data_type();
-    const auto src1_dt = src1.data_type();
-    const auto dst_dt = dst.data_type();
-
-    for (auto t : {src0_dt, src1_dt, dst_dt}) {
-        if (!utils::one_of(t, f32, bf16, f16, s32, s8, u8)) return false;
+    for (const auto &mdw : {src0, src1, dst}) {
+        if (!is_supported_type(mdw.data_type())) return false;
     }
 
     return true;
 }
 
-static bool check_convolution_formats(const memory_desc_wrapper &src0,
+inline bool check_convolution_formats(const memory_desc_wrapper &src0,
         const memory_desc_wrapper &src1, const memory_desc_wrapper &dst) {
     using namespace format_tag;
 
@@ -57,13 +51,25 @@ static bool check_convolution_formats(const memory_desc_wrapper &src0,
     return true;
 }
 
-static bool check_convolution_work_amount(
+inline bool check_convolution_work_amount(
         const memory_desc_wrapper &weights, dim_t OC) {
     auto elems = weights.nelems();
     auto work_per_output = elems / OC;
     // arbitrarily chosen threshold to avoid unreasonably long runtimes
     // such cases should use a different implementation
     return work_per_output < 200000;
+}
+
+inline bool check_convolution_scales_types(const primitive_attr_t *attr) {
+    const std::vector<int> supported_args
+            = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
+
+    const auto &scales = attr->scales_;
+    for (auto arg : supported_args) {
+        auto dt = scales.get(arg).data_type_;
+        if (!is_supported_type(dt)) { return false; }
+    }
+    return true;
 }
 
 struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
@@ -92,7 +98,8 @@ struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
                             | sm::zero_points_runtime | sm::post_ops
                             | sm::sum_dt)
                     && IMPLICATION(!attr()->scales_.has_default_values(),
-                            attr_scales_ok())
+                            attr_scales_ok()
+                                    && check_convolution_scales_types(attr()))
                     && sycl_post_ops_t::post_ops_ok(attr(), false)
                     && set_default_alg_kind(alg_kind::convolution_direct);
             if (!ok) return status::unimplemented;
@@ -149,7 +156,8 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
                     && attr()->has_default_values(sm::scales_runtime
                             | sm::zero_points_runtime | sm::sum_dt)
                     && IMPLICATION(!attr()->scales_.has_default_values(),
-                            attr_scales_ok())
+                            attr_scales_ok()
+                                    && check_convolution_scales_types(attr()))
                     && set_default_alg_kind(alg_kind::convolution_direct);
             if (!ok) return status::unimplemented;
 
@@ -205,7 +213,8 @@ struct ref_convolution_bwd_weights_t : public gpu::generic::sycl::primitive_t {
                     && attr()->has_default_values(sm::scales_runtime
                             | sm::zero_points_runtime | sm::sum_dt)
                     && IMPLICATION(!attr()->scales_.has_default_values(),
-                            attr_scales_ok())
+                            attr_scales_ok()
+                                    && check_convolution_scales_types(attr()))
                     && set_default_alg_kind(alg_kind::convolution_direct);
             if (!ok) return status::unimplemented;
 

--- a/src/gpu/generic/sycl/ref_matmul.hpp
+++ b/src/gpu/generic/sycl/ref_matmul.hpp
@@ -99,7 +99,6 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
         }
 
         bool scales_ok() const {
-            using namespace data_type;
             const std::vector<int> supported_args
                     = {DNNL_ARG_SRC_0, DNNL_ARG_WEIGHTS_0, DNNL_ARG_DST};
 
@@ -107,8 +106,7 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
             bool dt_ok = true;
             for (auto arg : supported_args) {
                 auto &s = scales.get(arg);
-                dt_ok = dt_ok
-                        && utils::one_of(s.data_type_, s8, s32, f32, f16, bf16);
+                dt_ok = dt_ok && is_supported_type(s.data_type_);
             }
             return dt_ok && attr_scales_ok(supported_args);
         }

--- a/src/gpu/generic/sycl/ref_resampling.hpp
+++ b/src/gpu/generic/sycl/ref_resampling.hpp
@@ -88,10 +88,10 @@ struct ref_resampling_bwd_t : public gpu::generic::sycl::primitive_t {
             const memory_desc_wrapper diff_dst_d(diff_dst_md(0));
             const memory_desc_wrapper diff_src_d(diff_src_md(0));
 
-            bool ok = !is_fwd() && is_supported_type(src_md(0)->data_type)
-                    && is_supported_type(dst_md(0)->data_type)
+            bool ok = !is_fwd() && is_supported_type(diff_src_md(0)->data_type)
+                    && is_supported_type(diff_dst_md(0)->data_type)
                     && set_default_params() == status::success
-                    && (src_md(0)->format_desc.blocking.inner_nblks == 0)
+                    && (diff_src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && (diff_dst_md(0)->format_desc.blocking.inner_nblks == 0)
                     && attr()->has_default_values()
                     && md_dims_in_range(diff_dst_md());

--- a/src/gpu/generic/sycl/ref_resampling.hpp
+++ b/src/gpu/generic/sycl/ref_resampling.hpp
@@ -41,18 +41,14 @@ struct ref_resampling_fwd_t : public gpu::generic::sycl::primitive_t {
         DECLARE_COMMON_PD_T("dpcpp:ref:any", ref_resampling_fwd_t);
 
         status_t init(impl::engine_t *engine) {
-            using namespace data_type;
             using namespace prop_kind;
             using namespace alg_kind;
             using sm = primitive_attr_t::skip_mask_t;
             const memory_desc_wrapper src_d(src_md(0));
             const memory_desc_wrapper dst_d(dst_md(0));
 
-            const bool ok = is_fwd()
-                    && utils::one_of(
-                            src_md(0)->data_type, f32, bf16, f16, s32, s8, u8)
-                    && utils::one_of(
-                            dst_md(0)->data_type, f32, bf16, f16, s32, s8, u8)
+            const bool ok = is_fwd() && is_supported_type(src_md(0)->data_type)
+                    && is_supported_type(dst_md(0)->data_type)
                     && attr()->has_default_values(sm::post_ops)
                     && set_default_params() == status::success
                     && attr_.set_default_formats(dst_md(0)) == status::success
@@ -92,7 +88,9 @@ struct ref_resampling_bwd_t : public gpu::generic::sycl::primitive_t {
             const memory_desc_wrapper diff_dst_d(diff_dst_md(0));
             const memory_desc_wrapper diff_src_d(diff_src_md(0));
 
-            bool ok = !is_fwd() && set_default_params() == status::success
+            bool ok = !is_fwd() && is_supported_type(src_md(0)->data_type)
+                    && is_supported_type(dst_md(0)->data_type)
+                    && set_default_params() == status::success
                     && (src_md(0)->format_desc.blocking.inner_nblks == 0)
                     && (diff_dst_md(0)->format_desc.blocking.inner_nblks == 0)
                     && attr()->has_default_values()

--- a/src/gpu/generic/sycl/sycl_io_helper.hpp
+++ b/src/gpu/generic/sycl/sycl_io_helper.hpp
@@ -28,6 +28,11 @@ namespace gpu {
 namespace generic {
 namespace sycl {
 
+inline bool is_supported_type(data_type_t dt) {
+    using namespace data_type;
+    return utils::one_of(dt, f32, f16, bf16, s32, s8, u8);
+}
+
 inline int load_int_value(data_type_t dt, const void *ptr, dim_t idx) {
 #define CASE(dt) \
     case dt: \


### PR DESCRIPTION
This PR cherry picks 301eeff2e9c35b4adbf2a951de8075b863201a67 and aa96c1e2299ee09fcdc667115e2652adf2e1bfc4 (which fixes an issue introduced in 301eeff2e9c35b4adbf2a951de8075b863201a67) into release 3.6 branch.