### PR TITLE
cpu: aarch64: Re-enable ACL indirect conv for BF16

### DIFF
--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -96,11 +96,13 @@ status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init(engine_t *engine) {
 
     const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
             && attr()->has_default_values(smask_t::post_ops, f16);
+    const bool is_bf16_ok = expect_data_types(bf16, bf16, bf16, bf16, undef)
+            && attr_.post_ops_.len() == 0;
     const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
             && attr()->has_default_values(
                     smask_t::post_ops | smask_t::fpmath_mode, f32);
     bool ok = is_fwd() && set_default_alg_kind(alg_kind::convolution_direct)
-            && utils::one_of(true, is_fp16_ok, is_fp32_ok)
+            && utils::one_of(true, is_fp16_ok, is_bf16_ok, is_fp32_ok)
             && !has_zero_dim_memory();
     if (!ok) return status::unimplemented;
 


### PR DESCRIPTION
# Description

cpu: aarch64: Re-enable ACL indirect conv for BF16

Fixes change caused by c547c7770f7eaf2330f410e481c3618ff75c3152

# Checklist

## General

- [ Y ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ Y ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
