### PR TITLE
cpu: aarch64: thread_local ThreadpoolScheduler setting

### DIFF
--- a/src/cpu/aarch64/acl_thread.cpp
+++ b/src/cpu/aarch64/acl_thread.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Arm Ltd. and affiliates
+* Copyright 2022-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,19 +55,21 @@ void acl_set_benchmark_scheduler_default() {
 #endif
 
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+
 void acl_set_tp_scheduler() {
-    static std::once_flag flag_once;
+    static thread_local std::once_flag flag_once;
     // Create threadpool scheduler
-    std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
-            = std::make_unique<ThreadpoolScheduler>();
-    // set CUSTOM scheduler in ACL
-    std::call_once(flag_once,
-            [&]() { arm_compute::Scheduler::set(threadpool_scheduler); });
+    std::call_once(flag_once, [&]() {
+        // Create threadpool scheduler
+        std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
+                = std::make_unique<ThreadpoolScheduler>();
+        arm_compute::Scheduler::set(threadpool_scheduler);
+    });
 }
 
 void acl_set_threadpool_num_threads() {
     using namespace dnnl::impl::threadpool_utils;
-    static std::once_flag flag_once;
+    static thread_local std::once_flag flag_once;
     threadpool_interop::threadpool_iface *tp = get_active_threadpool();
     // Check active threadpool
     bool is_main = get_active_threadpool() == tp;


### PR DESCRIPTION
# Description

Makes setting of ThreadpoolScheduler in ACL thread_local to enable use of multiple (thread_local) Schedulers in ACL.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
