### PR TITLE
Maintainers: year end cleanup and new nominations

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -117,6 +117,7 @@ Team: @oneapi-src/onednn-arch
 | Mourad Gouicem     | @mgouicem             | Intel Corporation | Maintainer |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
 | Ankit Manerikar    | @avmanerikar          | Intel Corporation | Code Owner |
+| Stefan Palicki     | @spalicki             | Intel Corporation | Code Owner |
 
 ## Graph API
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -223,6 +223,7 @@ Team: @oneapi-src/onednn-doc
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
+| Ranu Kundu         | @ranukund             | Intel Corporation | Code Owner |
 
 ### DevOps
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -144,6 +144,7 @@ Team: @oneapi-src/onednn-cpu-x64
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Andrey Kalinin     | @ankalinin            | Intel Corporation | Maintainer |
 | Tatyana Primak     | @tprimak              | Intel Corporation | Maintainer |
+| Alexey Makarevich  | @amakarev             | Intel Corporation | Code Owner |
 | David Eberius      | @davideberius         | Intel Corporation | Code Owner |
 | Stefan Palicki     | @spalicki             | Intel Corporation | Code Owner |
 | Tomasz Czeszun     | @tczeszun             | Intel Corporation | Code Owner |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -226,6 +226,7 @@ Team: @oneapi-src/onednn-doc
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
 | Ranu Kundu         | @ranukund             | Intel Corporation | Code Owner |
+| Tao Lv             | @TaoLv                | Intel Corporation | Code Owner |
 
 ### DevOps
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -130,9 +130,7 @@ Team: @oneapi-src/onednn-graph
 | Shaojie Cui        | @ShanSimu             | Intel Corporation | Code Owner |
 | Yonghao Gu         | @gyhintel             | Intel Corporation | Code Owner |
 | Rong Zhang         | @rongzha1             | Intel Corporation | Code Owner |
-| Zhailong Mu        | @muzhailong           | Intel Corporation | Code Owner |
 | Xiang Guo          | @xiang1guo            | Intel Corporation | Code Owner |
-| Jiaming Song       | @litchilitchy         | Intel Corporation | Code Owner |
 | Yixin Bao          | @ElaineBao            | Intel Corporation | Code Owner |
 
 ## CPU Engine
@@ -144,14 +142,11 @@ Team: @oneapi-src/onednn-cpu-x64
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Andrey Kalinin     | @ankalinin            | Intel Corporation | Maintainer |
-| Arthur Mitrano     | @aaraujom             | Intel Corporation | Maintainer |
-| Srinivas Putta     | @nivas-x86            | Intel Corporation | Maintainer |
 | Tatyana Primak     | @tprimak              | Intel Corporation | Maintainer |
 | David Eberius      | @davideberius         | Intel Corporation | Code Owner |
-| John Karasev       | @karashjoh000         | Intel Corporation | Code Owner |
 | Stefan Palicki     | @spalicki             | Intel Corporation | Code Owner |
 | Tomasz Czeszun     | @tczeszun             | Intel Corporation | Code Owner |
-| Xuxin Zen          | @xuxinzen             | Intel Corporation | Code Owner |
+| Xuxin Zeng         | @xuxinzen             | Intel Corporation | Code Owner |
 
 ### AArch64
 
@@ -216,10 +211,7 @@ Teams:
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Anton Mitkov       | @ShanoToni            | Codeplay Software | Code Owner |
-| Dylan Angus        | @dylan-angus-codeplay | Codeplay Software | Code Owner |
-| John Osorio        | @kala855              | Codeplay Software | Code Owner |
 | Mehdi Goli         | @mehdi-goli           | Codeplay Software | Code Owner |
-| Tadej Ciglarič     | @t4c1                 | Codeplay Software | Code Owner |
 | Svetlozar Georgiev | @sgeor255             | Codeplay Software | Code Owner |
 
 ## Support functions
@@ -231,7 +223,6 @@ Team: @oneapi-src/onednn-doc
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
-| Deb Taylor         | @deb-intel            | Intel Corporation | Code Owner |
 
 ### DevOps
 
@@ -247,6 +238,5 @@ Team: @oneapi-src/onednn-devops
 
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
-| Harry Mao          | @harrymao2022         | Intel Corporation | Maintainer |
 | Tatyana Primak     | @tprimak              | Intel Corporation | Maintainer |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |


### PR DESCRIPTION
Changes summary:
* Removed maintainers who changed assignments and no longer contribute to oneDNN.
* Added @ranukund as code owner for the documentation. Ranu is a technical writer [supporting](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+involves%3Aranukund) oneDNN documentation.
* Added @spalicki as code owner for the core. Stefan is established contributor to oneDNN who [switched focus to common parts](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+author%3Aspalicki) of the library.
* Added @amakarev as code owner for x64 CPU implementation. Alexey is focused on x64 CPU optimizations and has [history of contributions](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+author%3Aamakarev) to the component.
* Added @TaoLv as code owner for the documentation. Tao is an established contributor to oneDNN with [contributions to Graph API documentation](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+label%3Adocumentation+author%3Ataolv).
