### PR TITLE
xe: jit: gemm: implement qqw mul instructions

### DIFF
--- a/src/gpu/intel/jit/emulation.hpp
+++ b/src/gpu/intel/jit/emulation.hpp
@@ -621,13 +621,15 @@ struct EmulationImplementation {
         bool emulate64 = strategy.emulate64_mul;
 
         if (s0Q) {
-            if (!s1D || !dstQ) stub();
+            if (s1Q || !dstQ) stub();
             auto temp = s1Signed ? state.temp[0].d() : state.temp[0].ud();
             auto &src1Reg = [&]() -> ngen::RegData & {
-                if (std::is_base_of<ngen::RegData, S1>::value)
+                if (s1Immed || s1W) {
+                    g.mov(mod, temp, src1);
+                    return temp;
+                } else {
                     return *reinterpret_cast<ngen::RegData *>(&src1);
-                g.mov(1, temp, src1);
-                return temp;
+                }
             }();
             return emulInternal(g, mod, dst, src1Reg, src0, strategy, state);
         } else if (s1Q) {


### PR DESCRIPTION
Fixes [MFDNN-12978](https://jira.devtools.intel.com/browse/MFDNN-12978). The following layer (among others) is failing:
> ./benchdnn --mode=F --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=all --dt=f16:f16:f16 --stag=abc --wtag=abc --dtag=abc 192x663x64:192x64x663
onednn_verbose,v1,info,oneDNN v3.7.0 (commit 5890fc624e0d45ac585b35fd1e1d460456319f3a)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:64
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with Intel DL Boost
onednn_verbose,v1,info,gpu,runtime:OpenCL
onednn_verbose,v1,info,gpu,engine,opencl device count:2
onednn_verbose,v1,info,gpu,engine,0,name:Intel(R) Data Center GPU Max 1550,driver_version:24.39.31294,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,1,name:Intel(R) Data Center GPU Max 1550,driver_version:24.39.31294,binary_kernels:enabled
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,error,gpu,jit::gemm,Unimplemented,src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp:979
Error: Function 'create_primitive' at (/home/gta/simonewi/oneDNN/tests/benchdnn/dnnl_common.hpp:422) returned 'runtime_error'
Error: Function 'init_prim' at (/home/gta/simonewi/oneDNN/tests/benchdnn/dnnl_common.hpp:475) returned '1'
Error: Function 'createit' at (/home/gta/simonewi/oneDNN/tests/benchdnn/matmul/matmul.cpp:897) returned '1'
Error: Function 'create' at (/home/gta/simonewi/oneDNN/tests/benchdnn/utils/task.hpp:49) returned '1'
0:UNTESTED_FAILED __REPRO: --mode=F --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=all --dt=f16:f16:f16 --stag=abc --wtag=abc --dtag=abc 192x663x64:192x64x663
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,gpu,,,--mode=F --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=all --dt=f16:f16:f16 --stag=abc --wtag=abc --dtag=abc 192x663x64:192x64x663,10.8028,0.168213,0,0,0,0
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total perf: min(ms):0 avg(ms):0
total: 0.04s; fill: 0.00s (0%);

#2276 Introduced 64-bit arithmetic for large buffer support in gemm kernels, but some cases (specifically related to word operands) were left unimplemented which resulted in runtime errors. This implements those remaining cases via word -> dword conversion.