### PR TITLE
cpu: softmax: enable relaxed acc_mode (fixes MFDNN-12822)

### DIFF
--- a/doc/primitives/softmax.md
+++ b/doc/primitives/softmax.md
@@ -100,12 +100,28 @@ argument index as specified by the following table.
 Attributes enable you to modify the behavior of the softmax primitive.
 The following attributes are supported by the softmax primitive:
 
-| Propagation | Type      | Operation                                            | Description                                                   | Restrictions                                                           |
-|:------------|:----------|:-----------------------------------------------------|:--------------------------------------------------------------|:-----------------------------------------------------------------------|
-| forward     | attribute | [Scales](@ref dnnl::primitive_attr::set_scales_mask) | Scales the corresponding tensor by the given scale factor(s). | Supported only for int8 softmax and one scale per tensor is supported. |
-| forward     | post-op   | [Binary](@ref dnnl::post_ops::append_binary)         | Applies a @ref dnnl_api_binary operation to the result        | General binary post-op restrictions                                    |
-| forward     | Post-op   | [Eltwise](@ref dnnl::post_ops::append_eltwise)       | Applies an @ref dnnl_api_eltwise operation to the result.     |                                                                        |
+| Propagation | Type      | Operation                                                             | Description                                                   | Restrictions                                                           |
+|:------------|:----------|:----------------------------------------------------------------------|:--------------------------------------------------------------|:-----------------------------------------------------------------------|
+| forward     | attribute | [Scales](@ref dnnl::primitive_attr::set_scales_mask)                  | Scales the corresponding tensor by the given scale factor(s). | Supported only for int8 softmax and one scale per tensor is supported. |
+| forward     | post-op   | [Binary](@ref dnnl::post_ops::append_binary)                          | Applies a @ref dnnl_api_binary operation to the result        | General binary post-op restrictions                                    |
+| forward     | Post-op   | [Eltwise](@ref dnnl::post_ops::append_eltwise)                        | Applies an @ref dnnl_api_eltwise operation to the result.     |                                                                        |
+| forward     | attribute | [Accumulation mode](@ref dnnl::primitive_attr::set_accumulation_mode) | Defines the implementation's accumulation arithmetic.         | Only the values `strict`, `relaxed`, and `any` are supported.          |
 
+#### Accumulation Mode
+
+You can optimize performance of the forward operation when the source and
+destination floating-point data types of the operation are equal and different
+from `f32`. When the destination data type is different from `f32`, additional
+memory will be used to accumulate data and store it in the destination memory
+buffer for a requested data type. Using the additional memory can be opted-out
+with an accumulation mode setting set to
+[relaxed](@ref dnnl::accumulation_mode::relaxed) or
+[any](@ref dnnl::accumulation_mode::any), which will use the precision of
+destination data type to accumulate intermediate results directly into the
+destination memory buffer. This performance optimization, however, results in
+in a minor decrease in accuracy. Depending on the actual data, the difference
+between `strict` and `relaxed` accumulation can reach several units in the last
+piece (ulps).
 
 ### Data Type Support
 

--- a/src/cpu/ref_softmax.cpp
+++ b/src/cpu/ref_softmax.cpp
@@ -53,7 +53,9 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper dst_d(pd()->dst_md());
 
-    const auto interim_dt = data_type::f32;
+    const auto interim_dt = pd()->need_intermediate_scratchpad()
+            ? data_type::f32
+            : dst_d.data_type();
     const auto is_inplace = (src == dst);
     const auto has_padding = is_padding(dst_d);
     const auto zero_padding = has_padding && !is_inplace;
