### PR TITLE
xe: ocl: gemm: fix gemm_with_post_ops accumulator type

### DIFF
--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
@@ -98,7 +98,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src, __global BIA_DATA_T *bias,
 #else
     ACC_DATA_T acc = SRC_TO_ACC(src[data_idx]);
 #endif
-    float accumulator = acc;
+    float accumulator = convert_float(acc);
     if ((d0 == D0_WO_PADDING && d1 == D1_WO_PADDING && d2 == D2_WO_PADDING
                 && d3 == D3_WO_PADDING)
             || (d0 < D0_WO_PADDING && d1 < D1_WO_PADDING && d2 < D2_WO_PADDING
@@ -116,7 +116,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src, __global BIA_DATA_T *bias,
         const float b_scale
                 = B_SCALES ? WEI_SCALES_TO_REF(b_scales[scale_stride * d3]) : 1;
 #endif
-        acc *= A_SCALE * b_scale;
+        accumulator *= A_SCALE * b_scale;
 #endif
 
 #if WITH_BIAS == 1
@@ -127,7 +127,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src, __global BIA_DATA_T *bias,
 #else
         size_t bia_idx = BIA_OFF(d0, d1, 0, 0, 0);
 #endif
-        acc += BIA_TO_ACC(bias[bia_idx]);
+        accumulator += BIA_TO_ACC(bias[bia_idx]);
 #endif
 
         // Apply postops
@@ -136,7 +136,6 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src, __global BIA_DATA_T *bias,
         sum_src = DST_TO_ACC(dst[data_idx]);
 #endif
 
-        accumulator = acc;
 #if NDIMS == 2
         APPLY_POST_OPS_SERIAL(accumulator, float, sum_src, float, d0, 1, d1, 1,
                 0, 1, 0, 1, 0, 1, 0, 1);


### PR DESCRIPTION
Fixes the following error observed on XeLP.
```
$ ~/dnnl/build_clang/tests/benchdnn/benchdnn  --mode-modifier=P --matmul --engine=gpu --dt=s8:u8:f16 --attr-scales=src:common:0.25 2048x13:13x512
[   0][DST][0:0] exp_f32:         9.5 exp:         9.5 got:           9 diff:     0.5 rdiff:0.0526316
[   1][DST][0:1] exp_f32:         1.5 exp:         1.5 got:           1 diff:     0.5 rdiff:0.333333
[   2][DST][0:2] exp_f32:         5.5 exp:         5.5 got:           5 diff:     0.5 rdiff:0.0909091
[   3][DST][0:3] exp_f32:         9.5 exp:         9.5 got:           9 diff:     0.5 rdiff:0.0526316
[   4][DST][0:4] exp_f32:        4.25 exp:        4.25 got:           4 diff:    0.25 rdiff:0.0588235
[   5][DST][0:5] exp_f32:        14.5 exp:        14.5 got:          14 diff:     0.5 rdiff:0.0344828
[   8][DST][0:8] exp_f32:       -1.25 exp:       -1.25 got:          -1 diff:    0.25 rdiff:     0.2
[   9][DST][0:9] exp_f32:        9.25 exp:        9.25 got:           9 diff:    0.25 rdiff:0.027027
[  10][DST][0:10] exp_f32:       11.25 exp:       11.25 got:          11 diff:    0.25 rdiff:0.0222222
[  11][DST][0:11] exp_f32:        -2.5 exp:        -2.5 got:          -2 diff:     0.5 rdiff:     0.2
[COMPARE_STATS][DST]: trh=0 err_max_diff:    0.75 err_max_rdiff:       1 all_max_diff:    0.75 all_max_rdiff:       1
[PRIM_REF][INFO]: L2_size:327680 bytes; per_core_L3_size:2621440 bytes; nthr:24; impl_name:gemm:jit:f32
[PRIM_REF][REPRO]: --mode-modifier=P --matmul --engine=cpu --attr-scales=src:common:0.25 2048x13:13x512
0:FAILED (errors:776201 total:1048576) __REPRO: --mode-modifier=P --matmul --engine=gpu --dt=s8:u8:f16 --attr-scales=src:common:0.25 2048x13:13x512
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 0.47s; fill: 0.00s (0%); compute_ref: 0.01s (2%); compare: 0.01s (2%);
```

Fixes [MFDNN-12822](https://jira.devtools.intel.com/browse/MFDNN-12882) 