### PR TITLE
Introduce matmul-based IP for training

### DIFF
--- a/include/oneapi/dnnl/dnnl_types.h
+++ b/include/oneapi/dnnl/dnnl_types.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2547,6 +2547,12 @@ typedef const struct dnnl_primitive *const_dnnl_primitive_t;
 
 /// Bias tensor argument.
 #define DNNL_ARG_BIAS 41
+
+/// Reduce tensor argument.
+#define DNNL_ARG_REDUCE 42
+
+/// Note: when adding a new macro after `DNNL_ARG_REDUCE` please reserve a
+/// space for potential indices for `DNNL_ARG_REDUCE`.
 
 /// Mean values tensor argument.
 #define DNNL_ARG_MEAN 49

--- a/src/common/c_types_map.hpp
+++ b/src/common/c_types_map.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2060,6 +2060,14 @@ const query_t internal_only_start = (query_t)(1 << 12);
 const query_t zero_pad_d = internal_only_start;
 const query_t preferred_gpu_threads_per_eu = (query_t)(internal_only_start + 1);
 } // namespace query
+
+// There are no external values to map to because this is an internal feature
+// for now.
+using matmul_reduce_kind_t = int;
+namespace matmul_reduce_kind {
+const matmul_reduce_kind_t undef = 0;
+const matmul_reduce_kind_t src = 1;
+} // namespace matmul_reduce_kind
 
 using rnn_direction_t = dnnl_rnn_direction_t;
 

