### PR TITLE
Enable bfloat16 for micro sdpa kernel

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cl
+++ b/src/gpu/intel/ocl/micro_sdpa.cl
@@ -49,11 +49,11 @@ DECLARE_2D_TILE_LOAD_PACKED_HALF(
 #endif
 
 #ifdef BLOCK_A
-DECLARE_2D_TILE(a_tile_type_half, half, SUBGROUP_SIZE, ugemm_vs_sg_tile_m, 1, 1,
-        ugemm_vs_sg_tile_n)
+DECLARE_2D_TILE(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE, ugemm_vs_sg_tile_m,
+        1, 1, ugemm_vs_sg_tile_n)
 #else
-DECLARE_2D_TILE(a_tile_type_half, half, SUBGROUP_SIZE, ugemm_vs_sg_tile_m, 8, 1,
-        ugemm_vs_sg_tile_n / 8)
+DECLARE_2D_TILE(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE, ugemm_vs_sg_tile_m,
+        8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
 DECLARE_2D_TILE(s_tile_type_half2, uint, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
@@ -78,34 +78,34 @@ DECLARE_2D_TILE(
 #define mask_nbc ugemm_kq_c_type_nblock1
 #endif
 
-DECLARE_2D_TILE(mask_tile_type, half, SUBGROUP_SIZE, mask_br, mask_bc, mask_nbr,
-        mask_nbc)
+DECLARE_2D_TILE(mask_tile_type, MSK_DATA_T, SUBGROUP_SIZE, mask_br, mask_bc,
+        mask_nbr, mask_nbc)
 DECLARE_2D_TILE(mask_tile_type_float, float, SUBGROUP_SIZE, mask_br, mask_bc,
         mask_nbr, mask_nbc)
 
 #if BROADCAST_MASK_Q
-DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, half, SUBGROUP_SIZE, mask_br, mask_bc,
-        mask_nbr, mask_nbc)
+DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, MSK_DATA_T, SUBGROUP_SIZE, mask_br,
+        mask_bc, mask_nbr, mask_nbc)
 #endif
 
 #ifdef BLOCK_A
-DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_half, half, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 #endif
 #ifdef BLOCK_2D_A
-DECLARE_2D_TILE_BLOCK2D_OPS(a_tile_type_half, half, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK2D_OPS(a_tile_type_dst, DST_DATA_T, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
 #ifdef BLOCK_A
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
         ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
-        ugemm_vs_c_type_nblock1, a_tile_type_half, SUBGROUP_SIZE,
+        ugemm_vs_c_type_nblock1, a_tile_type_dst, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 #else
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
         ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
-        ugemm_vs_c_type_nblock1, a_tile_type_half, SUBGROUP_SIZE,
+        ugemm_vs_c_type_nblock1, a_tile_type_dst, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
@@ -160,10 +160,10 @@ DECLARE_2D_TILE_RSELECT(a_scale_tile_type, SUBGROUP_SIZE, ugemm_vs_sg_tile_n, 1,
 #define binary_add(x, y) ((x) + (y))
 
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) kernel void
-micro_sdpa(const global KEY_DATA_T *K, const global half *Q,
-        const global VAL_DATA_T *V, global half *A,
-        const global SCALE_DATA_T *scale_ptr, const global half *msk, int d,
-        int k, int q, const global KEY_ATTR_SCALES_DATA_T *K_scales,
+micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
+        const global VAL_DATA_T *V, global DST_DATA_T *A,
+        const global SCALE_DATA_T *scale_ptr, const global MSK_DATA_T *msk,
+        int d, int k, int q, const global KEY_ATTR_SCALES_DATA_T *K_scales,
         const global KEY_ATTR_ZP_DATA_T *K_zp,
         const global VAL_ATTR_SCALES_DATA_T *V_scales,
         const global VAL_ATTR_ZP_DATA_T *V_zp) {
@@ -195,8 +195,9 @@ micro_sdpa(const global KEY_DATA_T *K, const global half *Q,
     uint sg_j_vs = sg_ij / ugemm_vs_sg_per_wg_m;
 
     /* SLM allocations -- place in one array to work around compiler bug */
-#define Q_slm_size (D_MAX * ugemm_kq_wg_tile_n * sizeof(half))
-#define S_slm_size (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(half))
+#define Q_slm_size (D_MAX * ugemm_kq_wg_tile_n * sizeof(QRY_DATA_T))
+#define S_slm_size \
+    (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(QRY_DATA_T))
 #define S_sum_slm_size \
     (ugemm_kq_wg_tile_n * ugemm_kq_sg_per_wg_m * sizeof(float))
 #define S_max_slm_size (ugemm_kq_wg_tile_n * sizeof(float))
@@ -205,8 +206,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global half *Q,
     local char slm[Q_slm_size + S_slm_size + S_sum_slm_size + S_max_slm_size
             + ugemm_slm_size];
 
-    local half *Q_slm = (local half *)&slm[0];
-    local half *S_slm = (local half *)&slm[Q_slm_size];
+    local QRY_DATA_T *Q_slm = (local QRY_DATA_T *)&slm[0];
+    local QRY_DATA_T *S_slm = (local QRY_DATA_T *)&slm[Q_slm_size];
     local float *S_sum_slm = (local float *)&slm[Q_slm_size + S_slm_size];
     local float *S_max_slm
             = (local float *)&slm[Q_slm_size + S_slm_size + S_sum_slm_size];
@@ -580,17 +581,17 @@ micro_sdpa(const global KEY_DATA_T *K, const global half *Q,
     tile_hbroadcast_mul(&A_tile, A_scale_tile);
 
     /* Convert to half precision and store */
-    a_tile_type_half A_tile_half;
-    tile_copy_reblock(A_tile, &A_tile_half);
+    a_tile_type_dst A_tile_dst;
+    tile_copy_reblock(A_tile, &A_tile_dst);
 
     uint sg_i0_vs = sg_i_vs * ugemm_vs_sg_tile_m;
     uint sg_j0_vs = sg_j_vs * ugemm_vs_sg_tile_n + wg_j0;
 
 #ifdef BLOCK_2D_A
-    tile_store_block2d(A_tile_half, A, d, q, lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block2d(A_tile_dst, A, d, q, lda, sg_i0_vs, sg_j0_vs);
 #elif defined(BLOCK_A)
-    tile_store_block_rem_q(A_tile_half, A, q, lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block_rem_q(A_tile_dst, A, q, lda, sg_i0_vs, sg_j0_vs);
 #else
-    tile_store(A_tile_half, A, d, q, lda, sg_i0_vs, sg_j0_vs);
+    tile_store(A_tile_dst, A, d, q, lda, sg_i0_vs, sg_j0_vs);
 #endif
 }

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -402,7 +402,11 @@ status_t micro_sdpa_t::init(impl::engine_t *engine) {
     kernel_ctx.define_int("NDIMS", ndims);
 
     def_data_type(kernel_ctx, key_mdw.data_type(), "KEY");
+    def_data_type(kernel_ctx, qry_mdw.data_type(), "QRY");
     def_data_type(kernel_ctx, val_mdw.data_type(), "VAL");
+    def_data_type(kernel_ctx, dst_mdw.data_type(), "DST");
+    def_data_type(kernel_ctx,
+            pd()->with_attn_mask() ? msk_mdw.data_type() : dnnl_f32, "MSK");
 
     def_data_type(kernel_ctx, pd()->key_scales_dt(), "KEY_ATTR_SCALES");
     def_data_type(kernel_ctx, pd()->value_scales_dt(), "VAL_ATTR_SCALES");

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -227,7 +227,11 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
     GEMMProblem problem;
     problem.Ta_ext = jit::convert_dnnl_to_kernel_type(key_md()->data_type);
     problem.Tb_ext = jit::convert_dnnl_to_kernel_type(qry_md()->data_type);
-    problem.Ta = problem.Tb = Type::f16;
+    if (qry_md()->data_type == data_type::f16) {
+        problem.Ta = problem.Tb = Type::f16;
+    } else { // data_type is bf16
+        problem.Ta = problem.Tb = Type::bf16;
+    }
     problem.Tc = problem.Tc_ext = Type::f32;
     problem.Ts = problem.Tc;
 

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -65,8 +65,11 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         attn_mask_md()->dims[mask_k_index] == desc()->keys(),
                         VERBOSE_INVALID_BROADCAST, "attn_mask", mask_k_index);
             }
-            VDISPATCH_SDPA(utils::everyone_is(data_type::f16,
-                                   qry_md()->data_type, dst_md()->data_type),
+            VDISPATCH_SDPA(
+                    (utils::everyone_is(data_type::f16, qry_md()->data_type,
+                             dst_md()->data_type)
+                            || utils::everyone_is(data_type::bf16,
+                                    qry_md()->data_type, dst_md()->data_type)),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_SDPA(
                     utils::one_of(key_md()->data_type, f16, u8, s8, u4, s4),
@@ -74,6 +77,14 @@ struct micro_sdpa_t : public gpu_primitive_t {
             VDISPATCH_SDPA(
                     utils::one_of(val_md()->data_type, f16, u8, s8, u4, s4),
                     VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_SDPA(
+                    IMPLICATION(qry_md()->data_type == data_type::bf16,
+                            utils::everyone_is(data_type::bf16,
+                                    val_md()->data_type, key_md()->data_type,
+                                    attn_mask_md()->data_type,
+                                    desc()->scale_dt)),
+                    "Key and Value tensors (with scales and mask) should be "
+                    "bf16 if Query is bf16");
             VDISPATCH_SDPA(set_default_formats() == status::success,
                     VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_SDPA(desc()->values() == desc()->head_size(),

--- a/src/gpu/intel/ocl/tile_ops.h
+++ b/src/gpu/intel/ocl/tile_ops.h
@@ -18,6 +18,7 @@
 #define GPU_OCL_TILE_OPS_H
 
 #include "gpu/intel/ocl/ocl_generic_vector_ops.h"
+#include "gpu/intel/ocl/ocl_types.h"
 
 float __builtin_IB_atomic_max_local_f32(__local float *, float);
 
@@ -27,6 +28,11 @@ __attribute__((overloadable)) float local_atomic_max(local float *p, float v) {
 
 __attribute__((overloadable)) half local_atomic_max(
         local half *p, half v) { /* not implemented */
+    return v;
+}
+
+__attribute__((overloadable)) ushort local_atomic_max(
+        local ushort *p, ushort v) { /* not implemented */
     return v;
 }
 
@@ -91,6 +97,14 @@ DEF_BLOCK_LOAD_STORE(half, ushort, _us, 2)
 DEF_BLOCK_LOAD_STORE(half, ushort, _us, 4)
 DEF_BLOCK_LOAD_STORE(half, ushort, _us, 8)
 DEF_BLOCK_LOAD_STORE(half, ushort, _us, 16)
+
+typedef ushort ushort1 __attribute__((ext_vector_type(1)));
+DEF_BLOCK_LOAD_STORE1(ushort, ushort, _us)
+DEF_BLOCK_LOAD_STORE(ushort, ushort, _us, 2)
+DEF_BLOCK_LOAD_STORE(ushort, ushort, _us, 4)
+DEF_BLOCK_LOAD_STORE(ushort, ushort, _us, 8)
+DEF_BLOCK_LOAD_STORE(ushort, ushort, _us, 16)
+
 DEF_BLOCK_LOAD_STORE1(uint, uint, )
 DEF_BLOCK_LOAD_STORE(uint, uint, , 2)
 DEF_BLOCK_LOAD_STORE(uint, uint, , 4)
@@ -137,6 +151,9 @@ DEF_BLOCK_LOAD_STORE16(uint, uint, )
 DEF_BLOCK2D_LOAD_STORE(half, ushort, 8, 16, u16_m4k32v1, 32, 4)
 DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
 
+DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 8, 16, u16_m4k32v1, 32, 4)
+DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 16, 16, u16_m8k32v1, 32, 8)
+
 #define tile_fill(t, v) \
     do { \
         _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \
@@ -176,14 +193,15 @@ DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
                 = __builtin_convertvector(t.x[i], __typeof__(t_new.x[i])); \
     } while (0)
 
-#define tile_copy_to_half2(t, t_new) \
+#define tile_copy_to_vec2(t, t_new, type) \
     do { \
         _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \
                                i++) { \
             _Pragma("unroll") for (int s = 0; \
                                    s < sizeof(t.x[0]) / sizeof(t.x[0][0]) / 2; \
                                    s++) { \
-                half2 v = {t.x[i][2 * s], t.x[i][2 * s + 1]}; \
+                type v = {CONVERT_DATA_T(t.x[i][2 * s]), \
+                        CONVERT_DATA_T(t.x[i][2 * s + 1])}; \
                 t_new.x[i][s] = as_uint(v); \
             } \
         } \
@@ -477,8 +495,8 @@ DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
             tile_type0 t0, tile_type1 *t1) { \
         _Pragma("unroll") for (int j = 0; j < bc0 * nbc0; j++) { \
             _Pragma("unroll") for (int i0 = 0; i0 < br0 * nbr0; i0 += sg0) { \
-                tile_access(*t1, i0, j, sg1, br1, bc1, nbr1) \
-                        = tile_access(t0, i0, j, sg0, br0, bc0, nbr0); \
+                tile_access(*t1, i0, j, sg1, br1, bc1, nbr1) = CONVERT_DATA_T( \
+                        tile_access(t0, i0, j, sg0, br0, bc0, nbr0)); \
             } \
         } \
     }
@@ -572,16 +590,17 @@ DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
         tile_store_block2d(t, ptr, m, n, m, offset_r, offset_c); \
     }
 
-#define DECLARE_2D_TILE_LOAD_PACKED_HALF(tile_type, sg, br, bc, nbr, nbc) \
-    __attribute__((overloadable)) void tile_load_packed_half(tile_type *t, \
-            const global half *ptr, int m, int n, int ld, int offset_r, \
-            int offset_c) { \
+#define DECLARE_2D_TILE_LOAD_PACKED_VEC( \
+        tile_type, element_type, vec_type, sg, br, bc, nbr, nbc) \
+    __attribute__((overloadable)) void tile_load_packed_vec2(tile_type *t, \
+            const global element_type *ptr, int m, int n, int ld, \
+            int offset_r, int offset_c) { \
         ptr += ld * offset_c + offset_r; \
         _Pragma("unroll") for (int j = 0; j < bc * nbc; j++, ptr += ld) { \
             if (offset_c + j < n) { \
                 _Pragma("unroll") for (int i0 = 0; i0 < br * nbr; i0 += sg) { \
                     int i = 2 * (i0 + get_sub_group_local_id()); \
-                    half2 loaded = 0; \
+                    vec_type loaded = 0; \
                     if (offset_r + i < m) loaded.s0 = ptr[i]; \
                     if (offset_r + i + 1 < m) loaded.s1 = ptr[i + 1]; \
                     tile_access(*t, i0, j, sg, br, bc, nbr) = as_uint(loaded); \
@@ -589,10 +608,10 @@ DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
             } \
         } \
     } \
-    __attribute__((overloadable)) void tile_load_packed_half(tile_type *t, \
-            const global half *ptr, int m, int n, int offset_r, \
+    __attribute__((overloadable)) void tile_load_packed_vec2(tile_type *t, \
+            const global element_type *ptr, int m, int n, int offset_r, \
             int offset_c) { \
-        tile_load_packed_half(t, ptr, m, n, m, offset_r, offset_c); \
+        tile_load_packed_vec2(t, ptr, m, n, m, offset_r, offset_c); \
     }
 
 #define cooperative_prefetch_2d(ptr, r, c, ld, sg_id, n_sg, sg_size, caching) \


### PR DESCRIPTION
# Description

This PR focuses on enabling blfoat16 for micro_sdpa. It aims to make modification in the tile operations along with the micro sdpa kernel to enable this new data format.

Right now, this doesn't include quantization - this will be my next PR. 
Large test cases have slight precision issues for some of the data points in the tensor - likely related to cumulative chain effect in accumulation. Talking to @dzarukin about it.

Test cases of smaller sizes pass - for example:

```
> ./tests/benchdnn/benchdnn --engine=gpu --graph --dt=bf16 --in-shapes=0:1x1x16x64+1:1x1x16x64+8:1x1x16x64+5:1x1x1x16 -v7 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json                  [INFO] Graph dump:
> {(0) MatMul}
>     In: { (0):bf16:1x1x16x64, (1):bf16:1x1x16x64 }
>     Out: { (2):bf16:1x1x16x16 }
> {(1) Divide}
>     In: { (2):bf16:1x1x16x16, (3):bf16:1 }
>     Out: { (4):bf16:1x1x16x16 }
> {(2) Add}
>     In: { (4):bf16:1x1x16x16, (5):bf16:1x1x1x16 }
>     Out: { (6):bf16:1x1x16x16 }
> {(3) SoftMax}
>     In: { (6):bf16:1x1x16x16 }
>     Out: { (7):bf16:1x1x16x16 }
> {(4) MatMul}
>     In: { (7):bf16:1x1x16x16, (8):bf16:1x1x16x64 }
>     Out: { (9):bf16:1x1x16x64 }
> 
> run: --graph --engine=gpu --dt=bf16 --in-shapes=0:1x1x16x64+1:1x1x16x64+5:1x1x1x16+8:1x1x16x64 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
> 0:PASSED __REPRO: --graph --engine=gpu --dt=bf16 --in-shapes=0:1x1x16x64+1:1x1x16x64+5:1x1x1x16+8:1x1x16x64 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
> tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
```

 ```
 ./tests/benchdnn/benchdnn --engine=gpu --graph --dt=bf16 --in-shapes=0:1x1x16x32+1:1x1x16x32+9:1x1x16x32+4:1x1x1x1 -v7 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
[INFO] Graph dump:
{(3) MatMul}
    In: { (0):bf16:1x1x16x32, (1):bf16:1x1x16x32 }
    Out: { (2):bf16:1x1x16x16 }
{(6) Divide}
    In: { (2):bf16:1x1x16x16, (4):bf16:1x1x1x1 }
    Out: { (5):bf16:1x1x16x16 }
{(8) SoftMax}
    In: { (5):bf16:1x1x16x16 }
    Out: { (7):bf16:1x1x16x16 }
{(11) MatMul}
    In: { (7):bf16:1x1x16x16, (9):bf16:1x1x16x32 }
    Out: { (10):bf16:1x1x16x32 }

run: --graph --engine=gpu --dt=bf16 --in-shapes=0:1x1x16x32+1:1x1x16x32+4:1x1x1x1+9:1x1x16x32 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json

0:PASSED __REPRO: --graph --engine=gpu --dt=bf16 --in-shapes=0:1x1x16x32+1:1x1x16x32+4:1x1x1x1+9:1x1x16x32 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
```
