### PR TITLE
xe: jit: gemm: set lateScale lookahead to match load size

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/k_loop.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/k_loop.cxx
@@ -962,8 +962,8 @@ void BLASKernelGenerator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMM
     // A/B 2D quantization parameter loads.
     auto reqLoadAq = every(kaq_load) | lookahead(ka_repackMain);
     auto reqLoadBq = every(kbq_load) | lookahead(kb_loadMain);
-    auto reqLoadAqLate = every(kaq_loadLate) | lookahead(ka_loadMain);
-    auto reqLoadBqLate = every(kbq_loadLate) | lookahead(kb_loadMain);
+    auto reqLoadAqLate = every(kaq_loadLate) | lookahead(kaq_loadLate);
+    auto reqLoadBqLate = every(kbq_loadLate) | lookahead(kbq_loadLate);
 
     if (readA && dequantize2DA) ls.schedule(reqLoadAq, [&](Iteration h) {
         if (ao2D) gemmALoad(state.A_offsetRegs, state.A_offsetLayout, state.A_offsetAddrs, problem.AO,      strategy.AO,      problem, strategy, state);


### PR DESCRIPTION
# Description

Backport @dyoussif GEMM fix to rls-v3.7-pc. 

Fixes # MFDNN-12808

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
