### PR TITLE
xe: ocl: sdpa: integer SDPA strategy tweaks

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/microkernel_provider.cpp
+++ b/src/gpu/intel/jit/gemm/generator/microkernel_provider.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -264,12 +264,11 @@ static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool l
     } else if (!block2DA) {
         s.A.accessType = AccessType::Block;
         if (systolic)
-            s.ka_load = (problem.A.layout == MatrixLayout::T) ? 32 : 16;
+            s.ka_load = (problem.A.layout == MatrixLayout::T) ? (64 / problem.Ta_ext) : 16;
         s.slmA = true;
-
     } else if (problem.A.layout == MatrixLayout::T) {
         s.A.accessType = AccessType::Block2DTranspose;
-        s.ka_load = 32;
+        s.ka_load = 64 / problem.Ta_ext;
     } else if (problem.A.layout == MatrixLayout::N) {
         s.A.accessType = AccessType::Block2DVNNI;
         s.A_copies = 2;

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -52,15 +52,25 @@ sdpa_config_t xehpg_h32_s64 = {16, 16, 16, 8, 4, 4, 2, 8};
 sdpa_config_t xehpg_h32_s32 = {8, 8, 8, 8, 4, 4, 4, 4};
 sdpa_config_t xehpg_h32_2nd = {8, 32, 16, 8, 8, 1, 2, 4};
 
+sdpa_config_t xehpg_q_h32 = {32, 16, 16, 16, 2, 8, 2, 8};
+sdpa_config_t xehpg_q_h32_2nd = {32, 16, 8, 8, 8, 1, 4, 2};
+
 sdpa_config_t xehpg_h64 = {32, 16, 16, 16, 4, 8, 4, 8};
 sdpa_config_t xehpg_h64_s128 = {16, 16, 16, 16, 4, 8, 4, 8};
 sdpa_config_t xehpg_h64_s64 = {32, 16, 16, 8, 8, 4, 4, 8};
 sdpa_config_t xehpg_h64_2nd = {8, 16, 16, 8, 8, 1, 4, 2};
 
+sdpa_config_t xehpg_q_h64 = {32, 16, 16, 16, 4, 4, 4, 4};
+sdpa_config_t xehpg_q_h64_2nd = {16, 16, 8, 8, 16, 1, 8, 2};
+
 sdpa_config_t xehpg_h128 = {16, 16, 32, 8, 8, 4, 4, 8};
 sdpa_config_t xehpg_h128_s32 = {16, 16, 16, 8, 16, 2, 8, 4};
 sdpa_config_t xehpg_h128_2nd = {8, 16, 16, 8, 16, 1, 8, 2};
 sdpa_config_t xehpg_h128_s256_2nd = {8, 16, 32, 8, 8, 1, 4, 2};
+
+sdpa_config_t xehpg_q_h128 = {32, 16, 16, 16, 8, 4, 8, 4};
+sdpa_config_t xehpg_q_h128_2nd = {32, 16, 16, 8, 16, 1, 8, 2};
+sdpa_config_t xehpg_q_h128_s64_2nd = {16, 16, 16, 8, 16, 1, 8, 2};
 
 sdpa_config_t xehpg_h256 = {16, 16, 32, 8, 16, 2, 8, 4};
 sdpa_config_t xehpg_h256_s128 = {8, 16, 32, 16, 8, 4, 8, 4};
@@ -79,28 +89,53 @@ sdpa_config_t xehpc_h64_s32 = {16, 16, 16, 16, 4, 2, 4, 2};
 sdpa_config_t xehpc_h64_2nd = {32, 32, 32, 16, 4, 1, 2, 2};
 sdpa_config_t xehpc_h64_s64_2nd = {16, 16, 16, 16, 4, 1, 4, 1};
 
+sdpa_config_t xehpc_q_h64 = {16, 64, 32, 16, 8, 4, 2, 16};
+
 sdpa_config_t xehpc_h128 = {16, 64, 32, 16, 16, 2, 4, 8};
 sdpa_config_t xehpc_h128_s64 = {16, 32, 32, 32, 4, 2, 4, 2};
 sdpa_config_t xehpc_h128_s32 = {16, 16, 16, 16, 8, 2, 8, 2};
 sdpa_config_t xehpc_h128_2nd = {32, 32, 32, 16, 8, 1, 4, 2};
 
+sdpa_config_t xehpc_q_h128 = {16, 64, 16, 32, 16, 2, 8, 4};
+sdpa_config_t xehpc_q_h128_s64 = {16, 16, 32, 16, 4, 4, 4, 4};
+sdpa_config_t xehpc_q_h128_s32 = {16, 16, 32, 16, 4, 2, 4, 2};
+sdpa_config_t xehpc_q_h128_2nd = {32, 32, 16, 32, 4, 1, 4, 1};
+sdpa_config_t xehpc_q_h128_s32_2nd = {16, 32, 16, 16, 8, 1, 4, 2};
+
 sdpa_config_t xehpc_h256 = {16, 32, 32, 32, 8, 4, 8, 4};
 sdpa_config_t xehpc_h256_s64 = {16, 32, 32, 32, 8, 1, 8, 1};
 sdpa_config_t xehpc_h256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 
-sdpa_config_t *choose_config_xehpg(dim_t head_size, dim_t seq, dim_t thin_q) {
+sdpa_config_t *choose_config_xehpg(
+        dim_t head_size, dim_t seq, bool thin_q, bool quantized) {
     if (head_size <= 32) {
+        if (quantized && seq >= 128) {
+            if (thin_q) return &xehpg_q_h32_2nd;
+            return &xehpg_q_h32;
+        }
         if (thin_q) return &xehpg_h32_2nd;
         if (seq <= 32) return &xehpg_h32_s32;
         if (seq <= 64) return &xehpg_h32_s64;
         if (seq <= 256) return &xehpg_h32_s256;
         return &xehpg_h32;
     } else if (head_size <= 64) {
+        if (quantized) {
+            if (thin_q) return &xehpg_q_h64_2nd;
+            return &xehpg_q_h64;
+        }
         if (thin_q) return &xehpg_h64_2nd;
         if (seq <= 64) return &xehpg_h64_s64;
         if (seq <= 128) return &xehpg_h64_s128;
         return &xehpg_h64;
     } else if (head_size <= 128) {
+        if (quantized) {
+            if (thin_q) {
+                if (seq <= 64) return &xehpg_q_h128_s64_2nd;
+                return &xehpg_q_h128_2nd;
+            }
+            if (seq <= 32) return &xehpg_h128_s32;
+            return &xehpg_q_h128;
+        }
         if (thin_q) {
             if (seq <= 256) return &xehpg_h128_s256_2nd;
             return &xehpg_h128_2nd;
@@ -120,7 +155,8 @@ sdpa_config_t *choose_config_xehpg(dim_t head_size, dim_t seq, dim_t thin_q) {
     return nullptr;
 }
 
-sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q) {
+sdpa_config_t *choose_config_xehpc(
+        dim_t head_size, dim_t seq, bool thin_q, bool quantized) {
     if (head_size <= 32) {
         if (thin_q) return &xehpc_h32_2nd;
         if (seq <= 32) return &xehpc_h32_s32;
@@ -130,10 +166,20 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q) {
             if (seq <= 64) return &xehpc_h64_s64_2nd;
             return &xehpc_h64_2nd;
         }
+        if (quantized && seq >= 256) return &xehpc_q_h64;
         if (seq <= 32) return &xehpc_h64_s32;
         if (seq <= 64) return &xehpc_h64_s64;
         return &xehpc_h64;
     } else if (head_size <= 128) {
+        if (quantized) {
+            if (thin_q) {
+                if (seq <= 32) return &xehpc_q_h128_s32_2nd;
+                return &xehpc_q_h128_2nd;
+            }
+            if (seq <= 32) return &xehpc_q_h128_s32;
+            if (seq <= 64) return &xehpc_q_h128_s64;
+            return &xehpc_q_h128;
+        }
         if (thin_q) return &xehpc_h128_2nd;
         if (seq <= 32) return &xehpc_h128_s32;
         if (seq <= 64) return &xehpc_h128_s64;
@@ -190,15 +236,19 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
     /* Retrieve pre-tuned kernel configuration */
     sdpa_config_t *config = nullptr;
     bool thin_q = (d->queries() <= 16);
+    bool quantized = types::is_integral_dt(key_md()->data_type)
+            || types::is_integral_dt(val_md()->data_type);
 
     switch (arch_) {
         case arch_t::xe_hpg:
-            config = choose_config_xehpg(d->head_size(), d->keys(), thin_q);
+            config = choose_config_xehpg(
+                    d->head_size(), d->keys(), thin_q, quantized);
             break;
         case arch_t::xe_hpc:
         case arch_t::xe2:
         case arch_t::xe3:
-            config = choose_config_xehpc(d->head_size(), d->keys(), thin_q);
+            config = choose_config_xehpc(
+                    d->head_size(), d->keys(), thin_q, quantized);
         default: break;
     }
 


### PR DESCRIPTION
DG2/LNL quantized SDPA tuned configs for head sizes 64/128.

DG2, int8 K/V, first token performance vs. main (d = head size). For some cases (marked `*`), micro_sdpa was previously unimplemented (kernel/ukernel did not build).

sequence length | d = 32 | d = 64 | d = 128 
-- | -- | -- | --
32 | 100% | 104% | 100%
64 | 100% | 108% | 120%
128 | 190% | 178% | 120%
256 | 217% | 101% | 177%
512 | * | 101% | 222%
1024 | * | 101% | 153%

DG2, second token:

sequence length | d = 32 | d = 64 | d = 128 
-- | -- | -- | --
32 | 100% | 110% | 117%
64 | 100% | 109% | 105%
128 | 123% | 153% | 122%
256 | 180% | 214% | 188%
512 | 188% | 225% | 174%
1024 | 193% | 229% | 179%

LNL, first token:

sequence length | d = 64 | d = 128 
-- | -- | --
32 | 99% | 159%
64 | 104% | 112%
128 | 103% | 93%
256 | 113% | 116%
512 | 118% | 112%
1024 | 121% | 104%

LNL, second token. Strategies for d = 64 were not altered.

sequence length | d = 128 
-- | --
32 | 158%
64 | 147%
128 | 177%
256 | 122%
512 | 137%
1024 | 124%
