### PR TITLE
[GPU] Conv and Gemm fix

### DIFF
--- a/src/gpu/intel/jit/conv/zp_plan.cpp
+++ b/src/gpu/intel/jit/conv/zp_plan.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1268,7 +1268,7 @@ public:
             const expr_t &c_buf, const split_dispatcher_t &sd,
             int subtile_idx) const {
         const auto comp_type = comp_layout_.type();
-        const auto mask_type = mask_layout_.type();
+        const auto mask_type = type_t::s16();
         const dim_t kw_dim = comp_layout_.dim(comp_kw_idx_);
         std::vector<int> comp_off;
         std::vector<int> mask_off;


### PR DESCRIPTION
1) Fix data type for conv zp mask; set to `s16` instead of `s32`. This is to avoid invalid data type combination for the mad instruction,`mad dst:d src0:d src1:d src2:d`.

Failing case  
> --mode-modifier=P --conv --engine=gpu --skip-impl=ref --allow-enum-tags-only=false --check-ref-impl=true -- dt=u8:s8:u8 --attr-scales=wei:per_oc --attr-zero-points=src:per_dim_1 --attr-post-ops=hardswish:0.271:0.314+linear:0.271:0.314    g240mb32ic240ih28oc240oh14kh3sh2ph0n"f191c263e53dbb3ce0c02a13f311a72a*1"

2) Fix gemm hang for the following case on Xe2: -Fixed in https://github.com/oneapi-src/oneDNN/pull/2358#issuecomment-2580750925
> --matmul --engine=gpu --dt=f16:s4:f16 --wtag=acb --attr-scales=wei:per_ocic:f16:128x1 --attr-zero-points=wei:per_ocic:u4:128x1 --attr-fpmath=f16:true --skip-impl=ref 3x96x512:3x512x64


Seems `lookahead `should match `reqLoad`