### PR TITLE
src: attr: quantization refactor (part 1)

### DIFF
--- a/src/common/binary_pd.hpp
+++ b/src/common/binary_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -179,10 +179,13 @@ protected:
 
     bool attr_scales_ok(const std::vector<int> &supported_args
             = {DNNL_ARG_SRC_0, DNNL_ARG_SRC_1, DNNL_ARG_DST}) const {
-        bool ok = attr()->scales_.has_default_values(supported_args);
-        for (int arg : supported_args) {
-            const auto &mask = attr()->scales_.get(arg).mask_;
-            ok = ok && (mask == 0);
+        const auto &scales = attr()->scales_;
+        bool ok = scales.has_default_values(supported_args);
+
+        for (const auto &arg : supported_args) {
+            if (scales.has_default_values(arg)) continue;
+
+            ok = ok && scales.get_mask(arg) == 0;
         }
         return ok;
     }

--- a/src/common/convolution.cpp
+++ b/src/common/convolution.cpp
@@ -186,13 +186,19 @@ status_t conv_attr_check(const convolution_desc_t &desc, const engine_t *engine,
         // Check scales
         if (!attr->scales_.has_default_values()) {
             const auto &sc = attr->scales_;
-            const int mask_src = sc.get(DNNL_ARG_SRC).mask_;
-            const int mask_wei = sc.get(DNNL_ARG_WEIGHTS).mask_;
-            const int mask_dst = sc.get(DNNL_ARG_DST).mask_;
             const bool with_groups
                     = desc.src_desc.ndims != desc.weights_desc.ndims;
-            VCHECK_CONV_UNIMPL(utils::one_of(mask_wei, 0, with_groups ? 3 : 1)
-                            && utils::one_of(mask_dst, 0, 2) && mask_src == 0,
+            VCHECK_CONV_UNIMPL(IMPLICATION(!sc.has_default_values(DNNL_ARG_SRC),
+                                       sc.get_mask(DNNL_ARG_SRC) == 0),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VCHECK_CONV_UNIMPL(
+                    IMPLICATION(!sc.has_default_values(DNNL_ARG_WEIGHTS),
+                            utils::one_of(sc.get_mask(DNNL_ARG_WEIGHTS), 0,
+                                    with_groups ? 3 : 1)),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VCHECK_CONV_UNIMPL(
+                    IMPLICATION(!sc.has_default_values(DNNL_ARG_DST),
+                            utils::one_of(sc.get_mask(DNNL_ARG_DST), 0, 2)),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
 

--- a/src/common/convolution_pd.hpp
+++ b/src/common/convolution_pd.hpp
@@ -242,7 +242,9 @@ protected:
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) const {
         bool ok = attr()->scales_.has_default_values(supported_args);
         for (int arg : supported_args) {
-            const auto &mask = attr()->scales_.get(arg).mask_;
+            if (attr()->scales_.has_default_values(arg)) continue;
+
+            const auto &mask = attr()->scales_.get_mask(arg);
             if (arg == DNNL_ARG_WEIGHTS)
                 ok = ok && (mask == 0 || mask == (with_groups() ? 3 : 1));
             else if (arg == DNNL_ARG_DST)

--- a/src/common/deconvolution.cpp
+++ b/src/common/deconvolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -172,13 +172,20 @@ status_t deconv_attr_check(const deconvolution_desc_t &desc,
         // Check scales
         if (!attr->scales_.has_default_values()) {
             const auto &sc = attr->scales_;
-            const int mask_src = sc.get(DNNL_ARG_SRC).mask_;
-            const int mask_wei = sc.get(DNNL_ARG_WEIGHTS).mask_;
-            const int mask_dst = sc.get(DNNL_ARG_DST).mask_;
             const bool with_groups
                     = desc.src_desc.ndims != desc.weights_desc.ndims;
-            VCHECK_DECONV_UNIMPL(utils::everyone_is(0, mask_src, mask_dst)
-                            && utils::one_of(mask_wei, 0, with_groups ? 3 : 1),
+            VCHECK_DECONV_UNIMPL(
+                    IMPLICATION(!sc.has_default_values(DNNL_ARG_SRC),
+                            sc.get_mask(DNNL_ARG_SRC) == 0),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VCHECK_DECONV_UNIMPL(
+                    IMPLICATION(!sc.has_default_values(DNNL_ARG_WEIGHTS),
+                            utils::one_of(sc.get_mask(DNNL_ARG_WEIGHTS), 0,
+                                    with_groups ? 3 : 1)),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VCHECK_DECONV_UNIMPL(
+                    IMPLICATION(!sc.has_default_values(DNNL_ARG_DST),
+                            sc.get_mask(DNNL_ARG_DST) == 0),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
 

--- a/src/common/deconvolution_pd.hpp
+++ b/src/common/deconvolution_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -173,7 +173,9 @@ protected:
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) const {
         bool ok = attr()->scales_.has_default_values(supported_args);
         for (int arg : supported_args) {
-            const auto &mask = attr()->scales_.get(arg).mask_;
+            if (attr()->scales_.has_default_values(arg)) continue;
+
+            const auto &mask = attr()->scales_.get_mask(arg);
             if (arg == DNNL_ARG_WEIGHTS)
                 ok = ok && (mask == 0 || mask == (with_groups() ? 3 : 1));
             else

--- a/src/common/group_normalization_pd.hpp
+++ b/src/common/group_normalization_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -190,17 +190,17 @@ protected:
         return IMPLICATION(use_scale() || use_shift(),
                 weights_md()->data_type == data_type::f32);
     }
-    bool attr_scales_ok() const {
+    bool attr_scales_ok(const std::vector<int> &supported_args
+            = {DNNL_ARG_SRC, DNNL_ARG_DST}) const {
         using namespace data_type;
         const auto &scales = attr()->scales_;
-        const std::vector<int> supported_args({DNNL_ARG_SRC, DNNL_ARG_DST});
         bool ok = scales.has_default_values(supported_args);
 
         for (const auto &arg : supported_args) {
-            const auto &sc = scales.get(arg);
-            if (!sc.has_default_values()) {
+            if (!scales.has_default_values(arg)) {
                 const data_type_t dt = arg_md(arg)->data_type;
-                ok = ok && utils::one_of(dt, s8, u8) && sc.mask_ == 0;
+                ok = ok && utils::one_of(dt, s8, u8);
+                ok = ok && scales.get_mask(arg) == 0;
             }
         }
         return ok;

--- a/src/common/inner_product.cpp
+++ b/src/common/inner_product.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -133,12 +133,15 @@ status_t ip_attr_check(const inner_product_desc_t &desc, const engine_t *engine,
         // Check scales
         if (!attr->scales_.has_default_values()) {
             const auto &sc = attr->scales_;
-            const int mask_src = sc.get(DNNL_ARG_SRC).mask_;
-            const int mask_wei = sc.get(DNNL_ARG_WEIGHTS).mask_;
-            const int mask_dst = sc.get(DNNL_ARG_DST).mask_;
-
-            VCHECK_IP_UNIMPL(utils::everyone_is(0, mask_src, mask_dst)
-                            && utils::one_of(mask_wei, 0, 1),
+            VCHECK_IP_UNIMPL(IMPLICATION(!sc.has_default_values(DNNL_ARG_SRC),
+                                     sc.get_mask(DNNL_ARG_SRC) == 0),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VCHECK_IP_UNIMPL(
+                    IMPLICATION(!sc.has_default_values(DNNL_ARG_WEIGHTS),
+                            utils::one_of(sc.get_mask(DNNL_ARG_WEIGHTS), 0, 1)),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VCHECK_IP_UNIMPL(IMPLICATION(!sc.has_default_values(DNNL_ARG_DST),
+                                     sc.get_mask(DNNL_ARG_DST) == 0),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
 

--- a/src/common/inner_product_pd.hpp
+++ b/src/common/inner_product_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -184,7 +184,9 @@ protected:
             = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) const {
         bool ok = attr()->scales_.has_default_values(supported_args);
         for (auto arg : supported_args) {
-            int mask = attr()->scales_.get(arg).mask_;
+            if (attr()->scales_.has_default_values(arg)) continue;
+
+            int mask = attr()->scales_.get_mask(arg);
             if (arg == DNNL_ARG_WEIGHTS)
                 ok = ok && (mask == 0 || mask == (1 << 0));
             else

--- a/src/common/layer_normalization.cpp
+++ b/src/common/layer_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -164,12 +164,18 @@ status_t layer_normalization_attr_check(const layer_normalization_desc_t &desc,
 
         // Check scales
         if (!attr->scales_.has_default_values()) {
-            const auto &sc = attr->scales_;
-            const int mask_src = sc.get(DNNL_ARG_SRC).mask_;
-            const int mask_dst = sc.get(DNNL_ARG_DST).mask_;
-
-            VCHECK_LNORM_UNIMPL(utils::everyone_is(0, mask_src, mask_dst),
+            static const std::vector<int> supported_args {
+                    DNNL_ARG_SRC, DNNL_ARG_DST};
+            VCHECK_LNORM_UNIMPL(
+                    attr->scales_.has_default_values(supported_args),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+            for (int arg : supported_args) {
+                if (attr->scales_.has_default_values(arg)) continue;
+
+                const int mask = attr->scales_.get_mask(arg);
+                VCHECK_LNORM_UNIMPL(mask == 0, VERBOSE_UNSUPPORTED_SCALES_CFG);
+            }
         }
 
         // Check post-ops

--- a/src/common/layer_normalization_pd.hpp
+++ b/src/common/layer_normalization_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -248,11 +248,19 @@ protected:
         return false;
     }
 
-    bool attr_scales_ok() const {
+    bool attr_scales_ok(const std::vector<int> &supported_args
+            = {DNNL_ARG_SRC, DNNL_ARG_DST}) const {
+        using namespace data_type;
         const auto &scales = attr()->scales_;
-        bool ok = true;
-        for (const auto &e : scales.scales_) {
-            ok = ok && e.second.mask_ == 0;
+        bool ok = scales.has_default_values(supported_args);
+
+        for (const auto &arg : supported_args) {
+            if (!scales.has_default_values(arg)) {
+                // TODO: disallow non-int8 scales?
+                // const data_type_t dt = arg_md(arg)->data_type;
+                // ok = ok && utils::one_of(dt, s8, u8);
+                ok = ok && scales.get_mask(arg) == 0;
+            }
         }
         return ok;
     }

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -205,6 +205,17 @@ struct matmul_pd_t : public primitive_desc_t {
                                 utils::one_of(
                                         1, sc.group_dims_[0], sc.group_dims_[1])
                                         && wei_k_group_ok && wei_n_group_ok);
+
+                // Mask over K dim is allowed for decompression feature only.
+                const bool is_decompression_or_dynquant
+                        = utils::one_of(weights_md(0)->data_type, data_type::s8,
+                                  data_type::u8, data_type::s4, data_type::u4)
+                        && IMPLICATION(
+                                !types::is_integral_dt(src_md()->data_type),
+                                attr()->fpmath_.apply_to_int_);
+                ok = ok
+                        && IMPLICATION((mask & wei_qmask_K()),
+                                is_decompression_or_dynquant);
             } else if (arg == DNNL_ARG_SRC) {
                 ok = ok
                         && utils::one_of(mask, 0, src_qmask_K(),

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -35,11 +35,6 @@ const primitive_attr_t &default_attr() {
     return default_attr_instance;
 }
 
-const runtime_scales_t &default_runtime_scale() {
-    static const runtime_scales_t default_runtime_scale_instance;
-    return default_runtime_scale_instance;
-}
-
 void rnn_create_time_scales_t::set_single_scale(float scale) {
     count_ = 1;
     mask_ = 0;
@@ -543,8 +538,9 @@ status_t dnnl_primitive_attr_set_scratchpad_mode(
 
 status_t dnnl_primitive_attr_set_scales_mask(
         primitive_attr_t *attr, int arg, int mask) {
-    bool ok = attr && mask >= 0 && arg >= 0;
-    if (!ok) return invalid_arguments;
+    VCHECK_ATTR(attr, VERBOSE_NULL_ARG);
+    VCHECK_ATTR(mask >= 0, VERBOSE_BAD_PARAM, "mask");
+    VCHECK_ATTR(arg >= 0, VERBOSE_BAD_PARAM, "arg");
     return attr->scales_.set(arg, mask);
 }
 
@@ -560,7 +556,7 @@ status_t dnnl_primitive_attr_set_scales(primitive_attr_t *attr, int arg,
             VERBOSE_INVALID_DATATYPE, "scales");
     VCHECK_ATTR(IMPLICATION(ndims, validate_dims(ndims, group_dims)),
             VERBOSE_BAD_PARAM, "group_dims");
-    return attr->scales_.set(arg, mask, ndims, group_dims, data_type);
+    return attr->scales_.set(arg, mask, data_type, ndims, group_dims);
 }
 
 status_t dnnl_primitive_attr_set_zero_points_mask(

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -669,7 +669,7 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
     }
 
     // NOTE: make sure that the types below have overloaded comparison operator
-    dnnl::impl::arg_scales_t scales_;
+    dnnl::impl::scales_t scales_;
     dnnl::impl::zero_points_t zero_points_;
     dnnl::impl::scratchpad_mode_t scratchpad_mode_;
     dnnl::impl::fpmath_t fpmath_;

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@
 
 namespace dnnl {
 namespace impl {
+
+const primitive_attr_t &default_attr();
 
 struct rnn_data_qparams_t : public c_compatible {
     rnn_data_qparams_t() : scale_(1.f), shift_(0.f) {}

--- a/src/common/primitive_attr_quant.cpp
+++ b/src/common/primitive_attr_quant.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright 2024-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/primitive_attr_quant.hpp"
+#include "common/primitive_hashing.hpp"
+#include "common/verbose.hpp"
+
+namespace dnnl {
+namespace impl {
+
+const quant_entry_t &default_quant_entry() {
+    static const quant_entry_t default_quant_entry;
+    return default_quant_entry;
+}
+
+size_t quant_entry_t::get_hash() const {
+    size_t seed = 0;
+    seed = hash_combine(seed, mask_);
+    seed = hash_combine(seed, static_cast<size_t>(data_type_));
+    seed = hash_combine(seed, group_ndims_);
+    if (group_ndims_ > 0)
+        seed = primitive_hashing::get_array_hash(
+                seed, group_dims_, group_ndims_);
+    return seed;
+}
+
+void quant_entry_t::serialize(serialization_stream_t &sstream) const {
+    sstream.write(&mask_);
+    sstream.write(&data_type_);
+    sstream.write(&group_ndims_);
+    if (group_ndims_ > 0) sstream.write(group_dims_, group_ndims_);
+}
+
+std::string quant_entry_t::get_verbose() const {
+    std::string s;
+    s.append(std::to_string(mask_));
+    s.append(":").append(dnnl_dt2str(data_type_));
+    if (group_ndims_ > 0) {
+        s.append(":")
+                .append(std::to_string(group_dims_[0]))
+                .append("x")
+                .append(std::to_string(group_dims_[1]));
+    }
+    return s;
+}
+
+std::ostream &operator<<(std::ostream &ss, const quant_entry_t &e) {
+    ss << e.get_verbose();
+    return ss;
+}
+
+size_t scales_t::get_hash() const {
+    size_t seed = 0;
+    // Go through scales for all arguments.
+    for (const auto &e : scales_) {
+        seed = hash_combine(seed, e.first);
+        seed = hash_combine(seed, e.second.get_hash());
+    }
+    return seed;
+}
+
+void scales_t::serialize(serialization_stream_t &sstream) const {
+    for (const auto &e : scales_) {
+        sstream.write(&e.first);
+        e.second.serialize(sstream);
+    }
+}
+
+std::string scales_t::get_verbose() const {
+    std::string s;
+    std::string empty_delim, attr_delim = "+";
+    std::string delim = empty_delim;
+    for (const auto &scale : scales_) {
+        const auto &q = scale.second;
+        if (q.has_default_values()) continue;
+
+        int arg = scale.first;
+        s.append(delim)
+                .append(arg2str(arg))
+                .append(":")
+                .append(q.get_verbose());
+        delim = attr_delim;
+    }
+    return s;
+}
+
+} // namespace impl
+} // namespace dnnl

--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -37,7 +37,6 @@
 namespace dnnl {
 namespace impl {
 
-const primitive_attr_t &default_attr();
 struct runtime_scales_t;
 const runtime_scales_t &default_runtime_scale();
 

--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -28,172 +28,205 @@
 // dependency between headers when it comes to inclusion of opdesc.hpp which
 // sdpa_desc_t is a part of.
 
-#include "utils.hpp"
+#include "common/serialization_stream.hpp"
+#include "common/utils.hpp"
 
 #include <algorithm>
-#include <map>
+#include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace dnnl {
 namespace impl {
 
-struct runtime_scales_t;
-const runtime_scales_t &default_runtime_scale();
+struct quant_entry_t;
+const quant_entry_t &default_quant_entry();
 
-struct runtime_scales_t : public c_compatible {
-    runtime_scales_t() = default;
+struct quant_entry_t : public c_compatible {
+    quant_entry_t() = default;
 
-    runtime_scales_t &operator=(const runtime_scales_t &rhs) {
-        mask_ = rhs.mask_;
-        is_set_ = rhs.is_set_;
-        ndims_ = rhs.ndims_;
-        if (ndims_ > 0) utils::array_copy(group_dims_, rhs.group_dims_, ndims_);
-        data_type_ = rhs.data_type_;
-        return *this;
+    // `set(...)` approach is taken over constructors as the usage model assumes
+    // the change of state of this object but it doesn't require its destruction
+    // which would come with some performance price which prevails in this case.
+    status_t set(int mask, data_type_t data_type) {
+        return set(mask, data_type, 0, {});
     }
-
-    status_t set(int mask) { return set(0, mask, {}, data_type::f32); }
-
-    status_t set(int ndims, int mask, const dims_t group_dims,
-            data_type_t data_type = data_type::f32) {
+    status_t set(int mask, data_type_t data_type, int group_ndims,
+            const dims_t group_dims) {
         mask_ = mask;
-        is_set_ = true;
-        ndims_ = ndims;
-        if (ndims > 0) utils::array_copy(group_dims_, group_dims, ndims);
         data_type_ = data_type;
-        return status::success;
-    }
-
-    bool operator==(const runtime_scales_t &rhs) const {
-        return mask_ == rhs.mask_ && is_set_ == rhs.is_set_
-                && ndims_ == rhs.ndims_
-                && IMPLICATION(ndims_ > 0,
-                        utils::array_cmp(group_dims_, rhs.group_dims_, ndims_))
-                && data_type_ == rhs.data_type_;
-    }
-
-    bool has_default_values() const { return *this == default_runtime_scale(); }
-
-    bool has_default_groups() const { return 0 == ndims_; }
-    bool has_default_data_type() const { return data_type_ == data_type::f32; }
-
-    // TODO: replace with `-1` to remove `is_set_`.
-    // Hide `mask_` under `private:` to force interface usage.
-    int mask_ = 0;
-    bool is_set_ = false;
-    int ndims_ = 0;
-    dims_t group_dims_ = {};
-    data_type_t data_type_ = data_type::f32;
-};
-
-struct arg_scales_t : public c_compatible {
-    arg_scales_t() = default;
-
-    const runtime_scales_t &get(int arg) const {
-        static const runtime_scales_t default_scales;
-        const auto it = scales_.find(arg);
-        if (it == scales_.end()) return default_scales;
-        return it->second;
-    }
-
-    status_t set(int arg, const runtime_scales_t &scale) {
-        if (!check_arg(arg)) return status::invalid_arguments;
-        scales_[arg] = scale;
-        return status::success;
-    }
-
-    bool operator==(const arg_scales_t &rhs) const {
-        return scales_ == rhs.scales_;
-    }
-
-    bool has_default_values(const std::vector<int> &skip_args = {}) const {
-        auto predicate = [](const runtime_scales_t &s) {
-            return s.has_default_values();
-        };
-        return has_default_property(skip_args, predicate);
-    }
-
-    bool has_default_data_type(const std::vector<int> &skip_args = {}) const {
-        auto predicate = [](const runtime_scales_t &s) {
-            return s.has_default_data_type();
-        };
-        return has_default_property(skip_args, predicate);
-    }
-
-    bool has_default_groups(const std::vector<int> &skip_args = {}) const {
-        auto predicate = [](const runtime_scales_t &s) {
-            return s.has_default_groups();
-        };
-        return has_default_property(skip_args, predicate);
-    }
-
-    status_t set(int arg, int mask) {
-        return set(arg, mask, 0, {}, data_type::f32);
-    }
-
-    status_t set(int arg, int mask, int ndims, const dims_t group_dims,
-            data_type_t data_type) {
-        if (!check_arg(arg)) return status::invalid_arguments;
-        return scales_[arg].set(ndims, mask, group_dims, data_type);
-    }
-
-    // TODO: move to `private` and keep a single interface per entry.
-    status_t get(int arg, int *mask, bool *is_set, int *ndims = nullptr,
-            dims_t group_dims = nullptr,
-            data_type_t *data_type = nullptr) const {
-        if (!check_arg(arg)) return status::invalid_arguments;
-        const auto &s = get(arg);
-        if (mask) *mask = s.mask_;
-        if (is_set) *is_set = s.is_set_;
-        if (ndims) *ndims = s.ndims_;
-        if (group_dims && s.ndims_ > 0)
-            utils::array_copy(group_dims, s.group_dims_, s.ndims_);
-        if (data_type) *data_type = s.data_type_;
-        return status::success;
-    }
-
-    data_type_t get_data_type(int arg) const {
-        data_type_t data_type;
-        auto st = get(arg, nullptr, nullptr, nullptr, nullptr, &data_type);
-        if (st != status::success) return data_type::undef;
-        return data_type;
-    }
-
-    status_t reset(int arg) {
-        if (!check_arg(arg)) return status::invalid_arguments;
-        const auto it = scales_.find(arg);
-        if (it != scales_.end()) scales_.erase(it);
-        return status::success;
-    }
-
-    status_t copy_from(const arg_scales_t &other) {
-        for (auto it = other.scales_.begin(); it != other.scales_.end(); ++it) {
-            // Find an entry that can match the arguments without constructing a
-            // new object.
-            if (scales_.count(it->first) == 1) {
-                auto &entry = scales_[it->first];
-                if (entry == it->second) continue;
-            }
-
-            CHECK(set(it->first, it->second));
+        group_ndims_ = group_ndims;
+        if (group_ndims_ > 0) {
+            utils::array_copy(group_dims_, group_dims, group_ndims_);
         }
         return status::success;
     }
+    status_t set(const quant_entry_t &other) {
+        return set(other.mask_, other.data_type_, other.group_ndims_,
+                other.group_dims_);
+    }
 
-    std::map<int, runtime_scales_t> scales_;
+    quant_entry_t &operator=(const quant_entry_t &rhs) {
+        auto st = this->set(rhs);
+        assert(st == status::success);
+        UNUSED(st);
+        return *this;
+    }
+
+    bool has_default_values() const { return *this == default_quant_entry(); }
+    bool has_default_groups() const {
+        return this->group_ndims_ == default_quant_entry().group_ndims_;
+    }
+
+    int get_mask() const { return mask_; }
+    data_type_t get_data_type() const { return data_type_; }
+    dim_t get_group(int d) const {
+        // If groups were not requested, return `1` for convenience.
+        if (group_ndims_ == default_quant_entry().group_ndims_) return 1;
+        // But if they were, any out of bound access would return `0` and likely
+        // lead to a division by zero which is fast to catch.
+        if (d >= group_ndims_) return 0;
+        return group_dims_[d];
+    }
+
+    // Note: keep the definition here to satisfy the
+    // `gtests/internals/test_comparison_operators` linking requirements which
+    // mandates bodies to be in the header file.
+    bool operator==(const quant_entry_t &rhs) const {
+        return mask_ == rhs.mask_ && data_type_ == rhs.data_type_
+                && group_ndims_ == rhs.group_ndims_
+                && IMPLICATION(group_ndims_ > 0,
+                        utils::array_cmp(
+                                group_dims_, rhs.group_dims_, group_ndims_));
+    }
+
+    size_t get_hash() const;
+
+    void serialize(serialization_stream_t &sstream) const;
+
+    std::string get_verbose() const;
 
 private:
+    // Note: INT_MIN is used on purpose to avoid potential issues when
+    // `(mask & bit)` expression will return `true`. `INT_MIN` is represented
+    // as `10...0` in bits and will avoid such situations.
+    int mask_ = INT_MIN;
+    data_type_t data_type_ = data_type::undef;
+    int group_ndims_ = 0;
+    dims_t group_dims_ {};
+};
+
+std::ostream &operator<<(std::ostream &ss, const quant_entry_t &e);
+
+struct scales_t : public c_compatible {
+    scales_t() = default;
+
+    const quant_entry_t &get(int arg) const {
+        const auto it = scales_.find(arg);
+        if (it == scales_.end()) return default_quant_entry();
+        return it->second;
+    }
+
+    // See `set(...)` comment for `quant_entry_t` for a design choice
+    // explanation.
+    status_t set(int arg, int mask) {
+        return set(arg, mask, default_data_type, 0, {});
+    }
+    status_t set(int arg, int mask, data_type_t data_type, int group_ndims,
+            const dims_t group_dims) {
+        if (!check_arg(arg)) return status::invalid_arguments;
+        CHECK(scales_[arg].set(mask, data_type, group_ndims, group_dims));
+        return status::success;
+    }
+    // Use this interface with `default_quant_entry` when need to remove a
+    // specific scale.
+    status_t set(int arg, const quant_entry_t &other) {
+        return scales_[arg].set(other);
+    }
+
+    // This interface is different from the one below and is just a shortcut.
+    bool has_default_values(int arg) const {
+        return get(arg).has_default_values();
+    }
+
+    // This interface is used to make sure that other than `supported_args` have
+    // default values. It's to make sure that non-allowed arguments were not
+    // passed to the library.
+    bool has_default_values(const std::vector<int> &supported_args = {}) const {
+        auto predicate
+                = [](const quant_entry_t &s) { return s.has_default_values(); };
+        return has_default_property(supported_args, predicate);
+    }
+
+    // This interface is used to make sure that other than `supported_args` have
+    // default values. It's to make sure that non-allowed arguments were not
+    // passed to the library.
+    bool has_default_data_type(
+            const std::vector<int> &supported_args = {}) const {
+        auto predicate = [](const quant_entry_t &s) {
+            // Note: `data_type::undef` represents `default_quant_entry`.
+            return utils::one_of(
+                    s.get_data_type(), default_data_type, data_type::undef);
+        };
+        return has_default_property(supported_args, predicate);
+    }
+    // This interface checks specific argument. It exists because quant_entry_t
+    // doesn't have a notion of default data_type, only scales do.
+    // Note: can be removed once the library unconditionally supports data type
+    // for scales for every implementation, then this call can be removed as to
+    // make a proper load, the data type must be queried.
+    bool has_default_data_type(int arg) const {
+        // Note: `data_type::undef` represents `default_quant_entry`.
+        return utils::one_of(
+                get(arg).get_data_type(), default_data_type, data_type::undef);
+    }
+
+    // This interface is different from the one below and is just a shortcut.
+    bool has_default_groups(int arg) const {
+        return get(arg).has_default_groups();
+    }
+
+    // This interface is used to make sure that other than `supported_args` have
+    // default values. It's to make sure that non-allowed arguments were not
+    // passed to the library.
+    bool has_default_groups(const std::vector<int> &supported_args = {}) const {
+        auto predicate
+                = [](const quant_entry_t &s) { return s.has_default_groups(); };
+        return has_default_property(supported_args, predicate);
+    }
+
+    int get_mask(int arg) const { return get(arg).get_mask(); }
+    data_type_t get_data_type(int arg) const {
+        return get(arg).get_data_type();
+    }
+    dim_t get_group(int arg, int d) const { return get(arg).get_group(d); }
+
+    bool operator==(const scales_t &rhs) const {
+        return scales_ == rhs.scales_;
+    }
+
+    size_t get_hash() const;
+
+    void serialize(serialization_stream_t &sstream) const;
+
+    std::string get_verbose() const;
+
+private:
+    // Sorted property of `std::map` is used for hashing.
+    std::map<int, quant_entry_t> scales_;
+    static constexpr data_type_t default_data_type = data_type::f32;
+
     bool check_arg(int arg) const {
+        // regular
+        for (const auto &sa : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
+            if (arg == sa) return true;
+        }
         // binary
-        for (const auto &sa : {DNNL_ARG_SRC_0, DNNL_ARG_SRC_1}) {
+        for (const auto &sa : {DNNL_ARG_SRC_1}) {
             if (arg == sa) return true;
         }
         // concat
         if (arg & DNNL_ARG_MULTIPLE_SRC) return true;
-        // convolution
-        for (const auto &sa : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
-            if (arg == sa) return true;
-        }
         // depth-wise convolution post op
         for (const auto &sa : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | sa)) return true;
@@ -203,19 +236,23 @@ private:
         return false;
     }
 
-    bool has_default_property(const std::vector<int> &skip_args,
-            bool (*predicate)(const runtime_scales_t &)) const {
+    // The function makes sure that if any argument was specified by user, that
+    // only `supported_args` have their value customized, rest unsupported
+    // values were not updated.
+    bool has_default_property(const std::vector<int> &supported_args,
+            bool (*predicate)(const quant_entry_t &)) const {
         for (const auto &s : scales_) {
-            if (!predicate(s.second)) {
-                bool skip = false;
-                for (const auto &skip_a : skip_args)
-                    if (s.first == skip_a) {
-                        skip = true;
-                        break;
-                    }
-                if (skip) continue;
-                return false;
-            }
+            // Arg passed the condition, check the next one.
+            if (predicate(s.second)) continue;
+
+            bool allow_non_default = false;
+            for (const auto &supported_arg : supported_args)
+                if (s.first == supported_arg) {
+                    allow_non_default = true;
+                    break;
+                }
+            if (allow_non_default) continue;
+            return false;
         }
         return true;
     }

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -157,14 +157,14 @@ struct primitive_desc_t : public c_compatible {
         }
         if (arg & DNNL_ARG_ATTR_SCALES) {
             int scale_arg = arg & ~DNNL_ARG_ATTR_SCALES;
-            if (!attr()->scales_.get(scale_arg).has_default_values())
+            if (!attr()->scales_.has_default_values(scale_arg))
                 return arg_usage_t::input;
         }
         if ((arg == (DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0))
-                && !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values())
+                && !attr()->scales_.has_default_values(DNNL_ARG_SRC_0))
             return arg_usage_t::input;
         if ((arg == (DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_1))
-                && !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values())
+                && !attr()->scales_.has_default_values(DNNL_ARG_SRC_1))
             return arg_usage_t::input;
         if (arg == DNNL_ARG_SCRATCHPAD && !is_zero_md(scratchpad_md()))
             return arg_usage_t::output;

--- a/src/common/primitive_hashing.hpp
+++ b/src/common/primitive_hashing.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 
 #include "common/c_types_map.hpp"
 #include "common/engine_id.hpp"
-#include "common/primitive_attr.hpp"
 #include "common/type_helpers.hpp"
 #include "common/verbose.hpp"
 

--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -47,9 +47,9 @@ struct sdpa_desc_t : public op_desc_t {
 
     // primitive_attr_t can't be used because of deleted copy-ctor, but desc_t
     // must be copyable.
-    runtime_scales_t kq_scales {};
+    quant_entry_t kq_scales {};
     zero_points_t kq_zero_points {};
-    runtime_scales_t vs_scales {};
+    quant_entry_t vs_scales {};
     zero_points_t vs_zero_points {};
 
     memory_desc_t dst_desc {};

--- a/src/common/serialization_stream.hpp
+++ b/src/common/serialization_stream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #define COMMON_SERIALIZATION_STREAM_HPP
 
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 #include <type_traits>
 

--- a/src/common/softmax.cpp
+++ b/src/common/softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -112,13 +112,21 @@ status_t softmax_attr_check(const softmax_desc_t &desc, const engine_t *engine,
         VCHECK_SOFTMAX_UNIMPL(attr->has_default_values(fwd_attr_mask, dst_dt),
                 VERBOSE_UNSUPPORTED_ATTR);
 
+        // Check scales
         if (!attr->scales_.has_default_values()) {
-            const auto &sc = attr->scales_;
-            const int mask_src = sc.get(DNNL_ARG_SRC).mask_;
-            const int mask_dst = sc.get(DNNL_ARG_DST).mask_;
-
-            VCHECK_SOFTMAX_UNIMPL(utils::everyone_is(0, mask_src, mask_dst),
+            static const std::vector<int> supported_args {
+                    DNNL_ARG_SRC, DNNL_ARG_DST};
+            VCHECK_SOFTMAX_UNIMPL(
+                    attr->scales_.has_default_values(supported_args),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+            for (int arg : supported_args) {
+                if (attr->scales_.has_default_values(arg)) continue;
+
+                const int mask = attr->scales_.get_mask(arg);
+                VCHECK_SOFTMAX_UNIMPL(
+                        mask == 0, VERBOSE_UNSUPPORTED_SCALES_CFG);
+            }
         }
 
         // Check post-ops

--- a/src/common/softmax_pd.hpp
+++ b/src/common/softmax_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -176,11 +176,18 @@ protected:
                 dst_md_, src_md_.format_desc.blocking);
     }
 
-    bool attr_scales_ok() const {
+    bool attr_scales_ok(const std::vector<int> &supported_args
+            = {DNNL_ARG_SRC, DNNL_ARG_DST}) const {
         const auto &scales = attr()->scales_;
-        bool ok = true;
-        for (const auto &e : scales.scales_) {
-            ok = ok && e.second.mask_ == 0;
+        bool ok = scales.has_default_values(supported_args);
+
+        for (const auto &arg : supported_args) {
+            if (scales.has_default_values(arg)) continue;
+
+            // TODO: disallow non-int8 scales?
+            // const data_type_t dt = arg_md(arg)->data_type;
+            // ok = ok && utils::one_of(dt, s8, u8);
+            ok = ok && scales.get_mask(arg) == 0;
         }
         return ok;
     }

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -618,18 +618,6 @@ std::string md2desc_str(const memory_desc_t *md) {
     return s;
 }
 
-std::ostream &operator<<(std::ostream &ss, const runtime_scales_t &scale) {
-    ss << scale.mask_;
-    ss << ":" << scale.data_type_;
-    if (scale.ndims_) {
-        ss << ":";
-        for (int i = 0; i < scale.ndims_ - 1; ++i)
-            ss << scale.group_dims_[i] << 'x';
-        ss << scale.group_dims_[scale.ndims_ - 1];
-    }
-    return ss;
-}
-
 std::ostream &operator<<(
         std::ostream &ss, const rnn_create_time_scales_t &rnn_scales) {
     ss << rnn_scales.mask_;
@@ -742,20 +730,13 @@ std::ostream &operator<<(std::ostream &ss, const primitive_attr_t *attr) {
     if (deterministic) {
         ss << field_delim() << "attr-deterministic:" << deterministic;
     }
+
+    // Fast exit if rest attributes were not specified.
     if (attr->has_default_values()) return ss;
 
-    const arg_scales_t &as = attr->scales_;
-    if (!as.has_default_values()) {
-        std::string delim = empty_delim;
-        ss << field_delim() << "attr-scales:";
-        for (const auto &map_entry : as.scales_) {
-            const auto &val = map_entry.second;
-            if (val.has_default_values()) continue;
-
-            int arg = map_entry.first;
-            ss << delim << arg2str(arg) << ":" << val;
-            delim = attr_delim;
-        }
+    const scales_t &scales = attr->scales_;
+    if (!scales.has_default_values()) {
+        ss << field_delim() << "attr-scales:" << scales.get_verbose();
     }
 
     const zero_points_t &zp = attr->zero_points_;

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -382,6 +382,7 @@ std::string md2fmt_str(
         const char *name, const memory_desc_t *md, format_kind_t user_format);
 std::string md2dim_str(
         const memory_desc_t *md, dims_type_t dims_type = dims_type_t::dims);
+std::string arg2str(int arg);
 // Returns a verbose string of dimensions or descriptor from src, wei, and/or
 // dst memory descs. Can be called externally to provide info about actual
 // values of runtime dimensions.

--- a/src/cpu/aarch64/acl_reorder.hpp
+++ b/src/cpu/aarch64/acl_reorder.hpp
@@ -95,12 +95,12 @@ struct acl_reorder_fwd_t : public primitive_t {
 
             if (!ok) return status::unimplemented;
 
-            int mask = -1;
-            bool is_set = false;
-            CHECK(attr->scales_.get(DNNL_ARG_DST, &mask, &is_set));
-            const memory_desc_wrapper input_d(src_md);
-            if (input_d.has_runtime_dims_or_strides() && is_set && mask > 0)
-                return status::unimplemented;
+            if (!attr->scales_.has_default_values(DNNL_ARG_DST)) {
+                int mask = attr->scales_.get_mask(DNNL_ARG_DST);
+                const memory_desc_wrapper input_d(src_md);
+                if (input_d.has_runtime_dims_or_strides() && mask > 0)
+                    return status::unimplemented;
+            }
 
             // Create and check primitive descriptor
             auto _pd = make_unique_pd<pd_t>(attr, src_engine->kind(), src_md,

--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -297,21 +297,22 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
     if (brg->with_scales) {
         // Note. the current version supports only two different output scale
         // types:
-        //     1) common (mask_ = 0)
+        //     1) common (mask = 0)
         //     2) per_n_dim_scale - broadcast across n dimension;
         //        for convolution and inner product promitives it corresponds
-        //        to "per_oc" mask_ = 1 << 1; for matmul - to
-        //        mask_ = (1 << (ndims - 1))), where ndims is number of
+        //        to "per_oc" mask = 1 << 1; for matmul - to
+        //        mask = (1 << (ndims - 1))), where ndims is number of
         //        dimensions for original matmul problem
-        // So if wei_scales.mask_ != 0 (not common) it's assumed here that scale
-        // type is per_n_dim_scale and driver which calls brgemm kernel checked
-        // that mask has correct value for this case
-        brg->is_oc_scale = wei_scales.mask_ != 0;
+        // So if wei_scales.get_mask() > 0 (not common) it's assumed here that
+        // scale type is per_n_dim_scale and driver which calls brgemm kernel
+        // checked that mask has correct value for this case
+        brg->is_oc_scale = wei_scales.get_mask() > 0;
     }
 
     const auto &dst_scales = attr->scales_.get(DNNL_ARG_DST);
     brg->with_dst_scales = !dst_scales.has_default_values();
-    const bool scales_ok = src_scales.mask_ == 0 && dst_scales.mask_ == 0
+    const bool scales_ok = src_scales.get_mask() == 0
+            && dst_scales.get_mask() == 0
             && attr->scales_.has_default_values(
                     {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST});
     if (!scales_ok) return status::unimplemented;

--- a/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
@@ -200,7 +200,7 @@ status_t brdgmm_dw_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     const auto &wei_scales = attr_.scales_.get(DNNL_ARG_WEIGHTS);
     jcp.with_scale = !src_scales.has_default_values()
             || !wei_scales.has_default_values();
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
     const bool scales_ok
             = attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST});

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -1993,7 +1993,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.with_scales = !src_scales.has_default_values()
             || !wei_scales.has_default_values()
             || jcp.scale_adjust_factor != 1.0f;
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
     // disables the shape with small ic but large spatial
     // or specific large spatial shapes for int8 conv
@@ -2190,7 +2190,7 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.with_scales = !src_scales.has_default_values()
             || !wei_scales.has_default_values()
             || jcp.scale_adjust_factor != 1.0f;
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
     // enable ununroll_bd_loop for big shapes to reduce kernel sizes
     jcp.ununroll_bd_loop

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -325,8 +325,8 @@ struct jit_brgemm_kernel_post_ops : public jit_generator {
         const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
         // per_oc: conv: 1 << 0, (1 << 1) + (1 << 0) (with groups)
         // per_oc: ip: 1 << 0
-        is_oc_scale_
-                = utils::one_of(wei_scales.mask_, 1 << 0, (1 << 1) + (1 << 0));
+        is_oc_scale_ = utils::one_of(
+                wei_scales.get_mask(), 1 << 0, (1 << 1) + (1 << 0));
 
         LDD_ = brg.LDD;
         inp_dt_ = brg.dt_c;

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -140,10 +140,8 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
                     po, src0_md_, get_supported_postops_bcast_strategies());
     conf_.op_type = get_op_type(src0_md_);
     assert(conf_.op_type != op_t::none);
-    conf_.do_scale_src0
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
-    conf_.do_scale_src1
-            = !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
+    conf_.do_scale_src0 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.do_scale_src1 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_1);
     const auto sum_idx = po.find(primitive_kind::sum);
     conf_.do_sum = sum_idx != -1 && po.entry_[sum_idx].sum.scale != 0.f;
     conf_.with_eltwise = po.find(primitive_kind::eltwise) != -1;

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -2788,13 +2788,10 @@ status_t jit_uni_reorder_t::pd_t::init_scratchpad() {
                 compensation_reduce_size);
     }
 
-    const memory_desc_wrapper input_d(src_md());
-    int scales_mask = -1;
-    bool is_set = false;
-    CHECK(attr()->scales_.get(DNNL_ARG_DST, &scales_mask, &is_set));
-
-    if (is_set && scales_mask > 0) {
-        get_D_values(input_d, scales_mask, nullptr, &D_mask_, nullptr);
+    if (!attr()->scales_.has_default_values(DNNL_ARG_DST)) {
+        const memory_desc_wrapper input_d(src_md());
+        int mask = attr()->scales_.get_mask(DNNL_ARG_DST);
+        get_D_values(input_d, mask, nullptr, &D_mask_, nullptr);
         if (D_mask_ > 1) {
             scratchpad.template book<float>(
                     memory_tracking::names::key_reorder_precomputed_dst_scales,

--- a/src/cpu/aarch64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder_utils.cpp
@@ -276,24 +276,21 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
     p.src_scale_type = scale_type_t::NONE;
     int src_mask = 0;
-    bool is_src_set = false;
-    CHECK(attr->scales_.get(DNNL_ARG_SRC, &src_mask, &is_src_set));
-    if (is_src_set) {
+    if (!attr->scales_.has_default_values(DNNL_ARG_SRC)) {
+        src_mask = attr->scales_.get_mask(DNNL_ARG_SRC);
         p.src_scale_type
                 = src_mask == 0 ? scale_type_t::COMMON : scale_type_t::MANY;
     }
 
     p.dst_scale_type = scale_type_t::NONE;
     int dst_mask = 0;
-    bool is_dst_set = false;
-    CHECK(attr->scales_.get(DNNL_ARG_DST, &dst_mask, &is_dst_set));
-    if (is_dst_set) {
+    if (!attr->scales_.has_default_values(DNNL_ARG_DST)) {
+        dst_mask = attr->scales_.get_mask(DNNL_ARG_DST);
         p.dst_scale_type
                 = dst_mask == 0 ? scale_type_t::COMMON : scale_type_t::MANY;
     }
 
-    if (is_src_set && is_dst_set && src_mask != dst_mask)
-        return status::unimplemented;
+    if (src_mask != dst_mask) return status::unimplemented;
 
     p.scale_adjust = (om_d.extra().flags & memory_extra_flags::scale_adjust)
             ? om_d.extra().scale_adjust

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -52,13 +52,20 @@ status_t acl_lowp_matmul_sq_t::pd_t::init(engine_t *engine) {
             attr()->has_default_values(smask_t::scales_runtime
                     | smask_t::zero_points_runtime | smask_t::post_ops),
             "only scale, zero point and post-ops attrs supported");
-    VDISPATCH_MATMUL(attr()->scales_.get(DNNL_ARG_SRC).mask_ == 0
-                    && attr()->zero_points_.get(DNNL_ARG_SRC) == 0
-                    && attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0
+
+    static const std::vector<int> supported_args {
+            DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
+    for (int arg : supported_args) {
+        if (attr()->scales_.has_default_values(arg)) continue;
+
+        VDISPATCH_MATMUL(attr()->scales_.get_mask(arg) == 0,
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
+    }
+
+    VDISPATCH_MATMUL(attr()->zero_points_.get(DNNL_ARG_SRC) == 0
                     && attr()->zero_points_.get(DNNL_ARG_WEIGHTS) == 0
-                    && attr()->scales_.get(DNNL_ARG_DST).mask_ == 0
                     && attr()->zero_points_.get(DNNL_ARG_DST) == 0,
-            "common scales and zero points only");
+            "common zero points only");
     VDISPATCH_MATMUL(
             !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
     const memory_desc_wrapper src_d(src_md_);

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -72,9 +72,9 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         const std::vector<int> supported_args
                 = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
         bool ok = attr_scales_ok(supported_args);
-        if (!attr()->scales_.get(DNNL_ARG_SRC).has_default_values()
-                && !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values()
-                && attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ != 0) {
+        if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
+                && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
+                && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad
             if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
         }

--- a/src/cpu/cpu_primitive.hpp
+++ b/src/cpu/cpu_primitive.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
     alignas(16) float CONCAT2(scales, _buf16)[16] = {0}; \
     const float *scales {nullptr}; \
     if ((attr)) { \
-        if ((attr)->scales_.get(arg).has_default_values()) { \
+        if ((attr)->scales_.has_default_values(arg)) { \
             utils::array_set(CONCAT2(scales, _buf16), 1.0f, 16); \
             scales = CONCAT2(scales, _buf16); \
         } else { \
@@ -92,7 +92,7 @@
 
 #define ASSIGN_ARG_SCALE_VALUE(scale, mem_arg) \
     alignas(16) float CONCAT2(CONCAT2(scales, _buf16), mem_arg)[16] = {0}; \
-    if (pd()->attr()->scales_.get(mem_arg).has_default_values()) { \
+    if (pd()->attr()->scales_.has_default_values(mem_arg)) { \
         utils::array_set(CONCAT2(CONCAT2(scales, _buf16), mem_arg), 1.0f, 16); \
         scale = CONCAT2(CONCAT2(scales, _buf16), mem_arg); \
     } else { \

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -2133,8 +2133,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
     jcp.dst_os_stride = dst_d.is_blocking_desc()
             ? dst_d.blocking_desc().strides[ndims - 1]
             : 0;
-    jcp.scale_idx_mult = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_ != 0;
-    jcp.with_dst_scale = !attr.scales_.get(DNNL_ARG_DST).has_default_values();
+    jcp.scale_idx_mult = attr.scales_.get_mask(DNNL_ARG_WEIGHTS) > 0;
+    jcp.with_dst_scale = !attr.scales_.has_default_values(DNNL_ARG_DST);
     book_precomputed_scales(scratchpad, attr.scales_, jcp.ngroups * jcp.oc);
 
     if (jcp.zp.src_exists) {

--- a/src/cpu/gemm_inner_product_utils.cpp
+++ b/src/cpu/gemm_inner_product_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -157,17 +157,17 @@ pp_kernel_t::pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
     , bias_data_type_(bias_dt)
     , acc_data_type_(acc_dt)
     , dst_data_type_(dst_md->data_type)
-    , do_scale_(!attr->scales_.get(DNNL_ARG_SRC).has_default_values()
-              || !attr->scales_.get(DNNL_ARG_WEIGHTS).has_default_values())
+    , do_scale_(!attr->scales_.has_default_values(DNNL_ARG_SRC)
+              || !attr->scales_.has_default_values(DNNL_ARG_WEIGHTS))
     , ndims_(dst_md->ndims) {
 
-    if (do_scale_) {
-        int wei_mask = attr->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    if (!attr->scales_.has_default_values(DNNL_ARG_WEIGHTS)) {
+        int wei_mask = attr->scales_.get_mask(DNNL_ARG_WEIGHTS);
         // matmul: per_oc: 1 << (ndims_ - 1)
         // ip: per_oc: 1 << 0
         scale_idx_mult_ = wei_mask == (1 << (ndims_ - 1)) || wei_mask == 1 << 0;
     }
-    do_dst_scale_ = !attr->scales_.get(DNNL_ARG_DST).has_default_values();
+    do_dst_scale_ = !attr->scales_.has_default_values(DNNL_ARG_DST);
 
     post_ops_ = attr->post_ops_;
     const int eltwise_ind = post_ops_.find(primitive_kind::eltwise);

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -135,10 +135,9 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *scales = precompute_scales(scratchpad, src_scales, wei_scales,
-            pd()->IC(), pd()->OC(), false, wei_scale_mask != 0, pd()->attr());
+            pd()->IC(), pd()->OC(), false, wei_scale_mask > 0, pd()->attr());
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         status_t st_thr = execute_forward_thr(ithr, nthr, src_base, wei_base,
@@ -358,16 +357,15 @@ status_t gemm_x8s8s32x_convolution_bwd_data_t::execute_backward_data_thr(
     const auto diff_src_dt_size
             = types::data_type_size(diff_src_md.data_type());
 
-    const int scale_idx_mult = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_
+    const int scale_idx_mult = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS)
             == (1 << static_cast<int>(pd()->with_groups()));
     DEFINE_ARG_SCALES_BUFFER(src_scales, DNNL_ARG_SRC);
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *scales = precompute_scales(scratchpad, src_scales, wei_scales,
-            pd()->IC(), pd()->OC(), false, wei_scale_mask != 0, pd()->attr());
+            pd()->IC(), pd()->OC(), false, wei_scale_mask > 0, pd()->attr());
 
     const dim_t work_amount = jcp.ngroups * jcp.mb;
 

--- a/src/cpu/gemm_x8s8s32x_inner_product.cpp
+++ b/src/cpu/gemm_x8s8s32x_inner_product.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,10 +64,9 @@ status_t gemm_x8s8s32x_inner_product_fwd_t::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
     auto scratchpad = ctx.get_scratchpad_grantor();
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *scales = precompute_scales(scratchpad, src_scales, wei_scales,
-            IC, OC, false, wei_scale_mask != 0, pd()->attr());
+            IC, OC, false, wei_scale_mask > 0, pd()->attr());
 
     int32_t *acc = pd()->dst_is_acc_
             ? (int32_t *)dst

--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -105,9 +105,9 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
         engine_t *engine) {
     auto check_attr_scales = [&]() -> bool {
         bool ok = attr_scales_ok();
-        if (!attr()->scales_.get(DNNL_ARG_SRC).has_default_values()
-                && !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values()
-                && attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ != 0) {
+        if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
+                && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
+                && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
             if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
         }
@@ -145,11 +145,15 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
     // set state
     CHECK(params_.pp_attr_.copy_from(*attr()));
     params_.gemm_applies_output_scales_
-            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0 && !with_bias();
+            = attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) == 0 && !with_bias();
 
     if (params_.gemm_applies_output_scales_) {
-        params_.pp_attr_.scales_.reset(DNNL_ARG_SRC);
-        params_.pp_attr_.scales_.reset(DNNL_ARG_WEIGHTS);
+        VDISPATCH_MATMUL_SC(params_.pp_attr_.scales_.set(
+                                    DNNL_ARG_SRC, default_quant_entry()),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
+        VDISPATCH_MATMUL_SC(params_.pp_attr_.scales_.set(
+                                    DNNL_ARG_WEIGHTS, default_quant_entry()),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
     }
 
     // check post-ops
@@ -203,11 +207,10 @@ status_t gemm_bf16_matmul_t<dst_type>::execute_ref(
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
     auto scratchpad = ctx.get_scratchpad_grantor();
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *scales = precompute_scales(scratchpad, src_scales, wei_scales,
             src_d.dims()[ndims - 1], dst_d.dims()[ndims - 1], false,
-            wei_scale_mask != 0, pd()->attr());
+            wei_scale_mask > 0, pd()->attr());
 
     if (src_d.has_zero_dim() || weights_d.has_zero_dim()
             || dst_d.has_zero_dim())
@@ -254,7 +257,7 @@ status_t gemm_bf16_matmul_t<dst_type>::execute_ref(
     const float beta = params.gemm_beta_;
     const dim_t acc_ldc = dst_is_acc ? ldc : N;
     const int scale_idx_mult
-            = this->pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_
+            = this->pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS)
             == (1 << (ndims - 1));
 
     std::atomic<status_t> st(status::success);

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -61,9 +61,9 @@ status_t gemm_x8s8s32x_matmul_t::pd_t::init(engine_t *engine) {
 
     auto check_attr_scales = [&]() -> bool {
         bool ok = attr_scales_ok();
-        if (!attr()->scales_.get(DNNL_ARG_SRC).has_default_values()
-                && !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values()
-                && attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ != 0) {
+        if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
+                && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
+                && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
             // This case requires scratchpad with unknown size
             if (N() == DNNL_RUNTIME_DIM_VAL) ok = false;
         }
@@ -203,11 +203,10 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
     auto &scratchpad = ctx.get_scratchpad_grantor();
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *scales = precompute_scales(scratchpad, src_scales, wei_scales,
             src_d.dims()[ndims - 1], dst_d.dims()[ndims - 1], false,
-            wei_scale_mask != 0, pd()->attr());
+            wei_scale_mask > 0, pd()->attr());
 
     DEFINE_ZERO_POINT_VALUE(src_zero_point, DNNL_ARG_SRC);
     DEFINE_ZERO_POINT_VALUE(weights_zero_point, DNNL_ARG_WEIGHTS);
@@ -278,7 +277,7 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
     const float beta = params.gemm_beta_;
     const dim_t acc_ldc = dst_is_acc ? ldc : N;
     const int scale_idx_mult
-            = this->pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_
+            = this->pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS)
             == (1 << (ndims - 1));
 
     std::atomic<status_t> st(status::success);

--- a/src/cpu/matmul/matmul_utils.hpp
+++ b/src/cpu/matmul/matmul_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -156,6 +156,11 @@ struct matmul_helper_t {
     static status_t get_quant_md(memory_desc_t &md, const int ndims,
             const dims_t in_dims, const int quant_mask, const dim_t g0,
             const dim_t g1, const data_type_t dt) {
+        if (dt == data_type::undef) {
+            md = glob_zero_md;
+            return status::success;
+        }
+
         dims_t quant_dims {};
         utils::copy_dims_with_mask(quant_dims, in_dims, ndims, quant_mask,
                 /* fill_with_ones = */ true);
@@ -172,6 +177,8 @@ struct matmul_helper_t {
     static dim_t get_quant_off(const dims_t &input_idx, const int ndims,
             const int quant_mask, const dim_t g0, const dim_t g1,
             const memory_desc_t &quant_md) {
+        if (types::is_zero_md(&quant_md)) return 0;
+
         dims_t quant_idx {};
         utils::array_copy(quant_idx, input_idx, ndims);
         utils::apply_mask_on_dims(quant_idx, ndims, quant_mask);

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -112,25 +112,18 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
 
     // arg scales section
     const auto &attr_scales = pd()->attr()->scales_;
-    const bool with_src_scales
-            = !attr_scales.get(DNNL_ARG_SRC).has_default_values();
+    const bool with_src_scales = !attr_scales.has_default_values(DNNL_ARG_SRC);
     const bool with_wei_scales
-            = !attr_scales.get(DNNL_ARG_WEIGHTS).has_default_values();
-    const bool with_dst_scales
-            = !attr_scales.get(DNNL_ARG_DST).has_default_values();
-    const auto wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
+            = !attr_scales.has_default_values(DNNL_ARG_WEIGHTS);
+    const bool with_dst_scales = !attr_scales.has_default_values(DNNL_ARG_DST);
+    const auto wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
     const dim_t wei_scale_stride_n
             = (wei_scale_mask & pd()->wei_qmask_N()) ? 1 : 0;
-    const auto &wei_scale_dt = attr_scales.get(DNNL_ARG_WEIGHTS).data_type_;
+    const auto &wei_scale_dt = attr_scales.get_data_type(DNNL_ARG_WEIGHTS);
     const auto wei_scales_d
             = ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS);
-    const auto wei_scale_group_ndim = attr_scales.get(DNNL_ARG_WEIGHTS).ndims_;
-    const auto wei_scale_group_k = wei_scale_group_ndim > 0
-            ? attr_scales.get(DNNL_ARG_WEIGHTS).group_dims_[0]
-            : 1;
-    const auto wei_scale_group_n = wei_scale_group_ndim > 0
-            ? attr_scales.get(DNNL_ARG_WEIGHTS).group_dims_[1]
-            : 1;
+    const auto wei_scale_group_k = attr_scales.get_group(DNNL_ARG_WEIGHTS, 0);
+    const auto wei_scale_group_n = attr_scales.get_group(DNNL_ARG_WEIGHTS, 1);
     // Initialize a memory desc for quant entries for easier offset calculation.
     memory_desc_t wei_scale_md {};
     CHECK(matmul_helper_t::get_quant_md(wei_scale_md, ndims, weights_d.dims(),

--- a/src/cpu/ref_concat.hpp
+++ b/src/cpu/ref_concat.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,11 +58,10 @@ struct ref_concat_t : public primitive_t {
             reorder_pds_.resize(n_ + use_tent_dst());
             for (int i = 0; i < n_; ++i) {
                 primitive_attr_t r_attr;
-                if (!sc.get(DNNL_ARG_MULTIPLE_SRC + i).has_default_values()) {
-                    int mask = 0;
-                    CHECK(sc.get(DNNL_ARG_MULTIPLE_SRC + i, &mask, nullptr));
-                    if (mask != 0) return status::unimplemented;
-                    r_attr.scales_.set(DNNL_ARG_SRC, mask);
+                if (!sc.has_default_values(DNNL_ARG_MULTIPLE_SRC + i)) {
+                    int mask = sc.get_mask(DNNL_ARG_MULTIPLE_SRC + i);
+                    VDISPATCH_CONCAT(mask == 0, VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    CHECK(r_attr.scales_.set(DNNL_ARG_SRC, mask));
                 }
                 CHECK(reorder_primitive_desc_create(reorder_pds_[i], engine,
                         src_md(i), src_image_md(i), &r_attr));

--- a/src/cpu/ref_convolution_int8.cpp
+++ b/src/cpu/ref_convolution_int8.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ namespace {
 void dequantize(float &d, dim_t g, dim_t C, dim_t c, const float *wei_scales,
         bool with_groups, int wei_mask, const float *src_scales) {
     // scale_idx_mult = 1 for per_channel scales and 0, otherwise
-    const int wei_scale_idx_mult = wei_mask != 0;
+    const int wei_scale_idx_mult = wei_mask > 0;
     float scale = 1.0f;
     if (src_scales) scale *= src_scales[0];
     if (wei_scales) scale *= wei_scales[(g * C + c) * wei_scale_idx_mult];
@@ -63,8 +63,7 @@ status_t ref_convolution_int8_fwd_t::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
 
     DEFINE_ZERO_POINTS_BUFFER(src_zero_point, DNNL_ARG_SRC);
     DEFINE_ZERO_POINTS_BUFFER(dst_zero_point, DNNL_ARG_DST);
@@ -290,8 +289,7 @@ status_t ref_convolution_int8_bwd_data_t::execute_backward_data(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(diff_dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
 
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
     const memory_desc_wrapper diff_src_d(pd()->diff_src_md());

--- a/src/cpu/ref_fused_convolution.hpp
+++ b/src/cpu/ref_fused_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -224,10 +224,10 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
             primitive_attr_t attr_1x1(*attr());
             // erase dw_conv post-op scales
             for (auto arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
-                auto &scale
-                        = attr_1x1.scales_.get(DNNL_ARG_ATTR_POST_OP_DW | arg);
-                if (!scale.has_default_values())
-                    attr_1x1.scales_.reset(DNNL_ARG_ATTR_POST_OP_DW | arg);
+                if (!attr_1x1.scales_.has_default_values(
+                            DNNL_ARG_ATTR_POST_OP_DW | arg))
+                    CHECK(attr_1x1.scales_.set(DNNL_ARG_ATTR_POST_OP_DW | arg,
+                            default_quant_entry()));
             }
             // erase post-ops after fusion as they will be handled separately
             auto &e = attr_1x1.post_ops_.entry_;
@@ -250,7 +250,7 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
             arg_cache.append_ctx_arg(DNNL_ARG_SRC);
             arg_cache.append_ctx_arg(DNNL_ARG_WEIGHTS);
             for (auto arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST})
-                if (!attr_1x1.scales_.get(arg).has_default_values())
+                if (!attr_1x1.scales_.has_default_values(arg))
                     arg_cache.append_ctx_arg(DNNL_ARG_ATTR_SCALES | arg);
             if (desc()->bias_desc.data_type != data_type::undef)
                 arg_cache.append_ctx_arg(DNNL_ARG_BIAS);
@@ -316,12 +316,12 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
                 arg_cache.append_ctx_arg(DNNL_ARG_WEIGHTS,
                         DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS);
                 for (auto arg : {DNNL_ARG_WEIGHTS, DNNL_ARG_DST})
-                    if (!attr_dw.scales_.get(arg).has_default_values())
+                    if (!attr_dw.scales_.has_default_values(arg))
                         arg_cache.append_ctx_arg(DNNL_ARG_ATTR_SCALES | arg,
                                 DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_ATTR_SCALES
                                         | arg);
                 // dw_conv src_scale = 1x1_conv dst_scale
-                if (!attr_1x1.scales_.get(DNNL_ARG_DST).has_default_values())
+                if (!attr_1x1.scales_.has_default_values(DNNL_ARG_DST))
                     arg_cache.append_ctx_arg(
                             DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC,
                             DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);

--- a/src/cpu/ref_inner_product_int8.cpp
+++ b/src/cpu/ref_inner_product_int8.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -76,13 +76,12 @@ status_t ref_inner_product_int8_fwd_t::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
     const auto &attr_scales = pd()->attr()->scales_;
-    const bool with_dst_scales
-            = !attr_scales.get(DNNL_ARG_DST).has_default_values();
+    const bool with_dst_scales = !attr_scales.has_default_values(DNNL_ARG_DST);
 
     auto maybe_oscale = [&](float &d, dim_t oc) {
         // scale_idx_mult = 1 for per_oc scales and 0, otherwise
         const int scale_idx_mult
-                = attr_scales.get(DNNL_ARG_WEIGHTS).mask_ == (1 << 0);
+                = attr_scales.get_mask(DNNL_ARG_WEIGHTS) == (1 << 0);
         d *= src_scales[0] * wei_scales[oc * scale_idx_mult];
     };
 

--- a/src/cpu/ref_sum.hpp
+++ b/src/cpu/ref_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ struct ref_sum_t : public primitive_t {
             reorder_pds_.resize(n_ + need_output_reorder());
             for (int i = 0; i < n_; ++i) {
                 primitive_attr_t r_attr;
-                r_attr.scales_.set(DNNL_ARG_SRC, 0);
+                CHECK(r_attr.scales_.set(DNNL_ARG_SRC, 0));
                 if (i != 0) r_attr.post_ops_.append_sum(1.0);
                 CHECK(reorder_primitive_desc_create(reorder_pds_[i], engine,
                         src_md(i), dst_acc_md(), &r_attr));

--- a/src/cpu/reorder/cpu_reorder_pd.hpp
+++ b/src/cpu/reorder/cpu_reorder_pd.hpp
@@ -85,15 +85,15 @@ struct cpu_reorder_pd_t : public reorder_pd_t {
             const float *dst_scales) const {
         using namespace dnnl::impl::memory_tracking::names;
 
-        int mask = -1;
-        bool is_set = false;
-        auto status = attr->scales_.get(DNNL_ARG_DST, &mask, &is_set);
-        if (status != status::success) return nullptr;
+        if (attr->scales_.has_default_values(DNNL_ARG_DST)) {
+            return dst_scales;
+        }
 
         // It's possible that mask > 0 but `count` is still `1`. This case is
         //   covered by `DEFINE_ARG_SCALES_BUFFER` macro and no need to inverse
         //   in such case.
-        if (is_set && mask > 0 && count > 1) {
+        int mask = attr->scales_.get_mask(DNNL_ARG_DST);
+        if (mask > 0 && count > 1) {
             auto loc_scales = scratchpad.template get<float>(
                     key_reorder_precomputed_dst_scales);
             if (!loc_scales) return nullptr;

--- a/src/cpu/scale_utils.cpp
+++ b/src/cpu/scale_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,21 +32,18 @@ constexpr size_t scales_simd_w = 16;
 }
 
 void book_precomputed_scales(memory_tracking::registrar_t &scratchpad,
-        const arg_scales_t &attr_scales, size_t wei_scale_count,
+        const scales_t &attr_scales, size_t wei_scale_count,
         bool force_scales_book) {
     using namespace dnnl::impl::memory_tracking::names;
 
-    const bool with_src_scales
-            = !attr_scales.get(DNNL_ARG_SRC).has_default_values();
+    const bool with_src_scales = !attr_scales.has_default_values(DNNL_ARG_SRC);
     const bool with_wei_scales
-            = !attr_scales.get(DNNL_ARG_WEIGHTS).has_default_values();
-    const auto wei_scales_dt = attr_scales.get(DNNL_ARG_WEIGHTS).data_type_;
-    const auto wei_scale_groups_ndims
-            = attr_scales.get(DNNL_ARG_WEIGHTS).ndims_;
+            = !attr_scales.has_default_values(DNNL_ARG_WEIGHTS);
+
     if ((with_src_scales && with_wei_scales) || force_scales_book
-            || (wei_scales_dt != data_type::f32 && with_wei_scales)
-            || (wei_scale_groups_ndims > 0 && with_wei_scales)) {
-        const int wei_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
+            || !attr_scales.has_default_data_type(DNNL_ARG_WEIGHTS)
+            || !attr_scales.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
+        const int wei_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
         const size_t precomputed_scales_size = wei_mask == 0
                 ? scales_simd_w
                 : nstl::max(
@@ -60,27 +57,26 @@ void book_precomputed_scales(memory_tracking::registrar_t &scratchpad,
 bool req_copy_scales(
         const primitive_attr_t *attr, const float scale_adjust_factor) {
     const auto &attr_scales = attr->scales_;
-    const bool with_src_scales
-            = !attr_scales.get(DNNL_ARG_SRC).has_default_values();
+    const bool with_src_scales = !attr_scales.has_default_values(DNNL_ARG_SRC);
     const bool with_wei_scales
-            = !attr_scales.get(DNNL_ARG_WEIGHTS).has_default_values();
-    const auto wei_scales_dt = attr_scales.get(DNNL_ARG_WEIGHTS).data_type_;
-    const auto wei_scale_groups_ndims
-            = attr_scales.get(DNNL_ARG_WEIGHTS).ndims_;
+            = !attr_scales.has_default_values(DNNL_ARG_WEIGHTS);
     return (with_src_scales && with_wei_scales) || scale_adjust_factor != 1.0f
-            || (wei_scales_dt != data_type::f32 && with_wei_scales)
-            || (wei_scale_groups_ndims > 0 && with_wei_scales);
+            || !attr_scales.has_default_data_type(DNNL_ARG_WEIGHTS)
+            || !attr_scales.get(DNNL_ARG_WEIGHTS).has_default_groups();
 }
 
 const float *precompute_scales(const memory_tracking::grantor_t &scratchpad,
         const float *src_scales, const float *wei_scales, dim_t oc,
         const primitive_attr_t *attr, float scale_adjust_factor) {
-    // Note: per-ic-channel is no supported in default
-    const int wei_scale_mask = attr->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    // Note: per-ic-channel is no supported by default.
+    const int wei_scale_mask = attr->scales_.get_mask(DNNL_ARG_WEIGHTS);
     return precompute_scales(scratchpad, src_scales, wei_scales, 1, oc, false,
-            wei_scale_mask != 0, attr, scale_adjust_factor, false);
+            wei_scale_mask > 0, attr, scale_adjust_factor, false);
 }
 
+// Note: `wei_scale_per_ic` and `wei_scale_per_oc` could be identified in this
+// function unless different primitives have same definition of `per_ic` and
+// `per_oc` masks. Mostly, matmul is different from anybody else.
 const float *precompute_scales(const memory_tracking::grantor_t &scratchpad,
         const float *src_scales, const float *wei_scales, dim_t IC, dim_t OC,
         const bool wei_scale_per_ic, const bool wei_scale_per_oc,
@@ -89,14 +85,15 @@ const float *precompute_scales(const memory_tracking::grantor_t &scratchpad,
     using namespace dnnl::impl::memory_tracking::names;
 
     const auto &attr_scales = attr->scales_;
-    const bool with_src_scales
-            = !attr_scales.get(DNNL_ARG_SRC).has_default_values();
+    const bool with_src_scales = !attr_scales.has_default_values(DNNL_ARG_SRC);
     const auto wei_scale_count
             = (wei_scale_per_ic ? IC : 1) * (wei_scale_per_oc ? OC : 1);
 
     const float *scales = nullptr;
     if (req_copy_scales(attr, scale_adjust_factor)) {
-        const int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
+        const int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+        assert(wei_scale_mask >= 0);
+
         size_t size = 0;
         auto loc_scales
                 = scratchpad.template get<float>(key_precomputed_scales, &size);
@@ -108,12 +105,9 @@ const float *precompute_scales(const memory_tracking::grantor_t &scratchpad,
             const dim_t count = nstl::min(
                     static_cast<dim_t>(size / sizeof(float)), wei_scale_count);
             const auto wei_scale_dt
-                    = attr_scales.get(DNNL_ARG_WEIGHTS).data_type_;
-            const auto wei_scale_groups_ndims
-                    = attr_scales.get(DNNL_ARG_WEIGHTS).ndims_;
-            const auto wei_scale_groups_ic = wei_scale_groups_ndims > 0
-                    ? attr_scales.get(DNNL_ARG_WEIGHTS).group_dims_[0]
-                    : 1;
+                    = attr_scales.get_data_type(DNNL_ARG_WEIGHTS);
+            const auto wei_scale_groups_ic
+                    = attr_scales.get_group(DNNL_ARG_WEIGHTS, 0);
             // Note: per-ic-channel scales is only supported for
             // weights decompression for now
             if ((wei_scale_per_ic && wei_scale_groups_ic > 1)

--- a/src/cpu/scale_utils.hpp
+++ b/src/cpu/scale_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ namespace impl {
 namespace cpu {
 
 void book_precomputed_scales(memory_tracking::registrar_t &scratchpad,
-        const arg_scales_t &attr_scales, size_t wei_scales_count,
+        const scales_t &attr_scales, size_t wei_scales_count,
         bool force_scales_book = false);
 
 bool req_copy_scales(

--- a/src/cpu/x64/brgemm/capi/brgemm_api.cpp
+++ b/src/cpu/x64/brgemm/capi/brgemm_api.cpp
@@ -264,10 +264,9 @@ status_t brgemm_t::execute(const void *A_ptr, const void *B_ptr,
     // TODO: delegate extra memory to scratchpad?
     std::vector<float> wei_scales_v(N_);
 
-    const bool has_src_scales
-            = !attr_.scales_.get(DNNL_ARG_SRC).has_default_values();
+    const bool has_src_scales = !attr_.scales_.has_default_values(DNNL_ARG_SRC);
     const bool has_wei_scales
-            = !attr_.scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
+            = !attr_.scales_.has_default_values(DNNL_ARG_WEIGHTS);
 
     // Save src scale value to re-use it.
     float src_scale_val = 1.f;
@@ -284,7 +283,7 @@ status_t brgemm_t::execute(const void *A_ptr, const void *B_ptr,
         const void *wei_scales_ptr = attr_params->get_scales(DNNL_ARG_WEIGHTS);
         if (wei_scales_ptr == nullptr) return status::invalid_arguments;
 
-        int wei_mask = attr_.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+        int wei_mask = attr_.scales_.get_mask(DNNL_ARG_WEIGHTS);
         if (wei_mask > 0) {
             for (dim_t i = 0; i < N_; i++) {
                 const float wei_scale_val = cpu::io::load_float_value(
@@ -305,7 +304,7 @@ status_t brgemm_t::execute(const void *A_ptr, const void *B_ptr,
 
     // Destination scales. Require manual extending to full simd broadcast.
     alignas(64) float dst_scales_buf[16] = {0};
-    if (!attr_.scales_.get(DNNL_ARG_DST).has_default_values()) {
+    if (!attr_.scales_.has_default_values(DNNL_ARG_DST)) {
         const void *dst_scales_ptr = attr_params->get_scales(DNNL_ARG_DST);
         if (dst_scales_ptr == nullptr) return status::invalid_arguments;
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1217,9 +1217,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             = (avaliable_ops) ? ops_tile_store / avaliable_ops + 1 : 0;
     if (jcp.per_one_pstore > 12) jcp.per_one_pstore = 0;
 
-    const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = attr.scales_.get_mask(DNNL_ARG_WEIGHTS) > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     return status::success;

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,11 +73,10 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = scale_utils::precompute_scales(
             ctx.get_scratchpad_grantor(), src_scales, wei_scales, pd()->IC(),
-            pd()->OC(), false, wei_scale_mask != 0, pd()->attr(),
+            pd()->OC(), false, wei_scale_mask > 0, pd()->attr(),
             jit_scale_precompute_.get());
 
     DEFINE_ZERO_POINTS_BUFFER(src_zero_point, DNNL_ARG_SRC);

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -118,8 +118,8 @@ struct jit_avx512_core_amx_1x1_convolution_fwd_t : public primitive_t {
         const auto attr = pd()->attr();
         if (is_jit_supported && pd()->OC() > 1 && req_copy_scales(attr)) {
             const auto &attr_scales = attr->scales_;
-            int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
-            if (wei_scale_mask != 0) {
+            int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+            if (wei_scale_mask > 0) {
                 CHECK(safe_ptr_assign(jit_scale_precompute_,
                         new jit_avx512_core_scale_precompute_t(attr)));
                 CHECK(jit_scale_precompute_->create_kernel());

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -2655,7 +2655,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     // Note: currently unsupported, results in seg-fault
@@ -3969,7 +3969,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_ic_scale = wei_scales.mask_ != 0;
+    jcp.is_ic_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     return status::success;

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -99,11 +99,10 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = scale_utils::precompute_scales(
             ctx.get_scratchpad_grantor(), src_scales, wei_scales, pd()->IC(),
-            pd()->OC(), false, wei_scale_mask != 0, pd()->attr(),
+            pd()->OC(), false, wei_scale_mask > 0, pd()->attr(),
             jit_scale_precompute_.get());
 
     auto inp_p_buffer = ctx.get_scratchpad_grantor().template get<char>(
@@ -457,11 +456,10 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = scale_utils::precompute_scales(
             ctx.get_scratchpad_grantor(), src_scales, wei_scales, pd()->IC(),
-            pd()->OC(), false, wei_scale_mask != 0, pd()->attr(),
+            pd()->OC(), false, wei_scale_mask > 0, pd()->attr(),
             jit_scale_precompute_.get());
 
     // TODO: use block offset instead of hand-calculated one
@@ -831,11 +829,10 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = scale_utils::precompute_scales(
             ctx.get_scratchpad_grantor(), src_scales, wei_scales, pd()->IC(),
-            pd()->OC(), false, wei_scale_mask != 0, pd()->attr(),
+            pd()->OC(), false, wei_scale_mask > 0, pd()->attr(),
             jit_scale_precompute_.get());
 
     amx_utils::execute_backward_convolution_body(ctx, pd()->jcp_, kernel_,

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -120,8 +120,8 @@ struct jit_avx512_core_amx_convolution_fwd_t : public primitive_t {
         const auto attr = pd()->attr();
         if (is_jit_supported && pd()->OC() > 1 && req_copy_scales(attr)) {
             const auto &attr_scales = attr->scales_;
-            int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
-            if (wei_scale_mask != 0) {
+            int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+            if (wei_scale_mask > 0) {
                 CHECK(safe_ptr_assign(jit_scale_precompute_,
                         new jit_avx512_core_scale_precompute_t(attr)));
                 CHECK(jit_scale_precompute_->create_kernel());
@@ -203,8 +203,8 @@ struct jit_avx512_core_amx_convolution_bwd_data_t : public primitive_t {
         const auto attr = pd()->attr();
         if (is_jit_supported && pd()->OC() > 1 && req_copy_scales(attr)) {
             const auto &attr_scales = attr->scales_;
-            int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
-            if (wei_scale_mask != 0) {
+            int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+            if (wei_scale_mask > 0) {
                 CHECK(safe_ptr_assign(jit_scale_precompute_,
                         new jit_avx512_core_scale_precompute_t(attr)));
                 CHECK(jit_scale_precompute_->create_kernel());

--- a/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,11 +78,10 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = precompute_scales(ctx.get_scratchpad_grantor(),
             src_scales, wei_scales, src_d.dims()[1], dst_d.dims()[1], false,
-            wei_scale_mask != 0, pd()->attr());
+            wei_scale_mask > 0, pd()->attr());
 
     // The body of bwd/d convolution harness is called with:
     //   1. src as input instead of diff_dst

--- a/src/cpu/x64/jit_avx512_core_scale_precompute.hpp
+++ b/src/cpu/x64/jit_avx512_core_scale_precompute.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -70,17 +70,12 @@ struct jit_avx512_core_scale_precompute_t : public jit_generator {
             const primitive_attr_t *attr, const float scale_adjust_factor = 1)
         : jit_generator(jit_name())
         , attr_(attr)
-        , with_wei_scales_(
-                  !attr_->scales_.get(DNNL_ARG_WEIGHTS).has_default_values())
+        , with_wei_scales_(!attr_->scales_.has_default_values(DNNL_ARG_WEIGHTS))
         , wei_scales_dt_(with_wei_scales_
-                          ? attr_->scales_.get(DNNL_ARG_WEIGHTS).data_type_
+                          ? attr_->scales_.get_data_type(DNNL_ARG_WEIGHTS)
                           : data_type::f32)
         , wei_scales_dsz_(types::data_type_size(wei_scales_dt_))
-        , wei_groups_ic_(with_wei_scales_
-                                  && attr_->scales_.get(DNNL_ARG_WEIGHTS).ndims_
-                                          > 0
-                          ? attr_->scales_.get(DNNL_ARG_WEIGHTS).group_dims_[0]
-                          : 1)
+        , wei_groups_ic_(attr_->scales_.get_group(DNNL_ARG_WEIGHTS, 0))
         , scale_adjust_factor_(scale_adjust_factor)
         , compute_scale_factor_(scale_adjust_factor_ != 1) {}
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1206,7 +1206,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel::init_conf(
 
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     jcp.wei_adj_scale
@@ -1222,7 +1222,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel::init_scratchpad(
         const jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr) {
     using namespace dnnl::impl::memory_tracking::names;
 
-    const int wei_mask = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
     const dim_t scales_count
             = wei_mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
     const dim_t count = nstl::max<dim_t>(scales_count, (dim_t)jcp.ic_block);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2023 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward(
             = scratchpad.template get<float>(key_conv_adjusted_scales);
     // Src scale is always a single value
     float src_scale = src_scales[0];
-    int wei_mask = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.f;
@@ -92,7 +92,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward(
         auto dw_local_scales
                 = dw_scratchpad.template get<float>(key_conv_adjusted_scales);
         auto attr_dw = pd()->dw_conv_pd_->attr();
-        int wei_mask = attr_dw->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+        int wei_mask = attr_dw->scales_.get_mask(DNNL_ARG_WEIGHTS);
         dim_t count = wei_mask == 0 ? 1 : pd()->dw_conv_pd_->OC();
         float factor = 1.f / jcp_dw->wei_adj_scale;
         if (count == 1) {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1486,7 +1486,7 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
 
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     jcp.has_vnni = mayiuse(avx512_core_vnni);
@@ -1765,7 +1765,7 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
 void jit_avx512_core_x8s8s32x_fwd_kernel::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
-    const int wei_mask = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
     const dim_t scales_count = wei_mask == 0 ? 1 : jcp.oc * jcp.ngroups;
     dim_t count = wei_mask == 0 ? (dim_t)16 : scales_count;
     scratchpad.book<float>(key_conv_adjusted_scales, count);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ const float *jit_avx512_core_x8s8s32x_convolution_fwd_t::adjust_oscales(
         const float *wei_scales) const {
     auto loc_scales = scratchpad.template get<float>(key_conv_adjusted_scales);
     const float src_scale = src_scales[0];
-    const int wei_mask = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.f;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -294,7 +294,7 @@ status_t _jit_avx512_core_x8s8s32x_deconv_fwd_kernel::init_conf(
 
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     jcp.dst_dt = dst_d.data_type();
@@ -386,7 +386,7 @@ bool _jit_avx512_core_x8s8s32x_deconv_fwd_kernel::post_ops_ok(
 void _jit_avx512_core_x8s8s32x_deconv_fwd_kernel::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
-    const int mask = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
     const dim_t scales_count
             = mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
     const dim_t count = nstl::max<dim_t>(scales_count, 16);
@@ -1393,7 +1393,7 @@ const float *jit_avx512_core_x8s8s32x_deconvolution_fwd_t::adjust_oscales(
         const memory_tracking::grantor_t &scratchpad, const float *src_scales,
         const float *wei_scales) const {
     auto loc_scales = scratchpad.template get<float>(key_conv_adjusted_scales);
-    int wei_mask = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.0f;

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -240,7 +240,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
     const auto &wei_scales = attr_.scales_.get(DNNL_ARG_WEIGHTS);
     jcp.with_scale = !src_scales.has_default_values()
             || !wei_scales.has_default_values();
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
     const bool scales_ok
             = attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST});
@@ -557,8 +557,8 @@ status_t brdgmm_dw_convolution_fwd_t::init(engine_t *engine) {
     const auto attr = pd()->attr();
     if (is_jit_supported && pd()->OC() > 1 && req_copy_scales(attr)) {
         const auto &attr_scales = attr->scales_;
-        int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
-        if (wei_scale_mask != 0) {
+        int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+        if (wei_scale_mask > 0) {
             CHECK(safe_ptr_assign(jit_scale_precompute_,
                     new jit_avx512_core_scale_precompute_t(attr)));
             CHECK(jit_scale_precompute_->create_kernel());
@@ -588,11 +588,10 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
     DEFINE_ZERO_POINTS_BUFFER(src_zero_point, DNNL_ARG_SRC);
     DEFINE_ZERO_POINTS_BUFFER(dst_zero_point, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = scale_utils::precompute_scales(
             ctx.get_scratchpad_grantor(), src_scales, wei_scales, pd()->IC(),
-            pd()->OC(), false, wei_scale_mask != 0, pd()->attr(),
+            pd()->OC(), false, wei_scale_mask > 0, pd()->attr(),
             jit_scale_precompute_.get());
 
     const memory_desc_wrapper weights_d(pd()->weights_md(0));

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -286,8 +286,8 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
     if (is_jit_supported && pd()->OC() > 1
             && req_copy_scales(attr, jcp.scale_adjust_factor)) {
         const auto &attr_scales = attr->scales_;
-        int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
-        if (wei_scale_mask != 0) {
+        int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+        if (wei_scale_mask > 0) {
             CHECK(safe_ptr_assign(jit_scale_precompute_,
                     new jit_avx512_core_scale_precompute_t(
                             attr, jcp.scale_adjust_factor)));
@@ -723,11 +723,10 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::execute_forward_all(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = scale_utils::precompute_scales(scratchpad,
             src_scales, wei_scales, pd()->IC(), pd()->OC(), false,
-            wei_scale_mask != 0, pd()->attr(), jit_scale_precompute_.get(),
+            wei_scale_mask > 0, pd()->attr(), jit_scale_precompute_.get(),
             jcp.scale_adjust_factor);
 
     DEFINE_ZERO_POINT_VALUE(src_zero_point, DNNL_ARG_SRC);

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -933,8 +933,8 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
     if (is_jit_supported && pd()->OC() > 1
             && req_copy_scales(attr, jcp.scale_adjust_factor)) {
         const auto &attr_scales = attr->scales_;
-        int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
-        if (wei_scale_mask != 0) {
+        int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+        if (wei_scale_mask > 0) {
             CHECK(safe_ptr_assign(jit_scale_precompute_,
                     new jit_avx512_core_scale_precompute_t(
                             attr, jcp.scale_adjust_factor)));
@@ -1274,11 +1274,10 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 
     const memory_tracking::grantor_t scratchpad = ctx.get_scratchpad_grantor();
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales = scale_utils::precompute_scales(scratchpad,
             src_scales, wei_scales, pd()->IC(), pd()->OC(), false,
-            wei_scale_mask != 0, pd()->attr(), jit_scale_precompute_.get(),
+            wei_scale_mask > 0, pd()->attr(), jit_scale_precompute_.get(),
             jcp.scale_adjust_factor);
 
     brgemm_exec_ctx_t brgemm_ctx(ctx, _pd);

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2048,7 +2048,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         jcp.with_scales = !src_scales.has_default_values()
                 || !wei_scales.has_default_values()
                 || jcp.scale_adjust_factor != 1.0f;
-        jcp.is_ic_scale = wei_scales.mask_ != 0;
+        jcp.is_ic_scale = wei_scales.get_mask() > 0;
     }
 
     jcp.req_brg_comp_pad = false;

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -2348,7 +2348,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.with_scales = !src_scales.has_default_values()
             || !wei_scales.has_default_values()
             || jcp.scale_adjust_factor != 1.0f;
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
     const bool compensation_w_padding
             = (jcp.s8s8_compensation_required || jcp.src_zero_point)
@@ -2611,7 +2611,7 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.with_scales = !src_scales.has_default_values()
             || !wei_scales.has_default_values()
             || jcp.scale_adjust_factor != 1.0f;
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
     // enable ununroll_bd_loop for big shapes to reduce kernel sizes
     jcp.ununroll_bd_loop

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -94,8 +94,7 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
     DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
-    const int wei_scale_mask
-            = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_scale_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     const float *oscales
             = scale_utils::precompute_scales(scratchpad, src_scales, wei_scales,
                     pd()->IC(), pd()->OC(), false, wei_scale_mask == (1 << 0),

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -225,8 +225,8 @@ struct brgemm_inner_product_fwd_t : public primitive_t {
         const auto attr = pd()->attr();
         if (is_jit_supported && pd()->OC() > 1 && req_copy_scales(attr)) {
             const auto &attr_scales = attr->scales_;
-            int wei_scale_mask = attr_scales.get(DNNL_ARG_WEIGHTS).mask_;
-            if (wei_scale_mask != 0) {
+            int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
+            if (wei_scale_mask > 0) {
                 CHECK(safe_ptr_assign(jit_scale_precompute_,
                         new jit_avx512_core_scale_precompute_t(attr)));
                 CHECK(jit_scale_precompute_->create_kernel());

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -444,8 +444,7 @@ status_t jit_brgemm_ip_fwd_conf_t::init_conf(cpu_isa_t isa,
     const memory_desc_wrapper dst_d(&dst_md);
     if (!post_ops_ok(attr, dst_d)) return status::unimplemented;
     if (jbgp.with_scales) {
-        const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
-        jbgp.is_oc_scale = wei_scales.mask_ != 0;
+        jbgp.is_oc_scale = attr.scales_.get_mask(DNNL_ARG_WEIGHTS) > 0;
     }
 
     const int min_ic_divisor = is_amx_int8 ? 4 : is_amx_xf16 ? 2 : 1;

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -579,7 +579,8 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
     const auto &wei_scales = attr_.scales_.get(DNNL_ARG_WEIGHTS);
     // per_oc: conv: 1 << 0, (1 << 1) + (1 << 0) (with groups)
     // per_oc: ip: 1 << 0
-    is_oc_scale_ = utils::one_of(wei_scales.mask_, 1 << 0, (1 << 1) + (1 << 0));
+    is_oc_scale_
+            = utils::one_of(wei_scales.get_mask(), 1 << 0, (1 << 1) + (1 << 0));
 
     inp_dt_ = brg_.dt_c;
     out_dt_ = brg_.dt_d;

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -288,7 +288,7 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
 
     if (this->do_bias()) compute_vreg_bias_shift_ = compute_vregs_per_iter_++;
 
-    if (!attr->scales_.get(DNNL_ARG_DST).has_default_values()) {
+    if (!attr->scales_.has_default_values(DNNL_ARG_DST)) {
         this->do_dst_scale_ = true;
         vreg_dst_scale = Vmm(idx_compute_vreg_start_++);
     }

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -172,10 +172,8 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     conf_.is_f16 = conf_.dst_type == f16;
     conf_.op_type = get_op_type(src0_md_);
     assert(conf_.op_type != op_t::none);
-    conf_.do_scale_src0
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
-    conf_.do_scale_src1
-            = !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
+    conf_.do_scale_src0 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.do_scale_src1 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_1);
     const auto sum_idx = po.find(primitive_kind::sum);
     conf_.do_sum = sum_idx != -1 && po.entry_[sum_idx].sum.scale != 0.f;
     conf_.with_eltwise = po.find(primitive_kind::eltwise) != -1;

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -84,8 +84,8 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
         with_eltwise_ = post_ops.find(primitive_kind::eltwise) != -1;
 
         const auto &attr_scales = pd->attr()->scales_;
-        with_src_scales_ = !attr_scales.get(DNNL_ARG_SRC).has_default_values();
-        with_dst_scales_ = !attr_scales.get(DNNL_ARG_DST).has_default_values();
+        with_src_scales_ = !attr_scales.has_default_values(DNNL_ARG_SRC);
+        with_dst_scales_ = !attr_scales.has_default_values(DNNL_ARG_DST);
 
         io::io_conf_t io_conf;
         io::io_tail_conf_t io_tail_conf(simd_w_, axis_simd_tail_,

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,8 +82,8 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
         with_eltwise_ = post_ops.find(primitive_kind::eltwise) != -1;
 
         const auto &attr_scales = pd->attr()->scales_;
-        with_src_scales_ = !attr_scales.get(DNNL_ARG_SRC).has_default_values();
-        with_dst_scales_ = !attr_scales.get(DNNL_ARG_DST).has_default_values();
+        with_src_scales_ = !attr_scales.has_default_values(DNNL_ARG_SRC);
+        with_dst_scales_ = !attr_scales.has_default_values(DNNL_ARG_DST);
 
         io::io_conf_t io_conf;
         io::io_tail_conf_t io_tail_conf(simd_w_, axis_simd_tail_,

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -128,8 +128,8 @@ struct jit_stat_and_data_base_kernel_t : stat_and_data_kernel_t,
         with_eltwise_ = post_ops.find(primitive_kind::eltwise) != -1;
 
         const auto &attr_scales = pd_->attr()->scales_;
-        with_src_scales_ = !attr_scales.get(DNNL_ARG_SRC).has_default_values();
-        with_dst_scales_ = !attr_scales.get(DNNL_ARG_DST).has_default_values();
+        with_src_scales_ = !attr_scales.has_default_values(DNNL_ARG_SRC);
+        with_dst_scales_ = !attr_scales.has_default_values(DNNL_ARG_DST);
 
         io::io_conf_t io_conf;
         io::io_tail_conf_t io_tail_conf(simd_w_, axis_simd_tail_,

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2324,13 +2324,10 @@ status_t jit_uni_reorder_t::pd_t::init_scratchpad() {
                 compensation_reduce_size);
     }
 
-    const memory_desc_wrapper input_d(src_md());
-    int scales_mask = -1;
-    bool is_set = false;
-    CHECK(attr()->scales_.get(DNNL_ARG_DST, &scales_mask, &is_set));
-
-    if (is_set && scales_mask > 0) {
-        get_D_values(input_d, scales_mask, nullptr, &D_mask_, nullptr);
+    if (!attr()->scales_.has_default_values(DNNL_ARG_DST)) {
+        const memory_desc_wrapper input_d(src_md());
+        int mask = attr()->scales_.get_mask(DNNL_ARG_DST);
+        get_D_values(input_d, mask, nullptr, &D_mask_, nullptr);
         if (D_mask_ > 1) {
             scratchpad.template book<float>(
                     memory_tracking::names::key_reorder_precomputed_dst_scales,

--- a/src/cpu/x64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/x64/jit_uni_reorder_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -273,24 +273,21 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
     p.src_scale_type = scale_type_t::NONE;
     int src_mask = 0;
-    bool is_src_set = false;
-    CHECK(attr->scales_.get(DNNL_ARG_SRC, &src_mask, &is_src_set));
-    if (is_src_set) {
+    if (!attr->scales_.has_default_values(DNNL_ARG_SRC)) {
+        src_mask = attr->scales_.get_mask(DNNL_ARG_SRC);
         p.src_scale_type
                 = src_mask == 0 ? scale_type_t::COMMON : scale_type_t::MANY;
     }
 
     p.dst_scale_type = scale_type_t::NONE;
     int dst_mask = 0;
-    bool is_dst_set = false;
-    CHECK(attr->scales_.get(DNNL_ARG_DST, &dst_mask, &is_dst_set));
-    if (is_dst_set) {
+    if (!attr->scales_.has_default_values(DNNL_ARG_DST)) {
+        dst_mask = attr->scales_.get_mask(DNNL_ARG_DST);
         p.dst_scale_type
                 = dst_mask == 0 ? scale_type_t::COMMON : scale_type_t::MANY;
     }
 
-    if (is_src_set && is_dst_set && src_mask != dst_mask)
-        return status::unimplemented;
+    if (src_mask != dst_mask) return status::unimplemented;
 
     p.scale_adjust = (om_d.extra().flags & memory_extra_flags::scale_adjust)
             ? om_d.extra().scale_adjust

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -969,9 +969,9 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
 
         const auto &attr_scales = pd_->attr()->scales_;
         with_src_scales_ = is_superset(isa, avx2)
-                && !attr_scales.get(DNNL_ARG_SRC).has_default_values();
+                && !attr_scales.has_default_values(DNNL_ARG_SRC);
         with_dst_scales_ = is_superset(isa, avx2)
-                && !attr_scales.get(DNNL_ARG_DST).has_default_values();
+                && !attr_scales.has_default_values(DNNL_ARG_DST);
 
         io::io_conf_t io_conf;
         io::io_tail_conf_t io_tail_conf(simd_w_, axis_simd_tail_,
@@ -1529,9 +1529,9 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
 
         const auto &attr_scales = pd_->attr()->scales_;
         with_src_scales_ = is_superset(isa, avx2)
-                && !attr_scales.get(DNNL_ARG_SRC).has_default_values();
+                && !attr_scales.has_default_values(DNNL_ARG_SRC);
         with_dst_scales_ = is_superset(isa, avx2)
-                && !attr_scales.get(DNNL_ARG_DST).has_default_values();
+                && !attr_scales.has_default_values(DNNL_ARG_DST);
 
         io::io_conf_t io_conf;
         io::io_tail_conf_t io_tail_conf(simd_w_, axis_simd_tail_,

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -910,7 +910,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel<isa>::init_conf(
 
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     jcp.wei_adj_scale
@@ -927,7 +927,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel<isa>::init_scratchpad(
         const jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr) {
     using namespace dnnl::impl::memory_tracking::names;
 
-    const int wei_mask = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
     const dim_t scales_count
             = wei_mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
     const dim_t count = nstl::max<dim_t>(scales_count, 8);

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ status_t jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward(
     const float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.0f;
-    int wei_mask = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     if (wei_mask == 0) {
         utils::array_set(
                 local_scales, src_scales[0] * wei_scales[0] * factor, 8);
@@ -94,7 +94,7 @@ status_t jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward(
 
         auto dw_local_scales
                 = dw_scratchpad.template get<float>(key_conv_adjusted_scales);
-        int wei_mask = attr_dw->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+        int wei_mask = attr_dw->scales_.get_mask(DNNL_ARG_WEIGHTS);
         float factor = 1.f / jcp_dw->wei_adj_scale;
         if (wei_mask == 0) {
             utils::array_set(dw_local_scales,

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1315,7 +1315,7 @@ status_t jit_uni_x8s8s32x_fwd_kernel<isa>::init_conf(jit_conv_conf_t &jcp,
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
 
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     const auto zp = attr.zero_points_;
@@ -1614,7 +1614,7 @@ void jit_uni_x8s8s32x_fwd_kernel<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
 
-    const int mask = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
     const dim_t scales_count
             = mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
     dim_t count = scales_count == 1 ? (dim_t)8 : scales_count;

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ const float *jit_uni_x8s8s32x_convolution_fwd_t<isa>::adjust_oscales(
         const memory_tracking::grantor_t &scratchpad, const float *src_scales,
         const float *wei_scales) const {
     auto loc_scales = scratchpad.template get<float>(key_conv_adjusted_scales);
-    int wei_mask = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.0f;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -272,7 +272,7 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel<isa>::init_conf(
 
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
     const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    jcp.is_oc_scale = wei_scales.mask_ != 0;
+    jcp.is_oc_scale = wei_scales.get_mask() > 0;
     jcp.dst_scale = !dst_scales.has_default_values();
 
     jcp.post_ops = p;
@@ -386,7 +386,7 @@ template <cpu_isa_t isa>
 void jit_uni_x8s8s32x_deconv_fwd_kernel<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
-    const int mask = attr.scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    const int mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
     const dim_t scales_count
             = mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
     dim_t count = nstl::max<dim_t>(scales_count, 8);
@@ -1451,7 +1451,7 @@ const float *jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::adjust_oscales(
         const memory_tracking::grantor_t &scratchpad, const float *src_scales,
         const float *wei_scales) const {
     auto loc_scales = scratchpad.template get<float>(key_conv_adjusted_scales);
-    int wei_mask = pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_;
+    int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.0f;

--- a/src/gpu/generic/ref_concat.hpp
+++ b/src/gpu/generic/ref_concat.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,12 +60,8 @@ struct ref_concat_t : public gpu::primitive_t {
             reorder_pds_.resize(n_ + use_tent_dst());
             for (int i = 0; i < n_; ++i) {
                 primitive_attr_t r_attr;
-                int mask = 0;
-                bool is_set = false;
-                VDISPATCH_CONCAT_SC(
-                        sc.get(DNNL_ARG_MULTIPLE_SRC + i, &mask, &is_set),
-                        VERBOSE_UNSUPPORTED_SCALES_CFG);
-                if (is_set) {
+                if (!sc.get(DNNL_ARG_MULTIPLE_SRC + i).has_default_values()) {
+                    int mask = sc.get_mask(DNNL_ARG_MULTIPLE_SRC + i);
                     VDISPATCH_CONCAT(mask == 0, "non-zero mask");
                     VDISPATCH_CONCAT_SC(r_attr.scales_.set(DNNL_ARG_SRC, mask),
                             VERBOSE_UNSUPPORTED_SCALES_CFG);

--- a/src/gpu/generic/sycl/ref_binary.cpp
+++ b/src/gpu/generic/sycl/ref_binary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,10 +37,8 @@ status_t ref_binary_t::pd_t::init_conf() {
     conf_.alg_kind = desc()->alg_kind;
     // Limitations:
     // - Only common scale policy is supported.
-    conf_.do_scale_src0
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
-    conf_.do_scale_src1
-            = !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values();
+    conf_.do_scale_src0 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.do_scale_src1 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_1);
     conf_.is_tensor_op = is_tensor_op();
     for (size_t i = 0; i < xpu::sycl::md_t::max_dims; i++) {
         conf_.broadcast_dims0[i]

--- a/src/gpu/generic/sycl/ref_binary.hpp
+++ b/src/gpu/generic/sycl/ref_binary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,8 +87,7 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
             const auto &scales = attr()->scales_;
             bool dt_ok = true;
             for (auto arg : supported_args) {
-                auto &s = scales.get(arg);
-                dt_ok = dt_ok && is_supported_type(s.data_type_);
+                dt_ok = dt_ok && is_supported_type(scales.get_data_type(arg));
             }
             return dt_ok && attr_scales_ok(supported_args);
         }

--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,14 +38,11 @@ status_t ref_convolution_fwd_t::pd_t::init_conf() {
 
     conf_.wk_size = memory_desc_wrapper(dst_md()).nelems();
 
-    conf_.do_scale_data
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_data = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
     conf_.do_scale_weights
-            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
-    conf_.do_scale_dst
-            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
-    conf_.single_weight_scale
-            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+            = !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
+    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
+    conf_.single_weight_scale = attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) == 0;
 
     conf_.use_data_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);
@@ -103,14 +100,11 @@ status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
 
     conf_.wk_size = memory_desc_wrapper(diff_src_md()).nelems();
 
-    conf_.do_scale_data
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_data = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
     conf_.do_scale_weights
-            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
-    conf_.do_scale_dst
-            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
-    conf_.single_weight_scale
-            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+            = !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
+    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
+    conf_.single_weight_scale = attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) == 0;
 
     conf_.use_data_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);
@@ -169,14 +163,11 @@ status_t ref_convolution_bwd_weights_t::pd_t::init_conf() {
 
     conf_.wk_size = memory_desc_wrapper(diff_weights_md()).nelems();
 
-    conf_.do_scale_data
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_data = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
     conf_.do_scale_weights
-            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
-    conf_.do_scale_dst
-            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
-    conf_.single_weight_scale
-            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+            = !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
+    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
+    conf_.single_weight_scale = attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) == 0;
 
     conf_.use_data_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ inline bool check_convolution_scales_types(const primitive_attr_t *attr) {
 
     const auto &scales = attr->scales_;
     for (auto arg : supported_args) {
-        auto dt = scales.get(arg).data_type_;
+        const auto dt = scales.get_data_type(arg);
         if (!is_supported_type(dt)) { return false; }
     }
     return true;

--- a/src/gpu/generic/sycl/ref_layer_normalizations.cpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,15 +41,11 @@ status_t ref_layer_normalization_fwd_t::pd_t::init_conf() {
     conf_.block_size = 16;
 
     conf_.rt_scaling = !attr()->scales_.has_default_values();
-    conf_.src_def = attr()->scales_.get(DNNL_ARG_SRC).has_default_values();
-    conf_.dst_def = attr()->scales_.get(DNNL_ARG_DST).has_default_values();
+    conf_.src_def = attr()->scales_.has_default_values(DNNL_ARG_SRC);
+    conf_.dst_def = attr()->scales_.has_default_values(DNNL_ARG_DST);
 
-    conf_.scales_src_dt = conf_.src_def
-            ? data_type_t::dnnl_f32
-            : attr()->scales_.get(DNNL_ARG_SRC).data_type_;
-    conf_.scales_dst_dt = conf_.dst_def
-            ? data_type_t::dnnl_f32
-            : attr()->scales_.get(DNNL_ARG_DST).data_type_;
+    conf_.scales_src_dt = attr()->scales_.get_data_type(DNNL_ARG_SRC);
+    conf_.scales_dst_dt = attr()->scales_.get_data_type(DNNL_ARG_DST);
 
     conf_.use_scale = use_scale();
     conf_.use_shift = use_shift();

--- a/src/gpu/generic/sycl/ref_layer_normalizations.hpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ struct ref_layer_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
 
             const auto &scales = attr()->scales_;
             for (auto arg : supported_args) {
-                auto dt = scales.get(arg).data_type_;
+                const auto dt = scales.get_data_type(arg);
                 if (!is_supported_type(dt)) { return false; }
             }
             return true;

--- a/src/gpu/generic/sycl/ref_matmul.cpp
+++ b/src/gpu/generic/sycl/ref_matmul.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,14 +26,12 @@ namespace sycl {
 void ref_matmul_t::pd_t::init_conf() {
     conf_ = sycl_matmul_conf_t();
 
-    conf_.do_scale_data
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
+    conf_.do_scale_data = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
     conf_.do_scale_weights
-            = !attr()->scales_.get(DNNL_ARG_WEIGHTS).has_default_values();
-    conf_.do_scale_dst
-            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
+            = !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
+    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
     conf_.single_weights_scale
-            = attr()->scales_.get(DNNL_ARG_WEIGHTS).mask_ == 0;
+            = attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) == 0;
 
     conf_.use_data_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC_0);

--- a/src/gpu/generic/sycl/ref_matmul.hpp
+++ b/src/gpu/generic/sycl/ref_matmul.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -122,8 +122,7 @@ struct ref_matmul_t : public gpu::generic::sycl::primitive_t {
             const auto &scales = attr()->scales_;
             bool dt_ok = true;
             for (auto arg : supported_args) {
-                auto &s = scales.get(arg);
-                dt_ok = dt_ok && is_supported_type(s.data_type_);
+                dt_ok = dt_ok && is_supported_type(scales.get_data_type(arg));
             }
             return dt_ok && attr_scales_ok(supported_args);
         }

--- a/src/gpu/generic/sycl/ref_reorder.cpp
+++ b/src/gpu/generic/sycl/ref_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,12 +32,10 @@ status_t ref_reorder_t::pd_t::init_conf() {
 
     conf_.wk_size = memory_desc_wrapper(src_md(0)).nelems();
 
-    conf_.do_scale_src
-            = !attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values();
-    conf_.scale_src_mask = attr()->scales_.get(DNNL_ARG_SRC_0).mask_;
-    conf_.do_scale_dst
-            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
-    conf_.scale_dst_mask = attr()->scales_.get(DNNL_ARG_DST).mask_;
+    conf_.do_scale_src = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.scale_src_mask = attr()->scales_.get_mask(DNNL_ARG_SRC_0);
+    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
+    conf_.scale_dst_mask = attr()->scales_.get_mask(DNNL_ARG_DST);
     conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     return status::success;

--- a/src/gpu/generic/sycl/ref_reorder.hpp
+++ b/src/gpu/generic/sycl/ref_reorder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
 
             const auto &scales = attr()->scales_;
             for (auto arg : supported_args) {
-                auto dt = scales.get(arg).data_type_;
+                const auto dt = scales.get_data_type(arg);
                 if (!is_supported_type(dt)) { return false; }
             }
             return true;

--- a/src/gpu/generic/sycl/ref_softmax.cpp
+++ b/src/gpu/generic/sycl/ref_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,10 +36,8 @@ status_t ref_sycl_softmax_fwd_t::pd_t::init_conf() {
     conf_.channels = axis_size();
     conf_.wk_size = inner_size() * outer_size();
 
-    conf_.do_scale_src
-            = !attr()->scales_.get(DNNL_ARG_SRC).has_default_values();
-    conf_.do_scale_dst
-            = !attr()->scales_.get(DNNL_ARG_DST).has_default_values();
+    conf_.do_scale_src = !attr()->scales_.has_default_values(DNNL_ARG_SRC);
+    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
 
     conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 

--- a/src/gpu/generic/sycl/ref_softmax.hpp
+++ b/src/gpu/generic/sycl/ref_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
             VDISPATCH_SOFTMAX(attr()->has_default_values(
                                       sm::scales_runtime | sm::post_ops),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_SOFTMAX(attr_oscale_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_SOFTMAX(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_SOFTMAX(sycl_post_ops_t::post_ops_ok(attr(), true, false),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_SOFTMAX_SC(
@@ -66,15 +66,6 @@ struct ref_sycl_softmax_fwd_t : public gpu::generic::sycl::primitive_t {
 
         sycl_softmax_conf_t conf_;
         status_t init_conf();
-
-        bool attr_oscale_ok() const {
-            const auto &scales = attr()->scales_;
-            bool ok = true;
-            for (const auto &e : scales.scales_) {
-                ok = ok && e.second.mask_ == 0;
-            }
-            return ok;
-        }
 
         bool check_data_types(data_type_t src) {
             return utils::one_of(src, data_type::f32, data_type::bf16,

--- a/src/gpu/generic/sycl/ref_sum.hpp
+++ b/src/gpu/generic/sycl/ref_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,15 +60,13 @@ struct ref_sum_t : public gpu::generic::sycl::primitive_t {
 
                 // Block formats are not yet supported
                 // Dimensions can not be > 6
-                VDISPATCH_SUM(
-                        !(!src_d.is_plain()
-                                || src_d.ndims() > xpu::sycl::md_t::max_dims),
+                VDISPATCH_SUM(src_d.is_plain()
+                                && src_d.ndims() <= xpu::sycl::md_t::max_dims,
                         VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "src");
 
-                VDISPATCH_SUM(!(!attr()->scales_.has_default_values()
-                                      && !is_supported_type(
-                                              scales.get(DNNL_ARG_SRC + i)
-                                                      .data_type_)),
+                VDISPATCH_SUM(attr()->scales_.has_default_values()
+                                || is_supported_type(
+                                        scales.get_data_type(DNNL_ARG_SRC + i)),
                         VERBOSE_UNSUPPORTED_ATTR);
             }
 

--- a/src/gpu/generic/sycl/reorder_kernels.hpp
+++ b/src/gpu/generic/sycl/reorder_kernels.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,14 +73,14 @@ struct reorder_kernel_t {
                     = (i < src_md().ndims()) ? src_md().strides()[i] : INT_MAX;
         }
         dims_t dims_scales_src;
-        if (conf_.scale_src_mask != 0) {
+        if (conf_.scale_src_mask > 0) {
             for (int i = 0; i < max_supported_ndims; i++) {
                 dims_scales_src[i]
                         = conf_.scale_src_mask >> i & 1 ? dims[i] : 1;
             }
         }
         dims_t dims_scales_dst;
-        if (conf_.scale_dst_mask != 0) {
+        if (conf_.scale_dst_mask > 0) {
             for (int i = 0; i < max_supported_ndims; i++) {
                 dims_scales_dst[i]
                         = conf_.scale_dst_mask >> i & 1 ? dims[i] : 1;
@@ -97,7 +97,7 @@ struct reorder_kernel_t {
             auto src = src_mem.load(idx);
 
             if (conf_.do_scale_src) {
-                if (conf_.scale_src_mask != 0) {
+                if (conf_.scale_src_mask > 0) {
                     int scale_idx = 0;
                     for (int i = 0; i < max_supported_ndims; i++) {
                         if (i < src_md().ndims()) {
@@ -116,7 +116,7 @@ struct reorder_kernel_t {
             auto acc = src;
             acc = conf_.post_ops.apply(acc, dst_, dst_idx);
             if (conf_.do_scale_dst) {
-                if (conf_.scale_dst_mask != 0) {
+                if (conf_.scale_dst_mask > 0) {
                     int scale_idx = 0;
                     for (int i = 0; i < max_supported_ndims; i++) {
                         if (i < src_md().ndims()) {

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -974,7 +974,9 @@ bool post_ops_ok(const conv_problem_t &prb, const hw_t &hw) {
         scales[i] = scale_args[i].second;
     if (!attr->scales_.has_default_values(scales)) return false;
     for (int arg : scales) {
-        int mask = attr->scales_.get(arg).mask_;
+        if (attr->scales_.has_default_values(arg)) continue;
+
+        int mask = attr->scales_.get(arg).get_mask();
         // XXX: per_oc for BWD_D is treated as per_ic assuming it's called from
         // deconvolution.
         if (arg == DNNL_ARG_WEIGHTS) {

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
@@ -92,70 +92,66 @@ status_t jit_gemm_pd_t::init_post_ops() {
     }
 
     if (!wei_scales->has_default_values()) {
-        const auto &mask = wei_scales->mask_;
+        const auto &mask = wei_scales->get_mask();
         bool convert = (mask == 0 || math::is_pow2(mask));
-        if (wei_scales->ndims_ > 1)
-            convert |= (wei_scales->group_dims_[0] >= d->k());
+        if (!wei_scales->has_default_groups())
+            convert |= (wei_scales->get_group(0) >= d->k());
         if (convert) {
-            ok = ok && (mask == 0 || mask == (1 << (d->c_desc.ndims - 1)));
-
             dim_t dims = {(mask > 0) ? d->m() : 1};
             CHECK(memory_desc_init_by_tag(wei_scales_md, 1, &dims,
-                    wei_scales->data_type_, format_tag::a));
+                    wei_scales->get_data_type(), format_tag::a));
 
-            auto status = post_ops_.prepend_binary(binary_mul, &wei_scales_md);
-            if (status != status::success) return status;
+            CHECK(post_ops_.prepend_binary(binary_mul, &wei_scales_md));
 
             binary_srcs_.insert(binary_srcs_.begin(),
                     binary_src_t {binary_src_t::scales, DNNL_ARG_WEIGHTS});
         }
     }
     if (!src_scales->has_default_values()) {
-        const auto &mask = src_scales->mask_;
+        const auto &mask = src_scales->get_mask();
         bool convert = (mask == 0);
-        if (src_scales->ndims_ > 1) {
-            convert |= (src_scales->group_dims_[1] >= d->k());
+        if (!src_scales->has_default_groups()) {
+            convert |= (src_scales->get_group(1) >= d->k());
         }
         if (convert) {
             if (mask == 0) {
                 dim_t dims = 1;
                 CHECK(memory_desc_init_by_tag(src_scales_md, 1, &dims,
-                        src_scales->data_type_, format_tag::a));
-            } else if (src_scales->ndims_ > 1) {
-                int n_group = src_scales->group_dims_[0];
-                int k_group = src_scales->group_dims_[1];
+                        src_scales->get_data_type(), format_tag::a));
+            } else if (!src_scales->has_default_groups()) {
+                // TODO: is it inverted?
+                int n_group = src_scales->get_group(0);
+                int k_group = src_scales->get_group(1);
                 dim_t dims[]
                         = {(mask & (d->batch() > 1 ? 2 : 1)) ? d->n() / n_group
                                                              : 1,
                                 d->k() / k_group};
                 CHECK(memory_desc_init_by_tag(src_scales_md, 2, dims,
-                        src_scales->data_type_, format_tag::ab));
+                        src_scales->get_data_type(), format_tag::ab));
             } else {
                 dim_t dims[] = {d->n(), 1};
                 CHECK(memory_desc_init_by_tag(src_scales_md, 2, dims,
-                        src_scales->data_type_, format_tag::ab));
+                        src_scales->get_data_type(), format_tag::ab));
             }
 
-            auto status = post_ops_.prepend_binary(binary_mul, &src_scales_md);
-            if (status != status::success) return status;
+            CHECK(post_ops_.prepend_binary(binary_mul, &src_scales_md));
 
             binary_srcs_.insert(binary_srcs_.begin(),
                     binary_src_t {binary_src_t::scales, DNNL_ARG_SRC});
         }
     }
     if (!c_scales->has_default_values()) {
-        const auto &mask = c_scales->mask_;
+        const auto &mask = c_scales->get_mask();
         bool convert = (mask == 0 || math::is_pow2(mask));
-        if (c_scales->ndims_ > 1)
-            convert |= (c_scales->group_dims_[0] >= d->m());
+        if (!c_scales->has_default_groups())
+            convert |= (c_scales->get_group(0) >= d->m());
         if (convert) {
             ok = ok && (mask == 0 || mask == (1 << (d->c_desc.ndims - 1)));
             dim_t dims = {(mask > 0) ? d->m() : 1};
             CHECK(memory_desc_init_by_tag(c_scales_md, 1, &dims,
-                    c_scales->data_type_, format_tag::a));
+                    c_scales->get_data_type(), format_tag::a));
 
-            auto status = post_ops_.append_binary(binary_div, &c_scales_md);
-            if (status != status::success) return status;
+            CHECK(post_ops_.append_binary(binary_div, &c_scales_md));
 
             binary_srcs_.push_back(
                     binary_src_t {binary_src_t::scales, DNNL_ARG_DST});

--- a/src/gpu/intel/jit/ir/tensor_config.cpp
+++ b/src/gpu/intel/jit/ir/tensor_config.cpp
@@ -59,9 +59,8 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
     auto scale_args = get_scale_args();
     for (int i = 0; i < (int)scale_args.size(); i++) {
         int arg = scale_args[i].second;
-        auto &s = attr.scales_.get(arg);
-        if (s.has_default_values()) continue;
-        std::vector<dim_t> dims = {(s.mask_ == 0) ? 1 : oc};
+        if (attr.scales_.has_default_values(arg)) continue;
+        std::vector<dim_t> dims = {(attr.scales_.get_mask(arg) == 0) ? 1 : oc};
         layout_t layout(type_t::f32(), 0, dims);
         int arg_key = DNNL_ARG_ATTR_SCALES | arg;
         tensor_cfg.add_tensor(scale_args[i].first, arg_key, /*is_input=*/true,

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -58,8 +58,13 @@ status_t gen_reorder_t::pd_t::init(impl::engine_t *engine,
         return true;
     };
     auto scales_ok = [&]() {
-        return (attr()->scales_.get(DNNL_ARG_SRC).mask_ == 0)
-                && (attr()->scales_.get(DNNL_ARG_DST).mask_ == 0);
+        const bool src_scale_ok
+                = attr()->scales_.has_default_values(DNNL_ARG_SRC)
+                || attr()->scales_.get_mask(DNNL_ARG_SRC) == 0;
+        const bool dst_scale_ok
+                = attr()->scales_.has_default_values(DNNL_ARG_DST)
+                || attr()->scales_.get_mask(DNNL_ARG_DST) == 0;
+        return src_scale_ok && dst_scale_ok;
     };
     auto is_bf16_or_f32_or_f8 = [](data_type_t dt) {
         return utils::one_of(dt, bf16, f32, f8_e5m2, f8_e4m3);

--- a/src/gpu/intel/ocl/convolution_inner_product.cpp
+++ b/src/gpu/intel/ocl/convolution_inner_product.cpp
@@ -198,7 +198,7 @@ status_t convolution_inner_product_fwd_t::execute_forward(
 
     const auto &args = ctx.args();
     for (const int arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
-        if (pd()->attr()->scales_.get(arg).has_default_values()) continue;
+        if (pd()->attr()->scales_.has_default_values(arg)) continue;
 
         c_args[DNNL_ARG_ATTR_SCALES | arg]
                 = args.at(DNNL_ARG_ATTR_SCALES | arg);

--- a/src/gpu/intel/ocl/gemm/ref_gemm.hpp
+++ b/src/gpu/intel/ocl/gemm/ref_gemm.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -136,9 +136,14 @@ struct ref_gemm_t : public gpu_gemm_t {
 
         bool attr_oscale_ok() const {
             const auto &scales = attr()->scales_;
-            return scales.get(DNNL_ARG_SRC).mask_ == 0
-                    && scales.get(DNNL_ARG_WEIGHTS).mask_ == 0
-                    && scales.get(DNNL_ARG_DST).mask_ == 0;
+            const bool src_scale_ok = scales.has_default_values(DNNL_ARG_SRC)
+                    || scales.get_mask(DNNL_ARG_SRC) == 0;
+            const bool wei_scale_ok
+                    = scales.has_default_values(DNNL_ARG_WEIGHTS)
+                    || scales.get_mask(DNNL_ARG_WEIGHTS) == 0;
+            const bool dst_scale_ok = scales.has_default_values(DNNL_ARG_DST)
+                    || scales.get_mask(DNNL_ARG_DST) == 0;
+            return src_scale_ok && wei_scale_ok && dst_scale_ok;
         }
 
         bool attr_zp_ok() const {

--- a/src/gpu/intel/ocl/gen9_binary.hpp
+++ b/src/gpu/intel/ocl/gen9_binary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -63,13 +63,17 @@ struct gen9_binary_t : public gpu_primitive_t {
             VDISPATCH_BINARY(!is_ternary_op(), VERBOSE_BAD_ALGORITHM);
             VDISPATCH_BINARY(
                     IMPLICATION(!attr()->scales_.has_default_values(),
-                            utils::one_of(dst_md()->data_type, s8, u8)
-                                    && utils::everyone_is(
-                                            attr()->scales_.get(DNNL_ARG_SRC_0)
-                                                    .mask_,
-                                            attr()->scales_.get(DNNL_ARG_SRC_1)
-                                                    .mask_,
-                                            0)),
+                            utils::one_of(dst_md()->data_type, s8, u8)),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_BINARY(
+                    IMPLICATION(
+                            !attr()->scales_.has_default_values(DNNL_ARG_SRC_0),
+                            attr()->scales_.get_mask(DNNL_ARG_SRC_0) == 0),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_BINARY(
+                    IMPLICATION(
+                            !attr()->scales_.has_default_values(DNNL_ARG_SRC_1),
+                            attr()->scales_.get_mask(DNNL_ARG_SRC_1) == 0),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_BINARY(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);

--- a/src/gpu/intel/ocl/gen9_softmax.hpp
+++ b/src/gpu/intel/ocl/gen9_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -215,9 +215,9 @@ struct gen9_softmax_fwd_t : public gpu_primitive_t {
         kernel_ctx.add_option("-cl-std=CL2.0");
         kernel_ctx.define_int("LOGSOFTMAX", pd()->is_logsoftmax());
         kernel_ctx.define_int("WITH_SRC_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_SRC).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC));
         kernel_ctx.define_int("WITH_DST_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_DST).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_DST));
 
         const memory_desc_wrapper dst_mdw(pd()->dst_md());
         const memory_desc_wrapper src_mdw(pd()->src_md());

--- a/src/gpu/intel/ocl/generic_reorder.cpp
+++ b/src/gpu/intel/ocl/generic_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -791,8 +791,8 @@ status_t generic_reorder_t::pd_t::init_conf(impl::engine_t *engine) {
     memcpy(&new_a, src_md(), sizeof(new_a));
     memcpy(&new_b, dst_md(), sizeof(new_b));
     compress(new_a, new_b, src_mask, dst_mask);
-    if (src_mask) CHECK(attr_copy.scales_.set(DNNL_ARG_SRC, src_mask));
-    if (dst_mask) CHECK(attr_copy.scales_.set(DNNL_ARG_DST, dst_mask));
+    if (src_mask >= 0) { CHECK(attr_copy.scales_.set(DNNL_ARG_SRC, src_mask)); }
+    if (dst_mask >= 0) { CHECK(attr_copy.scales_.set(DNNL_ARG_DST, dst_mask)); }
 
     if (!is_generic_faster_than_ref(new_a, new_b)) return status::unimplemented;
 

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -203,10 +203,11 @@ sdpa_config_t *choose_config_xehpc(
 ///   |  3 (1100) | true    |
 ///   |  1 (1000) | true    |
 ///   |  8 (0001) | false   |
-bool with_quantize_common(const runtime_scales_t &scales) {
-    return !scales.has_default_values()
-            && (((scales.mask_ & 3) != 0 && (scales.mask_ & 12) == 0)
-                    || scales.mask_ == 0);
+bool with_quantize_common(const quant_entry_t &scale_entry) {
+    return !scale_entry.has_default_values()
+            && (((scale_entry.get_mask() & 3) != 0
+                        && (scale_entry.get_mask() & 12) == 0)
+                    || scale_entry.get_mask() == 0);
 }
 
 /// Returns true if a common zero points value is used for each slice of the

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -92,7 +92,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
                     "tensors",
                     qry_md()->dims[1], key_md()->dims[1], val_md()->dims[1]);
 
-            int kq_scales_mask = desc()->kq_scales.mask_;
+            int kq_scales_mask = desc()->kq_scales.get_mask();
             int kq_zp_mask = desc()->kq_zero_points.get(DNNL_ARG_WEIGHTS);
             if (!desc()->kq_scales.has_default_values()
                     && !desc()->kq_zero_points.has_default_values())
@@ -119,7 +119,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         key_group_size());
             }
 
-            int vs_scales_mask = desc()->vs_scales.mask_;
+            int vs_scales_mask = desc()->vs_scales.get_mask();
             int vs_zp_mask = desc()->vs_zero_points.get(DNNL_ARG_WEIGHTS);
             if (!desc()->vs_scales.has_default_values()
                     && !desc()->vs_zero_points.has_default_values())

--- a/src/gpu/intel/ocl/multi_po_reorder_binary.hpp
+++ b/src/gpu/intel/ocl/multi_po_reorder_binary.hpp
@@ -42,8 +42,8 @@ struct multi_po_reorder_binary_t : public gpu_primitive_t {
                 "multi_po_reorder_binary", multi_po_reorder_binary_t);
 
         status_t init(impl::engine_t *engine) {
-            if (attr()->scales_.get(DNNL_ARG_SRC_0).is_set_
-                    || attr()->scales_.get(DNNL_ARG_SRC_1).is_set_
+            if (!attr()->scales_.has_default_values(DNNL_ARG_SRC_0)
+                    || !attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values()
                     || attr()->post_ops_.len() >= 1) {
                 VDISPATCH_BINARY(false, VERBOSE_UNSUPPORTED_ATTR);
             }

--- a/src/gpu/intel/ocl/ocl_conversion.h
+++ b/src/gpu/intel/ocl/ocl_conversion.h
@@ -102,6 +102,7 @@ IF_DOUBLE_SUPPORTED(IF_HALF_SUPPORTED(def_std_into(double, half)));
 
 def_undef_into(float);
 def_undef_into(int);
+IF_DOUBLE_SUPPORTED(def_undef_into(double));
 
 #undef def_std_into
 #undef def_std_into_sat

--- a/src/gpu/intel/ocl/ocl_io.h
+++ b/src/gpu/intel/ocl/ocl_io.h
@@ -147,6 +147,9 @@ DEF_load(float, e8m0);
 #endif // cl_khr_fp16
 
 #ifdef cl_khr_fp64
+// Included for compile time compatibility
+DEF_load(double, undef_data);
+
 DEF_load(float, double); // Needed for src=f64, dst=f32
 DEF_load(double, bf16);
 DEF_load(double, float);

--- a/src/gpu/intel/ocl/ref_group_normalization.cpp
+++ b/src/gpu/intel/ocl/ref_group_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -108,9 +108,9 @@ status_t ref_group_normalization_fwd_t::pd_t::init_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
 
     kernel_ctx.define_int("WITH_SRC_SCALES",
-            !attr()->scales_.get(DNNL_ARG_SRC).has_default_values());
+            !attr()->scales_.has_default_values(DNNL_ARG_SRC));
     kernel_ctx.define_int("WITH_DST_SCALES",
-            !attr()->scales_.get(DNNL_ARG_DST).has_default_values());
+            !attr()->scales_.has_default_values(DNNL_ARG_DST));
     init_kernel_ctx_common(kernel_ctx, this);
 
     // promote macros defined by parameters to OpenCL command line

--- a/src/gpu/intel/ocl/ref_layer_normalization.hpp
+++ b/src/gpu/intel/ocl/ref_layer_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -93,9 +93,9 @@ struct ref_layer_normalization_fwd_t : public gpu_primitive_t {
         CHECK(status);
 
         kernel_ctx.define_int("WITH_SRC_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_SRC).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC));
         kernel_ctx.define_int("WITH_DST_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_DST).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_DST));
 
         CHECK(create_kernel(engine, &kernel_, "ref_lnorm_fwd", kernel_ctx));
         if (!kernel_) return status::runtime_error;

--- a/src/gpu/intel/ocl/ref_matmul.hpp
+++ b/src/gpu/intel/ocl/ref_matmul.hpp
@@ -233,19 +233,19 @@ struct ref_matmul_t : public gpu_primitive_t {
         def_data_type(kernel_ctx, pd()->bia_dt_, "BIA");
         def_data_type(kernel_ctx, pd()->desc()->accum_data_type, "ACC");
         def_data_type(kernel_ctx,
-                pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).data_type_,
+                pd()->attr()->scales_.get_data_type(DNNL_ARG_WEIGHTS),
                 "WEI_SCALES");
         def_data_type(kernel_ctx,
                 pd()->attr()->zero_points_.get_data_type(DNNL_ARG_WEIGHTS),
                 "WEI_ZP");
         def_data_type(kernel_ctx,
-                pd()->attr()->scales_.get(DNNL_ARG_SRC).data_type_,
+                pd()->attr()->scales_.get_data_type(DNNL_ARG_SRC),
                 "SRC_SCALES");
         def_data_type(kernel_ctx,
                 pd()->attr()->zero_points_.get_data_type(DNNL_ARG_SRC),
                 "SRC_ZP");
         def_data_type(kernel_ctx,
-                pd()->attr()->scales_.get(DNNL_ARG_DST).data_type_,
+                pd()->attr()->scales_.get_data_type(DNNL_ARG_DST),
                 "DST_SCALES");
         kernels_.resize(2);
         CHECK(create_kernel(engine, &kernels_[0], "ref_matmul", kernel_ctx));

--- a/src/gpu/intel/ocl/reusable_lnorm.cpp
+++ b/src/gpu/intel/ocl/reusable_lnorm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ static status_t init_conf_common(const layer_normalization_pd_t *pd,
     conf->dst_dt = dst_buf.data_type;
 
     auto scales = pd->attr()->scales_;
-    conf->with_src_scale = !scales.get(DNNL_ARG_SRC).has_default_values();
-    conf->with_dst_scale = !scales.get(DNNL_ARG_DST).has_default_values();
+    conf->with_src_scale = !scales.has_default_values(DNNL_ARG_SRC);
+    conf->with_dst_scale = !scales.has_default_values(DNNL_ARG_DST);
 
     // We require that the lnorm axis is a single dense block, so that it can
     // be represented by a stride + size alone.

--- a/src/gpu/intel/ocl/simple_binary.hpp
+++ b/src/gpu/intel/ocl/simple_binary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ struct simple_binary_t : public gpu_primitive_t {
         status_t init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const;
 
         bool with_scales(int position) const {
-            return !attr()->scales_.get(position).has_default_values();
+            return !attr()->scales_.has_default_values(position);
         }
 
         bool with_scales() const {

--- a/src/gpu/intel/ocl/simple_layer_normalization.hpp
+++ b/src/gpu/intel/ocl/simple_layer_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -92,9 +92,9 @@ struct simple_layer_normalization_fwd_t : public gpu_primitive_t {
         CHECK(status);
 
         kernel_ctx.define_int("WITH_SRC_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_SRC).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC));
         kernel_ctx.define_int("WITH_DST_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_DST).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_DST));
 
         CHECK(create_kernel(engine, &kernel_, "simple_lnorm_fwd", kernel_ctx));
         if (!kernel_) return status::runtime_error;

--- a/src/gpu/intel/ocl/simple_softmax.hpp
+++ b/src/gpu/intel/ocl/simple_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -140,9 +140,9 @@ struct simple_softmax_fwd_t : public gpu_primitive_t {
         kernel_ctx.add_option("-cl-std=CL2.0");
         kernel_ctx.define_int("LOGSOFTMAX", pd()->is_logsoftmax());
         kernel_ctx.define_int("WITH_SRC_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_SRC).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC));
         kernel_ctx.define_int("WITH_DST_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_DST).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_DST));
 
         const memory_desc_wrapper dst_mdw(pd()->dst_md());
         const memory_desc_wrapper src_mdw(pd()->src_md());

--- a/src/gpu/intel/ocl/vectorized_lnorm.hpp
+++ b/src/gpu/intel/ocl/vectorized_lnorm.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,9 +89,9 @@ struct vectorized_lnorm_fwd_t : public gpu_primitive_t {
         CHECK(status);
 
         kernel_ctx.define_int("WITH_SRC_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_SRC).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC));
         kernel_ctx.define_int("WITH_DST_SCALES",
-                !pd()->attr()->scales_.get(DNNL_ARG_DST).has_default_values());
+                !pd()->attr()->scales_.has_default_values(DNNL_ARG_DST));
 
         CHECK(create_kernel(
                 engine, &kernel_, "vectorized_lnorm_fwd", kernel_ctx));

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -83,9 +83,8 @@ struct attr_info_t {
     bool with_src_scales;
     bool with_wei_scales;
     bool with_dst_scales;
-    bool src_scales_mask;
-    bool wei_scales_mask;
-    bool dst_scales_mask;
+    int wei_scales_mask;
+    int dst_scales_mask;
     data_type_t src_scales_data_type;
     data_type_t wei_scales_data_type;
     data_type_t dst_scales_data_type;

--- a/src/gpu/nvidia/cudnn_binary.cpp
+++ b/src/gpu/nvidia/cudnn_binary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,11 +35,11 @@ status_t cudnn_binary_t::execute(const exec_ctx_t &ctx) const {
     nvidia::stream_t *cuda_stream
             = utils::downcast<nvidia::stream_t *>(ctx.stream());
 
-    if (!pd()->attr()->scales_.get(DNNL_ARG_SRC_0).has_default_values())
+    if (!pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC_0))
         CHECK(stream_utils::copy_input_arg_to_host(ctx, cuda_stream,
                 &host_scales_[0], DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0,
                 sizeof(float)));
-    if (!pd()->attr()->scales_.get(DNNL_ARG_SRC_1).has_default_values())
+    if (!pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC_1))
         CHECK(stream_utils::copy_input_arg_to_host(ctx, cuda_stream,
                 &host_scales_[1], DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_1,
                 sizeof(float)));

--- a/src/gpu/nvidia/cudnn_binary.hpp
+++ b/src/gpu/nvidia/cudnn_binary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,12 +66,7 @@ struct cudnn_binary_t : public gpu::primitive_t {
                     || has_zero_dims(dst_md()->dims, dst_md()->ndims);
         }
 
-        bool check_scales_mask() const {
-            for (const auto &s : attr()->scales_.scales_) {
-                if (s.second.mask_ != 0) return false;
-            }
-            return true;
-        }
+        bool check_scales_mask() const { return attr_scales_ok(); }
 
         bool check_no_blocking() const {
             // Blocking is not supported by cudnnOpTensor, return false if any

--- a/src/gpu/nvidia/cudnn_convolution.hpp
+++ b/src/gpu/nvidia/cudnn_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -155,15 +155,17 @@ struct cudnn_convolution_fwd_t : public gpu::primitive_t {
                     && ndims() < 5;
         }
 
-        bool attr_scales_ok() const {
-            const auto &scales = attr()->scales_;
-            const auto &supported_args
-                    = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
-            if (!scales.has_default_values(supported_args)) return false;
-            // cuDNN does not support scaling per dimension.
-            for (auto arg : supported_args)
-                if (scales.get(arg).mask_ != 0) return false;
-            return true;
+        bool attr_scales_ok(const std::vector<int> &supported_args
+                = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) const {
+            bool ok = attr()->scales_.has_default_values(supported_args);
+            for (int arg : supported_args) {
+                if (attr()->scales_.has_default_values(arg)) continue;
+
+                const auto &mask = attr()->scales_.get_mask(arg);
+                // cuDNN does not support scaling per dimension.
+                ok = ok && (mask == 0);
+            }
+            return ok;
         }
     };
 

--- a/src/gpu/nvidia/cudnn_convolution_impl.hpp
+++ b/src/gpu/nvidia/cudnn_convolution_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -143,13 +143,10 @@ public:
         with_bias = pd->with_bias();
         beta = 0.0f;
         do_scaling = !pd->attr()->scales_.has_default_values();
-        do_dst_scaling
-                = !pd->attr()->scales_.get(DNNL_ARG_DST).has_default_values();
-        do_src_scaling
-                = !pd->attr()->scales_.get(DNNL_ARG_SRC).has_default_values();
-        do_wei_scaling = !pd->attr()
-                                  ->scales_.get(DNNL_ARG_WEIGHTS)
-                                  .has_default_values();
+        do_dst_scaling = !pd->attr()->scales_.has_default_values(DNNL_ARG_DST);
+        do_src_scaling = !pd->attr()->scales_.has_default_values(DNNL_ARG_SRC);
+        do_wei_scaling
+                = !pd->attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
         dnnl_descs[x] = *pd->invariant_src_md();
         dnnl_descs[weights] = *pd->invariant_wei_md();
         dnnl_descs[y] = *pd->invariant_dst_md();

--- a/src/gpu/nvidia/cudnn_matmul.hpp
+++ b/src/gpu/nvidia/cudnn_matmul.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,10 +101,11 @@ struct cudnn_matmul_t : public gpu::primitive_t {
             if (!scales.has_default_values(supported_args)) return false;
             // cuDNN does not support scaling per dimension.
             for (auto arg : supported_args) {
-                auto &s = scales.get(arg);
-                if (scales.get(arg).mask_ != 0
-                        || !utils::one_of(
-                                s.data_type_, s8, s32, f32, f16, bf16))
+                if (scales.has_default_values(arg)) continue;
+
+                if (scales.get_mask(arg) > 0) return false;
+                if (!utils::one_of(
+                            scales.get_data_type(arg), s8, s32, f32, f16, bf16))
                     return false;
             }
             return true;

--- a/src/gpu/nvidia/cudnn_matmul_impl.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,7 +50,7 @@ struct cublas_params : cublas_base_params {
             return status::unimplemented;
         }
 
-        with_dst_scale_ = !attr->scales_.get(DNNL_ARG_DST).has_default_values();
+        with_dst_scale_ = !attr->scales_.has_default_values(DNNL_ARG_DST);
         with_separate_bias_ = with_bias;
         if ((with_separate_bias_)
                 && (bias_md->data_type != dst_md->data_type)) {

--- a/src/gpu/nvidia/cudnn_matmul_lt_impl.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_lt_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 * Copyright 2024 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,20 +55,23 @@ struct cublas_lt_params : cublas_base_params {
                 || dst_d.has_runtime_dims_or_strides()
                 || weights_d.has_runtime_dims_or_strides();
 
-        if (attr->scales_.get(DNNL_ARG_SRC).has_default_values()) {
-            auto src_scale = attr->scales_.get(DNNL_ARG_SRC);
-            if (src_scale.mask_ != 0) { multi_src_scale_ = true; }
+        if (attr->scales_.has_default_values(DNNL_ARG_SRC)) {
+            if (attr->scales_.get_mask(DNNL_ARG_SRC) > 0) {
+                multi_src_scale_ = true;
+            }
         }
 
-        if (attr->scales_.get(DNNL_ARG_WEIGHTS).has_default_values()) {
-            auto wei_scale = attr->scales_.get(DNNL_ARG_WEIGHTS);
-            if (wei_scale.mask_ != 0) { multi_wei_scale_ = true; }
+        if (attr->scales_.has_default_values(DNNL_ARG_WEIGHTS)) {
+            if (attr->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {
+                multi_wei_scale_ = true;
+            }
         }
 
-        with_dst_scale_ = !attr->scales_.get(DNNL_ARG_DST).has_default_values();
+        with_dst_scale_ = !attr->scales_.has_default_values(DNNL_ARG_DST);
         if (with_dst_scale_) {
-            auto dst_scale = attr->scales_.get(DNNL_ARG_DST);
-            if (dst_scale.mask_ != 0) { multi_dst_scale_ = true; }
+            if (attr->scales_.get_mask(DNNL_ARG_DST) > 0) {
+                multi_dst_scale_ = true;
+            }
         }
 
         // Initialise flags and variables for the imma case (E.g. imma_case_ flag).

--- a/src/gpu/nvidia/cudnn_softmax.cpp
+++ b/src/gpu/nvidia/cudnn_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020-2022 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,12 +33,12 @@ status_t cudnn_softmax_fwd_t::execute(const exec_ctx_t &ctx) const {
     nvidia::stream_t *cuda_stream
             = utils::downcast<nvidia::stream_t *>(ctx.stream());
 
-    if (!pd()->attr()->scales_.get(DNNL_ARG_SRC).has_default_values())
+    if (!pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC))
         CHECK(stream_utils::copy_input_arg_to_host(ctx, cuda_stream,
                 &host_scales_[0], DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC,
                 sizeof(float)));
 
-    if (!pd()->attr()->scales_.get(DNNL_ARG_DST).has_default_values())
+    if (!pd()->attr()->scales_.has_default_values(DNNL_ARG_DST))
         CHECK(stream_utils::copy_input_arg_to_host(ctx, cuda_stream,
                 &host_scales_[1], DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
                 sizeof(float)));

--- a/src/gpu/nvidia/cudnn_softmax.hpp
+++ b/src/gpu/nvidia/cudnn_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,19 +56,13 @@ struct cudnn_softmax_fwd_t : public gpu::primitive_t {
                     && set_default_formats() == status::success
                     && src_d.is_plain() && dst_d.is_plain() && dst_d == src_d
                     && IMPLICATION(!attr()->scales_.has_default_values(),
-                            check_scales_mask()
+                            attr_scales_ok()
                                     && dst_d.data_type() != data_type::s8);
             if (!ok) return status::unimplemented;
 
             softmax_impl_.reset(new cudnn_softmax_fwd_impl_t());
 
             return softmax_impl_->init(this);
-        }
-        bool check_scales_mask() const {
-            for (const auto &s : attr()->scales_.scales_) {
-                if (s.second.mask_ != 0) return false;
-            }
-            return true;
         }
 
         std::shared_ptr<cudnn_softmax_impl_base_t> softmax_impl_;

--- a/tests/gtests/test_batch_normalization.cpp
+++ b/tests/gtests/test_batch_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ protected:
         auto eng = get_test_engine();
         auto strm = make_stream(eng);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         aa.po_eltwise = true;
 
         auto src_md = memory::desc(p.dims, p.src_dt, p.src_tag);
@@ -227,7 +227,7 @@ protected:
         // batch_normalization specific types and values
         using pd_t = batch_normalization_backward::primitive_desc;
         using hint_pd_t = batch_normalization_forward::primitive_desc;
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);

--- a/tests/gtests/test_binary.cpp
+++ b/tests/gtests/test_binary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ protected:
 
         // binary specific types and values
         using pd_t = binary::primitive_desc;
-        allows_attr_t aa {false};
+        allows_attr_t aa {};
         aa.scales = true;
         aa.po_sum = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);
         aa.po_eltwise = !is_nvidia_gpu(eng) && !is_amd_gpu(eng);

--- a/tests/gtests/test_concat.cpp
+++ b/tests/gtests/test_concat.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -168,8 +168,9 @@ protected:
         // test construction from a C pd
         concat_pd = pd_t(concat_pd.get());
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         aa.scales = true;
+        aa.scales_arg = DNNL_ARG_MULTIPLE_SRC;
 
         test_fwd_pd_constructors<pd_t>(concat_pd, aa, dst_desc,
                 static_cast<int>(p.concat_dimension), srcs_md);

--- a/tests/gtests/test_deconvolution.cpp
+++ b/tests/gtests/test_deconvolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2023 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -309,7 +309,7 @@ protected:
                         *dec_src_desc, *dec_weights_desc, *dec_dst_desc,
                         strides, padL, padR);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
 
 #ifndef DNNL_SYCL_GENERIC
         aa.po_binary = !is_amd_gpu(eng);
@@ -420,7 +420,7 @@ protected:
                         *dec_weights_desc, *dec_dst_desc, strides, padL, padR,
                         deconv_primitive_desc);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         test_bwd_pd_constructors<pd_t, hint_pd_t>(
                 deconv_bwd_data_primitive_desc, deconv_primitive_desc, aa,
                 algorithm::deconvolution_direct, *dec_src_desc,
@@ -493,7 +493,7 @@ protected:
                         *dec_weights_desc, *dec_bias_desc, *dec_dst_desc,
                         strides, padL, padR, deconv_primitive_desc);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         test_bwd_pd_constructors<pd_t, hint_pd_t>(
                 deconv_bwd_weights_primitive_desc, deconv_primitive_desc, aa,
                 algorithm::deconvolution_direct, *dec_src_desc,

--- a/tests/gtests/test_eltwise.cpp
+++ b/tests/gtests/test_eltwise.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ protected:
         auto eng = get_test_engine();
         auto strm = make_stream(eng);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         aa.po_binary = !is_amd_gpu(eng);
 
         auto src_md = memory::desc(p.dims, p.src_dt, p.src_tag);
@@ -186,7 +186,7 @@ protected:
         // eltwise specific types and values
         using pd_t = eltwise_backward::primitive_desc;
         using hint_pd_t = eltwise_forward::primitive_desc;
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);

--- a/tests/gtests/test_group_normalization.cpp
+++ b/tests/gtests/test_group_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,14 +74,10 @@ protected:
 
         const bool is_src_int8 = p.src_dt == memory::data_type::s8
                 || p.src_dt == memory::data_type::u8;
-        auto aa = allows_attr_t {
-                false, /* po_sum */
-                true, /* po_eltwise */
-                true, /* po_binary*/
-                false, /* po_prelu*/
-                false, /* zp */
-                is_src_int8, /* scales */
-        };
+        allows_attr_t aa {};
+        aa.po_eltwise = true;
+        aa.po_binary = true;
+        aa.scales = is_src_int8;
 
         auto src_md = memory::desc(p.dims, p.src_dt, p.src_tag);
         auto dst_md = memory::desc(p.dims, p.dst_dt, p.dst_tag);
@@ -195,7 +191,7 @@ protected:
         // group_normalization specific types and values
         using pd_t = group_normalization_backward::primitive_desc;
         using hint_pd_t = group_normalization_forward::primitive_desc;
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);

--- a/tests/gtests/test_iface_attr.cpp
+++ b/tests/gtests/test_iface_attr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 * Copyright 2020-2021 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -281,15 +281,17 @@ HANDLE_EXCEPTIONS_FOR_TEST_F(attr_test_t, TestScalesWithGroups) {
     for (auto arg : supported_args) {
         // single non-default scales for supported arg
         attr.set_scales(arg, 0, {});
-        // multiple scales with groups
+        // multiple scales with a single group dim
         attr.set_scales(arg, 1 << 0, {4});
+        // multiple scales with multiple group dims
+        attr.set_scales(arg, 1 << 0, {4, 1});
         // scales with groups and a data type
-        attr.set_scales(arg, 1 << 0, {4}, data_type::f32);
+        attr.set_scales(arg, 1 << 0, {4, 1}, data_type::f32);
     }
 
     for (auto arg : unsupported_args) {
         // multiple scales with groups for unsupported args
-        EXPECT_ANY_THROW(attr.set_scales(arg, 1 << 0, {4}));
+        EXPECT_ANY_THROW(attr.set_scales(arg, 1 << 0, {4, 1}));
         // multiple scales with non-default data type for unsupported args
         EXPECT_ANY_THROW(attr.set_scales(arg, 1 << 0, {}, data_type::bf16));
     }

--- a/tests/gtests/test_inner_product_backward_data.cpp
+++ b/tests/gtests/test_inner_product_backward_data.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ protected:
         auto ip_primitive_desc = pd_t(eng, ip_diff_src_desc, ip_weights_desc,
                 ip_diff_dst_desc, ip_fwd_pdesc);
 
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
         test_bwd_pd_constructors<pd_t, hint_pd_t>(ip_primitive_desc,
                 ip_fwd_pdesc, aa, ip_diff_src_desc, ip_weights_desc,
                 ip_diff_dst_desc);

--- a/tests/gtests/test_inner_product_backward_weights.cpp
+++ b/tests/gtests/test_inner_product_backward_weights.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ protected:
                         ip_src_desc, ip_diff_weights_desc, ip_diff_dst_desc,
                         ip_fwd_pdesc);
 
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
         test_bwd_pd_constructors<pd_t, hint_pd_t>(ip_primitive_desc,
                 ip_fwd_pdesc, aa, ip_src_desc, ip_diff_weights_desc,
                 ip_diff_dst_desc);

--- a/tests/gtests/test_inner_product_forward.cpp
+++ b/tests/gtests/test_inner_product_forward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ protected:
                 : pd_t(eng, p.aprop_kind, ip_src_desc, ip_weights_desc,
                         ip_dst_desc);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         aa.po_eltwise = true;
         aa.po_sum = true;
 #ifdef DNNL_SYCL_GENERIC

--- a/tests/gtests/test_layer_normalization.cpp
+++ b/tests/gtests/test_layer_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ protected:
                 || impl::utils::one_of(dst_md->get_data_type(),
                         memory::data_type::s8, memory::data_type::u8);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         const bool is_cpu = get_test_engine_kind() == engine::kind::cpu;
         aa.po_eltwise = is_cpu;
         aa.po_binary = is_cpu;

--- a/tests/gtests/test_lrn.cpp
+++ b/tests/gtests/test_lrn.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ protected:
         auto eng = get_test_engine();
         auto strm = make_stream(eng);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
 
         auto src_md = memory::desc(p.dims, p.src_dt, p.src_tag);
         auto dst_md = memory::desc(p.dims, p.dst_dt, p.dst_tag);
@@ -188,7 +188,7 @@ protected:
         // lrn specific types and values
         using pd_t = lrn_backward::primitive_desc;
         using hint_pd_t = lrn_forward::primitive_desc;
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -259,7 +259,7 @@ protected:
 
         auto matmul_pd = pd_t(eng, src_md, weights_md, bia_md, dst_md, attr);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         aa.po_binary = !is_amd_gpu(eng);
         aa.po_eltwise = true;
         aa.po_prelu = !is_amd_gpu(eng);

--- a/tests/gtests/test_pooling_backward.cpp
+++ b/tests/gtests/test_pooling_backward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 * Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -233,7 +233,7 @@ protected:
         auto pool_bwd_prim_desc = pd_t(eng, p.aalgorithm, *src_desc, *dst_desc,
                 strides, ker, dilation, pad_l, pad_r, pool_prim_desc);
         // test all pd ctors
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
         test_bwd_pd_constructors<pd_t, hint_pd_t>(pool_bwd_prim_desc,
                 pool_prim_desc, aa, p.aalgorithm, *src_desc, *dst_desc, strides,
                 ker, dilation, pad_l, pad_r);

--- a/tests/gtests/test_pooling_forward.cpp
+++ b/tests/gtests/test_pooling_forward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 * Copyright 2022-2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -333,7 +333,7 @@ protected:
         auto pool_prim_desc = pd_t(eng, p.aprop_kind, p.aalgorithm, p_src_desc,
                 p_dst_desc, strides, ker, dilation, pad_l, pad_r);
         // test all pd ctors
-        allows_attr_t aa {false};
+        allows_attr_t aa {};
         if (!(is_nvidia_gpu(eng) || is_amd_gpu(eng))) {
             aa.po_eltwise = true;
             aa.po_binary = true;

--- a/tests/gtests/test_prelu.cpp
+++ b/tests/gtests/test_prelu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ protected:
         auto eng = get_test_engine();
         auto strm = make_stream(eng);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
 
         auto src_md = memory::desc(p.src_dims, p.src_dt, p.src_tag);
         auto wei_md = memory::desc(p.wei_dims, p.wei_dt, p.wei_tag);
@@ -151,7 +151,7 @@ protected:
         // prelu specific types and values
         using pd_t = prelu_backward::primitive_desc;
         using hint_pd_t = prelu_forward::primitive_desc;
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);

--- a/tests/gtests/test_reduction.cpp
+++ b/tests/gtests/test_reduction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -85,10 +85,10 @@ protected:
     void Test() {
         // reduction specific types and values
         using pd_t = reduction::primitive_desc;
-        allows_attr_t allowed_attributes {false}; // doesn't support anything
-        allowed_attributes.po_sum = true;
-        allowed_attributes.po_eltwise = true;
-        allowed_attributes.po_binary = true;
+        allows_attr_t aa {};
+        aa.po_sum = true;
+        aa.po_eltwise = true;
+        aa.po_binary = true;
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);
@@ -101,8 +101,8 @@ protected:
         // regular pd ctor
         pd = pd_t(eng, p.aalgorithm, desc_src, desc_dst, p.p, p.eps);
         // test all pd ctors
-        test_fwd_pd_constructors<pd_t>(pd, allowed_attributes, p.aalgorithm,
-                desc_src, desc_dst, p.p, p.eps);
+        test_fwd_pd_constructors<pd_t>(
+                pd, aa, p.aalgorithm, desc_src, desc_dst, p.p, p.eps);
 
         EXPECT_ANY_THROW(reduction(pd, {}));
         // default primitive ctor

--- a/tests/gtests/test_shuffle.cpp
+++ b/tests/gtests/test_shuffle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ protected:
         auto eng = get_test_engine();
         auto strm = make_stream(eng);
 
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
 
         auto src_md = memory::desc(p.dims, p.src_dt, p.src_tag);
         auto dst_md = memory::desc(p.dims, p.dst_dt, p.dst_tag);
@@ -125,7 +125,7 @@ protected:
         // shuffle specific types and values
         using pd_t = shuffle_backward::primitive_desc;
         using hint_pd_t = shuffle_forward::primitive_desc;
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);

--- a/tests/gtests/test_softmax.cpp
+++ b/tests/gtests/test_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -167,7 +167,7 @@ protected:
         prop_kind pk = !is_fwd(p.aprop_kind) ? prop_kind::forward_training
                                              : p.aprop_kind;
 
-        allows_attr_t aa {false};
+        allows_attr_t aa {};
         if (!is_amd_gpu(eng)) {
             aa.po_eltwise = true;
             aa.po_binary = true;
@@ -260,7 +260,7 @@ protected:
         // softmax specific types and values
         using pd_t = softmax_backward::primitive_desc;
         using hint_pd_t = softmax_forward::primitive_desc;
-        allows_attr_t aa {false}; // doesn't support anything
+        allows_attr_t aa {}; // doesn't support anything
 
         auto eng = get_test_engine();
         auto strm = make_stream(eng);

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -224,7 +224,7 @@ protected:
         dst = test::make_memory(sum_pd.dst_desc(), eng);
 
         // test all pd ctors
-        auto aa = allows_attr_t {false};
+        allows_attr_t aa {};
         if (p.is_output_omitted)
             test_fwd_pd_constructors<pd_t>(sum_pd, aa, p.scale, srcs_md);
         else {


### PR DESCRIPTION
Every year around Christmas time something happens to quantization:
* 2022 - a move to runtime happened, lots of obsolete code left behind
* 2023 - advanced quantization with groups appeared, even more code that could use some love left behind.
* 2023.5 - extension of zero-points for SRC argument happened, zero-points has become a warehouse of variable to access directly.
* 2024 - time for refactor now!

The whole point of this refactor is to move quantization attributes to C++ way of doing things - provide clear and simple interfaces to operate with objects and close members.
This part 1 covers scales which were not that bad in terms of interfaces but could be better with argument members which this part covers.

Interface for both scales and its new underlying object, quant_entry_t, provide getters for a mask, data_type and groups (no need to worry about ndims any longer!), as well as default values checks.
Initialization is still done through `set`, `reset` was replaced with `set`, 

> Any operations with masks should happen only after verifying that specific arg scale is not default! It's forced now through an invalid mask value which can't be used as is.

Among legacy use-cases here are the main changes across sources:
common:
* some primitive attribute checkers got more checks added.
cpu:
* many places updated `mask != 0` which was the default value for common and non-initialized scales to `mask > 0` as now the default mask is negative.
  - A check for equality is still valid while it's highly recommended to avoid unequal comparison (unless you really know what you are doing).
gpu:
* found some bugs in `gemm_with_post_ops` implementations.
* changed logic in several generic/cudnn kernels to match the new behavior.
tests:
* updated gtests to comply with updated primitive checks.

Part 2 will cover zero-points.

Disclaimer: the change is somewhat fundamental, the bug leaks are highly possible even if all tests are passing. Feel free to report any if I missed something.