### PR TITLE
graph: backend: dnnl: support select with binary primitive

### DIFF
--- a/src/graph/backend/dnnl/dnnl_op_def.hpp
+++ b/src/graph/backend/dnnl/dnnl_op_def.hpp
@@ -701,6 +701,7 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_binary, 1,
                 .set_num_outputs(2)
                 .set_input(0, "a")
                 .set_input(1, "b")
+                .set_input(2, "cond")
                 .set_output(0, "output")
                 .set_output(1, "scratchpad")
                 // Attributes inherited from front binary ops (Add, Multiply,

--- a/src/graph/backend/dnnl/dnnl_shape_infer.hpp
+++ b/src/graph/backend/dnnl/dnnl_shape_infer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -100,6 +100,10 @@ status_t infer_dnnl_pool_bwd_output_shape(op_t *n,
         std::vector<logical_tensor_t *> &outputs);
 
 status_t infer_dnnl_binary_output_shape(op_t *n,
+        std::vector<logical_tensor_t *> &inputs,
+        std::vector<logical_tensor_t *> &outputs);
+
+status_t infer_binary_select_output_shape(op_t *n,
         std::vector<logical_tensor_t *> &inputs,
         std::vector<logical_tensor_t *> &outputs);
 

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -36,6 +36,8 @@ void larger_partition_kernel_t::setup_pipeline_stage1(
         pass_pipeline_t &pipeline) {
     // Directly lower down (1 to 1 mapping)
     BACKEND_DNNL_ADD_PASS(pipeline, lower_down);
+    // Decompose select to binary ops if necessary
+    BACKEND_DNNL_ADD_PASS(pipeline, decompose_select_to_binary_ops);
 
     // Indirectly lower down (N to 1 mapping)
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_reciprocal_mul_to_div);

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -50,6 +50,9 @@ status_t matmul_t<quantized>::compile_impl(const dnnl_partition_impl_t *part,
     pass_pipeline_t pipeline(vis);
 
     BACKEND_DNNL_ADD_PASS(pipeline, lower_down);
+    // Decompose select to binary ops if necessary
+    BACKEND_DNNL_ADD_PASS(pipeline, decompose_select_to_binary_ops);
+
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_bias_add);
     // check if bias exists
     BACKEND_DNNL_ADD_PASS(pipeline, check_with_bias);

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,6 +60,8 @@ status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
     pass_pipeline_t pipeline = pass_pipeline_t(vis);
     pass_pipeline_t select_pipeline = pass_pipeline_t(vis);
     BACKEND_DNNL_ADD_PASS(pipeline, lower_down);
+    // Decompose select to binary ops if necessary
+    BACKEND_DNNL_ADD_PASS(pipeline, decompose_select_to_binary_ops);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_reshape_for_gqa);
     // Fusion and canonicalization passes begin
     if (quantized) {

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,6 +56,23 @@ bool sdp_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
         auto scale_sz = ltw(inputs[graph_inport[2]]).nelems();
         VCHECK_SDP_DECOMP(scale_sz == 1, false,
                 "Only supports single scale value, but got %lld", scale_sz);
+    }
+
+    // Check select cond and src0 shape
+    if (graph_inport[5] != -1 && graph_inport[6] != -1) {
+        const auto select_cond_dims = ltw(inputs[graph_inport[5]]).vdims();
+        const auto select_src0_dims = ltw(inputs[graph_inport[6]]).vdims();
+        VCHECK_SDP_DECOMP(select_cond_dims.size() == select_src0_dims.size(),
+                false,
+                "Select cond and src0 dims should be same, but got %zu and %zu",
+                select_cond_dims.size(), select_src0_dims.size());
+        for (size_t i = 0; i < select_cond_dims.size(); i++) {
+
+            VCHECK_SDP_DECOMP(select_cond_dims[i] == select_src0_dims[i], false,
+                    "Select cond and src0 dims should be same, but got %lld "
+                    "and %lld",
+                    select_cond_dims[i], select_src0_dims[i]);
+        }
     }
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP

