### PR TITLE
[GPU] Coverity fixups

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/matrix_access.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/matrix_access.cxx
@@ -518,8 +518,8 @@ void BLASKernelGenerator<hw>::loadLoadStoreDescriptors(bool load, bool store, Re
             exdescStore.parts.extMessageLen = 0;
             descLoad.parts.responseLen = 0;
 
-            int underlyingSIMD = std::max<int>(block.simdSize, maxScatteredSIMD(hw, astrategy) >> 1);
-            int log2GRFs = ilog2(underlyingSIMD * (int)block.ebytes) - GRF::log2Bytes(hw);
+            uint32_t underlyingSIMD = std::max<uint32_t>(block.simdSize, (uint32_t)maxScatteredSIMD(hw, astrategy) >> 1);
+            int log2GRFs = ilog2(underlyingSIMD * block.ebytes) - GRF::log2Bytes(hw);
             int log2Components = int(block.splitComplex);
 
             if (channel) mov(1, t2, 0x1000 << log2Components);

--- a/src/gpu/intel/jit/pooling/ir_builder.cpp
+++ b/src/gpu/intel/jit/pooling/ir_builder.cpp
@@ -240,13 +240,14 @@ stmt_t pooling_ir_builder_t::try_build(pooling_ir_builder_t &pb,
                 = (s0.is_empty()) ? dim_idx::invalid : src_view.vvar_index(s0);
         dim_idx_t s1_idx = src_view.vvar_index(s1);
         dim_idx_t ns_idx = src_view.vvar_index(ns);
-        ir_assert((s0_idx <= 4) && (s1_idx <= 4) && (ns_idx <= 4));
+        ir_assert((s0_idx <= 4 || s0_idx == dim_idx::invalid) && (s1_idx <= 4)
+                && (ns_idx <= 4));
 
         // s1 and ns may swap sides, which affects their fusing order: it has
         // to strictly replicate that of the arguments passed to this lambda!
-        const bool need_swap = (s1_idx >= 0) && (s1_idx <= 1);
+        const bool need_swap = (s1_idx <= 1);
         // 2 spatials and 2 non-spatials disallowed; only 1 of each or bust
-        ir_assert(need_swap != ((ns_idx >= 0) && (ns_idx <= 1)));
+        ir_assert(need_swap != (ns_idx <= 1));
         if (need_swap) {
             std::swap(s1_idx, ns_idx);
             std::swap(s1, ns);

--- a/third_party/ngen/ngen_pseudo.hpp
+++ b/third_party/ngen/ngen_pseudo.hpp
@@ -602,7 +602,7 @@ void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127
 void loadargs(const GRF &base, int argGRFs, const GRF &temp = GRF(127), bool inPrologue = true, SourceLocation loc = {}) {
     if (hardware >= HW::XeHP) {
         if (argGRFs > 0) {
-            bool lsc = (hardware >= HW::XeHPG);
+            const bool lsc = (hardware >= HW::XeHPG);
             auto tempAddr = temp[lsc ? 0 : 2];
             auto dst = base;
             auto dmSave = defaultModifier;


### PR DESCRIPTION
Fixes a mistake in #2365/addresses the final Coverity hit from [MFDNN-12963](https://jira.devtools.intel.com/browse/MFDNN-12963). Addresses [MFDNN-12986](https://jira.devtools.intel.com/browse/MFDNN-12986).

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?