### PR TITLE
xe: gemm: fixup postop formats and correctness failure

### DIFF
--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
@@ -142,7 +142,9 @@ status_t gemm_with_post_ops_t::pd_t::init_kernel_ctx(
     auto c_type = dst_md(0)->data_type;
     const auto src_info = memory_desc_info_t::create(gemm_pd_->dst_md(0));
     const auto bias_info = [&]() {
-        auto info = memory_desc_info_t::create(src_md(2));
+        // If no bias, just default to same layout as dst - any valid layout will work, it's just a dummy
+        auto info = memory_desc_info_t::create(
+                with_bias() ? src_md(2) : dst_md(0));
         if (info.data_type == data_type::undef) info.data_type = data_type::f32;
         return info;
     }();


### PR DESCRIPTION
Fixes [MFDNN-12752](https://jira.devtools.intel.com/browse/MFDNN-12752), and a miscellaneous error that needed a fixup.

Fixup: https://github.com/oneapi-src/oneDNN/commit/3bab3477800cda65732763152b3a18174da7bd49 introduced a bug when running `gemm_with_postops` without bias, resulting in an assertion error. This fix uses the dst tensor to create bias macros when not using a bias, which removes the error and does not affect results.

MFDNN-12752: The following layer was reported to fail:
> $ ./oneDNN/build/tests/benchdnn/benchdnn --matmul --engine=gpu --allow-enum-tags-only=false --dt=u8:s8:bf16 --stag=abcd --wtag=abdc --attr-scales=src:common:0.5+wei:common:0.5 --attr-zero-points=src:common:1+wei:common:1 --attr-post-ops=mul:f32:8:abx+add:bf16:8:abx+div:bf16:0:abx+add:bf16:9:abcd --attr-scratchpad=user 4x16x1x256:4x16x256x1042
[   1][DST][0:0:0:1] exp_f32:     -11.125 exp:     -11.125 got:         -20 diff:   8.875 rdiff:0.797753
[   2][DST][0:0:0:2] exp_f32:         -21 exp:         -21 got:      -18.25 diff:    2.75 rdiff:0.130952
[   3][DST][0:0:0:3] exp_f32:    -3.28125 exp:    -3.28125 got:     -11.625 diff: 8.34375 rdiff: 2.54286
[   4][DST][0:0:0:4] exp_f32:    -2.67188 exp:    -2.67188 got:    0.667969 diff: 3.33984 rdiff:    1.25
[   5][DST][0:0:0:5] exp_f32:          25 exp:          25 got:     6.03125 diff: 18.9688 rdiff: 0.75875
[   6][DST][0:0:0:6] exp_f32:     2.32812 exp:     2.32812 got:      -13.75 diff: 16.0781 rdiff: 6.90604
[   7][DST][0:0:0:7] exp_f32:       -11.5 exp:       -11.5 got:       -19.5 diff:       8 rdiff:0.695652
[   8][DST][0:0:0:8] exp_f32:     7.09375 exp:     7.09375 got:    -1.04688 diff: 8.14062 rdiff: 1.14758
[   9][DST][0:0:0:9] exp_f32:    0.357422 exp:    0.357422 got:      -15.75 diff: 16.1074 rdiff: 45.0656
[  10][DST][0:0:0:10] exp_f32:          -8 exp:          -8 got:     -14.625 diff:   6.625 rdiff:0.828125
[COMPARE_STATS][DST]: trh=0 err_max_diff: 40.6172 err_max_rdiff: 610.149 all_max_diff: 40.6172 all_max_rdiff: 610.149
[PRIM_REF][INFO]: L2_size:1310720 bytes; per_core_L3_size:1572864 bytes; nthr:64; impl_name:brg_matmul:avx512_core_vnni
[PRIM_REF][REPRO]: --matmul --engine=cpu --allow-enum-tags-only=false --dt=u8:s8:bf16 --attr-scales=src:common:0.5+wei:common:0.5 --attr-zero-points=src:common:1+wei:common:1 --attr-post-ops=mul:f32:8:abx+add:f32:8:abx+div:f32:0:abx+add:f32:9:abx --attr-scratchpad=user 4x16x1x256:4x16x256x1042
0:FAILED (errors:66604 total:66688) __REPRO: --matmul --engine=gpu --allow-enum-tags-only=false --dt=u8:s8:bf16 --stag=abcd --wtag=abdc --attr-scales=src:common:0.5+wei:common:0.5 --attr-zero-points=src:common:1+wei:common:1 --attr-post-ops=mul:f32:8:abx+add:bf16:8:abx+div:bf16:0:abx+add:bf16:9:abcd --attr-scratchpad=user 4x16x1x256:4x16x256x1042
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 2.11s; fill: 0.60s (29%); compute_ref: 0.03s (1%); compare: 0.06s (3%);

This is fixed in two ways:
1. The underlying issue with the existing implementation was fixed. While collapsing batch dimensions to 1 or 0 dimensions, the algorithm would alter the binary post op descriptor - even if such a collapse is impossible (as in this case). The fix is to copy the descriptor while attempting this.
2. Dispatching to jit:gemm:any is improved to catch this case. This should come with performance improvements (will update the description when data is available from CI). This layer in question improves from 0.021 ms to 0.015 ms (on PVC). EDIT: this introduced failing layers in CI, so it has been removed from this PR. Will be added in a future one.