--- a/src/graph/backend/dnnl/kernels/select.cpp
+++ b/src/graph/backend/dnnl/kernels/select.cpp
@@ -49,6 +49,9 @@ status_t select_t::compile_impl(const dnnl_partition_impl_t *part,
     pass_pipeline_t pipeline(vis);
 
     BACKEND_DNNL_ADD_PASS(pipeline, lower_down);
+    // Decompose select to binary ops if necessary
+    BACKEND_DNNL_ADD_PASS(pipeline, decompose_select_to_binary_ops);
+
     BACKEND_DNNL_ADD_PASS(pipeline, binary_canonicalization);
 
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_post_ops);

--- a/src/graph/backend/dnnl/passes/lower.cpp
+++ b/src/graph/backend/dnnl/passes/lower.cpp
@@ -664,114 +664,33 @@ static status_t select_handler(
     auto cond = in_vals[0];
     auto src0 = in_vals[1];
     auto src1 = in_vals[2];
-    cond->set_data_type(dnnl::impl::data_type::u8);
+    // For the binary select operation, the conditional input tensor can
+    // only be of `s8` data type.
+    cond->set_data_type(dnnl::impl::data_type::s8);
 
-    //TODO: This reorder can be removed once eltwise_clip support int8 input
-    op_ptr type_cast = std::make_shared<op_t>(op_kind::dnnl_reorder);
-    type_cast->set_attr<bool>(op_attr::change_layout, false);
-
-    op_ptr clip = std::make_shared<op_t>(op_kind::dnnl_eltwise);
-    clip->set_attr<int64_t>(op_attr::alg_kind,
-            static_cast<int64_t>(dnnl::algorithm::eltwise_clip));
-    clip->set_attr<float>(op_attr::alpha, 0.f);
-    clip->set_attr<float>(op_attr::beta, 1.f);
-
-    // After reorder and clip. The cond value is 0 or 1.
-    // Then output = src0.*cond+src1.*(cond*-1 + 1)
-    op_ptr mul1 = std::make_shared<op_t>(op_kind::dnnl_binary);
-    mul1->set_attr<int64_t>(op_attr::alg_kind,
-            static_cast<int64_t>(dnnl::algorithm::binary_mul));
-    mul1->merge_attributes(op->get_attributes());
-
-    op_ptr mul2 = std::make_shared<op_t>(op_kind::dnnl_binary);
-    mul2->set_attr<int64_t>(op_attr::alg_kind,
-            static_cast<int64_t>(dnnl::algorithm::binary_mul));
-    mul2->merge_attributes(op->get_attributes());
-
-    op_ptr linear = std::make_shared<op_t>(op_kind::dnnl_eltwise);
-    linear->set_attr<int64_t>(op_attr::alg_kind,
-            static_cast<int64_t>(dnnl::algorithm::eltwise_linear));
-    const float alpha_value = -1.0f, beta_value = 1.0f;
-    linear->set_attr<float>(op_attr::alpha, alpha_value);
-    linear->set_attr<float>(op_attr::beta, beta_value);
-
-    op_ptr add = std::make_shared<op_t>(op_kind::dnnl_binary);
-    add->set_attr<int64_t>(op_attr::alg_kind,
-            static_cast<int64_t>(dnnl::algorithm::binary_add));
+    op_ptr new_op = std::make_shared<op_t>(op_kind::dnnl_binary);
+    new_op->set_attr<int64_t>(op_attr::alg_kind,
+            static_cast<int64_t>(get_binary_alg_map().at(op->get_kind())));
+    new_op->merge_attributes(op->get_attributes());
 
     // reconnect
     cond->remove_consumer(*op, 0);
     src0->remove_consumer(*op, 1);
     src1->remove_consumer(*op, 2);
 
-    // first reorder and clip
-    cond->add_consumer(*type_cast, 0);
-    type_cast->add_input(cond);
-    logical_tensor_t float_cond = empty_logical_tensor_with_default_id();
-    auto float_cond_val
-            = std::make_shared<value_t>(*type_cast, 0, float_cond, true);
-    float_cond_val->set_data_type(dnnl::impl::data_type::f32);
-    type_cast->add_output(float_cond_val);
-    insert_empty_scratchpad(type_cast);
+    // binary select primitive places the condition input tensor as the
+    // third input tensor.
+    src0->add_consumer(*new_op, 0);
+    src1->add_consumer(*new_op, 1);
+    cond->add_consumer(*new_op, 2);
 
-    float_cond_val->add_consumer(*clip, 0);
-    clip->add_input(float_cond_val);
-    logical_tensor_t clip_cond = empty_logical_tensor_with_default_id();
-    auto clip_cond_val = std::make_shared<value_t>(*clip, 0, clip_cond, true);
-    clip_cond_val->set_data_type(
-            float_cond_val->get_logical_tensor().data_type);
-    clip->add_output(clip_cond_val);
-    insert_empty_scratchpad(clip);
+    new_op->add_input(src0);
+    new_op->add_input(src1);
+    new_op->add_input(cond);
+    new_op->add_output(out_vals[0]);
 
-    // first multiply
-    src0->add_consumer(*mul1, 0);
-    clip_cond_val->add_consumer(*mul1, 1);
-    mul1->add_input(src0);
-    mul1->add_input(clip_cond_val);
-
-    logical_tensor_t src0_cond = empty_logical_tensor_with_default_id();
-    auto src0_val = std::make_shared<value_t>(*mul1, 0, src0_cond, true);
-    src0_val->set_data_type(src0->get_logical_tensor().data_type);
-    mul1->add_output(src0_val);
-    insert_empty_scratchpad(mul1);
-
-    //cond.*{-1} + 1
-    clip_cond_val->add_consumer(*linear, 0);
-    linear->add_input(clip_cond_val);
-
-    logical_tensor_t cond_inv = empty_logical_tensor_with_default_id();
-    auto cond_inv_val = std::make_shared<value_t>(*linear, 0, cond_inv, true);
-    cond_inv_val->set_data_type(clip_cond_val->get_logical_tensor().data_type);
-    linear->add_output(cond_inv_val);
-    insert_empty_scratchpad(linear);
-
-    //src1.*(cond_inv)
-
-    src1->add_consumer(*mul2, 0);
-    cond_inv_val->add_consumer(*mul2, 1);
-    mul2->add_input(src1);
-    mul2->add_input(cond_inv_val);
-
-    logical_tensor_t src1_cond = empty_logical_tensor_with_default_id();
-    auto src1_val = std::make_shared<value_t>(*mul2, 0, src1_cond, true);
-    src1_val->set_data_type(src1->get_logical_tensor().data_type);
-    mul2->add_output(src1_val);
-    insert_empty_scratchpad(mul2);
-
-    src0_val->add_consumer(*add, 0);
-    src1_val->add_consumer(*add, 1);
-    add->add_input(src0_val);
-    add->add_input(src1_val);
-    add->add_output(out_vals[0]);
-    insert_empty_scratchpad(add);
-
-    // add new ops and delete select op
-    rewriter.to_insert(type_cast);
-    rewriter.to_insert(clip);
-    rewriter.to_insert(mul1);
-    rewriter.to_insert(linear);
-    rewriter.to_insert(mul2);
-    rewriter.to_insert(add);
+    insert_empty_scratchpad(new_op);
+    rewriter.to_insert(new_op);
     rewriter.to_remove(op);
 
     return status::success;

--- a/src/graph/backend/dnnl/passes/transform.hpp
+++ b/src/graph/backend/dnnl/passes/transform.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2024 Intel Corporation
+ * Copyright 2021-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,14 @@ status_t fuse_to_dnnl_sum(std::shared_ptr<subgraph_t> &sg);
 // This pass is used to insert unsqueeze op before dnnl_binary op's inputs to
 // make the input shape meet the requirement of oneDNN binary primitive
 status_t binary_canonicalization(std::shared_ptr<subgraph_t> &sg);
+
+// For now, we support two impl paths for select op: one is to use binary
+// primitive with select alorithm, the other is to use multiple binary ops(we
+// call it "legacy impl" here). However, during the lowering pass, we directly
+// lower the front-end select op to single binary select op, this pass is used
+// to decide which impl path to apply and then decompose the select binary op
+// back to multiple binary ops if it's the case to use legacy impl.
+status_t decompose_select_to_binary_ops(std::shared_ptr<subgraph_t> &sg);
 
 // This pass is used to swap two inputs to broadcast src1 which is optimized in
 // oneDNN binary primitive. Notice that this should be applied after

--- a/src/graph/backend/dnnl/passes/utils.cpp
+++ b/src/graph/backend/dnnl/passes/utils.cpp
@@ -250,7 +250,8 @@ const std::map<op_kind_t, dnnl::algorithm> &get_binary_alg_map() {
                     {graph::op_kind::Maximum, dnnl::algorithm::binary_max},
                     {graph::op_kind::Subtract, dnnl::algorithm::binary_sub},
                     {graph::op_kind::BiasAdd, dnnl::algorithm::binary_add},
-                    {graph::op_kind::GreaterEqual, dnnl::algorithm::binary_ge}};
+                    {graph::op_kind::GreaterEqual, dnnl::algorithm::binary_ge},
+                    {graph::op_kind::Select, dnnl::algorithm::binary_select}};
     return binary_alg_map;
 }
 
