### PR TITLE
Add support for non-power of 2 head size with quantization

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -325,8 +325,9 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
         problem_vs.aOffset = ABOffset::Calc;
     }
     if (with_value_scales() || with_value_zp()) {
-        problem_vs.aqGroupM
-                = (vs_common_scales || vs_common_zp) ? 1 : value_group_size();
+        problem_vs.aqGroupM = (vs_common_scales || vs_common_zp)
+                ? 1
+                : utils::rnd_up_pow2(value_group_size());
         problem_vs.aqGroupK = 1;
     }
     opts_vs.scaleA = with_value_scales() && !vs_common_scales;

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include "common/c_types_map.hpp"
 #include "common/gemm_types.hpp"
 #include "common/gemm_utils.hpp"
+#include "common/math_utils.hpp"
 #include "common/primitive.hpp"
 #include "common/sdpa_pd.hpp"
 #include "common/type_helpers.hpp"
@@ -138,6 +139,16 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         "if vs zero points data type is s4 or u4 then the "
                         "group size(%d) must be 16.",
                         value_group_size());
+            }
+
+            if (!desc()->vs_scales.has_default_values()
+                    || !desc()->vs_zero_points.has_default_values()) {
+                int vgs = value_group_size();
+                VDISPATCH_SDPA(
+                        math::is_pow2<int>(vgs) || vgs == val_md()->dims[3],
+                        "the value group size(%d) must be a power of 2 or "
+                        "equal to the number of values(%d).",
+                        vgs, val_md()->dims[3]);
             }
 
             CHECK(init_microkernels(engine));

--- a/src/gpu/intel/ocl/tile_ops.h
+++ b/src/gpu/intel/ocl/tile_ops.h
@@ -134,6 +134,7 @@ DEF_BLOCK_LOAD_STORE16(uint, uint, )
                 pp, w - 1, h - 1, ld - 1, coord, as_##itype##vl(v)); \
     }
 
+DEF_BLOCK2D_LOAD_STORE(half, ushort, 8, 16, u16_m8k16v1, 16, 8)
 DEF_BLOCK2D_LOAD_STORE(half, ushort, 8, 16, u16_m4k32v1, 32, 4)
 DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
 

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -56,3 +56,8 @@
 --reset --expected-n-partitions=0 --in-shapes=4:20x117x48x128+3:20x1x128x117+0:20x1x117x128 --case=complex_fusion/mha/MHA-starcoder-inf-int8-bs1.json
 --reset --expected-n-partitions=0 --in-shapes=4:32x16x384x64+3:32x16x64x384+0:32x16x384x64+1:32x1x1x384 --case=complex_fusion/mha/dynamic_quantized_mha-Bert_large-inf-int8-bs1-fake.json
 --reset --in-shapes=4:20x16x384x64+3:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json
+
+# phi3-mini-4k-instruct
+--reset
+--in-shapes=0:1x32x96x384*abdc+1:1x32x1x384+2:1x32x1x384+3:1x32x384x96+5:1x1x384x384+6:1x32x384x96+7:1x32x384x1+8:1x32x384x1
+--op-attrs=34107656704:group_shape:1x1x96x1+34107752448:group_shape:1x1x1x96 --in-shapes= --case=complex_fusion/mha/sdpa-compressed-kv-int8-gs128.json


### PR DESCRIPTION
# Description

This pull request adds the ability to support quantization with head size that is not a power of two. This was a limitation on the vs ugemm and was required by the phi3-mini-4k-instruct model.

The shape that was failing was  Q [1x32xSEQ_LENx96] KV [1x32xSEQ_LENx96] which now passes with this change.

Additionally this PR addresses a failure to build when the vs work group was configured with an 16x16 work group tile.
