### PR TITLE
xe: jit: enable kernel debug information

### DIFF
--- a/src/gpu/intel/jit/binary_format.cpp
+++ b/src/gpu/intel/jit/binary_format.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ class binary_format_kernel_t : public jit_generator<hw> {
     NGEN_FORWARD_OPENCL(hw);
 
 public:
-    binary_format_kernel_t() {
+    binary_format_kernel_t()
+        : jit_generator<hw>({GENERATOR_NAME, GENERATOR_LINE}) {
 
         auto low_half = [](uint64_t q) -> uint32_t { return q & 0xFFFFFFFF; };
         auto high_half = [](uint64_t q) -> uint32_t { return q >> 32; };

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -187,9 +187,11 @@ public:
     friend class ir_to_ngen_t<hw>;
     friend class send_impl_t;
 
-    ir_kernel_t(
-            const kernel_desc_base_t &desc, const kernel_info_t &kernel_info)
-        : kernel_name_(desc.kernel_name())
+    ir_kernel_t(const kernel_desc_base_t &desc,
+            const kernel_info_t &kernel_info,
+            const debug_config_t &debug_config)
+        : jit_generator<hw>(debug_config)
+        , kernel_name_(desc.kernel_name())
         , exec_cfg_(desc.exec_cfg())
         , kernel_info_(kernel_info)
         , local_range_(desc.local_range())
@@ -203,8 +205,10 @@ public:
 
     ir_kernel_t(const std::string &kernel_name, const exec_config_t &exec_cfg,
             const kernel_info_t &kernel_info,
-            const compute::range_t &local_range, bool require_dpas)
-        : kernel_name_(kernel_name)
+            const compute::range_t &local_range, bool require_dpas,
+            const debug_config_t &debug_config)
+        : jit_generator<hw>(debug_config)
+        , kernel_name_(kernel_name)
         , exec_cfg_(exec_cfg)
         , kernel_info_(kernel_info)
         , local_range_(local_range)

--- a/src/gpu/intel/jit/conv/conv_kernel.hpp
+++ b/src/gpu/intel/jit/conv/conv_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,7 +56,8 @@ conv_kernel_t<hw>::conv_kernel_t(const conv_config_t &cfg,
         const kernel_info_t &kernel_info, const compute::range_t &local_range,
         const layout_t &zp_dst)
     : ir_kernel_t<hw>("gen_conv", cfg.exec_cfg(), kernel_info, local_range,
-            utils::one_of(cfg.fma_kind(), fma_kind_t::dpas, fma_kind_t::dpasw))
+            utils::one_of(cfg.fma_kind(), fma_kind_t::dpas, fma_kind_t::dpasw),
+            {GENERATOR_NAME, GENERATOR_LINE})
     , prb_(cfg.prb())
     , cfg_(cfg) {
 

--- a/src/gpu/intel/jit/conv/zero_out.hpp
+++ b/src/gpu/intel/jit/conv/zero_out.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +36,8 @@ public:
     zero_out_kernel_t(const exec_config_t &exec_cfg,
             const kernel_info_t &kernel_info, bool require_dpas)
         : ir_kernel_t<hw>("zero_out", exec_cfg, kernel_info,
-                kernel_info.nd_range().local_range(), require_dpas) {
+                kernel_info.nd_range().local_range(), require_dpas,
+                {GENERATOR_NAME, GENERATOR_LINE}) {
 
         setup_interface();
         generate_prologue();

--- a/src/gpu/intel/jit/emulated_generator.hpp
+++ b/src/gpu/intel/jit/emulated_generator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2024 Intel Corporation
+ * Copyright 2024-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,11 @@ protected:
     NGEN_FORWARD_OPENCL(hw);
 
 public:
-    emulated_generator_t(
-            const compute::device_info_t &device_info, const std::string &name)
-        : ra_(hw, name), emu_strategy(hw, device_info.stepping_id()) {}
+    emulated_generator_t(const compute::device_info_t &device_info,
+            const std::string &name, const debug_config_t &debug_config)
+        : jit_generator<hw>(debug_config)
+        , ra_(hw, name)
+        , emu_strategy(hw, device_info.stepping_id()) {}
 
 protected:
     reg_allocator_t ra_;

--- a/src/gpu/intel/jit/gemm/include/generator.hpp
+++ b/src/gpu/intel/jit/gemm/include/generator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ class BLASKernelGenerator : public GENERATOR_BASE(hw) {
 public:
     using super = GENERATOR_SUPER(hw);
 
-    BLASKernelGenerator() {}
+    BLASKernelGenerator(): GENERATOR_BASE(hw)({GENERATOR_NAME, GENERATOR_LINE}) {}
 
     FORWARD(hw)
 

--- a/src/gpu/intel/jit/gen9_simple_sum_kernel_f32.hpp
+++ b/src/gpu/intel/jit/gen9_simple_sum_kernel_f32.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019-2024 Intel Corporation
+ * Copyright 2019-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ namespace jit {
 
 class gen9_simple_sum_kernel_f32_t : public jit_generator<gpu_gen9> {
 public:
-    gen9_simple_sum_kernel_f32_t() : jit_generator<gpu_gen9>() {
+    gen9_simple_sum_kernel_f32_t()
+        : jit_generator<gpu_gen9>({GENERATOR_NAME, GENERATOR_LINE}) {
         using namespace ngen;
         constexpr auto GlobalPtr = ExternalArgumentType::GlobalPtr;
         constexpr auto Scalar = ExternalArgumentType::Scalar;

--- a/src/gpu/intel/jit/jit_reduction_generator.hpp
+++ b/src/gpu/intel/jit/jit_reduction_generator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2024 Intel Corporation
+ * Copyright 2024-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ protected:
 public:
     jit_reduction_generator_t(const compute::device_info_t &device_info,
             alg_kind_t alg, dim_t stride, dim_t iters, int nregs)
-        : emulated_generator_t<hw>(device_info, "ngen_jit_reduction") {
+        : emulated_generator_t<hw>(device_info, "ngen_jit_reduction",
+                {GENERATOR_NAME, GENERATOR_LINE}) {
         constexpr auto GlobalPtr = ngen::ExternalArgumentType::GlobalPtr;
 
         // Number of dst elements computed per thread

--- a/src/gpu/intel/jit/ngen/ngen.hpp
+++ b/src/gpu/intel/jit/ngen/ngen.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@
 
 #include "ngen_core.hpp"
 #include "ngen_auto_swsb.hpp"
+#include "ngen_debuginfo.hpp"
 
 namespace NGEN_NAMESPACE {
 
@@ -182,6 +183,8 @@ protected:
     Label _lastFenceLabel;
     RegData _lastFenceDst;
 
+    DebugLine debugLine;
+
 private:
     InstructionModifier defaultModifier;
 
@@ -194,105 +197,107 @@ private:
     void addFixup(LabelFixup fixup) { streamStack.back()->addFixup(fixup); }
 
     template <bool forceWE = false, typename D, typename S0, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, SourceLocation loc);
     template <bool forceWE = false, typename D, typename S0, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, SourceLocation loc);
     template <bool forceWE = false, typename D, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0, SourceLocation loc);
     template <bool forceWE = false, typename D, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0, SourceLocation loc);
 
     template <bool forceWE = false, typename D, typename S0, typename S1, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, SourceLocation loc);
     template <bool forceWE = false, typename D, typename S0, typename S1, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, SourceLocation loc);
     template <bool forceWE = false, typename D, typename S0, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1, SourceLocation loc);
     template <bool forceWE = false, typename D, typename S0, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1, SourceLocation loc);
 
     template <HW hw_ = hw>
-    typename std::enable_if<hwLE(hw_, HW::Gen9)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, RegData dst, RegData src0, RegData src1, RegData src2);
+    typename std::enable_if<hwLE(hw_, HW::Gen9)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, RegData dst, RegData src0, RegData src1, RegData src2, SourceLocation loc);
     template <HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, Align16Operand dst, Align16Operand src0, Align16Operand src1, Align16Operand src2);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, Align16Operand dst, Align16Operand src0, Align16Operand src1, Align16Operand src2, SourceLocation loc);
     template <typename D, typename S0, typename S1, typename S2, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2, SourceLocation loc);
     template <typename D, typename S0, typename S1, typename S2, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2, SourceLocation loc);
 
     template <typename DS0>
-    void opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0);
+    void opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0, SourceLocation loc);
     template <typename DS0, typename S1>
-    void opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0, S1 src1);
+    void opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0, S1 src1, SourceLocation loc);
 
     template <typename D, typename S0, typename S2>
-    void opBfn(Opcode op, DataType defaultType, const InstructionModifier &mod, int bfnCtrl, D dst, S0 src0, RegData src1, S2 src2);
-    void opDpas(Opcode op, DataType defaultType, const InstructionModifier &mod, int sdepth, int rcount, RegData dst, RegData src0, RegData src1, RegData src2);
+    void opBfn(Opcode op, DataType defaultType, const InstructionModifier &mod, int bfnCtrl, D dst, S0 src0, RegData src1, S2 src2, SourceLocation loc);
+    void opDpas(Opcode op, DataType defaultType, const InstructionModifier &mod, int sdepth, int rcount, RegData dst, RegData src0, RegData src1, RegData src2, SourceLocation loc);
 
     template <typename D, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, uint32_t exdesc, D desc);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, uint32_t exdesc, D desc, SourceLocation loc);
     template <typename D, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, const RegData &exdesc, D desc);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, const RegData &exdesc, D desc, SourceLocation loc);
     template <typename ED, typename D, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, ED exdesc, D desc);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, ED exdesc, D desc, SourceLocation loc);
 
     template <HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc, SourceLocation loc);
     template <HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc, SourceLocation loc);
     template <typename D, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, D desc);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, D desc, SourceLocation loc);
 
     template <typename ED, typename D, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, ED exdesc, D desc);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, ED exdesc, D desc, SourceLocation loc);
     template <typename D, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, D desc);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, D desc, SourceLocation loc);
     template <typename D, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, RegData exdesc, D desc);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, RegData exdesc, D desc, SourceLocation loc);
 
     template <HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip, SourceLocation loc);
     template <HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip, SourceLocation loc);
     template <bool forceWE = false, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, SourceLocation loc);
     template <bool forceWE = false, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, SourceLocation loc);
     template <bool forceWE = false, bool small12 = true, HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc);
     template <bool forceWE = false, bool small12 = true, HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc);
 
-    void opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, Label &uip);
+    void opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, Label &uip, SourceLocation loc);
     template <bool forceWE = false>
-    void opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip);
-    void opCall(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip);
+    void opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, SourceLocation loc);
+    void opCall(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, SourceLocation loc);
 
     template <HW hw_ = hw>
-    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip);
+    typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip, SourceLocation loc);
     template <HW hw_ = hw>
-    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip);
-    void opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, Label &jip);
+    typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip, SourceLocation loc);
+    void opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, Label &jip, SourceLocation loc);
 
-    void opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod);
-    void opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, RegData src0);
-    void opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, const Immediate &src0);
+    void opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, SourceLocation loc);
+    void opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, RegData src0, SourceLocation loc);
+    void opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, const Immediate &src0, SourceLocation loc);
 
-    void opNop(Opcode op);
+    void opNop(Opcode op, SourceLocation loc);
 
     inline void unsupported();
 
 #include "ngen_compiler_fix.hpp"
 
 public:
-    explicit BinaryCodeGenerator(Product product_) : product{product_}, defaultModifier{}, labelManager{},
+    explicit BinaryCodeGenerator(Product product_, DebugConfig debugConfig = {})
+        : product{product_}, debugLine(debugConfig), defaultModifier{}, labelManager{},
+
                                                      sync{this}, load{this}, store{this}, atomic{this}
     {
         _workaround_();
         pushStream(rootStream);
     }
 
