### PR TITLE
cpu: x64: matmul: fixes correctness issue about tags

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1665,7 +1665,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             : 0;
 
     bgmmc.LDB = bm_conf_utils.get_actual_LDB();
-    bgmmc.LDD = dst_d.blocking_desc().strides[bgmmc.ndims - 2];
+    bgmmc.LDD = dst_d.ndims() == 2 && dst_d.count_non_unit_dims(1)
+            ? bgmmc.N
+            : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
     bgmmc.LDC = bgmmc.use_buffer_c && bgmmc.nthr_k <= 1
             ? bgmmc.N_blk * (bgmmc.is_runtime_N ? bgmmc.N_chunk_size : 1)
             : bgmmc.LDD;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1870,9 +1870,13 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
             const dim_t src_stride = src_d.matches_tag(acbd)
                     ? bgmmc.A_strides[1]
                     : bgmmc.A_strides[0];
+            const dim_t copy_A_src_stride = src_d.matches_tag(dabc)
+                            && bgmmc.K * bgmmc.batch
+                                    == src_d.blocking_desc().strides[0]
+                    ? src_d.blocking_desc().strides[0]
+                    : src_d.blocking_desc().strides[0] * bgmmc.K;
             bgmmc.copy_A_src_stride
-                    = nstl::min(src_d.blocking_desc().strides[0],
-                              src_stride / factor)
+                    = nstl::min(copy_A_src_stride, src_stride / factor)
                     * factor;
         }
 

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_f32
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_f32
@@ -24,3 +24,7 @@
 # test correct LDA initialization, when batches are merged into M dimension
 --reset
 --stag=abcd --dtag=abcd 2x1x8x2:1x1x2x8_n"merge_batches_into_M"
+
+# test special tag that can be matched with adbc
+--reset
+--stag=dabc --wtag=abx --dtag=abx 1x2x2x32:2x2x32x7

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_int8
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_int8
@@ -20,3 +20,9 @@
 --dt=s8:s8:s8
 --stag=ab,ba --wtag=ba --dtag=AB16b16a
 11x13:13x16
+
+# verify transpose dst tag can be treated as plain
+--reset
+--dt=s8:s8:f32
+--stag=ab --wtag=ab --dtag=ba,ab
+1x1:1x200


### PR DESCRIPTION
Fixes # (MFDNN-12707, MFDNN-12625)

When one tag can be treated as plain or adbc, some offsets should be updated.
WIP: checking if additional test cases are needed