### PR TITLE
graph: sdpa: Fix k/v only pattern to allow for optional mask/scale

### DIFF
--- a/src/graph/backend/dnnl/patterns/sdp.cpp
+++ b/src/graph/backend/dnnl/patterns/sdp.cpp
@@ -101,6 +101,28 @@ void create_gpt_sdp(
     }
 }
 
+graph::utils::pm::repetition_t *optional_scale_and_masks(
+        const std::shared_ptr<pb_graph_t> &pgraph, pm::pb_op_t *matmul_qk) {
+    auto scale_graph = std::make_shared<pb_graph_t>();
+    auto scale = scale_graph->append_alternation(
+            {graph::op_kind::Divide, graph::op_kind::Multiply});
+    scale_graph->create_input_port(0, scale, 0);
+    scale_graph->create_output_port(0, scale, 0);
+    auto optional_scale
+            = pgraph->append_optional(scale_graph, {in_edge(0, matmul_qk, 0)});
+
+    auto optional_mask = std::make_shared<pb_graph_t>();
+    auto fscore_add = optional_mask->append_op(graph::op_kind::Add);
+    optional_mask->create_input_port(0, fscore_add, 0);
+    optional_mask->create_output_port(0, fscore_add, 0);
+    auto mask = pgraph->append_optional(
+            optional_mask, {in_edge(0, optional_scale, 0)});
+
+    // Optional select for distilbert
+    auto p_select2 = optional_select(pgraph, mask, 2);
+    return p_select2;
+}
+
 DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(sdp)
 
 DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, float_sdp_fusion)
@@ -110,27 +132,11 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, float_sdp_fusion)
                 [](const std::shared_ptr<pb_graph_t> &pgraph) -> void {
                     auto matmul_qk = pgraph->append_op(graph::op_kind::MatMul);
 
-                    std::shared_ptr<pb_graph_t> scale_graph;
-                    scale_graph = std::make_shared<pb_graph_t>();
-                    auto scale = scale_graph->append_alternation(
-                            {graph::op_kind::Divide, graph::op_kind::Multiply});
-                    scale_graph->create_input_port(0, scale, 0);
-                    scale_graph->create_output_port(0, scale, 0);
-                    auto optional_scale = pgraph->append_optional(
-                            scale_graph, {in_edge(0, matmul_qk, 0)});
-
-                    auto optional_mask = std::make_shared<pb_graph_t>();
-                    auto fscore_add
-                            = optional_mask->append_op(graph::op_kind::Add);
-                    optional_mask->create_input_port(0, fscore_add, 0);
-                    optional_mask->create_output_port(0, fscore_add, 0);
-                    auto mask = pgraph->append_optional(
-                            optional_mask, {in_edge(0, optional_scale, 0)});
-
                     // Optional select for distilbert
-                    auto p_select2 = optional_select(pgraph, mask, 2);
+                    auto optional_scale_and_mask
+                            = optional_scale_and_masks(pgraph, matmul_qk);
                     auto softmax = pgraph->append_op(graph::op_kind::SoftMax,
-                            {in_edge(0, p_select2, 0)});
+                            {in_edge(0, optional_scale_and_mask, 0)});
                     auto matmul_v = pgraph->append_op(
                             graph::op_kind::MatMul, {in_edge(0, softmax, 0)});
                     // Optional transpose + reshape/reorder
@@ -401,23 +407,11 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, sdp_with_compressed_kv_fusion)
                     auto matmul_qk = pgraph->append_op(graph::op_kind::MatMul,
                             {in_edge(1, dequantize_key, 0)});
 
