### PR TITLE
Introduce GPU kernel metadata support

### DIFF
--- a/src/common/cache_blob.hpp
+++ b/src/common/cache_blob.hpp
@@ -32,7 +32,7 @@ struct cache_blob_impl_t {
         : pos_(0), data_(data), size_(size) {}
 
     status_t add_binary(const uint8_t *binary, size_t binary_size) {
-        if (!binary || binary_size == 0) { return status::invalid_arguments; }
+        if (!binary && binary_size != 0) { return status::invalid_arguments; }
         if (pos_ + sizeof(binary_size) + binary_size > size_) {
             return status::invalid_arguments;
         }

--- a/src/gpu/intel/compute/compute_engine.hpp
+++ b/src/gpu/intel/compute/compute_engine.hpp
@@ -72,7 +72,9 @@ public:
     }
 
     virtual status_t create_kernel_from_binary(compute::kernel_t &kernel,
-            const xpu::binary_t &binary, const char *kernel_name) const = 0;
+            const xpu::binary_t &kernel_binary,
+            const xpu::binary_t &metadata_binary,
+            const char *kernel_name) const = 0;
 
     virtual status_t create_kernels_from_cache_blob(
             const cache_blob_t &cache_blob,

--- a/src/gpu/intel/gpu_primitive.hpp
+++ b/src/gpu/intel/gpu_primitive.hpp
@@ -54,20 +54,14 @@ struct gpu_primitive_t : public gpu::primitive_t {
         virtual status_t get_cache_blob_size_impl(
                 impl::engine_t *engine, size_t *size) const override {
             if (empty()) return status::success;
-            size_t sz = 0;
-            CHECK(kernel().get_binary_size(engine, &sz));
-            // We need additional sizeof(size_t) bytes to store the size
-            // of the binary when packing.
-            (*size) += sz + sizeof(size_t);
+            CHECK(kernel().get_blob_size(engine, size));
             return status::success;
         }
 
         virtual status_t get_cache_blob_impl(
                 impl::engine_t *engine, cache_blob_t &blob) const override {
             if (empty()) return status::success;
-            xpu::binary_t binary;
-            CHECK(kernel().get_binary(engine, binary));
-            CHECK(blob.add_binary(binary.data(), binary.size()));
+            CHECK(kernel().add_cache_blob(engine, blob));
             return status::success;
         }
 

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -53,7 +53,9 @@ struct ir_generator_t : public jit_generator_base {
 
     const char *kernel_name() const override { return kernel_name_.c_str(); }
 
-    xpu::binary_t get_binary(cl_context context, cl_device_id device) override {
+    xpu::binary_t get_binary(cl_context context, cl_device_id device,
+            xpu::binary_t &metadata) override {
+        UNUSED(metadata);
         kernel_info_t kernel_info;
         auto status = kernel_desc_.init_kernel_info(kernel_info);
         if (status != status::success) return xpu::binary_t();

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -890,7 +890,8 @@ void gen_gemm_kernel_t::init_interface() {
 }
 
 xpu::binary_t gen_gemm_kernel_t::get_binary(
-        cl_context context, cl_device_id device) {
+        cl_context context, cl_device_id device, xpu::binary_t &metadata) {
+    UNUSED(metadata);
     init_interface();
     maybe_print_verbose();
 

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.hpp
@@ -152,7 +152,8 @@ struct gen_gemm_kernel_t : public jit_generator_base {
         : desc_(desc) {}
 
     const char *kernel_name() const override { return "gemm_kernel"; }
-    xpu::binary_t get_binary(cl_context context, cl_device_id device) override;
+    xpu::binary_t get_binary(cl_context context, cl_device_id device,
+            xpu::binary_t &metadata) override;
 
     const gen_gemm_kernel_desc_t *desc() const { return &desc_; }
 

--- a/src/gpu/intel/jit/jit_generator.hpp
+++ b/src/gpu/intel/jit/jit_generator.hpp
@@ -138,7 +138,9 @@ public:
         return ngen::OpenCLCodeGenerator<hw>::getExternalName().c_str();
     }
 
-    xpu::binary_t get_binary(cl_context context, cl_device_id device) override {
+    xpu::binary_t get_binary(cl_context context, cl_device_id device,
+            xpu::binary_t &metadata) override {
+        UNUSED(metadata);
         return ngen::OpenCLCodeGenerator<hw>::getBinary(context, device);
     }
 

--- a/src/gpu/intel/jit/jit_generator_base.hpp
+++ b/src/gpu/intel/jit/jit_generator_base.hpp
@@ -31,7 +31,8 @@ namespace jit {
 struct jit_generator_base {
     virtual ~jit_generator_base() = default;
     virtual const char *kernel_name() const = 0;
-    virtual xpu::binary_t get_binary(cl_context context, cl_device_id device)
+    virtual xpu::binary_t get_binary(
+            cl_context context, cl_device_id device, xpu::binary_t &metadata)
             = 0;
 };
 

--- a/src/gpu/intel/ocl/ocl_gpu_engine.hpp
+++ b/src/gpu/intel/ocl/ocl_gpu_engine.hpp
@@ -52,7 +52,8 @@ public:
             const compute::kernel_ctx_t &kernel_ctx) const;
 
     status_t create_kernel_from_binary(compute::kernel_t &kernel,
-            const xpu::binary_t &binary,
+            const xpu::binary_t &kernel_binary,
+            const xpu::binary_t &metadata_binary,
             const char *kernel_name) const override;
 
     status_t create_kernels_from_cache_blob(const cache_blob_t &cache_blob,

--- a/src/gpu/intel/ocl/ocl_gpu_kernel.cpp
+++ b/src/gpu/intel/ocl/ocl_gpu_kernel.cpp
@@ -118,13 +118,13 @@ ocl_gpu_kernel_t::ocl_gpu_kernel_t(xpu::ocl::wrapper_t<cl_kernel> &&ocl_kernel,
     cache_ = std::make_shared<ocl_gpu_kernel_cache_t>(ocl_kernel_);
 }
 
-status_t ocl_gpu_kernel_t::get_binary(
+status_t ocl_gpu_kernel_t::get_kernel_binary(
         const impl::engine_t *engine, xpu::binary_t &binary) const {
     auto *ocl_engine = utils::downcast<const ocl_gpu_engine_t *>(engine);
     return get_ocl_program_binary(ocl_kernel(), ocl_engine->device(), binary);
 }
 
-status_t ocl_gpu_kernel_t::get_binary_size(
+status_t ocl_gpu_kernel_t::get_kernel_binary_size(
         const impl::engine_t *engine, size_t *binary_size) const {
     auto *ocl_engine = utils::downcast<const ocl_gpu_engine_t *>(engine);
     return get_ocl_program_binary_size(

--- a/src/gpu/intel/ocl/ocl_gpu_kernel.hpp
+++ b/src/gpu/intel/ocl/ocl_gpu_kernel.hpp
@@ -40,9 +40,9 @@ public:
 
     cl_kernel ocl_kernel() const { return ocl_kernel_; }
 
-    status_t get_binary(
+    status_t get_kernel_binary(
             const impl::engine_t *engine, xpu::binary_t &binary) const override;
-    status_t get_binary_size(
+    status_t get_kernel_binary_size(
             const impl::engine_t *engine, size_t *binary_size) const override;
 
     status_t parallel_for(impl::stream_t &stream,


### PR DESCRIPTION
This PR introduces optional metadata support for GPU kernels. Metadata is stored in the binary form and may be used in an implementation-dependent manner.

The original use case originates from shapeless convolution:

- Shapeless kernel is reusable and it's created based on a so-called "descriptor"
- The descriptor is the only way to communicate kernel parameters to the kernel 
- In the opposite direction (from kernel creation back to the creation call site), there is no simple way to communicate anything back:
    - This is where kernel metadata is used, kernel creation goes through multiple steps where information about required kernel arguments is recorded. This information is then accessed by the caller to prepare kernel arguments accordingly (in the same order as registered originally)
- Examples of kernel arguments that we'd like to generate ad-hoc (instead of supplying them independently of kernel creation):
    - "Magic" values for integer division. Kernel grid indices contain fused dimension indices and we need to prepare "magic" values on the host and provide them to the kernel. Sometimes we need magic values of derivative sizes (like `div_up(ic, 32)`)
    - Some problem sizes don't need "magic" values: e.g. the outer kernel grid dimension is computed via inner dimension sizes
    - Some problem sizes/parameters are unused, e.g. for kernels supporting only 1D or 2D shapes

As a counter-point: we could replicate the kernel-side logic to figure out what parameters are needed (including magic values, etc) but it's non trivial (we need to repeat some logic to understand what divisions are to be used, what parameters are hard-coded, etc) and is generally more error-prone. The metadata-based approach is simpler in this regard: the kernel explicitly requests whatever it needs and arguments are prepared according to this.