### PR TITLE
doc: conv: add note for the dilation computation formula

### DIFF
--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -100,6 +100,12 @@ Here:
 - \f$OW = \left\lfloor{\frac{IW - DKW + PW_L + PW_R}{SW}}
         \right\rfloor + 1,\f$ where \f$DKW = 1 + (KW - 1) \cdot (DW + 1)\f$.
 
+@note In oneDNN, convolution without dilation is defined by setting the dilation
+parameters to `0`. This differs from PyTorch and TensorFlow, where a non-dilated
+case corresponds to a dilation value of `1`. As a result, the PyTorch and
+TensorFlow dilation parameters need to be adjusted by subtracting `1` (for example,
+\f$DH_onednn = DH_torch - 1\f$, and \f$DW_onednn = DW_torch - 1\f$).
+
 #### Deconvolution (Transposed Convolution)
 
 Deconvolutions (also called fractionally strided convolutions or transposed

--- a/examples/primitives/pooling.cpp
+++ b/examples/primitives/pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,6 +66,17 @@ void pooling_example(dnnl::engine::kind engine_kind) {
             DH = 1, // height-wise dilation
             DW = 1; // width-wise dilation
 
+    // oneDNN uses the following formula to calculate destination dimensions:
+    // dst = (src - ((weights - 1) * (dilation_onednn + 1) + 1)) / stride + 1
+    //
+    // PyTorch and TensorFlow use a different formula:
+    // dst = (src - ((weights - 1) * dilation_torch + 1)) / stride + 1
+    //
+    // As a result, the PyTorch and Tensorflow dilation parameters need to be
+    // adjusted by subtracting 1:
+    // dilation_onednn = dilation_torch - 1.
+    //
+    // Output tensor height and width.
     const memory::dim OH = (IH - ((KH - 1) * DH + KH) + PH_L + PH_R) / SH + 1;
     const memory::dim OW = (IW - ((KW - 1) * DW + KW) + PW_L + PW_R) / SW + 1;
 


### PR DESCRIPTION
# Description

The formula for dilated convolution and dilated pooling in oneDNN differs from that used in PyTorch and some other applications. This difference has led to confusion and several related questions in oneDNN, including #2355, #1652, and #438. This PR clarifies the differences in the documentation and updates the code example comments accordingly.

Fixes #2355