-    explicit BinaryCodeGenerator(int stepping_ = 0) : BinaryCodeGenerator({genericProductFamily(hw), stepping_}) {}
+    explicit BinaryCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : BinaryCodeGenerator({genericProductFamily(hw), stepping_}, debugConfig) {}
 
     ~BinaryCodeGenerator() {
         for (size_t sn = 1; sn < streamStack.size(); sn++)
@@ -345,472 +350,483 @@ protected:
 
     // Instructions.
     template <typename DT = void>
-    void add(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::add, getDataType<DT>(), mod, dst, src0, src1);
+    void add(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::add, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void add(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::add, getDataType<DT>(), mod, dst, src0, src1);
+    void add(const InstructionModifier &mod, const RegData &dst,
+             const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::add, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void addc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::addc, getDataType<DT>(), mod | AccWrEn, dst, src0, src1);
+    void addc(const InstructionModifier &mod, const RegData &dst,
+              const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::addc, getDataType<DT>(), mod | AccWrEn, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void addc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::addc, getDataType<DT>(), mod | AccWrEn, dst, src0, src1);
+    void addc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::addc, getDataType<DT>(), mod | AccWrEn, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void add3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
+    void add3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void add3(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2) {
+    void add3(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void add3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2) {
+    void add3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void add3(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2) {
+    void add3(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::add3, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void and_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::and_gen12 : Opcode::and_, getDataType<DT>(), mod, dst, src0, src1);
+    void and_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::and_gen12 : Opcode::and_, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void and_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::and_gen12 : Opcode::and_, getDataType<DT>(), mod, dst, src0, src1);
+    void and_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::and_gen12 : Opcode::and_, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
 #ifndef NGEN_NO_OP_NAMES
     template <typename DT = void>
-    void and(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        and_<DT>(mod, dst, src0, src1);
+    void and(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        and_<DT>(mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void and(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        and_<DT>(mod, dst, src0, src1);
+    void and(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        and_<DT>(mod, dst, src0, src1, loc);
     }
 #endif
     template <typename DT = void>
-    void asr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::asr_gen12 : Opcode::asr, getDataType<DT>(), mod, dst, src0, src1);
+    void asr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::asr_gen12 : Opcode::asr, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void asr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::asr_gen12 : Opcode::asr, getDataType<DT>(), mod, dst, src0, src1);
+    void asr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::asr_gen12 : Opcode::asr, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void avg(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::avg, getDataType<DT>(), mod, dst, src0, src1);
+    void avg(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::avg, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void avg(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::avg, getDataType<DT>(), mod, dst, src0, src1);
+    void avg(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::avg, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void bfe(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
-        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfe(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfe(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2) {
-        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfe(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfe(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2) {
-        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfe(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfe(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2) {
-        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfe(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfe_gen12 : Opcode::bfe, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfi1(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::bfi1_gen12 : Opcode::bfi1, getDataType<DT>(), mod, dst, src0, src1);
+    void bfi1(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfi1_gen12 : Opcode::bfi1, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void bfi1(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::bfi1_gen12 : Opcode::bfi1, getDataType<DT>(), mod, dst, src0, src1);
+    void bfi1(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfi1_gen12 : Opcode::bfi1, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void bfi2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
-        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfi2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfi2(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2) {
-        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfi2(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfi2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2) {
-        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfi2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfi2(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2) {
-        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void bfi2(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfi2_gen12 : Opcode::bfi2, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
+    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2);
+        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2) {
+    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2);
+        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2) {
+    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2);
+        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2) {
+    void bfn(const InstructionModifier &mod, uint8_t ctrl, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
         if (hw < HW::XeHP) unsupported();
-        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2);
+        opBfn(Opcode::bfn, getDataType<DT>(), mod, ctrl, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void bfrev(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(isGen12 ? Opcode::bfrev_gen12 : Opcode::bfrev, getDataType<DT>(), mod, dst, src0);
+    void bfrev(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfrev_gen12 : Opcode::bfrev, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void bfrev(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(isGen12 ? Opcode::bfrev_gen12 : Opcode::bfrev, getDataType<DT>(), mod, dst, src0);
+    void bfrev(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::bfrev_gen12 : Opcode::bfrev, getDataType<DT>(), mod, dst, src0, loc);
     }
-    void brc(const InstructionModifier &mod, Label &jip, Label &uip) {
-        opBranch(Opcode::brc, mod, isGen12 ? null.ud() : ip.d(), jip, uip);
+    void brc(const InstructionModifier &mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        opBranch(Opcode::brc, mod, isGen12 ? null.ud() : ip.d(), jip, uip, loc);
     }
-    void brc(const InstructionModifier &mod, RegData src0) {
+    void brc(const InstructionModifier &mod, RegData src0, SourceLocation loc = {}) {
         src0.setRegion(2, 2, 1);
-        opBranch<true, true>(Opcode::brc, mod, isGen12 ? null.ud() : ip.d(), src0);
+        opBranch<true, true>(Opcode::brc, mod, isGen12 ? null.ud() : ip.d(), src0, loc);
     }
-    void brd(const InstructionModifier &mod, Label &jip) {
-        opBranch(Opcode::brd, mod, isGen12 ? null.ud() : ip.d(), jip);
+    void brd(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
+        opBranch(Opcode::brd, mod, isGen12 ? null.ud() : ip.d(), jip, loc);
     }
-    void brd(const InstructionModifier &mod, RegData src0) {
+    void brd(const InstructionModifier &mod, RegData src0, SourceLocation loc = {}) {
         src0.setRegion(2, 2, 1);
-        opBranch<true, true>(Opcode::brd, mod, isGen12 ? null.ud() : ip.d(), src0);
+        opBranch<true, true>(Opcode::brd, mod, isGen12 ? null.ud() : ip.d(), src0, loc);
     }
-    void break_(const InstructionModifier &mod, Label &jip, Label &uip) {
-        opBranch(Opcode::break_, mod, null, jip, uip);
+    void break_(const InstructionModifier &mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        opBranch(Opcode::break_, mod, null, jip, uip, loc);
     }
-    void call(const InstructionModifier &mod, const RegData &dst, Label &jip) {
-        opCall(Opcode::call, mod, dst, jip);
+    void call(const InstructionModifier &mod, const RegData &dst, Label &jip, SourceLocation loc = {}) {
+        opCall(Opcode::call, mod, dst, jip, loc);
     }
-    void call(const InstructionModifier &mod, const RegData &dst, RegData jip) {
+    void call(const InstructionModifier &mod, const RegData &dst, RegData jip, SourceLocation loc = {}) {
         if (isGen12)
-            opBranch<true, true>(Opcode::call, mod, dst, jip);
+            opBranch<true, true>(Opcode::call, mod, dst, jip, loc);
         else {
             jip.setRegion(0, 1, 0);
-            opX<true>(Opcode::call, DataType::d, mod, dst, null.ud(0)(0, 1, 0), jip);
+            opX<true>(Opcode::call, DataType::d, mod, dst, null.ud(0)(0, 1, 0), jip, loc);
         }
     }
-    void calla(const InstructionModifier &mod, const RegData &dst, int32_t jip) {
+    void calla(const InstructionModifier &mod, const RegData &dst, int32_t jip, SourceLocation loc = {}) {
         if (isGen12)
-            opBranch<true>(Opcode::calla, mod, dst, jip);
+            opBranch<true>(Opcode::calla, mod, dst, jip, loc);
         else
-            opX<true>(Opcode::calla, DataType::d, mod, dst, (hw <= HW::Gen9) ? null.ud(0)(2,2,1) : null.ud(0)(0,1,0), Immediate::d(jip));
+            opX<true>(Opcode::calla, DataType::d, mod, dst, (hw <= HW::Gen9) ? null.ud(0)(2,2,1) : null.ud(0)(0,1,0), Immediate::d(jip), loc);
     }
-    void calla(const InstructionModifier &mod, const RegData &dst, RegData jip) {
+    void calla(const InstructionModifier &mod, const RegData &dst, RegData jip, SourceLocation loc = {}) {
         if (isGen12)
-            opBranch<true, true>(Opcode::calla, mod, dst, jip);
+            opBranch<true, true>(Opcode::calla, mod, dst, jip, loc);
         else {
             jip.setRegion(0, 1, 0);
-            opX<true>(Opcode::calla, DataType::d, mod, dst, null.ud(0)(0, 1, 0), jip);
+            opX<true>(Opcode::calla, DataType::d, mod, dst, null.ud(0)(0, 1, 0), jip, loc);
         }
     }
     template <typename DT = void>
-    void cbit(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::cbit, getDataType<DT>(), mod, dst, src0);
+    void cbit(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::cbit, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void cbit(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::cbit, getDataType<DT>(), mod, dst, src0);
+    void cbit(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::cbit, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void cmp(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::cmp_gen12 : Opcode::cmp, getDataType<DT>(), mod, dst, src0, src1);
+    void cmp(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::cmp_gen12 : Opcode::cmp, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void cmp(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::cmp_gen12 : Opcode::cmp, getDataType<DT>(), mod, dst, src0, src1);
+    void cmp(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::cmp_gen12 : Opcode::cmp, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void cmpn(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::cmpn_gen12 : Opcode::cmpn, getDataType<DT>(), mod, dst, src0, src1);
+    void cmpn(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::cmpn_gen12 : Opcode::cmpn, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void csel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
-        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void csel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void csel(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2) {
-        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void csel(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void csel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2) {
-        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void csel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void csel(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2) {
-        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void csel(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::csel_gen12 : Opcode::csel, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
-    void cont(const InstructionModifier &mod, Label &jip, Label &uip) {
-        opBranch(Opcode::cont, mod, null, jip, uip);
-    }
-    template <typename DT = void>
-    void dp2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::dp2, getDataType<DT>(), mod, dst, src0, src1);
+    void cont(const InstructionModifier &mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        opBranch(Opcode::cont, mod, null, jip, uip, loc);
     }
     template <typename DT = void>
-    void dp2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::dp2, getDataType<DT>(), mod, dst, src0, src1);
+    void dp2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::dp2, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void dp3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::dp3, getDataType<DT>(), mod, dst, src0, src1);
+    void dp2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::dp2, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void dp3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::dp3, getDataType<DT>(), mod, dst, src0, src1);
+    void dp3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::dp3, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void dp4(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::dp4, getDataType<DT>(), mod, dst, src0, src1);
+    void dp3(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::dp3, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void dp4(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::dp4, getDataType<DT>(), mod, dst, src0, src1);
+    void dp4(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::dp4, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void dp4a(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
+    void dp4(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::dp4, getDataType<DT>(), mod, dst, src0, src1, loc);
+    }
+    template <typename DT = void>
+    void dp4a(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
         if (hw < HW::Gen12LP) unsupported();
-        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void dp4a(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2) {
+    void dp4a(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
         if (hw < HW::Gen12LP) unsupported();
-        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void dp4a(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2) {
+    void dp4a(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
         if (hw < HW::Gen12LP) unsupported();
-        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void dp4a(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2) {
+    void dp4a(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
         if (hw < HW::Gen12LP) unsupported();
-        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::dp4a, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void dpas(const InstructionModifier &mod, uint8_t sdepth, uint8_t rcount, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
-        opDpas(Opcode::dpas, getDataType<DT>(), mod, sdepth, rcount, dst, src0, src1, src2);
+    void dpas(const InstructionModifier &mod, uint8_t sdepth, uint8_t rcount, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opDpas(Opcode::dpas, getDataType<DT>(), mod, sdepth, rcount, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void dpasw(const InstructionModifier &mod, uint8_t sdepth, uint8_t rcount, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
-        opDpas(Opcode::dpasw, getDataType<DT>(), mod, sdepth, rcount, dst, src0, src1, src2);
+    void dpasw(const InstructionModifier &mod, uint8_t sdepth, uint8_t rcount, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opDpas(Opcode::dpasw, getDataType<DT>(), mod, sdepth, rcount, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void dph(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::dph, getDataType<DT>(), mod, dst, src0, src1);
+    void dph(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::dph, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void dph(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::dph, getDataType<DT>(), mod, dst, src0, src1);
+    void dph(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::dph, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
-    void else_(InstructionModifier mod, Label &jip, Label &uip, bool branchCtrl = false) {
+    void else_(InstructionModifier mod, Label &jip, Label &uip, bool branchCtrl, SourceLocation loc = {}) {
         mod.setBranchCtrl(branchCtrl);
-        opBranch(Opcode::else_, mod, null, jip, uip);
+        opBranch(Opcode::else_, mod, null, jip, uip, loc);
     }
-    void else_(InstructionModifier mod, Label &jip) {
-        else_(mod, jip, jip);
+    void else_(InstructionModifier mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        else_(mod, jip, uip, false, loc);
     }
-    void endif(const InstructionModifier &mod, Label &jip) {
-        opBranch(Opcode::endif, mod, null, jip);
+    void else_(InstructionModifier mod, Label &jip, SourceLocation loc = {}) {
+        else_(mod, jip, jip, false, loc);
     }
-    void endif(const InstructionModifier &mod) {
-        opBranch(Opcode::endif, mod, null, sizeof(Instruction8));
+    void endif(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
+        opBranch(Opcode::endif, mod, null, jip, loc);
     }
-    template <typename DT = void>
-    void fbh(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::fbh, getDataType<DT>(), mod, dst, src0);
-    }
-    template <typename DT = void>
-    void fbh(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::fbh, getDataType<DT>(), mod, dst, src0);
+    void endif(const InstructionModifier &mod, SourceLocation loc = {}) {
+        opBranch(Opcode::endif, mod, null, sizeof(Instruction8), loc);
     }
     template <typename DT = void>
-    void fbl(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::fbl, getDataType<DT>(), mod, dst, src0);
+    void fbh(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::fbh, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void fbl(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::fbl, getDataType<DT>(), mod, dst, src0);
+    void fbh(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::fbh, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void frc(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::frc, getDataType<DT>(), mod, dst, src0);
+    void fbl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::fbl, getDataType<DT>(), mod, dst, src0, loc);
     }
-    void goto_(InstructionModifier mod, Label &jip, Label &uip, bool branchCtrl = false) {
+    template <typename DT = void>
+    void fbl(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::fbl, getDataType<DT>(), mod, dst, src0, loc);
+    }
+    template <typename DT = void>
+    void frc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::frc, getDataType<DT>(), mod, dst, src0, loc);
+    }
+    void goto_(InstructionModifier mod, Label &jip, Label &uip, bool branchCtrl, SourceLocation loc = {}) {
         mod.setBranchCtrl(branchCtrl);
-        opBranch(Opcode::goto_, mod, null, jip, uip);
+        opBranch(Opcode::goto_, mod, null, jip, uip, loc);
     }
-    void goto_(const InstructionModifier &mod, Label &jip) {
-        goto_(mod, jip, jip);
+    void goto_(const InstructionModifier &mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        goto_(mod, jip, uip, false, loc);
     }
-    void halt(const InstructionModifier &mod, Label &jip, Label &uip) {
-        opBranch(Opcode::halt, mod, null, jip, uip);
+    void goto_(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
+        goto_(mod, jip, jip, loc);
     }
-    void halt(const InstructionModifier &mod, Label &jip) {
-        halt(mod, jip, jip);
+    void halt(const InstructionModifier &mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        opBranch(Opcode::halt, mod, null, jip, uip, loc);
     }
-    void if_(InstructionModifier mod, Label &jip, Label &uip, bool branchCtrl = false) {
+    void halt(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
+        halt(mod, jip, jip, loc);
+    }
+    void if_(InstructionModifier mod, Label &jip, Label &uip, bool branchCtrl = false, SourceLocation loc = {}) {
         mod.setBranchCtrl(branchCtrl);
-        opBranch(Opcode::if_, mod, null, jip, uip);
+        opBranch(Opcode::if_, mod, null, jip, uip, loc);
     }
-    void if_(const InstructionModifier &mod, Label &jip) {
-        if_(mod, jip, jip);
+    void if_(const InstructionModifier &mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        if_(mod, jip, uip, false, loc);
     }
-    void illegal() {
-        opX(Opcode::illegal, DataType::invalid, InstructionModifier(), null, null, null);
+    void if_(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
+        if_(mod, jip, jip, false, loc);
     }
-    void join(InstructionModifier mod, Label &jip) {
-        opBranch(Opcode::join, mod, null, jip);
+    void illegal(SourceLocation loc = {}) {
+        opX(Opcode::illegal, DataType::invalid, InstructionModifier(), null, null, null, loc);
     }
-    void join(InstructionModifier mod) {
-        opBranch(Opcode::join, mod, null, sizeof(Instruction8));
+    void join(InstructionModifier mod, Label &jip, SourceLocation loc = {}) {
+        opBranch(Opcode::join, mod, null, jip, loc);
     }
-    void jmpi(const InstructionModifier &mod, Label &jip) {
+    void join(InstructionModifier mod, SourceLocation loc = {}) {
+        opBranch(Opcode::join, mod, null, sizeof(Instruction8), loc);
+    }
+    void jmpi(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
         auto dst = isGen12 ? ARF(null) : ARF(ip);
-        opJmpi(Opcode::jmpi, mod, dst, dst, jip);
+        opJmpi(Opcode::jmpi, mod, dst, dst, jip, loc);
     }
-    void jmpi(const InstructionModifier &mod, const RegData &jip) {
+    void jmpi(const InstructionModifier &mod, const RegData &jip, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (!isGen12 && jip.getType() != DataType::d && jip.getType() != DataType::invalid)
             throw invalid_type_exception();
 #endif
         if (isGen12)
-            opBranch<true, false>(Opcode::jmpi, mod, null, jip);
+            opBranch<true, false>(Opcode::jmpi, mod, null, jip, loc);
         else
-            opX(Opcode::jmpi, DataType::d, mod, ip, ip, jip);
+            opX(Opcode::jmpi, DataType::d, mod, ip, ip, jip, loc);
     }
     template <typename DT = void>
-    void line(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
+    void line(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
         if (hw >= HW::Gen11) unsupported();
-        opX(Opcode::line, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::line, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void line(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
+    void line(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
         if (hw >= HW::Gen11) unsupported();
-        opX(Opcode::line, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::line, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void lrp(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
-        opX(Opcode::lrp, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void lrp(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(Opcode::lrp, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void lzd(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::lzd, getDataType<DT>(), mod, dst, src0);
+    void lzd(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::lzd, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void lzd(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::lzd, getDataType<DT>(), mod, dst, src0);
+    void lzd(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::lzd, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1);
+    void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1);
+    void mac(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::mac, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::mach, getDataType<DT>(), (hw >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1);
+    void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::mach, getDataType<DT>(), (hw >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::mach, getDataType<DT>(), (hw >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1);
+    void mach(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::mach, getDataType<DT>(), (hw >= HW::XeHPC) ? mod : (mod | AccWrEn), dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
+    void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (hw < HW::Gen10) unsupported();
 #endif
-        opX((hw >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1);
+        opX((hw >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
+    void macl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (hw < HW::Gen10) unsupported();
 #endif
-        opX((hw >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1);
+        opX((hw >= HW::XeHPC) ? Opcode::macl : Opcode::mach, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void mad(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2) {
-        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void mad(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void mad(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2) {
-        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void mad(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const RegData &src2, SourceLocation loc = {}) {
+        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void mad(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2) {
-        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void mad(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void mad(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2) {
-        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2);
+    void mad(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, const RegData &src1, const Immediate &src2, SourceLocation loc = {}) {
+        opX(Opcode::mad, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void, HW hw_ = hw>
     typename std::enable_if<hwLE(hw_, HW::Gen9)>::type
-    madm(const InstructionModifier &mod, const ExtendedReg &dst, const ExtendedReg &src0, const ExtendedReg &src1, const ExtendedReg &src2) {
-        opX(Opcode::madm, getDataType<DT>(), mod, extToAlign16(dst), extToAlign16(src0), extToAlign16(src1), extToAlign16(src2));
+    madm(const InstructionModifier &mod, const ExtendedReg &dst, const ExtendedReg &src0, const ExtendedReg &src1, const ExtendedReg &src2, SourceLocation loc = {}) {
+        opX(Opcode::madm, getDataType<DT>(), mod, extToAlign16(dst), extToAlign16(src0), extToAlign16(src1), extToAlign16(src2), loc);
     }
     template <typename DT = void, HW hw_ = hw>
     typename std::enable_if<hwGT(hw_, HW::Gen9)>::type
-    madm(const InstructionModifier &mod, const ExtendedReg &dst, ExtendedReg src0, ExtendedReg src1, const ExtendedReg &src2) {
+    madm(const InstructionModifier &mod, const ExtendedReg &dst, ExtendedReg src0, ExtendedReg src1, const ExtendedReg &src2, SourceLocation loc = {}) {
         src0.getBase().setRegion(4,4,1);
         src1.getBase().setRegion(4,4,1);
-        opX(Opcode::madm, getDataType<DT>(), mod, dst, src0, src1, src2);
+        opX(Opcode::madm, getDataType<DT>(), mod, dst, src0, src1, src2, loc);
     }
     template <typename DT = void>
-    void math(const InstructionModifier &mod, MathFunction fc, const RegData &dst, const RegData &src0) {
+    void math(const InstructionModifier &mod, MathFunction fc, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (mathArgCount(fc) != 1) throw invalid_operand_count_exception();
+        if (mathArgCount(hw, fc) != 1) throw invalid_operand_count_exception();
 #endif
-        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0);
+        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, loc);
     }
     template <typename DT = void>
-    void math(const InstructionModifier &mod, MathFunction fc, const RegData &dst, const RegData &src0, const RegData &src1) {
+    void math(const InstructionModifier &mod, MathFunction fc, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
-        if (mathArgCount(fc) != 2) throw invalid_operand_count_exception();
+        if (mathArgCount(hw, fc) != 2) throw invalid_operand_count_exception();
 #endif
-        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, src1);
+        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void math(const InstructionModifier &mod, MathFunction fc, const RegData &dst, const RegData &src0, const Immediate &src1) {
+    void math(const InstructionModifier &mod, MathFunction fc, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (fc == MathFunction::invm || fc == MathFunction::rsqtm) throw invalid_operand_exception();
 #endif
-        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, src1.forceInt32());
+        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, src1.forceInt32(), loc);
     }
     template <typename DT = void, HW hw_ = hw>
     typename std::enable_if<hwLT(hw_, HW::Gen11)>::type
-    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, const ExtendedReg &src0) {
+    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, const ExtendedReg &src0, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (fc != MathFunction::rsqtm) throw invalid_operand_exception();
 #endif
-        opMath(Opcode::math, getDataType<DT>(), mod, fc, extToAlign16(dst), extToAlign16(src0));
+        opMath(Opcode::math, getDataType<DT>(), mod, fc, extToAlign16(dst), extToAlign16(src0), loc);
     }
     template <typename DT = void, HW hw_ = hw>
     typename std::enable_if<hwGE(hw_, HW::Gen11)>::type
-    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, ExtendedReg src0) {
+    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, ExtendedReg src0, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (fc != MathFunction::rsqtm) throw invalid_operand_exception();
 #endif
@@ -818,19 +834,19 @@ protected:
             src0.getBase().setRegion(2,2,1);
         else
             src0.getBase().setRegion(1,1,0);
-        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0);
+        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, loc);
     }
     template <typename DT = void, HW hw_ = hw>
     typename std::enable_if<hwLT(hw_, HW::Gen11)>::type
-    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, const ExtendedReg &src0, const ExtendedReg &src1) {
+    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, const ExtendedReg &src0, const ExtendedReg &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (fc != MathFunction::invm) throw invalid_operand_exception();
 #endif
-        opMath(Opcode::math, getDataType<DT>(), mod, fc, extToAlign16(dst), extToAlign16(src0), extToAlign16(src1));
+        opMath(Opcode::math, getDataType<DT>(), mod, fc, extToAlign16(dst), extToAlign16(src0), extToAlign16(src1), loc);
     }
     template <typename DT = void, HW hw_ = hw>
     typename std::enable_if<hwGE(hw_, HW::Gen11)>::type
-    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, ExtendedReg src0, ExtendedReg src1) {
+    math(const InstructionModifier &mod, MathFunction fc, const ExtendedReg &dst, ExtendedReg src0, ExtendedReg src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (fc != MathFunction::invm) throw invalid_operand_exception();
 #endif
@@ -841,338 +857,338 @@ protected:
             src0.getBase().setRegion(1,1,0);
             src1.getBase().setRegion(1,1,0);
         }
-        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, src1);
+        opMath(Opcode::math, getDataType<DT>(), mod, fc, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void mov(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(isGen12 ? Opcode::mov_gen12 : Opcode::mov, getDataType<DT>(), mod, dst, src0);
+    void mov(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::mov_gen12 : Opcode::mov, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void mov(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(isGen12 ? Opcode::mov_gen12 : Opcode::mov, getDataType<DT>(), mod, dst, src0);
+    void mov(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::mov_gen12 : Opcode::mov, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void movi(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
+    void movi(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
         if (hardware >= HW::Gen10)
             movi<DT>(mod, dst, src0, null.ud(0)(1,1,0));
         else
-            opX(isGen12 ? Opcode::movi_gen12 : Opcode::movi, getDataType<DT>(), mod, dst, src0);
+            opX(isGen12 ? Opcode::movi_gen12 : Opcode::movi, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void movi(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
+    void movi(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (hardware < HW::Gen10) throw unsupported_instruction();
 #endif
-        opX(isGen12 ? Opcode::movi_gen12 : Opcode::movi, getDataType<DT>(), mod, dst, src0, src1);
+        opX(isGen12 ? Opcode::movi_gen12 : Opcode::movi, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void movi(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
+    void movi(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (hardware < HW::Gen10) throw unsupported_instruction();
 #endif
-        opX(isGen12 ? Opcode::movi_gen12 : Opcode::movi, getDataType<DT>(), mod, dst, src0, src1);
+        opX(isGen12 ? Opcode::movi_gen12 : Opcode::movi, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void mul(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::mul, getDataType<DT>(), mod, dst, src0, src1);
+    void mul(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::mul, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void mul(const InstructionModifier &mod, const RegData &dst, const RegData &src0, Immediate src1) {
+    void mul(const InstructionModifier &mod, const RegData &dst, const RegData &src0, Immediate src1, SourceLocation loc = {}) {
         if (dst.getBytes() == 8)
             src1 = src1.forceInt32();
-        opX(Opcode::mul, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::mul, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
-    void nop() {
-        opNop(isGen12 ? Opcode::nop_gen12 : Opcode::nop);
+    void nop(SourceLocation loc = {}) {
+        opNop(isGen12 ? Opcode::nop_gen12 : Opcode::nop, loc);
     }
-    void nop(const InstructionModifier &mod) {
-        opX(isGen12 ? Opcode::nop_gen12 : Opcode::nop, DataType::invalid, mod, null, null, null);
-    }
-    template <typename DT = void>
-    void not_(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(isGen12 ? Opcode::not_gen12 : Opcode::not_, getDataType<DT>(), mod, dst, src0);
+    void nop(const InstructionModifier &mod, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::nop_gen12 : Opcode::nop, DataType::invalid, mod, null, null, null, loc);
     }
     template <typename DT = void>
-    void not_(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(isGen12 ? Opcode::not_gen12 : Opcode::not_, getDataType<DT>(), mod, dst, src0);
+    void not_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::not_gen12 : Opcode::not_, getDataType<DT>(), mod, dst, src0, loc);
+    }
+    template <typename DT = void>
+    void not_(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::not_gen12 : Opcode::not_, getDataType<DT>(), mod, dst, src0, loc);
     }
 #ifndef NGEN_NO_OP_NAMES
     template <typename DT = void>
-    void not(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        not_<DT>(mod, dst, src0);
+    void not(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        not_<DT>(mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void not(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        not_<DT>(mod, dst, src0);
+    void not(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        not_<DT>(mod, dst, src0, loc);
     }
 #endif
     template <typename DT = void>
-    void or_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::or_gen12 : Opcode::or_, getDataType<DT>(), mod, dst, src0, src1);
+    void or_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::or_gen12 : Opcode::or_, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void or_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::or_gen12 : Opcode::or_, getDataType<DT>(), mod, dst, src0, src1);
+    void or_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::or_gen12 : Opcode::or_, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
 #ifndef NGEN_NO_OP_NAMES
     template <typename DT = void>
-    void or(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        or_<DT>(mod, dst, src0, src1);
+    void or(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        or_<DT>(mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void or(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        or_<DT>(mod, dst, src0, src1);
+    void or(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        or_<DT>(mod, dst, src0, src1, loc);
     }
 #endif
     template <typename DT = void>
-    void pln(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
+    void pln(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
         if (hw >= HW::Gen11) unsupported();
-        opX(Opcode::pln, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::pln, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
-    void ret(const InstructionModifier &mod, RegData src0) {
+    void ret(const InstructionModifier &mod, RegData src0, SourceLocation loc = {}) {
         src0.setRegion(2,2,1);
         if (isGen12)
-            opBranch<true, true>(Opcode::ret, mod, null, src0);
+            opBranch<true, true>(Opcode::ret, mod, null, src0, loc);
         else
-            opX<true>(Opcode::ret, DataType::ud, mod, null, src0);
+            opX<true>(Opcode::ret, DataType::ud, mod, null, src0, loc);
     }
     template <typename DT = void>
-    void rndd(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::rndd, getDataType<DT>(), mod, dst, src0);
+    void rndd(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::rndd, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rndd(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::rndd, getDataType<DT>(), mod, dst, src0);
+    void rndd(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::rndd, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rnde(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::rnde, getDataType<DT>(), mod, dst, src0);
+    void rnde(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::rnde, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rnde(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::rnde, getDataType<DT>(), mod, dst, src0);
+    void rnde(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::rnde, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rndu(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::rndu, getDataType<DT>(), mod, dst, src0);
+    void rndu(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::rndu, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rndu(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::rndu, getDataType<DT>(), mod, dst, src0);
+    void rndu(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::rndu, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rndz(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-        opX(Opcode::rndz, getDataType<DT>(), mod, dst, src0);
+    void rndz(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+        opX(Opcode::rndz, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rndz(const InstructionModifier &mod, const RegData &dst, const Immediate &src0) {
-        opX(Opcode::rndz, getDataType<DT>(), mod, dst, src0);
+    void rndz(const InstructionModifier &mod, const RegData &dst, const Immediate &src0, SourceLocation loc = {}) {
+        opX(Opcode::rndz, getDataType<DT>(), mod, dst, src0, loc);
     }
     template <typename DT = void>
-    void rol(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::rol_gen12 : Opcode::rol, getDataType<DT>(), mod, dst, src0, src1);
+    void rol(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::rol_gen12 : Opcode::rol, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void rol(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::rol_gen12 : Opcode::rol, getDataType<DT>(), mod, dst, src0, src1);
+    void rol(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::rol_gen12 : Opcode::rol, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void ror(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::ror_gen12 : Opcode::ror, getDataType<DT>(), mod, dst, src0, src1);
+    void ror(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::ror_gen12 : Opcode::ror, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void ror(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::ror_gen12 : Opcode::ror, getDataType<DT>(), mod, dst, src0, src1);
+    void ror(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::ror_gen12 : Opcode::ror, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void sad2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
+    void sad2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
         if (hw >= HW::Gen12LP) unsupported();
-        opX(Opcode::sad2, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::sad2, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void sad2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
+    void sad2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
         if (hw >= HW::Gen12LP) unsupported();
-        opX(Opcode::sad2, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::sad2, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void sada2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
+    void sada2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
         if (hw >= HW::Gen12LP) unsupported();
-        opX(Opcode::sada2, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::sada2, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void sada2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
+    void sada2(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
         if (hw >= HW::Gen12LP) unsupported();
-        opX(Opcode::sada2, getDataType<DT>(), mod, dst, src0, src1);
+        opX(Opcode::sada2, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void sel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::sel_gen12 : Opcode::sel, getDataType<DT>(), mod, dst, src0, src1);
+    void sel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::sel_gen12 : Opcode::sel, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void sel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::sel_gen12 : Opcode::sel, getDataType<DT>(), mod, dst, src0, src1);
+    void sel(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::sel_gen12 : Opcode::sel, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
 
     /* Gen12-style sends */
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, uint32_t desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, const RegData &desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, uint32_t desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, const RegData &desc) {
-        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void send(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, uint32_t desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, src1, -1, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, const RegData &desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const GRFRange &src1, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, src1[0], src1.getLen(), exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, uint32_t desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, const RegData &desc) {
-        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc);
+    void sendc(const InstructionModifier &mod, SharedFunction sf, const RegData &dst, const RegData &src0, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, sf, dst, src0, NullRegister(), 0, exdesc, desc, loc);
     }
     /* Pre-Gen12-style sends; also supported on Gen12. */
-    void send(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc) {
-        opSend(Opcode::send, mod, dst, src0, exdesc, desc);
+    void send(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, dst, src0, exdesc, desc, loc);
     }
-    void send(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc) {
-        opSend(Opcode::send, mod, dst, src0, exdesc, desc);
+    void send(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::send, mod, dst, src0, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc) {
-        opSend(Opcode::sendc, mod, dst, src0, exdesc, desc);
+    void sendc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, dst, src0, exdesc, desc, loc);
     }
-    void sendc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc) {
-        opSend(Opcode::sendc, mod, dst, src0, exdesc, desc);
+    void sendc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSend(Opcode::sendc, mod, dst, src0, exdesc, desc, loc);
     }
-    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc) {
-        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc);
+    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc, loc);
     }
-    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc) {
-        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc);
+    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc, loc);
     }
-    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc) {
-        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc);
+    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc, loc);
     }
-    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc) {
-        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc);
+    void sends(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSends(Opcode::sends, mod, dst, src0, src1, exdesc, desc, loc);
     }
-    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc) {
-        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc);
+    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc, loc);
     }
-    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc) {
-        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc);
+    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc, loc);
     }
-    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc) {
-        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc);
+    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, uint32_t desc, SourceLocation loc = {}) {
+        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc, loc);
     }
-    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc) {
-        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc);
+    void sendsc(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &exdesc, const RegData &desc, SourceLocation loc = {}) {
+        opSends(Opcode::sendsc, mod, dst, src0, src1, exdesc, desc, loc);
     }
 
     template <typename DT = void>
-    void shl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::shl_gen12 : Opcode::shl, getDataType<DT>(), mod, dst, src0, src1);
+    void shl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::shl_gen12 : Opcode::shl, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void shl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::shl_gen12 : Opcode::shl, getDataType<DT>(), mod, dst, src0, src1);
+    void shl(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::shl_gen12 : Opcode::shl, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1);
+    void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1);
+    void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void smov(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::smov_gen12 : Opcode::smov, getDataType<DT>(), mod, dst, src0, src1);
+    void smov(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::smov_gen12 : Opcode::smov, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void srnd(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::srnd, getDataType<DT>(), mod, dst, src0, src1);
+    void srnd(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::srnd, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void srnd(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::srnd, getDataType<DT>(), mod, dst, src0, src1);
+    void srnd(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::srnd, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void subb(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(Opcode::subb, getDataType<DT>(), mod | AccWrEn, dst, src0, src1);
+    void subb(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(Opcode::subb, getDataType<DT>(), mod | AccWrEn, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void subb(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(Opcode::subb, getDataType<DT>(), mod | AccWrEn, dst, src0, src1);
+    void subb(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(Opcode::subb, getDataType<DT>(), mod | AccWrEn, dst, src0, src1, loc);
     }
-    void wait(const InstructionModifier &mod, const RegData &nreg) {
+    void wait(const InstructionModifier &mod, const RegData &nreg, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (!nreg.isARF() || nreg.getARFType() != ARFType::n) throw invalid_arf_exception();
 #endif
-        opX(Opcode::wait, DataType::invalid, mod, nreg, nreg);
+        opX(Opcode::wait, DataType::invalid, mod, nreg, nreg, loc);
     }
-    void while_(const InstructionModifier &mod, Label &jip) {
-        opBranch(Opcode::while_, mod, null, jip);
-    }
-    template <typename DT = void>
-    void xor_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        opX(isGen12 ? Opcode::xor_gen12 : Opcode::xor_, getDataType<DT>(), mod, dst, src0, src1);
+    void while_(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
+        opBranch(Opcode::while_, mod, null, jip, loc);
     }
     template <typename DT = void>
-    void xor_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        opX(isGen12 ? Opcode::xor_gen12 : Opcode::xor_, getDataType<DT>(), mod, dst, src0, src1);
+    void xor_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::xor_gen12 : Opcode::xor_, getDataType<DT>(), mod, dst, src0, src1, loc);
+    }
+    template <typename DT = void>
+    void xor_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        opX(isGen12 ? Opcode::xor_gen12 : Opcode::xor_, getDataType<DT>(), mod, dst, src0, src1, loc);
     }
 #ifndef NGEN_NO_OP_NAMES
     template <typename DT = void>
-    void xor(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-        xor_<DT>(mod, dst, src0, src1);
+    void xor(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+        xor_<DT>(mod, dst, src0, src1, loc);
     }
     template <typename DT = void>
-    void xor(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-        xor_<DT>(mod, dst, src0, src1);
+    void xor(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+        xor_<DT>(mod, dst, src0, src1, loc);
     }
 #endif
 
@@ -1182,116 +1198,122 @@ private:
 
         Sync(BinaryCodeGenerator<hw> *parent_) : parent(*parent_) {}
 
-        void operator()(SyncFunction fc, const InstructionModifier &mod = InstructionModifier()) {
-            parent.opSync(Opcode::sync, fc, mod);
+        void operator()(SyncFunction fc, const InstructionModifier &mod = InstructionModifier(), SourceLocation loc = {}) {
+            parent.opSync(Opcode::sync, fc, mod, loc);
         }
-        void operator()(SyncFunction fc, const RegData &src0) {
-            this->operator()(fc, InstructionModifier(), src0);
+        void operator()(SyncFunction fc, const RegData &src0, SourceLocation loc) {
+            this->operator()(fc, InstructionModifier(), src0, loc);
         }
-        void operator()(SyncFunction fc, const InstructionModifier &mod, const RegData &src0) {
-            parent.opSync(Opcode::sync, fc, mod, src0);
+        void operator()(SyncFunction fc, const InstructionModifier &mod, const RegData &src0, SourceLocation loc) {
+            parent.opSync(Opcode::sync, fc, mod, src0, loc);
         }
-        void operator()(SyncFunction fc, int src0) {
-            this->operator()(fc, InstructionModifier(), src0);
+        void operator()(SyncFunction fc, int src0, SourceLocation loc) {
+            this->operator()(fc, InstructionModifier(), src0, loc);
         }
-        void operator()(SyncFunction fc, const InstructionModifier &mod, uint32_t src0) {
-            parent.opSync(Opcode::sync, fc, mod, Immediate::ud(src0));
+        void operator()(SyncFunction fc, const InstructionModifier &mod, uint32_t src0, SourceLocation loc) {
+            parent.opSync(Opcode::sync, fc, mod, Immediate::ud(src0), loc);
         }
-        void allrd() {
-            allrd(null.ud(0)(0, 1, 1));
+        void allrd(SourceLocation loc = {}) {
+            allrd(null.ud(0)(0, 1, 1), loc);
         }
-        void allrd(const InstructionModifier &mod) {
-            allrd(mod, null.ud(0)(0, 1, 1));
+        void allrd(const InstructionModifier &mod, SourceLocation loc = {}) {
+            allrd(mod, null.ud(0)(0, 1, 1), loc);
         }
-        void allrd(const RegData &src0) {
-            allrd(InstructionModifier(), src0);
+        void allrd(const RegData &src0, SourceLocation loc = {}) {
+            allrd(InstructionModifier(), src0, loc);
         }
-        void allrd(const InstructionModifier &mod, const RegData &src0) {
-            this->operator()(SyncFunction::allrd, mod, src0);
+        void allrd(const InstructionModifier &mod, const RegData &src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::allrd, mod, src0, loc);
         }
-        void allrd(uint32_t src0) {
-            allrd(InstructionModifier(), src0);
+        void allrd(uint32_t src0, SourceLocation loc = {}) {
+            allrd(InstructionModifier(), src0, loc);
         }
-        void allrd(const InstructionModifier &mod, uint32_t src0) {
-            this->operator()(SyncFunction::allrd, mod, src0);
+        void allrd(const InstructionModifier &mod, uint32_t src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::allrd, mod, src0, loc);
         }
-        void allwr() {
-            allwr(null);
+        void allwr(SourceLocation loc = {}) {
+            allwr(null, loc);
         }
-        void allwr(const InstructionModifier &mod) {
-            allwr(mod, null);
+        void allwr(const InstructionModifier &mod, SourceLocation loc = {}) {
+            allwr(mod, null, loc);
         }
-        void allwr(const RegData &src0) {
-            allwr(InstructionModifier(), src0);
+        void allwr(const RegData &src0, SourceLocation loc = {}) {
+            allwr(InstructionModifier(), src0, loc);
         }
-        void allwr(const InstructionModifier &mod, const RegData &src0) {
-            this->operator()(SyncFunction::allwr, mod, src0);
+        void allwr(const InstructionModifier &mod, const RegData &src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::allwr, mod, src0, loc);
         }
-        void allwr(uint32_t src0) {
-            allwr(InstructionModifier(), src0);
+        void allwr(uint32_t src0, SourceLocation loc = {}) {
+            allwr(InstructionModifier(), src0, loc);
         }
-        void allwr(const InstructionModifier &mod, uint32_t src0) {
-            this->operator()(SyncFunction::allwr, mod, src0);
+        void allwr(const InstructionModifier &mod, uint32_t src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::allwr, mod, src0, loc);
         }
-        void bar(const InstructionModifier &mod = InstructionModifier()) {
-            this->operator()(SyncFunction::bar, mod);
+        void bar(const InstructionModifier &mod = InstructionModifier(), SourceLocation loc = {}) {
+            this->operator()(SyncFunction::bar, mod, loc);
         }
-        void bar(const InstructionModifier &mod, uint32_t src0) {
-            this->operator()(SyncFunction::bar, mod, src0);
+        void bar(const InstructionModifier &mod, uint32_t src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::bar, mod, src0, loc);
         }
-        void bar(const InstructionModifier &mod, const RegData &src0) {
-            this->operator()(SyncFunction::bar, mod, src0);
+        void bar(const InstructionModifier &mod, const RegData &src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::bar, mod, src0, loc);
         }
-        void bar(uint32_t src0) {
-            this->operator()(SyncFunction::bar, InstructionModifier(), src0);
+        void bar(uint32_t src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::bar, InstructionModifier(), src0, loc);
         }
-        void bar(const RegData &src0) {
-            this->operator()(SyncFunction::bar, InstructionModifier(), src0);
+        void bar(const RegData &src0, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::bar, InstructionModifier(), src0, loc);
         }
-        void flush() {
-            flush(InstructionModifier());
+        void flush(SourceLocation loc = {}) {
+            flush(InstructionModifier(), loc);
         }
-        void flush(const InstructionModifier &mod) {
-            this->operator()(SyncFunction::flush, InstructionModifier(), null);
+        void flush(const InstructionModifier &mod, SourceLocation loc = {}) {
+            this->operator()(SyncFunction::flush, InstructionModifier(), null, loc);
         }
-        void host(const InstructionModifier &mod = InstructionModifier()) {
-            this->operator()(SyncFunction::host, mod);
+        void host(const InstructionModifier &mod = InstructionModifier(), SourceLocation loc = {}) {
+            this->operator()(SyncFunction::host, mod, loc);
         }
-        void nop(const InstructionModifier &mod = InstructionModifier()) {
-            this->operator()(SyncFunction::nop, mod);
+        void nop(const InstructionModifier &mod = InstructionModifier(), SourceLocation loc = {}) {
+            this->operator()(SyncFunction::nop, mod, loc);
         }
     };
 public:
     Sync sync;
 
-    void ignoredep(Operand op) {
+    void ignoredep(Operand op, SourceLocation loc = {}) {
         if (hw >= HW::Gen12LP)
-            opX(Opcode::directive, DataType::ud, InstructionModifier(), GRF(static_cast<int>(op)), NullRegister(), NullRegister());
+            opX(Opcode::directive, DataType::ud, InstructionModifier(), GRF(static_cast<int>(op)), NullRegister(), NullRegister(), loc);
     }
-    void subdep(Operand op, const GRFRange &r) {
-        ignoredep(op);
-        wrdep(r);
+    void subdep(Operand op, const GRFRange &r, SourceLocation loc) {
+        if (op == Operand::dst && !r.isEmpty()) {
+#ifdef NGEN_SAFE
+            if (r.getLen() > 32) throw invalid_directive_exception();
+#endif
+            opX(Opcode::directive, DataType::ud, InstructionModifier::createAutoSWSB(), GRF(static_cast<int>(Directive::subdep_dst)), r[0], r[r.getLen() - 1], loc);
+        } else {
+            ignoredep(op, loc);
+            wrdep(r, loc);
+        }
     }
-    void subdep(Operand op, const GRF &r) {
-        ignoredep(op);
-        wrdep(r);
+    void subdep(Operand op, const GRF &r, SourceLocation loc = {}) {
+        subdep(op, r-r, loc);
     }
-    void wrdep(const GRFRange &r) {
+    void wrdep(const GRFRange &r, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
         if (hw < HW::Gen12LP) throw unsupported_instruction();
 #endif
         int len = r.getLen();
         for (int o = 0; o < len; o += 32) {
             int thisLen = std::min(len - o, 32);
-            opX(Opcode::directive, DataType::ud, InstructionModifier::createAutoSWSB(), GRF(static_cast<int>(Directive::wrdep)), r[o], r[o + thisLen - 1]);
+            opX(Opcode::directive, DataType::ud, InstructionModifier::createAutoSWSB(), GRF(static_cast<int>(Directive::wrdep)), r[o], r[o + thisLen - 1], loc);
         }
     }
-    void wrdep(const GRF &r) {
-        wrdep(r-r);
+    void wrdep(const GRF &r, SourceLocation loc = {}) {
+        wrdep(r-r, loc);
     }
-    void fencedep(Label &fenceLocation) {
+    void fencedep(Label &fenceLocation, SourceLocation loc) {
         addFixup(LabelFixup(fenceLocation.getID(labelManager), LabelFixup::JIPOffset));
-        opX(Opcode::directive, DataType::ud, InstructionModifier::createAutoSWSB(), GRF(static_cast<int>(Directive::fencedep)), Immediate::ud(0));
+        opX(Opcode::directive, DataType::ud, InstructionModifier::createAutoSWSB(), GRF(static_cast<int>(Directive::fencedep)), Immediate::ud(0), loc);
     }
 
     using _self = BinaryCodeGenerator<hw>;
@@ -1303,121 +1325,155 @@ NGEN_FORWARD_NO_ELF_OVERRIDES(hw) \
 NGEN_FORWARD_EXTRA_ELF_OVERRIDES(hw) \
 void requireGRF(int grfs) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::requireGRF(grfs); }
 
+#define NGEN_NILARY_OP(op) void op(NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(loc);}
+#define NGEN_UNARY_OP(op) template <typename A0> void op(A0 &&a0, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(std::forward<A0>(a0), loc);}
+#define NGEN_BINARY_OP(op) template <typename A0, typename A1> void op(A0 &&a0, A1 &&a1, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(std::forward<A0>(a0), std::forward<A1>(a1), loc);}
+#define NGEN_TERNARY_OP(op) template <typename A0, typename A1, typename A2> void op(A0 &&a0, A1 &&a1, A2 &&a2, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), loc);}
+#define NGEN_QUADRARY_OP(op) template <typename A0, typename A1, typename A2, typename A3> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), loc);}
+#define NGEN_PENTARY_OP(op) template <typename A0, typename A1, typename A2, typename A3, typename A4> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), loc);}
+#define NGEN_HEXARY_OP(op) template <typename A0, typename A1, typename A2, typename A3, typename A4, typename A5> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), loc);}
+#define NGEN_SEPTARY_OP(op) template <typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, A6 &&a6, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), std::forward<A6>(a6), loc);}
+
+#define NGEN_FORWARD_OP(op) \
+  NGEN_UNARY_OP(op) \
+  NGEN_BINARY_OP(op) \
+  NGEN_TERNARY_OP(op) \
+  NGEN_QUADRARY_OP(op) \
+  NGEN_PENTARY_OP(op) \
+  NGEN_HEXARY_OP(op) \
+  NGEN_SEPTARY_OP(op) \
+
+#define NGEN_BINARY_DT_OP(op) template <typename DT = void, typename A0, typename A1> void op(const NGEN_NAMESPACE::InstructionModifier &mod, A0 &&a0, A1 &&a1, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template op<DT>(mod, std::forward<A0>(a0), std::forward<A1>(a1), loc);}
+#define NGEN_TERNARY_DT_OP(op) template <typename DT = void, typename A0, typename A1, typename A2> void op(const NGEN_NAMESPACE::InstructionModifier &mod, A0 &&a0, A1 &&a1, A2 &&a2, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template op<DT>(mod, std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), loc);}
+#define NGEN_QUADRARY_DT_OP(op) template <typename DT = void, typename A0, typename A1, typename A2, typename A3> void op(const NGEN_NAMESPACE::InstructionModifier &mod, A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template op<DT>(mod, std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), loc);}
+#define NGEN_PENTARY_DT_OP(op) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4> void op(const NGEN_NAMESPACE::InstructionModifier &mod, A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template op<DT>(mod, std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), loc);}
+#define NGEN_HEXARY_DT_OP(op) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5> void op(const NGEN_NAMESPACE::InstructionModifier &mod, A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template op<DT>(mod, std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), loc);}
+#define NGEN_OCTARY_DT_OP(op) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7> void op(const NGEN_NAMESPACE::InstructionModifier &mod, A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, A6 &&a6, A7 &&a7, NGEN_NAMESPACE::SourceLocation loc = {}) {NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template op<DT>(mod, std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), std::forward<A6>(a6), std::forward<A7>(a7), loc);}
+
+#define NGEN_FORWARD_DT_OP(op) \
+  NGEN_BINARY_DT_OP(op) \
+  NGEN_TERNARY_DT_OP(op) \
+  NGEN_QUADRARY_DT_OP(op) \
+  NGEN_PENTARY_DT_OP(op) \
+  NGEN_HEXARY_DT_OP(op) \
+  NGEN_OCTARY_DT_OP(op) \
+
 #define NGEN_FORWARD_NO_ELF_OVERRIDES(hw) \
 using InstructionStream = typename NGEN_NAMESPACE::BinaryCodeGenerator<hw>::InstructionStream; \
 using NGEN_NAMESPACE::BinaryCodeGenerator<hw>::isGen12; \
-template <typename DT = void, typename... Targs> void add(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template add<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void add3(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template add3<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void addc(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template addc<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void and_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template and_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void asr(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template asr<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void avg(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template avg<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void bfe(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template bfe<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void bfi1(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template bfi1<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void bfi2(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template bfi2<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void bfn(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template bfn<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void bfrev(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template bfrev<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void cbit(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template cbit<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void cmp(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template cmp<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void cmpn(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template cmpn<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void csel(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template csel<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void dp2(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template dp2<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void dp3(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template dp3<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void dp4(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template dp4<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void dp4a(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template dp4a<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void dpas(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template dpas<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void dpasw(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template dpasw<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void dph(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template dph<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void fbh(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template fbh<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void fbl(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template fbl<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void frc(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template frc<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void line(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template line<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void lrp(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template lrp<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void lzd(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template lzd<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void mac(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template mac<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void macl(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template macl<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void mach(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template mach<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void mad(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template mad<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void madm(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template madm<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void math(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template math<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void mov(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template mov<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void movi(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template movi<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void mul(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template mul<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void not_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template not_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void or_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template or_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void pln(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template pln<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void rndd(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template rndd<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void rnde(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template rnde<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void rndu(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template rndu<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void rndz(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template rndz<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void rol(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template rol<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void ror(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template ror<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void sad2(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template sad2<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void sada2(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template sada2<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void sel(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template sel<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void shl(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template shl<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void shr(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template shr<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void smov(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template smov<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void subb(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template subb<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void xor_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template xor_<DT>(std::forward<Targs>(args)...); } \
-template <typename... Targs> void brc(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::brc(std::forward<Targs>(args)...); } \
-template <typename... Targs> void brd(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::brd(std::forward<Targs>(args)...); } \
-template <typename... Targs> void break_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::break_(std::forward<Targs>(args)...); } \
-template <typename... Targs> void call(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::call(std::forward<Targs>(args)...); } \
-template <typename... Targs> void calla(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::calla(std::forward<Targs>(args)...); } \
-template <typename... Targs> void cont(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::cont(std::forward<Targs>(args)...); } \
-template <typename... Targs> void else_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::else_(std::forward<Targs>(args)...); } \
-template <typename... Targs> void endif(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::endif(std::forward<Targs>(args)...); } \
-template <typename... Targs> void goto_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::goto_(std::forward<Targs>(args)...); } \
-template <typename... Targs> void halt(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::halt(std::forward<Targs>(args)...); } \
-template <typename... Targs> void if_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::if_(std::forward<Targs>(args)...); } \
-template <typename... Targs> void illegal(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::illegal(std::forward<Targs>(args)...); } \
-template <typename... Targs> void join(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::join(std::forward<Targs>(args)...); } \
-template <typename... Targs> void jmpi(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::jmpi(std::forward<Targs>(args)...); } \
-template <typename... Targs> void nop(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::nop(std::forward<Targs>(args)...); } \
-template <typename... Targs> void ret(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::ret(std::forward<Targs>(args)...); } \
-template <typename... Targs> void send(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::send(std::forward<Targs>(args)...); } \
-template <typename... Targs> void sendc(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::sendc(std::forward<Targs>(args)...); } \
-template <typename... Targs> void sends(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::sends(std::forward<Targs>(args)...); } \
-template <typename... Targs> void sendsc(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::sendsc(std::forward<Targs>(args)...); } \
+NGEN_FORWARD_DT_OP(add) \
+NGEN_FORWARD_DT_OP(addc) \
+NGEN_FORWARD_DT_OP(add3) \
+NGEN_FORWARD_DT_OP(and_) \
+NGEN_FORWARD_DT_OP(asr) \
+NGEN_FORWARD_DT_OP(avg) \
+NGEN_FORWARD_DT_OP(bfe) \
+NGEN_FORWARD_DT_OP(bfi1) \
+NGEN_FORWARD_DT_OP(bfi2) \
+NGEN_FORWARD_DT_OP(bfn) \
+NGEN_FORWARD_DT_OP(bfrev) \
+NGEN_FORWARD_DT_OP(cbit) \
+NGEN_FORWARD_DT_OP(cmp) \
+NGEN_FORWARD_DT_OP(cmpn) \
+NGEN_FORWARD_DT_OP(csel) \
+NGEN_FORWARD_DT_OP(dp2) \
+NGEN_FORWARD_DT_OP(dp3) \
+NGEN_FORWARD_DT_OP(dp4) \
+NGEN_FORWARD_DT_OP(dp4a) \
+NGEN_FORWARD_DT_OP(dpas) \
+NGEN_FORWARD_DT_OP(dpasw) \
+NGEN_FORWARD_DT_OP(dph) \
+NGEN_FORWARD_DT_OP(fbh) \
+NGEN_FORWARD_DT_OP(fbl) \
+NGEN_FORWARD_DT_OP(frc) \
+NGEN_FORWARD_DT_OP(line) \
+NGEN_FORWARD_DT_OP(lrp) \
+NGEN_FORWARD_DT_OP(lzd) \
+NGEN_FORWARD_DT_OP(mac) \
+NGEN_FORWARD_DT_OP(macl) \
+NGEN_FORWARD_DT_OP(mach) \
+NGEN_FORWARD_DT_OP(mad) \
+NGEN_FORWARD_DT_OP(madm) \
+NGEN_FORWARD_DT_OP(math) \
+NGEN_FORWARD_DT_OP(mov) \
+NGEN_FORWARD_DT_OP(movi) \
+NGEN_FORWARD_DT_OP(mul) \
+NGEN_FORWARD_DT_OP(not_) \
+NGEN_FORWARD_DT_OP(or_) \
+NGEN_FORWARD_DT_OP(pln) \
+NGEN_FORWARD_DT_OP(rndd) \
+NGEN_FORWARD_DT_OP(rnde) \
+NGEN_FORWARD_DT_OP(rndu) \
+NGEN_FORWARD_DT_OP(rndz) \
+NGEN_FORWARD_DT_OP(rol) \
+NGEN_FORWARD_DT_OP(ror) \
+NGEN_FORWARD_DT_OP(sad2) \
+NGEN_FORWARD_DT_OP(sada2) \
+NGEN_FORWARD_DT_OP(sel) \
+NGEN_FORWARD_DT_OP(shl) \
+NGEN_FORWARD_DT_OP(shr) \
+NGEN_FORWARD_DT_OP(smov) \
+NGEN_FORWARD_DT_OP(subb) \
+NGEN_FORWARD_DT_OP(xor_) \
+NGEN_FORWARD_OP(brc) \
+NGEN_FORWARD_OP(brd) \
+NGEN_FORWARD_OP(break_) \
+NGEN_FORWARD_OP(call) \
+NGEN_FORWARD_OP(calla) \
+NGEN_FORWARD_OP(cont) \
+NGEN_FORWARD_OP(else_) \
+NGEN_FORWARD_OP(endif) \
+NGEN_FORWARD_OP(goto_) \
+NGEN_FORWARD_OP(halt) \
+NGEN_FORWARD_OP(if_) \
+NGEN_NILARY_OP(illegal) \
+NGEN_FORWARD_OP(join) \
+NGEN_FORWARD_OP(jmpi) \
+NGEN_NILARY_OP(nop) \
+NGEN_FORWARD_OP(ret) \
+NGEN_FORWARD_OP(send) \
+NGEN_FORWARD_OP(sendc) \
+NGEN_FORWARD_OP(sends) \
+NGEN_FORWARD_OP(sendsc) \
 using NGEN_NAMESPACE::BinaryCodeGenerator<hw>::sync; \
-template <typename... Targs> void wait(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::wait(std::forward<Targs>(args)...); } \
-template <typename... Targs> void while_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::while_(std::forward<Targs>(args)...); } \
-template <typename... Targs> void ignoredep(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::ignoredep(std::forward<Targs>(args)...); } \
-template <typename... Targs> void subdep(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::subdep(std::forward<Targs>(args)...); } \
-template <typename... Targs> void wrdep(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::wrdep(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void min_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template min_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void max_(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template max_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void bfi(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template bfi<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void cos(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template cos<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void exp(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template exp<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void fdiv(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template fdiv<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void idiv(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template idiv<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void inv(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template inv<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void invm(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template invm<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void iqot(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template iqot<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void irem(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template irem<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void log(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template log<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void pow(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template pow<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void rsqt(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template rsqt<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void rsqtm(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template rsqtm<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void sin(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template sin<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void sqt(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template sqt<DT>(std::forward<Targs>(args)...); } \
+NGEN_FORWARD_OP(wait) \
+NGEN_FORWARD_OP(while_) \
+NGEN_FORWARD_OP(ignoredep) \
+NGEN_FORWARD_OP(subdep) \
+NGEN_FORWARD_OP(wrdep) \
+NGEN_FORWARD_DT_OP(min_) \
+NGEN_FORWARD_DT_OP(max_) \
+NGEN_FORWARD_DT_OP(bfi) \
+NGEN_FORWARD_DT_OP(cos) \
+NGEN_FORWARD_DT_OP(exp) \
+NGEN_FORWARD_DT_OP(fdiv) \
+NGEN_FORWARD_DT_OP(idiv) \
+NGEN_FORWARD_DT_OP(inv) \
+NGEN_FORWARD_DT_OP(invm) \
+NGEN_FORWARD_DT_OP(iqot) \
+NGEN_FORWARD_DT_OP(irem) \
+NGEN_FORWARD_DT_OP(log) \
+NGEN_FORWARD_DT_OP(pow) \
+NGEN_FORWARD_DT_OP(rsqt) \
+NGEN_FORWARD_DT_OP(rsqtm) \
+NGEN_FORWARD_DT_OP(sin) \
+NGEN_FORWARD_DT_OP(sqt) \
 template <typename DT = void, typename... Targs> void fdiv_ieee(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template fdiv_ieee<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void inv_ieee(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template inv_ieee<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void sqt_ieee(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template sqt_ieee<DT>(std::forward<Targs>(args)...); } \
-template <typename... Targs> void threadend(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::threadend(std::forward<Targs>(args)...); } \
+NGEN_FORWARD_DT_OP(inv_ieee) \
+NGEN_FORWARD_DT_OP(sqt_ieee) \
+NGEN_FORWARD_OP(threadend) \
 template <typename... Targs> void barrierheader(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::barrierheader(std::forward<Targs>(args)...); } \
-template <typename... Targs> void barriermsg(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::barriermsg(std::forward<Targs>(args)...); } \
+NGEN_FORWARD_OP(barriermsg) \
 template <typename... Targs> void barriersignal(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::barriersignal(std::forward<Targs>(args)...); } \
-template <typename... Targs> void barrierwait(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::barrierwait(std::forward<Targs>(args)...); } \
+NGEN_NILARY_OP(barrierwait) \
+NGEN_FORWARD_OP(barrierwait) \
 template <typename... Targs> void barrier(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::barrier(std::forward<Targs>(args)...); } \
 using NGEN_NAMESPACE::BinaryCodeGenerator<hw>::load; \
 using NGEN_NAMESPACE::BinaryCodeGenerator<hw>::store; \
 using NGEN_NAMESPACE::BinaryCodeGenerator<hw>::atomic; \
 template <typename... Targs> void memfence(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::memfence(std::forward<Targs>(args)...); } \
 template <typename... Targs> void slmfence(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::slmfence(std::forward<Targs>(args)...); } \
-template <typename... Targs> void fencewait(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::fencewait(std::forward<Targs>(args)...); } \
+NGEN_NILARY_OP(fencewait) \
 template <typename... Targs> void loadlid(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::loadlid(std::forward<Targs>(args)...); } \
 template <typename... Targs> void loadargs(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::loadargs(std::forward<Targs>(args)...); } \
 template <typename... Targs> void epilogue(int GRFCount, bool hasSLM, const NGEN_NAMESPACE::RegData &r0_info) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::epilogue(GRFCount, hasSLM, r0_info); } \
@@ -1451,18 +1507,18 @@ NGEN_FORWARD_REGISTERS(hw)
 #define NGEN_FORWARD_OP_NAMES(hw)
 #else
 #define NGEN_FORWARD_OP_NAMES(hw) \
-template <typename DT = void, typename... Targs> void and(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template and_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void not(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template not_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void or(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template or_<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void xor(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template xor_<DT>(std::forward<Targs>(args)...); }
+NGEN_FORWARD_DT_OP(and) \
+NGEN_FORWARD_DT_OP(not) \
+NGEN_FORWARD_DT_OP(or) \
+NGEN_FORWARD_DT_OP(xor)
 #endif
 
 #ifdef NGEN_WINDOWS_COMPAT
 #define NGEN_FORWARD_MIN_MAX(hw)
 #else
 #define NGEN_FORWARD_MIN_MAX(hw) \
-template <typename DT = void, typename... Targs> void min(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template min<DT>(std::forward<Targs>(args)...); } \
-template <typename DT = void, typename... Targs> void max(Targs&&... args) { NGEN_NAMESPACE::BinaryCodeGenerator<hw>::template max<DT>(std::forward<Targs>(args)...); }
+NGEN_FORWARD_DT_OP(min) \
+NGEN_FORWARD_DT_OP(max)
 #endif
 
 #ifdef NGEN_GLOBAL_REGS
@@ -1666,8 +1722,12 @@ std::vector<uint8_t> BinaryCodeGenerator<hw>::getCode()
 
         result.resize(rootStream.length() + syncs.size() * sizeof(Instruction12));
 
-        auto *psrc = reinterpret_cast<const Instruction12 *>(rootStream.code.data());
-        auto *pdst = reinterpret_cast<Instruction12 *>(result.data());
+        auto *psrc_start = reinterpret_cast<const Instruction12 *>(rootStream.code.data());
+        auto *psrc = psrc_start;
+        auto *pdst_start = reinterpret_cast<Instruction12 *>(result.data());
+        auto *pdst = pdst_start;
+        auto &srcLines = debugLine.srcLines;
+
         auto nextSync = syncs.begin();
 
         for (uint32_t isrc = 0; isrc < program.size(); isrc++, psrc++) {
@@ -1675,6 +1735,9 @@ std::vector<uint8_t> BinaryCodeGenerator<hw>::getCode()
                 continue;
             while ((nextSync != syncs.end()) && (nextSync->second->inum == isrc))
                 *pdst++ = encodeSyncInsertion<hw>(*(nextSync++)->second);
+
+            if(!srcLines.empty())
+                srcLines[psrc - psrc_start].address = sizeof(*pdst) * (pdst - pdst_start);
             *pdst++ = *psrc;
         }
 
@@ -1687,8 +1750,9 @@ std::vector<uint8_t> BinaryCodeGenerator<hw>::getCode()
 template <HW hw>
 template <bool forceWE, typename D, typename S0, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
     if (forceWE)
@@ -1719,8 +1783,9 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <bool forceWE, typename D, typename S0, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
 
@@ -1751,8 +1816,10 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <bool forceWE, typename D, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
     if (forceWE)
@@ -1786,8 +1853,10 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <bool forceWE, typename D, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, const Immediate &src0, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
 
@@ -1813,7 +1882,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
     i.binary.cmod = static_cast<int>(mod.getCMod());
 
     auto val = static_cast<uint64_t>(src0);
-    i.imm32.value = val;
+    i.imm32.value = uint32_t(val);
     if (getBytes(src0.getType()) == 8) {
 #ifdef NGEN_SAFE
         if (mod.getCMod() != ConditionModifier::none) throw invalid_modifiers_exception();
@@ -1827,8 +1896,10 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <bool forceWE, typename D, typename S0, typename S1, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
 
     InstructionModifier emod = mod | defaultModifier;
@@ -1870,8 +1941,10 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <bool forceWE, typename D, typename S0, typename S1, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
 
@@ -1906,8 +1979,10 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <bool forceWE, typename D, typename S0, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
     if (forceWE)
@@ -1943,8 +2018,10 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <bool forceWE, typename D, typename S0, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, const Immediate &src1, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
 
@@ -1973,7 +2050,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
     i.binary.cmod = static_cast<int>(mod.getCMod());
 
     i.binary.src1Imm = true;
-    i.imm32.value = static_cast<uint64_t>(src1);
+    i.imm32.value = uint32_t(static_cast<uint64_t>(src1));
 
     db(i);
 }
@@ -1981,18 +2058,20 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwLE(hw_, HW::Gen9)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, RegData dst, RegData src0, RegData src1, RegData src2)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, RegData dst, RegData src0, RegData src1, RegData src2, SourceLocation loc)
 {
     opX(op, defaultType, mod, emulateAlign16Dst(dst),  emulateAlign16Src(src0),
-                              emulateAlign16Src(src1), emulateAlign16Src(src2));
+                              emulateAlign16Src(src1), emulateAlign16Src(src2), loc);
 }
 
 
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, Align16Operand dst, Align16Operand src0, Align16Operand src1, Align16Operand src2)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, Align16Operand dst, Align16Operand src0, Align16Operand src1, Align16Operand src2, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
 #ifdef NGEN_SAFE
     if (dst.getReg().isARF())  throw grf_expected_exception();
     if (src0.getReg().isARF()) throw grf_expected_exception();
@@ -2032,10 +2111,12 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <typename D, typename S0, typename S1, typename S2, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2, SourceLocation loc)
 {
     if (hw < HW::Gen10)
         unsupported();
+
+    debugLine.add(rootStream.length(), loc);
 
 #ifdef NGEN_SAFE
     if (src0.isARF()) throw grf_expected_exception();
@@ -2066,8 +2147,10 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 template <HW hw>
 template <typename D, typename S0,typename S1, typename S2, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2)
+BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionModifier &mod, D dst, S0 src0, S1 src1, S2 src2, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
     InstructionModifier emod = mod | defaultModifier;
@@ -2093,30 +2176,32 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
 
 template <HW hw>
 template <typename DS0>
-void BinaryCodeGenerator<hw>::opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0)
+void BinaryCodeGenerator<hw>::opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0, SourceLocation loc)
 {
     InstructionModifier mmod = mod;
 
     mmod.setCMod(static_cast<ConditionModifier>(fc));
-    opX(op, defaultType, mmod, dst, src0);
+    opX(op, defaultType, mmod, dst, src0, loc);
 }
 
 template <HW hw>
 template <typename DS0, typename S1>
-void BinaryCodeGenerator<hw>::opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0, S1 src1)
+void BinaryCodeGenerator<hw>::opMath(Opcode op, DataType defaultType, const InstructionModifier &mod, MathFunction fc, DS0 dst, DS0 src0, S1 src1, SourceLocation loc)
 {
     InstructionModifier mmod = mod;
 
     mmod.setCMod(static_cast<ConditionModifier>(fc));
-    opX(op, defaultType, mmod, dst, src0, src1);
+    opX(op, defaultType, mmod, dst, src0, src1, loc);
 }
 
 template <HW hw>
 template <typename D, typename S0, typename S2>
-void BinaryCodeGenerator<hw>::opBfn(Opcode op, DataType defaultType, const InstructionModifier &mod, int bfnCtrl, D dst, S0 src0, RegData src1, S2 src2)
+void BinaryCodeGenerator<hw>::opBfn(Opcode op, DataType defaultType, const InstructionModifier &mod, int bfnCtrl, D dst, S0 src0, RegData src1, S2 src2, SourceLocation loc)
 {
     if (hw < HW::XeHP)
         unsupported();
+
+    debugLine.add(rootStream.length(), loc);
 
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
@@ -2145,14 +2230,9 @@ void BinaryCodeGenerator<hw>::opBfn(Opcode op, DataType defaultType, const Instr
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opDpas(Opcode op, DataType defaultType, const InstructionModifier &mod, int sdepth, int rcount, RegData dst, RegData src0, RegData src1, RegData src2)
+static inline void encodeDPAS(Instruction12 &i, Opcode op, DataType defaultType, const InstructionModifier &emod, int sdepth, int rcount, RegData dst, RegData src0, RegData src1, RegData src2)
 {
-    if (hw < HW::XeHP)
-        unsupported();
-
     typename EncodingTag12Dispatch<hw>::tag tag;
-    Instruction12 i{};
-    InstructionModifier emod = mod | defaultModifier;
 
     dst.fixup(hw, emod.getExecSize(), 0, defaultType, -1, 3);
     src0.fixup(hw, emod.getExecSize(), 0, defaultType, 0, 3);
@@ -2174,33 +2254,46 @@ void BinaryCodeGenerator<hw>::opDpas(Opcode op, DataType defaultType, const Inst
     i.dpas.src1SubBytePrecision = encodeSubBytePrecision12(src1.getType());
     i.dpas.src2SubBytePrecision = encodeSubBytePrecision12(src2.getType());
 
-    i.ternary.cmod = static_cast<int>(mod.getCMod());
+    i.ternary.cmod = static_cast<int>(emod.getCMod());
+}
 
+template <HW hw>
+void BinaryCodeGenerator<hw>::opDpas(Opcode op, DataType defaultType, const InstructionModifier &mod, int sdepth, int rcount, RegData dst, RegData src0, RegData src1, RegData src2, SourceLocation loc)
+{
+    if (hw < HW::XeHP)
+        unsupported();
+
+    debugLine.add(rootStream.length(), loc);
+
+    Instruction12 i{};
+    encodeDPAS<hw>(i, op, defaultType, mod | defaultModifier, sdepth, rcount, dst, src0, src1, src2);
     db(i);
 }
 
 template <HW hw>
 template <typename D, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, uint32_t exdesc, D desc)
+BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, uint32_t exdesc, D desc, SourceLocation loc)
 {
     exdesc |= uint32_t(static_cast<uint8_t>(sfid));
-    opSends(static_cast<Opcode>(static_cast<uint8_t>(op) | 2), mod, dst, src0, src1, exdesc, desc);
+    opSends(static_cast<Opcode>(static_cast<uint8_t>(op) | 2), mod, dst, src0, src1, exdesc, desc, loc);
 }
 
 template <HW hw>
 template <typename D, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, const RegData &exdesc, D desc)
+BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0, const RegData &src1, int src1Length, const RegData &exdesc, D desc, SourceLocation loc)
 {
-    opSends(static_cast<Opcode>(static_cast<uint8_t>(op) | 2), mod, dst, src0, src1, exdesc, desc);
+    opSends(static_cast<Opcode>(static_cast<uint8_t>(op) | 2), mod, dst, src0, src1, exdesc, desc, loc);
 }
 
 template <HW hw>
 template <typename ED, typename D, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0_, const RegData &src1, int src1Length, ED exdesc, D desc)
+BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, SharedFunction sfid, const RegData &dst, const RegData &src0_, const RegData &src1, int src1Length, ED exdesc, D desc, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
     InstructionModifier emod = mod | defaultModifier;
@@ -2209,7 +2302,7 @@ BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, Share
     bool src0Indirect = (hw >= HW::Xe3 && src0.isIndirect());
     if (src0Indirect)
         src0 = src0.getIndirectReg();
- 
+
     encodeCommon12(i, op, emod, dst, tag);
 
     i.send.fusionCtrl = emod.isSerialized();
@@ -2239,8 +2332,10 @@ BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, Share
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc)
+BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, uint32_t desc, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
 
@@ -2272,8 +2367,10 @@ BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc)
+BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, const RegData &desc, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
 #ifdef NGEN_SAFE
     // Only a0.0:ud is allowed for desc.
     if (!desc.isARF() || desc.getARFType() != ARFType::a || desc.getARFBase() != 0 || desc.getOffset() != 0)
@@ -2309,16 +2406,18 @@ BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const
 template <HW hw>
 template <typename D, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, D desc)
+BinaryCodeGenerator<hw>::opSend(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, uint32_t exdesc, D desc, SourceLocation loc)
 {
-    opSends(op, mod, dst, src0, null, exdesc, desc);
+    opSends(op, mod, dst, src0, null, exdesc, desc, loc);
 }
 
 template <HW hw>
 template <typename ED, typename D, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, ED exdesc, D desc)
+BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, ED exdesc, D desc, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
 
@@ -2344,7 +2443,7 @@ BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, cons
 template <HW hw>
 template <typename D, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, RegData exdesc, D desc)
+BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, RegData exdesc, D desc, SourceLocation loc)
 {
 #ifdef NGEN_SAFE
     throw sfid_needed_exception();
@@ -2354,17 +2453,19 @@ BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, cons
 template <HW hw>
 template <typename D, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, D desc)
+BinaryCodeGenerator<hw>::opSends(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, uint32_t exdesc, D desc, SourceLocation loc)
 {
     Opcode mop = static_cast<Opcode>(static_cast<int>(op) & ~2);
-    opSend(mop, mod, static_cast<SharedFunction>(exdesc & 0x1F), dst, src0, src1, -1, exdesc, desc);
+    opSend(mop, mod, static_cast<SharedFunction>(exdesc & 0x1F), dst, src0, src1, -1, exdesc, desc, loc);
 }
 
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip)
+BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
 
@@ -2384,8 +2485,10 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip)
+BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, int32_t uip, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
     InstructionModifier emod = mod | defaultModifier;
@@ -2408,8 +2511,10 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
 template <HW hw>
 template <bool forceWE, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip)
+BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
     if (forceWE)
@@ -2430,8 +2535,10 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
 template <HW hw>
 template <bool forceWE, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip)
+BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, int32_t jip, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
     InstructionModifier emod = mod | defaultModifier;
@@ -2452,8 +2559,10 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
 template <HW hw>
 template <bool forceWE, bool small12, HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0)
+BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier;
     if (forceWE)
@@ -2474,8 +2583,10 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
 template <HW hw>
 template <bool forceWE, bool small12, HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0)
+BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
     InstructionModifier emod = mod | defaultModifier;
@@ -2496,36 +2607,38 @@ BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, con
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, Label &uip)
+void BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, Label &uip, SourceLocation loc)
 {
     addFixup(LabelFixup(jip.getID(labelManager), LabelFixup::JIPOffset));
     addFixup(LabelFixup(uip.getID(labelManager), LabelFixup::UIPOffset));
-    opBranch(op, mod, dst, 0, 0);
+    opBranch(op, mod, dst, 0, 0, loc);
 }
 
 template <HW hw>
 template <bool forceWE>
-void BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip)
+void BinaryCodeGenerator<hw>::opBranch(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, SourceLocation loc)
 {
     addFixup(LabelFixup(jip.getID(labelManager), LabelFixup::JIPOffset));
-    opBranch<forceWE>(op, mod, dst, 0);
+    opBranch<forceWE>(op, mod, dst, 0, loc);
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opCall(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip)
+void BinaryCodeGenerator<hw>::opCall(Opcode op, const InstructionModifier &mod, const RegData &dst, Label &jip, SourceLocation loc)
 {
     addFixup(LabelFixup(jip.getID(labelManager), LabelFixup::JIPOffset));
     if (isGen12)
-        opBranch<true>(op, mod, dst, 0);
+        opBranch<true>(op, mod, dst, 0, loc);
     else
-        opX<true>(op, DataType::d, mod, dst, null.ud(0)(0, 1, 0), Immediate::d(0));
+        opX<true>(op, DataType::d, mod, dst, null.ud(0)(0, 1, 0), Immediate::d(0), loc);
 }
 
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwLT(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip)
+BinaryCodeGenerator<hw>::opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
     InstructionModifier emod = mod | defaultModifier | NoMask;
 
@@ -2547,26 +2660,28 @@ BinaryCodeGenerator<hw>::opJmpi(Opcode op, const InstructionModifier &mod, const
 template <HW hw>
 template <HW hw_>
 typename std::enable_if<hwGE(hw_, HW::Gen12LP)>::type
-BinaryCodeGenerator<hw>::opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip)
+BinaryCodeGenerator<hw>::opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, RegData src0, uint32_t jip, SourceLocation loc)
 {
-    opBranch<true>(op, mod, dst, jip);
+    opBranch<true>(op, mod, dst, jip, loc);
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, Label &jip)
+void BinaryCodeGenerator<hw>::opJmpi(Opcode op, const InstructionModifier &mod, const RegData &dst, const RegData &src0, Label &jip, SourceLocation loc)
 {
     if (hw >= HW::Gen12LP)
         addFixup(LabelFixup(jip.getID(labelManager), LabelFixup::JIPOffset));
-    opJmpi(op, mod, dst, src0, 0);
+    opJmpi(op, mod, dst, src0, 0, loc);
     if (hw < HW::Gen12LP)
         addFixup(LabelFixup(jip.getID(labelManager), LabelFixup::JIPOffsetJMPI));
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod)
+void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, SourceLocation loc)
 {
     if (hw < HW::Gen12LP)
         unsupported();
+
+    debugLine.add(rootStream.length(), loc);
 
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
@@ -2581,11 +2696,13 @@ void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const Instructi
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, RegData src0)
+void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, RegData src0, SourceLocation loc)
 {
     typename EncodingTag12Dispatch<hw>::tag tag;
     if (hw < HW::Gen12LP)
         unsupported();
+
+    debugLine.add(rootStream.length(), loc);
 
     Instruction12 i{};
     InstructionModifier emod = mod | defaultModifier;
@@ -2604,10 +2721,12 @@ void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const Instructi
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, const Immediate &src0)
+void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const InstructionModifier &mod, const Immediate &src0, SourceLocation loc)
 {
     if (hw < HW::Gen12LP)
         unsupported();
+
+    debugLine.add(rootStream.length(), loc);
 
     typename EncodingTag12Dispatch<hw>::tag tag;
     Instruction12 i{};
@@ -2620,14 +2739,16 @@ void BinaryCodeGenerator<hw>::opSync(Opcode op, SyncFunction fc, const Instructi
     i.binary.src0Imm = true;
     i.binary.cmod = static_cast<int>(fc);
 
-    i.imm32.value = static_cast<uint64_t>(src0);
+    i.imm32.value = uint32_t(static_cast<uint64_t>(src0));
 
     db(i);
 }
 
 template <HW hw>
-void BinaryCodeGenerator<hw>::opNop(Opcode op)
+void BinaryCodeGenerator<hw>::opNop(Opcode op, SourceLocation loc)
 {
+    debugLine.add(rootStream.length(), loc);
+
     Instruction8 i{};
 
     i.qword[0] = static_cast<int>(op);

--- a/src/gpu/intel/jit/ngen/ngen_config.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_config.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/jit/ngen/ngen_config.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_config.hpp
@@ -31,4 +31,13 @@ using half = dnnl::impl::float16_t;
 #define NGEN_BFLOAT16_TYPE
 #define NGEN_HALF_TYPE
 
+#if (!defined(NDEBUG) || defined(DNNL_DEV_MODE)) && (__cplusplus >= 202002L || _MSVC_LANG >= 202002L)
+#if __has_include(<version>)
+#include <version>
+#if __cpp_lib_source_location >= 201907L
+#define NGEN_ENABLE_SOURCE_LOCATION true
+#endif
+#endif
+#endif
+
 #endif /* header guard */

--- a/src/gpu/intel/jit/ngen/ngen_debuginfo.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_debuginfo.hpp
@@ -1,0 +1,419 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef NGEN_DEBUGINFO_HPP
+#define NGEN_DEBUGINFO_HPP
+
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+#include "ngen_utils.hpp"
+
+#ifdef NGEN_ENABLE_SOURCE_LOCATION
+#include <source_location>
+#endif
+
+
+namespace NGEN_NAMESPACE {
+
+struct DebugConfig {
+    DebugConfig() = default;
+    DebugConfig(const char * name, uint32_t line, bool enableLineMapping): nameCU(name), programLine(line), enableLineMapping(enableLineMapping) {};
+
+    const char *nameCU = "(unknown)";
+    uint32_t programLine = 0;
+    bool enableLineMapping = false;
+};
+
+struct SourceLocation {
+#ifdef NGEN_ENABLE_SOURCE_LOCATION
+    SourceLocation(std::source_location where = std::source_location::current())
+        : value(where) {}
+    SourceLocation(const SourceLocation &) = default;
+    SourceLocation(SourceLocation &&) = default;
+    const char *filePath() { return value.file_name(); }
+    uint32_t line() { return value.line(); }
+    std::source_location value;
+    std::string str() {
+        std::ostringstream oss;
+        oss << value.file_name() << ":" << value.line();
+        return oss.str();
+    }
+#endif
+};
+
+struct DebugLine {
+    DebugLine(const DebugConfig & conf): enableSrcLines(conf.enableLineMapping), programLine(conf.programLine) {
+#ifndef NGEN_ENABLE_SOURCE_LOCATION
+        // Unsupported
+        enableSrcLines = false;
+#endif
+        // Reuse .debug_line_str for simplicity
+        add(conf.nameCU);
+    }
+
+    struct Line {
+        Line(uint64_t address, uint32_t fileEntry, uint32_t line)
+            : address(address), fileEntry(fileEntry), line(line) {}
+        uint64_t address;
+        uint32_t fileEntry;
+        uint32_t line;
+        std::string str() {
+            std::ostringstream oss;
+            oss << "0x" << std::hex << address << " -> " << fileEntry;
+            return oss.str();
+        }
+    };
+    uint32_t add(const char * filePath) {
+        uint32_t entry = 0;
+        auto f = fileMap.find(filePath);
+        if(f == fileMap.end()) {
+            const char * filenamePtr = [&]() {
+                for(int64_t i = strlen(filePath) - 1; i >= 0; i--) {
+                    if(filePath[i] == '/' || filePath[i] == '\\')
+                        return filePath + i + 1;
+                }
+                return filePath;
+            }();
+            std::string filename = filenamePtr;
+            std::string dirName = filenamePtr == filePath ? "" : std::string(filePath, filenamePtr - filePath - 1);
+            uint32_t dirEntryIndex = [&]() {
+                auto e = dirMap.find(dirName);
+                if (e != dirMap.end())
+                    return e->second;
+
+                uint32_t ret = static_cast<uint32_t>(dirEntries.size());
+
+                // Add new directory entry
+                DirEntry dirEntry = {static_cast<uint32_t>(strTable.size())};
+                for (char c : dirName) {
+                    strTable.emplace_back(c);
+                }
+                strTable.emplace_back(0);
+                dirEntries.emplace_back(dirEntry);
+                dirMap[dirName] = ret;
+
+                return ret;
+            }();
+
+            FileEntry fileEntry = {static_cast<uint32_t>(strTable.size()),
+                                   dirEntryIndex};
+            for (char c : filename) {
+                strTable.emplace_back(c);
+            }
+            strTable.emplace_back(0);
+            fileEntries.emplace_back(fileEntry);
+            entry = static_cast<uint32_t>(fileEntries.size() - 1);
+            fileMap[filePath] = entry;
+        } else {
+            entry = f->second;
+        }
+        return entry;
+    }
+
+    void add(uint64_t address, SourceLocation loc) {
+#ifdef NGEN_ENABLE_SOURCE_LOCATION
+        if(enableSrcLines) srcLines.emplace_back(address, add(loc.filePath()), loc.line());
+#endif
+    }
+
+    std::string str() {
+        std::ostringstream oss;
+        oss << "Directory Table: \n";
+        for (auto &e : dirEntries)
+            if (strTable[e.strTableOffset] == 0)
+                oss << "\t.\n";
+            else
+                oss << "\t" << &strTable[e.strTableOffset] << "\n";
+
+        oss << "File Table: \n";
+        for (auto &e : fileEntries) {
+            const char *dir =
+                &strTable[dirEntries[e.dirEntriesIndex].strTableOffset];
+            if (*dir == 0)
+                oss << "\t" << &strTable[e.strTableOffset] << "\n";
+            else
+                oss << "\t" << dir << "/" << &strTable[e.strTableOffset] << "\n";
+        }
+
+        for (auto &line : srcLines) {
+            oss << line.str() << "\n";
+        }
+        return oss.str();
+    }
+
+#pragma pack(push, 1)
+    struct DebugLineHeaderBase {
+        uint32_t unitLength; // Length of all debug line information excluding itself
+        uint16_t version = 5;
+        uint8_t addressSize = sizeof(void*);
+        uint8_t segmentSelectorSize = 0;
+        uint32_t headerLength;
+        uint8_t minimumInstructionLength = 16; // sizeof(Instruction12), hard-coded to avoid dependency
+        uint8_t maximumOperationsPerInstruction = 1;
+        uint8_t defaultIsStmt = 1;
+        int8_t lineBase = -32;
+        uint8_t lineRange = 192;
+        uint8_t opcodeBase = 5;
+        uint8_t opCodeLengths[4] = {0, 1, 1, 1};
+
+        enum DWARF_FORM : uint8_t {
+            DATA2 = 0x05,
+            DATA4 = 0x06,
+            DATA8 = 0x07,
+            STRING = 0x08,
+            DATA1 = 0x0b,
+            STRP = 0x0e,
+            LINEPTR = 0x17,
+            FLAG_PRESENT = 0x19,
+            LINE_STRP = 0x1f,
+        };
+
+        enum DWARF_LNCT : uint8_t {
+            PATH = 0x1,
+            DIRECTORY_INDEX = 0x2,
+        };
+
+        struct DirEntriesHeader {
+            uint8_t directoryEntryFormatCount = 1;
+            struct {
+                uint8_t type;
+                uint8_t form;
+            } directoryEntryFormat[1] = {
+                {DWARF_LNCT::PATH, DWARF_FORM::LINE_STRP},
+            };
+        };
+
+        struct FileEntriesHeader {
+            uint8_t filenameEntryFormatCount = 2;
+            struct {
+                uint8_t type;
+                uint8_t form;
+            } filenameEntryFormat[2] = {
+                {DWARF_LNCT::PATH, DWARF_FORM::LINE_STRP},
+                {DWARF_LNCT::DIRECTORY_INDEX, DWARF_FORM::DATA4},
+            };
+        };
+    };
+#pragma pack(pop)
+
+    static void encodeLEB128(std::vector<char> &out, int64_t a) {
+        do {
+            out.emplace_back(static_cast<uint8_t>((a & 0x7f) | 0x80));
+            a >>= 7;
+        } while (a != 0 && a != -1);
+        if (a == -1 && (out.back() & 0x40) == 0) {
+            out.emplace_back(0x7f);
+        } else if (a == 0 && (out.back() & 0x40)) {
+            out.emplace_back(0x00);
+        } else  {
+            out.back() &= 0x7f;
+        }
+    }
+
+    static void encodeULEB128(std::vector<char> &out, size_t a) {
+        do {
+            out.emplace_back(static_cast<uint8_t>((a & 0x7f) | 0x80));
+            a >>= 7;
+        } while (a > 0);
+        out.back() &= 0x7f;
+    };
+
+    static std::vector<char> toULEB128(size_t a) {
+        std::vector<char> ret;
+        encodeULEB128(ret, a);
+        return ret;
+    };
+
+    std::pair<std::vector<char>, uint64_t> encodeLineStatements(const DebugLineHeaderBase & base) const {
+        struct {
+            uint64_t address = 0;
+            uint64_t line = 1;
+            uint32_t file = 1;
+            bool isStmt = 1;
+            uint32_t isa = 0;
+            uint32_t discriminator = 0;
+
+            int8_t lineBase;
+            uint8_t lineRange;
+            uint8_t opcodeBase;
+            uint8_t addressScale;
+
+            enum StandardOps {
+                extendedOp = 0,
+                copy = 1,
+                advancePC = 2,
+                advanceLine = 3,
+                setFile = 4,
+            };
+
+            enum ExtendedOps { endSequence = 1, setAddress = 2 };
+
+            uint64_t initPC(std::vector<char> &out) {
+                out.emplace_back(extendedOp);
+                encodeULEB128(out, 9);
+                out.emplace_back(setAddress);
+                uint64_t relocationOffset = out.size();
+                for (int i = 0; i < 8; i++) {
+                    out.emplace_back(0);
+                }
+                return relocationOffset;
+            }
+
+            void finalize(std::vector<char> &out) {
+                out.emplace_back(advancePC);
+                encodeULEB128(out, 1);
+                out.emplace_back(extendedOp);
+                encodeULEB128(out, 1);
+                out.emplace_back(endSequence);
+            }
+
+            void encode(std::vector<char> &out, const Line &l) {
+                size_t lineAddress = l.address / addressScale;
+
+                if(l.fileEntry != file) {
+                    out.emplace_back(setFile);
+                    encodeULEB128(out, l.fileEntry);
+                    file = l.fileEntry;
+                }
+
+                if (l.line >= line + lineBase &&
+                    l.line < line + lineBase + lineRange) {
+                    int64_t specialOp = (l.line - line) - lineBase +
+                        (lineAddress - address) * lineRange +
+                        opcodeBase;
+                    if (specialOp > 0 && specialOp <= 255) {
+                        out.emplace_back(static_cast<uint8_t>(specialOp));
+                        line = l.line;
+                        address = lineAddress;
+                        return;
+                    }
+                }
+
+                if(lineAddress != address) {
+                    out.emplace_back(advancePC);
+                    encodeULEB128(out, lineAddress - address);
+                    address = lineAddress;
+                }
+
+                if(l.line != line) {
+                    out.emplace_back(advanceLine);
+                    encodeLEB128(out, static_cast<int64_t>(l.line) - line);
+                    line = l.line;
+                }
+
+                out.emplace_back(copy);
+            }
+        } encodeState;
+
+        encodeState.isStmt = base.defaultIsStmt;
+        encodeState.lineBase = base.lineBase;
+        encodeState.lineRange = base.lineRange;
+        encodeState.opcodeBase = base.opcodeBase;
+        encodeState.addressScale = base.minimumInstructionLength;
+
+        std::vector<char> ret;
+        uint64_t relocation_offset = encodeState.initPC(ret);
+        for(const auto & l: srcLines) {
+            encodeState.encode(ret, l);
+        }
+        encodeState.finalize(ret);
+
+        return {ret, relocation_offset};
+    }
+
+    std::pair<std::vector<char>, uint64_t> createDebugLine() const {
+
+        DebugLineHeaderBase base;
+        DebugLineHeaderBase::DirEntriesHeader dirHeader;
+        std::vector<char> directoriesCount = toULEB128(dirEntries.size());
+        uint32_t dirEntriesBytes = static_cast<uint32_t>(dirEntries.size() * sizeof(dirEntries[0]));
+        DebugLineHeaderBase::FileEntriesHeader fileHeader;
+        std::vector<char> filenamesCount = toULEB128(fileEntries.size());
+        uint32_t fileEntriesBytes = static_cast<uint32_t>(fileEntries.size() * sizeof(fileEntries[0]));
+        auto encode = encodeLineStatements(base);
+        std::vector<char> lineStatements = encode.first;
+        uint64_t relocation_offset = encode.second;
+
+        uint32_t headerEntriesSize = static_cast<uint32_t> (sizeof(dirHeader) + directoriesCount.size()
+            + dirEntriesBytes + sizeof(fileHeader) + filenamesCount.size() + fileEntriesBytes);
+        uint32_t lineTableSize = static_cast<uint32_t>(lineStatements.size());
+
+        base.unitLength = sizeof(base) - sizeof(base.unitLength) + headerEntriesSize + lineTableSize;
+        base.headerLength = sizeof(base) -
+            ((offsetof(DebugLineHeaderBase, headerLength)) +
+            sizeof(base.headerLength)) + headerEntriesSize;
+
+        std::vector<char> ret(base.unitLength + sizeof(base.unitLength));
+
+        char *data = ret.data();
+
+        // Write header base data
+        memcpy(data, &base, sizeof(base));
+        data += sizeof(base);
+
+        // Write directory entries
+        memcpy(data, &dirHeader, sizeof(dirHeader));
+        data += sizeof(dirHeader);
+        memcpy(data, directoriesCount.data(), directoriesCount.size());
+        data += directoriesCount.size();
+        memcpy(data, dirEntries.data(), dirEntriesBytes);
+        data += dirEntriesBytes;
+
+        // Write file entries
+        memcpy(data, &fileHeader, sizeof(fileHeader));
+        data += sizeof(fileHeader);
+        memcpy(data, filenamesCount.data(), filenamesCount.size());
+        data += filenamesCount.size();
+        memcpy(data, fileEntries.data(), fileEntriesBytes);
+        data += fileEntriesBytes;
+
+        // Write line statements
+        relocation_offset += data - ret.data();
+        memcpy(data, lineStatements.data(), lineStatements.size());
+        data += lineStatements.size();
+
+        return {ret, relocation_offset};
+    };
+    const std::vector<char> & getDebugLineStr() {
+        return strTable;
+    }
+
+    std::vector<char> strTable = {0};
+    struct DirEntry {
+        uint32_t strTableOffset;
+    };
+    std::vector<DirEntry> dirEntries = {{0}};
+    std::unordered_map<std::string, uint32_t> dirMap = {{"", 0}};
+
+    struct FileEntry {
+        uint32_t strTableOffset;
+        uint32_t dirEntriesIndex;
+    };
+
+    std::vector<FileEntry> fileEntries = {{0, 0}};
+    std::unordered_map<std::string, uint32_t> fileMap {{"", 0}};
+
+    std::vector<Line> srcLines;
+
+    bool enableSrcLines = false;
+    uint32_t programLine = 0;
+};
+
+} // namespace NGEN_NAMESPACE
+
+#endif

--- a/src/gpu/intel/jit/ngen/ngen_gen12.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_gen12.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -173,7 +173,7 @@ public:
         auto result = SWSBInfo(pipe(op), dist());
         if (combined.mode) {
             bool src, dst;
-            if (op == Opcode::send || op == Opcode::sendc)
+            if (isSend(op))
                 src = dst = true;
             else if (op == Opcode::dpas) {
                 src = (combined.mode <= 2);
@@ -200,7 +200,7 @@ public:
     }
     constexpr14 Pipe pipe(Opcode op) const {
         if (combined.mode) {
-            if (op == Opcode::send || op == Opcode::sendc)
+            if (isSend(op))
                 return (combined.mode == 1) ? Pipe::A : (combined.mode == 2) ? Pipe::F : Pipe::I;
             if (op == Opcode::dpas)
                 return Pipe::Default;
@@ -474,7 +474,7 @@ struct InstructionXeHPC : public Instruction12 {
     bool getOperandRegion(autoswsb::DependencyRegion &region, int opNum) const {
         return Instruction12::getOperandRegion<EncodingTagXeHPC>(region, opNum);
     }
- 
+
     bool eot() const {
         return Instruction12::eot();
     }
@@ -838,9 +838,9 @@ static inline int decodeDPASTypecodeBytes12(unsigned dt)
 
 inline ARFType normalizeARFType(ARFType type, HW hw)
 {
-   if (hw >= HW::Xe3 && type == ARFType::sp)
+    if (hw >= HW::Xe3 && type == ARFType::sp)
         type = ARFType::s;
-   return type;
+    return type;
 }
 
 template <typename Tag>

--- a/src/gpu/intel/jit/ngen/ngen_level_zero.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_level_zero.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,11 +41,13 @@ template <HW hw>
 class LevelZeroCodeGenerator : public ELFCodeGenerator<hw>
 {
 public:
-    explicit LevelZeroCodeGenerator(Product product_) : ELFCodeGenerator<hw>(product_) {
+    explicit LevelZeroCodeGenerator(Product product_, DebugConfig debugConfig = {}) : ELFCodeGenerator<hw>(product_, debugConfig) {
         this->interface_.setInlineGRFCount(0);
     }
 
-    explicit LevelZeroCodeGenerator(int stepping_ = 0) : LevelZeroCodeGenerator({genericProductFamily(hw), stepping_}) {}
+    explicit LevelZeroCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : LevelZeroCodeGenerator({genericProductFamily(hw), stepping_}, debugConfig) {}
+
+    explicit LevelZeroCodeGenerator(DebugConfig debugConfig) : LevelZeroCodeGenerator({genericProductFamily(hw), 0}, debugConfig) {}
 
     inline ze_module_handle_t getModule(ze_context_handle_t context, ze_device_handle_t device, const std::string &options = "");
     static inline HW detectHW(ze_context_handle_t context, ze_device_handle_t device);

--- a/src/gpu/intel/jit/ngen/ngen_opencl.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_opencl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,8 +53,9 @@ template <HW hw>
 class OpenCLCodeGenerator : public ELFCodeGenerator<hw>
 {
 public:
-    explicit OpenCLCodeGenerator(Product product_)  : ELFCodeGenerator<hw>(product_) {}
-    explicit OpenCLCodeGenerator(int stepping_ = 0) : ELFCodeGenerator<hw>(stepping_) {}
+    explicit OpenCLCodeGenerator(Product product_, DebugConfig debugConfig = {})  : ELFCodeGenerator<hw>(product_, debugConfig) {}
+    explicit OpenCLCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : ELFCodeGenerator<hw>(stepping_, debugConfig) {}
+    explicit OpenCLCodeGenerator(DebugConfig debugConfig) : ELFCodeGenerator<hw>(0, debugConfig) {}
 
     inline std::vector<uint8_t> getBinary(cl_context context, cl_device_id device, const std::string &options = "-cl-std=CL2.0");
     inline cl_kernel getKernel(cl_context context, cl_device_id device, const std::string &options = "-cl-std=CL2.0");

--- a/src/gpu/intel/jit/ngen/ngen_pseudo.hpp
+++ b/src/gpu/intel/jit/ngen/ngen_pseudo.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,140 +21,140 @@
 
 // Pseudo-instructions and macros.
 template <typename DT = void>
-void min_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    sel<DT>(mod | lt | f0[0], dst, src0, src1);
+void min_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | lt | f0[0], dst, src0, src1, loc);
 }
 template <typename DT = void>
-void min_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    sel<DT>(mod | lt | f0[0], dst, src0, src1);
+void min_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | lt | f0[0], dst, src0, src1, loc);
 }
 #ifndef NGEN_WINDOWS_COMPAT
 template <typename DT = void>
-void min(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    sel<DT>(mod | lt | f0[0], dst, src0, src1);
+void min(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | lt | f0[0], dst, src0, src1, loc);
 }
 template <typename DT = void>
-void min(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    sel<DT>(mod | lt | f0[0], dst, src0, src1);
+void min(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | lt | f0[0], dst, src0, src1, loc);
 }
 #endif
 template <typename DT = void>
-void max_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    sel<DT>(mod | ge | f0[0], dst, src0, src1);
+void max_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | ge | f0[0], dst, src0, src1, loc);
 }
 template <typename DT = void>
-void max_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    sel<DT>(mod | ge | f0[0], dst, src0, src1);
+void max_(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | ge | f0[0], dst, src0, src1, loc);
 }
 #ifndef NGEN_WINDOWS_COMPAT
 template <typename DT = void>
-void max(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    sel<DT>(mod | ge | f0[0], dst, src0, src1);
+void max(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | ge | f0[0], dst, src0, src1, loc);
 }
 template <typename DT = void>
-void max(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    sel<DT>(mod | ge | f0[0], dst, src0, src1);
+void max(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    sel<DT>(mod | ge | f0[0], dst, src0, src1, loc);
 }
 #endif
 
 template <typename DT = void>
-void bfi(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, const RegData &src3) {
-    bfi1<DT>(mod, dst, src0, src1);
-    bfi2<DT>(mod, dst, dst, src2, src3);
+void bfi(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, const RegData &src2, const RegData &src3, SourceLocation loc = {}) {
+    bfi1<DT>(mod, dst, src0, src1, loc);
+    bfi2<DT>(mod, dst, dst, src2, src3, loc);
 }
 
 // Brief compare instructions.
 template <typename DT = void>
-void cmp(const InstructionModifier &mod, const RegData &src0, const RegData &src1) {
+void cmp(const InstructionModifier &mod, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
     auto dt = getDataType<DT>();
     if (dt == DataType::invalid)
         dt = src0.getType();
-    cmp<DT>(mod, null.retype(dt), src0, src1);
+    cmp<DT>(mod, null.retype(dt), src0, src1, loc);
 }
 template <typename DT = void>
-void cmp(const InstructionModifier &mod, const RegData &src0, const Immediate &src1) {
+void cmp(const InstructionModifier &mod, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
     auto dt = getDataType<DT>();
     if (dt == DataType::invalid)
         dt = src0.getType();
-    cmp<DT>(mod, null.retype(dt), src0, src1);
+    cmp<DT>(mod, null.retype(dt), src0, src1, loc);
 }
 
 // Brief math instructions.
 template <typename DT = void>
-void cos(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-    math<DT>(mod, MathFunction::cos, dst, src0);
+void cos(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::cos, dst, src0, loc);
 }
 template <typename DT = void>
-void exp(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-    math<DT>(mod, MathFunction::exp, dst, src0);
+void exp(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::exp, dst, src0, loc);
 }
 template <typename DT = void>
-void fdiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    math<DT>(mod, MathFunction::fdiv, dst, src0, src1);
+void fdiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::fdiv, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void fdiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    math<DT>(mod, MathFunction::fdiv, dst, src0, src1);
+void fdiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::fdiv, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void idiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    math<DT>(mod, MathFunction::idiv, dst, src0, src1);
+void idiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::idiv, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void idiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    math<DT>(mod, MathFunction::idiv, dst, src0, src1);
+void idiv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::idiv, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void inv(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-    math<DT>(mod, MathFunction::inv, dst, src0);
+void inv(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::inv, dst, src0, loc);
 }
 template <typename DT = void>
-void invm(const InstructionModifier &mod, const ExtendedReg &dst, const ExtendedReg &src0, const ExtendedReg &src1) {
-    math<DT>(mod, MathFunction::invm, dst, src0, src1);
+void invm(const InstructionModifier &mod, const ExtendedReg &dst, const ExtendedReg &src0, const ExtendedReg &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::invm, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void iqot(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    math<DT>(mod, MathFunction::iqot, dst, src0, src1);
+void iqot(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::iqot, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void iqot(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    math<DT>(mod, MathFunction::iqot, dst, src0, src1);
+void iqot(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::iqot, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void irem(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    math<DT>(mod, MathFunction::irem, dst, src0, src1);
+void irem(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::irem, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void irem(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    math<DT>(mod, MathFunction::irem, dst, src0, src1);
+void irem(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::irem, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void log(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-    math<DT>(mod, MathFunction::log, dst, src0);
+void log(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::log, dst, src0, loc);
 }
 template <typename DT = void>
-void pow(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1) {
-    math<DT>(mod, MathFunction::pow, dst, src0, src1);
+void pow(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const RegData &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::pow, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void pow(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1) {
-    math<DT>(mod, MathFunction::pow, dst, src0, src1);
+void pow(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::pow, dst, src0, src1, loc);
 }
 template <typename DT = void>
-void rsqt(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-    math<DT>(mod, MathFunction::rsqt, dst, src0);
+void rsqt(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::rsqt, dst, src0, loc);
 }
 template <typename DT = void>
-void rsqtm(const InstructionModifier &mod, const ExtendedReg &dst, const ExtendedReg &src0) {
-    math<DT>(mod, MathFunction::rsqtm, dst, src0);
+void rsqtm(const InstructionModifier &mod, const ExtendedReg &dst, const ExtendedReg &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::rsqtm, dst, src0, loc);
 }
 template <typename DT = void>
-void sin(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-    math<DT>(mod, MathFunction::sin, dst, src0);
+void sin(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::sin, dst, src0, loc);
 }
 template <typename DT = void>
-void sqt(const InstructionModifier &mod, const RegData &dst, const RegData &src0) {
-    math<DT>(mod, MathFunction::sqt, dst, src0);
+void sqt(const InstructionModifier &mod, const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
+    math<DT>(mod, MathFunction::sqt, dst, src0, loc);
 }
 
 #define TMP(n) tmp[n].retype(dst.getType())
@@ -164,8 +164,8 @@ void sqt(const InstructionModifier &mod, const RegData &dst, const RegData &src0
 //   dst, num, denom must be distinct GRFs.
 template <typename DT = void, typename A>
 void fdiv_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, RegData num, RegData denom,
-               RegData zero, RegData one, const A &tmp, InstructionModifier cfmod = InstructionModifier())
-{
+               RegData zero, RegData one, const A &tmp, InstructionModifier cfmod = InstructionModifier(),
+               SourceLocation loc = {}) {
     DataType dt = getDataType<DT>();
     if (dt == DataType::invalid)
         dt = dst.getType();
@@ -176,40 +176,40 @@ void fdiv_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, R
 
     switch (dt) {
         case DataType::hf:
-            fdiv<DT>(mod, dst, num, denom);
+            fdiv<DT>(mod, dst, num, denom, loc);
             break;
         case DataType::f:
-            invm<DT>(mod | eo | flag,         dst | mme0,      num | nomme,   denom | nomme);
-            if_(cfmod | ~flag, labelSkip);
+            invm<DT>(mod | eo | flag,         dst | mme0,      num | nomme,   denom | nomme, loc);
+            if_(cfmod | ~flag, labelSkip, loc);
 
-            madm<DT>(mod, TMP(0) | mme1,     zero | nomme,     num | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(1) | mme2,      one | nomme,  -denom | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(2) | mme3,      dst | mme0,   TMP(1) | mme2,      dst | mme0);
-            madm<DT>(mod, TMP(3) | mme4,      num | nomme,  -denom | nomme,  TMP(0) | mme1);
-            madm<DT>(mod, TMP(0) | mme5,   TMP(0) | mme1,   TMP(3) | mme4,   TMP(2) | mme3);
-            madm<DT>(mod, TMP(1) | mme6,      num | nomme,  -denom | nomme,  TMP(0) | mme5);
-            madm<DT>(mod,    dst | nomme,  TMP(0) | mme5,   TMP(1) | mme6,   TMP(2) | mme3);
+            madm<DT>(mod, TMP(0) | mme1,     zero | nomme,     num | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(1) | mme2,      one | nomme,  -denom | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(2) | mme3,      dst | mme0,   TMP(1) | mme2,      dst | mme0, loc);
+            madm<DT>(mod, TMP(3) | mme4,      num | nomme,  -denom | nomme,  TMP(0) | mme1, loc);
+            madm<DT>(mod, TMP(0) | mme5,   TMP(0) | mme1,   TMP(3) | mme4,   TMP(2) | mme3, loc);
+            madm<DT>(mod, TMP(1) | mme6,      num | nomme,  -denom | nomme,  TMP(0) | mme5, loc);
+            madm<DT>(mod,    dst | nomme,  TMP(0) | mme5,   TMP(1) | mme6,   TMP(2) | mme3, loc);
 
             mark(labelSkip);
-            endif(cfmod);
+            endif(cfmod, loc);
             break;
         case DataType::df:
-            invm<DT>(mod | eo | flag,         dst | mme0,      num | nomme,   denom | nomme);
-            if_(cfmod | ~flag, labelSkip);
+            invm<DT>(mod | eo | flag,         dst | mme0,      num | nomme,   denom | nomme, loc);
+            if_(cfmod | ~flag, labelSkip, loc);
 
-            madm<DT>(mod, TMP(0) | mme1,     zero | nomme,     num | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(1) | mme2,      one | nomme,  -denom | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(2) | mme3,      num | nomme,  -denom | nomme,  TMP(0) | mme1);
-            madm<DT>(mod, TMP(3) | mme4,      dst | mme0,   TMP(1) | mme2,      dst | mme0);
-            madm<DT>(mod, TMP(4) | mme5,      one | nomme,  -denom | nomme,  TMP(3) | mme4);
-            madm<DT>(mod,    dst | mme6,      dst | mme0,   TMP(1) | mme2,   TMP(3) | mme4);
-            madm<DT>(mod, TMP(0) | mme7,   TMP(0) | mme1,   TMP(2) | mme3,   TMP(3) | mme4);
-            madm<DT>(mod, TMP(3) | mme0,   TMP(3) | mme4,      dst | mme6,   TMP(4) | mme5);
-            madm<DT>(mod, TMP(2) | mme1,      num | nomme,  -denom | nomme,  TMP(0) | mme7);
-            madm<DT>(mod,    dst | nomme,  TMP(0) | mme7,   TMP(2) | mme1,   TMP(3) | mme0);
+            madm<DT>(mod, TMP(0) | mme1,     zero | nomme,     num | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(1) | mme2,      one | nomme,  -denom | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(2) | mme3,      num | nomme,  -denom | nomme,  TMP(0) | mme1, loc);
+            madm<DT>(mod, TMP(3) | mme4,      dst | mme0,   TMP(1) | mme2,      dst | mme0, loc);
+            madm<DT>(mod, TMP(4) | mme5,      one | nomme,  -denom | nomme,  TMP(3) | mme4, loc);
+            madm<DT>(mod,    dst | mme6,      dst | mme0,   TMP(1) | mme2,   TMP(3) | mme4, loc);
+            madm<DT>(mod, TMP(0) | mme7,   TMP(0) | mme1,   TMP(2) | mme3,   TMP(3) | mme4, loc);
+            madm<DT>(mod, TMP(3) | mme0,   TMP(3) | mme4,      dst | mme6,   TMP(4) | mme5, loc);
+            madm<DT>(mod, TMP(2) | mme1,      num | nomme,  -denom | nomme,  TMP(0) | mme7, loc);
+            madm<DT>(mod,    dst | nomme,  TMP(0) | mme7,   TMP(2) | mme1,   TMP(3) | mme0, loc);
 
             mark(labelSkip);
-            endif(cfmod);
+            endif(cfmod, loc);
             break;
         default:
 #ifdef NGEN_SAFE
@@ -224,8 +224,7 @@ void fdiv_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, R
 //   dst and src must be distinct GRFs.
 template <typename DT = void, typename A>
 void inv_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, RegData src, RegData one,
-              const A &tmp, InstructionModifier cfmod = InstructionModifier())
-{
+              const A &tmp, InstructionModifier cfmod = InstructionModifier(), SourceLocation loc = {}) {
     DataType dt = getDataType<DT>();
     if (dt == DataType::invalid)
         dt = dst.getType();
@@ -236,35 +235,35 @@ void inv_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, Re
 
     switch (dt) {
         case DataType::hf:
-            inv<DT>(mod, dst, src);
+            inv<DT>(mod, dst, src, loc);
             break;
         case DataType::f:
-            invm<DT>(mod | eo | flag,         dst | mme0,      one | nomme,     src | nomme);
-            if_(cfmod | ~flag, labelSkip);
+            invm<DT>(mod | eo | flag,         dst | mme0,      one | nomme,     src | nomme, loc);
+            if_(cfmod | ~flag, labelSkip, loc);
 
-            madm<DT>(mod, TMP(1) | mme2,      one | nomme,    -src | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(2) | mme3,      dst | mme0,   TMP(1) | mme2,      dst | mme0);
-            madm<DT>(mod, TMP(0) | mme5,      dst | mme0,   TMP(1) | mme2,   TMP(2) | mme3);
-            madm<DT>(mod, TMP(1) | mme6,      one | nomme,    -src | nomme,  TMP(0) | mme5);
-            madm<DT>(mod,    dst | nomme,  TMP(0) | mme5,   TMP(1) | mme6,   TMP(2) | mme3);
+            madm<DT>(mod, TMP(1) | mme2,      one | nomme,    -src | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(2) | mme3,      dst | mme0,   TMP(1) | mme2,      dst | mme0, loc);
+            madm<DT>(mod, TMP(0) | mme5,      dst | mme0,   TMP(1) | mme2,   TMP(2) | mme3, loc);
+            madm<DT>(mod, TMP(1) | mme6,      one | nomme,    -src | nomme,  TMP(0) | mme5, loc);
+            madm<DT>(mod,    dst | nomme,  TMP(0) | mme5,   TMP(1) | mme6,   TMP(2) | mme3, loc);
 
             mark(labelSkip);
-            endif(cfmod);
+            endif(cfmod, loc);
             break;
         case DataType::df:
-            invm<DT>(mod | eo | flag,        dst | mme0,      one | nomme,     src | nomme);
-            if_(cfmod | ~flag, labelSkip);
+            invm<DT>(mod | eo | flag,        dst | mme0,      one | nomme,     src | nomme, loc);
+            if_(cfmod | ~flag, labelSkip, loc);
 
-            madm<DT>(mod, TMP(0) | mme2,     one | nomme,    -src | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(1) | mme4,     dst | mme0,   TMP(0) | mme2,      dst | mme0);
-            madm<DT>(mod, TMP(2) | mme5,     one | nomme,    -src | nomme,  TMP(1) | mme4);
-            madm<DT>(mod,    dst | mme6,     dst | mme0,   TMP(0) | mme2,   TMP(1) | mme4);
-            madm<DT>(mod, TMP(1) | mme0,  TMP(1) | mme4,      dst | mme6,   TMP(2) | mme5);
-            madm<DT>(mod, TMP(0) | mme1,     one | nomme,    -src | nomme,     dst | mme6);
-            madm<DT>(mod,    dst | nomme,    dst | mme6,   TMP(0) | mme1,   TMP(1) | mme0);
+            madm<DT>(mod, TMP(0) | mme2,     one | nomme,    -src | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(1) | mme4,     dst | mme0,   TMP(0) | mme2,      dst | mme0, loc);
+            madm<DT>(mod, TMP(2) | mme5,     one | nomme,    -src | nomme,  TMP(1) | mme4, loc);
+            madm<DT>(mod,    dst | mme6,     dst | mme0,   TMP(0) | mme2,   TMP(1) | mme4, loc);
+            madm<DT>(mod, TMP(1) | mme0,  TMP(1) | mme4,      dst | mme6,   TMP(2) | mme5, loc);
+            madm<DT>(mod, TMP(0) | mme1,     one | nomme,    -src | nomme,     dst | mme6, loc);
+            madm<DT>(mod,    dst | nomme,    dst | mme6,   TMP(0) | mme1,   TMP(1) | mme0, loc);
 
             mark(labelSkip);
-            endif(cfmod);
+            endif(cfmod, loc);
             break;
         default:
 #ifdef NGEN_SAFE
@@ -280,8 +279,8 @@ void inv_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, Re
 //   dst and src must be distinct GRFs.
 template <typename DT = void, typename A>
 void sqt_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, RegData src,
-               RegData zero, RegData oneHalf, RegData one, const A &tmp, InstructionModifier cfmod = InstructionModifier())
-{
+              RegData zero, RegData oneHalf, RegData one, const A &tmp, InstructionModifier cfmod = InstructionModifier(),
+              SourceLocation loc = {}) {
     DataType dt = getDataType<DT>();
     if (dt == DataType::invalid)
         dt = dst.getType();
@@ -292,41 +291,41 @@ void sqt_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, Re
 
     switch (dt) {
         case DataType::hf:
-            sqt<DT>(mod, dst, src);
+            sqt<DT>(mod, dst, src, loc);
             break;
         case DataType::f:
-            rsqtm<DT>(mod | eo | flag,        dst | mme0,       src | nomme);
-            if_(cfmod | ~flag, labelSkip);
+            rsqtm<DT>(mod | eo | flag,        dst | mme0,       src | nomme, loc);
+            if_(cfmod | ~flag, labelSkip, loc);
 
-            madm<DT>(mod, TMP(0) | mme1,     zero | nomme,  oneHalf | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(1) | mme2,     zero | nomme,      src | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(2) | mme3,  oneHalf | nomme,  -TMP(1) | mme2,   TMP(0) | mme1);
-            madm<DT>(mod, TMP(0) | mme4,   TMP(0) | mme1,    TMP(2) | mme3,   TMP(0) | mme1);
-            madm<DT>(mod,    dst | mme5,   TMP(1) | mme2,    TMP(2) | mme3,   TMP(1) | mme2);
-            madm<DT>(mod, TMP(2) | mme6,      src | nomme,     -dst | mme5,      dst | mme5);
-            madm<DT>(mod,    dst | nomme,     dst | mme5,    TMP(0) | mme4,   TMP(2) | mme6);
+            madm<DT>(mod, TMP(0) | mme1,     zero | nomme,  oneHalf | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(1) | mme2,     zero | nomme,      src | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(2) | mme3,  oneHalf | nomme,  -TMP(1) | mme2,   TMP(0) | mme1, loc);
+            madm<DT>(mod, TMP(0) | mme4,   TMP(0) | mme1,    TMP(2) | mme3,   TMP(0) | mme1, loc);
+            madm<DT>(mod,    dst | mme5,   TMP(1) | mme2,    TMP(2) | mme3,   TMP(1) | mme2, loc);
+            madm<DT>(mod, TMP(2) | mme6,      src | nomme,     -dst | mme5,      dst | mme5, loc);
+            madm<DT>(mod,    dst | nomme,     dst | mme5,    TMP(0) | mme4,   TMP(2) | mme6, loc);
 
             mark(labelSkip);
-            endif(cfmod);
+            endif(cfmod, loc);
             break;
         case DataType::df:
-            rsqtm<DT>(mod | eo | flag,        dst | mme0,       src | nomme);
-            if_(cfmod | ~flag, labelSkip);
+            rsqtm<DT>(mod | eo | flag,        dst | mme0,       src | nomme, loc);
+            if_(cfmod | ~flag, labelSkip, loc);
 
-            madm<DT>(mod, TMP(0) | mme1,     zero | mme0,   oneHalf | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(1) | mme2,     zero | mme0,       src | nomme,     dst | mme0);
-            madm<DT>(mod, TMP(2) | mme3,  oneHalf | nomme,  -TMP(1) | mme2,   TMP(0) | mme1);
-            madm<DT>(mod, TMP(3) | mme4,      one | nomme,  oneHalf | nomme,     dst | nomme);
-            madm<DT>(mod, TMP(3) | mme5,      one | nomme,   TMP(3) | mme4,   TMP(2) | mme3);
-            madm<DT>(mod,    dst | mme6,     zero | mme0,    TMP(2) | mme3,   TMP(1) | mme2);
-            madm<DT>(mod, TMP(2) | mme7,     zero | mme0,    TMP(2) | mme3,   TMP(0) | mme1);
-            madm<DT>(mod,    dst | mme6,   TMP(1) | mme2,    TMP(3) | mme5,      dst | mme6);
-            madm<DT>(mod, TMP(3) | mme5,   TMP(0) | mme1,    TMP(3) | mme5,   TMP(2) | mme7);
-            madm<DT>(mod, TMP(0) | mme1,      src | nomme,     -dst | mme6,      dst | mme6);
-            madm<DT>(mod,    dst | nomme,     dst | mme6,    TMP(0) | mme1,   TMP(3) | mme5);
+            madm<DT>(mod, TMP(0) | mme1,     zero | mme0,   oneHalf | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(1) | mme2,     zero | mme0,       src | nomme,     dst | mme0, loc);
+            madm<DT>(mod, TMP(2) | mme3,  oneHalf | nomme,  -TMP(1) | mme2,   TMP(0) | mme1, loc);
+            madm<DT>(mod, TMP(3) | mme4,      one | nomme,  oneHalf | nomme,     dst | nomme, loc);
+            madm<DT>(mod, TMP(3) | mme5,      one | nomme,   TMP(3) | mme4,   TMP(2) | mme3, loc);
+            madm<DT>(mod,    dst | mme6,     zero | mme0,    TMP(2) | mme3,   TMP(1) | mme2, loc);
+            madm<DT>(mod, TMP(2) | mme7,     zero | mme0,    TMP(2) | mme3,   TMP(0) | mme1, loc);
+            madm<DT>(mod,    dst | mme6,   TMP(1) | mme2,    TMP(3) | mme5,      dst | mme6, loc);
+            madm<DT>(mod, TMP(3) | mme5,   TMP(0) | mme1,    TMP(3) | mme5,   TMP(2) | mme7, loc);
+            madm<DT>(mod, TMP(0) | mme1,      src | nomme,     -dst | mme6,      dst | mme6, loc);
+            madm<DT>(mod,    dst | nomme,     dst | mme6,    TMP(0) | mme1,   TMP(3) | mme5, loc);
 
             mark(labelSkip);
-            endif(cfmod);
+            endif(cfmod, loc);
             break;
         default:
 #ifdef NGEN_SAFE
@@ -339,115 +338,148 @@ void sqt_ieee(const InstructionModifier &mod, FlagRegister flag, RegData dst, Re
 #undef TMP
 
 // Thread spawner messages.
-void threadend(const InstructionModifier &mod, const RegData &r0_info)
-{
+void threadend(const InstructionModifier &mod, const RegData &r0_info, SourceLocation loc = {}) {
     {
         auto sf = (hardware <= HW::XeHP) ? SharedFunction::ts
                                          : SharedFunction::gtwy;
         uint32_t exdesc = 0x20 | (static_cast<int>(sf) & 0xF);
-        send(8 | EOT | mod | NoMask, null, r0_info, exdesc, 0x2000010);
+        send(8 | EOT | mod | NoMask, null, r0_info, exdesc, 0x2000010, loc);
     }
 }
 
-void threadend(const RegData &r0_info) { threadend(InstructionModifier(), r0_info); }
+void threadend(const RegData &r0_info, SourceLocation loc = {}) {
+    threadend(InstructionModifier(), r0_info, loc);
+}
 
 // Gateway messages.
-void barriermsg(const InstructionModifier &mod, const GRF &header)
-{
+void barriermsg(const InstructionModifier &mod, const GRF &header, SourceLocation loc = {}) {
     {
         uint32_t exdesc = static_cast<int>(SharedFunction::gtwy) & 0xF;
-        send(1 | mod | NoMask, null, header, exdesc, 0x2000004);
+        send(1 | mod | NoMask, null, header, exdesc, 0x2000004, loc);
     }
 }
 
-void barriermsg(const GRF &header) { barriermsg(InstructionModifier(), header); }
+void barriermsg(const GRF &header, SourceLocation loc = {}) { barriermsg(InstructionModifier(), header, loc); }
 
 // Prepare barrier header.
-void barrierheader(const GRF &header, const GRF &r0_info = r0)
-{
+void barrierheader(const GRF &header, const GRF &r0_info = r0, SourceLocation loc = {}) {
     if (hardware >= HW::XeHPG) {
-        mov(1 | NoMask, header.hf(4), Immediate::hf(0));
-        mov(2 | NoMask, header.ub(10)(1), r0_info.ub(11)(0));
+        mov(1 | NoMask, header.hf(4), Immediate::hf(0), loc);
+        mov(2 | NoMask, header.ub(10)(1), r0_info.ub(11)(0), loc);
     } else
-        and_(8 | NoMask, header.ud(), r0_info.ud(2), uint32_t((hardware >= HW::Gen11) ? 0x7F000000 : 0x8F000000));
+        and_(8 | NoMask, header.ud(), r0_info.ud(2), uint32_t((hardware >= HW::Gen11) ? 0x7F000000 : 0x8F000000), loc);
 }
 
-void barrierheader(const GRF &header, uint32_t threadCount, const GRF &r0_info = r0)
-{
+void barrierheader(const GRF &header, uint32_t threadCount, const GRF &r0_info = r0, SourceLocation loc = {}) {
     if (hardware >= HW::XeHPG)
-        mov(1 | NoMask, header.ud(2), (threadCount << 24) | (threadCount << 16));
+        mov(1 | NoMask, header.ud(2), (threadCount << 24) | (threadCount << 16), loc);
     else {
-        and_(8 | NoMask, header.ud(), r0_info.ud(2), uint32_t((hardware >= HW::Gen11) ? 0x7F000000 : 0x8F000000));
-        mov(1 | NoMask, header.ub(9), 0x80 | (threadCount & 0x7F));
+        and_(8 | NoMask, header.ud(), r0_info.ud(2), uint32_t((hardware >= HW::Gen11) ? 0x7F000000 : 0x8F000000), loc);
+        mov(1 | NoMask, header.ub(9), 0x80 | (threadCount & 0x7F), loc);
     }
 }
 
-void barriersignal(const InstructionModifier &mod, const GRF &temp, const GRF &r0_info = r0)
-{
+void barriersignal(const InstructionModifier &mod, const GRF &temp, const GRF &r0_info = r0, SourceLocation loc = {}) {
     {
-        barrierheader(temp, r0_info);
-        barriermsg(mod, temp);
+        barrierheader(temp, r0_info, loc);
+        barriermsg(mod, temp, loc);
     }
 }
 
-void barriersignal(const InstructionModifier &mod, const GRF &temp, uint32_t threadCount, const GRF &r0_info = r0)
-{
-    barrierheader(temp, threadCount, r0_info);
-    barriermsg(mod, temp);
+void barriersignal(const InstructionModifier &mod, const GRF &temp, uint32_t threadCount, const GRF &r0_info = r0, SourceLocation loc = {}) {
+    barrierheader(temp, threadCount, r0_info, loc);
+    barriermsg(mod, temp, loc);
 }
 
-void barriersignal(const GRF &temp, const GRF &r0_info = r0) { barriersignal(InstructionModifier(), temp, r0_info); }
-void barriersignal(const GRF &temp, uint32_t threadCount, const GRF &r0_info = r0) { barriersignal(InstructionModifier(), temp, threadCount, r0_info); }
+void barriersignal(const GRF &temp, const GRF &r0_info = r0, SourceLocation loc = {}) { barriersignal(InstructionModifier(), temp, r0_info, loc); }
+void barriersignal(const GRF &temp, uint32_t threadCount, const GRF &r0_info = r0, SourceLocation loc = {}) { barriersignal(InstructionModifier(), temp, threadCount, r0_info, loc); }
 
 // Named barriers.
-void nbarriermsg(const InstructionModifier &mod, const GRF &header)
-{
-        barriermsg(mod, header);
+void nbarriermsg(const InstructionModifier &mod, const GRF &header, SourceLocation loc = {}) {
+        barriermsg(mod, header, loc);
 }
 
-void nbarriermsg(const GRF &header) { nbarriermsg(InstructionModifier(), header); }
+void nbarriermsg(const GRF &header, SourceLocation loc = {}) { nbarriermsg(InstructionModifier(), header, loc); }
 
-void barriersignal(const InstructionModifier &mod, uint32_t barrierID, const GRF &temp, const GRF &r0_info = r0)
-{
+void barriersignal(const InstructionModifier &mod, uint32_t barrierID, const GRF &temp, const GRF &r0_info = r0, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
     if (hardware < HW::XeHPC)
         throw unsupported_message();
 #endif
-    mov(1 | NoMask, temp.uw(4), uint8_t(barrierID));
-    mov(2 | NoMask, temp.ub(10)(1), r0_info.ub(11)(0));
-    nbarriermsg(mod, temp);
+    mov(1 | NoMask, temp.uw(4), uint8_t(barrierID), loc);
+    mov(2 | NoMask, temp.ub(10)(1), r0_info.ub(11)(0), loc);
+    nbarriermsg(mod, temp, loc);
 }
 
-void barriersignal(const InstructionModifier &mod, uint32_t barrierID, const GRF &temp, BarrierType barrierType, uint32_t producers, uint32_t consumers)
-{
+void barriersignal(const InstructionModifier &mod, uint32_t barrierID, const GRF &temp, BarrierType barrierType, uint32_t producers, uint32_t consumers, SourceLocation loc = {}) {
 #ifdef NGEN_SAFE
     if (hardware < HW::XeHPC)
         throw unsupported_message();
 #endif
-    mov(1 | NoMask, temp.ud(2), (barrierID & 0xFF) | (static_cast<uint32_t>(barrierType) << 14) | ((producers & 0xFF) << 16) | ((consumers & 0xFF) << 24));
-    nbarriermsg(mod, temp);
+    mov(1 | NoMask, temp.ud(2), (barrierID & 0xFF) | (static_cast<uint32_t>(barrierType) << 14) | ((producers & 0xFF) << 16) | ((consumers & 0xFF) << 24), loc);
+    nbarriermsg(mod, temp, loc);
 }
 
-void barriersignal(uint32_t barrierID, const GRF &temp, const GRF &r0_info = r0) { barriersignal(InstructionModifier(), barrierID, temp, r0_info); }
-void barriersignal(uint32_t barrierID, const GRF &temp, BarrierType barrierType, uint32_t producers, uint32_t consumers) { barriersignal(InstructionModifier(), barrierID, temp, barrierType, producers, consumers); }
+void barriersignal(uint32_t barrierID, const GRF &temp, const GRF &r0_info = r0, SourceLocation loc = {}) { barriersignal(InstructionModifier(), barrierID, temp, r0_info, loc); }
+void barriersignal(uint32_t barrierID, const GRF &temp, BarrierType barrierType, uint32_t producers, uint32_t consumers, SourceLocation loc = {}) { barriersignal(InstructionModifier(), barrierID, temp, barrierType, producers, consumers, loc); }
 
-void barrierwait()
-{
+void barrierwait(SourceLocation loc = {}) {
     if (isGen12)
-        sync.bar(NoMask);
+        sync.bar(NoMask, loc);
     else
-        wait(NoMask, n0[0]);
+        wait(NoMask, n0[0], loc);
 }
 
-template <typename... Targs>
-void barrier(const Targs &...barrierArgs)
-{
-    barriersignal(barrierArgs...);
-    barrierwait();
+void barrier(const InstructionModifier &mod, const GRF &temp, const GRF &r0_info = r0,
+             SourceLocation loc = {}) {
+    barriersignal(mod, temp, r0_info, loc);
+    barrierwait(loc);
 }
 
-void registerfence(const RegData &dst)
-{
+void barrier(const InstructionModifier &mod, const GRF &temp, uint32_t threadCount,
+             const GRF &r0_info = r0, SourceLocation loc = {}) {
+    barriersignal(mod, temp, threadCount, r0_info, loc);
+    barrierwait(loc);
+}
+
+void barrier(const GRF &temp, const GRF &r0_info = r0, SourceLocation loc = {}) {
+    barriersignal(InstructionModifier(), temp, r0_info, loc);
+    barrierwait(loc);
+}
+
+void barrier(const GRF &temp, uint32_t threadCount, const GRF &r0_info = r0,
+             SourceLocation loc = {}) {
+    barriersignal(temp, threadCount, r0_info, loc);
+    barrierwait(loc);
+}
+
+void barrier(const InstructionModifier &mod, uint32_t barrierID,
+             const GRF &temp, const GRF &r0_info = r0,
+             SourceLocation loc = {}) {
+    barriersignal(mod, barrierID, temp, r0_info, loc);
+    barrierwait(loc);
+}
+
+void barrier(const InstructionModifier &mod, uint32_t barrierID,
+             const GRF &temp, BarrierType barrierType, uint32_t producers,
+             uint32_t consumers, SourceLocation loc = {}) {
+    barriersignal(mod, barrierID, temp, barrierType, producers, consumers, loc);
+    barrierwait(loc);
+}
+
+void barrier(uint32_t barrierID, const GRF &temp, const GRF &r0_info = r0,
+             SourceLocation loc = {}) {
+    barriersignal(barrierID, temp, r0_info, loc);
+    barrierwait(loc);
+}
+
+void barrier(uint32_t barrierID, const GRF &temp, BarrierType barrierType,
+             uint32_t producers, uint32_t consumers, SourceLocation loc = {}) {
+    barriersignal(barrierID, temp, barrierType, producers, consumers, loc);
+    barrierwait(loc);
+}
+
+void registerfence(const RegData &dst, SourceLocation loc = {}) {
     _lastFenceDst = dst;
     if (isGen12) {
         _lastFenceLabel = Label();
@@ -456,9 +488,8 @@ void registerfence(const RegData &dst)
 }
 
 // Global memory fence.
-void memfence(const InstructionModifier &mod, FenceScopeLSC scope, FlushTypeLSC flushing, const RegData &dst = NullRegister(), const RegData &header = GRF(0))
-{
-    registerfence(dst);
+void memfence(const InstructionModifier &mod, FenceScopeLSC scope, FlushTypeLSC flushing, const RegData &dst = NullRegister(), const RegData &header = GRF(0), SourceLocation loc = {}) {
+    registerfence(dst, loc);
 
     if (hardware >= HW::XeHPG) {
         if (flushing == FlushTypeLSC::None && hardware == HW::XeHPG && scope > FenceScopeLSC::Subslice)
@@ -467,55 +498,49 @@ void memfence(const InstructionModifier &mod, FenceScopeLSC scope, FlushTypeLSC 
         uint32_t desc = 0x0210011F;
         desc |= static_cast<uint32_t>(scope) << 9;
         desc |= static_cast<uint32_t>(flushing) << 12;
-        send(1 | mod | NoMask, SharedFunction::ugm, dst, header, null, 0, desc);
+        send(1 | mod | NoMask, SharedFunction::ugm, dst, header, null, 0, desc, loc);
     } else {
         const uint32_t exdesc = static_cast<int>(SharedFunction::dc0) & 0xF;
-        send(8 | mod | NoMask, dst, header, exdesc, 0x219E000);
+        send(8 | mod | NoMask, dst, header, exdesc, 0x219E000, loc);
     }
 }
 
-void memfence(const InstructionModifier &mod, const RegData &dst = NullRegister(), const RegData &header = GRF(0))
-{
-    memfence(mod, FenceScopeLSC::GPU, FlushTypeLSC::None, dst, header);
+void memfence(const InstructionModifier &mod, const RegData &dst = NullRegister(), const RegData &header = GRF(0), SourceLocation loc = {}) {
+    memfence(mod, FenceScopeLSC::GPU, FlushTypeLSC::None, dst, header, loc);
 }
 
-void memfence(FenceScopeLSC scope, FlushTypeLSC flushing, const RegData &dst = NullRegister(), const RegData &header = GRF(0))
-{
-    memfence(InstructionModifier(), scope, flushing, dst, header);
+void memfence(FenceScopeLSC scope, FlushTypeLSC flushing, const RegData &dst = NullRegister(), const RegData &header = GRF(0), SourceLocation loc = {}) {
+    memfence(InstructionModifier(), scope, flushing, dst, header, loc);
 }
 
-void memfence(const RegData &dst = NullRegister(), const RegData &header = GRF(0))
-{
-    memfence(InstructionModifier(), dst, header);
+void memfence(const RegData &dst = NullRegister(), const RegData &header = GRF(0), SourceLocation loc = {}) {
+    memfence(InstructionModifier(), dst, header, loc);
 }
 
 // SLM-only memory fence.
-void slmfence(const InstructionModifier &mod, const RegData &dst = NullRegister(), const RegData &header = GRF(0))
-{
-    registerfence(dst);
+void slmfence(const InstructionModifier &mod, const RegData &dst = NullRegister(), const RegData &header = GRF(0), SourceLocation loc = {}) {
+    registerfence(dst, loc);
 
     if (hardware >= HW::XeHPG)
-        send(1 | mod | NoMask, SharedFunction::slm, dst, header, null, 0, 0x210011F);
+        send(1 | mod | NoMask, SharedFunction::slm, dst, header, null, 0, 0x210011F, loc);
     else {
         const uint32_t exdesc = static_cast<int>(SharedFunction::dc0) & 0xF;
-        send(8 | mod | NoMask, dst, header, exdesc, 0x219E0FE);
+        send(8 | mod | NoMask, dst, header, exdesc, 0x219E0FE, loc);
     }
 }
 
-void slmfence(const RegData &dst = NullRegister(), const RegData &header = GRF(0)) { slmfence(InstructionModifier(), dst, header); }
+void slmfence(const RegData &dst = NullRegister(), const RegData &header = GRF(0), SourceLocation loc = {}) { slmfence(InstructionModifier(), dst, header, loc); }
 
 // Wait on the last global memory or SLM fence.
-void fencewait()
-{
+void fencewait(SourceLocation loc = {}) {
     if (isGen12)
-        fencedep(_lastFenceLabel);
+        fencedep(_lastFenceLabel, loc);
     else
-        mov<uint32_t>(8 | NoMask, null, _lastFenceDst);
+        mov<uint32_t>(8 | NoMask, null, _lastFenceDst, loc);
 }
 
 // XeHP+ prologues.
-void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127), int paddedSize = 0)
-{
+void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127), int paddedSize = 0, SourceLocation loc = {}) {
     if (hardware >= HW::XeHP) {
         if (paddedSize < 0)
             paddedSize = 12*16;
@@ -534,22 +559,22 @@ void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127
             {
                 insns = lsc ? 5 : 6;
                 if (!lsc)
-                    mov<uint32_t>(8, temp, uint16_t(0));
-                and_<uint32_t>(1, temp[2], r0[0], uint32_t(~0x1F));
-                and_<uint16_t>(1, temp[0], r0[4], uint16_t(0xFF));
-                add<uint32_t>(1, temp[2], temp[2], uint16_t(argBytes));
+                    mov<uint32_t>(8, temp, uint16_t(0), loc);
+                and_<uint32_t>(1, temp[2], r0[0], uint32_t(~0x1F), loc);
+                and_<uint16_t>(1, temp[0], r0[4], uint16_t(0xFF), loc);
+                add<uint32_t>(1, temp[2], temp[2], uint16_t(argBytes), loc);
                 if (simd == 1) {
-                    mad<uint32_t>(1, tempAddr, temp[2], temp.uw(0), uint16_t(grfSize));
-                    lsc ? load(1, r1, D32T(4) | L1C_L3C,      A32,   temp)
-                        : load(8, r1, aligned_block_oword(1), A32NC, temp);
+                    mad<uint32_t>(1, tempAddr, temp[2], temp.uw(0), uint16_t(grfSize), loc);
+                    lsc ? load(1, r1, D32T(4) | L1C_L3C,      A32,   temp, loc)
+                        : load(8, r1, aligned_block_oword(1), A32NC, temp, loc);
                 } else {
-                    mad<uint32_t>(1, tempAddr, temp[2], temp.uw(0), uint16_t(3 * simdGRFs * grfSize));
-                    lsc ? load(1, r1, D32T(simdGRFs * ((dims == 1) ? 1 : 2) * grfOW * 4) | L1C_L3C,  A32,   temp)
-                        : load(8, r1, aligned_block_oword(simdGRFs * ((dims == 1) ? 1 : 2) * grfOW), A32NC, temp);
+                    mad<uint32_t>(1, tempAddr, temp[2], temp.uw(0), uint16_t(3 * simdGRFs * grfSize), loc);
+                    lsc ? load(1, r1, D32T(simdGRFs * ((dims == 1) ? 1 : 2) * grfOW * 4) | L1C_L3C,  A32,   temp, loc)
+                        : load(8, r1, aligned_block_oword(simdGRFs * ((dims == 1) ? 1 : 2) * grfOW), A32NC, temp, loc);
                     if (dims == 3) {
-                        add<uint32_t>(1, tempAddr, tempAddr, uint16_t(2 * simdGRFs * grfSize));
-                        lsc ? load(1, GRF(1 + 2 * simdGRFs), D32T(grfOW * 4 * simdGRFs) | L1C_L3C,  A32,   temp)
-                            : load(8, GRF(1 + 2 * simdGRFs), aligned_block_oword(grfOW * simdGRFs), A32NC, temp);
+                        add<uint32_t>(1, tempAddr, tempAddr, uint16_t(2 * simdGRFs * grfSize), loc);
+                        lsc ? load(1, GRF(1 + 2 * simdGRFs), D32T(grfOW * 4 * simdGRFs) | L1C_L3C,  A32,   temp, loc)
+                            : load(8, GRF(1 + 2 * simdGRFs), aligned_block_oword(grfOW * simdGRFs), A32NC, temp, loc);
                         insns += 2;
                     }
                 }
@@ -565,7 +590,7 @@ void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127
             if (nops < 0)         throw invalid_operand_exception();
 #endif
             for (int i = 0; i < nops; i++)
-                nop();
+                nop(loc);
         }
 
         if (!_labelLocalIDsLoaded.defined(labelManager))
@@ -574,8 +599,7 @@ void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127
     }
 }
 
-void loadargs(const GRF &base, int argGRFs, const GRF &temp = GRF(127), bool inPrologue = true)
-{
+void loadargs(const GRF &base, int argGRFs, const GRF &temp = GRF(127), bool inPrologue = true, SourceLocation loc = {}) {
     if (hardware >= HW::XeHP) {
         if (argGRFs > 0) {
             bool lsc = (hardware >= HW::XeHPG);
@@ -586,17 +610,17 @@ void loadargs(const GRF &base, int argGRFs, const GRF &temp = GRF(127), bool inP
 
             {
                 if (!lsc)
-                    mov<uint32_t>(8, temp, uint16_t(0));
-                and_<uint32_t>(1, tempAddr, r0[0], uint32_t(~0x1F));
+                    mov<uint32_t>(8, temp, uint16_t(0), loc);
+                and_<uint32_t>(1, tempAddr, r0[0], uint32_t(~0x1F), loc);
                 while (argGRFs > 0) {
                     int nload = std::min(utils::rounddown_pow2(argGRFs), lsc ? 8 : 4);
                     int loadBytes = nload * GRF::bytes(hardware);
-                    lsc ? load(1, dst, D64T(loadBytes >> 3) | L1C_L3C,      A32,   temp)
-                        : load(8, dst, aligned_block_oword(loadBytes >> 4), A32NC, temp);
+                    lsc ? load(1, dst, D64T(loadBytes >> 3) | L1C_L3C,      A32,   temp, loc)
+                        : load(8, dst, aligned_block_oword(loadBytes >> 4), A32NC, temp, loc);
                     argGRFs -= nload;
                     dst += nload;
                     if (argGRFs > 0)
-                        add<uint32_t>(1, tempAddr, tempAddr, uint32_t(loadBytes));
+                        add<uint32_t>(1, tempAddr, tempAddr, uint32_t(loadBytes), loc);
                 }
             }
 
@@ -608,11 +632,10 @@ void loadargs(const GRF &base, int argGRFs, const GRF &temp = GRF(127), bool inP
     }
 }
 
-void epilogue(int GRFCount, bool hasSLM, const RegData &r0_info)
-{
+void epilogue(int GRFCount, bool hasSLM, const RegData &r0_info, SourceLocation loc = {}) {
     GRF tmp0(GRFCount - 3);
     GRF tmp1(GRFCount - 2);
-    GRF lastReg(GRFCount - 1);
+    GRF r0_copy(GRFCount - 4);
 
     bool doMemFence = false;
     bool doSLMFence = false;
@@ -634,20 +657,20 @@ void epilogue(int GRFCount, bool hasSLM, const RegData &r0_info)
     if (!hasSLM) doSLMFence = false;
 
     int dwordsPerReg = GRF::bytes(hardware) / sizeof(uint32_t);
-    mov<uint32_t>(dwordsPerReg, lastReg, r0_info);
+    mov<uint32_t>(dwordsPerReg, r0_copy, r0_info, loc);
 
-    if (doMemFence) memfence(tmp0, r0_info);
-    if (doSLMFence) slmfence(tmp1, r0_info);
+    if (doMemFence) memfence(tmp0, r0_info, loc);
+    if (doSLMFence) slmfence(tmp1, r0_info, loc);
 
     if (setAccToZero) {
-        mov(16, acc0.f(), 0.f);
-        if (hardware == HW::XeHP) mov(16, acc2.f(), 0.f);
+        mov(16, acc0.f(), 0.f, loc);
+        if (hardware == HW::XeHP) mov(16, acc2.f(), 0.f, loc);
     }
 
-    if (doMemFence) wrdep(tmp0);
-    if (doSLMFence) wrdep(tmp1);
+    if (doMemFence) wrdep(tmp0, loc);
+    if (doSLMFence) wrdep(tmp1, loc);
 
-    threadend(lastReg);
+    threadend(r0_copy, loc);
 }
 
 
@@ -659,19 +682,19 @@ struct Load {
     Load(_self *parent_) : parent(*parent_) {}
 
     template <typename DataSpec>
-    void operator()(const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const RegData &addr)
+    void operator()(const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const RegData &addr, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, mod, dst, spec, base, GRFDisp(addr));
+        this->operator()(SharedFunction::automatic, mod, dst, spec, base, GRFDisp(addr), loc);
     }
 
     template <typename DataSpec>
-    void operator()(const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr)
+    void operator()(const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, mod, dst, spec, base, addr);
+        this->operator()(SharedFunction::automatic, mod, dst, spec, base, addr, loc);
     }
 
     template <typename DataSpec>
-    void operator()(SharedFunction sfid, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr)
+    void operator()(SharedFunction sfid, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr, SourceLocation loc = {})
     {
         {
             MessageDescriptor desc;
@@ -682,25 +705,25 @@ struct Load {
             encodeLoadDescriptors(parent.hardware, desc, exdesc, mod, dst, spec, base, addr);
             if (sfid != SharedFunction::automatic)
                 exdesc.parts.sfid = static_cast<unsigned>(sfid);
-            parent.send(mod, dst, addr.getBase(), exdesc.all, desc.all);
+            parent.send(mod, dst, addr.getBase(), exdesc.all, desc.all, loc);
         }
     }
 
-    void ugm(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr)
+    void ugm(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugm, mod, dst, spec, base, addr);
+        this->operator()(SharedFunction::ugm, mod, dst, spec, base, addr, loc);
     }
-    void ugml(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr)
+    void ugml(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugml, mod, dst, spec, base, addr);
+        this->operator()(SharedFunction::ugml, mod, dst, spec, base, addr, loc);
     }
-    void tgm(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr)
+    void tgm(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::tgm, mod, dst, spec, base, addr);
+        this->operator()(SharedFunction::tgm, mod, dst, spec, base, addr, loc);
     }
-    void slm(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr)
+    void slm(const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::slm, mod, dst, spec, base, addr);
+        this->operator()(SharedFunction::slm, mod, dst, spec, base, addr, loc);
     }
 };
 
@@ -710,19 +733,19 @@ struct Store {
     Store(_self *parent_) : parent(*parent_) {}
 
     template <typename DataSpec>
-    void operator()(const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const RegData &addr, const RegData &data)
+    void operator()(const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const RegData &addr, const RegData &data, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, mod, spec, base, GRFDisp(addr), data);
+        this->operator()(SharedFunction::automatic, mod, spec, base, GRFDisp(addr), data, loc);
     }
 
     template <typename DataSpec>
-    void operator()(const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data)
+    void operator()(const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, mod, spec, base, addr, data);
+        this->operator()(SharedFunction::automatic, mod, spec, base, addr, data, {});
     }
 
     template <typename DataSpec>
-    void operator()(SharedFunction sfid, const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data)
+    void operator()(SharedFunction sfid, const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data, SourceLocation loc = {})
     {
         {
             MessageDescriptor desc;
@@ -733,25 +756,25 @@ struct Store {
             encodeStoreDescriptors(parent.hardware, desc, exdesc, mod, spec, base, addr);
             if (sfid != SharedFunction::automatic)
                 exdesc.parts.sfid = static_cast<unsigned>(sfid);
-            parent.sends(mod, NullRegister(), addr.getBase(), data, exdesc.all, desc.all);
+            parent.sends(mod, NullRegister(), addr.getBase(), data, exdesc.all, desc.all, loc);
         }
     }
 
-    void ugm(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data)
+    void ugm(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugm, mod, spec, base, addr, data);
+        this->operator()(SharedFunction::ugm, mod, spec, base, addr, data, loc);
     }
-    void ugml(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data)
+    void ugml(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugml, mod, spec, base, addr, data);
+        this->operator()(SharedFunction::ugml, mod, spec, base, addr, data, loc);
     }
-    void tgm(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data)
+    void tgm(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::tgm, mod, spec, base, addr, data);
+        this->operator()(SharedFunction::tgm, mod, spec, base, addr, data, loc);
     }
-    void slm(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data)
+    void slm(const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data, SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::slm, mod, spec, base, addr, data);
+        this->operator()(SharedFunction::slm, mod, spec, base, addr, data, loc);
     }
 };
 
@@ -761,28 +784,28 @@ struct Atomic_ {
     Atomic_(_self *parent_) : parent(*parent_) {}
 
     template <typename DataSpec>
-    void operator()(AtomicOp op, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const RegData &addr, const RegData &data = NullRegister())
+    void operator()(AtomicOp op, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const RegData &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, op, mod, dst, spec, base, GRFDisp(addr), data);
+        this->operator()(SharedFunction::automatic, op, mod, dst, spec, base, GRFDisp(addr), data, loc);
     }
     template <typename DataSpec>
-    void operator()(AtomicOp op, const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const RegData &addr, const RegData &data = NullRegister())
+    void operator()(AtomicOp op, const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const RegData &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, op, mod, NullRegister(), spec, base, GRFDisp(addr), data);
+        this->operator()(SharedFunction::automatic, op, mod, NullRegister(), spec, base, GRFDisp(addr), data, loc);
     }
 
     template <typename DataSpec>
-    void operator()(AtomicOp op, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void operator()(AtomicOp op, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, op, mod, dst, spec, base, addr, data);
+        this->operator()(SharedFunction::automatic, op, mod, dst, spec, base, addr, data, loc);
     }
     template <typename DataSpec>
-    void operator()(AtomicOp op, const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void operator()(AtomicOp op, const InstructionModifier &mod, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::automatic, op, mod, NullRegister(), spec, base, addr, data);
+        this->operator()(SharedFunction::automatic, op, mod, NullRegister(), spec, base, addr, data, loc);
     }
     template <typename DataSpec>
-    void operator()(SharedFunction sfid, AtomicOp op, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data)
+    void operator()(SharedFunction sfid, AtomicOp op, const InstructionModifier &mod, const RegData &dst, const DataSpec &spec, AddressBase base, const GRFDisp &addr, const RegData &data, SourceLocation loc = {})
     {
         {
             MessageDescriptor desc;
@@ -794,43 +817,43 @@ struct Atomic_ {
             if (sfid != SharedFunction::automatic)
                 exdesc.parts.sfid = static_cast<unsigned>(sfid);
             if (data.isNull())
-                parent.send(mod, dst, addr.getBase(), exdesc.all, desc.all);
+                parent.send(mod, dst, addr.getBase(), exdesc.all, desc.all, loc);
             else
-                parent.sends(mod, dst, addr.getBase(), data, exdesc.all, desc.all);
+                parent.sends(mod, dst, addr.getBase(), data, exdesc.all, desc.all, loc);
         }
     }
 
-    void ugm(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void ugm(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugm, op, mod, dst, spec, base, addr, data);
+        this->operator()(SharedFunction::ugm, op, mod, dst, spec, base, addr, data, loc);
     }
-    void ugm(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void ugm(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugm, op, mod, NullRegister(), spec, base, addr, data);
+        this->operator()(SharedFunction::ugm, op, mod, NullRegister(), spec, base, addr, data, loc);
     }
-    void ugml(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void ugml(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugml, op, mod, dst, spec, base, addr, data);
+        this->operator()(SharedFunction::ugml, op, mod, dst, spec, base, addr, data, loc);
     }
-    void ugml(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void ugml(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::ugml, op, mod, NullRegister(), spec, base, addr, data);
+        this->operator()(SharedFunction::ugml, op, mod, NullRegister(), spec, base, addr, data, loc);
     }
-    void tgm(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void tgm(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::tgm, op, mod, dst, spec, base, addr, data);
+        this->operator()(SharedFunction::tgm, op, mod, dst, spec, base, addr, data, loc);
     }
-    void tgm(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void tgm(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::tgm, op, mod, NullRegister(), spec, base, addr, data);
+        this->operator()(SharedFunction::tgm, op, mod, NullRegister(), spec, base, addr, data, loc);
     }
-    void slm(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void slm(AtomicOp op, const InstructionModifier &mod, const RegData &dst, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::slm, op, mod, dst, spec, base, addr, data);
+        this->operator()(SharedFunction::slm, op, mod, dst, spec, base, addr, data, loc);
     }
-    void slm(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister())
+    void slm(AtomicOp op, const InstructionModifier &mod, DataSpecLSC spec, AddressBase base, const GRFDisp &addr, const RegData &data = NullRegister(), SourceLocation loc = {})
     {
-        this->operator()(SharedFunction::slm, op, mod, NullRegister(), spec, base, addr, data);
+        this->operator()(SharedFunction::slm, op, mod, NullRegister(), spec, base, addr, data, loc);
     }
 };
 

--- a/src/gpu/intel/jit/pooling/pooling_kernel.hpp
+++ b/src/gpu/intel/jit/pooling/pooling_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +41,8 @@ public:
     pooling_kernel_t(pooling_config_t &cfg, const std::string &kernel_name,
             const kernel_info_t &kernel_info, const primitive_desc_t &pd)
         : ir_kernel_t<hw>(kernel_name, cfg.exec_cfg(), kernel_info,
-                kernel_info.nd_range().local_range(), /*require_dpas=*/false) {
+                kernel_info.nd_range().local_range(), /*require_dpas=*/false,
+                {GENERATOR_NAME, GENERATOR_LINE}) {
         pooling_ir_builder_t builder(cfg, kernel_info, pd);
         stmt_t body = builder.stmt();
         setup_interface(body);

--- a/src/gpu/intel/jit/reorder/reorder_kernel.hpp
+++ b/src/gpu/intel/jit/reorder/reorder_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ public:
             const std::string &kernel_name, const kernel_info_t &kernel_info,
             bool require_dpas, const primitive_desc_t *pd = nullptr)
         : ir_kernel_t<hw>(kernel_name, cfg.exec_cfg(), kernel_info,
-                kernel_info.nd_range().local_range(), require_dpas) {
+                kernel_info.nd_range().local_range(), require_dpas,
+                {GENERATOR_NAME, GENERATOR_LINE}) {
         const primitive_attr_t *attr = (pd) ? pd->attr() : nullptr;
         const memory_desc_t *dst_md = (pd) ? pd->dst_md() : nullptr;
         reorder_ir_builder_t builder(cfg, kernel_info, attr, dst_md);

--- a/src/gpu/intel/jit/v2/conv/kernel.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public:
 template <ngen::HW hw>
 kernel_t<hw>::kernel_t(
         const kernel_desc_base_t &_desc, const kernel_info_t &kernel_info)
-    : ir_kernel_t<hw>(_desc, kernel_info) {
+    : ir_kernel_t<hw>(_desc, kernel_info, {GENERATOR_NAME, GENERATOR_LINE}) {
 
     auto &desc = static_cast<const kernel_desc_t &>(_desc);
 


### PR DESCRIPTION
Downstreams new nGEN code. In particular downstreams support for DWARF debug information. The basic debug information was originally implemented in #2227, and was further extended to include a line table. The line table is only enabled in DNNL_DEV_MODE to avoid overhead in release builds (potentially this condition should be removed to improve the information collected by profiling tools) and under C++20 builds (due to a dependency on `std::source_location`.) This line table works with `gdb-onapi` as can be seen with the following picture:

![image](https://github.com/user-attachments/assets/86d1eedd-d273-42c8-a84a-554075e8df86)


Sample usage (requires using SYCL gpu runtime for gdb to work):
```
$ cat env/gdb-oneapi_env.sh
source ~/intel/gdb-oneapi/setvars.sh --force
export ZET_ENABLE_PROGRAM_DEBUGGING=1

for f in /sys/class/drm/card*/prelim_enable_eu_debug; do
    val=$(cat $f)
    if [ $val == 0 ]; then
        sudo sh -c "echo 1 > $f"
    fi
done
$ source env/gdb-oneapi_env.sh

:: initializing oneAPI environment ...
   -bash: BASH_VERSION = 5.1.16(1)-release
   args: Using "$@" for setvars.sh arguments:
:: debugger -- latest
:: oneAPI environment initialized ::
$ gdb-oneapi --args ~/dnnl/build/tests/benchdnn/benchdnn --matmul --engine=gpu 2048x13:13x512
...
(gdb) break _entry
Function "_entry" not defined.
Make breakpoint pending on future shared library load? (y or [n]) y
Breakpoint 1 (_entry) pending.
(gdb) r
...
Thread 2.1414 hit Breakpoint 1, with SIMD lanes [0-15], gemm_kernel ()
    at ~/dnnl/src/gpu/intel/jit/gemm/generator/pieces/common.cxx:42
42          or_(1, cr0, cr0, cr0Enable);
(gdb)
```