### PR TITLE
xe: increase concat lws[0] size w/new optimal calculation

### DIFF
--- a/src/gpu/intel/ocl/reusable_simple_concat.cpp
+++ b/src/gpu/intel/ocl/reusable_simple_concat.cpp
@@ -154,7 +154,7 @@ static status_t init_conf_common(impl::engine_t *engine, const concat_pd_t *pd,
     }
 
     rt_conf.lws_d = compute::get_optimal_lws(
-            rt_conf.gws_d, 0, device_info->gpu_arch());
+            rt_conf.gws_d, dim_idx::invalid, device_info->gpu_arch());
 
     conf.use_large_index = (total_bytes > std::numeric_limits<int>::max());
     return status::success;


### PR DESCRIPTION
# Description

This PR adresses performance regressions discovered as part of regular monitoring by increasing the lws[0] as much as possible. The new get_optimal_lws() logic is biased towards a more n-dimensional lws. Removing the requested vectorization axis (-1) will create a lws[0] as large as possible. If maximizing lws[0] will cause new slowdowns an updated reverted get_optimal_lws() will be used instead.

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
![image](https://github.com/user-attachments/assets/dcfe8727-5971-46ee-8c00-2ab53004a2e3)