### PR TITLE
src: cpu: aarch64: Enable jit bf16 -> f32 reorder

### DIFF
--- a/tests/benchdnn/inputs/reorder/test_reorder_bfloat16
+++ b/tests/benchdnn/inputs/reorder/test_reorder_bfloat16
@@ -1,6 +1,6 @@
-# f32, s8, u8 <--> bf16
+# f32, bf16, s8, u8 <--> bf16
 --reset
---sdt=f32,s8,u8,f8_e5m2,f8_e4m3 --ddt=bf16
+--sdt=f32,bf16,s8,u8,f8_e5m2,f8_e4m3 --ddt=bf16
 --stag=abx
 --dtag=aBx16b 2x64x14x14 2x56x14x14
 --dtag=gOIhw16i16o 2x64x64x3x3 2x56x56x3x3


### PR DESCRIPTION
# Description

This enables `jit:uni` reorder for dtype-> ` bf16 -> f32` 

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? - Yes
- [ ] Have you formatted the code using clang-format? - Yes 

## Performance improvements

Adding a small testcase logs to demonstrate perf numbers before and after. 

TC: `ONEDNN_VERBOSE=all ./benchdnn --reorder --sdt=bf16 --ddt=f32 --mode=p   1x4096x4096` 

(new) jit:any : 
> onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:bf16::blocked:abc::f0 dst:f32::blocked:abc::f0,,,1x4096x4096,**0.493896**

(old) simple:any : 
> onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:bf16::blocked:abc::f0 dst:f32::blocked:abc::f0,,,1x4096x4096,**11.9778**

