### PR TITLE
xe: jit: use F pipe for zero initialization

### DIFF
--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -522,7 +522,7 @@ private:
     void fill_buf(const ngen_operand_t &buf_op, int size,
             const ngen_operand_t &pattern = {}) const {
         auto &rd = buf_op.reg_buf_data();
-        type_t type = type_t::u32();
+        type_t type = (pattern.is_invalid() ? type_t::f32() : type_t::u32());
         int grf_size = ngen::GRF::bytes(hw);
         int step = 2 * grf_size;
         for (int i = 0; i < size; i += step) {


### PR DESCRIPTION
PR fixes MFDNN-12763.

The original regression is introduced by https://github.com/oneapi-src/oneDNN/commit/ee32525d4f.