### PR TITLE
cpu: aarch64: non-global stats mode for ACL lnorm

### DIFF
--- a/.github/automation/test_aarch64.sh
+++ b/.github/automation/test_aarch64.sh
@@ -54,7 +54,6 @@ fi
 if [[ "$OS" == "Linux" ]]; then
     if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
-        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|cpu-primitives-matmul-cpp"
         SKIPPED_TEST_FAILURES+="|test_convolution_backward_weights_f32"
@@ -71,7 +70,6 @@ if [[ "$OS" == "Linux" ]]; then
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_cpu"
     elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
-        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|cpu-graph-gqa-cpp"
         SKIPPED_TEST_FAILURES+="|cpu-graph-mqa-cpp"
         SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
@@ -83,15 +81,12 @@ if [[ "$OS" == "Linux" ]]; then
 elif [[ "$OS" == "Darwin" ]]; then
     if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
-        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_smoke_cpu"
         SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_brgemm_ci_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_cpu"
     elif [[ "$CMAKE_BUILD_TYPE" == "Release" ]]; then
         SKIPPED_TEST_FAILURES="cpu-primitives-deconvolution-cpp"
-        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_smoke_cpu"
-        SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_lnorm_ci_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_cpu"
         SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_cpu"
     fi

--- a/src/cpu/aarch64/acl_layer_normalization.hpp
+++ b/src/cpu/aarch64/acl_layer_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -81,9 +81,10 @@ struct acl_layer_normalization_fwd_t : public primitive_t {
             // dir and flags
             ACL_CHECK_SUPPORT(
                     !is_fwd(), "ACL lnorm supports forward propagation only");
-            ACL_CHECK_SUPPORT(is_training() && !use_global_stats(),
-                    "ACL only supports forward training with lnorm if stats "
-                    "are provided (use global stats)");
+            ACL_CHECK_SUPPORT(
+                    is_training(), "ACL supports inference only for lnorm");
+            ACL_CHECK_SUPPORT(use_global_stats(),
+                    "ACL does not support global stats with lnorm");
             ACL_CHECK_SUPPORT(use_scale() || use_shift(),
                     "ACL does not support lnorm scale and shift");
 

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2024 Intel Corporation
+* Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -635,10 +636,14 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 std::vector<data_kind_t> get_kinds_to_check(const prb_t *prb) {
     std::vector<data_kind_t> check_kinds;
     if (prb->dir & FLAG_FWD) {
+// ACL lnorm does not return mean and variance, so these tests would fail
+// even if the normalization layer worked correctly
+#if !(DNNL_AARCH64_USE_ACL)
         if (!(prb->flags & GLOB_STATS) && !(prb->dir & FLAG_INF)) {
             check_kinds.push_back(MEAN);
             check_kinds.push_back(VAR);
         }
+#endif
         check_kinds.push_back(DST);
     } else {
         if (prb->dir & FLAG_WEI) {


### PR DESCRIPTION
  * Change acl_layer_normalization to support non-global stats only
  * Remove mean and variance check for ACL lnorm from benchdnn