### PR TITLE
github: workflows: Streamline AArch64 CI

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -34,40 +34,60 @@ concurrency:
 permissions: read-all
 
 jobs:
-  macos:
-    runs-on: macos-14
+  build-and-test:
     strategy:
       matrix:
         config: [
-          { toolset: clang, build: Release },
-          { toolset: gcc, build: Release }
+          { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release, testset: SMOKE },
+          { name: c6g, label: ah-ubuntu_22_04-c6g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }, 
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug, testset: SMOKE },
+          { name: c7g, label: ah-ubuntu_22_04-c7g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }
         ]
 
-    name: MacOS, ${{ matrix.config.toolset }}, ${{ matrix.config.build }}
+    name: ${{ matrix.config.name }}, ${{ matrix.config.toolset }}, ${{ matrix.config.threading }}, ${{ matrix.config.build }}
+    runs-on: ${{ matrix.config.label }}
     steps:
+
       - name: Checkout oneDNN
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: oneDNN
 
-      - name: Install Scons
-        uses: threeal/pipx-install-action@b0bf0add7d5aefda03a3d4e47d651df807889e10 # v1.0.0
+      - name: Get latest CMake and Ninja
+        uses: lukka/get-cmake@5979409e62bdf841487c5fb3c053149de97a86d3 # v3.31.2
         with:
-          packages: scons
+          cmakeVersion: 3.31.0
+          ninjaVersion: 1.12.0
+
+      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.threading == 'OMP')) }}
+        name: Install openmp
+        run: |
+          sudo apt install -y libomp-dev
+
+      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'gcc')) }}
+        name: Install gcc
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt update -y
+          sudo apt install -y g++-13
+
+      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'clang')) }}
+        name: Install clang
+        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
+        with:
+          version: "17"
 
       - name: Clone ACL
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
         env:
           ACL_ACTION: clone
-          ACL_CONFIG: ${{ matrix.config.build }}
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.config.toolset }}
-          GCC_VERSION: 14
+          ACL_VERSION: v24.11.1
 
       - name: Get ACL commit hash for cache key
         id: get_acl_commit_hash
         run: (cd ${{ github.workspace }}/ComputeLibrary && echo "ACLCommitHash=$(git rev-parse --short HEAD)") >> $GITHUB_OUTPUT
-
+  
       - name: Get system name
         id: get_system_name
         run: (echo "SystemName=$(uname)") >> $GITHUB_OUTPUT
@@ -79,15 +99,22 @@ jobs:
           key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
           path: ${{ github.workspace }}/ComputeLibrary/build
 
+      - name: Configure ACL
+        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        env:
+          ACL_ACTION: configure
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          ACL_THREADING: ${{ matrix.config.threading }}
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
+          GCC_VERSION: 13
+
       - name: Build ACL
         if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
         env:
           ACL_ACTION: build
-          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.config.toolset }}
-          ACL_CONFIG: ${{ matrix.config.build }}
-          GCC_VERSION: 14
 
       - name: Save ACL in cache
         if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
@@ -97,125 +124,37 @@ jobs:
           key: ${{ steps.cache-acl-restore.outputs.cache-primary-key }}
           path: ${{ github.workspace }}/ComputeLibrary/build
 
-      - name: Build oneDNN
+      - name: Configure oneDNN
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
         working-directory: ${{ github.workspace }}/oneDNN
         env:
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
-          GCC_VERSION: 14
-    
-      - if: matrix.config.toolset == 'clang'
-        name: Run oneDNN smoke tests
-        run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
-        working-directory: ${{ github.workspace }}/oneDNN/build
-        env:
-          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
-          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
-  
-  # We only run the linux aarch64 runners if macos smoke tests pass.
-  linux:
-    needs: macos
-    strategy:
-      matrix:
-        threading: [OMP]
-        toolset: [clang, gcc]
-        config: [Debug, Release]
-        host: [
-          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50 }, 
-          { name: c7g, label: ah-ubuntu_22_04-c7g_2x-50 }
-        ]
-
-    name: ${{ matrix.host.name }}, ${{ matrix.toolset }}, ${{ matrix.threading }}, ${{ matrix.config }}
-    runs-on: ${{ matrix.host.label }}
-    steps:
-      - name: Checkout oneDNN
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: oneDNN
-
-      - name: Install dev tools
-        run: |
-          sudo apt update -y
-          sudo apt install -y scons cmake make
-
-      - if: matrix.threading == 'OMP'
-        name: Install openmp
-        run: |
-          sudo apt install -y libomp-dev
-
-      - if: matrix.toolset == 'gcc'
-        name: Install gcc
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-          sudo apt update -y
-          sudo apt install -y g++-13
-
-      - if: matrix.toolset == 'clang'
-        name: Install clang
-        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
-        with:
-          version: "17"
-
-      - name: Clone ACL
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: clone
-          ACL_CONFIG: ${{ matrix.config }}
-          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.toolset }}
+          CMAKE_GENERATOR: Ninja
           GCC_VERSION: 13
-
-      - name: Get ACL commit hash for cache key
-        id: get_acl_commit_hash
-        run: (cd ${{ github.workspace }}/ComputeLibrary && echo "ACLCommitHash=$(git rev-parse --short HEAD)") >> $GITHUB_OUTPUT
-  
-      - name: Get system name
-        id: get_system_name
-        run: (echo "SystemName=$(uname)") >> $GITHUB_OUTPUT
-
-      - name: Restore cached ACL
-        id: cache-acl-restore
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.toolset }}-${{ matrix.config }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
-          path: ${{ github.workspace }}/ComputeLibrary/build
-
-      - name: Build ACL
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: build
-          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.toolset }}
-          ACL_CONFIG: ${{ matrix.config }}
-          GCC_VERSION: 13
-          ACL_THREADING: ${{ matrix.threading }}
-
-      - name: Save ACL in cache
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        id: cache-acl_build-save
-        uses: actions/cache/save@v4
-        with:
-          key: ${{ steps.cache-acl-restore.outputs.cache-primary-key }}
-          path: ${{ github.workspace }}/ComputeLibrary/build
+          ONEDNN_ACTION: configure
+          ONEDNN_TEST_SET: ${{ matrix.config.testset }}
+          ONEDNN_THREADING: ${{ matrix.config.threading }}
 
       - name: Build oneDNN
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
         working-directory: ${{ github.workspace }}/oneDNN
         env:
-          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          BUILD_TOOLSET: ${{ matrix.toolset }}
-          CMAKE_BUILD_TYPE: ${{ matrix.config }}
-          GCC_VERSION: 13
-          ONEDNN_THREADING: ${{ matrix.threading }}
+          ONEDNN_ACTION: build
 
       - name: Run oneDNN tests
         run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
         working-directory: ${{ github.workspace }}/oneDNN/build
         env:
-          BUILD_TOOLSET: ${{ matrix.toolset }}
-          CMAKE_BUILD_TYPE: ${{ matrix.config }}
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
-          ONEDNN_THREADING: ${{ matrix.threading }}     
+          ONEDNN_THREADING: ${{ matrix.config.threading }}     
+
+  AArch64:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print success
+        run: echo Success


### PR DESCRIPTION
- Reduction in runners to increase throughput
- Shift to CMake for ACL
- Test CI test-set instead of smoke to improve coverage
- Linux runners now do not depend on MacOS