### PR TITLE
 Fix CI failing tests for matmul and convolution

### DIFF
--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -70,6 +70,8 @@ status_t acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::pd_t::init(
     CHECK(acl_convolution_utils::acl_init_conf(
             acp_, src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr()));
 
+    CHECK(post_ops.init(engine, attr_.post_ops_, dst_md_, acp_.act_info));
+
     // Validate convolution manually to check for return status
     ACL_CHECK_VALID(Op::validate(&acp_.src_tensor_info, &acp_.wei_tensor_info,
             acp_.with_bias ? &acp_.bia_tensor_info : nullptr,
@@ -83,10 +85,9 @@ status_t acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::pd_t::init(
             acp_.dilation_info, acp_.act_info, acp_.fast_math);
 
     auto scratchpad = scratchpad_registry().registrar();
-    const auto mem_req = conv.workspace();
-    return init_scratchpad(conv, scratchpad, gemm_conv_keys, engine, post_ops,
-            attr_.post_ops_, acp_.act_info, acp_.use_dst_acc_for_sum, dst_md_,
-            bias_md_, acp_.is_quantized);
+    return init_scratchpad(conv, scratchpad, gemm_conv_keys, engine,
+            post_ops, attr_.post_ops_, acp_.act_info, acp_.use_dst_acc_for_sum,
+            dst_md_, bias_md_, acp_.is_quantized);
 }
 
 template <data_type_t src_t, data_type_t wei_t, data_type_t dst_t,

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -75,8 +75,10 @@ status_t acl_lowp_matmul_sq_t::pd_t::init(engine_t *engine) {
                             && wei_d.data_type() == s8
                             && src_d.data_type() == s8
                     ? dst_d.data_type() == s8
-                    : dst_d.data_type() == u8
-                            && utils::one_of(bia_d.data_type(), f32, undef),
+                    : dst_d.data_type() == u8,
+            VERBOSE_UNSUPPORTED_DT_CFG);
+
+    VDISPATCH_MATMUL(utils::one_of(bia_d.data_type(), f32, undef),
             VERBOSE_UNSUPPORTED_DT_CFG);
 
     VDISPATCH_MATMUL(src_d.matches_tag(format_tag::ab)
@@ -223,7 +225,7 @@ status_t acl_lowp_matmul_sq_t::execute(const exec_ctx_t &ctx) const {
     acl_obj.wei_tensor.info()->set_quantization_info(
             arm_compute::QuantizationInfo(*wei_scale, -wei_zero_point, true));
 
-    // for efficiency reasons, oneDNN saves the inverse of the destination
+    // for efficiency reasons, OneDNN saves the inverse of the destination
     acl_obj.dst_tensor.info()->set_quantization_info(
             arm_compute::QuantizationInfo(
                     1.0 / (*dst_scale), dst_zero_point, true));

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -225,7 +225,7 @@ status_t acl_lowp_matmul_sq_t::execute(const exec_ctx_t &ctx) const {
     acl_obj.wei_tensor.info()->set_quantization_info(
             arm_compute::QuantizationInfo(*wei_scale, -wei_zero_point, true));
 
-    // for efficiency reasons, OneDNN saves the inverse of the destination
+    // for efficiency reasons, oneDNN saves the inverse of the destination
     acl_obj.dst_tensor.info()->set_quantization_info(
             arm_compute::QuantizationInfo(
                     1.0 / (*dst_scale), dst_zero_point, true));


### PR DESCRIPTION
# Description

Tests `test_benchdnn_modeC_conv_ci_cpu` and `test_benchdnn_modeC_matmul_ci_cpu` are failing, and this patch fixes them.

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?