### PR TITLE
Improvements for commit message checker

### DIFF
--- a/.github/automation/commit-msg-check.py
+++ b/.github/automation/commit-msg-check.py
@@ -67,7 +67,7 @@ def main():
     head: str = args.head
 
     commit_range = base + ".." + head
-    messages = subprocess.run(["git", "rev-list", "--ancestry-path", commit_range, "--format=oneline"], capture_output=True, text=True).stdout
+    messages = subprocess.run(["git", "rev-list", "--format=oneline", commit_range], capture_output=True, text=True).stdout
 
     is_ok = True
     for i in messages.splitlines():

--- a/.github/workflows/commit-msg-check.yml
+++ b/.github/workflows/commit-msg-check.yml
@@ -31,10 +31,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  title:
-    if: github.repository == 'oneapi-src/oneDNN'
+  commit-message-check:
+    name: Commit message checker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Pass pull request commit messages through script.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check commit messages
         run: python3 ./.github/automation/commit-msg-check.py "${{ github.event.pull_request.head.sha }}" "${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/commit-msg-check.yml
+++ b/.github/workflows/commit-msg-check.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Check commit messages


### PR DESCRIPTION
Three main things:
* Makes the action to actually fail when commit messages do not meet requirements.
* Script output now clearly indicates which commit message are are bad and what specific checks failed.
* Extends limit to commit message from 72 to 100 character, as Github and terminals handle this length without line breaks just fine.

Sample output:
```
47f9fbd58700f56cf3732b946b40a1e6cbc5a7db governance: extended commit message length limit to 100
Message length: OK
Message scope:  OK
6de15ad81ed6bb86c1d92c689ac0a796afbbb449 TMP: commit with veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery long message
Message length: FAILED: Commit message summary must not exceed 100 characters.
Message scope:  OK
2370ea1c1ae4e2b112be8bdfa73fa3bc62dcd400 TMP cpu: commit with bad scope
Message length: OK
Message scope:  FAILED: Same-level scopes must be comma-separated. Bad token: 'TMP cpu'
cc51ad99ea0b9ea3d0166f0fab5dec57144ce5b3 TMP 360 noscope commit for testing purposes
Message length: OK
Message scope:  FAILED: Commit message does not include scope
6633c64686882a55b8988bc9c4ce8667114f00c4 github: worklflows: fixed checkout depth
Message length: OK
Message scope:  OK
777109c9d17d6a59b3eae0c4b7c0683a693f7743 github: automation: fixed git command in message checker
Message length: OK
Message scope:  OK
03f2b9f404b949a9de6978974614ecd486274d22 github: automation: improved diagnostics for commit message checker
Message length: OK
Message scope:  OK
Some commit message checks failed. Please align commit messages with Contributing Guidelines and update the PR.
```

Demo/Test: https://github.com/vpirogov/oneDNN/pull/1