--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 * Copyright 2024-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,6 +166,7 @@ enum {
     key_brgemm_primitive_buffer_d,
     key_brgemm_primitive_zp_comp_a,
     key_brgemm_primitive_zp_comp_b,
+    key_brgemm_primitive_buffer_reduce,
     key_concat_iptrs,
     key_concat_istrides,
     key_concat_nelems,

--- a/src/common/opdesc.hpp
+++ b/src/common/opdesc.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -273,6 +273,10 @@ struct matmul_desc_t : public op_desc_t {
     memory_desc_t bias_desc {};
     // Destination memory descriptor.
     memory_desc_t dst_desc {};
+    // Reduce memory descriptor;
+    memory_desc_t reduce_desc {};
+    // Reduce kind.
+    matmul_reduce_kind_t reduce_kind {};
     // The accumulator data type. Initialized automatically.
     data_type_t accum_data_type {};
 };

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -576,6 +576,9 @@ size_t get_desc_hash(const matmul_desc_t &desc) {
     seed = hash_combine(seed, get_md_hash(desc.weights_desc));
     seed = hash_combine(seed, get_md_hash(desc.bias_desc));
     seed = hash_combine(seed, get_md_hash(desc.dst_desc));
+    seed = hash_combine(seed, get_md_hash(desc.reduce_desc));
+    // Reduce kind.
+    seed = hash_combine(seed, static_cast<size_t>(desc.reduce_kind));
     // Accumulator type
     seed = hash_combine(seed, static_cast<size_t>(desc.accum_data_type));
     // Combined hash for matmul op desc

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -813,6 +813,8 @@ inline bool operator==(const matmul_desc_t &lhs, const matmul_desc_t &rhs) {
             && COMPARE_DESC_MEMBERS(weights_desc)
             && COMPARE_DESC_MEMBERS(bias_desc)
             && COMPARE_DESC_MEMBERS(dst_desc)
+            && COMPARE_DESC_MEMBERS(reduce_desc)
+            && COMPARE_DESC_MEMBERS(reduce_kind)
             && COMPARE_DESC_MEMBERS(accum_data_type);
     return ret;
 }

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -126,6 +126,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         BRGEMM_FP8_FWD_IP(f8_e4m3, f8_e4m3, f8_e4m3),
 
         {{backward_data, f32, f32, f32}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx>) // bf32
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_inner_product_bwd_data_t<avx2>)
@@ -134,6 +135,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         })},
         {{backward_data, f32, bf16, bf16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_data_t<f32>)
@@ -141,6 +143,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         })},
         {{backward_data, bf16, bf16, bf16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_data_t<bf16>)
@@ -148,12 +151,14 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         })},
         {{backward_data, f32, f16, f16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core_fp16>)
             CPU_INSTANCE(ref_inner_product_bwd_data_t)
             nullptr,
         })},
         {{backward_data, f16, f16, f16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_data_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_data_t<avx512_core_fp16>)
             CPU_INSTANCE(ref_inner_product_bwd_data_t)

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -165,6 +165,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         })},
         {{backward_weights, f32, f32, f32}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx>) // bf32
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_inner_product_bwd_weights_t<avx2>)
@@ -173,6 +174,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         })},
         {{backward_weights, bf16, f32, bf16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_weights_t<f32>)
@@ -180,6 +182,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         })},
         {{backward_weights, bf16, bf16, bf16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_bwd_weights_t<bf16>)
@@ -187,12 +190,14 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         })},
         {{backward_weights, f16, f32, f16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core_fp16>)
             CPU_INSTANCE(ref_inner_product_bwd_weights_t)
             nullptr,
         })},
         {{backward_weights, f16, f16, f16}, REG_BWD_PK({
+            CPU_INSTANCE_X64(matmul_inner_product_bwd_weights_t)
             CPU_INSTANCE_AMX(brgemm_inner_product_bwd_weights_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AVX512(brgemm_inner_product_bwd_weights_t<avx512_core_fp16>)
             CPU_INSTANCE(ref_inner_product_bwd_weights_t)

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -83,6 +83,23 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         return IMPLICATION(with_bias(), is_bia_dt_correct && is_bias_1xN());
     };
 
+    auto check_reduce = [&]() -> bool {
+        if (!with_reduce()) return true;
+
+        bool ok = reduce_kind() == matmul_reduce_kind::src;
+        ok = ok && src_md()->ndims == 2;
+        ok = ok && one_of(src_dt, f32, bf16, f16);
+
+        const memory_desc_wrapper src_mdw(src_md_);
+        ok = ok && !src_mdw.has_runtime_dims();
+        ok = ok && src_mdw.matches_tag(format_tag::ba);
+
+        const auto skip_mask = primitive_attr_t::skip_mask_t::fpmath_mode;
+        ok = ok && attr()->has_default_values(skip_mask);
+
+        return ok;
+    };
+
     auto check_attr_scales = [&]() -> bool {
         const std::vector<int> supported_args
                 = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
@@ -157,6 +174,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     VDISPATCH_MATMUL(check_attr_scales(), VERBOSE_UNSUPPORTED_SCALES_CFG);
     VDISPATCH_MATMUL(check_attr_zero_points(), VERBOSE_UNSUPPORTED_ZP_CFG);
     VDISPATCH_MATMUL(check_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
+    VDISPATCH_MATMUL(check_reduce(), VERBOSE_UNSUPPORTED_FEATURE,
+            "reduce is not supported");
 
     CHECK(init_brgemm_matmul_conf(isa, bgmmc_, *desc(), src_md_, weights_md_,
             dst_md_, bias_md_, attr_));
@@ -285,6 +304,25 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
         CHECK(safe_ptr_assign(brg_kernels_[idx], ker));
         if (is_superset(pd()->get_brg_desc(idx).isa_impl, avx512_core_amx))
             brgemm_palettes_.insert(idx, pd()->get_brg_desc(idx));
+
+        if (pd()->with_reduce()) {
+            if (pd()->reduce_kind() == matmul_reduce_kind::src) {
+                if (i_N == 0 && i_init == i_init_start) {
+                    reducers_[i_M][i_K] = nullptr;
+                    auto db_desc = pd()->get_brg_desc(idx);
+                    db_desc.reduce_dim = i_K ? bgmmc.K_tail : bgmmc.K_blk;
+                    db_desc.load_dim = i_M ? bgmmc.M_tail : bgmmc.M_blk;
+
+                    if (db_desc.reduce_dim > 0 && db_desc.load_dim > 0) {
+                        CHECK(safe_ptr_assign(reducers_[i_M][i_K],
+                                new reducer_t(bgmmc, db_desc)));
+                        CHECK(reducers_[i_M][i_K]->create_kernel());
+                    }
+                }
+            } else {
+                assert(!"unsupported reduce kind");
+            }
+        }
     }
 
     if (bgmmc.use_buffer_b && !bgmmc.packed_sparse_weights)
@@ -293,7 +331,7 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
     if (bgmmc.use_buffer_a || bgmmc.use_buffer_a_tail_only)
         CHECK(create_brgemm_matmul_copy_a(copy_A_kernel_, &bgmmc));
 
-    if (bgmmc.nthr_k > 1 && bgmmc.acc_dt == f32) {
+    if (pd()->with_reduce() || (bgmmc.nthr_k > 1 && bgmmc.acc_dt == f32)) {
         CHECK(safe_ptr_assign(
                 acc_ker_f32_, new cpu_accumulator_1d_t<data_type::f32>()));
         CHECK(acc_ker_f32_->create_kernel());
@@ -437,6 +475,7 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
         if (is_amx) { amx_tile_release(); }
     });
 
+    maybe_reduce_and_convert_partial_results_A(brgmm_ctx);
     maybe_reduce_partial_results_and_apply_postops(brgmm_ctx);
 
     return status::success;
@@ -539,6 +578,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
                     (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
                     &leading_dimensions);
         }
+
+        maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
+                k_chunk_idx, do_init, is_K_tail, /* do_K_tail */ false);
     }
     if (is_K_tail) {
         brgmm_ctx.init_brgemm_batch_elements_values(ithr, gemm_batch, 1,
@@ -592,10 +634,175 @@ void brgemm_matmul_t<isa>::compute_kernel(
                     (void *)ptr_C, is_amx ? (void *)wsp_tile : nullptr,
                     &leading_dimensions);
         }
+
+        maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
+                k_chunk_idx, do_init, is_K_tail,
+                /* do_K_tail */ true);
     }
 
     brgmm_ctx.maybe_restore_dst_values_from_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
