### PR TITLE
Skip Jit uni reorder if 4d matrix and zero point is defined

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -2840,6 +2840,11 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
     _pd->ker_desc_ = ker_desc;
     CHECK(_pd->init_scratchpad_md());
 
+    bool has_zero_point
+            = !_pd->attr()->zero_points_.has_default_values(DNNL_ARG_FROM)
+            || !_pd->attr()->zero_points_.has_default_values(DNNL_ARG_TO);
+    if (src_md->ndims == 4 && has_zero_point) { return status::unimplemented; }
+
     return safe_ptr_assign(*reorder_pd, _pd.release());
 }
 

--- a/tests/benchdnn/inputs/reorder/test_reorder_ci
+++ b/tests/benchdnn/inputs/reorder/test_reorder_ci
@@ -12,6 +12,13 @@
 --oflag=
 2x16x3x4 1x17x5x3 30x1
 
+# 4d reorders
+--sdt=s8,u8
+--ddt=f32
+--attr-zero-points=src:common:-1
+--stag=adbc
+1x12x128x33
+
 --reset
 # compensation reorders without groups
 --sdt=f32,s8,bf16


### PR DESCRIPTION
# Description

Jit:uni reorders for certain 4d matrices are returning incorrect results when the src zero point != 0. A guard has been added to skip jit uni reorders for any 4d matrices where src zero point != 0 so the simple:any implementation will be used. A new testcase has also been added to benchdnn.

Reproduction:
```
./tests/benchdnn/benchdnn --reorder  --sdt=u8 --ddt=f32 --stag=adbc --attr-zero-points=src:common:1 1x32x128x33
```

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?

