### PR TITLE
Restricted x64 CI to relevant changes

### DIFF
--- a/.github/automation/.azure-pipeline.yml
+++ b/.github/automation/.azure-pipeline.yml
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 #===============================================================================
 # Copyright 2019-2024 Intel Corporation
 #
@@ -16,9 +14,48 @@
 # limitations under the License.
 #===============================================================================
 
+# Reference:
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+
 trigger:
-- main
-- rls-*
+  batch: true
+  branches:
+    include: [ main, 'rls-*' ]
+  paths:
+    include:
+      - .github
+      - cmake
+      - examples
+      - include
+      - src
+      - tests
+      - CMakeLists.txt
+    exclude:
+      - src/gpu
+      - src/cpu/aarch64
+      - src/cpu/ppc64
+      - src/cpu/rv64
+      - src/cpu/s390x
+
+pr:
+  autoCancel: true
+  branches:
+    include: [ main, 'rls-*' ]
+  paths:
+    include:
+      - .github
+      - cmake
+      - examples
+      - include
+      - src
+      - tests
+      - CMakeLists.txt
+    exclude:
+      - src/gpu
+      - src/cpu/aarch64
+      - src/cpu/ppc64
+      - src/cpu/rv64
+      - src/cpu/s390x
 
 jobs:
   - job: 'Ubuntu20'

--- a/.github/automation/.azure-pipeline.yml
+++ b/.github/automation/.azure-pipeline.yml
@@ -21,17 +21,6 @@ trigger:
 - rls-*
 
 jobs:
-  - job: 'ClangFormat'
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-      - script: |
-          .github/automation/env/clang.sh 11
-        displayName: 'init'
-      - script: |
-          .github/automation/clang-format.sh
-        displayName: 'ClangFormat_Check'
-        failOnStderr: true 
   - job: 'Ubuntu20'
     timeoutInMinutes: 120
     pool:

--- a/.github/automation/clang-format.sh
+++ b/.github/automation/clang-format.sh
@@ -16,10 +16,17 @@
 # limitations under the License.
 #===============================================================================
 
-echo "Using clang-format version: $(clang-format --version)"
+CLANG_FORMAT=clang-format-11
+
+echo "Checking ${CLANG_FORMAT}"
+if ! ${CLANG_FORMAT} --version; then
+    echo ${CLANG_FORMAT} is not available or not working correctly.
+    exit 1
+fi
+
 echo "Starting format check..."
 
-for filename in $(find "$(pwd)" -type f | grep -P ".*\.(c|cpp|h|hpp|cl)$"); do clang-format -style=file -i $filename; done
+for filename in $(find "$(pwd)" -type f | grep -P ".*\.(c|cpp|h|hpp|cl)$"); do ${CLANG_FORMAT} -style=file -i $filename; done
 
 RETURN_CODE=0
 echo $(git status) | grep "nothing to commit" > /dev/null

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 # *******************************************************************************
 
-name: "PR Checks"
+name: "PR Linters"
 
 on:
   pull_request:
@@ -31,8 +31,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  commit-message-check:
-    name: Commit message checker
+  pr-formatting:
+    name: Formatting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,3 +41,7 @@ jobs:
           fetch-depth: 0
       - name: Check commit messages
         run: python3 ./.github/automation/commit-msg-check.py "${{ github.event.pull_request.head.sha }}" "${{ github.event.pull_request.base.sha }}"
+      - name: Install clang-format
+        run: sudo apt update && sudo apt install -y "clang-format-11"
+      - name: Check code formatting
+        run: .github/automation/clang-format.sh


### PR DESCRIPTION
This PR updates Azure Pipelines configuration to only trigger x64 CI for changes that can break it, specifically:
* .github to catch CI related changes
* cmake, examples, include, tests
* src/common, src/cpu/common, src/cpu/x64

Also clang-format check moved from Azure Pipelines to Github Actions, as Azure does not seem to allow jobs with different triggers.

