### PR TITLE
github: workflows: Reduce MacOS CI configs

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -24,25 +24,26 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# TODO: Fix job cancellation.
 #* Stop stale workflows when pull requests are updated: https://stackoverflow.com/a/70972844
 #* Does not apply to the main branch.
-# concurrency:
-#   group: ${{ github.ref }}
-#   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Declare default permissions as read only.
 permissions: read-all
 
 jobs:
   macos:
-    name: macOS
     runs-on: macos-14
     strategy:
       matrix:
-        toolset: [clang, gcc]
-        config: [Debug, Release]
+        config: [
+          { toolset: clang, build: Release },
+          { toolset: gcc, build: Release }
+        ]
 
+    name: MacOS, ${{ matrix.config.toolset }}, ${{ matrix.config.build }}
     steps:
       - name: Checkout oneDNN
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -58,10 +59,10 @@ jobs:
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
         env:
           ACL_ACTION: clone
-          ACL_CONFIG: ${{ matrix.config }}
+          ACL_CONFIG: ${{ matrix.config.build }}
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.toolset }}
-          GCC_VERSION: 13
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          GCC_VERSION: 14
 
       - name: Get ACL commit hash for cache key
         id: get_acl_commit_hash
@@ -75,7 +76,7 @@ jobs:
         id: cache-acl-restore
         uses: actions/cache/restore@v4
         with:
-          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.toolset }}-${{ matrix.config }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
+          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
           path: ${{ github.workspace }}/ComputeLibrary/build
 
       - name: Build ACL
@@ -84,9 +85,9 @@ jobs:
         env:
           ACL_ACTION: build
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.toolset }}
-          ACL_CONFIG: ${{ matrix.config }}
-          GCC_VERSION: 13
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          ACL_CONFIG: ${{ matrix.config.build }}
+          GCC_VERSION: 14
 
       - name: Save ACL in cache
         if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
@@ -101,16 +102,16 @@ jobs:
         working-directory: ${{ github.workspace }}/oneDNN
         env:
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.toolset }}
-          CMAKE_BUILD_TYPE: ${{ matrix.config }}
-          GCC_VERSION: 13
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
+          GCC_VERSION: 14
     
-      - if: matrix.toolset == 'clang'
+      - if: matrix.config.toolset == 'clang'
         name: Run oneDNN smoke tests
         run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
         working-directory: ${{ github.workspace }}/oneDNN/build
         env:
-          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
   
   # We only run the linux aarch64 runners if macos smoke tests pass.


### PR DESCRIPTION
MacOS github runners are taking too much time. Reduced the configs as well as added more robust stale job kill policies.