### PR TITLE
graph: backend: dnnl: fuse dst scale/zps for layout propagation in sdpa primitive kernel

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -74,6 +74,10 @@ status_t sdp_primitive_kernel_t<quantized>::compile_impl(
         BACKEND_DNNL_ADD_PASS(pipeline, convert_to_runtime_src_zero_points);
         BACKEND_DNNL_ADD_PASS(pipeline, fuse_src_zero_points);
         BACKEND_DNNL_ADD_PASS(pipeline, insert_runtime_u8_to_s8_for_matmul);
+        BACKEND_DNNL_ADD_PASS(pipeline, convert_to_runtime_dst_scales);
+        BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_scales);
+        BACKEND_DNNL_ADD_PASS(pipeline, convert_to_runtime_dst_zero_points);
+        BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_zero_points);
     }
     BACKEND_DNNL_ADD_PASS(pipeline, binary_canonicalization);
     BACKEND_DNNL_ADD_PASS(pipeline, insert_permute_for_matmul);
@@ -83,6 +87,7 @@ status_t sdp_primitive_kernel_t<quantized>::compile_impl(
 
     pipeline.reset_visualize_arg(true, false);
     BACKEND_DNNL_ADD_PASS(pipeline, infer_shape);
+    BACKEND_DNNL_ADD_PASS(pipeline, fuse_src_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, layout_propagation);
 


### PR DESCRIPTION
## Description

Currently in oneDNN Graph, the MHA cases that passed the initial check of sdpa primitive on GPU will go through the passes and try to create a sdpa primitive. If the creation fails, it will fall back to the reference computation.

With the introduction of int4 sdpa, we added some quantization passes to sdpa primitive kernel, but missed fusion for dst scale and dst, leading to the result that some case with subsequent reorders might fail during layout propagation. The PR has fixed the problem.

```
./tests/benchdnn/benchdnn --graph --engine=gpu --case=tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
0:PASSED __REPRO: --graph --engine=gpu --case=tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 2.67s; fill: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);`
```