-                    auto fscore_scale = pgraph->append_alternation(
-                            {graph::op_kind::Divide, graph::op_kind::Multiply},
-                            {in_edge(0, matmul_qk, 0)});
-
-                    auto optional_mask = std::make_shared<pb_graph_t>();
-                    auto fscore_add
-                            = optional_mask->append_op(graph::op_kind::Add);
-                    optional_mask->create_input_port(0, fscore_add, 0);
-                    optional_mask->create_output_port(0, fscore_add, 0);
-                    auto mask = pgraph->append_optional(
-                            optional_mask, {in_edge(0, fscore_scale, 0)});
-
-                    // Optional select for distilbert
-                    auto p_select2 = optional_select(pgraph, mask, 2);
+                    auto optional_scale_and_mask
+                            = optional_scale_and_masks(pgraph, matmul_qk);
 
                     auto softmax = pgraph->append_op(graph::op_kind::SoftMax,
-                            {in_edge(0, p_select2, 0)});
+                            {in_edge(0, optional_scale_and_mask, 0)});
                     auto dequantize_value = pgraph->append_op(
                             graph::op_kind::DynamicDequantize);
                     pgraph->append_op(graph::op_kind::MatMul,
@@ -436,23 +430,10 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, sdp_with_compressed_v_fusion)
                 [](const std::shared_ptr<pb_graph_t> &pgraph) -> void {
                     auto matmul_qk = pgraph->append_op(graph::op_kind::MatMul);
 
-                    auto fscore_scale = pgraph->append_alternation(
-                            {graph::op_kind::Divide, graph::op_kind::Multiply},
-                            {in_edge(0, matmul_qk, 0)});
-
-                    auto optional_mask = std::make_shared<pb_graph_t>();
-                    auto fscore_add
-                            = optional_mask->append_op(graph::op_kind::Add);
-                    optional_mask->create_input_port(0, fscore_add, 0);
-                    optional_mask->create_output_port(0, fscore_add, 0);
-                    auto mask = pgraph->append_optional(
-                            optional_mask, {in_edge(0, fscore_scale, 0)});
-
-                    // Optional select for distilbert
-                    auto p_select2 = optional_select(pgraph, mask, 2);
-
+                    auto optional_scale_and_mask
+                            = optional_scale_and_masks(pgraph, matmul_qk);
                     auto softmax = pgraph->append_op(graph::op_kind::SoftMax,
-                            {in_edge(0, p_select2, 0)});
+                            {in_edge(0, optional_scale_and_mask, 0)});
                     auto dequantize_value = pgraph->append_op(
                             graph::op_kind::DynamicDequantize);
                     pgraph->append_op(graph::op_kind::MatMul,
@@ -474,23 +455,11 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, sdp_with_compressed_k_fusion)
                     auto matmul_qk = pgraph->append_op(graph::op_kind::MatMul,
                             {in_edge(1, dequantize_key, 0)});
 
-                    auto fscore_scale = pgraph->append_alternation(
-                            {graph::op_kind::Divide, graph::op_kind::Multiply},
-                            {in_edge(0, matmul_qk, 0)});
-
-                    auto optional_mask = std::make_shared<pb_graph_t>();
-                    auto fscore_add
-                            = optional_mask->append_op(graph::op_kind::Add);
-                    optional_mask->create_input_port(0, fscore_add, 0);
-                    optional_mask->create_output_port(0, fscore_add, 0);
-                    auto mask = pgraph->append_optional(
-                            optional_mask, {in_edge(0, fscore_scale, 0)});
-
-                    // Optional select for distilbert
-                    auto p_select2 = optional_select(pgraph, mask, 2);
+                    auto optional_scale_and_mask
+                            = optional_scale_and_masks(pgraph, matmul_qk);
 
                     auto softmax = pgraph->append_op(graph::op_kind::SoftMax,
-                            {in_edge(0, p_select2, 0)});
+                            {in_edge(0, optional_scale_and_mask, 0)});
                     pgraph->append_op(
                             graph::op_kind::MatMul, {in_edge(0, softmax, 0)});
                 })


### PR DESCRIPTION
# Description

SDPA K only and V only patterns required the mask/scale nodes in order to find the pattern in the graph. This PR makes the mask and scale nodes as optional.