### PR TITLE
build: cmake: enabling frame pointers

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -120,6 +120,16 @@ endif()
 if(MSVC)
     set(USERCONFIG_PLATFORM "x64")
     append_if(DNNL_WERROR CMAKE_CCXX_FLAGS "/WX")
+
+    # Generating frame pointers for easier performance profiling
+    if(DNNL_TARGET_ARCH STREQUAL "X64")
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            append(CMAKE_CCXX_FLAGS "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
+        else()
+            append(CMAKE_CCXX_FLAGS "/Oy-")
+        endif()
+    endif()
+
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
         append(CMAKE_CCXX_FLAGS "/MP")
         # increase number of sections in obj file
@@ -233,6 +243,11 @@ elseif(UNIX OR MINGW)
         append(CMAKE_CCXX_FLAGS "-Wsign-compare")
     endif()
 
+    # Generating frame pointers for easier performance profiling
+    if(DNNL_TARGET_ARCH STREQUAL "X64")
+        append(CMAKE_CCXX_FLAGS "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
+    endif()
+
     platform_unix_and_mingw_common_ccxx_flags(CMAKE_CCXX_FLAGS)
     platform_unix_and_mingw_common_cxx_flags(CMAKE_CXX_FLAGS)
     platform_unix_and_mingw_noexcept_ccxx_flags(CMAKE_CMAKE_CCXX_NOEXCEPT_FLAGS)
@@ -280,8 +295,11 @@ elseif(UNIX OR MINGW)
             if(DNNL_USE_CLANG_SANITIZER STREQUAL "MemoryWithOrigin")
                 append(CMAKE_CCXX_SANITIZER_FLAGS
                     "-fsanitize-memory-track-origins=2")
-                append(CMAKE_CCXX_SANITIZER_FLAGS
-                    "-fno-omit-frame-pointer")
+                # Already enabled for x64
+                if(NOT DNNL_TARGET_ARCH STREQUAL "X64")
+                    append(CMAKE_CCXX_SANITIZER_FLAGS
+                        "-fno-omit-frame-pointer")
+                endif()
             endif()
             set(DNNL_ENABLED_CLANG_SANITIZER "${DNNL_USE_CLANG_SANITIZER}")
         elseif(DNNL_USE_CLANG_SANITIZER STREQUAL "Undefined")
@@ -306,7 +324,12 @@ elseif(UNIX OR MINGW)
             message(STATUS
                 "Using Clang ${DNNL_ENABLED_CLANG_SANITIZER} "
                 "sanitizer (experimental!)")
-            append(CMAKE_CCXX_SANITIZER_FLAGS "-g -fno-omit-frame-pointer")
+            append(CMAKE_CCXX_SANITIZER_FLAGS "-g")
+            # Already enabled for x64
+            if(NOT DNNL_TARGET_ARCH STREQUAL "X64")
+                append(CMAKE_CCXX_SANITIZER_FLAGS "-fno-omit-frame-pointer")
+            endif()
+
             # Blacklist to ignore false-positive cases. Each case may be
             # assigned to a specific sanitizer. See online doc for help.
             append(CMAKE_CCXX_SANITIZER_FLAGS
@@ -439,9 +462,9 @@ if (DNNL_TARGET_ARCH STREQUAL "RV64")
     # Check if the RVV Intrinsics can be compiled with the current toolchain and flags
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("#include <riscv_vector.h>
-                               int main() { 
+                               int main() {
                                 size_t size = 64;
-                                return vsetvl_e32m2(size); 
+                                return vsetvl_e32m2(size);
                                };"
                                CAN_COMPILE_RVV_INTRINSICS
     )


### PR DESCRIPTION
Adding flags that build oneDNN with frame pointers, which can be used to walk CPU stack frames by profilers. First step for #1232 