@@ -210,7 +212,9 @@ status_t ref_softmax_fwd_t::execute_forward_generic(
 
     void *interim_ptr
             = pd()->need_intermediate_scratchpad() ? interim_scratchpad : dst;
-    const auto interim_dt = data_type::f32;
+    const auto interim_dt = pd()->need_intermediate_scratchpad()
+            ? data_type::f32
+            : dst_d.data_type();
     const auto is_inplace = (src == dst);
     const auto has_padding = is_padding(dst_d);
     if (has_padding && !is_inplace) {

--- a/src/cpu/ref_softmax.hpp
+++ b/src/cpu/ref_softmax.hpp
@@ -79,9 +79,19 @@ struct ref_softmax_fwd_t : public primitive_t {
         int nthr_; // To not exceed the limit in execute used for set up.
 
         bool need_intermediate_scratchpad() const {
-            return dst_md()->data_type
-                    != types::default_accum_data_type(
-                            src_md()->data_type, dst_md()->data_type);
+            const auto src_dt = src_md()->data_type;
+            const auto dst_dt = dst_md()->data_type;
+            // Relaxed accumulation allows to downconvert intermediate results
+            // directly from xf16 or xf8 to dst avoiding scratchpad memory.
+            const bool relaxed_acc = src_dt == dst_dt
+                    && !types::is_integral_dt(dst_dt)
+                    && utils::one_of(attr()->acc_mode_,
+                            accumulation_mode::relaxed, accumulation_mode::any);
+            const bool need_scratchpad = dst_md()->data_type
+                            != types::default_accum_data_type(
+                                    src_md()->data_type, dst_md()->data_type)
+                    && !relaxed_acc;
+            return need_scratchpad;
         }
 
     private:

--- a/tests/benchdnn/inputs/softmax/test_softmax_ci
+++ b/tests/benchdnn/inputs/softmax/test_softmax_ci
@@ -10,17 +10,20 @@
 --dir=FWD_D,BWD_D
 --sdt=f32,f64,bf16,f16
 --ddt=f32,f64,bf16,f16
+--attr-acc-mode=strict,relaxed
 --batch=shapes_ci
 
 --dir=FWD_I
 --sdt=f32,bf16,f16,s8,u8
 --ddt=s8,u8
+--attr-acc-mode=strict,relaxed
 --attr-scales=src:common:64+dst:common:0.5
 --attr-post-ops=,add:f32:per_oc,mul:f32:per_tensor,linear:0.5:2
 --batch=shapes_ci
 
 --sdt=s8,u8
 --ddt=f32,bf16,f16
+--attr-acc-mode=strict,relaxed
 --attr-scales=src:common:64
 --attr-post-ops=,add:f32:per_oc,mul:f32:per_tensor,linear:0.5:2
 --batch=shapes_ci

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -249,11 +249,12 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
     const float trh = trh_f32;
 #else
     const bool is_strict_acc
-            = prb->attr.acc_mode == dnnl_accumulation_mode_strict;
-    // Relaxed fp16 computation can get an ulp difference with f32 ref values.
-    const float trh = is_flt_or_dbl || (trh_dt == dnnl_f16 && !is_strict_acc)
-            ? trh_f32
-            : 0.f;
+            = prb->attr.acc_mode == dnnl_accumulation_mode_strict
+            || prb->attr.acc_mode == dnnl_accumulation_mode_f32;
+    const bool is_relaxed_xf16
+            = !is_strict_acc && (trh_dt == dnnl_f16 || trh_dt == dnnl_bf16);
+    // Relaxed xf16 computation can get an ulp difference with f32 ref values.
+    const float trh = is_flt_or_dbl || is_relaxed_xf16 ? trh_f32 : 0.f;
 #endif
     cmp.set_threshold(trh);
 


### PR DESCRIPTION
Fixes MFDNN-12822
Fixes #2237

Numbers are obtained not from the perf machine but the trend is visible:

```
perf,cpu,jit:avx10_1_512,,--mode=P --softmax --dir=FWD_I --sdt=bf16 --ddt=bf16 --stag=abcd --dtag=abcd --axis=3 --attr-acc-mode=relaxed 64x16x100x100,0,0.270752,0.192383,0,0.20202,0
perf,cpu,jit:avx10_1_512,,--mode=P --softmax --dir=FWD_I --sdt=bf16 --ddt=bf16 --stag=abcd --dtag=abcd --axis=3 64x16x100x100,0,0.208252,1.38135,0,1.44547,0
```