### PR TITLE
benchdnn: graph: enhance input displace and shape rewrite for linked attribute and shapes

### DIFF
--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -498,6 +498,7 @@ bool deserialized_graph::check_tensor_with_mb(size_t tensor_id,
         return mb_rewrite_ret.at(tensor_id);
 
     bool ret = true;
+    // TODO: initialize with false to avoid multiple re-initialization
     for (const auto &aop : in_lt_2_ops_.at(tensor_id)) {
         const bool matmul_mb_rewrite = (aop.kind_ == "MatMul")
                 && aop.in_lts_[0].shape_.size() > 2

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -402,22 +402,42 @@ std::ostream &operator<<(std::ostream &s, const deserialized_op &dop) {
     s << "}\n";
 
     const auto it_attr_scales = dop.attrs_.find("scales");
+    const auto it_attr_group_shape = dop.attrs_.find("group_shape");
     const bool has_scales = it_attr_scales != dop.attrs_.end();
-    if (has_scales) {
+    const bool has_group_shape = it_attr_group_shape != dop.attrs_.end();
+
+    if (has_scales || has_group_shape) {
         s << "    Attrs: { ";
 
-        const auto &scales_v = it_attr_scales->second.f32_vector_;
-        const auto size = scales_v.size();
-        std::string size_str = " (" + std::to_string(size) + ")";
-        s << "Scales" << (size > 1 ? size_str : "") << ": { ";
-        for (size_t i = 0; i < size; i++) {
-            s << scales_v[i];
-            if (i != size - 1) s << ",";
-            s << " ";
+        if (has_scales) {
+            const auto &scales_v = it_attr_scales->second.f32_vector_;
+            const auto size = scales_v.size();
+            std::string size_str = " (" + std::to_string(size) + ")";
+            s << "Scales" << (size > 1 ? size_str : "") << ": { ";
+            for (size_t i = 0; i < size; i++) {
+                s << scales_v[i];
+                if (i != size - 1) s << ",";
+                s << " ";
+            }
+            s << "} "; // Scales
         }
-        s << "} "; // Scales
+
+        if (has_group_shape) {
+            const auto &group_shape_v = it_attr_group_shape->second.s64_vector_;
+            const auto size = group_shape_v.size();
+            std::string size_str = " (" + std::to_string(size) + ")";
+            s << "Group shape:" << (size > 1 ? size_str : "") << ": { ";
+            for (size_t i = 0; i < size; i++) {
+                s << group_shape_v[i];
+                if (i != size - 1) s << ",";
+                s << " ";
+            }
+            s << "} "; // Group Shape
+        }
+
         s << "}\n"; // Attrs
     }
+
     return s;
 }
 

--- a/tests/benchdnn/graph/deserialize.hpp
+++ b/tests/benchdnn/graph/deserialize.hpp
@@ -168,6 +168,7 @@ private:
             "SigmoidBackward", "SoftMaxBackward", "SoftPlusBackward",
             "SqrtBackward", "TanhBackward"};
 
+    // Check whether the tensor supports mb rewrite.
     bool check_tensor_with_mb(size_t tensor_id,
             std::unordered_map<size_t, bool> &mb_rewrite_ret) const;
 };

--- a/tests/benchdnn/graph/deserialize.hpp
+++ b/tests/benchdnn/graph/deserialize.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -168,7 +168,8 @@ private:
             "SigmoidBackward", "SoftMaxBackward", "SoftPlusBackward",
             "SqrtBackward", "TanhBackward"};
 
-    bool check_tensor_with_mb(size_t tensor_id) const;
+    bool check_tensor_with_mb(size_t tensor_id,
+            std::unordered_map<size_t, bool> &mb_rewrite_ret) const;
 };
 std::ostream &operator<<(std::ostream &s, const deserialized_graph &dg);
 

--- a/tests/benchdnn/graph/flex_rewrite.hpp
+++ b/tests/benchdnn/graph/flex_rewrite.hpp
@@ -74,6 +74,10 @@ private:
     void graph_attrs_rewrite(deserialized_graph &dgraph);
     void dt_rewrite(deserialized_graph &dgraph);
     void dt_map_rewrite(deserialized_graph &dgraph);
