### PR TITLE
Fix for issue with generated CMake config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,66 +16,6 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-# Use INTERFACE_LINK_LIBRARIES as the source of the link interface
-if(POLICY CMP0022)
-    cmake_policy(SET CMP0022 NEW)
-endif()
-
-# Do not mix INTERFACE_LINK_LIBRARIES signatures
-if(POLICY CMP0023)
-    cmake_policy(SET CMP0023 NEW)
-endif()
-
-# Compiler id for Apple's Clang is now AppleClang
-if(POLICY CMP0025)
-    cmake_policy(SET CMP0025 NEW)
-endif()
-
-# Foo::Bar always refers to an IMPORTED target
-if(POLICY CMP0028)
-    cmake_policy(SET CMP0028 NEW)
-endif()
-
-# Enable RPATH on MacOS/OSX
-if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 NEW)
-endif()
-
-# The project() command manages VERSION variables
-if(POLICY CMP0042)
-    cmake_policy(SET CMP0048 NEW)
-endif()
-
-# Interpret unquoted if() arguments as variables or keywords
-if(POLICY CMP0054)
-    cmake_policy(SET CMP0054 NEW)
-endif()
-
-# Pass linker flags to try_compile
-if(POLICY CMP0056)
-    cmake_policy(SET CMP0056 NEW)
-endif()
-
-# Always link with full path
-if(POLICY CMP0060)
-    cmake_policy(SET CMP0060 NEW)
-endif()
-
-# Do not export symbols from executables
-if(POLICY CMP0065)
-    cmake_policy(SET CMP0065 NEW)
-endif()
-
-# Pass compiler flags to try_compile
-if(POLICY CMP0066)
-    cmake_policy(SET CMP0066 NEW)
-endif()
-
-# Use <PackageName>_ROOT env. variable as a prefix
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
 # Install rules order
 if(POLICY CMP0082)
     cmake_policy(SET CMP0082 NEW)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -142,6 +142,14 @@ macro(append_to_windows_path_list path_list path)
     endif()
 endmacro()
 
+# Strip paths from libraries before populating INSTALL_INTERFACE
+function(target_link_libraries_install target list)
+    foreach(lib ${list})
+        get_filename_component(base "${lib}" NAME)
+        target_link_libraries(${target} PUBLIC "$<INSTALL_INTERFACE:${base}>")
+    endforeach(lib)
+endfunction()
+
 function(find_libm var)
     if(UNIX)
         find_library(${var} m REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,9 +209,9 @@ target_include_directories(${LIB_PACKAGE_NAME} PUBLIC
     )
 
 target_link_libraries(${LIB_PACKAGE_NAME} PUBLIC "$<BUILD_INTERFACE:${EXTRA_SHARED_LIBS};${EXTRA_STATIC_LIBS}>")
-target_link_libraries(${LIB_PACKAGE_NAME} PUBLIC "$<INSTALL_INTERFACE:${EXTRA_SHARED_LIBS}>")
+target_link_libraries_install(${LIB_PACKAGE_NAME} "${EXTRA_SHARED_LIBS}")
 if(DNNL_LIBRARY_TYPE STREQUAL "STATIC")
-    target_link_libraries(${LIB_PACKAGE_NAME} PUBLIC "$<INSTALL_INTERFACE:${EXTRA_STATIC_LIBS}>")
+    target_link_libraries_install(${LIB_PACKAGE_NAME} "${EXTRA_STATIC_LIBS}")
 endif()
 
 set(LIB_EXPORT_NAME "${LIB_PACKAGE_NAME}-targets")


### PR DESCRIPTION
This PR is a follow up to #2225 including two changes:
* Restored `target_link_libraries_install` function to strip paths from libraries that end up in CMake config.
* Removes CMake policy settings [redundant for version 3.13](https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-13).

Fixes MFDNN-12931.

