### PR TITLE
xe: fix various GEMM issues on XeLP

### DIFF
--- a/src/gpu/intel/jit/emulation.hpp
+++ b/src/gpu/intel/jit/emulation.hpp
@@ -17,6 +17,11 @@
 #ifndef GPU_INTEL_JIT_EMULATION_HPP
 #define GPU_INTEL_JIT_EMULATION_HPP
 
+#include "gpu/intel/jit/ngen/ngen_config.hpp"
+#ifdef NGEN_ENABLE_SOURCE_LOCATION
+#include <source_location>
+#endif
+
 #include <exception>
 
 namespace dnnl {
@@ -66,9 +71,18 @@ struct EmulationState {
 // Implementation wrapped as static methods in non-instantiated class.
 // Clients should declare EmulationImplementation as a friend.
 struct EmulationImplementation {
+#ifdef NGEN_ENABLE_SOURCE_LOCATION
+    [[noreturn]] static void stub(
+            std::source_location where = std::source_location::current()) {
+        throw std::runtime_error(std::string("Unimplemented (at ")
+                + std::string(where.file_name()) + ":"
+                + std::to_string(where.line()) + ")");
+    }
+#else
     [[noreturn]] static void stub() {
         throw std::runtime_error("Unimplemented");
     }
+#endif
 
     template <typename DT, typename O>
     static void applyDefaultType(O &op) {

--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
@@ -46,7 +46,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
         const uint b_scale_dim = (NDIMS == 2) ? d1 : (NDIMS == 3) ? d2 : d3;
         float b_scale = 1;
         if (B_SCALES) load(&b_scale, b_scales + scale_stride * b_scale_dim);
-        acc *= a_scale * b_scale;
+        if (A_SCALES || B_SCALES) acc *= a_scale * b_scale;
 
         if (bias) {
             ACC_DATA_T b;

--- a/src/gpu/intel/ocl/ocl_conversion.h
+++ b/src/gpu/intel/ocl/ocl_conversion.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -72,6 +72,8 @@ def_std_into_sat(uchar, float);
 def_std_into_sat(uchar, int);
 IF_DOUBLE_SUPPORTED(def_std_into_sat(uchar, double));
 IF_HALF_SUPPORTED(def_std_into_sat(uchar, half));
+
+def_std_into_sat(int, float);
 
 IF_HALF_SUPPORTED(def_std_into(half, char));
 IF_HALF_SUPPORTED(def_std_into(half, uchar));

--- a/src/gpu/intel/ocl/ocl_io.h
+++ b/src/gpu/intel/ocl/ocl_io.h
@@ -77,6 +77,7 @@ DEF_load(float, char);
 DEF_load(float, uchar);
 DEF_load(int, char);
 DEF_load(int, uchar);
+DEF_load(int, int);
 DEF_load(float, bf16);
 
 // Writes
@@ -88,6 +89,7 @@ DEF_write(float, float);
 DEF_write(char, int);
 DEF_write(uchar, int);
 DEF_write(bf16, int);
+DEF_write(int, int);
 DEF_write(float, int);
 DEF_write(int, float);
 


### PR DESCRIPTION
Fixes an emulate gap uncovered by #2276 ,  a support gap uncovered by #2289, and fixes a type conversion issue uncovered by #2289.