### PR TITLE
xe: enable source code information for OpenCL kernels

### DIFF
--- a/cmake/gen_gpu_kernel.cmake
+++ b/cmake/gen_gpu_kernel.cmake
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2019-2024 Intel Corporation
+# Copyright 2019-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,14 +22,17 @@
 
 file(READ ${CL_FILE} cl_file_lines)
 
-# Remove C++ style comments
-string(REGEX REPLACE "//[^\n]*\n" "\n" cl_file_lines "${cl_file_lines}")
-# Remove repeated whitespaces
-string(REGEX REPLACE " +" " " cl_file_lines "${cl_file_lines}")
-# Remove leading whitespaces
-string(REGEX REPLACE "\n " "\n" cl_file_lines "${cl_file_lines}")
-# Remove empty lines
-string(REGEX REPLACE "\n+" "\n" cl_file_lines "${cl_file_lines}")
+string(LENGTH "${cl_file_lines}" len)
+if(MINIFY OR len GREATER 65535)
+    # Remove C++ style comments
+    string(REGEX REPLACE "//[^\n]*\n" "\n" cl_file_lines "${cl_file_lines}")
+    # Remove repeated whitespaces
+    string(REGEX REPLACE " +" " " cl_file_lines "${cl_file_lines}")
+    # Remove leading whitespaces
+    string(REGEX REPLACE "\n " "\n" cl_file_lines "${cl_file_lines}")
+    # Remove empty lines
+    string(REGEX REPLACE "\n+" "\n" cl_file_lines "${cl_file_lines}")
+endif()
 
 string(LENGTH "${cl_file_lines}" len)
 if(len GREATER 65535)

--- a/cmake/gen_gpu_kernel_list.cmake
+++ b/cmake/gen_gpu_kernel_list.cmake
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2020-2021 Intel Corporation
+# Copyright 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,11 @@ endfunction()
 function(gen_gpu_kernel_list ker_list_templ ker_list_src ker_sources headers)
     set(_sources "${SOURCES}")
 
+    set(MINIFY "ON")
+    if(DNNL_DEV_MODE OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(MINIFY "OFF")
+    endif()
+
     set(KER_LIST_EXTERN)
     set(KER_LIST_ENTRIES)
     set(KER_HEADERS_EXTERN)
@@ -62,6 +67,7 @@ function(gen_gpu_kernel_list ker_list_templ ker_list_src ker_sources headers)
             COMMAND ${CMAKE_COMMAND}
                 -DCL_FILE="${header_path}"
                 -DGEN_FILE="${gen_file}"
+                -DMINIFY="${MINIFY}"
                 -P ${PROJECT_SOURCE_DIR}/cmake/gen_gpu_kernel.cmake
             DEPENDS ${header_path}
         )
@@ -81,6 +87,7 @@ function(gen_gpu_kernel_list ker_list_templ ker_list_src ker_sources headers)
             COMMAND ${CMAKE_COMMAND}
                 -DCL_FILE="${ker_path}"
                 -DGEN_FILE="${gen_file}"
+                -DMINIFY="${MINIFY}"
                 -P ${PROJECT_SOURCE_DIR}/cmake/gen_gpu_kernel.cmake
             DEPENDS ${ker_path}
         )

--- a/src/gpu/intel/compute/compute_engine.hpp
+++ b/src/gpu/intel/compute/compute_engine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -72,7 +72,8 @@ public:
     }
 
     virtual status_t create_kernel_from_binary(compute::kernel_t &kernel,
-            const xpu::binary_t &binary, const char *kernel_name) const = 0;
+            const xpu::binary_t &binary, const char *kernel_name,
+            const program_src_t &src) const = 0;
 
     virtual status_t create_kernels_from_cache_blob(
             const cache_blob_t &cache_blob,

--- a/src/gpu/intel/ocl/ocl_gpu_engine.cpp
+++ b/src/gpu/intel/ocl/ocl_gpu_engine.cpp
@@ -269,16 +269,6 @@ status_t ocl_gpu_engine_t::build_program_from_source(
     return status::success;
 }
 
-status_t ocl_gpu_engine_t::create_binary_from_ocl_source(xpu::binary_t &binary,
-        const char *code_string,
-        const compute::kernel_ctx_t &kernel_ctx) const {
-    xpu::ocl::wrapper_t<cl_program> program;
-    CHECK(build_program_from_source(program, code_string, kernel_ctx));
-
-    CHECK(get_ocl_program_binary(program, device(), binary));
-    return status::success;
-}
-
 status_t ocl_gpu_engine_t::create_kernel_from_binary(compute::kernel_t &kernel,
         const xpu::binary_t &binary, const char *kernel_name) const {
     xpu::ocl::wrapper_t<cl_program> program;

--- a/src/gpu/intel/ocl/ocl_gpu_engine.hpp
+++ b/src/gpu/intel/ocl/ocl_gpu_engine.hpp
@@ -47,10 +47,6 @@ public:
     status_t create_stream(
             impl::stream_t **stream, impl::stream_impl_t *stream_impl) override;
 
-    status_t create_binary_from_ocl_source(xpu::binary_t &binary,
-            const char *code_string,
-            const compute::kernel_ctx_t &kernel_ctx) const;
-
     status_t create_kernel_from_binary(compute::kernel_t &kernel,
             const xpu::binary_t &binary,
             const char *kernel_name) const override;

--- a/src/gpu/intel/ocl/ocl_gpu_engine.hpp
+++ b/src/gpu/intel/ocl/ocl_gpu_engine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,8 +48,8 @@ public:
             impl::stream_t **stream, impl::stream_impl_t *stream_impl) override;
 
     status_t create_kernel_from_binary(compute::kernel_t &kernel,
-            const xpu::binary_t &binary,
-            const char *kernel_name) const override;
+            const xpu::binary_t &binary, const char *kernel_name,
+            const compute::program_src_t &src) const override;
 
     status_t create_kernels_from_cache_blob(const cache_blob_t &cache_blob,
             std::vector<compute::kernel_t> &kernels,
@@ -64,7 +64,8 @@ public:
 
     static status_t create_kernels_from_program(
             std::vector<compute::kernel_t> *kernels,
-            const std::vector<const char *> &kernel_names, cl_program program);
+            const std::vector<const char *> &kernel_names, cl_program program,
+            const compute::program_src_t &src);
 
     const impl_list_item_t *get_concat_implementation_list() const override {
         return gpu_impl_list_t::get_concat_implementation_list();
@@ -100,6 +101,7 @@ public:
     }
 
     status_t create_program(xpu::ocl::wrapper_t<cl_program> &program,
+            compute::program_src_t &src,
             const std::vector<const char *> &kernel_names,
             const compute::kernel_ctx_t &kernel_ctx) const;
 
