### PR TITLE
xe: conv_v2: introduce Stream-K support

### DIFF
--- a/src/gpu/intel/jit/conv/zero_out.cpp
+++ b/src/gpu/intel/jit/conv/zero_out.cpp
@@ -42,8 +42,9 @@ void zero_out_kernel_desc_t::init_kernel_iface(
     kernel_iface.register_arg("ptr", type_t::byte_ptr());
 }
 
-void zero_out_kernel_desc_t::init_kernel_info(
-        kernel_info_t &kernel_info, const kernel_params_base_t &_params) const {
+void zero_out_kernel_desc_t::init_kernel_info(kernel_info_t &kernel_info,
+        const kernel_params_base_t &_params,
+        const impl::engine_t *engine) const {
     auto &params = static_cast<const zero_out_kernel_params_t &>(_params);
     for (int i = 0; i < kernel_info.nargs(); i++) {
         auto &name = kernel_info.arg_name(i);

--- a/src/gpu/intel/jit/conv/zero_out.hpp
+++ b/src/gpu/intel/jit/conv/zero_out.hpp
@@ -43,7 +43,8 @@ public:
     compute::range_t local_range() const override;
     void init_kernel_iface(kernel_iface_t &kernel_iface) const override;
     void init_kernel_info(kernel_info_t &kernel_info,
-            const kernel_params_base_t &params) const override;
+            const kernel_params_base_t &params,
+            const impl::engine_t *engine) const override;
     status_t create_kernel(compute::kernel_t &kernel,
             gpu_primitive_t *primitive, impl::engine_t *engine) const override;
     status_t create_generator(const compute::compute_engine_t &engine,

--- a/src/gpu/intel/jit/ir/kernel_desc.hpp
+++ b/src/gpu/intel/jit/ir/kernel_desc.hpp
@@ -49,7 +49,8 @@ public:
     virtual compute::range_t local_range() const = 0;
     virtual void init_kernel_iface(kernel_iface_t &kernel_iface) const = 0;
     virtual void init_kernel_info(kernel_info_t &kernel_info,
-            const kernel_params_base_t &params) const = 0;
+            const kernel_params_base_t &params,
+            const impl::engine_t *engine) const = 0;
     virtual status_t create_kernel(compute::kernel_t &kernel,
             gpu_primitive_t *primitive, impl::engine_t *engine) const = 0;
     virtual serialized_t serialize() const = 0;

--- a/src/gpu/intel/jit/ir/primitive_plan.hpp
+++ b/src/gpu/intel/jit/ir/primitive_plan.hpp
@@ -123,10 +123,13 @@ private:
     };
 
     buffer_entry_t find_buf(const std::string &name) const;
-    kernel_info_t create_kernel_info(const kernel_desc_base_t &desc) const;
+    kernel_info_t create_kernel_info(const kernel_desc_base_t &desc,
+            const std::unordered_map<std::string, std::string> &buf_map) const;
     status_t add_kernel(primitive_exec_plan_t &exec_plan,
             const kernel_desc_base_t &desc, const kernel_params_base_t &params,
-            gpu_primitive_t *primitive, impl::engine_t *engine) const;
+            gpu_primitive_t *primitive, impl::engine_t *engine,
+            const std::unordered_map<std::string, std::string> &buf_map
+            = {}) const;
     status_t add_zero_out_kernel(primitive_exec_plan_t &exec_plan,
             const buffer_entry_t &buf, gpu_primitive_t *primitive,
             impl::engine_t *engine) const;

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -278,6 +278,7 @@ public:
     pvar_tile_t thread_group_tile;
     loop_desc_t loop_desc;
 
+    bool use_stream_k = false;
     bool use_2d_access = false;
     align_desc_t align;
 
