### PR TITLE
common: verbose: fix acc-mode option dump and softmax diff_dst dump (fixes MFDNN-12921)

### DIFF
--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -216,7 +216,7 @@ class Converter(metaclass=ConverterMeta):
 
     scratchpad_mode = attribute_flag("scratchpad")
     fpmath_mode = attribute_flag("fpmath")
-    acc_mode = attribute_flag("acc")
+    acc_mode = attribute_flag("acc_mode")
 
     @property
     def dropout(self):

--- a/scripts/verbose_converter/src/ir.py
+++ b/scripts/verbose_converter/src/ir.py
@@ -319,7 +319,7 @@ class RoundingMode(CompositeAttribute, enum.Enum):
 
 
 Attribute = Union[
-    str,  # acc, etc
+    str,  # acc-mode, etc
     FPMathMode,
     Dropout,
     List[PostOp],
@@ -371,7 +371,7 @@ class Attributes(Mapping):
     def __len__(self):
         return len(self._attributes)
 
-    acc = attribute_accessor("acc")
+    acc_mode = attribute_accessor("acc-mode")
     deterministic = attribute_accessor("deterministic")
     dropout = attribute_accessor("dropout")
     fpmath = attribute_accessor("fpmath")

--- a/scripts/verbose_converter/src/parse.py
+++ b/scripts/verbose_converter/src/parse.py
@@ -267,7 +267,7 @@ class ParserImpl:
             name, args = spec.read_str(), ""
             if spec.read_literal(":"):
                 args = spec.buf
-            if name == "attr-acc":
+            if name == "attr-acc-mode":
                 parsed[name] = self.parse_acc_mode(args)
             elif name == "attr-deterministic":
                 parsed[name] = self.parse_deterministic(args)
@@ -275,6 +275,7 @@ class ParserImpl:
                 parsed[name] = self.parse_dropout(args)
             elif name == "attr-fpmath":
                 parsed[name] = self.parse_fpmath_mode(args)
+            # Kept for compatibility with v2.7 and below.
             elif name == "attr-oscale":
                 parsed[name] = self.parse_oscale(args)
             elif name == "attr-post-ops":

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -728,7 +728,8 @@ std::ostream &operator<<(std::ostream &ss, const primitive_attr_t *attr) {
 
     const accumulation_mode_t &am = attr->acc_mode_;
     if (am != accumulation_mode::strict) {
-        ss << field_delim() << "attr-acc:" << dnnl_accumulation_mode2str(am);
+        ss << field_delim()
+           << "attr-acc-mode:" << dnnl_accumulation_mode2str(am);
     }
 
     const auto &rm = attr->rounding_mode_;
@@ -1569,8 +1570,9 @@ std::string init_info_softmax(const engine_t *e, const pd_t *pd) {
        << " ";
     ss << md2fmt_str("dst", dst_md, pd->dst_md(0, true)->format_kind);
     if (!types::is_zero_md(diff_dst_md)) {
-        ss << md2fmt_str(
-                "diff_dst", diff_dst_md, pd->diff_dst_md(0, true)->format_kind);
+        ss << " "
+           << md2fmt_str("diff_dst", diff_dst_md,
+                      pd->diff_dst_md(0, true)->format_kind);
     }
 
     ss << "," << pd->attr() << ",";


### PR DESCRIPTION
MFDNN-12921

Turned out the option was named incorrectly in the script. Pulled out some consecutive changes on top of that.