@@ -646,6 +647,21 @@ bool inverse_mul_scales(std::shared_ptr<op_t> &scale_op) {
     return true;
 }
 
+bool need_broadcast_for_inputs(
+        const std::shared_ptr<op_t> &op, size_t index1, size_t index2) {
+    auto in_vals = op->get_input_values();
+
+    const dims input1_dims
+            = logical_tensor_wrapper_t(in_vals[index1]->get_logical_tensor())
+                      .vdims();
+    const dims input2_dims
+            = logical_tensor_wrapper_t(in_vals[index2]->get_logical_tensor())
+                      .vdims();
+
+    if (input1_dims != input2_dims) { return true; }
+
+    return false;
+}
 } // namespace dnnl_impl
 } // namespace graph
 } // namespace impl

--- a/src/graph/backend/dnnl/passes/utils.hpp
+++ b/src/graph/backend/dnnl/passes/utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -347,6 +347,9 @@ std::shared_ptr<op_t> clone_mul_scales(const std::shared_ptr<op_t> &scale_op);
 
 // This function is used to inverse scales of a dnnl_mul_scales op
 bool inverse_mul_scales(std::shared_ptr<op_t> &scale_op);
+
+bool need_broadcast_for_inputs(
+        const std::shared_ptr<op_t> &op, size_t index1, size_t index2);
 
 } // namespace dnnl_impl
 } // namespace graph