@@ -367,7 +368,8 @@ public:
 
     void init_kernel_iface(kernel_iface_t &kernel_iface) const override;
     void init_kernel_info(kernel_info_t &kernel_info,
-            const kernel_params_base_t &params) const override;
+            const kernel_params_base_t &params,
+            const impl::engine_t *engine) const override;
     status_t create_kernel(compute::kernel_t &kernel,
             gpu_primitive_t *primitive, impl::engine_t *engine) const override;
     status_t create_generator(const compute::compute_engine_t &engine,
@@ -506,6 +508,7 @@ struct trivial_key_validator_t<jit::v2::conv::kernel_desc_t> {
                 && (t.thread_group_tile == tmp.thread_group_tile)
                 && (t.loop_desc == tmp.loop_desc)
                 && (t.prefetch == tmp.prefetch) && (t.align == tmp.align)
+                && (t.use_stream_k == tmp.use_stream_k)
                 && (t.use_2d_access == tmp.use_2d_access)
                 && (t.is_finalized == tmp.is_finalized);
     }

--- a/src/gpu/intel/jit/v2/conv/plan.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan.cpp
@@ -684,8 +684,8 @@ private:
         }
         plan.bias_reduce_cond = std::move(reduce_cond);
         plan.bias_layout = bias_reg_layout;
-        ir_check(init_epilogue_store_bias(/*is_atomic=*/false, bias_reg_layout,
-                bias_mem_view, plan.store, reqs));
+        ir_check(init_epilogue_store_bias(/*is_atomic=*/desc_.use_stream_k,
+                bias_reg_layout, bias_mem_view, plan.store, reqs));
         return true;
     }
 
@@ -805,8 +805,8 @@ private:
         auto c_mem_view = view_t(c_mapper, c_layout_, c_coord, c_tile);
         plan.c_reg_layout = c_reg_layout;
         plan.c_coord = c_mem_view.coord();
-        ir_check(init_epilogue_store_plan(/*is_atomic=*/false, c_reg_layout,
-                c_mem_view, plan.store, reqs));
+        ir_check(init_epilogue_store_plan(/*is_atomic=*/desc_.use_stream_k,
+                c_reg_layout, c_mem_view, plan.store, reqs));
         return true;
     }
 


### PR DESCRIPTION
PR introduces initial Stream-K support in convolution. It's disabled by default, enabling will be done in a future PR. In the meantime Stream-K support can be enabled manually:



```
# Default (no Stream-K):
$ export desc="--hw xehpc --prop bwd_w --src axb:bf16 --wei axcb:f32 --dst axb:bf16 --fma dpas --simd 16 --regs 256 --iter ic32oc64mb16 --tg ic8oc2 --loop_desc mb,ow,oh,od --2d 1 --prefetch x3 --reqs dd0id1kd1od1pd0sd1"
$ ./build/tests/benchdnn/benchdnn --engine=gpu --conv --mode=f --dt=bf16:bf16:bf16 --dir=BWD_W --impl=v2 --stag=axb --wtag=xba --dtag=axb mb128ic512ih28oc128oh28kh3
perf,gpu,jit:ir_v2,,--mode=F --conv --engine=gpu --dir=BWD_W --dt=bf16:bf16:bf16 --stag=axb --wtag=xba --dtag=axb --attr-scratchpad=library --impl=v2 mb128ic512ih28oc128oh28kh3ph1,112.81,87.6985,2.99376,37681.7,3.00074,37594.1

# With Stream-K
export desc="$desc --stream-k 1"
$ ./build/tests/benchdnn/benchdnn --engine=gpu --conv --mode=f --dt=bf16:bf16:bf16 --dir=BWD_W --impl=v2 --stag=axb --wtag=xba --dtag=axb mb128ic512ih28oc128oh28kh3
perf,gpu,jit:ir_v2,,--mode=F --conv --engine=gpu --dir=BWD_W --dt=bf16:bf16:bf16 --stag=axb --wtag=xba --dtag=axb --attr-scratchpad=library --impl=v2 mb128ic512ih28oc128oh28kh3ph1,112.81,512.915,0.55216,204307,0.560303,201337
```