### PR TITLE
cpu : aarch64 : reorder : zp correction for 4d shapes

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -791,7 +791,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             // transposition on the fly
             const bool fast_return = prb_.src_scale_type != scale_type_t::MANY
                     && prb_.dst_scale_type != scale_type_t::MANY
-                    && prb_.beta == 0.f;
+                    && prb_.beta == 0.f && !prb_.req_src_zp && !prb_.req_dst_zp;
             if (fast_return) {
                 if (prb_.src_scale_type == scale_type_t::COMMON)
                     for (int ur = 0; ur < reg_unroll; ur += load_step)

--- a/tests/benchdnn/inputs/reorder/test_reorder_ci
+++ b/tests/benchdnn/inputs/reorder/test_reorder_ci
@@ -13,6 +13,15 @@
 2x16x3x4 1x17x5x3 30x1
 
 --reset
+
+# 4d reorders
+--sdt=s8,u8
+--ddt=f32
+--attr-zero-points=src:common:-1
+--stag=adbc
+1x12x128x33
+
+--reset
 # compensation reorders without groups
 --sdt=f32,s8,bf16
 --ddt=s8


### PR DESCRIPTION
# Description

This PR is the fix for the issue : https://github.com/oneapi-src/oneDNN/issues/2213 raised on github.
There was a missing condition that had to be added when zero-points are involved in the reorder.

# Checklist

## General

- [y] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
```
make test

99% tests passed, 2 tests failed out of 218

Total Test time (real) = 1695.47 sec

The following tests FAILED:
	167 - test_graph_unit_dnnl_large_partition_cpu (Failed)
	199 - test_benchdnn_modeC_graph_ci_cpu (Failed)
Errors while running CTest
Output from these tests are in: /home/shreyas/G/shr-fuj/oneDNN_open_source/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8
```

- [y] Have you formatted the code using clang-format?