@@ -111,7 +113,7 @@ protected:
     }
 
     status_t build_program_from_source(xpu::ocl::wrapper_t<cl_program> &program,
-            const char *code_string,
+            compute::program_src_t &src, const char *code_string,
             const compute::kernel_ctx_t &kernel_ctx) const;
 
     ~ocl_gpu_engine_t() override = default;

--- a/src/gpu/intel/ocl/ocl_gpu_kernel.cpp
+++ b/src/gpu/intel/ocl/ocl_gpu_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -111,9 +111,11 @@ private:
 };
 
 ocl_gpu_kernel_t::ocl_gpu_kernel_t(xpu::ocl::wrapper_t<cl_kernel> &&ocl_kernel,
-        const std::vector<gpu::intel::compute::scalar_type_t> &arg_types)
+        const std::vector<gpu::intel::compute::scalar_type_t> &arg_types,
+        compute::program_src_t src)
     : ocl_kernel_(std::move(ocl_kernel))
     , arg_types_(arg_types)
+    , src_(std::move(src))
     , save_events_(false) {
     cache_ = std::make_shared<ocl_gpu_kernel_cache_t>(ocl_kernel_);
 }

--- a/src/gpu/intel/ocl/ocl_gpu_kernel.hpp
+++ b/src/gpu/intel/ocl/ocl_gpu_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,7 +35,8 @@ class ocl_gpu_kernel_cache_t;
 class ocl_gpu_kernel_t : public compute::kernel_impl_t {
 public:
     ocl_gpu_kernel_t(xpu::ocl::wrapper_t<cl_kernel> &&ocl_kernel,
-            const std::vector<gpu::intel::compute::scalar_type_t> &arg_types);
+            const std::vector<gpu::intel::compute::scalar_type_t> &arg_types,
+            compute::program_src_t src);
     ~ocl_gpu_kernel_t() override = default;
 
     cl_kernel ocl_kernel() const { return ocl_kernel_; }
@@ -59,11 +60,13 @@ public:
 
     status_t dump() const override;
     std::string name() const override;
+    const compute::program_src_t &src() const { return src_; }
 
 private:
     xpu::ocl::wrapper_t<cl_kernel> ocl_kernel_;
     std::vector<gpu::intel::compute::scalar_type_t> arg_types_;
     std::shared_ptr<ocl_gpu_kernel_cache_t> cache_;
+    compute::program_src_t src_;
     bool save_events_;
 };
 

--- a/src/gpu/intel/sycl/sycl_interop_gpu_kernel.hpp
+++ b/src/gpu/intel/sycl/sycl_interop_gpu_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,8 +29,9 @@ namespace sycl {
 
 class sycl_interop_gpu_kernel_t : public gpu::intel::compute::kernel_impl_t {
 public:
-    sycl_interop_gpu_kernel_t(std::unique_ptr<::sycl::kernel> &&sycl_kernel)
-        : sycl_kernel_(std::move(sycl_kernel)) {}
+    sycl_interop_gpu_kernel_t(std::unique_ptr<::sycl::kernel> &&sycl_kernel,
+            gpu::intel::compute::program_src_t src)
+        : sycl_kernel_(std::move(sycl_kernel)), src_(src) {}
 
     ::sycl::kernel sycl_kernel() const { return *sycl_kernel_; }
 
@@ -48,10 +49,12 @@ public:
     std::string name() const override {
         return sycl_kernel_->get_info<::sycl::info::kernel::function_name>();
     }
+    const compute::program_src_t &src() const { return src_; }
 
 private:
     std::unique_ptr<::sycl::kernel> sycl_kernel_;
     std::vector<gpu::intel::compute::scalar_type_t> arg_types_;
+    gpu::intel::compute::program_src_t src_;
 };
 
 } // namespace sycl


### PR DESCRIPTION
As the difficult case for handling nGEN was already handled in #2297, it seems only fitting to enable debug information in the simpler case where we use OpenCL C kernels. This PR limits the scope of support for this to Linux due to the nuances required for handling temporary files. It should be fairly easy to extend with Windows support when it becomes useful.