### PR TITLE
build: cmake: remove old cmake policies for examples and tests

### DIFF
--- a/examples/CMakeLists.txt.in
+++ b/examples/CMakeLists.txt.in
@@ -28,16 +28,6 @@ project (DNNL_EXAMPLES)
 set(DNNL_CPU_RUNTIME "@DNNL_CPU_RUNTIME@")
 set(DNNL_GPU_RUNTIME "@DNNL_GPU_RUNTIME@")
 
-# link_directories() are relative to the source dir
-if(POLICY CMP0015)
-    cmake_policy(SET CMP0015 NEW)
-endif()
-
-# Use <PackageName>_ROOT env. variable as a prefix
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
 set(DNNL_INSTALL_MODE "@DNNL_INSTALL_MODE@")
 set(IS_NEW_DIR_LAYOUT FALSE)
 if(DNNL_INSTALL_MODE STREQUAL "BUNDLE_V2")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,11 +18,6 @@ if (NOT DNNL_BUILD_TESTS)
     return()
 endif()
 
-# Do not export symbols from executables
-if(POLICY CMP0065)
-    cmake_policy(SET CMP0065 NEW)
-endif()
-
 # propagate TEST specific flags
 append(CMAKE_C_FLAGS "${CMAKE_TEST_CCXX_FLAGS}")
 append(CMAKE_CXX_FLAGS "${CMAKE_TEST_CCXX_FLAGS}")


### PR DESCRIPTION
Remove redundant policies setting in examples and tests CMakeLists.txt after moving to CMake 3.13.