### PR TITLE
Restricted AArch64 CI to relevant changes

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         config: [
           { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release, testset: SMOKE },
-          { name: c6g, label: ah-ubuntu_22_04-c6g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }, 
+          { name: c6g, label: ah-ubuntu_22_04-c6g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI },
           { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug, testset: SMOKE },
           { name: c7g, label: ah-ubuntu_22_04-c7g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }
         ]
@@ -108,7 +108,7 @@ jobs:
       - name: Get ACL commit hash for cache key
         id: get_acl_commit_hash
         run: (cd ${{ github.workspace }}/ComputeLibrary && echo "ACLCommitHash=$(git rev-parse --short HEAD)") >> $GITHUB_OUTPUT
-  
+
       - name: Get system name
         id: get_system_name
         run: (echo "SystemName=$(uname)") >> $GITHUB_OUTPUT
@@ -172,10 +172,12 @@ jobs:
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
           ONEDNN_THREADING: ${{ matrix.config.threading }}
-
-  AArch64:
+  # This job adds a check named "CI AArch64" that represents overall
+  # workflow status and can be used in branch rulesets
+  status:
     needs: build-and-test
     runs-on: ubuntu-latest
+    name: "CI AArch64"
     steps:
       - name: Print success
         run: echo Success

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -21,8 +21,29 @@ name: "CI AArch64"
 #* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
 on:
   push:
+    branches: [ main, 'rls-*' ]
+    paths:
+      - '.github/**'
+      - 'cmake/**'
+      - 'examples/**'
+      - 'include/**'
+      - 'src/cpu/*'
+      - 'src/cpu/common/**'
+      - 'src/cpu/aarch64/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - '.github/**'
+      - 'cmake/**'
+      - 'examples/**'
+      - 'include/**'
+      - 'src/cpu/*'
+      - 'src/cpu/common/**'
+      - 'src/cpu/aarch64/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
 
 #* Stop stale workflows when pull requests are updated: https://stackoverflow.com/a/70972844
 #* Does not apply to the main branch.
@@ -150,7 +171,7 @@ jobs:
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
-          ONEDNN_THREADING: ${{ matrix.config.threading }}     
+          ONEDNN_THREADING: ${{ matrix.config.threading }}
 
   AArch64:
     needs: build-and-test


### PR DESCRIPTION
There's no need to run AArch64 CI on changes that are unlikely to affect this platform.
