### PR TITLE
github: workflows: added labels for common code changes

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -41,6 +41,28 @@ documentation:
 - changed-files:
   - any-glob-to-any-file: ['**/*.md', 'doc/**']
 
+# Common code
+component:build:
+  - any-glob-to-any-file: 'cmake/**'
+
+component:examples:
+  - any-glob-to-any-file: 'examples/**'
+
+component:tests:
+- changed-files:
+  - any-glob-to-any-file: 'tests/**'
+
+component:api:
+- changed-files:
+  - any-glob-to-any-file: 'include/**'
+
+component:graph-api:
+- changed-files:
+  - any-glob-to-any-file: 
+    - 'src/graph/**'
+    - 'tests/benchdnn/graph/**'
+    - 'tests/gtests/graph/**'
+
 # CPU Engine
 platform:cpu-aarch64:
 - changed-files:


### PR DESCRIPTION
We have `platform:XXX` labels for platform specific code, but no way to identify PRs touching on common code. This PR adds `component:XXX` labels:
* build (for CMake files)
* examples
* tests
* api
* graph-api
