### PR TITLE
Fix sdpa descriptor hashing function

### DIFF
--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -766,11 +766,16 @@ size_t get_desc_hash(const sdpa_desc_t &desc) {
     seed = hash_combine(seed, get_md_hash(desc.q_desc));
     seed = hash_combine(seed, get_md_hash(desc.k_desc));
     seed = hash_combine(seed, get_md_hash(desc.v_desc));
+    seed = hash_combine(seed, get_runtime_scale_hash(desc.kq_scales));
+    seed = hash_combine(seed, get_zero_points_hash(desc.kq_zero_points));
+    seed = hash_combine(seed, get_runtime_scale_hash(desc.vs_scales));
+    seed = hash_combine(seed, get_zero_points_hash(desc.vs_zero_points));
     seed = hash_combine(seed, get_md_hash(desc.dst_desc));
     seed = hash_combine(seed, get_md_hash(desc.attn_mask_desc));
     // Scale type
     seed = hash_combine(seed, static_cast<size_t>(desc.scale_dt));
     seed = hash_combine(seed, desc.invert_scale);
+    seed = hash_combine(seed, desc.kv_head_number);
     // Combined hash for sdpa desc
     return seed;
 }

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -974,10 +974,15 @@ inline bool operator==(const sdpa_desc_t &lhs, const sdpa_desc_t &rhs) {
             && COMPARE_DESC_MEMBERS(q_desc)
             && COMPARE_DESC_MEMBERS(k_desc)
             && COMPARE_DESC_MEMBERS(v_desc)
+            && COMPARE_DESC_MEMBERS(kq_scales)
+            && COMPARE_DESC_MEMBERS(kq_zero_points)
+            && COMPARE_DESC_MEMBERS(vs_scales)
+            && COMPARE_DESC_MEMBERS(vs_zero_points)
             && COMPARE_DESC_MEMBERS(dst_desc)
             && COMPARE_DESC_MEMBERS(attn_mask_desc)
             && COMPARE_DESC_MEMBERS(scale_dt)
-            && COMPARE_DESC_MEMBERS(invert_scale);
+            && COMPARE_DESC_MEMBERS(invert_scale)
+            && COMPARE_DESC_MEMBERS(kv_head_number);
     return ret;
 }
 


### PR DESCRIPTION
# Description

The sdpa descriptor has hadn't been updated with the new scales and zero points parameters so the primitive caching mechanism was reusing primitives with invalid configurations. This PR updates the sdpa primitive hash functions to take those parameters into account.
