### PR TITLE
[rls-v3.6 backport] cpu: x64: matmul/brgemm: enable f16 dst dt for int8 matmul 

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -145,8 +145,11 @@ void set_isa_impl(brgemm_desc_t *brg) {
                     is_isa_ok(avx512_core_fp16), avx512_core_fp16);
         }
     } else if (brg->is_int8) {
-        brg->isa_impl = utils::map(true, isa_undef, is_isa_ok(avx512_core_amx),
-                avx512_core_amx, is_isa_ok(avx512_core_vnni), avx512_core_vnni,
+        brg->isa_impl = utils::map(true, isa_undef,
+                is_isa_ok(avx512_core_amx_fp16), avx512_core_amx_fp16,
+                is_isa_ok(avx512_core_amx), avx512_core_amx,
+                is_isa_ok(avx512_core_fp16), avx512_core_fp16,
+                is_isa_ok(avx512_core_vnni), avx512_core_vnni,
                 is_isa_ok(avx512_core), avx512_core, is_isa_ok(avx2_vnni_2),
                 avx2_vnni_2, is_isa_ok(avx2_vnni), avx2_vnni);
     } else if (brg->is_fp8) {
@@ -847,7 +850,8 @@ void init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
 
     brg->isa_user = isa;
     set_isa_impl(brg);
-    brg->is_int8_tmm = brg->is_int8 && brg->isa_impl == avx512_core_amx;
+    brg->is_int8_tmm
+            = brg->is_int8 && is_superset(brg->isa_impl, avx512_core_amx);
     brg->is_bf16_tmm = brg->is_bf16 && brg->isa_impl == avx512_core_amx;
     brg->is_f16_tmm = brg->is_f16 && brg->isa_impl == avx512_core_amx_fp16;
     brg->is_bf32 = is_bf32

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -52,7 +52,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
     const bool is_f32 = everyone_is(f32, src_dt, wei_dt, dst_dt);
     const bool is_int8 = one_of(src_dt, u8, s8) && wei_dt == s8
-            && one_of(dst_dt, u8, s8, s32, f32, bf16);
+            && one_of(dst_dt, u8, s8, s32, f32, f16, bf16);
     const bool is_f8 = one_of(src_dt, f8_e5m2, f8_e4m3)
             && one_of(wei_dt, f8_e5m2, f8_e4m3)
             && one_of(dst_dt, f32, f16, bf16, f8_e5m2, f8_e4m3);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -178,8 +178,8 @@ status_t check_isa_with_datatype(
             = IMPLICATION(bm_conf_utils.is_f32(),
                       one_of(isa, avx512_core, avx2) || bm_conf_utils.is_bf32())
             && IMPLICATION(bm_conf_utils.is_int8(),
-                    one_of(isa, avx512_core_amx, avx512_core_vnni, avx512_core,
-                            avx2_vnni_2, avx2_vnni))
+                    is_superset(isa, avx512_core)
+                            || is_superset(isa, avx2_vnni))
             && IMPLICATION(bm_conf_utils.is_bf16(),
                     one_of(isa, avx512_core_amx, avx512_core_bf16, avx2_vnni_2))
             && IMPLICATION(bm_conf_utils.is_f16(),

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -1,6 +1,6 @@
 # Plain cases
 --reset
---dt=f64,f32,bf16,f16,f8_e5m2,f8_e4m3,f8_e5m2:f8_e4m3:f32,u8:s8:s8,s8:s8:f32
+--dt=f64,f32,bf16,f16,f8_e5m2,f8_e4m3,f8_e5m2:f8_e4m3:f32,u8:s8:s8,s8:s8:f32,s8:s8:f16,s8:u8:f16
 --bia_dt=f32
 --bia_mask=2
 --batch=shapes_2d_ci
@@ -10,7 +10,7 @@
 
 # Post-ops check for different data types
 --reset
---dt=f32,bf16,f16,f8_e5m2,f8_e4m3,u8:s8:s8,s8:s8:f32
+--dt=f32,bf16,f16,f8_e5m2,f8_e4m3,u8:s8:s8,s8:s8:f32,s8:s8:f16,s8:u8:f16
 --attr-post-ops=sum+relu:0.5+add:f32
 --batch=shapes_2d_ci
 
@@ -31,7 +31,7 @@
 
 # Different tags
 --reset
---dt=f64,f32,bf16,f16,f8_e5m2,f8_e4m3,u8:s8:s8,s8:s8:f32
+--dt=f64,f32,bf16,f16,f8_e5m2,f8_e4m3,u8:s8:s8,s8:s8:f32,s8:s8:f16,s8:u8:f16
 --stag=ab,ba
 --wtag=ab,ba
 --dtag=ab,ba
@@ -54,7 +54,7 @@
 
 # Arg scales check
 --reset
---dt=f64,f32,bf16,f16,f8_e5m2,f8_e4m3,u8:s8:u8,s8:s8:f32
+--dt=f64,f32,bf16,f16,f8_e5m2,f8_e4m3,u8:s8:u8,s8:s8:f32,s8:s8:f16,s8:u8:f16
 --attr-scales=src:common:0.25+wei:common:0.5+dst:common:2,wei:per_oc
 --batch=shapes_2d_ci
 
@@ -68,7 +68,7 @@
 
 # Zero-points check
 --reset
---dt=s8:s8:s8,u8:s8:f32,u8:s8:bf16
+--dt=s8:s8:s8,u8:s8:f32,u8:s8:bf16,s8:s8:f16,s8:u8:f16
 --attr-zero-points=src:common:1+wei:common:-1+dst:common:2
 --batch=shapes_2d_ci
 

--- a/tests/benchdnn/inputs/matmul/test_matmul_int8
+++ b/tests/benchdnn/inputs/matmul/test_matmul_int8
@@ -1,7 +1,7 @@
 # int8
 --reset
 
---dt=u8:s8:s8,s8:s8:f32
+--dt=u8:s8:s8,s8:s8:f32,s8:s8:f16,s8:u8:f16
 --stag=ab --wtag=ab,ba --dtag=ab
 --runtime_dims_masks=0,2:1,1:0,3:1
 --bia_dt=undef,f32 --bia_mask=2


### PR DESCRIPTION
backport for https://github.com/oneapi-src/oneDNN/pull/2253