+}
+
+template <cpu_isa_t isa>
+void brgemm_matmul_t<isa>::maybe_reduce_A(
+        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, int gemm_batch,
+        int m_blk_idx, int n_blk_idx, int k_chunk_idx, bool do_init,
+        bool has_K_tail, bool do_K_tail) const {
+
+    if (!pd()->with_reduce()) return;
+
+    const bool reduce_a = pd()->reduce_kind() == matmul_reduce_kind::src;
+    // Only `matmul_reduce_kind::src` is supported for now.
+    assert(reduce_a);
+
+    const auto &bgmmc = pd()->get_brgemm_matmul_conf();
+    const auto *addr_batch = brgmm_ctx.get_batch_elem_ptr(ithr);
+
+    if (reduce_a && n_blk_idx == 0) {
+        const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
+
+        auto *reduce_ptr = bgmmc.use_buffer_reduce
+                ? brgmm_ctx.get_buf_reduce_ptr(ithr, m)
+                : brgmm_ctx.get_data_reduce_ptr(m);
+
+        brgemm_kernel_diff_bias_t p;
+
+        p.ptr_diff_bias_acc = (void *)reduce_ptr;
+        p.ptr_diff_bias = (void *)brgmm_ctx.get_data_reduce_ptr(m);
+
+        const int m_ker_idx = brgmm_ctx.get_M_kernel_idx(m_blk_idx);
+
+        if (!do_K_tail) {
+            for (int gb = 0; gb < gemm_batch; gb++) {
+                p.ptr_diff_dst = (void *)addr_batch[gb].ptr.A;
+
+                const bool is_first = do_init && gb == 0;
+                const bool is_last = (bgmmc.nthr_k == 1 || bgmmc.K_chunks == 1)
+                        && k_chunk_idx == bgmmc.K_chunks - 1
+                        && gb == gemm_batch - 1 && !has_K_tail;
+
+                p.flags = 0 | (is_first ? FLAG_REDUCE_FIRST : 0)
+                        | (is_last ? FLAG_REDUCE_LAST : 0);
+
+                (*reducers_[m_ker_idx][do_K_tail])(&p);
+            }
+        } else {
+            p.ptr_diff_dst = (void *)addr_batch[0].ptr.A;
+
+            const bool is_first = do_init && gemm_batch == 0;
+            const bool is_last = (bgmmc.nthr_k == 1 || bgmmc.K_chunks == 1)
+                    && k_chunk_idx == bgmmc.K_chunks - 1;
+
+            p.flags = 0 | (is_first ? FLAG_REDUCE_FIRST : 0)
+                    | (is_last ? FLAG_REDUCE_LAST : 0);
+
+            (*reducers_[m_ker_idx][do_K_tail])(&p);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void brgemm_matmul_t<isa>::maybe_reduce_and_convert_partial_results_A(
+        const brg_matmul_exec_ctx_t &brgmm_ctx) const {
+    // Partial results appear when parallel reduction is used.
+    //
+    // There are two cases that require slightly different handling.
+    // - (Figure 1): when reduce data type is not f32. In this case there are
+    //   three steps:
+    //     * Step 1: add partial results from all reduce buffers except the last
+    //       one to the first reduce buffer (reduce_buf_0).
+    //     * Step 2 and step 3: add partial results from the first and the last
+    //       reduce buffers, convert the result to the reduce data type and
+    //       store it to the user provided reduce buffer.
+    //
+    // - (Figure 2): when reduce data type is f32. In this case the user
+    //   provided reduce buffer is used as one of the reduce buffers and there
+    //   is only 1 step:
+    //     * Step 1: add partial results from all reduce buffers to the user
+    //     provided reduce buffer.
+    //       buffer.
+    //
+    //                    Figure 1.
+    //             +--------------------+
+    //             | reduce (bf16/f16)  |<------+ Step 3.
+    //             +--------------------+       |
+    //             +--------------------+       |
+    //         +-->| reduce_buf_0 (f32) |--->   |
+    // Step 1. |   +--------------------+   |   |
+    //         |   +--------------------+   |   |
+    //         +<--| reduce_buf_1 (f32) |   +---> Step 2.
+    //             +--------------------+   |
+    //             +--------------------+   |
+    //             | reduce_buf_2 (f32) |--->
+    //             +--------------------+
+    //
+    //                    Figure 2.
+    //             +--------------------+
+    //         +-->|    reduce (f32)    |
+    //         |   +--------------------+
+    //         |   +--------------------+
+    // Step 1. +<--| reduce_buf_0 (f32) |
+    //         |   +--------------------+
+    //         |   +--------------------+
+    //         +<--| reduce_buf_1 (f32) |
+    //             +--------------------+
+
+    if (!pd()->with_reduce() || !brgmm_ctx.parallel_reduction_is_used()) return;
+
+    const auto &bgmmc = pd()->get_brgemm_matmul_conf();
+    const int num_threads = brgmm_ctx.get_num_threads_for_parallelization();
+
+    parallel(num_threads, [&](const int ithr, const int nthr) {
+        const int ithr_bmn = brgmm_ctx.get_thread_idx_for_bmn(ithr);
+        const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
+        if (ithr_bmn < 0 || ithr_k < 0) return;
+
+        const int M_chunks = brgmm_ctx.get_M_chunks();
+
+        int start_mc {0}, end_mc {0};
+        balance211(M_chunks, brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn,
+                start_mc, end_mc);
+        if (start_mc != end_mc && ithr_k == 0) {
+            const size_t m = start_mc * bgmmc.M_chunk_elems;
+            const size_t mc_work = end_mc - start_mc;
+            const size_t acc_size
+                    = std::min(mc_work * bgmmc.M_chunk_elems, bgmmc.M - m);
+
+            const bool is_reduce_f32 = bgmmc.reduce_dt == f32;
+
+            float *reduce_acc = is_reduce_f32
+                    ? (float *)brgmm_ctx.get_data_reduce_ptr(m)
+                    : (float *)brgmm_ctx.get_buf_reduce_ptr_by_index(0, m);
+
+            int ibuf = !is_reduce_f32;
+            for (; ibuf < bgmmc.nthr_k - 1; ibuf++) {
+                float *reduce_buf
+                        = (float *)brgmm_ctx.get_buf_reduce_ptr_by_index(
+                                ibuf, m);
+                acc_ker_f32_->accumulate(reduce_acc, reduce_buf, acc_size);
+            }
+
+            if (!is_reduce_f32) {
+                float *reduce_buf
+                        = (float *)brgmm_ctx.get_buf_reduce_ptr_by_index(
+                                ibuf, m);
+                switch (bgmmc.reduce_dt) {
+                    case data_type::bf16:
+                        add_floats_and_cvt_to_bfloat16(
+                                (bfloat16_t *)brgmm_ctx.get_data_reduce_ptr(m),
+                                reduce_acc, reduce_buf, acc_size);
+                        break;
+                    case data_type::f16:
+                        add_floats_and_cvt_to_float16(
+                                (float16_t *)brgmm_ctx.get_data_reduce_ptr(m),
+                                reduce_acc, reduce_buf, acc_size);
+                        break;
+                    default: assert(!"invalid data type");
+                }
+            }
+        }
+    });
 }
 
 template <cpu_isa_t isa>
@@ -888,7 +1095,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         , dst_d_(pd->dst_md())
         , data_A_ptr_(CTX_IN_MEM(const char *, DNNL_ARG_SRC))
         , data_B_ptr_(CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS))
-        , data_C_ptr_(CTX_OUT_MEM(char *, DNNL_ARG_DST)) {
+        , data_C_ptr_(CTX_OUT_MEM(char *, DNNL_ARG_DST))
+        , data_reduce_ptr_(CTX_OUT_MEM(char *, DNNL_ARG_REDUCE)) {
 
         const memory_desc_wrapper weights_d(pd->weights_md(0));
         if (bgmmc_.packed_sparse_weights) {
@@ -899,6 +1107,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         }
 
         bias_ptr_ = CTX_IN_MEM(const char *, DNNL_ARG_BIAS);
+
         oscales_ptr_ = oscales;
         dst_scales_ptr_ = dst_scales;
         memory_tracking::grantor_t scratchpad = ctx.get_scratchpad_grantor();
@@ -923,6 +1132,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         buf_D_ptr_ = (bgmmc.is_runtime_M || bgmmc.is_runtime_N)
                 ? scratchpad.template get<char>(key_brgemm_primitive_buffer_d)
+                : nullptr;
+
+        buf_reduce_ptr_ = bgmmc.use_buffer_reduce
+                ? scratchpad.template get<char>(
+                        key_brgemm_primitive_buffer_reduce)
                 : nullptr;
 
         is_amx_ = is_superset(isa, avx512_core_amx);
@@ -1449,6 +1663,36 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return off;
     }
 
+    // Returns a pointer to the user-provided reduce buffer, shifted by
+    // the specified offset @p off.
+    char *get_data_reduce_ptr(int off) const {
+        if (!bgmmc_.with_reduce) return nullptr;
+        return data_reduce_ptr_ + off * bgmmc_.reduce_dt_sz;
+    }
+
+    // Returns a pointer to the scratchpad reduce buffer for the
+    // corresponding @p ithr, shifted by the specified offset @p off.
+    char *get_buf_reduce_ptr(int ithr, int off) const {
+        if (!bgmmc_.with_reduce) return nullptr;
+        assert(bgmmc_.acc_dt == f32);
+        const int ithr_k = get_thread_idx_for_k(ithr);
+        // Use the user-provided reduce buffer as one of the reduce buffers.
+        const bool is_reduce_f32 = bgmmc_.reduce_dt == f32;
+        if (is_reduce_f32 && ithr_k == 0) return get_data_reduce_ptr(off);
+
+        return buf_reduce_ptr_
+                + (ithr_k - is_reduce_f32) * bgmmc_.buffer_reduce_per_thread_sz
+                + off * bgmmc_.acc_dt_sz;
+    }
+
+    // Returns a pointer to the scratchpad reduce buffer for the
+    // corresponding index @p ibuf, shifted by the specified offset @p off.
+    char *get_buf_reduce_ptr_by_index(int ibuf, int off) const {
+        if (!bgmmc_.with_reduce) return nullptr;
+        const size_t _off = bgmmc_.M * ibuf + off;
+        return buf_reduce_ptr_ + _off * bgmmc_.acc_dt_sz;
+    }
+
     const char *get_bias_ptr(int n) const {
         if (!bgmmc_.with_bias) return nullptr;
 
@@ -1796,12 +2040,14 @@ private:
     int B_packed_sparse_block_size_;
 
     char *data_C_ptr_;
+    char *data_reduce_ptr_;
     brgemm_batch_element_t *batch_element_ptr_;
 
     char *buf_A_ptr_;
     char *buf_B_ptr_;
     char *buf_C_ptr_;
     char *buf_D_ptr_;
+    char *buf_reduce_ptr_;
 
     char *wsp_tile_ptr_;
     const char *bias_ptr_;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1288,6 +1288,11 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.wei_dt = weights_d.data_type();
     bgmmc.orig_wei_dt = weights_d.data_type();
 
+    bgmmc.with_reduce = mmd.reduce_desc.format_kind != format_kind::undef;
+    bgmmc.reduce_dt
+            = bgmmc.with_reduce ? mmd.reduce_desc.data_type : data_type::undef;
+    bgmmc.reduce_kind = mmd.reduce_kind;
+
     bgmmc.with_bias = mmd.bias_desc.format_kind != format_kind::undef;
     bgmmc.bia_dt = bgmmc.with_bias ? mmd.bias_desc.data_type : data_type::undef;
     bgmmc.s8s8_compensation_required = bgmmc.src_dt == s8 && !isa_has_s8s8(isa);
@@ -1358,6 +1363,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.c_dt_sz = types::data_type_size(bgmmc.dst_dt);
     bgmmc.acc_dt_sz = types::data_type_size(bgmmc.acc_dt);
     if (bgmmc.with_bias) bgmmc.bias_dt_sz = types::data_type_size(bgmmc.bia_dt);
+    if (bgmmc.with_reduce)
+        bgmmc.reduce_dt_sz = types::data_type_size(bgmmc.reduce_dt);
 
     const auto &src_scales = attr.scales_.get(DNNL_ARG_SRC);
     const auto &wei_scales = attr.scales_.get(DNNL_ARG_WEIGHTS);
@@ -1671,6 +1678,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             = is_batch_layout_trivial(dst_d, bgmmc.batch);
     init_aux_values(bgmmc, src_d, weights_d, dst_d);
 
+    bgmmc.use_buffer_reduce
+            = (bgmmc.reduce_dt != data_type::f32) || (bgmmc.nthr_k > 1);
+
     // Dispatch small shapes to VNNI for better performance
     const bool runtime_dims
             = bgmmc.is_runtime_M || bgmmc.is_runtime_N || bgmmc.is_runtime_K;
@@ -1831,6 +1841,12 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.buffer_b_per_thread_sz
             = bgmmc.buffer_b_chunk_sz * bgmmc.brgemm_batch_size;
 
+    bgmmc.buffer_reduce_per_thread_sz = 0;
+    if (bgmmc.reduce_kind == matmul_reduce_kind::src) {
+        assert(bgmmc.acc_dt == f32);
+        bgmmc.buffer_reduce_per_thread_sz = bgmmc.M * bgmmc.acc_dt_sz;
+    }
+
     bgmmc.s8s8_comp_ithr_str
             = bgmmc.use_buffer_b ? bgmmc.wei_n_blk * bgmmc.N_chunk_size : 0;
     bgmmc.s8s8_comp_b_str = bgmmc.use_buffer_b
@@ -1957,6 +1973,14 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
     if (bgmmc.use_buffer_c)
         scratchpad.book(key_brgemm_primitive_buffer,
                 bgmmc.nthr * bgmmc.buffer_c_per_thread_sz, default_data_align);
+
+    if (bgmmc.use_buffer_reduce) {
+        const bool is_reduce_f32 = bgmmc.reduce_dt == f32;
+        scratchpad.book(key_brgemm_primitive_buffer_reduce,
+                (bgmmc.nthr_k - is_reduce_f32)
+                        * bgmmc.buffer_reduce_per_thread_sz,
+                default_data_align);
+    }
 
     if (bgmmc.has_zero_point_a) {
         const auto num_elems = bgmmc.nthr * bgmmc.zp_a_comp_elems_per_thr;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -95,7 +95,10 @@ struct brgemm_matmul_conf_t {
 
     cpu_isa_t isa;
 
+    matmul_reduce_kind_t reduce_kind;
+
     format_tag_t src_tag, wei_tag, dst_tag, bia_tag;
+    bool with_reduce;
     bool with_bias;
     bool with_sum;
     bool with_eltwise;
@@ -114,6 +117,7 @@ struct brgemm_matmul_conf_t {
     bool use_buffer_a_tail_only;
     bool use_buffer_b;
     bool use_buffer_c;
+    bool use_buffer_reduce;
 
     brgemm_matmul_bcast_desc_t bcast_A_desc;
     brgemm_matmul_bcast_desc_t bcast_B_desc;
@@ -123,13 +127,14 @@ struct brgemm_matmul_conf_t {
     data_type_t wei_dt;
     data_type_t acc_dt;
     data_type_t bia_dt;
+    data_type_t reduce_dt;
     data_type_t orig_src_dt;
     data_type_t orig_wei_dt;
     int nthr;
     int nthr_k;
 
     // Auxiliary values for init_config() and execute()
-    dim_t a_dt_sz, b_dt_sz, c_dt_sz, acc_dt_sz, bias_dt_sz;
+    dim_t a_dt_sz, b_dt_sz, c_dt_sz, acc_dt_sz, bias_dt_sz, reduce_dt_sz;
 
     // used for transposed buffer datatype when different from x_dt_sz
     // (e.g. used in BF32 implementations having to down-convert to BF16
@@ -164,6 +169,9 @@ struct brgemm_matmul_conf_t {
 
     dim_t buffer_b_chunk_sz;
     dim_t buffer_b_per_thread_sz;
+
+    dim_t buffer_reduce_per_thread_sz;
+
     dim_t s8s8_comp_ithr_str;
     dim_t s8s8_comp_b_str;
     dim_t s8s8_comp_n_str;

--- a/src/cpu/x64/matmul_inner_product.hpp
+++ b/src/cpu/x64/matmul_inner_product.hpp
@@ -39,6 +39,9 @@ status_t create_matmul_pd(std::shared_ptr<primitive_desc_t> &matmul_pd,
 status_t init_matmul_md(memory_desc_t &mm_md, const memory_desc_t &ip_md,
         format_tag_t tag, bool swap_dims = false);
 
+status_t set_training_formats(memory_desc_t *src_md, memory_desc_t *wei_md,
+        memory_desc_t *bias_md, memory_desc_t *dst_md);
+
 struct matmul_inner_product_fwd_t : public primitive_t {
     using primitive_t::primitive_t;
     struct pd_t : public cpu_inner_product_fwd_pd_t {
@@ -98,6 +101,77 @@ struct matmul_inner_product_fwd_t : public primitive_t {
     status_t init(impl::engine_t *engine) override {
         CHECK(pd()->matmul_pd_->create_primitive(matmul_, engine));
         return status::success;
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::shared_ptr<impl::primitive_t> matmul_;
+};
+
+struct matmul_inner_product_bwd_data_t : public primitive_t {
+    using primitive_t::primitive_t;
+    struct pd_t : public cpu_inner_product_bwd_data_pd_t {
+        using cpu_inner_product_bwd_data_pd_t::cpu_inner_product_bwd_data_pd_t;
+
+        DECLARE_COMMON_PD_T((matmul_pd_ ? matmul_pd_->name() : "matmul"),
+                matmul_inner_product_bwd_data_t);
+
+        bool has_type(data_type_t v) const {
+            return utils::one_of(v, weights_md()->data_type,
+                    diff_src_md()->data_type, diff_dst_md()->data_type);
+        }
+
+        status_t init(impl::engine_t *engine) {
+            using namespace data_type;
+            using skip_mask_t = primitive_attr_t::skip_mask_t;
+
+            const auto diff_src_dt = invariant_src_md()->data_type;
+            const auto diff_dst_dt = invariant_dst_md()->data_type;
+            const auto wei_dt = invariant_wei_md()->data_type;
+
+            VDISPATCH_INNER_PRODUCT(get_prop_kind() == prop_kind::backward_data,
+                    VERBOSE_BAD_PROPKIND);
+            VDISPATCH_INNER_PRODUCT_SC(set_formats(), VERBOSE_UNSUPPORTED_TAG);
+            VDISPATCH_INNER_PRODUCT(
+                    !has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+            VDISPATCH_INNER_PRODUCT(utils::one_of(diff_dst_dt, f32, bf16, f16,
+                                            f8_e5m2, f8_e4m3),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_INNER_PRODUCT(wei_dt == diff_dst_dt,
+                    VERBOSE_INCONSISTENT_DT, "weights", "diff_dst");
+            VDISPATCH_INNER_PRODUCT(
+                    utils::one_of(diff_src_dt, f32, diff_dst_dt),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_INNER_PRODUCT(
+                    attr()->has_default_values(skip_mask_t::fpmath_mode),
+                    VERBOSE_UNSUPPORTED_ATTR);
+            VDISPATCH_INNER_PRODUCT_SC(
+                    init_matmul_params(engine), "init_matmul_params");
+            init_scratchpad();
+
+            return status::success;
+        }
+
+        std::shared_ptr<primitive_desc_t> matmul_pd_;
+
+    private:
+        status_t init_matmul_params(engine_t *engine);
+        status_t set_formats() {
+            return set_training_formats(
+                    &diff_src_md_, &weights_md_, nullptr, &diff_dst_md_);
+        }
+
+        void init_scratchpad() {
+            auto scratchpad = scratchpad_registry().registrar();
+            scratchpad.book(memory_tracking::names::key_nested,
+                    matmul_pd_->scratchpad_registry());
+        }
+    };
+
+    status_t init(impl::engine_t *engine) override {
+        return pd()->matmul_pd_->create_primitive(matmul_, engine);
     }
 
     status_t execute(const exec_ctx_t &ctx) const override;


### PR DESCRIPTION
This PR introduces matmul-based IP implementation for training.
* When IP is created for `forward_training` plain layouts are always used to be consistent with the corresponding tensors used for  `backward_data` and `backward_weights` 
* To support bias gradients for `backward_weights` case the matmul primitive has been extended with an internal feature that enables matmul to reduce matrix A. The reduction is fused.
* Verbose was not extended to cover the new internal feature intentionally because having it in verbose doesn't provide any information that would be helpful, information about bias for IP is already enough.
* This matmul-based implementation for training is meant to be a full replacement for the existing brgemm-based one however, the latter one will stay available through the primitive descriptor iterator for some time but no further development is planned for it and it will eventually be removed.

The performance data below is collected using a custom benchmark that mimics a training scenario that is defined as follows:
* brgemm-based: `reorder weights (plain -> blocked) -> forward -> backward data -> backward weights with bias -> reorder weights (blocked -> plan)`
* matmul-based: `forward -> backward data -> backward weights with bias` - no reorders required because the weights are used as is (in the plain layout)

The parameters are taken from the data set used in the performance testing. The following models are covered:
* BERT Large
* DLRM-v2
* DLRM
* MaskRCNN
* Transformer LT

![image](https://github.com/user-attachments/assets/6823f80f-7111-46ae-92f4-3d7f8307946b)
