### PR TITLE
gpu: generic: sycl: fix typos in VDISPATCH_SUM calls

### DIFF
--- a/src/gpu/generic/sycl/ref_sum.hpp
+++ b/src/gpu/generic/sycl/ref_sum.hpp
@@ -73,7 +73,7 @@ struct ref_sum_t : public gpu::generic::sycl::primitive_t {
             }
 
             VDISPATCH_SUM_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
-            DISPATCH_SUM(n <= DNNL_REF_SUM_MAX_NUM_TENSORS, VERBOSE_BAD_PARAM,
+            VDISPATCH_SUM(n <= DNNL_REF_SUM_MAX_NUM_TENSORS, VERBOSE_BAD_PARAM,
                     "n_inputs");
 
             return init_conf();

--- a/src/gpu/generic/sycl/ref_sum_many_inputs.hpp
+++ b/src/gpu/generic/sycl/ref_sum_many_inputs.hpp
@@ -46,11 +46,11 @@ struct ref_sum_many_inputs_t : public gpu::generic::sycl::primitive_t {
 
             const int n = n_inputs();
             VDISPATCH_SUM_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_SUM_SC(
+            VDISPATCH_SUM(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             // prevent inf recursion
-            VDISPATCH_SUM_SC(n > DNNL_REF_SUM_MAX_NUM_TENSORS,
-                    VERBOSE_BAD_PARAM, "n_inputs");
+            VDISPATCH_SUM(n > DNNL_REF_SUM_MAX_NUM_TENSORS, VERBOSE_BAD_PARAM,
+                    "n_inputs");
 
             // the first kernel handles up to 8 inputs and remaining ones up to 7
             const int n_kernels = n == 1


### PR DESCRIPTION
This fixes the generic GPU SyCL build failing due to typos in VDISPATCH_SUM macro calls.