### PR TITLE
build: enabled __cplusplus preprocessor macro for MSVC compiler

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -138,6 +138,8 @@ if(MSVC)
         append(CMAKE_CCXX_FLAGS "/Zc:preprocessor")
         # Set UTF-8 as default encoding to be consistent with other compilers
         append(CMAKE_CCXX_FLAGS "/utf-8")
+        # Enable __cplusplus macro to align behavior with other compilers
+        append(CMAKE_CCXX_FLAGS "/Zc:__cplusplus")
         # int64_t -> int (tent)
         append(CMAKE_CCXX_NOWARN_FLAGS "/wd4244")
         # workaround: macro outputs defined token in msvs header


### PR DESCRIPTION
MSVC does not define __cplusplus macro by default. This results in oneDNN failing to build with C++ 17 and C++ 20 flags.

Reference: https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170

Fixes MFDNN-12942.
