### PR TITLE
tests: benchdnn: add experimental support for sycl graph

### DIFF
--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2020-2024 Intel Corporation
+# Copyright 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ set(DNNL_TEST_SET_COVERAGE "0")
 set(DNNL_TEST_SET_COVERAGE_STR "")
 set(DNNL_TEST_SET_HAS_NO_CORR "0")
 set(DNNL_TEST_SET_HAS_ADD_BITWISE "0")
+set(DNNL_TEST_SET_HAS_GRAPH_EXE "0")
 
 function(check_consistency entry)
     if(NOT DNNL_TEST_SET_COVERAGE EQUAL 0)
@@ -57,6 +58,8 @@ foreach(entry ${DNNL_TEST_SET})
         set(DNNL_TEST_SET_HAS_NO_CORR "1")
     elseif(entry STREQUAL "ADD_BITWISE")
         set(DNNL_TEST_SET_HAS_ADD_BITWISE "1")
+    elseif(entry STREQUAL "GRAPH_EXE")
+        set(DNNL_TEST_SET_HAS_GRAPH_EXE "1")
     elseif(entry STREQUAL "CI_NO_CORR") # Left here for compatibility till v4.0
         set(DNNL_TEST_SET_COVERAGE ${DNNL_TEST_SET_CI})
         set(DNNL_TEST_SET_COVERAGE_STR "CI")
@@ -68,7 +71,7 @@ foreach(entry ${DNNL_TEST_SET})
         message(FATAL_ERROR
                 "The DNNL_TEST_SET entry ${entry} is not recognized. "
                 "Supported values are:"
-                "NIGHTLY, CI, SMOKE, NO_CORR, ADD_BITWISE.")
+                "NIGHTLY, CI, SMOKE, NO_CORR, ADD_BITWISE, GRAPH_EXE.")
     endif()
 endforeach()
 
@@ -78,4 +81,7 @@ if(DNNL_TEST_SET_HAS_NO_CORR EQUAL 1)
 endif()
 if(DNNL_TEST_SET_HAS_ADD_BITWISE EQUAL 1)
     message(STATUS "Enabled testing modifier: Add bitwise validation")
+endif()
+if(DNNL_TEST_SET_HAS_GRAPH_EXE EQUAL 1)
+    message(STATUS "Enabled testing modifier: Use graph execution")
 endif()

--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2017-2024 Intel Corporation
+# Copyright 2017-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -84,6 +84,10 @@ function(register_benchdnn_test engine driver test_file)
         string(REPLACE "test_" "test_benchdnn_mode${tm}_" target_name ${test_file})
         set(cmd "--mode=${tm} ${mode_modifier} -v1 --engine=${engine} --${driver} --batch=${test_file}")
         set(benchdnn_target ${target_name}_${engine})
+
+        if(DNNL_TEST_SET_HAS_GRAPH_EXE EQUAL 1)
+            string(PREPEND cmd "--execution-mode=graph")
+        endif()
 
         if(NOT WIN32 OR DNNL_BUILD_FOR_CI)
             string(REPLACE " " ";" cmd "benchdnn ${cmd}")

--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -75,6 +75,8 @@ bool allow_enum_tags_only {true};
 int test_start {0};
 bool attr_same_pd_check {false};
 bool check_ref_impl {false};
+
+execution_mode_t execution_mode {execution_mode_t::direct};
 
 int main(int argc, char **argv) {
     using namespace parser;

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -920,6 +920,8 @@ std::ostream &dump_global_params(std::ostream &s) {
 #endif
     if (canonical || cold_cache_mode != default_cold_cache_mode)
         s << "--cold-cache=" << cold_cache_mode << " ";
+    if (canonical || execution_mode != execution_mode_t::direct)
+        s << "--execution-mode=" << execution_mode2str(execution_mode) << " ";
 
     return s;
 }

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -654,6 +654,12 @@ bool check_md_consistency_with_tag(
         const_dnnl_memory_desc_t md, const std::string &tag);
 
 memory_kind_ext_t str2memory_kind(const char *str);
+
+enum class execution_mode_t { direct, graph };
+extern execution_mode_t execution_mode;
+
+const char *execution_mode2str(execution_mode_t mode);
+execution_mode_t str2execution_mode(const char *str);
 
 float reorder_rescale_factor();
 

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -146,6 +146,13 @@ Additional information is printed to the stdout depending on a level `N`. `N` is
 a non-negative integer value. The default value is `0`. Refer to
 [verbose](knobs_verbose.md) for details.
 
+### --execution-mode
+`--execution-mode=MODE` specifies the execution mode to be used. When `MODE`
+is set to `direct` (the default), the driver will execute normally. When `MODE`
+is set to `graph` it instructs the driver to execute on a graph backend.
+Currently this feature is limited to the experimental SYCL Graph feature on
+DPC++ runtime with Level Zero backend.
+
 ## Correctness mode settings
 
 ### --attr-same-pd-check

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1353,6 +1353,33 @@ static bool parse_verbose(
     return false;
 }
 
+static bool parse_execution_mode(
+        const char *str, const std::string &option_name = "execution-mode") {
+    static const std::string help
+            = "MODE    (Default: direct)\n"
+              "    Specifies a `MODE` of execution.\n"
+              "    `MODE` values are:\n"
+              "    * `direct` instruction the driver to execute the primitive "
+              "directly.\n"
+              "    * `graph` to execute the primitive using a graph backend.\n"
+              "          Currently limited to the experimental SYCL Graph on "
+              "DPC++ builds.\n";
+    bool parsed = parse_single_value_option(execution_mode,
+            execution_mode_t::direct, str2execution_mode, str, option_name,
+            help);
+
+#if !defined(DNNL_WITH_SYCL)
+    if (parsed) {
+        BENCHDNN_PRINT(0,
+                "Error: option `--%s` is supported with DPC++ "
+                "builds only, exiting...\n",
+                option_name.c_str());
+        SAFE_V(FAIL);
+    }
+#endif
+    return parsed;
+}
+
 bool parse_bench_settings(const char *str) {
     last_parsed_is_problem = false; // if start parsing, expect an option
 
@@ -1377,7 +1404,8 @@ bool parse_bench_settings(const char *str) {
             || parse_repeats_per_prb(str) || parse_mem_check(str)
             || parse_memory_kind(str) || parse_mode(str)
             || parse_mode_modifier(str) || parse_start(str)
-            || parse_stream_kind(str) || parse_verbose(str);
+            || parse_stream_kind(str) || parse_verbose(str)
+            || parse_execution_mode(str);
 
     // Last condition makes this help message to be triggered once driver_name
     // is already known.


### PR DESCRIPTION
Adds ability to run benchdnn tests using graph execution by adding `--execution-mode=[direct(default)|graph]` option. It is currently limited to SyCL GPU engine executing on L0 backend.