### PR TITLE
xe: jit: ngen: add symbol table

### DIFF
--- a/src/gpu/intel/jit/ngen/ngen_interface.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_interface.hpp
@@ -125,6 +125,7 @@ public:
     void setInlineGRFCount(int grfs)                     { requestedInlineGRFs = grfs; }
     void setSkipPerThreadOffset(int32_t offset)          { offsetSkipPerThread = offset; }
     void setSkipCrossThreadOffset(int32_t offset)        { offsetSkipCrossThread = offset; }
+    int32_t getSkipCrossThreadOffset() const                                { return offsetSkipCrossThread; }
 
     inline GRF getCrossthreadBase(bool effective = true) const;
     inline GRF getArgLoadBase() const;


### PR DESCRIPTION

Note for use: gdb-oneapi only supports the L0 backend.

Sample session:

```
$ cat env/gdb-oneapi_env.sh
source ~/intel/gdb-oneapi/setvars.sh --force
export ZET_ENABLE_PROGRAM_DEBUGGING=1

for f in /sys/class/drm/card*/prelim_enable_eu_debug; do
    val=$(cat $f)
    if [ $val == 0 ]; then
        sudo sh -c "echo 1 > $f"
    fi
done
$ source env/gdb-oneapi_env.sh

:: initializing oneAPI environment ...
   -bash: BASH_VERSION = 5.1.16(1)-release
   args: Using "$@" for setvars.sh arguments:
:: debugger -- latest
:: oneAPI environment initialized ::

$ gdb-oneapi --args ~/dnnl/build/tests/benchdnn/benchdnn --matmul --engine=gpu --impl=jit 16x16:16x16
GNU gdb (Intel(R) Distribution for GDB* 2025.0.0) 15.1
...
(gdb) break gen_gemm_t::execute
Function "gen_gemm_t::execute" not defined.
Make breakpoint pending on future shared library load? (y or [n]) y
Breakpoint 1 (gen_gemm_t::execute) pending.
(gdb) r
Starting program: ~/dnnl/build/tests/benchdnn/benchdnn --matmul --engine=gpu --impl=jit 16x16:16x16
Registering SYCL extensions for gdb
...
[Switching to thread 1.1 (Thread 0x7fffefaf51c0 (LWP 105829))]

Thread 1.1 "benchdnn" hit Breakpoint 1, dnnl::impl::gpu::intel::jit::gen_gemm_t::execute (this=0x555557f68f20, ctx=...)
    at ~/dnnl/src/gpu/intel/jit/gemm/gen_gemm.cpp:229
229                 = utils::downcast<compute::compute_stream_t *>(ctx.stream());
(gdb) inferior 2
[Switching to inferior 2 [device [0000:3a:00.0]] (<noexec>)]
[Switching to thread 2.1 (ZE 0.0.0.0) unavailable]
#0  <unavailable> in ?? ()
(gdb) break _entry  // the gemm_kernel symbol will not trigger a breakpoint due to a bug. The _entry symbol can be used instead for any kernel.
Breakpoint 2 at 0x8000fffb00e0
(gdb) c
Continuing.
...
[Switching to thread 2.41:0 (ZE 0.0.5.0 lane 0)]

Thread 2.41 hit Breakpoint 2, with SIMD lanes [0-15], 0x00008000fffb00e0 in gemm_kernel () from <in-memory@0x555558d9c190-0x555558db0550>
(gdb) disassemble &_entry,&_entry+0x100
Dump of assembler code from 0x8000fffb00e0 to 0x8000fffb01e0:
=> 0x00008000fffb00e0 <gemm_kernel+224>:        (W)     or (1|M0)                cr0.0<1>:ud   cr0.0<0;1,0>:ud   0x14C4:uw              {A@1}
   0x00008000fffb00f0 <gemm_kernel+240>:        (W)     sync.nop                             null                             {A@1}
   0x00008000fffb0100 <gemm_kernel+256>:        (W)     shr (1|M0)               r4.3<1>:ud    r4.3<0;1,0>:ud    0x4:uw              {$1.dst}
   0x00008000fffb0110 <gemm_kernel+272>:        (W)     shr (1|M0)               r1.0<1>:uw    r1.0<0;1,0>:uw    0x4:uw              {$0.dst}
   0x00008000fffb0120 <gemm_kernel+288>:        (W)     shl (1|M0)               r5.4<1>:ud    r5.4<0;1,0>:ud    0x2:uw
   0x00008000fffb0130 <gemm_kernel+304>:        (W)     shl (1|M0)               r5.5<1>:ud    r5.5<0;1,0>:ud    0x2:uw
   0x00008000fffb0140 <gemm_kernel+320>:        (W)     shl (1|M0)               r5.6<1>:ud    r5.6<0;1,0>:ud    0x2:uw
   0x00008000fffb0150 <gemm_kernel+336>:        (W)     shl (1|M0)               r4.7<1>:q     r4.7<0;1,0>:q     0x2:uw
   0x00008000fffb0160 <gemm_kernel+352>:        (W)     shl (1|M0)               r5.0<1>:q     r5.0<0;1,0>:q     0x2:uw
   0x00008000fffb0170 <gemm_kernel+368>:        (W)     shl (1|M0)               r5.1<1>:q     r5.1<0;1,0>:q     0x2:uw
   0x00008000fffb0180 <gemm_kernel+384>:        (W)     mov (1|M0)               r0.16<1>:uw   r1.0<0;1,0>:uw                   {@7}
   0x00008000fffb0190 <gemm_kernel+400>:        (W)     mov (1|M0)               r0.17<1>:uw   r2.0<0;1,0>:uw
   0x00008000fffb01a0 <gemm_kernel+416>:        (W)     add (1|M0)               r8.0<1>:ud    r4.8<0;1,0>:ud    r4.14<0;1,0>:ud  {@5}
   0x00008000fffb01b0 <gemm_kernel+432>:        (W)     mul (1|M0)               acc0.0<1>:ud  r5.4<0;1,0>:ud    r5.18<0;1,0>:uw
   0x00008000fffb01c0 <gemm_kernel+448>:        (W)     mach (1|M0)              r7.0<1>:ud    r5.4<0;1,0>:ud    r5.9<0;1,0>:d
   0x00008000fffb01d0 <gemm_kernel+464>:        (W)     add (1|M0)    (ov)f0.1   r8.0<1>:ud    acc0.0<0;1,0>:ud  r8.0<0;1,0>:ud   {@3}
End of assembler dump.
(gdb) quit
A debugging session is active.

        Inferior 1 [process 105829] will be killed.
        Inferior 2 [device [0000:3a:00.0]] will be detached.

Quit anyway? (y or n) y
Detached from device [0000:3a:00.0]
[Inferior 2 (device [0000:3a:00.0]) detached]
intelgt: inferior 2 (gdbserver-ze) has been removed.
```