### PR TITLE
cpu: x64: brgemm, matmul: add f32:f16 configuration support on AVX2 and AVX512_CORE (fixes MFDNN-11992)

### DIFF
--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -61,8 +61,8 @@ struct ref_matmul_t : public primitive_t {
                                      f8_e4m3, f4_e2m1, f4_e3m0),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_MATMUL((src_type == wei_type
-                                     || utils::one_of(wei_type, u8, s8, u4, s4,
-                                             f4_e3m0)),
+                                     || utils::one_of(wei_type, f16, u8, s8, u4,
+                                             s4, f4_e3m0)),
                     VERBOSE_UNSUPPORTED_DT);
             /* int8 weights decompression support */
             VDISPATCH_MATMUL(IMPLICATION(utils::one_of(wei_type, u8, s8),
@@ -82,10 +82,10 @@ struct ref_matmul_t : public primitive_t {
                             utils::one_of(
                                     bia_type, f32, bf16, f16, f8_e5m2, f8_e4m3)
                                     && IMPLICATION(
-                                            src_type == f32, bia_type == f32)
-                                    && IMPLICATION(src_type == f16,
+                                            wei_type == f32, bia_type == f32)
+                                    && IMPLICATION(wei_type == f16,
                                             utils::one_of(bia_type, f32, f16))
-                                    && IMPLICATION(src_type == bf16,
+                                    && IMPLICATION(wei_type == bf16,
                                             utils::one_of(bia_type, f32, bf16))
                             // TODO: any implication on allowed bias
                             // data type for fp8?

--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -61,8 +61,8 @@ struct ref_matmul_t : public primitive_t {
                                      f8_e4m3, f4_e2m1, f4_e3m0),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_MATMUL((src_type == wei_type
-                                     || utils::one_of(wei_type, f16, u8, s8, u4,
-                                             s4, f4_e3m0)),
+                                     || utils::one_of(wei_type, bf16, f16, u8,
+                                             s8, u4, s4, f4_e3m0)),
                     VERBOSE_UNSUPPORTED_DT);
             /* int8 weights decompression support */
             VDISPATCH_MATMUL(IMPLICATION(utils::one_of(wei_type, u8, s8),

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -140,6 +140,12 @@ void set_isa_impl(brgemm_desc_t *brg) {
                     is_isa_ok(avx512_core_amx_fp16), avx512_core_amx_fp16,
                     is_isa_ok(avx512_core_fp16), avx512_core_fp16,
                     is_isa_ok(avx2_vnni_2), avx2_vnni_2);
+        } else if (brg->dt_a == data_type::f32 && brg->dt_b == data_type::f16) {
+            // Distinguish f32:f16 case upconversion for f16 on AVX512_CORE and
+            // AVX2.
+            brg->isa_impl = utils::map(true, isa_undef,
+                    is_isa_ok(avx512_core_fp16), avx512_core_fp16,
+                    is_isa_ok(avx512_core), avx512_core, is_isa_ok(avx2), avx2);
         } else {
             brg->isa_impl = utils::map(true, isa_undef,
                     is_isa_ok(avx512_core_fp16), avx512_core_fp16);

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2202,19 +2202,17 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                             vcvtneeph2ps(vmm_load, addr);
                         else
                             vcvtneoph2ps(vmm_load, addr);
+                    } else if (brg.is_f16_b_non_amx_vnni()) {
+                        const auto vnni_addr = ptr[reg_aux_B
+                                + B_offset(ld, utils::rnd_dn(rd, 2))];
+                        vmovups(vmm_load, vnni_addr);
+                        if (rd % 2 == 0)
+                            vpermw(vmm_load, f16_perm_even_vreg_, vmm_load);
+                        else
+                            vpermw(vmm_load, f16_perm_odd_vreg_, vmm_load);
+                        vcvtph2psx(vmm_load, Vmm_lower_t(vmm_load.getIdx()));
                     } else {
-                        if (brg.is_f16_b_non_amx_vnni()) {
-                            const auto vnni_addr = ptr[reg_aux_B
-                                    + B_offset(ld, utils::rnd_dn(rd, 2))];
-                            vmovups(vmm_load, vnni_addr);
-                            if (rd % 2 == 0)
-                                vpermw(vmm_load, f16_perm_even_vreg_, vmm_load);
-                            else
-                                vpermw(vmm_load, f16_perm_odd_vreg_, vmm_load);
-                            vcvtph2psx(
-                                    vmm_load, Vmm_lower_t(vmm_load.getIdx()));
-                        } else
-                            vcvtph2psx(vmm_load, addr);
+                        vcvtph2psx(vmm_load, addr);
                     }
                 } else if (brg.dt_b == data_type::bf16
                         && brg.isa_impl == avx2_vnni_2) {
@@ -2257,21 +2255,18 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                             vcvtneeph2ps(vmm_load, addr);
                         else
                             vcvtneoph2ps(vmm_load, addr);
+                    } else if (brg.is_f16_b_non_amx_vnni()) {
+                        const auto actual_B_offset
+                                = B_offset(ld, utils::rnd_dn(rd, 2));
+                        const auto vnni_addr = ptr[reg_aux_B + actual_B_offset];
+                        vmovups(vmm_load, vnni_addr);
+                        if (rd % 2 == 0)
+                            vpermw(vmm_load, f16_perm_even_vreg_, vmm_load);
+                        else
+                            vpermw(vmm_load, f16_perm_odd_vreg_, vmm_load);
+                        vcvtph2psx(vmm_load, Vmm_lower_t(vmm_load.getIdx()));
                     } else {
-                        if (brg.is_f16_b_non_amx_vnni()) {
-                            const auto actual_B_offset
-                                    = B_offset(ld, utils::rnd_dn(rd, 2));
-                            const auto vnni_addr
-                                    = ptr[reg_aux_B + actual_B_offset];
-                            vmovups(vmm_load, vnni_addr);
-                            if (rd % 2 == 0)
-                                vpermw(vmm_load, f16_perm_even_vreg_, vmm_load);
-                            else
-                                vpermw(vmm_load, f16_perm_odd_vreg_, vmm_load);
-                            vcvtph2psx(
-                                    vmm_load, Vmm_lower_t(vmm_load.getIdx()));
-                        } else
-                            vcvtph2psx(vmm_load, addr);
+                        vcvtph2psx(vmm_load, addr);
                     }
                 } else if (brg.dt_b == data_type::bf16
                         && brg.isa_impl == avx2_vnni_2) {

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -494,7 +494,8 @@ inline data_type_t get_mac_emu_data_type(const data_type_t data_type,
     using namespace data_type;
     if (req_emulation) switch (data_type) {
             case bf16:
-                if (isa == avx2_vnni_2) return f32;
+                if (utils::one_of(isa, avx2, avx2_vnni_2, avx512_core))
+                    return f32;
                 break;
             case f16:
                 if (utils::one_of(isa, avx2, avx2_vnni_2, avx512_core,

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -497,7 +497,8 @@ inline data_type_t get_mac_emu_data_type(const data_type_t data_type,
                 if (isa == avx2_vnni_2) return f32;
                 break;
             case f16:
-                if (utils::one_of(isa, avx2_vnni_2, avx512_core_fp16))
+                if (utils::one_of(isa, avx2, avx2_vnni_2, avx512_core,
+                            avx512_core_fp16))
                     return f32;
                 break;
             case f8_e5m2:

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -289,6 +289,8 @@ public:
     template <typename T>
     Xbyak::Address EVEX_compress_addr(
             Xbyak::Reg64 base, T raw_offt, bool bcast = false) {
+        assert(is_valid_isa(avx512_core));
+
         using Xbyak::Address;
         using Xbyak::Reg64;
         using Xbyak::RegExp;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -195,6 +195,11 @@ status_t check_isa_with_datatype(
             && IMPLICATION(bm_conf_utils.is_f32_f16(),
                     one_of(isa, avx512_core_fp16, avx2_vnni_2, avx512_core,
                             avx2))
+            // `avx512_core_amx` is not supported for plain upconversion as HW
+            // supports native compute.
+            && IMPLICATION(bm_conf_utils.is_f32_bf16(),
+                    one_of(isa, avx512_core_bf16, avx2_vnni_2, avx512_core,
+                            avx2))
             && IMPLICATION(bm_conf_utils.is_int8_with_bf16_dst(),
                     is_superset(isa, avx512_core) || isa == avx2_vnni_2)
             && IMPLICATION(bm_conf_utils.is_bf16_with_int_wei(),
@@ -207,12 +212,13 @@ status_t check_isa_with_datatype(
 }
 
 status_t check_datatype_cfg(const brgemm_matmul_conf_utils_t &bm_conf_utils) {
-    const bool ok = one_of(true, bm_conf_utils.is_f32(),
-                            bm_conf_utils.is_bf16(), bm_conf_utils.is_f16(),
-                            bm_conf_utils.is_f32_f16(), bm_conf_utils.is_bf32(),
-                            bm_conf_utils.is_f8(), bm_conf_utils.is_int8(),
-                            bm_conf_utils.is_bf16_with_int_wei(),
-                            bm_conf_utils.is_f16_with_int_wei())
+    const bool ok
+            = one_of(true, bm_conf_utils.is_f32(), bm_conf_utils.is_bf16(),
+                      bm_conf_utils.is_f16(), bm_conf_utils.is_f32_f16(),
+                      bm_conf_utils.is_f32_bf16(), bm_conf_utils.is_bf32(),
+                      bm_conf_utils.is_f8(), bm_conf_utils.is_int8(),
+                      bm_conf_utils.is_bf16_with_int_wei(),
+                      bm_conf_utils.is_f16_with_int_wei())
             && IMPLICATION(bm_conf_utils.is_bf16_with_int_wei()
                             || bm_conf_utils.is_f16_with_int_wei(),
                     bm_conf_utils.with_weights_decompression());
@@ -251,6 +257,10 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
     // avx2 as there's no kernel for such combination.
     , f32_f16_dt(bgmmc.src_dt == f32 && bgmmc.wei_dt == f16
               && one_of(bgmmc.dst_dt, f16, f32))
+    // Keep this var separate from bf16_dt to not slip bf16:bf16 on avx512_core
+    // and avx2 as there's no kernel for such combination.
+    , f32_bf16_dt(bgmmc.src_dt == f32 && bgmmc.wei_dt == bf16
+              && one_of(bgmmc.dst_dt, bf16, f32))
     , f16_with_int_wei_dt(weights_decompression_support && bgmmc.src_dt == f16
               && one_of(bgmmc.dst_dt, f16, f32))
     , A_any_layout(A_any_layout)
@@ -372,7 +382,7 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_tags(memory_desc_t &A_md,
         const bool is_adbc_allowed
                 = (this->is_bf16() || this->is_f32() || this->is_bf32()
                           || this->is_f16() || this->is_f32_f16()
-                          || this->is_bf16_with_int_wei()
+                          || this->is_f32_bf16() || this->is_bf16_with_int_wei()
                           || this->is_f16_with_int_wei())
                 && !xf16_avx2_vnni_2;
         bgmmc.src_tag = is_adbc_allowed
@@ -475,7 +485,7 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
         }
 
     if (this->is_bf16() || this->is_bf16_with_int_wei()
-            || ((this->is_f16() || this->is_f32_f16()
+            || ((this->is_f16() || this->is_f32_f16() || this->is_f32_bf16()
                         || this->is_f16_with_int_wei())
                     && (is_superset(bgmmc.isa, avx512_core_amx)
                             || is_superset(bgmmc.isa, avx2_vnni_2))))
@@ -488,7 +498,8 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
         }
     // Note: bf32 assumes f32 blocking
     if (this->is_f32() || this->is_bf32() || this->is_f16()
-            || this->is_f32_f16() || this->is_f16_with_int_wei())
+            || this->is_f32_f16() || this->is_f32_bf16()
+            || this->is_f16_with_int_wei())
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c : BA16a64b;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c : BA16a48b;
@@ -742,7 +753,8 @@ void compute_blocking_heuristic_amx(const brgemm_matmul_conf_t &bgmmc,
             = div_up(static_cast<int>(bgmmc.K), min_k_per_thread);
     const bool is_amx_xf16 = bgmmc.is_amx
             && (bm_conf_utils.is_bf16() || bm_conf_utils.is_f16()
-                    || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_bf32()
+                    || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
+                    || bm_conf_utils.is_bf32()
                     || bm_conf_utils.is_bf16_with_int_wei()
                     || bm_conf_utils.is_f16_with_int_wei());
     const bool is_amx_int8 = bgmmc.is_amx && bm_conf_utils.is_int8();
@@ -1297,6 +1309,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.is_bf16_with_int_wei = bm_conf_utils.is_bf16_with_int_wei();
     bgmmc.is_f16_with_int_wei = bm_conf_utils.is_f16_with_int_wei();
     bgmmc.is_f32_f16 = bm_conf_utils.is_f32_f16();
+    bgmmc.is_f32_bf16 = bm_conf_utils.is_f32_bf16();
     bgmmc.with_wei_decompression = bm_conf_utils.with_weights_decompression();
     bgmmc.is_int4_weights = one_of(bgmmc.wei_dt, data_type::s4, data_type::u4);
 
@@ -1314,15 +1327,17 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.wei_dt = f32;
         bgmmc.tr_a_dt_sz = types::data_type_size(f32);
         bgmmc.tr_b_dt_sz = types::data_type_size(f32);
-    } else if (bm_conf_utils.is_f32_f16() && is_superset(bgmmc.isa, avx2)) {
+    } else if ((bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16())
+            && is_superset(bgmmc.isa, avx2)) {
         // Note 1: Keep this branch separately from f16 one to have different
-        // ISA conditions (f16 includes f16:f32 and f16:f16 combinations).
+        // ISA conditions (f16 includes f16:f32 and f16:f16 combinations). Same
+        // applies for bf16 (which includes bf16:bf16).
         // Note 2: If `use_buffer_b()` is false, let the kernel perform the
         // conversion. Otherwise, make the copy_b routine handle the conversion
         // and set kernel data types to f32.
         // Note 3: Since `use_buffer_b()` depends on `bgmmc.wei_tag`, which is
         // set later in the code due to its dependencies, the update of data
-        // types to f32 happens below in ANCHOR: `CONVERT_F32_F16_DATA_TYPES`.
+        // types to f32 happens below in ANCHOR: `CONVERT_F32_XF16_DATA_TYPES`.
     } else if (bgmmc.is_f16_with_int_wei && bgmmc.isa != avx512_core_fp16) {
         bgmmc.src_dt = f16;
         bgmmc.wei_dt = f16;
@@ -1449,9 +1464,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             && bgmmc.is_oscale_per_k && bgmmc.is_oscale_per_n
             && bgmmc.transposed_B;
 
-    if (bm_conf_utils.is_f32_f16() && is_superset(bgmmc.isa, avx2)
-            && bm_conf_utils.use_buffer_b()) {
-        // ANCHOR: `CONVERT_F32_F16_DATA_TYPES`
+    if ((bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16())
+            && is_superset(bgmmc.isa, avx2) && bm_conf_utils.use_buffer_b()) {
+        // ANCHOR: `CONVERT_F32_XF16_DATA_TYPES`
         bgmmc.src_dt = f32;
         bgmmc.wei_dt = f32;
         bgmmc.tr_a_dt_sz = types::data_type_size(f32);
@@ -1660,7 +1675,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     is_small_shapes = is_small_shapes && (bgmmc.isa != avx512_core_amx_fp16);
 
     if (bm_conf_utils.is_bf16() || bm_conf_utils.is_f16()
-            || bm_conf_utils.is_f32_f16()
+            || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
             || bm_conf_utils.is_bf16_with_int_wei()
             || bm_conf_utils.is_f16_with_int_wei()) {
         // empirical observation for performance breakpoint between amx and vnni

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -191,6 +191,7 @@ struct brgemm_matmul_conf_t {
     bool is_bf16_with_int_wei = false;
     bool is_f16_with_int_wei = false;
     bool is_f32_f16 = false;
+    bool is_f32_bf16 = false;
     bool is_int4_weights = false;
     bool req_wei_vnni_downconvert = false;
     bool is_runtime_M = false;
@@ -303,6 +304,8 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool is_f32_f16() const { return f32_f16_dt; }
 
+    inline bool is_f32_bf16() const { return f32_bf16_dt; }
+
     inline bool is_f16_with_int_wei() const { return f16_with_int_wei_dt; }
 
     inline bool with_weights_decompression() const {
@@ -341,7 +344,7 @@ private:
 
     const bool f32_dt, bf16_dt, f16_dt, f8_dt, int8_dt, bf32_dt;
     const bool weights_decompression_support, bf16_with_int_wei_dt, f32_f16_dt,
-            f16_with_int_wei_dt;
+            f32_bf16_dt, f16_with_int_wei_dt;
 
     const bool A_any_layout;
     const bool B_any_layout;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -190,6 +190,7 @@ struct brgemm_matmul_conf_t {
     bool is_bf32 = false;
     bool is_bf16_with_int_wei = false;
     bool is_f16_with_int_wei = false;
+    bool is_f32_f16 = false;
     bool is_int4_weights = false;
     bool req_wei_vnni_downconvert = false;
     bool is_runtime_M = false;
@@ -230,10 +231,8 @@ struct brgemm_matmul_conf_utils_t {
     inline bool use_buffer_b(bool use_heuristic = true) const {
         if (bgmmc.is_runtime_N) return true;
         if (bgmmc.is_bf16_with_int_wei) return true;
+        if (bgmmc.is_f16_with_int_wei) return true;
         if (bgmmc.apply_scales_in_buffer_b) return true;
-        if (utils::one_of(true, bgmmc.is_runtime_N, bgmmc.is_bf16_with_int_wei,
-                    bgmmc.is_f16_with_int_wei, bgmmc.apply_scales_in_buffer_b))
-            return true;
 
         if (bgmmc.is_amx)
             // use b_buffer for AMX when:
@@ -302,6 +301,8 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool is_bf16_with_int_wei() const { return bf16_with_int_wei_dt; }
 
+    inline bool is_f32_f16() const { return f32_f16_dt; }
+
     inline bool is_f16_with_int_wei() const { return f16_with_int_wei_dt; }
 
     inline bool with_weights_decompression() const {
@@ -339,7 +340,7 @@ private:
     brgemm_matmul_conf_t &bgmmc;
 
     const bool f32_dt, bf16_dt, f16_dt, f8_dt, int8_dt, bf32_dt;
-    const bool weights_decompression_support, bf16_with_int_wei_dt,
+    const bool weights_decompression_support, bf16_with_int_wei_dt, f32_f16_dt,
             f16_with_int_wei_dt;
 
     const bool A_any_layout;

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
@@ -1,6 +1,6 @@
 --reset
 
---dt=bf16,bf16:bf16:f32
+--dt=bf16,bf16:bf16:f32,f32:bf16:f32
 --bia_dt=undef,f32,bf16
 --beta=0,1
 --attr-post-ops=,sum:2,relu

--- a/tests/benchdnn/inputs/matmul/test_matmul_bfloat16
+++ b/tests/benchdnn/inputs/matmul/test_matmul_bfloat16
@@ -1,7 +1,7 @@
 # bf16
 --reset
 
---dt=bf16:bf16:f32,bf16
+--dt=bf16:bf16:f32,bf16,f32:bf16:f32
 --stag=ab,ba --wtag=ab,ba --dtag=ab
 --runtime_dims_masks=0,2:1,1:0,3:1
 --bia_dt=undef,f32 --bia_mask=2
@@ -28,13 +28,13 @@
 
 # test any
 --reset
---dt=bf16:bf16:f32,bf16
+--dt=bf16:bf16:f32,bf16,f32:bf16:f32
 --stag=ab,ba,any --wtag=ab,ba,any --dtag=ab,any
 --batch=shapes_2d
 
 # 3d
 --reset
---dt=bf16:bf16:f32,bf16
+--dt=bf16:bf16:f32,bf16,f32:bf16:f32
 --stag=abc,acb --wtag=abc,acb --dtag=abc
 --bia_dt=undef,f32 --bia_mask=4,6
 

--- a/tests/benchdnn/inputs/matmul/test_matmul_float16
+++ b/tests/benchdnn/inputs/matmul/test_matmul_float16
@@ -1,7 +1,8 @@
 # f16
 --reset
 
---dt=f16:f16:f32,f16
+--skip-impl=ref
+--dt=f16:f16:f32,f16,f32:f16:f32
 --stag=ab,ba --wtag=ab,ba --dtag=ab
 --runtime_dims_masks=0,2:1,1:0,3:1
 --bia_dt=undef,f32 --bia_mask=2
@@ -28,13 +29,13 @@
 
 # test any
 --reset
---dt=f16:f16:f32,f16
+--dt=f16:f16:f32,f16,f32:f16:f32
 --stag=ab,ba,any --wtag=ab,ba,any --dtag=ab,any
 --batch=shapes_2d
 
 # 3d
 --reset
---dt=f16:f16:f32,f16
+--dt=f16:f16:f32,f16,f32:f16:f32
 --stag=abc,acb --wtag=abc,acb --dtag=abc
 --bia_dt=undef,f32 --bia_mask=4,6
 


### PR DESCRIPTION
MFDNN-11992

The change adds f32:f16:f32 support on AVX512_CORE and AVX2 through a up-conversion path.
Extended a brgemm kernel (thanks @dmitry-gorokhov) and brgemm matmul copy routines to support the conversion.