### PR TITLE
src : cpu : aarch64 : Jit_sve_conv_kernel 

### DIFF
--- a/src/cpu/aarch64/jit_sve_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.cpp
@@ -1250,8 +1250,7 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::store_output(int ur_w) {
 
     auto out_load = [=](int aux_output_offset, int idx, int prev_ofs) {
         int ofs = aux_output_offset;
-        if ((VL_OFS(ofs, isa) < LDRMAX) && (VL_OFS(ofs, isa) >= (-1 * LDRMAX))
-                && ((ofs & 0x3f) == 0)) {
+        if (ldr_imm_check(ofs) && (ofs % 64 == 0)) {
             add_imm(X_DEFAULT_ADDR, reg_src, ofs, X_TMP_0);
             ld1w(zreg_tmp(idx).s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
         } else {
@@ -1273,8 +1272,7 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::store_output(int ur_w) {
     auto out_str = [=](int j, int k, int aux_output_offset, int prev_ofs) {
         int ofs = aux_output_offset;
 
-        if ((VL_OFS(ofs, isa) < LDRMAX) && (VL_OFS(ofs, isa) >= (-1 * LDRMAX))
-                && ((ofs & 0x3f) == 0)) {
+        if (ldr_imm_check(ofs) && (ofs % 64) == 0) {
             add_imm(X_DEFAULT_ADDR, reg_src, ofs, X_TMP_0);
             st1w(zreg_out(j, k).s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
 
@@ -1415,8 +1413,7 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::compute_loop_fma(
     auto ker_load = [=](int i, int aux_kernel_offset) {
         int ofs = aux_kernel_offset;
 
-        if ((VL_OFS(ofs, isa) < LDRMAX) && (VL_OFS(ofs, isa) >= (-1 * LDRMAX))
-                && ((ofs & 0x3f) == 0)) {
+        if (ldr_imm_check(ofs) && (ofs % 64 == 0)) {
             add_imm(X_DEFAULT_ADDR, aux_reg_ker, ofs, X_TMP_0);
             ld1w(zreg_ker(i).s, P_ALL_ONE / T_z, ptr(X_DEFAULT_ADDR));
 


### PR DESCRIPTION
# Description

 ldr_imm_check function feature is utilized to improve the readability of code. This feature was already present in the code but not utilized in some part of the code.

# Checklist
make test

        Start   1: cpu-bnorm-u8-via-binary-postops-cpp
  1/218 Test   #1: cpu-bnorm-u8-via-binary-postops-cpp .....................   Passed    0.08 sec
        Start   2: cpu-cnn-inference-f32-c
  2/218 Test   #2: cpu-cnn-inference-f32-c .................................   Passed    0.07 sec
        Start   3: cpu-cnn-inference-f32-cpp
.....
190/218 Test #190: test_benchdnn_modeC_binary_ci_cpu .......................   Passed    1.64 sec
        Start 191: test_benchdnn_modeC_binary_different_dt_ci_cpu
191/218 Test #191: test_benchdnn_modeC_binary_different_dt_ci_cpu ..........   Passed    3.07 sec
        Start 192: test_benchdnn_modeC_bnorm_ci_cpu
192/218 Test #192: test_benchdnn_modeC_bnorm_ci_cpu ........................   Passed    2.84 sec
        Start 193: test_benchdnn_modeC_brgemm_ci_cpu
193/218 Test #193: test_benchdnn_modeC_brgemm_ci_cpu .......................   Passed    1.73 sec
        Start 194: test_benchdnn_modeC_concat_ci_cpu
194/218 Test #194: test_benchdnn_modeC_concat_ci_cpu .......................   Passed    1.54 sec
        Start 195: test_benchdnn_modeC_conv_ci_cpu
195/218 Test #195: test_benchdnn_modeC_conv_ci_cpu .........................   Passed   64.63 sec
        Start 196: test_benchdnn_modeC_deconv_ci_cpu
196/218 Test #196: test_benchdnn_modeC_deconv_ci_cpu .......................   Passed   16.88 sec
.....
217/218 Test #217: test_benchdnn_modeC_zeropad_ci_cpu ......................   Passed   38.44 sec
        Start 218: noexcept-cpp
218/218 Test #218: noexcept-cpp ............................................   Passed    0.02 sec

99% tests passed, 2 tests failed out of 218

Total Test time (real) = 762.67 sec

The following tests FAILED:
        167 - test_graph_unit_dnnl_large_partition_cpu (Failed)
        199 - test_benchdnn_modeC_graph_ci_cpu (Failed)
Errors while running CTest
Output from these tests are in: /home/nikhil/oneDNN/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8

## General

-  Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? YES.
-  Have you formatted the code using clang-format? YES.