### PR TITLE
github: automation: fixed rules for commit scope check

### DIFF
--- a/.github/automation/commit-msg-check.py
+++ b/.github/automation/commit-msg-check.py
@@ -31,22 +31,22 @@ def __scopeCheck(msg: str):
     status = "Message scope: "
 
     if not re.match('^[a-z0-9]+(, [a-z0-9]+)*: ', msg):
-        print(f"{status} FAILED: Commit message must follow the format <scope>:[ <scope>:] <short description>")
+        print(f"{status} FAILED: Commit message must follow the format "
+               "<scope>:[ <scope>:] <short description>")
         return False
 
     print(f"{status} OK")
     return True
 
-# Ensuring a character limit for the first line.
+# Ensure  a character limit for the first line.
 def __numCharacterCheck(msg: str):
     status = "Message length:"
-    summary = msg.partition("\n")[0]
-    msgSummaryLen = len(summary)
-    if msgSummaryLen <= 72:
+    if len(msg) <= 72:
         print(f"{status} OK")
         return True
     else:
-        print(f"{status} FAILED: Commit message summary must not exceed 72 characters.")
+        print(f"{status} FAILED: Commit message summary must not "
+               "exceed 72 characters.")
         return False
 
 def main():
@@ -58,7 +58,8 @@ def main():
     head: str = args.head
 
     commit_range = base + ".." + head
-    messages = subprocess.run(["git", "rev-list", "--format=oneline", commit_range], capture_output=True, text=True).stdout
+    messages = subprocess.run(["git", "rev-list", "--format=oneline",
+        commit_range], capture_output=True, text=True).stdout
 
     is_ok = True
     for i in messages.splitlines():
@@ -72,7 +73,8 @@ def main():
     if is_ok:
         print("All commmit messages are formatted correctly. ")
     else:
-        print("Some commit message checks failed. Please align commit messages with Contributing Guidelines and update the PR.")
+        print("Some commit message checks failed. Please align commit messages "
+              "with Contributing Guidelines and update the PR.")
         exit(1)
 
 

--- a/.github/automation/commit-msg-check.py
+++ b/.github/automation/commit-msg-check.py
@@ -20,33 +20,24 @@
 
 import argparse
 import subprocess
+import re
 
-# * Ensuring the scopes end in colon and same level scopes are comma delimited.
+# Ensure the scope ends in a colon and that same level scopes are
+# comma delimited.
+# Current implementation only checks the first level scope as ':' can be used
+# in the commit description (ex: TBB::tbb or bf16:bf16).
 # TODO: Limit scopes to an acceptable list of tags.
 def __scopeCheck(msg: str):
     status = "Message scope: "
 
-    firstLine = (msg.partition("\n")[0]).strip()
-
-    if not ":" in firstLine:
-        print(f"{status} FAILED: Commit message does not include scope")
+    if not re.match('^[a-z0-9]+(, [a-z0-9]+)*: ', msg):
+        print(f"{status} FAILED: Commit message must follow the format <scope>:[ <scope>:] <short description>")
         return False
-
-    # The last element of the split is the title, which we don't care about.
-    scopesArray = firstLine.split(":")[:-1]
-
-    for scopes in scopesArray:
-        numWords = len(scopes.split())
-        numCommas = scopes.count(",")
-
-        if numWords != numCommas + 1:
-            print(f"{status} FAILED: Same-level scopes must be comma-separated. Bad token: '{scopes}'")
-            return False
 
     print(f"{status} OK")
     return True
 
-# * Ensuring a character limit for the first line.
+# Ensuring a character limit for the first line.
 def __numCharacterCheck(msg: str):
     status = "Message length:"
     summary = msg.partition("\n")[0]
@@ -79,7 +70,7 @@ def main():
       is_ok = is_ok and result
 
     if is_ok:
-        print("All commmit messages are formtted correctly. ")
+        print("All commmit messages are formatted correctly. ")
     else:
         print("Some commit message checks failed. Please align commit messages with Contributing Guidelines and update the PR.")
         exit(1)


### PR DESCRIPTION
This PR updates commit checker to avoid false positives in #2279 ([job link](https://github.com/oneapi-src/oneDNN/actions/runs/12393533080/job/34594975133)), #2276, and #2272.

As `:` can be used in commit message itself there's no good way to reliably identify cases with multi-level scope.