+    // Rewrite some linked attribute and shapes, such as group-shape and
+    // scale/zp shape of dynamic dequantization for per-group quantization, to
+    // simplify the cml input of rewriting.
+    void rewrite_linked_shape_and_attr(deserialized_graph &dgraph);
 };
 
 } // namespace graph

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -127,8 +127,13 @@ bool get_driver_axis(const deserialized_op &base_op_ref, int &axis) {
 
 bool get_driver_bia_dt(const deserialized_op &base_op_ref,
         dnnl_data_type_t &bia_dt, const dnnl_data_type_t dt) {
-    // bia_dt is the same as src_dt
-    bia_dt = base_op_ref.in_lts_.size() <= 2 ? dnnl_data_type_undef : dt;
+    if (base_op_ref.in_lts_.size() <= 2)
+        bia_dt = dnnl_data_type_undef;
+    else if (is_integral_dt(dt)) {
+        bia_dt = convert_dt(base_op_ref.in_lts_[2].get_data_type());
+    } else {
+        bia_dt = dt;
+    }
     return true;
 }
 

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -32,7 +32,7 @@
 # Re-written graphs
 --reset --dt=f32,bf16,f16 --in-shapes=4:4x16x32x256+5:4x16x256x33+0:4x16x33x256+1:4x1x1x33+3:4x1x32x33 --case=complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
 --reset --expected-n-partitions=0 --dt=f32,bf16,f16 --in-shapes=3:4x32x32x128+4:4x32x128x33+0:4x32x33x128+1:4x1x32x33 --case=complex_fusion/mha/MHA-LLaMa-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --in-shapes=3:20x16x384x64+4:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
+--reset --dt=f32,bf16,f16 --mb=20 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=3:10x16x384x64+4:10x1x64x384+0:10x1x384x64+1:10x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=4:56x12x128x64+5:56x12x64x128+0:56x12x128x64+1:56x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=2:1x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
@@ -48,6 +48,7 @@
 --reset --dt=f32,bf16,f16 --in-shapes=3:384,3:384x384,3:1x16x384x384 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
 --reset --op-attrs=34107656704:group_shape:1x1x1x32+34107654464:transpose_b:1 --in-shapes=0:1x32x32x128+1:1x32x32x4+2:1x32x32x4 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 --reset --op-attrs=34107656704:qtype:per_channel*axis:3 --in-shapes=1:32+2:1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
+--reset --op-attrs=34107656704:group_shape:1x1x128x1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 
 # Re-written int8 graphs
 --reset --in-shapes=5:4x16x32x256+4:4x16x256x33+0:4x16x33x256+1:4x1x1x33+3:4x1x32x33 --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json


### PR DESCRIPTION
## Description

The PR enhances input displacement and rewrite functionality in benchdnn graph for the following aspects:
1. Support mb rewrite on SRC1 of `MatMul` and scale and zp of `DynamicDequantize` to support SDPA patterns rewriting.
2. Support shape rewrite for linked attributes and shapes, such as `group_shape` and scale/zp input of `DynamicDequantize`. If user provides  shapes for one of the attributes or input shapes, benchdnn graph will update the other accordingly after performing some checks.
3. Fix the data type setting for input displacement in case the primitive cannot be created, which solved two specific cases: f8_e4m3 cases as primitive creating might fail as f8_e4m3:f8_e4m3:f8_e5m2 is not supported, and bf16:int4:bf16 matmul cases where f32:int4:bf16 matmul is not supported.

For example:
```
# Rewrite input shape only
0:PASSED __REPRO: --graph --in-shapes=7:1x16x128x1+8:1x16x128x1 --case=/home/wangzhitao/oneDNN-src/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-v-int8-gs32.json
# Rewrite group-shape only
1:PASSED __REPRO: --graph --op-attrs=34107656704:group_shape:1x1x128x1 --case=/home/wangzhitao/oneDNN-src/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
# Rewrite mb size
2:PASSED __REPRO: --graph --mb=10 --case=/home/wangzhitao/oneDNN-src/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-v-int8-gs32.json
```
