### PR TITLE
gpu: nvidia: skip unsupported gtests

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -75,7 +75,10 @@ if(DNNL_SYCL_CUDA)
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/lstm.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/layer_normalization.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/primitives/reorder.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/shuffle.cpp)
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/shuffle.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/group_normalization.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/vanilla_rnn.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/primitives/lbr_gru.cpp)
 endif()
 
 # Remove examples for Graph API if graph component is not enabled

--- a/tests/gtests/sycl/api/CMakeLists.txt
+++ b/tests/gtests/sycl/api/CMakeLists.txt
@@ -24,12 +24,12 @@ register_exe(${TEST_EXE} "${TEST_SOURCES}" "test" "dnnl_gtest")
 # so they need to be compiled with the correct device triple
 if(DNNL_WITH_SYCL)
     if(DNNL_SYCL_GENERIC)
-        CHECK_CXX_COMPILER_FLAG("-fsycl -fsycl-targets=nvptx64-nvidia-cuda" NVIDIA_TARGET_SUPPORTED)
+        CHECK_CXX_COMPILER_FLAG("-fsycl -fsycl-targets=nvptx64-nvidia-cuda,spir64" NVIDIA_TARGET_SUPPORTED)
     endif()
 
     # Enable linking SYCL kernels.
     if(DNNL_SYCL_CUDA OR (DNNL_SYCL_GENERIC AND NVIDIA_TARGET_SUPPORTED))
-        append(CMAKE_CXX_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda")
+        append(CMAKE_CXX_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda,spir64")
         append(CMAKE_CXX_FLAGS "-Wno-linker-warnings")
     endif()
 

--- a/tests/gtests/test_deconvolution.cpp
+++ b/tests/gtests/test_deconvolution.cpp
@@ -312,10 +312,10 @@ protected:
         auto aa = allows_attr_t {false};
 
 #ifndef DNNL_SYCL_GENERIC
-        aa.po_binary = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
-        aa.po_eltwise = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
-        aa.po_prelu = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
-        aa.po_sum = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
+        aa.po_binary = !is_amd_gpu(eng);
+        aa.po_eltwise = !is_amd_gpu(eng);
+        aa.po_prelu = !is_amd_gpu(eng);
+        aa.po_sum = !is_amd_gpu(eng);
 #else
         aa.po_eltwise = true;
         aa.po_sum = true;

--- a/tests/gtests/test_group_normalization.cpp
+++ b/tests/gtests/test_group_normalization.cpp
@@ -46,6 +46,8 @@ private:
 
 protected:
     void SetUp() override {
+        SKIP_IF_CUDA(
+                true, "Group Normalization operator is not supported in CUDA");
         SKIP_IF_HIP(
                 true, "Group Normalization operator is not supported in HIP");
         SKIP_IF_GENERIC(true,

--- a/tests/gtests/test_iface_attr_quantization.cpp
+++ b/tests/gtests/test_iface_attr_quantization.cpp
@@ -432,6 +432,9 @@ TEST_F(attr_quantization_test_t, TestLRN) {
 }
 
 TEST_F(attr_quantization_test_t, TestMatmul) {
+    // cuDNN doesn't support zero points
+    SKIP_IF_CUDA(true, "Test not supported on cuda");
+
     for (auto a_dt : {data_type::f32, data_type::u8}) {
         const data_type b_dt
                 = a_dt == data_type::f32 ? data_type::f32 : data_type::s8;

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -260,9 +260,9 @@ protected:
         auto matmul_pd = pd_t(eng, src_md, weights_md, bia_md, dst_md, attr);
 
         auto aa = allows_attr_t {false};
-        aa.po_binary = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
+        aa.po_binary = !is_amd_gpu(eng);
         aa.po_eltwise = true;
-        aa.po_prelu = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
+        aa.po_prelu = !is_amd_gpu(eng);
         aa.po_sum = true;
         // scales are not supported by HIP
         aa.scales = !is_amd_gpu(eng);

--- a/tests/gtests/test_softmax.cpp
+++ b/tests/gtests/test_softmax.cpp
@@ -168,7 +168,7 @@ protected:
                                              : p.aprop_kind;
 
         allows_attr_t aa {false};
-        if (!(is_nvidia_gpu(eng) || is_amd_gpu(eng))) {
+        if (!is_amd_gpu(eng)) {
             aa.po_eltwise = true;
             aa.po_binary = true;
         }


### PR DESCRIPTION
# Description

This PR adds skips in gtests for unimplemented primitives on nvidia.
