### PR TITLE
benchdnn: graph: check partition number by default

### DIFF
--- a/tests/benchdnn/doc/driver_graph.md
+++ b/tests/benchdnn/doc/driver_graph.md
@@ -50,9 +50,10 @@ where *graph-knobs* are:
             Multiple attributes value changes may be specified using the `*`
             delimeter. Multiple ops modification may be specified using the `+`
             delimeter. By default, the option value is empty, meaning values are taken from original graph.
- - `--expected-n-partitions=INT` -- Specify the number of expected partitions 
+ - `--expected-n-partitions=INT` -- Specify the number of expected partitions
     returned from the graph. `INT` is a non-negative integer value. When `INT`
-    value is `0` (the default), the check is skipped.
+    value is `0`, the check is skipped. By default, the value is `1` which means
+    the graph should be fused as one partition.
  - `--dt={undef [default], f32, bf16, f16}` -- Specify the data types in the
    input JSON file. Currently, you can define data types for pure floating-point
    input graph only. For example, you can specify `--dt=f16` for an `f32` graph

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -382,7 +382,7 @@ std::string case_to_str(const std::string &json_file,
         s << " ";
     }
 
-    if (expected_n_partitions != 0) {
+    if (expected_n_partitions != 1) {
         s << "--expected-n-partitions=" << std::to_string(expected_n_partitions)
           << " ";
     }
@@ -475,19 +475,6 @@ int doit(const prb_t *prb, res_t *res) {
         if (aop.kind_ == "End") { end_opid_v.emplace_back(aop.id_); }
     }
 
-    if (prb->expected_n_partition != 0) {
-        // If the expected partition num is specified by user with command line
-        // knob
-        if (partitions.size() != prb->expected_n_partition) {
-            BENCHDNN_PRINT(0,
-                    "Error: the expected number of partitions (%zu) doesn't "
-                    "coincide with the actual number of partitions returned "
-                    "(%zu).\n ",
-                    prb->expected_n_partition, partitions.size());
-            return res->state = FAILED, FAIL;
-        }
-    }
-
     if (partitions.empty()) {
         BENCHDNN_PRINT(0, "%s\n", "Error: partitions are empty");
         return res->state = FAILED, FAIL;
@@ -555,6 +542,16 @@ int doit(const prb_t *prb, res_t *res) {
         BENCHDNN_PRINT(3, "[INFO]: partition #%zd is unsupported!\n", i);
         res->state = UNIMPLEMENTED;
         return FAIL;
+    }
+
+    if (prb->expected_n_partition != 0
+            && partitions.size() != prb->expected_n_partition) {
+        BENCHDNN_PRINT(0,
+                "Error: the expected number of partitions (%zu) doesn't "
+                "coincide with the actual number of partitions returned "
+                "(%zu).\n ",
+                prb->expected_n_partition, partitions.size());
+        return res->state = FAILED, FAIL;
     }
 
     if (res->state == SKIPPED || res->state == UNIMPLEMENTED) return OK;

--- a/tests/benchdnn/graph/graph.hpp
+++ b/tests/benchdnn/graph/graph.hpp
@@ -47,9 +47,10 @@ struct settings_t : public base_settings_t {
     std::string json_file;
     std::vector<std::map<size_t, std::string>> in_shapes_vec {{{0, "default"}}};
     std::vector<std::map<size_t, std::string>> op_attrs_vec {{{0, "default"}}};
-    // `0` means not specified by user with command line knob, will skip
-    // the partition num check.
-    std::vector<size_t> expected_n_partition_vec {0};
+    // By default, we expect the graph should be fused as a single partition.
+    // The user can specify `--expected-n-partitions=0` to skip the partition
+    // number check.
+    std::vector<size_t> expected_n_partition_vec {1};
     std::vector<graph_fpmath_mode_t> fpmath_mode_vec {graph_fpmath_mode_t {}};
     std::vector<dnnl_data_type_t> dt {dnnl_data_type_undef};
 

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -2,13 +2,13 @@
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/JAX-MHA-inf-fp32.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/JAX-MQA-inf-fp32.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-LLaMa-inf-fp32-bs1.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-LLaMa-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-starcoder-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA_backward-Bert_large-train-fp32-bs4.json
---reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA_forward-Bert_large-train-fp32-bs4.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-starcoder-inf-fp32-bs1.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA_backward-Bert_large-train-fp32-bs4.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA_forward-Bert_large-train-fp32-bs4.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/GQA-fp16.json
@@ -17,11 +17,11 @@
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json
---reset --case=complex_fusion/mha/MHA-LLaMa-inf-int8-bs1.json
+--reset --expected-n-partitions=0 --case=complex_fusion/mha/MHA-LLaMa-inf-int8-bs1.json
 --reset --case=complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
 --reset --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
---reset --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
---reset --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
+--reset --expected-n-partitions=0 --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
+--reset --expected-n-partitions=0 --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
 --reset --case=complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json
 --reset --case=complex_fusion/mha/sdpa-compressed-kv-int4-gs32.json
 --reset --case=complex_fusion/mha/sdpa-compressed-kv-int8-gs128.json
@@ -30,14 +30,14 @@
 
 # Re-written graphs
 --reset --dt=f32,bf16,f16 --in-shapes=4:4x16x32x256+5:4x16x256x33+0:4x16x33x256+1:4x1x1x33+3:4x1x32x33 --case=complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --in-shapes=3:4x32x32x128+4:4x32x128x33+0:4x32x33x128+1:4x1x32x33 --case=complex_fusion/mha/MHA-LLaMa-inf-fp32-bs1.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --in-shapes=3:4x32x32x128+4:4x32x128x33+0:4x32x33x128+1:4x1x32x33 --case=complex_fusion/mha/MHA-LLaMa-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=3:20x16x384x64+4:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=3:10x16x384x64+4:10x1x64x384+0:10x1x384x64+1:10x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=4:56x12x128x64+5:56x12x64x128+0:56x12x128x64+1:56x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=0:56x8x1024x80+1:56x8x77x80+2:56x8x77x80 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --in-shapes=5:20x117x48x128+6:20x1x128x117+19:20x1x117x128 --case=complex_fusion/mha/MHA-starcoder-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --in-shapes=2514:32x16x512x64+2518:32x16x512x64+2543:32x1x512x512+2547:32x16x512x512+2525:32x16x512x64 --op-attrs=4837:shape:16384x1024 --case=complex_fusion/mha/MHA_forward-Bert_large-train-fp32-bs4.json
---reset --dt=f32,bf16,f16 --in-shapes=2514:32x16x512x64+2518:32x16x512x64+2591:32x16x512x512+2545:32x16x512x512+2547:32x16x512x512+2525:32x16x512x64+2548:32x16x512x512+5178:16384x1024 --op-attrs=7392:shape:32x512x16x64 --case=complex_fusion/mha/MHA_backward-Bert_large-train-fp32-bs4.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --in-shapes=5:20x117x48x128+6:20x1x128x117+19:20x1x117x128 --case=complex_fusion/mha/MHA-starcoder-inf-fp32-bs1.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --in-shapes=2514:32x16x512x64+2518:32x16x512x64+2543:32x1x512x512+2547:32x16x512x512+2525:32x16x512x64 --op-attrs=4837:shape:16384x1024 --case=complex_fusion/mha/MHA_forward-Bert_large-train-fp32-bs4.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --in-shapes=2514:32x16x512x64+2518:32x16x512x64+2591:32x16x512x512+2545:32x16x512x512+2547:32x16x512x512+2525:32x16x512x64+2548:32x16x512x512+5178:16384x1024 --op-attrs=7392:shape:32x512x16x64 --case=complex_fusion/mha/MHA_backward-Bert_large-train-fp32-bs4.json
 --reset --dt=f32,bf16,f16 --in-shapes=0:20x16x384x64+1:20x16x384x64+8:20x16x384x64+5:20x1x1x384 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=5:1x1x384x384,5:1x16x384x384 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --in-shapes=0:2x16x384x64+1:2x16x384x64+5:2x1x1x384+8:2x16x384x64  --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
@@ -47,9 +47,9 @@
 
 # Re-written int8 graphs
 --reset --in-shapes=5:4x16x32x256+4:4x16x256x33+0:4x16x33x256+1:4x1x1x33+3:4x1x32x33 --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json
---reset --in-shapes=4:4x32x32x128+3:4x32x128x33+0:4x32x33x128+1:4x1x32x33 --case=complex_fusion/mha/MHA-LLaMa-inf-int8-bs1.json
+--reset --expected-n-partitions=0 --in-shapes=4:4x32x32x128+3:4x32x128x33+0:4x32x33x128+1:4x1x32x33 --case=complex_fusion/mha/MHA-LLaMa-inf-int8-bs1.json
 --reset --in-shapes=4:20x16x384x64+3:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
 --reset --in-shapes=5:56x12x128x64+4:56x12x64x128+0:56x12x128x64+1:56x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
---reset --in-shapes=4:20x117x48x128+3:20x1x128x117+0:20x1x117x128 --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
---reset --in-shapes=4:32x16x384x64+3:32x16x64x384+0:32x16x384x64+1:32x1x1x384 --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
+--reset --expected-n-partitions=0 --in-shapes=4:20x117x48x128+3:20x1x128x117+0:20x1x117x128 --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
+--reset --expected-n-partitions=0 --in-shapes=4:32x16x384x64+3:32x16x64x384+0:32x16x384x64+1:32x1x1x384 --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
 --reset --in-shapes=4:20x16x384x64+3:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
@@ -2,11 +2,11 @@
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/JAX-MHA-inf-fp32.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/JAX-MQA-inf-fp32.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-LLaMa-inf-fp32-bs1.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-LLaMa-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-starcoder-inf-fp32-bs1.json
+--reset --expected-n-partitions=0 --dt=f32,bf16,f16 --case=complex_fusion/mha/MHA-starcoder-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/GQA-fp16.json
@@ -15,11 +15,11 @@
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json
---reset --case=complex_fusion/mha/MHA-LLaMa-inf-int8-bs1.json
+--reset --expected-n-partitions=0 --case=complex_fusion/mha/MHA-LLaMa-inf-int8-bs1.json
 --reset --case=complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
 --reset --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
---reset --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
---reset --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
+--reset --expected-n-partitions=0 --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
+--reset --expected-n-partitions=0 --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
 --reset --case=complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json
 --reset --case=complex_fusion/mha/sdpa-compressed-kv-int8-gs128.json
 --reset --case=complex_fusion/mha/sdpa-compressed-v-int8-gs32.json

--- a/tests/benchdnn/inputs/graph/pattern/harness_bf16_all
+++ b/tests/benchdnn/inputs/graph/pattern/harness_bf16_all
@@ -3,8 +3,8 @@
 --reset --dt=bf16 --case=pattern/f32/bn_relu_fusion.json
 --reset --dt=bf16 --case=pattern/f32/conv_bias_post_ops_fusion.json
 # This fusion pattern is not support on GPU engine for now, will split into 2
-# partitions with GPU engine
---reset --dt=bf16 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+# partitions with GPU engine. Skip the partition number check for it.
+--reset --dt=bf16  --expected-n-partitions=0 --case=pattern/f32/conv_depthwise_fusion_cpu.json
 --reset --dt=bf16 --case=pattern/f32/conv_post_ops_fusion.json
 --reset --dt=bf16 --case=pattern/f32/convtranspose_post_ops_fusion.json
 --reset --dt=bf16 --case=pattern/f32/matmul_bias_post_ops_chain_fusion.json

--- a/tests/benchdnn/inputs/graph/pattern/harness_f16_all
+++ b/tests/benchdnn/inputs/graph/pattern/harness_f16_all
@@ -3,8 +3,8 @@
 --reset --dt=f16 --case=pattern/f32/bn_relu_fusion.json
 --reset --dt=f16 --case=pattern/f32/conv_bias_post_ops_fusion.json
 # This fusion pattern is not support on GPU engine for now, will split into 2
-# partitions with GPU engine
---reset --dt=f16 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+# partitions with GPU engine. Skip the partition number check for it.
+--reset --dt=f16 --expected-n-partitions=0 --case=pattern/f32/conv_depthwise_fusion_cpu.json
 --reset --dt=f16 --case=pattern/f32/conv_post_ops_fusion.json
 --reset --dt=f16 --case=pattern/f32/convtranspose_post_ops_fusion.json
 --reset --dt=f16 --case=pattern/f32/matmul_bias_post_ops_chain_fusion.json

--- a/tests/benchdnn/inputs/graph/pattern/harness_f32_all
+++ b/tests/benchdnn/inputs/graph/pattern/harness_f32_all
@@ -24,28 +24,28 @@
 --reset --in-shapes=0:50x64x56x56+1:64x64x1x1+2:64 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/f32/conv_bias_post_ops_fusion.json
 --reset --in-shapes=0:50x64x56x56+1:64x64x3x3+2:64 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:1 --case=pattern/f32/conv_bias_post_ops_fusion.json
 # This fusion pattern is not support on GPU engine for now, will split into 2
-# partitions with GPU engine
---reset --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --case=pattern/f32/conv_bias_relu_depthwise_bias_relu_fusion_cpu.json
---reset --case=pattern/f32/conv_bias_mul_mul_depthwise_bias_swish_fusion_cpu.json
---reset --in-shapes=0:2x128x56x56+1:128x128x1x1+3:128x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:128 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x24x56x56+1:144x24x1x1+3:144x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:144 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x256x28x28+1:256x256x1x1+3:256x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:256 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x32x112x112+1:64x32x1x1+3:64x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:64 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x512x14x14+1:512x512x1x1+3:512x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:512 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x64x28x28+1:384x64x1x1+3:384x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:384 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x96x14x14+1:576x96x1x1+3:576x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:576 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x128x28x28+1:256x128x1x1+3:256x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:256 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x160x7x7+1:960x160x1x1+3:960x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:960 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x24x56x56+1:144x24x1x1+3:144x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:144 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x256x14x14+1:512x256x1x1+3:512x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:512 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x32x112x112+1:32x32x1x1+3:32x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x32x28x28+1:192x32x1x1+3:192x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:192 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x512x14x14+1:512x512x1x1+3:512x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:512 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x512x7x7+1:1024x512x1x1+3:1024x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:1024 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x64x28x28+1:384x64x1x1+3:384x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:384 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x64x56x56+1:128x64x1x1+3:128x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:128 --case=pattern/f32/conv_depthwise_fusion_cpu.json
---reset --in-shapes=0:2x96x14x14+1:576x96x1x1+3:576x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:576 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+# partitions with GPU engine. Skip the partition number check for them.
+--reset --expected-n-partitions=0 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --case=pattern/f32/conv_bias_relu_depthwise_bias_relu_fusion_cpu.json
+--reset --expected-n-partitions=0 --case=pattern/f32/conv_bias_mul_mul_depthwise_bias_swish_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x128x56x56+1:128x128x1x1+3:128x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:128 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x24x56x56+1:144x24x1x1+3:144x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:144 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x256x28x28+1:256x256x1x1+3:256x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:256 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x32x112x112+1:64x32x1x1+3:64x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:64 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x512x14x14+1:512x512x1x1+3:512x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:512 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x64x28x28+1:384x64x1x1+3:384x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:384 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x96x14x14+1:576x96x1x1+3:576x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:2x2*dilations:1x1*pads_begin:1x1*pads_end:0x0*groups:576 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x128x28x28+1:256x128x1x1+3:256x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:256 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x160x7x7+1:960x160x1x1+3:960x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:960 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x24x56x56+1:144x24x1x1+3:144x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:144 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x256x14x14+1:512x256x1x1+3:512x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:512 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x32x112x112+1:32x32x1x1+3:32x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x32x28x28+1:192x32x1x1+3:192x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:192 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x512x14x14+1:512x512x1x1+3:512x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:512 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x512x7x7+1:1024x512x1x1+3:1024x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:1024 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x64x28x28+1:384x64x1x1+3:384x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:384 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x64x56x56+1:128x64x1x1+3:128x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:128 --case=pattern/f32/conv_depthwise_fusion_cpu.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x96x14x14+1:576x96x1x1+3:576x1x3x3 --op-attrs=0:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1+1:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:576 --case=pattern/f32/conv_depthwise_fusion_cpu.json
 --reset --case=pattern/f32/conv_post_ops_fusion.json
 --reset --case=pattern/f32/convtranspose_post_ops_fusion.json
 --reset --case=pattern/f32/matmul_bias_post_ops_chain_fusion.json
@@ -167,8 +167,8 @@
 # softmax
 --reset --case=pattern/f32/softmax_post_ops_unary_fusion.json
 --reset --case=pattern/f32/softmax_post_ops_binary_fusion.json
-# layernorm
---reset --case=pattern/f32/lnorm_gelu.json
+# layernorm: skip partition number check as it may not fuse on gpu.
+--reset --expected-n-partitions=0 --case=pattern/f32/lnorm_gelu.json
 # shuffle
 --reset --in-shapes=0:1x512x75x75 --op-attrs=0:shape:1x512x75x25x3+2:shape:1x512x75x75 --case=pattern/f32/shuffle_fusion.json
 # large scope

--- a/tests/benchdnn/inputs/graph/pattern/harness_f8_all
+++ b/tests/benchdnn/inputs/graph/pattern/harness_f8_all
@@ -1,6 +1,7 @@
---reset --case=pattern/f8/f8_conv_add_add_fusion.json
---reset --case=pattern/f8/f8_conv_fwd.json
---reset --case=pattern/f8/f8_conv_post_ops_fusion.json
---reset --case=pattern/f8/f8_conv_post_ops_int8_add_fusion.json
---reset --case=pattern/f8/f8_conv_bias_relu_fusion.json
---reset --case=pattern/f8/f8_matmul.json
+# f8 cases: skip partition number check as they may not fuse on some platforms.
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_add_add_fusion.json
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_fwd.json
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_post_ops_fusion.json
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_post_ops_int8_add_fusion.json
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_bias_relu_fusion.json
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_matmul.json

--- a/tests/benchdnn/inputs/graph/pattern/harness_f8_ci
+++ b/tests/benchdnn/inputs/graph/pattern/harness_f8_ci
@@ -1,2 +1,3 @@
---reset --case=pattern/f8/f8_conv_fwd.json
---reset --case=pattern/f8/f8_matmul.json
+# f8 cases: skip partition number check as they may not fuse on some platforms.
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_fwd.json
+--reset --expected-n-partitions=0 --case=pattern/f8/f8_matmul.json

--- a/tests/benchdnn/inputs/graph/pattern/harness_int8_all
+++ b/tests/benchdnn/inputs/graph/pattern/harness_int8_all
@@ -14,7 +14,7 @@
 --reset --case=pattern/int8/int8_bf16_matmul_sum_add_mul_relu.json
 --reset --attr-fpmath=strict:false,bf16:false,tf32:false --case=pattern/int8/int8_avgpool_reshape_fusion.json
 --reset --case=pattern/int8/int8_avgpool_transpose_fusion.json
---reset --case=pattern/int8/int8_bf16_conv_add_relu_mul.json
+--reset --expected-n-partitions=0 --case=pattern/int8/int8_bf16_conv_add_relu_mul.json
 --reset --case=pattern/int8/int8_bf16_matmul_tc_add_quant_fusion.json
 --reset --case=pattern/int8/int8_bf16_conv_binary_add_fusion_2.json
 
@@ -23,13 +23,13 @@
 --reset --in-shapes=0:1x2048x14x14+1:2048x64x3x3+2:2048 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/int8/int8_conv_bias_mish_fusion.json
 --reset --in-shapes=0:1x2048x14x14+1:2048x64x3x3+2:2048 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/int8/int8_conv_bias_relu_fusion_2.json
 --reset --in-shapes=0:1x2048x14x14+1:2048x64x3x3+2:2048 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/int8/int8_conv_bias_relu_fusion_3.json
---reset --in-shapes=0:50x64x56x56+1:64x64x1x1+2:1x1x1x1+3:1x1x1x1 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_add_add_fusion.json
---reset --op-attrs=8209:zps:1 --case=pattern/int8/int8_conv_add_add_fusion.json
+--reset --expected-n-partitions=0 --in-shapes=0:50x64x56x56+1:64x64x1x1+2:1x1x1x1+3:1x1x1x1 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_add_add_fusion.json
+--reset --expected-n-partitions=0 --op-attrs=8209:zps:1 --case=pattern/int8/int8_conv_add_add_fusion.json
 --reset --in-shapes=0:50x64x56x56+1:64x64x1x1+2:1x1x1x1+3:1x64x1x1 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_add_mul_fusion.json
---reset --op-attrs=8209:zps:2 --case=pattern/int8/int8_conv_add_mul_fusion.json
+--reset --expected-n-partitions=0 --op-attrs=8209:zps:2 --case=pattern/int8/int8_conv_add_mul_fusion.json
 --reset --in-shapes=0:50x64x56x56+1:64x64x1x1 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_relu_fusion.json
 --reset --case=pattern/int8/int8_bf16_conv_add_fusion.json
---reset --op-attrs=8209:zps:1 --case=pattern/int8/int8_bf16_conv_add_fusion.json
+--reset --expected-n-partitions=0 --op-attrs=8209:zps:1 --case=pattern/int8/int8_bf16_conv_add_fusion.json
 --reset --in-shapes=0:0x64x56x56+2:0x64x56x56 --case=pattern/int8/int8_bf16_conv_add_fusion.json
 # quantized conv 
 --reset --in-shapes=0:50x64x56x56+1:64x64x1x1+2:64 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_2d_fusion.json
@@ -45,8 +45,8 @@
 --reset --in-shapes=0:2x64x3x3 --case=pattern/int8/int8_reorder_fusion_3.json
 # matmul
 --reset --in-shapes=0:16x256+1:256x1+2:1x1+3:1x1 --case=pattern/int8/int8_matmul_add_mul_fusion.json
---reset --op-attrs=8209:zps:3 --case=pattern/int8/int8_matmul_add_mul_fusion.json
---reset --in-shapes=0:16x256+1:256x1+2:1x1+3:1x1+4:1x1 --case=pattern/int8/int8_matmul_mul_add_mul_fusion.json
+--reset --expected-n-partitions=0 --op-attrs=8209:zps:3 --case=pattern/int8/int8_matmul_add_mul_fusion.json
+--reset --expected-n-partitions=0 --in-shapes=0:16x256+1:256x1+2:1x1+3:1x1+4:1x1 --case=pattern/int8/int8_matmul_mul_add_mul_fusion.json
 --reset --in-shapes=0:16x256+1:256x1+2:1x1 --case=pattern/int8/int8_matmul_logistic_fusion.json
 --reset --in-shapes=0:16x1024+1:1024x1024+2:1x1024 --op-attrs=4113:scales:2 --case=pattern/int8/int8_matmul_logistic_fusion.json
 --reset --in-shapes=0:16x1024+1:1024x512+2:1x512 --op-attrs=4113:scales:2 --case=pattern/int8/int8_matmul_logistic_fusion.json
@@ -65,7 +65,7 @@
 --reset --in-shapes=0:16x13+3:13x512+6208:16x512 --case=pattern/int8/int8_bf16_matmul_add_fusion.json
 --reset --case=pattern/int8/int8_bf16_matmul_mul_w_smooth_quant_fusion.json
 --reset --case=pattern/int8/int8_bf16_matmul_relu_w_smooth_quant_fusion.json
---reset --op-attrs=8209:zps:4 --case=pattern/int8/int8_bf16_matmul_add_fusion.json
+--reset --expected-n-partitions=0 --op-attrs=8209:zps:4 --case=pattern/int8/int8_bf16_matmul_add_fusion.json
 --reset --in-shapes=0:16x13+1:13x512+2:1x1+3:1x1 --case=pattern/int8/int8_bf16_matmul_mul_add_fusion_2.json
 --reset --in-shapes=0:16x512+1:512x256+2:1x1+3:1x1 --case=pattern/int8/int8_f32_matmul_mul_add_fusion.json
 --reset --case=pattern/int8/int8_f32_matmul_mul_add_fusion_2.json
@@ -83,7 +83,7 @@
 --reset --in-shapes=0:2x16x5x5+1:16x4x3x3 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:4 --case=pattern/int8/int8_convtranspose_post_ops_square_fusion.json
 --reset --in-shapes=0:50x64x56x56+1:64x64x1x1+2:1x1x1x1+3:1x64x1x1 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_convtranspose_post_ops_chain_fusion.json
 --reset --in-shapes=0:2x17x8x8+1:17x16x3x3+2:2x16x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:3x3*pads_end:2x2*groups:1 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
---reset --op-attrs=8209:zps:4 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
+--reset --expected-n-partitions=0 --op-attrs=8209:zps:4 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
 --reset --in-shapes=0:2x16x5x5+1:16x16x1x1+2:2x16x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
 --reset --in-shapes=0:2x16x5x5+1:16x16x3x3+2:2x16x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:1 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
 --reset --in-shapes=0:2x16x5x5+1:16x17x1x1+2:2x17x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
@@ -95,8 +95,8 @@
 --reset --in-shapes=0:2x17x5x5+1:17x16x3x3+2:2x16x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:1 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
 --reset --in-shapes=0:2x17x5x5+1:17x3x3x3+2:2x3x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:1 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion.json
 --reset --in-shapes=0:2x20x5x5+1:20x4x3x3+2:16+3:1x1x1x1 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:4 --case=pattern/int8/int8_convtranspose_post_ops_add_fusion.json
---reset --in-shapes=0:2x16x8x8+1:16x17x3x3+2:17+3:2x17x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:3x3*pads_end:2x2*groups:1+8209:zps:4 --case=pattern/int8/int8_convtranspose_post_ops_add_fusion.json
---reset --in-shapes=0:2x16x5x5+1:16x5x3x3+2:20+3:2x20x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:4 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion_2.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x16x8x8+1:16x17x3x3+2:17+3:2x17x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:3x3*pads_end:2x2*groups:1+8209:zps:4 --case=pattern/int8/int8_convtranspose_post_ops_add_fusion.json
+--reset --expected-n-partitions=0 --in-shapes=0:2x16x5x5+1:16x5x3x3+2:20+3:2x20x5x5 --op-attrs=5:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:4 --case=pattern/int8/int8_convtranspose_post_ops_sum_fusion_2.json
 # bnorm
 --reset --in-shapes=0:1x56x56x64+2:64+3:64+4:64+5:64 --op-attrs=1:data_format:NXC --case=pattern/int8/int8_bnorm_relu_fusion.json
 --reset --in-shapes=0:1x64x56x56+2:64+3:64+4:64+5:64 --op-attrs=1:data_format:NCX --case=pattern/int8/int8_bnorm_relu_fusion.json
@@ -114,14 +114,14 @@
 --reset --in-shapes=0:1x64x600x600*acdb+1:1x64x600x600*acdb+2:1x64x600x600*acdb --op-attrs=3:axis:1 --case=pattern/int8/int8_concat_fusion_3.json
 --reset --in-shapes=0:1x64x300x300*cdba+1:1x64x300x300*cdba+2:1x64x300x300*cdba --op-attrs=3:axis:3 --case=pattern/int8/int8_concat_fusion_3.json
 --reset --in-shapes=0:1x128x150x150*acdb+1:1x128x150x150*acdb+2:1x128x150x150*acdb --op-attrs=3:axis:0 --case=pattern/int8/int8_concat_fusion_3.json
-#layernorm
---reset --case=pattern/int8/int8_lnorm_gelu_quantize.json
+#layernorm: skip partition number check as it may not fuse on gpu.
+--reset --expected-n-partitions=0 --case=pattern/int8/int8_lnorm_gelu_quantize.json
 # layernorm with zp != 0
---reset --op-attrs=2:zps:1 --case=pattern/int8/int8_lnorm_gelu_quantize.json
---reset --case=pattern/int8/int8_lnorm_multiply_quantize.json
---reset --case=pattern/int8/int8_lnorm_tc_multiply_quantize.json
+--reset --expected-n-partitions=0 --op-attrs=2:zps:1 --case=pattern/int8/int8_lnorm_gelu_quantize.json
+--reset --expected-n-partitions=0 --case=pattern/int8/int8_lnorm_multiply_quantize.json
+--reset --expected-n-partitions=0 --case=pattern/int8/int8_lnorm_tc_multiply_quantize.json
 # layernorm with zp != 0 and broadcast binary
---reset --op-attrs=3:zps:1  --in-shapes=5:512 --case=pattern/int8/int8_lnorm_tc_multiply_quantize.json
+--reset --expected-n-partitions=0 --op-attrs=3:zps:1  --in-shapes=5:512 --case=pattern/int8/int8_lnorm_tc_multiply_quantize.json
 #softmax
 --reset --case=pattern/int8/int8_softmax_add.json
 --reset --op-attrs=3:zps:32 --case=pattern/int8/int8_softmax_add.json


### PR DESCRIPTION
Currently on main branch, `--expected-n-partitions` is 0 by default (if not provided in benchdnn command line), which means to skip checking the partition number returned from an input graph.
This PR changes the default value of `--expected-n-partitions` to 1 which means the input graph should be fused into one partition.
Most of the cases we have in CI/Nightly should fused into one partition. With this check enabled by default, we can detect that if a PR breaks a fusion into multiple partitions. Before this change, those multiple partitions will silently pass the correctness check of benchdnn.
Apparently, we still have a few cases which cannot fuse into one partition due to:
- the cases previously were added for graph compiler backend.
- the cases can fuse on cpu but not on gpu, or vice versa.

Partition number check is skipped for these cases explicitly by setting `--expected-n-partitions=0` in the command lines. We can track and remove these settings when the fusions are implemented in the future.