### PR TITLE
src: handle DNNL_VERBOSE=OFF support through an early exit (fixes MFDNN-12862)

### DIFF
--- a/src/cpu/x64/brgemm/capi/brgemm_api.cpp
+++ b/src/cpu/x64/brgemm/capi/brgemm_api.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -334,7 +334,8 @@ status_t brgemm_t::execute(const void *A_ptr, const void *B_ptr,
 status_t brgemm_t::create_verbose_info() {
 #if defined(DISABLE_VERBOSE)
     return status::success;
-#else
+#endif
+
     const auto &d = brgemm_desc_;
     std::stringstream ss;
 
@@ -362,7 +363,6 @@ status_t brgemm_t::create_verbose_info() {
 
     verbose_info_ = ss.str();
     return status::success;
-#endif
 }
 
 dnnl_transform::dnnl_transform(dim_t K, dim_t N, pack_type_t in_pack_type,
@@ -476,7 +476,8 @@ status_t transform_t::execute(const void *src, void *dst) const {
 status_t transform_t::create_verbose_info() {
 #if defined(DISABLE_VERBOSE)
     return status::success;
-#else
+#endif
+
     std::stringstream ss;
 
     memory_desc_t src_md;
@@ -493,7 +494,6 @@ status_t transform_t::create_verbose_info() {
 
     verbose_info_ = ss.str();
     return status::success;
-#endif
 }
 
 ////////////////

--- a/src/gpu/intel/ocl/ocl_gpu_engine.cpp
+++ b/src/gpu/intel/ocl/ocl_gpu_engine.cpp
@@ -57,7 +57,10 @@ status_t engine_create(impl::engine_t **engine, engine_kind_t engine_kind,
 
 void maybe_print_build_info(const std::vector<const char *> &kernel_names,
         const compute::kernel_ctx_t &kernel_ctx) {
-#ifndef DISABLE_VERBOSE
+#if defined(DISABLE_VERBOSE)
+    return;
+#endif
+
     // Print out kernel options if the correct verbosity is set
     if (get_verbose(verbose_t::debuginfo) >= 5) {
         std::ostringstream oss;
@@ -68,7 +71,6 @@ void maybe_print_build_info(const std::vector<const char *> &kernel_names,
                 VERBOSE_debug, "kernel options,%s,%s", oss.str().c_str(),
                 kernel_ctx.options().c_str());
     }
-#endif
 }
 
 status_t ocl_gpu_engine_t::init() {

--- a/src/graph/utils/verbose.cpp
+++ b/src/graph/utils/verbose.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,15 +55,6 @@ void print_verbose_header() {
                 "info,graph,backend,%zu:%s\n", i, bkd->get_name().c_str());
     }
 }
-
-#if defined(DISABLE_VERBOSE)
-void partition_info_t::init(
-        const engine_t *engine, const compiled_partition_t *partition) {
-    UNUSED(engine);
-    UNUSED(partition);
-}
-
-#else
 
 namespace {
 
@@ -241,6 +232,7 @@ std::string init_info_partition(const engine_t *engine,
 
 void partition_info_t::init(const engine_t *engine,
         const compiled_partition_t *compiled_partition) {
+    // Handles VERBOSE_DISABLE since `is_initialized_` is set to `true`.
     if (is_initialized_) return;
 
     std::call_once(initialization_flag_, [&] {
@@ -248,8 +240,6 @@ void partition_info_t::init(const engine_t *engine,
         is_initialized_ = true;
     });
 }
-
-#endif
 
 } // namespace utils
 } // namespace graph


### PR DESCRIPTION
Fixes MFDNN-12862

Disabled verbose shouldn't print data even if requested. The change is complied with this requirement with a marginal price of the library size for disabled verbose build, but easier way to support this mode.

