### PR TITLE
github: codeowners: add graph team to review graph doc

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2024 Intel Corporation
+# Copyright 2024-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ component:graph-api:
     - 'src/graph/**'
     - 'tests/benchdnn/graph/**'
     - 'tests/gtests/graph/**'
+    - 'doc/graph/**'
 
 # CPU Engine
 platform:cpu-aarch64:


### PR DESCRIPTION
I wanted to review the changes of graph document, but Github refused me to label #2301  with `component:graph-api` .