### PR TITLE
brgemm: support arbitrary K on AMX

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -513,7 +513,8 @@ int brgemm_cmp(const brgemm_t &lhs, const brgemm_t &rhs) {
     CMP_BRGEMM_FIELD(brgattr.hint_prfB.dist2);
     CMP_BRGEMM_FIELD(brgattr.hint_prfC.dist1);
     CMP_BRGEMM_FIELD(brgattr.hint_prfC.dist2);
-    CMP_BRGEMM_FIELD(brgattr.wary_tail_read);
+    CMP_BRGEMM_FIELD(brgattr.wary_A_k_tail_read);
+    CMP_BRGEMM_FIELD(brgattr.extendable_k);
     CMP_BRGEMM_FIELD(brgattr.generate_skip_accumulation);
     CMP_BRGEMM_FIELD(brgattr.bd_mask_level);
     CMP_BRGEMM_FIELD(brgattr.use_uker);

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -133,7 +133,8 @@ struct DNNL_API brgemm_attr_t {
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
     brgemm_prf_t hint_prfA, hint_prfB, hint_prfC;
 
-    bool wary_tail_read;
+    bool wary_A_k_tail_read {false};
+    bool extendable_k {false};
     bool generate_skip_accumulation;
     // Value of bd_mask_level specifies how bd_mask is used in brgemm kernel
     // 0 – bd_mask is not used

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -265,7 +265,7 @@ status_t brgemm_convolution_fwd_t<isa, use_inversion>::pd_t::add_brg_descriptor(
     brgattr.hint_expected_B_size = 0;
     brgattr.hint_expected_C_size = 0;
 
-    brgattr.wary_tail_read = false;
+    brgattr.wary_A_k_tail_read = false;
     brgattr.bd_mask_level = jcp_.use_M_mask;
 
     brgattr.max_top_vpad = jcp_.max_vpad;

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -620,10 +620,11 @@ status_t brgemm_kernel_destroy(brgemm_kernel_t *brg_kernel) {
 status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
     if (!brg.is_tmm) return status::unimplemented;
 
-    //TODO: Add support of tail processing by reduction dimension
     auto rd_block = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
     if (brg.is_input_convert())
         rd_block = utils::rnd_up(rd_block, 2 /*vnni_granularity*/);
+    else
+        rd_block = utils::rnd_up(rd_block, brg.rd_step);
 
     palette_config_t *buff = (palette_config_t *)(palette);
 
@@ -765,7 +766,8 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(brgattr.hint_prfB.dist2);
     CMP_BRGEMM_FIELD(brgattr.hint_prfC.dist1);
     CMP_BRGEMM_FIELD(brgattr.hint_prfC.dist2);
-    CMP_BRGEMM_FIELD(brgattr.wary_tail_read);
+    CMP_BRGEMM_FIELD(brgattr.wary_A_k_tail_read);
+    CMP_BRGEMM_FIELD(brgattr.extendable_k);
     CMP_BRGEMM_FIELD(brgattr.generate_skip_accumulation);
     CMP_BRGEMM_FIELD(brgattr.bd_mask_level);
     CMP_BRGEMM_FIELD(brgattr.use_uker);

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 #include "cpu/x64/brgemm/jit_brdgmm_kernel.hpp"
 #include "cpu/x64/cpu_barrier.hpp"
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
-#include "cpu/x64/jit_generator.hpp"
 
 #define GET_OFF(field) offsetof(brgemm_kernel_params_t, field)
 #define GET_OFF_BATCH_ELEMENT(field) offsetof(brgemm_batch_element_t, field)
@@ -39,7 +38,7 @@ using namespace Xbyak;
 template <typename Wmm>
 jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
         const brgemm_desc_t &abrd)
-    : jit_generator(jit_name(), abrd.isa_impl)
+    : jit_base_brgemm_kernel_t(jit_name(), abrd.isa_impl)
     , brg(abrd)
     , simd_w_(vreg_traits<Vmm>::vlen / brg.typesize_C)
     , max_vmms_(isa_num_vregs(brg.isa_impl))

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace cpu {
 namespace x64 {
 
 template <typename Wmm>
-struct jit_brdgmm_kernel_base_t : public jit_generator {
+struct jit_brdgmm_kernel_base_t : public jit_base_brgemm_kernel_t {
     jit_brdgmm_kernel_base_t(const brgemm_desc_t &abrd);
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brdgmm_kernel_base_t)
@@ -159,6 +159,8 @@ struct jit_brdgmm_kernel_base_t : public jit_generator {
         auto vmm_alloc = vmm_allocator_helper_t(brg);
         return vmm_alloc.get_compute_vmm_count();
     }
+
+    const brgemm_desc_t &get_brg() const override { return brg; }
 
 private:
     // note: this kernel doesn't yet support TMM's. We differentiate Wmm and Vmm

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@
 #include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/x64/jit_avx512_core_fp8cvt.hpp"
-#include "cpu/x64/jit_generator.hpp"
 
 #define GET_OFF(field) offsetof(brgemm_kernel_params_t, field)
 #define GET_OFF_BATCH_ELEMENT(field) offsetof(brgemm_batch_element_t, field)
@@ -39,9 +38,9 @@ namespace x64 {
 using namespace dnnl::impl::utils;
 using namespace Xbyak;
 
-struct jit_brgemm_amx_uker_base_t : public jit_generator {
+struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
     jit_brgemm_amx_uker_base_t(const brgemm_desc_t &abrg)
-        : jit_generator(jit_name(), abrg.isa_impl)
+        : jit_base_brgemm_kernel_t(jit_name(), abrg.isa_impl)
         , brg(abrg)
         , postops_injector_(nullptr) {
 
@@ -134,6 +133,8 @@ struct jit_brgemm_amx_uker_base_t : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_amx_uker_base_t)
 
     brgemm_desc_t brg;
+
+    const brgemm_desc_t &get_brg() const override { return brg; }
 
 private:
     using po_injector_t = injector::jit_uni_postops_injector_base_t<Zmm>;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ namespace x64 {
 using namespace dnnl::impl::utils;
 using namespace Xbyak;
 template <typename Wmm>
-struct jit_brgemm_kernel_t : public jit_generator {
+struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
     jit_brgemm_kernel_t(const brgemm_desc_t &abrg)
-        : jit_generator(jit_name(), abrg.isa_impl)
+        : jit_base_brgemm_kernel_t(jit_name(), abrg.isa_impl)
         , brg(abrg)
         , postops_injector_(nullptr)
         , max_effective_vregs(get_max_effective_vregs(brg)) {
@@ -128,9 +128,11 @@ struct jit_brgemm_kernel_t : public jit_generator {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_t)
 
-    brgemm_desc_t brg;
+    const brgemm_desc_t &get_brg() const override { return brg; }
 
 private:
+    brgemm_desc_t brg;
+
     enum matrix_kind_t { matrix_A, matrix_B };
     static constexpr int zmm_width_in_bytes_
             = cpu_isa_traits<avx512_core>::vlen;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -22,6 +22,7 @@
 #include "common/utils.hpp"
 
 #include "cpu/platform.hpp"
+#include "cpu/x64/brgemm/brgemm.hpp"
 #include "cpu/x64/brgemm/brgemm_types.hpp"
 #include "cpu/x64/cpu_barrier.hpp"
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
@@ -276,6 +277,7 @@ private:
     Xbyak::Opmask ld_tail_mask = Xbyak::Opmask(3);
     Xbyak::Opmask fp8_col_mask = Xbyak::Opmask(4);
     Xbyak::Opmask kmask_fp8_aux = Xbyak::Opmask(5);
+    Xbyak::Opmask rd_tail_mask = Xbyak::Opmask(6);
 
     static int get_max_effective_vregs(const brgemm_desc_t &brg) {
         auto used_vregs = 0;
@@ -340,6 +342,8 @@ private:
     Vmm xmm_fp8_emu_aux4 = Vmm(4);
     Vmm xmm_fp8_emu_aux5 = Vmm(5);
 
+    Zmm zmm_tmp_1() const noexcept { return Zmm(1); }
+
     // Required in every dot product for INT8 non-VNNI computation.
     Vmm int8_ones_words() const noexcept {
         return Vmm(isa_num_vregs(brg.isa_impl) - 1);
@@ -397,17 +401,20 @@ private:
     void maybe_pre_process_data(matrix_kind_t matrix_kind, const Tmm &t1,
             reg64_t reg_base, size_t offset, reg64_t reg_stride, int num_rows,
             int num_col_bytes, bool is_rd_tail);
+    bool maybe_pre_process_k_tail(bool last_bdb, bool is_rd_tail, const Tmm &t1,
+            reg64_t reg_base, size_t offset, reg64_t reg_stride,
+            matrix_kind_t mk);
     void maybe_tileloadd_nt(matrix_kind_t matrix_kind, int idx, int offset,
-            bool is_rd_tail, bool is_tail);
+            bool is_rd_tail, bool is_tail, bool last_bdb);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
     void gemm_microkernel(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_rd_tail, bool is_ld_tail, int vpad, int rows_for_rd_tail);
-    void gemm_microkernel_amx(int bd_block2, bool is_bdb_tail, int ld_block,
-            bool is_rd_tail, bool is_ld_tail);
+    void gemm_microkernel_amx(int bd_block2, bool is_bdb_tail, int ld_block2,
+            bool is_rd_tail, bool is_ld_tail, bool last_bdb);
 
     void ldb_loop(int bd_block2, bool is_bdb_tail, int ld_block,
             int ldb_loop_length, bool is_reg_tail, bool is_ld_tail,
-            bool check_top_vpad, bool check_bottom_vpad, int rows_for_rd_tail,
+            bool first_bdb, bool last_bdb, int rows_for_rd_tail,
             bool skip_accumulation);
     void bdb_loop();
 
@@ -448,6 +455,7 @@ private:
     bool n_bcast_1_load = false;
     bool vpad_exist = false;
     bool need_comp_pads = false;
+    palette_config_t palette_;
 };
 
 template <typename Wmm>
@@ -1005,10 +1013,9 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(int num_rows,
     assert(max_num_cols > 0);
 
     if (col_tail) {
-        const int tail_mask = (1 << col_tail) - 1;
-        auto reg_tmp_32 = reg_tmp_gpr.cvt32();
-        mov(reg_tmp_32, tail_mask);
-        kmovd(fp8_col_mask, reg_tmp_32);
+        const auto tail_mask = (static_cast<size_t>(1) << col_tail) - 1;
+        mov(reg_tmp_gpr, tail_mask);
+        kmovq(fp8_col_mask, reg_tmp_gpr);
     }
     // Note: using the same register used in col_tail, so order is important
     const auto reg_data_aux = reg_tmp_gpr;
@@ -1883,9 +1890,8 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
         const Tmm &t1, reg64_t reg_base, size_t offset, reg64_t reg_stride,
         int num_rows, int num_col_bytes, bool is_rd_tail) {
-    constexpr int tile_size = 1024;
     const auto transform_offset = brg.brgattr.use_interleave_stores
-            ? brg.get_num_C_tiles() * tile_size
+            ? brg.get_num_C_tiles() * brgemm_desc_t::tilesize
             : 0;
     add(reg_buf_aux, transform_offset);
 
@@ -1908,7 +1914,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
-        int idx, int offset, bool is_rd_tail, bool is_tail) {
+        int idx, int offset, bool is_rd_tail, bool is_tail, bool last_bdb) {
 
     const bool is_A = matrix_kind == matrix_kind_t::matrix_A;
 
@@ -1951,6 +1957,10 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
         mov(reg64_fp8_aux, ptr[rsp + reg_val_tmp_1_]);
         mov(reg_buf_aux, ptr[rsp + reg_val_tmp_2_]);
     } else {
+        if (maybe_pre_process_k_tail(last_bdb, is_rd_tail, t1, reg_base, offset,
+                    reg_stride, matrix_kind))
+            return;
+
         const size_t cache_footprint = static_cast<size_t>(brg.typesize_A)
                         * brg.brgattr.hint_expected_A_size
                 + static_cast<size_t>(brg.typesize_B)
@@ -1966,8 +1976,73 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
 }
 
 template <typename Wmm>
+bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
+        bool is_rd_tail, const Tmm &t1, reg64_t reg_base, size_t offset,
+        reg64_t reg_stride, matrix_kind_t mk) {
+
+    // TODO: check is it last bs to calculate need_k_tail_processing
+    const auto need_k_tail_processing = mk == matrix_A && brg.amx_wary_k_tail()
+            && brg.rdb_tail != 0 && last_bdb && is_rd_tail;
+
+    if (!need_k_tail_processing) return false;
+
+    const auto zmm_width_in_bytes = cpu_isa_traits<avx512_core>::vlen;
+
+    auto transform_offset = brg.get_num_C_tiles() * brgemm_desc_t::tilesize
+            + brg.get_convert_wsp_buffer_size();
+
+    //TODO: reuse transformed data from matrix A for ldi > 0
+    const auto num_rows = palette_.rows[t1.getIdx()];
+    const auto num_col_bytes = palette_.cols[t1.getIdx()];
+
+    const auto max_num_cols
+            = nstl::min<int>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
+    const size_t col_tail
+            = max_num_cols % (zmm_width_in_bytes / brg.typesize_A);
+    if (col_tail) {
+        const auto tail_mask = (static_cast<size_t>(1) << col_tail) - 1;
+        mov(reg_tmp_gpr, tail_mask);
+        kmovq(rd_tail_mask, reg_tmp_gpr);
+    }
+    auto zmm_1 = zmm_tmp_1();
+    auto zmm_1_masked = col_tail ? zmm_1 | rd_tail_mask | T_z : zmm_1;
+
+    assert(max_num_cols > 0);
+
+    mov(ptr[rsp + reg_val_tmp_2_], reg_buf_aux);
+
+    mov(reg_buf_aux, ptr[rsp + reg_buf_offs_]);
+    if (transform_offset) add(reg_buf_aux, transform_offset);
+
+    for (int r = 0; r < num_rows; ++r) {
+        const auto row_offset = offset + r * brg.typesize_A * brg.LDA;
+        switch (brg.dt_a) {
+            case data_type::bf16:
+            case data_type::f16:
+                vmovdqu16(zmm_1_masked, ptr[reg_base + row_offset]);
+                break;
+            case data_type::f8_e5m2:
+            case data_type::f8_e4m3:
+            case data_type::s8:
+            case data_type::u8:
+                vmovdqu8(zmm_1_masked, ptr[reg_base + row_offset]);
+                break;
+            default: assert(!"unsupported data type");
+        }
+        vmovups(ptr[reg_buf_aux + r * zmm_width_in_bytes], zmm_1);
+    }
+    // load into tmm from the transformed data.
+    mov(reg_converted_stride, zmm_width_in_bytes);
+    tileloadd(t1, ptr[reg_buf_aux + reg_converted_stride]);
+    mov(reg_buf_aux, ptr[rsp + reg_val_tmp_2_]);
+
+    return true;
+}
+
+template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(int bd_block2,
-        bool is_bdb_tail, int ld_block2, bool is_rd_tail, bool is_ld_tail) {
+        bool is_bdb_tail, int ld_block2, bool is_rd_tail, bool is_ld_tail,
+        bool last_bdb) {
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         if (brg.is_fp8) {
             if (brg.is_fp8_via_convert())
@@ -1995,14 +2070,14 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(int bd_block2,
         for (int bdb = 0; bdb < bd_block2; bdb++) {
             maybe_tileloadd_nt(matrix_kind_t::matrix_A, bdb,
                     rdb * rdb_A_offset() + A_offset(bdb, 0, true), is_rd_tail,
-                    is_bdb_tail);
+                    is_bdb_tail, last_bdb && bdb == bd_block2 - 1);
         }
         for (int ldb = 0; ldb < ld_block2; ldb++) {
 
             const int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
             maybe_tileloadd_nt(matrix_kind_t::matrix_B, idx,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
-                    is_ld_tail);
+                    is_ld_tail, false);
             for (int bdb = 0; bdb < bd_block2; bdb++) {
                 tdpbxxd(Tmm(brg.get_C_tensor(
                                 bdb, idx, is_bdb_tail, is_ld_tail)),
@@ -2177,7 +2252,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
         compute_int8_compensation(
                 rd_loop, bd_b, bd_e, bd_block, ld_block2, is_ld_tail, vpad);
 
-    bool maybe_load_bytes = (rows_for_rd_tail > 0 || brg.brgattr.wary_tail_read)
+    bool maybe_load_bytes
+            = (rows_for_rd_tail > 0 || brg.brgattr.wary_A_k_tail_read)
             && is_rd_tail && rd_tail_size != 0 && (brg.is_bf16 || brg.is_int8);
     if (n_bcast_1_load) {
         for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
@@ -2187,7 +2263,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
             auto rows_by_load_bytes = have_to_load_bytes ? rows_for_rd_tail : 0;
             for (int bd = bd_b; bd < bd_e && !is_emdbd; bd++) {
                 const auto bd_by_load_bytes = (bd >= bd_e - rows_by_load_bytes
-                        || brg.brgattr.wary_tail_read);
+                        || brg.brgattr.wary_A_k_tail_read);
                 broadcast(bcst(bd), A_offset(bd, rd),
                         have_to_load_bytes && bd_by_load_bytes, brg.dt_a);
             }
@@ -2300,7 +2376,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                 if (!is_emdbd) {
                     const auto bd_by_load_bytes
                             = (bd >= bd_e - rows_by_load_bytes
-                                    || brg.brgattr.wary_tail_read);
+                                    || brg.brgattr.wary_A_k_tail_read);
                     broadcast(bcst(), A_offset(bd, rd),
                             have_to_load_bytes && bd_by_load_bytes, brg.dt_a);
                 }
@@ -2324,7 +2400,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
         int ld_block2, int ldb_loop_length, bool is_reg_tail, bool is_ld_tail,
-        bool check_top_vpad, bool check_bottom_vpad, int rows_for_rd_tail,
+        bool first_bdb, bool last_bdb, int rows_for_rd_tail,
         bool skip_accumulation) {
 
     Label ldb_loop_label;
@@ -2332,7 +2408,7 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
 
     copy_post_ops_stack_values_to_aux(is_reg_tail);
 
-    auto ld_loop_body = [&](int vpad) {
+    auto ld_loop_body = [&](int vpad, bool last_bdb) {
         set_A_B_matrices();
 
         int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
@@ -2344,8 +2420,8 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
 
         if (brg.is_tmm) {
             const bool is_rd_tail = false;
-            gemm_microkernel_amx(
-                    bd_block2, is_bdb_tail, ld_block2, is_rd_tail, is_ld_tail);
+            gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2, is_rd_tail,
+                    is_ld_tail, last_bdb);
         } else {
             if (brg.rdb > 0) {
                 Label rdb_loop_label;
@@ -2369,7 +2445,7 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
             const bool is_rd_tail = true;
             if (brg.is_tmm) {
                 gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2,
-                        is_rd_tail, is_ld_tail);
+                        is_rd_tail, is_ld_tail, last_bdb);
             } else {
                 gemm_microkernel(bd_block2, is_bdb_tail, ld_block2, is_rd_tail,
                         is_ld_tail, vpad, rows_for_rd_tail);
@@ -2420,7 +2496,7 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
             if (brg.brgattr.max_bs > 1) mov(reg_BS_loop, reg_BS);
             L_aligned(BS_loop_label, 64);
             {
-                if (check_top_vpad || check_bottom_vpad) {
+                if (first_bdb || last_bdb) {
                     const auto vpad_first = -brg.brgattr.max_bottom_vpad;
                     const auto vpad_last = brg.brgattr.max_top_vpad;
                     const auto n_vpads = vpad_last - vpad_first + 2;
@@ -2450,10 +2526,10 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
                     for (int vpad = vpad_first; vpad <= vpad_last; vpad++) {
                         const auto label_vpad = vpad - vpad_first;
                         L(Vpad_loop_iter_label[label_vpad]);
-                        if (!check_top_vpad && vpad > 0) continue;
-                        if (!check_bottom_vpad && vpad < 0) continue;
+                        if (!first_bdb && vpad > 0) continue;
+                        if (!last_bdb && vpad < 0) continue;
                         auto real_vpad = vpad;
-                        if (check_bottom_vpad && brg.bdb_tail && vpad < 0) {
+                        if (last_bdb && brg.bdb_tail && vpad < 0) {
                             if (!is_bdb_tail) {
                                 // for last full block before
                                 // bdb_tail && -vpad greater than bdb_tail
@@ -2473,14 +2549,14 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
                         }
                         cmp(reg_aux_A_vpad, vpad);
                         jne(Vpad_loop_iter_label[label_vpad + 1], T_NEAR);
-                        ld_loop_body(real_vpad);
+                        ld_loop_body(real_vpad, last_bdb);
                         jmp(Vpad_loop_end_label, T_NEAR);
                     }
                     L(Vpad_loop_iter_label[n_vpads - 1]);
-                    ld_loop_body(0);
+                    ld_loop_body(0, last_bdb);
                     L(Vpad_loop_end_label);
                 } else {
-                    ld_loop_body(0);
+                    ld_loop_body(0, last_bdb);
                 }
                 if (brg.brgattr.max_bs > 1) {
                     dec(reg_BS_loop);
@@ -2516,37 +2592,36 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
-    auto do_ldb_loop = [this](int bd_block2, bool is_bdb_tail,
-                               bool check_top_vpad, bool check_bottom_vpad,
-                               int rows_for_rd_tail, bool skip_accumulation) {
+    auto do_ldb_loop = [this](int bd_block2, bool is_bdb_tail, bool first_bdb,
+                               bool last_bdb, int rows_for_rd_tail,
+                               bool skip_accumulation) {
         if (brg.ldb2 > 0) {
             const bool is_ld_reg_tail = false;
             const bool is_ld_tail = false;
             ldb_loop(bd_block2, is_bdb_tail, brg.ld_block2, brg.ldb2,
-                    is_ld_reg_tail, is_ld_tail, check_top_vpad,
-                    check_bottom_vpad, rows_for_rd_tail, skip_accumulation);
+                    is_ld_reg_tail, is_ld_tail, first_bdb, last_bdb,
+                    rows_for_rd_tail, skip_accumulation);
         }
         if (brg.ldb2_tail > 0) {
             const bool is_ld_reg_tail = (brg.ldb2 == 0) ? false : true;
             const bool is_ld_tail = false;
             ldb_loop(bd_block2, is_bdb_tail, brg.ldb2_tail, 1, is_ld_reg_tail,
-                    is_ld_tail, check_top_vpad, check_bottom_vpad,
-                    rows_for_rd_tail, skip_accumulation);
+                    is_ld_tail, first_bdb, last_bdb, rows_for_rd_tail,
+                    skip_accumulation);
         }
         if (brg.ldb_tail > 0) {
             const bool is_ld_reg_tail
                     = (brg.ldb2 == 0 && brg.ldb2_tail == 0) ? false : true;
             const bool is_ld_tail = true;
             ldb_loop(bd_block2, is_bdb_tail, 1, 1, is_ld_reg_tail, is_ld_tail,
-                    check_top_vpad, check_bottom_vpad, rows_for_rd_tail,
-                    skip_accumulation);
+                    first_bdb, last_bdb, rows_for_rd_tail, skip_accumulation);
         }
     };
 
     auto bdb_loop_body = [this, do_ldb_loop](int bd_block2, bool is_bdb_tail,
-                                 bool check_top_vpad, bool check_bottom_vpad,
+                                 bool first_bdb, bool last_bdb,
                                  int rows_for_rd_tail, bool skip_accumulation) {
-        do_ldb_loop(bd_block2, is_bdb_tail, check_top_vpad, check_bottom_vpad,
+        do_ldb_loop(bd_block2, is_bdb_tail, first_bdb, last_bdb,
                 rows_for_rd_tail, skip_accumulation);
 
         if (brg.is_runtime_ldc) {
@@ -2689,26 +2764,60 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         L_aligned(bdb_loop_end_label, 64);
     };
     auto bdb_loop_amx = [&](bool skip_accumulation) {
-        Label bdb_loop_label;
-        if (brg.bd_block2 >= 1) {
-            mov(reg_bdb_loop, brg.bdb2);
-            mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
-            L_aligned(bdb_loop_label, 64);
-            {
-                bdb_loop_body(brg.bd_block2, false, false, false, 0,
-                        skip_accumulation);
-                mov(reg_bdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
-                dec(reg_bdb_loop);
-                cmp(reg_bdb_loop, 0);
+        if (brg.amx_wary_k_tail()) {
+            Label bdb_loop_label;
+            auto bdblocks = brg.bdb2;
+            if (bdblocks > 1) {
+                mov(reg_bdb_loop, brg.bdb2);
                 mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
+                L_aligned(bdb_loop_label, 64);
+                {
+                    bdb_loop_body(brg.bd_block2, false, false, false, 0,
+                            skip_accumulation);
+                    mov(reg_bdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
+                    dec(reg_bdb_loop);
+                    cmp(reg_bdb_loop, 1);
+                    mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
+                }
+                jg(bdb_loop_label, T_NEAR);
+                bdblocks = 1;
             }
-            jg(bdb_loop_label, T_NEAR);
+            if (bdblocks == 1) {
+                const bool last_bdb = brg.bdb2_tail == 0 && brg.bdb_tail == 0;
+                bdb_loop_body(brg.bd_block2, false, false, last_bdb, 0,
+                        skip_accumulation);
+            }
+
+            if (brg.bdb2_tail > 0) {
+                const bool last_bdb = brg.bdb_tail == 0;
+                bdb_loop_body(brg.bdb2_tail, false, false, last_bdb, 0,
+                        skip_accumulation);
+            }
+            if (brg.bdb_tail > 0)
+                do_ldb_loop(1, true, false, false, 0, skip_accumulation);
+
+        } else {
+            Label bdb_loop_label;
+            if (brg.bd_block2 >= 1) {
+                mov(reg_bdb_loop, brg.bdb2);
+                mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
+                L_aligned(bdb_loop_label, 64);
+                {
+                    bdb_loop_body(brg.bd_block2, false, false, false, 0,
+                            skip_accumulation);
+                    mov(reg_bdb_loop, ptr[rsp + reg_bdb_loop_offs_]);
+                    dec(reg_bdb_loop);
+                    cmp(reg_bdb_loop, 0);
+                    mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
+                }
+                jg(bdb_loop_label, T_NEAR);
+            }
+            if (brg.bdb2_tail > 0)
+                bdb_loop_body(brg.bdb2_tail, false, false, false, 0,
+                        skip_accumulation);
+            if (brg.bdb_tail > 0)
+                do_ldb_loop(1, true, false, false, 0, skip_accumulation);
         }
-        if (brg.bdb2_tail > 0)
-            bdb_loop_body(
-                    brg.bdb2_tail, false, false, false, 0, skip_accumulation);
-        if (brg.bdb_tail > 0)
-            do_ldb_loop(1, true, false, false, 0, skip_accumulation);
     };
 
     auto bdb_loop_general = [&](bool skip_accumulation) {
@@ -2779,6 +2888,11 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
         vmovups(f16_perm_odd_vreg_, ptr[reg_tmp_gpr]);
     }
 
+    if (brg.is_tmm && brg.amx_wary_k_tail()) {
+        // save tiles description for later use
+        brgemm_init_tiles(brg, (char *)(&palette_));
+    }
+
     read_params();
 
     bdb_loop();
@@ -2844,7 +2958,8 @@ brgemm_attr_t::brgemm_attr_t()
     , hint_innermost_loop(brgemm_ld_loop_innermost)
     , hint_loop_order(brgemm_kernel_loop_order_t::brgemm_lo_default)
     , hint_prefetching(brgemm_kernel_prefetching_t::brgemm_prf_default)
-    , wary_tail_read(true)
+    , wary_A_k_tail_read(true)
+    , extendable_k(false)
     , generate_skip_accumulation(false)
     , bd_mask_level(0)
     , use_uker(false)

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -200,7 +200,6 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         brgattr.hint_expected_B_size = vN * vK;
         brgattr.hint_expected_C_size = bd_blocking * vN;
 
-        brgattr.wary_tail_read = false;
         brgattr.use_uker = jcp_.use_uker;
         brgattr.use_interleave_stores = jcp_.use_interleave_stores;
         brgattr.hint_prefetching = jcp_.hint_prefetching;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -300,7 +300,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
         brgattr.hint_expected_C_size = 0;
     }
 
-    brgattr.wary_tail_read = false;
+    brgattr.wary_A_k_tail_read = false;
     brgattr.bd_mask_level = jcp_.use_M_mask;
 
     if (is_amx) {

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -274,7 +274,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(
         brgattr.hint_expected_C_size = 0;
     }
 
-    brgattr.wary_tail_read = false;
+    brgattr.wary_A_k_tail_read = false;
     // use_M_mask is always 0 for brgemm_convolution_bwd_strided_t
     brgattr.bd_mask = nullptr;
     brgattr.bd_mask_level = jcp_.use_M_mask;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -133,7 +133,7 @@ status_t brgemm_convolution_bwd_weights_t::pd_t::init(engine_t *engine) {
                 brgattr.hint_expected_B_size = 0;
                 brgattr.hint_expected_C_size = 0;
 
-                brgattr.wary_tail_read = false;
+                brgattr.wary_A_k_tail_read = false;
                 brgattr.bd_mask_level = jcp_.use_M_mask;
 
                 brgattr.max_top_vpad = 0;

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ struct brgemm_inner_product_fwd_t : public primitive_t {
                 brgemm_attr_t brgattr;
                 if (jbgp_.is_amx) {
                     brgattr.max_bs = bs;
-                    brgattr.wary_tail_read = false;
+                    brgattr.wary_A_k_tail_read = false;
                     brgattr.hint_expected_A_size = jbgp_.mb * jbgp_.ic;
                     brgattr.hint_expected_B_size = jbgp_.oc * jbgp_.ic;
                     brgattr.hint_expected_C_size = jbgp_.mb * jbgp_.oc;
@@ -321,7 +321,7 @@ struct brgemm_inner_product_bwd_data_t : public primitive_t {
                 if (jbgp_.is_amx) {
                     brgemm_attr_t brgattr;
                     brgattr.max_bs = bs;
-                    brgattr.wary_tail_read = false;
+                    brgattr.wary_A_k_tail_read = false;
                     brgattr.hint_expected_A_size = jbgp_.mb * jbgp_.oc;
                     brgattr.hint_expected_B_size = jbgp_.oc * jbgp_.ic;
                     brgattr.hint_expected_C_size = jbgp_.mb * jbgp_.ic;
@@ -497,7 +497,7 @@ struct brgemm_inner_product_bwd_weights_t : public primitive_t {
                 if (jbgp_.is_amx) {
                     brgemm_attr_t brgattr;
                     brgattr.max_bs = bs;
-                    brgattr.wary_tail_read = false;
+                    brgattr.wary_A_k_tail_read = false;
                     brgattr.hint_expected_A_size = jbgp_.mb * jbgp_.ic;
                     brgattr.hint_expected_B_size = jbgp_.mb * jbgp_.oc;
                     brgattr.hint_expected_C_size = jbgp_.ic * jbgp_.oc;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -816,6 +816,7 @@ struct jit_brgemm_conv_conf_t {
     int vnni_block {1};
     bool has_uneven_iw;
     int trans_dim_koef {1};
+    bool extendable_k = false;
 };
 
 struct jit_shuffle_conf_t {

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -219,8 +219,6 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             brgattr.use_uker = true;
             brgattr.use_interleave_stores = true;
             brgattr.max_bs = bs;
-            brgattr.wary_tail_read = false;
-
             // TODO: change expected sizes to local chunks wrt L2 blocking
             brgattr.hint_expected_A_size = vM * vK * bs;
             brgattr.hint_expected_B_size = vN * vK * bs;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2159,11 +2159,12 @@ protected:
     inline void load(int blk, int i, bool is_tail) {}
     inline void kmovq(Opmask k, size_t q) {}
     virtual void init_permute() {}
-    virtual void copy_block(int nrows, int ncolumns, bool n_tail) {
+    virtual void copy_block(
+            int nrows, int ncolumns, bool n_tail, bool zeropad) {
         UNUSED(n_tail);
-        copy_4x64(nrows, ncolumns);
+        copy_4x64(nrows, ncolumns, zeropad);
     }
-    virtual void copy_4x64(int nrows, int ncolumns) {}
+    virtual void copy_4x64(int nrows, int ncolumns, bool zeropad) {}
     inline void dot_product(Vmm v1, Vmm v2, Vmm v3) {
         if (!avx512_core_dot_product_)
             vpdpbusd(v1, v2, v3,
@@ -2242,9 +2243,10 @@ private:
         vmovdqa64(vreg_idx_hi_128, (const void *)idx_hi_8);
     }
 
-    void copy_block(int nrows, int ncolumns, bool n_tail) override {
+    void copy_block(
+            int nrows, int ncolumns, bool n_tail, bool zeropad) override {
         if (!is_dynamic_N_ || !n_tail) {
-            copy_4x64(nrows, ncolumns);
+            copy_4x64(nrows, ncolumns, zeropad);
             return;
         }
 
@@ -2266,7 +2268,7 @@ private:
         {
             mov(ptr[rsp + reg_src_offs_], reg_src);
             add(reg_src, reg_copy_block_n_shift);
-            copy_4x64(nrows, n_blk_step_);
+            copy_4x64(nrows, n_blk_step_, zeropad);
             add(reg_copy_block_n_shift, n_blk_step_ * typesize);
             add(reg_src, n_blk_step_ * typesize);
             add(reg_tr_src, n_blk_step_ * k_blk_step_ * typesize);
@@ -2289,7 +2291,7 @@ private:
             jle(loop_row_done, T_NEAR);
 
             add(reg_src, reg_copy_block_n_shift);
-            copy_4x64(nrows, 1 /* to force tail case */);
+            copy_4x64(nrows, 1 /* to force tail case */, zeropad);
         }
         L(loop_row_done);
 
@@ -2298,7 +2300,7 @@ private:
         mov(reg_tr_src, ptr[rsp + reg_tr_src_offs_]);
     }
 
-    void copy_4x64(int nrows, int ncolumns) override {
+    void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
         const bool is_tail = ncolumns < n_blk_step_;
         const auto tail_mask = size_t(((size_t)1 << ncolumns) - 1);
 
@@ -2313,32 +2315,36 @@ private:
                 k++) {
             const int row_start = (kb * max_unroll + k) * k_blk_step_;
             const int row_end = nstl::min(row_start + k_blk_step_, nrows);
-
-            for (int i = row_start; i < row_end; i++)
-                load(k, i, is_tail);
-            if (row_end == nrows && nrows % k_blk_step_ > 0) {
-                for (int i = nrows; i < rnd_up(nrows, k_blk_step_); i++) {
-                    auto src_reg = get_vmm(k, i % k_blk_step_);
-                    vpxord(src_reg, src_reg, src_reg);
-                }
-            }
-
-            vmovups(get_vmm(k, 4), vreg_idx_lo_256);
-            vpermi2b(get_vmm(k, 4), get_vmm(k, 0), get_vmm(k, 2));
-            vmovups(get_vmm(k, 5), vreg_idx_hi_256);
-            vpermi2b(get_vmm(k, 5), get_vmm(k, 0), get_vmm(k, 2));
-            vmovups(get_vmm(k, 0), vreg_idx_lo_256);
-            vpermi2b(get_vmm(k, 0), get_vmm(k, 1), get_vmm(k, 3));
-            vmovups(get_vmm(k, 2), vreg_idx_hi_256);
-            vpermi2b(get_vmm(k, 2), get_vmm(k, 1), get_vmm(k, 3));
-
-            vmovups(get_vmm(k, 1), vreg_idx_lo_128);
-            vpermi2b(get_vmm(k, 1), get_vmm(k, 4), get_vmm(k, 0));
             dim_t tr_src_off_base = (kb * max_unroll + k) * tr_src_stride_;
-            vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base),
-                    get_vmm(k, 1));
-            if (do_compute_compensation_)
-                vpdpbusd(get_comp_acc(0), vmm_comp_mul, get_vmm(k, 1));
+
+            if (!zeropad) {
+                for (int i = row_start; i < row_end; i++)
+                    load(k, i, is_tail);
+                if (row_end == nrows && nrows % k_blk_step_ > 0) {
+                    for (int i = nrows; i < rnd_up(nrows, k_blk_step_); i++) {
+                        auto src_reg = get_vmm(k, i % k_blk_step_);
+                        vpxord(src_reg, src_reg, src_reg);
+                    }
+                }
+                vmovups(get_vmm(k, 4), vreg_idx_lo_256);
+                vpermi2b(get_vmm(k, 4), get_vmm(k, 0), get_vmm(k, 2));
+                vmovups(get_vmm(k, 5), vreg_idx_hi_256);
+                vpermi2b(get_vmm(k, 5), get_vmm(k, 0), get_vmm(k, 2));
+                vmovups(get_vmm(k, 0), vreg_idx_lo_256);
+                vpermi2b(get_vmm(k, 0), get_vmm(k, 1), get_vmm(k, 3));
+                vmovups(get_vmm(k, 2), vreg_idx_hi_256);
+                vpermi2b(get_vmm(k, 2), get_vmm(k, 1), get_vmm(k, 3));
+
+                vmovups(get_vmm(k, 1), vreg_idx_lo_128);
+                vpermi2b(get_vmm(k, 1), get_vmm(k, 4), get_vmm(k, 0));
+                vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base),
+                        get_vmm(k, 1));
+                if (do_compute_compensation_)
+                    vpdpbusd(get_comp_acc(0), vmm_comp_mul, get_vmm(k, 1));
+            } else {
+                vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base),
+                        vmm_zero);
+            }
             const bool dynamic_tail = is_dynamic_N_ && ncolumns < n_blk_step_;
 
             Label k_loop_done;
@@ -2346,7 +2352,7 @@ private:
                 cmp(reg_dynamic_tail, 16);
                 jle(k_loop_done, T_NEAR);
             }
-            if (ncolumns > 16 || dynamic_tail) {
+            if (!zeropad && (ncolumns > 16 || dynamic_tail)) {
                 vmovups(get_vmm(k, 3), vreg_idx_hi_128);
                 vpermi2b(get_vmm(k, 3), get_vmm(k, 4), get_vmm(k, 0));
                 vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base + 64),
@@ -2362,7 +2368,7 @@ private:
                 cmp(reg_dynamic_tail, 32);
                 jle(k_loop_done, T_NEAR);
             }
-            if (ncolumns > 32 || dynamic_tail) {
+            if (!zeropad && (ncolumns > 32 || dynamic_tail)) {
                 vmovups(get_vmm(k, 4), vreg_idx_lo_128);
                 vpermi2b(get_vmm(k, 4), get_vmm(k, 5), get_vmm(k, 2));
                 vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base + 128),
@@ -2378,7 +2384,7 @@ private:
                 cmp(reg_dynamic_tail, 48);
                 jle(k_loop_done, T_NEAR);
             }
-            if (ncolumns > 48 || dynamic_tail) {
+            if (!zeropad && (ncolumns > 48 || dynamic_tail)) {
                 vmovups(get_vmm(k, 0), vreg_idx_hi_128);
                 vpermi2b(get_vmm(k, 0), get_vmm(k, 5), get_vmm(k, 2));
                 vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base + 192),
@@ -2419,7 +2425,7 @@ private:
         vmovdqa64(vreg_idx_hi_128, (const void *)idx_hi_128);
     }
 
-    void copy_4x64(int nrows, int ncolumns) override {
+    void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
         const bool is_tail = ncolumns < n_blk_step_;
         if (is_tail) {
             const auto tail_mask = size_t(((size_t)1 << ncolumns) - 1);
@@ -2435,44 +2441,49 @@ private:
                 k++) {
             const int row_start = (kb * max_unroll + k) * k_blk_step_;
             const int row_end = nstl::min(row_start + k_blk_step_, nrows);
+            dim_t tr_src_off_base = (kb * max_unroll + k) * tr_src_stride_;
 
-            for (int i = row_start; i < row_end; i++)
-                load(k, i, is_tail);
-            if (row_end == nrows && nrows % k_blk_step_ > 0) {
-                for (int i = nrows; i < rnd_up(nrows, k_blk_step_); i++) {
-                    auto src_reg = get_vmm(k, i % k_blk_step_);
-                    vpxord(src_reg, src_reg, src_reg);
+            if (!zeropad) {
+                for (int i = row_start; i < row_end; i++)
+                    load(k, i, is_tail);
+                if (row_end == nrows && nrows % k_blk_step_ > 0) {
+                    for (int i = nrows; i < rnd_up(nrows, k_blk_step_); i++) {
+                        auto src_reg = get_vmm(k, i % k_blk_step_);
+                        vpxord(src_reg, src_reg, src_reg);
+                    }
                 }
+
+                vpunpcklbw(get_vmm(k, 4), get_vmm(k, 0), get_vmm(k, 1));
+                vpunpckhbw(get_vmm(k, 5), get_vmm(k, 0), get_vmm(k, 1));
+                vpunpcklbw(get_vmm(k, 0), get_vmm(k, 2), get_vmm(k, 3));
+                vpunpckhbw(get_vmm(k, 1), get_vmm(k, 2), get_vmm(k, 3));
+
+                vpunpcklwd(get_vmm(k, 2), get_vmm(k, 4), get_vmm(k, 0));
+                vpunpckhwd(get_vmm(k, 3), get_vmm(k, 4), get_vmm(k, 0));
+                vpunpcklwd(get_vmm(k, 4), get_vmm(k, 5), get_vmm(k, 1));
+                vpunpckhwd(get_vmm(k, 5), get_vmm(k, 5), get_vmm(k, 1));
+
+                vmovups(get_vmm(k, 0), vreg_idx_lo_256);
+                vpermi2q(get_vmm(k, 0), get_vmm(k, 2), get_vmm(k, 4));
+                vmovups(get_vmm(k, 1), vreg_idx_hi_256);
+                vpermi2q(get_vmm(k, 1), get_vmm(k, 2), get_vmm(k, 4));
+                vmovups(get_vmm(k, 2), vreg_idx_lo_256);
+                vpermi2q(get_vmm(k, 2), get_vmm(k, 3), get_vmm(k, 5));
+                vmovups(get_vmm(k, 4), vreg_idx_hi_256);
+                vpermi2q(get_vmm(k, 4), get_vmm(k, 3), get_vmm(k, 5));
+
+                vmovups(get_vmm(k, 3), vreg_idx_lo_128);
+                vpermi2q(get_vmm(k, 3), get_vmm(k, 0), get_vmm(k, 2));
+                vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base),
+                        get_vmm(k, 3));
+                if (do_compute_compensation_)
+                    dot_product(get_comp_acc(0), vmm_comp_mul, get_vmm(k, 3));
+            } else {
+                vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base),
+                        vmm_zero);
             }
 
-            vpunpcklbw(get_vmm(k, 4), get_vmm(k, 0), get_vmm(k, 1));
-            vpunpckhbw(get_vmm(k, 5), get_vmm(k, 0), get_vmm(k, 1));
-            vpunpcklbw(get_vmm(k, 0), get_vmm(k, 2), get_vmm(k, 3));
-            vpunpckhbw(get_vmm(k, 1), get_vmm(k, 2), get_vmm(k, 3));
-
-            vpunpcklwd(get_vmm(k, 2), get_vmm(k, 4), get_vmm(k, 0));
-            vpunpckhwd(get_vmm(k, 3), get_vmm(k, 4), get_vmm(k, 0));
-            vpunpcklwd(get_vmm(k, 4), get_vmm(k, 5), get_vmm(k, 1));
-            vpunpckhwd(get_vmm(k, 5), get_vmm(k, 5), get_vmm(k, 1));
-
-            vmovups(get_vmm(k, 0), vreg_idx_lo_256);
-            vpermi2q(get_vmm(k, 0), get_vmm(k, 2), get_vmm(k, 4));
-            vmovups(get_vmm(k, 1), vreg_idx_hi_256);
-            vpermi2q(get_vmm(k, 1), get_vmm(k, 2), get_vmm(k, 4));
-            vmovups(get_vmm(k, 2), vreg_idx_lo_256);
-            vpermi2q(get_vmm(k, 2), get_vmm(k, 3), get_vmm(k, 5));
-            vmovups(get_vmm(k, 4), vreg_idx_hi_256);
-            vpermi2q(get_vmm(k, 4), get_vmm(k, 3), get_vmm(k, 5));
-
-            vmovups(get_vmm(k, 3), vreg_idx_lo_128);
-            vpermi2q(get_vmm(k, 3), get_vmm(k, 0), get_vmm(k, 2));
-            dim_t tr_src_off_base = (kb * max_unroll + k) * tr_src_stride_;
-            vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base),
-                    get_vmm(k, 3));
-            if (do_compute_compensation_)
-                dot_product(get_comp_acc(0), vmm_comp_mul, get_vmm(k, 3));
-
-            if (ncolumns > 16) {
+            if (!zeropad && ncolumns > 16) {
                 vmovups(get_vmm(k, 5), vreg_idx_hi_128);
                 vpermi2q(get_vmm(k, 5), get_vmm(k, 0), get_vmm(k, 2));
                 vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base + 64),
@@ -2484,7 +2495,7 @@ private:
                         vmm_zero);
             }
 
-            if (ncolumns > 32) {
+            if (!zeropad && ncolumns > 32) {
                 vmovups(get_vmm(k, 0), vreg_idx_lo_128);
                 vpermi2q(get_vmm(k, 0), get_vmm(k, 1), get_vmm(k, 4));
                 vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base + 128),
@@ -2496,7 +2507,7 @@ private:
                         vmm_zero);
             }
 
-            if (ncolumns > 48) {
+            if (!zeropad && ncolumns > 48) {
                 vmovups(get_vmm(k, 2), vreg_idx_hi_128);
                 vpermi2q(get_vmm(k, 2), get_vmm(k, 1), get_vmm(k, 4));
                 vmovups(EVEX_compress_addr(reg_tr_src, tr_src_off_base + 192),
@@ -2533,7 +2544,7 @@ private:
             uni_vmovups(vmm_src, ptr[reg_src + offset]);
     }
 
-    void copy_4x64(int nrows, int ncolumns) override {
+    void copy_4x64(int nrows, int ncolumns, bool zeropad) override {
         const bool is_tail = ncolumns < n_blk_step_;
         const int k_end = div_up(nrows, k_blk_step_);
         for_(int k = 0; k < k_end; k++)
@@ -2545,39 +2556,44 @@ private:
                     = tr_src_off_base + pass * 2 * n_blk_step_;
             const int row_start = k * k_blk_step_;
             const int row_end = nstl::min(row_start + k_blk_step_, nrows);
-            for (int i = row_start; i < rnd_up(row_end, k_blk_step_); i++) {
-                const bool do_load = i < row_end
-                        && IMPLICATION(pass == 1, ncolumns >= simd_w_);
-                if (do_load) {
-                    const bool do_tail = is_tail
-                            && IMPLICATION(pass == 0, ncolumns < simd_w_);
-                    const auto offset
-                            = (is_dynamic_stride_ ? 0 : i * src_stride_)
-                            + pass * simd_w_;
-                    load_ymm(i % 4, offset, do_tail, ncolumns - pass * simd_w_);
-                    if (is_dynamic_stride_) add(reg_src, reg_src_stride);
-                } else {
-                    const auto src_ymm_1 = get_ymm(i % 4);
-                    uni_vpxor(src_ymm_1, src_ymm_1, src_ymm_1);
+            if (!zeropad) {
+                for (int i = row_start; i < rnd_up(row_end, k_blk_step_); i++) {
+                    const bool do_load = i < row_end
+                            && IMPLICATION(pass == 1, ncolumns >= simd_w_);
+                    if (do_load) {
+                        const bool do_tail = is_tail
+                                && IMPLICATION(pass == 0, ncolumns < simd_w_);
+                        const auto offset
+                                = (is_dynamic_stride_ ? 0 : i * src_stride_)
+                                + pass * simd_w_;
+                        load_ymm(i % 4, offset, do_tail,
+                                ncolumns - pass * simd_w_);
+                        if (is_dynamic_stride_) add(reg_src, reg_src_stride);
+                    } else {
+                        const auto src_ymm_1 = get_ymm(i % 4);
+                        uni_vpxor(src_ymm_1, src_ymm_1, src_ymm_1);
+                    }
                 }
+                if (pass == 0 && ncolumns >= simd_w_)
+                    mov(reg_src, reg_src_backup);
+
+                vpunpcklbw(get_ymm(4), get_ymm(0), get_ymm(1));
+                vpunpckhbw(get_ymm(5), get_ymm(0), get_ymm(1));
+                vpunpcklbw(get_ymm(0), get_ymm(2), get_ymm(3));
+                vpunpckhbw(get_ymm(1), get_ymm(2), get_ymm(3));
+
+                vpunpcklwd(get_ymm(2), get_ymm(4), get_ymm(0));
+                vpunpckhwd(get_ymm(3), get_ymm(4), get_ymm(0));
+                vpunpcklwd(get_ymm(4), get_ymm(5), get_ymm(1));
+                vpunpckhwd(get_ymm(5), get_ymm(5), get_ymm(1));
             }
-            if (pass == 0 && ncolumns >= simd_w_) mov(reg_src, reg_src_backup);
-
-            vpunpcklbw(get_ymm(4), get_ymm(0), get_ymm(1));
-            vpunpckhbw(get_ymm(5), get_ymm(0), get_ymm(1));
-            vpunpcklbw(get_ymm(0), get_ymm(2), get_ymm(3));
-            vpunpckhbw(get_ymm(1), get_ymm(2), get_ymm(3));
-
-            vpunpcklwd(get_ymm(2), get_ymm(4), get_ymm(0));
-            vpunpckhwd(get_ymm(3), get_ymm(4), get_ymm(0));
-            vpunpcklwd(get_ymm(4), get_ymm(5), get_ymm(1));
-            vpunpckhwd(get_ymm(5), get_ymm(5), get_ymm(1));
 
             auto get_accum
                     = [&](int idx) { return get_comp_acc(idx + pass * 4); };
 
-            if (IMPLICATION(
-                        pass == 1, ncolumns > 32)) { // check against {0, 32}
+            if (!zeropad
+                    && IMPLICATION(pass == 1,
+                            ncolumns > 32)) { // check against {0, 32}
                 vperm2i128(get_ymm(0), get_ymm(2), get_ymm(3), perm2i128_l);
                 vperm2i128(get_ymm(1), get_ymm(4), get_ymm(5), perm2i128_l);
                 uni_vmovups(ptr[reg_tr_src + set_1_tr_src_offset], get_ymm(0));
@@ -2597,7 +2613,7 @@ private:
 
             const int set_2_tr_src_offset = set_1_tr_src_offset + n_blk_step_;
             const int upper_check = 16 + pass * 32; // check against {16, 48}
-            if (ncolumns > upper_check) {
+            if (!zeropad && ncolumns > upper_check) {
                 vperm2i128(get_ymm(2), get_ymm(2), get_ymm(3), perm2i128_h);
                 vperm2i128(get_ymm(3), get_ymm(4), get_ymm(5), perm2i128_h);
                 uni_vmovups(ptr[reg_tr_src + set_2_tr_src_offset], get_ymm(2));
@@ -2631,7 +2647,6 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
     uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
     mov(reg_src, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
-    mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
     mov(reg_N_blk, ptr[param1 + GET_OFF(current_N_blk)]);
     if (is_dynamic_stride_) {
         mov(reg_src_stride, ptr[param1 + GET_OFF(dynamic_src_stride)]);
@@ -2647,33 +2662,33 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         uni_vpbroadcastb(vmm_comp_mul, reg_tmp.cvt8());
     }
 
-    auto compute_K_loop = [&](bool is_N_tail) {
+    auto compute_K_loop_body = [&](const reg64_t &reg_K, int ncolumns,
+                                       bool is_N_tail, bool zeropad) {
         const int k_unroll = 4;
-        int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
-
         Label K_loop_unrolled, K_loop_single, K_loop_tail_or_done;
-        cmp(reg_K_iters, k_unroll * k_blk_step_);
+        cmp(reg_K, k_unroll * k_blk_step_);
         jl(K_loop_single, T_NEAR);
 
         L(K_loop_unrolled);
-        copy_block(k_unroll * k_blk_step_, ncolumns, is_N_tail);
-        if (!is_dynamic_stride_)
+        copy_block(k_unroll * k_blk_step_, ncolumns, is_N_tail, zeropad);
+        if (!zeropad && !is_dynamic_stride_)
             add(reg_src, k_unroll * k_blk_step_ * src_stride_);
         add(reg_tr_src, k_unroll * tr_src_stride_);
 
-        sub(reg_K_iters, k_unroll * k_blk_step_);
-        cmp(reg_K_iters, k_unroll * k_blk_step_);
+        sub(reg_K, k_unroll * k_blk_step_);
+        cmp(reg_K, k_unroll * k_blk_step_);
         jge(K_loop_unrolled, T_NEAR);
 
         L(K_loop_single);
-        cmp(reg_K_iters, k_blk_step_);
+        cmp(reg_K, k_blk_step_);
         jl(K_loop_tail_or_done, T_NEAR);
 
-        copy_block(k_blk_step_, ncolumns, is_N_tail);
-        if (!is_dynamic_stride_) add(reg_src, k_blk_step_ * src_stride_);
+        copy_block(k_blk_step_, ncolumns, is_N_tail, zeropad);
+        if (!zeropad && !is_dynamic_stride_)
+            add(reg_src, k_blk_step_ * src_stride_);
         add(reg_tr_src, tr_src_stride_);
 
-        sub(reg_K_iters, k_blk_step_);
+        sub(reg_K, k_blk_step_);
         jmp(K_loop_single, T_NEAR);
 
         L(K_loop_tail_or_done);
@@ -2681,13 +2696,22 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         int k_blk_tail = conf_->K % k_blk_step_;
         if (k_blk_tail > 0) {
             Label K_loop_done;
-            cmp(reg_K_iters, 0);
+            cmp(reg_K, 0);
             jle(K_loop_done, T_NEAR);
 
-            copy_block(k_blk_tail, ncolumns, is_N_tail);
-            sub(reg_K_iters, k_blk_tail);
+            copy_block(k_blk_tail, ncolumns, is_N_tail, zeropad);
+            add(reg_tr_src, tr_src_stride_);
+            sub(reg_K, k_blk_tail);
             L(K_loop_done);
         }
+    };
+
+    auto compute_K_loop = [&](bool is_N_tail) {
+        int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
+        compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, false);
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+        compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, true);
     };
 
     Label done;
@@ -2945,8 +2969,8 @@ private:
         }
     }
     void load_data(const Vmm vmm_in, const Xbyak::Operand &op, bool is_tail);
-    void copy_block(int nrows, int ncolumns, bool n_tail);
-    void copy_2x32(int nrows, int ncolumns);
+    void copy_block(int nrows, int ncolumns, bool n_tail, bool zeropad);
+    void copy_2x32(int nrows, int ncolumns, bool zeropad);
     void init_masks();
     void generate() override;
 };
@@ -2989,7 +3013,8 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::load_data(
 }
 
 template <typename Vmm>
-void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(int nrows, int ncolumns) {
+void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
+        int nrows, int ncolumns, bool zeropad) {
 
     const int columns_tail = ncolumns % n_blk_step;
     if (columns_tail > 0 && columns_tail < n_blk_step) {
@@ -3077,7 +3102,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(int nrows, int ncolumns) {
             }
         }
 
-        if (ncolumns - n <= 0) {
+        if (ncolumns - n <= 0 || zeropad) {
             uni_vmovups(store_addr, vmm_zero);
             if (!is_superset(conf_->isa, avx512_core))
                 uni_vmovups(store_addr_ymm1, vmm_zero);
@@ -3146,9 +3171,9 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::init_masks() {
 
 template <typename Vmm>
 void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_block(
-        int nrows, int ncolumns, bool n_tail) {
+        int nrows, int ncolumns, bool n_tail, bool zeropad) {
     if (!is_dynamic_N || !n_tail) {
-        copy_2x32(nrows, ncolumns);
+        copy_2x32(nrows, ncolumns, zeropad);
         return;
     }
 
@@ -3169,7 +3194,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_block(
     {
         mov(ptr[rsp + reg_src_offs], reg_src);
         add(reg_src, reg_copy_block_n_shift);
-        copy_2x32(nrows, n_blk_step);
+        copy_2x32(nrows, n_blk_step, zeropad);
         add(reg_copy_block_n_shift, n_blk_step * typesize);
         add(reg_src, n_blk_step * typesize);
         add(reg_tr_src, n_blk_step * k_blk_step * tr_typesize);
@@ -3192,7 +3217,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_block(
         jle(loop_row_done, T_NEAR);
 
         add(reg_src, reg_copy_block_n_shift);
-        copy_2x32(nrows, 1 /* to force tail case */);
+        copy_2x32(nrows, 1 /* to force tail case */, zeropad);
     }
     L(loop_row_done);
 
@@ -3210,7 +3235,6 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
 
     mov(reg_src, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
-    mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
     mov(reg_N_blk, ptr[param1 + GET_OFF(current_N_blk)]);
     mov(reg_scales, ptr[param1 + GET_OFF(scales_ptr)]);
     if (is_dynamic_stride) {
@@ -3224,38 +3248,40 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
     }
 
     init_masks();
-    auto compute_K_loop = [&](bool is_N_tail) {
-        const int k_unroll = 8;
-        int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
 
+    auto compute_K_loop_body = [&](const reg64_t &reg_K, int ncolumns,
+                                       bool is_N_tail, bool zeropad) {
+        const int k_unroll = 8;
         Label K_loop_unrolled, K_loop_single, K_loop_tail_or_done;
-        cmp(reg_K_iters, k_unroll * k_blk_step);
+
+        cmp(reg_K, k_unroll * k_blk_step);
         jl(K_loop_single, T_NEAR);
 
         L(K_loop_unrolled);
-        copy_block(k_unroll * k_blk_step, ncolumns, is_N_tail);
+        copy_block(k_unroll * k_blk_step, ncolumns, is_N_tail, zeropad);
 
-        if (!is_dynamic_stride)
+        if (!zeropad && !is_dynamic_stride)
             add(reg_src, (k_unroll * k_blk_step * src_stride) / typesize_scale);
-        if (req_apply_scales)
+        if (!zeropad && req_apply_scales)
             add(reg_scales, k_unroll * k_blk_step * scales_N_stride);
         add(reg_tr_src, k_unroll * tr_src_stride);
 
-        sub(reg_K_iters, k_unroll * k_blk_step);
-        cmp(reg_K_iters, k_unroll * k_blk_step);
+        sub(reg_K, k_unroll * k_blk_step);
+        cmp(reg_K, k_unroll * k_blk_step);
         jge(K_loop_unrolled, T_NEAR);
 
         L(K_loop_single);
-        cmp(reg_K_iters, k_blk_step);
+        cmp(reg_K, k_blk_step);
         jl(K_loop_tail_or_done, T_NEAR);
 
-        copy_block(k_blk_step, ncolumns, is_N_tail);
-        if (!is_dynamic_stride)
+        copy_block(k_blk_step, ncolumns, is_N_tail, zeropad);
+        if (!zeropad && !is_dynamic_stride)
             add(reg_src, (k_blk_step * src_stride) / typesize_scale);
-        if (req_apply_scales) add(reg_scales, k_blk_step * scales_N_stride);
+        if (!zeropad && req_apply_scales)
+            add(reg_scales, k_blk_step * scales_N_stride);
         add(reg_tr_src, tr_src_stride);
 
-        sub(reg_K_iters, k_blk_step);
+        sub(reg_K, k_blk_step);
         jmp(K_loop_single, T_NEAR);
 
         L(K_loop_tail_or_done);
@@ -3263,13 +3289,22 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
         int k_blk_tail = conf_->K % k_blk_step;
         if (k_blk_tail > 0) {
             Label K_loop_done;
-            cmp(reg_K_iters, 0);
+            cmp(reg_K, 0);
             jle(K_loop_done, T_NEAR);
 
-            copy_block(k_blk_tail, ncolumns, is_N_tail);
-            sub(reg_K_iters, k_blk_tail);
+            copy_block(k_blk_tail, ncolumns, is_N_tail, zeropad);
+            add(reg_tr_src, tr_src_stride);
+            sub(reg_K, k_blk_tail);
             L(K_loop_done);
         }
+    };
+
+    auto compute_K_loop = [&](bool is_N_tail) {
+        int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
+        compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, false);
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+        compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, true);
     };
 
     Label done;
@@ -4542,7 +4577,7 @@ private:
     void load_int(const Vmm vmm_in, const Xbyak::Operand &op);
     void get_scales(const int blk, const int k, const int n,
             const bool is_n_tail, const bool is_k_tail);
-    void copy_block(const int nrows, const int ncolumns);
+    void copy_block(const int nrows, const int ncolumns, bool zeropad);
     void generate() override;
 };
 
@@ -4621,7 +4656,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::get_scales(const int blk,
 
 template <typename Vmm>
 void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
-        const int nrows, int ncolumns) {
+        const int nrows, int ncolumns, bool zeropad) {
     const int columns_tail = ncolumns % n_blk_step;
     if (columns_tail > 0 && columns_tail < n_blk_step) {
         const auto regw_tmp = reg_tmp.cvt32();
@@ -4681,8 +4716,12 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
                 = maybe_EVEX_compress_addr(reg_tr_src, tr_src_off);
         const int blk_idx = iter % max_unroll;
 
-        load(blk_idx, k, n);
-        uni_vmovups(store_addr, get_vmm(blk_idx, 0));
+        const auto store_vmm = get_vmm(blk_idx, 0);
+        if (zeropad)
+            uni_vpxor(store_vmm, store_vmm, store_vmm);
+        else
+            load(blk_idx, k, n);
+        uni_vmovups(store_addr, store_vmm);
 
         iter++;
     }
@@ -4697,7 +4736,6 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
 
     mov(reg_src, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
-    mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
     mov(reg_N_blk, ptr[param1 + GET_OFF(current_N_blk)]);
     mov(reg_scales, ptr[param1 + GET_OFF(scales_ptr)]);
 
@@ -4706,48 +4744,58 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
         uni_vpbroadcastd(vmm_zp_b_val, ptr[reg_tmp]);
     }
 
+    auto compute_K_loop_body
+            = [&](const reg64_t &reg_K, int ncolumns, bool zeropad) {
+                  const int k_unroll = 8;
+
+                  Label K_loop_unrolled, K_loop_single, K_loop_tail_or_done;
+                  cmp(reg_K, k_unroll * k_blk_step);
+                  jl(K_loop_single, T_NEAR);
+
+                  L(K_loop_unrolled);
+                  copy_block(k_unroll * k_blk_step, ncolumns, zeropad);
+                  add(reg_src, k_unroll * src_stride_);
+                  add(reg_tr_src, k_unroll * tr_src_stride_);
+                  if (req_apply_scales_)
+                      add(reg_scales, k_unroll * k_blk_step * scales_N_stride_);
+
+                  sub(reg_K, k_unroll * k_blk_step);
+                  cmp(reg_K, k_unroll * k_blk_step);
+                  jge(K_loop_unrolled, T_NEAR);
+
+                  L(K_loop_single);
+                  cmp(reg_K, k_blk_step);
+                  jl(K_loop_tail_or_done, T_NEAR);
+
+                  copy_block(k_blk_step, ncolumns, zeropad);
+                  add(reg_src, src_stride_);
+                  add(reg_tr_src, tr_src_stride_);
+                  if (req_apply_scales_)
+                      add(reg_scales, k_blk_step * scales_N_stride_);
+
+                  sub(reg_K, k_blk_step);
+                  jmp(K_loop_single, T_NEAR);
+
+                  L(K_loop_tail_or_done);
+
+                  const int k_blk_tail = conf_->K % k_blk_step;
+                  if (k_blk_tail > 0) {
+                      Label K_loop_done;
+                      cmp(reg_K, 0);
+                      jle(K_loop_done, T_NEAR);
+
+                      copy_block(k_blk_tail, ncolumns, zeropad);
+                      add(reg_tr_src, tr_src_stride_);
+                      sub(reg_K, k_blk_tail);
+                      L(K_loop_done);
+                  }
+              };
+
     auto compute_K_loop = [&](const int ncolumns) {
-        const int k_unroll = 8;
-
-        Label K_loop_unrolled, K_loop_single, K_loop_tail_or_done;
-        cmp(reg_K_iters, k_unroll * k_blk_step);
-        jl(K_loop_single, T_NEAR);
-
-        L(K_loop_unrolled);
-        copy_block(k_unroll * k_blk_step, ncolumns);
-        add(reg_src, k_unroll * src_stride_);
-        add(reg_tr_src, k_unroll * tr_src_stride_);
-        if (req_apply_scales_)
-            add(reg_scales, k_unroll * k_blk_step * scales_N_stride_);
-
-        sub(reg_K_iters, k_unroll * k_blk_step);
-        cmp(reg_K_iters, k_unroll * k_blk_step);
-        jge(K_loop_unrolled, T_NEAR);
-
-        L(K_loop_single);
-        cmp(reg_K_iters, k_blk_step);
-        jl(K_loop_tail_or_done, T_NEAR);
-
-        copy_block(k_blk_step, ncolumns);
-        add(reg_src, src_stride_);
-        add(reg_tr_src, tr_src_stride_);
-        if (req_apply_scales_) add(reg_scales, k_blk_step * scales_N_stride_);
-
-        sub(reg_K_iters, k_blk_step);
-        jmp(K_loop_single, T_NEAR);
-
-        L(K_loop_tail_or_done);
-
-        const int k_blk_tail = conf_->K % k_blk_step;
-        if (k_blk_tail > 0) {
-            Label K_loop_done;
-            cmp(reg_K_iters, 0);
-            jle(K_loop_done, T_NEAR);
-
-            copy_block(k_blk_tail, ncolumns);
-            sub(reg_K_iters, k_blk_tail);
-            L(K_loop_done);
-        }
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
+        compute_K_loop_body(reg_K_iters, ncolumns, false);
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+        compute_K_loop_body(reg_K_iters, ncolumns, true);
     };
 
     Label done;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ struct jit_brgemm_matmul_copy_b_t {
 
         dim_t current_K_start;
         dim_t current_K_iters;
+        dim_t current_K_pad {0};
         dim_t current_N_blk;
         dim_t dynamic_src_stride;
     };

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -512,6 +512,8 @@ struct matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
         , k_blk_(0)
         , k_chunk_size_(0)
         , k_chunk_elems_(0)
+        , use_buffer_a_(false)
+        , extendable_k_(false)
         , current_lda_(0)
         , need_buf_c_(false)
         , blocking_chunk_mem_size_(0)
@@ -531,6 +533,8 @@ struct matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
         , k_blk_(K_blk)
         , k_chunk_size_(brgemm_batch_size)
         , k_chunk_elems_(k_blk_ * k_chunk_size_)
+        , use_buffer_a_(use_buffer_a)
+        , extendable_k_(extendable_k)
         , current_lda_(LDA)
         , need_buf_c_(use_buffer_c)
         , blocking_chunk_mem_size_(0)
@@ -552,6 +556,9 @@ private:
     dim_t n_blk_, n_chunk_size_, n_chunk_elems_;
     dim_t m_blk_, m_chunk_size_, m_chunk_elems_;
     dim_t k_blk_, k_chunk_size_, k_chunk_elems_;
+
+    bool use_buffer_a_;
+    bool extendable_k_;
 
     dim_t current_lda_;
     bool need_buf_c_;
@@ -1146,6 +1153,7 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
         // AMX BRGEMM kernel requires (K_brgemm % 64 == 0 || K_brgemm < 64)
         // for K_brgemm reduction value to avoid AMX tiles re-configuration.
         // To satisfy this condition K_tail value is fixed to K % wei_k_blk here.
+
         const bool fixed_K_tail_size
                 = bgmmc.K % bgmmc.wei_k_blk > 0 && bgmmc.K > bgmmc.wei_k_blk;
         bgmmc.K_blk = bgmmc.K < bgmmc.wei_k_blk
@@ -1527,10 +1535,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     if (bgmmc.is_amx && bm_conf_utils.is_int8())
         prefer_copy_a &= bgmmc.N >= 256;
 
-    const bool is_copy_a_required
-            = (bgmmc.is_amx
-                      && ((bgmmc.K % bgmmc.required_k_granularity != 0)
-                              || bm_conf_utils.is_bf32()))
+    const bool is_copy_a_required = (bgmmc.is_amx && bm_conf_utils.is_bf32())
             || ((bm_conf_utils.is_f16() || bm_conf_utils.is_f16_with_int_wei())
                     && isa == avx512_core_fp16)
             || (bgmmc.wei_zp_type != brgemm_broadcast_t::none
@@ -1601,7 +1606,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.M_tail = bgmmc.is_runtime_M ? 0 : bgmmc.M % bgmmc.M_blk;
     bgmmc.N_tail = bgmmc.is_runtime_N ? 0 : bgmmc.N % bgmmc.N_blk;
     bgmmc.K_tail = bgmmc.K > bgmmc.K_blk
-            ? rnd_up(bgmmc.K % bgmmc.K_blk, bgmmc.required_k_granularity)
+            ? (bgmmc.extendable_k ? bgmmc.K % bgmmc.K_blk
+                                  : rnd_up(bgmmc.K % bgmmc.K_blk,
+                                          bgmmc.required_k_granularity))
             : 0;
 
     bgmmc.LDB = bm_conf_utils.get_actual_LDB();
@@ -1979,16 +1986,32 @@ void matmul_amx_blocking_params_t::set_blocking_parameters(
                     : kc1;
         }
 
+        k_chunk_elems_ = k_blk_ * k_chunk_size_;
+
         const dim_t current_k_tail = K % k_blk_;
-        if (current_k_tail == 0 && K % (k_blk_ * k_chunk_size_) == 0) {
-            k_blk_ *= k_chunk_size_;
+
+        extendable_k_
+                = !use_buffer_a && K % wei_k_blk && k_chunk_elems_ > wei_k_blk;
+
+        if (extendable_k_) {
+            if (k_chunk_elems_ >= K) {
+                k_blk_ = K;
+                k_chunk_size_ = 1;
+            } else {
+                k_blk_ = k_chunk_elems_;
+                k_chunk_size_ = 1;
+            }
+        } else if (current_k_tail == 0 && K % (k_blk_ * k_chunk_size_) == 0) {
+            k_blk_ = k_chunk_elems_;
             k_chunk_size_ = 1;
         } else if (nthr_k_ == 1
                 && K == k_blk_ * k_chunk_size_ + current_k_tail) {
-            k_blk_ *= k_chunk_size_;
+            k_blk_ = k_chunk_elems_;
             k_chunk_size_ = 2;
         }
     }
+    use_buffer_a_
+            = use_buffer_a || (!extendable_k_ && K % required_k_granularity);
 
     blocking_chunk_mem_size_ = calculate_chunk_memory_size();
 
@@ -2031,7 +2054,7 @@ float matmul_amx_blocking_params_t::get_copied_data_reusage_scores() {
     const dim_t desired_M_chunk_size = is_runtime_M
             ? effective_m_chunk_sz
             : nstl::min(M, effective_m_chunk_sz);
-    const dim_t effective_n_chunk_sz = 64 * (use_buffer_a ? 4 : 1);
+    const dim_t effective_n_chunk_sz = 64 * (use_buffer_a_ ? 4 : 1);
     const dim_t desired_N_chunk_size = is_runtime_N
             ? effective_n_chunk_sz
             : nstl::min(N, effective_n_chunk_sz);
@@ -2091,10 +2114,12 @@ void matmul_amx_blocking_params_t::update_configuration(
 
     bgmmc.use_buffer_c = need_buf_c_;
     bgmmc.LDA = current_lda_;
+    bgmmc.use_buffer_a = use_buffer_a_;
+    bgmmc.extendable_k = extendable_k_;
 }
 
 dim_t matmul_amx_blocking_params_t::get_actual_lda() {
-    if (!use_buffer_a)
+    if (!use_buffer_a_)
         return treat_transposed_A_as_plain
                 ? K
                 : A_strides[1 - transposed_A] / a_dt_sz;
@@ -2118,7 +2143,7 @@ size_t matmul_amx_blocking_params_t::calculate_chunk_memory_size() {
     update_k_blocking_dependent_params();
 
     size_t A_chunk_sz = a_dt_sz * k_chunk_elems_ * m_chunk_elems_;
-    size_t A_buf_sz = use_buffer_a
+    size_t A_buf_sz = use_buffer_a_
             ? tr_a_dt_sz * current_lda_ * k_chunk_size_ * m_chunk_elems_
             : 0;
     size_t B_chunk_sz = b_dt_sz * k_chunk_elems_ * n_chunk_elems_;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -201,6 +201,8 @@ struct brgemm_matmul_conf_t {
     bool is_oscale_per_n = false;
     bool is_oscale_per_k = false;
     bool apply_scales_in_buffer_b = false;
+    bool extendable_k = false;
+
     inline bool lda_big_pow2() const {
         const dim_t big_stride_threshold_in_bytes = 8192;
         const dim_t big_K_threshold = big_stride_threshold_in_bytes / a_dt_sz;

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -135,7 +135,8 @@ dnnl_status_t brgemm_attr_init(
         PROCESS_KEY_VAL(hint_expected_A_size);
         PROCESS_KEY_VAL(hint_expected_B_size);
         PROCESS_KEY_VAL(hint_expected_C_size);
-        PROCESS_KEY_VAL(wary_tail_read);
+        PROCESS_KEY_VAL(wary_A_k_tail_read);
+        PROCESS_KEY_VAL(extendable_k);
         PROCESS_KEY_VAL(generate_skip_accumulation);
         // TODO: `bd_mask` can't be passed to the kernel at this moment, that's
         // why `bd_mask_level` has to stay `0` for now until it's enabled.


### PR DESCRIPTION
There are two problems regarding brgemm K value on AMX:

brgemm doesn't support K not divisible by vnni granularity
for K not divisible by tile width (32 or 64) the blocking by K dimension may be not optimal.
To get around this limitation brgemm primitives are forced to either transform the matrix A or call many small brgemm kernels with different tile configurations. Both ways leads to performance lost.
This PR implements support of arbitrary K in brgemm on AMX and implements corresponding updates in 1x1 convolutions and in matmul to use this new ability.

Performance update for convolutions:
![image](https://github.com/user-attachments/assets/53ca1011-d9da-4be2-b76a-066100c44084)


Performance update for matmul
![image](https://github.com/user-attachments/assets/3c8a4ae6-7bc2-4390-9db5-7753639605e4)

