### PR TITLE
github: automation: azure: updated macOS 12 to 14

### DIFF
--- a/.github/automation/.azure-pipeline.yml
+++ b/.github/automation/.azure-pipeline.yml
@@ -82,10 +82,10 @@ jobs:
           .github/automation/test.sh --build-dir $(pwd)/build --report-dir $(pwd)/report
         displayName: 'test'
         failOnStderr: true
-  - job: 'macOS12'
+  - job: 'macOS13'
     timeoutInMinutes: 120
     pool:
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-13'
     steps:
       - script: |
           .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build
@@ -94,10 +94,10 @@ jobs:
           .github/automation/test.sh --build-dir $(pwd)/build --report-dir $(pwd)/report
         displayName: 'test'
         failOnStderr: true
-  - job: 'macOS13'
+  - job: 'macOS14'
     timeoutInMinutes: 120
     pool:
-      vmImage: 'macOS-13'
+      vmImage: 'macOS-14'
     steps:
       - script: |
           .github/automation/build.sh --threading omp --mode Release --source-dir $(pwd) --build-dir $(pwd)/build


### PR DESCRIPTION
macOS 12 runners [were deprecated](https://github.com/actions/runner-images/issues/10721) in Azure and CI jobs on this platform are now failing.
