### PR TITLE
[risc-v] cmake: added rvv intrinsics compilation check

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -438,7 +438,10 @@ if (DNNL_TARGET_ARCH STREQUAL "RV64")
     # Check if the RVV Intrinsics can be compiled with the current toolchain and flags
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("#include <riscv_vector.h>
-                               int main() { return 0; };"
+                               int main() { 
+                                size_t size = 64;
+                                return vsetvl_e32m2(size); 
+                               };"
                                CAN_COMPILE_RVV_INTRINSICS
     )
     # set CAN_COMPILE_RVV_INTRINSICS to TRUE / FALSE instead of 1 / "" (Undefined)


### PR DESCRIPTION
# Description

OneDNN build with https://github.com/riscv-collab/riscv-gnu-toolchain fails with the following error:
![image](https://github.com/user-attachments/assets/078f7f7d-6e72-439f-bbdd-8a62966f1b95)

The [GNU toolchain for RISC-V](https://github.com/riscv-collab/riscv-gnu-toolchain) now supports RVV by default - ratified RVV1.0. All intrinsics have prefix __riscv64. Some compilers (clang, llvm) can compile a code contained intrinsics without this prefix (have overloaded functions). But GCC from riscv-gnu-toolchain doesn't have them - so cannot compile max pooling primitive from oneDNN.

The fix adds cmake configuration time check that corresponding intrinsics are really supported by the compiler.

This change is upstreamed from [oneDNN fork repo](https://github.com/openvinotoolkit/oneDNN) maintained by [OpenVINO organization](https://github.com/openvinotoolkit).