--- a/src/graph/interface/shape_infer.cpp
+++ b/src/graph/interface/shape_infer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,9 +32,6 @@ namespace dnnl {
 namespace impl {
 namespace graph {
 
-// utils function
-namespace {
-
 std::string dims2str(const dims &dims) {
     if (dims.empty()) return std::string("");
 
@@ -44,8 +41,6 @@ std::string dims2str(const dims &dims) {
         str += ("x" + std::to_string(dims[d]));
     return str;
 }
-
-} // namespace
 
 /// convert shape to ncx or oix
 dims canonicalize(const dims &shape, const std::string &format) {

--- a/src/graph/interface/shape_infer.hpp
+++ b/src/graph/interface/shape_infer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,6 +73,8 @@ status_t infer_auto_pad(const dim_t in_dim, const dim_t stride,
 /// numpy broadcasting
 /// TODO(xxx): 0-D broadcasting?
 status_t broadcast(const dims &lhs, const dims &rhs, dims &broadcasted);
+
+std::string dims2str(const dims &dims);
 
 status_t one_way_broadcast(const dims &lhs, const dims &rhs);
 

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -35,6 +35,7 @@
 --reset --dt=f32,bf16,f16 --in-shapes=3:20x16x384x64+4:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=3:10x16x384x64+4:10x1x64x384+0:10x1x384x64+1:10x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=4:56x12x128x64+5:56x12x64x128+0:56x12x128x64+1:56x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
+--reset --dt=f32,bf16,f16 --in-shapes=2:1x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=0:56x8x1024x80+1:56x8x77x80+2:56x8x77x80 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
 --reset --expected-n-partitions=0 --dt=f32,bf16,f16 --in-shapes=5:20x117x48x128+6:20x1x128x117+19:20x1x117x128 --case=complex_fusion/mha/MHA-starcoder-inf-fp32-bs1.json
 --reset --expected-n-partitions=0 --dt=f32,bf16,f16 --in-shapes=2514:32x16x512x64+2518:32x16x512x64+2543:32x1x512x512+2547:32x16x512x512+2525:32x16x512x64 --op-attrs=4837:shape:16384x1024 --case=complex_fusion/mha/MHA_forward-Bert_large-train-fp32-bs4.json
@@ -51,6 +52,7 @@
 --reset --expected-n-partitions=0 --in-shapes=4:4x32x32x128+3:4x32x128x33+0:4x32x33x128+1:4x1x32x33 --case=complex_fusion/mha/MHA-LLaMa-inf-int8-bs1.json
 --reset --in-shapes=4:20x16x384x64+3:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
 --reset --in-shapes=5:56x12x128x64+4:56x12x64x128+0:56x12x128x64+1:56x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
+--reset --in-shapes=2:1x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
 --reset --expected-n-partitions=0 --in-shapes=4:20x117x48x128+3:20x1x128x117+0:20x1x117x128 --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
 --reset --expected-n-partitions=0 --in-shapes=4:32x16x384x64+3:32x16x64x384+0:32x16x384x64+1:32x1x1x384 --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
 --reset --in-shapes=4:20x16x384x64+3:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/op/harness_bf16_all
+++ b/tests/benchdnn/inputs/graph/op/harness_bf16_all
@@ -153,6 +153,8 @@
 --reset --dt=bf16 --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json
 --reset --dt=bf16 --in-shapes=1:1 --case=op/f32/greaterequal.json
 
+# select
+--reset --dt=bf16 --in-shapes=2:1x1x1x128 --case=op/f32/select.json
 # concat
 --reset --dt=bf16 --in-shapes=0:1x4096x14x14+1:1x4096x14x14 --case=op/f32/concat.json
 --reset --dt=bf16 --in-shapes=0:64x128x28x28+1:64x128x28x28 --op-attrs=0:axis:1 --case=op/f32/concat.json

--- a/tests/benchdnn/inputs/graph/op/harness_f16_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f16_all
@@ -153,6 +153,8 @@
 --reset --dt=f16 --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json
 --reset --dt=f16 --in-shapes=1:1 --case=op/f32/greaterequal.json
 
+# select
+--reset --dt=bf16 --in-shapes=2:1x1x1x128 --case=op/f32/select.json
 # concat
 --reset --dt=f16 --in-shapes=0:1x4096x14x14+1:1x4096x14x14 --case=op/f32/concat.json
 --reset --dt=f16 --in-shapes=0:64x128x28x28+1:64x128x28x28 --op-attrs=0:axis:1 --case=op/f32/concat.json

--- a/tests/benchdnn/inputs/graph/op/harness_f32_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f32_all
@@ -948,6 +948,7 @@
 --reset --in-shapes=0:2x9x3x5x7*acdeb+1:2x9x2x8x12*acdeb --op-attrs=0:sizes:2x8x12*mode:linear --case=op/f32/interpolate_bwd.json
 --reset --in-shapes=0:2x9x3x8x6*acdeb+1:2x9x2x5x12*acdeb --op-attrs=0:sizes:2x5x12*mode:linear --case=op/f32/interpolate_bwd.json
 --reset --in-shapes=0:2x9x3x8x7*acdeb+1:2x9x2x5x12*acdeb --op-attrs=0:sizes:2x5x12*mode:linear --case=op/f32/interpolate_bwd.json
+--reset --in-shapes=2:1x1x1x128 --case=op/f32/select.json
 --reset --case=op/f32/select.json
 --reset --case=op/f32/gnorm.json
 --reset --case=op/f32/static_reshape.json


### PR DESCRIPTION
# Description
1. `cond` input is defined for dnnl binary op
2. For now, as primitive doesn't support broadcast for `cond` input, we use binary select primitive for non-broadcast case only, the lowering logic is: always lower select to binary primitive and then decide which impl path to use in pass `decompose_select_to_multiple_binary_ops` and decompose it to multiple binary ops if necessary.
3. It's unsupported on GPU as binary primitive doesn't support either.

# Performance
relative perf:

platform: Intel(R) Xeon(R) Platinum 8490H

case | speedup
-- | --
./tests/benchdnn/benchdnn --graph --mode=P --reset --in-shapes=1:1x12x128x128+2:1x12x128x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json | 98.24%
./tests/benchdnn/benchdnn --graph --mode=P --reset --dt=bf16 --in-shapes=1:1x12x128x128+2:1x12x128x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json | 170.12%
./tests/benchdnn/benchdnn --graph --mode=P --reset --in-shapes=1:1x12x128x128+2:1x12x128x128 --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json | 140.41%

