### PR TITLE
test: aarch64: Fix unimplemented error when --cpu-isa-hints=prefer_ymm

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -82,6 +82,8 @@ status_t set_max_cpu_isa(dnnl_cpu_isa_t isa) {
 status_t set_cpu_isa_hints(dnnl_cpu_isa_hints_t isa_hints) {
 #if DNNL_X64
     return x64::set_cpu_isa_hints(isa_hints);
+#elif DNNL_AARCH64
+    return status::success;
 #else
     return status::unimplemented;
 #endif


### PR DESCRIPTION
When running with --cpu-isa-hints=prefer_ymm, tests fail on aarch64 due to an unimplmented error. This change will instead allow the code to run the reference implementations.

Reproducible:
```
./tests/benchdnn/benchdnn --conv --cpu-isa-hints=prefer_ymm --dt=bf16:bf16:bf16 --stag=axb --dtag=axb --attr-post-ops=sum+tanh:1:1 g1ic64ih1000oc64oh1000kh3ph128dh127
```