### PR TITLE
graph: fix coverity issues

### DIFF
--- a/src/graph/backend/dnnl/op_executable.cpp
+++ b/src/graph/backend/dnnl/op_executable.cpp
@@ -1782,7 +1782,10 @@ groupnorm_executable_t::desc_t groupnorm_executable_t::create_desc(
 
 void genindex_executable_t ::execute(const stream &stream,
         const std::unordered_map<int, memory> &args) const {
-    auto &output = args.find(DNNL_ARG_DST)->second;
+    const auto &it_dst = args.find(DNNL_ARG_DST);
+    if (it_dst == args.end()) return;
+
+    auto &output = it_dst->second;
     auto output_ptr = static_cast<int32_t *>(output.get_data_handle());
     dnnl::impl::parallel_nd(nelems_, [&](dim_t i) {
         dims_t input_dims; // decomposition for physical offsets

--- a/src/graph/utils/pm/nested_matcher.cpp
+++ b/src/graph/utils/pm/nested_matcher.cpp
@@ -977,7 +977,10 @@ bool match_alternation(const binding_t &bind_arg, match_context_t *ctx,
             } else {
                 // alternation is restricted to have only 1 in port
                 if (local_ctx.in_port_map.size() != 1) return false;
-                op_t *current_op = local_ctx.in_port_map.find(0)->second.first;
+                const auto &iter = local_ctx.in_port_map.find(0);
+                if (iter == local_ctx.in_port_map.end()) return false;
+
+                op_t *current_op = iter->second.first;
                 size_t current_port
                         = local_ctx.in_port_map.find(0)->second.second;
                 binding_t current_bind(BIND_OUT, current_op, current_port,
@@ -1084,8 +1087,10 @@ bool repetition_matcher_t::prepare_next_matching_round(
             // for next round's match
             iport_t iport = pmap_.second;
             // start op for last round's match
-            op_t *start_op
-                    = local_cached_ctx.in_port_map.find(iport)->second.first;
+            const auto &it_iport = local_cached_ctx.in_port_map.find(iport);
+            if (it_iport == local_cached_ctx.in_port_map.end()) return false;
+
+            op_t *start_op = it_iport->second.first;
             pb_op_t *start_pb_op = updated_op_map_[start_op];
             op_t *next_op = nullptr;
             size_t next_op_iport = 0;
@@ -1118,8 +1123,10 @@ bool repetition_matcher_t::prepare_next_matching_round(
     } else { // backward matching
         single_iter_bind_.bind_kind = BIND_OUT;
         iport_t iport = pmap_.second;
-        op_t *current_op
-                = local_cached_ctx.in_port_map.find(iport)->second.first;
+        const auto &it_iport = local_cached_ctx.in_port_map.find(iport);
+        if (it_iport == local_cached_ctx.in_port_map.end()) return false;
+
+        op_t *current_op = it_iport->second.first;
         if (iport >= current_op->num_inputs()) return true;
         auto in_value = current_op->get_input_value(iport);
         single_iter_bind_.bind_op = &(in_value->get_producer());
@@ -1192,11 +1199,11 @@ bool repetition_matcher_t::match_next_op(const binding_t &bind_arg) {
         assertm(bind_arg.bind_node->get_inputs().size() <= 1,
                 "repetition is restricted to have only 1 input");
         if (bind_arg.bind_node->get_inputs().size() == 1) {
-            op_t *current_op = rep_global_ctx_.in_port_map.find(pmap_.second)
-                                       ->second.first;
-            size_t current_port
-                    = rep_global_ctx_.in_port_map.find(pmap_.second)
-                              ->second.second;
+            const auto &iter = rep_global_ctx_.in_port_map.find(pmap_.second);
+            if (iter == rep_global_ctx_.in_port_map.end()) return false;
+
+            op_t *current_op = iter->second.first;
+            size_t current_port = iter->second.second;
             binding_t current_bind(BIND_OUT, current_op, current_port,
                     rep_node_, bind_arg.bind_port);
             if (!match_node_inputs(current_bind, parent_ctx_, updated_op_map_))

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -1734,8 +1734,6 @@ bool get_reorder_attrs(const deserialized_op &base_op_ref,
         std::vector<int64_t> group_shape;
         base_op_ref.get_attr_s64_vector(group_shape, "group_shape");
         groups = {group_shape[ndims - 2], group_shape[ndims - 1]};
-        scale_dt = static_cast<dnnl_data_type_t>(
-                base_op_ref.in_lts_[1].get_data_type());
     }
 
     if (op_kind == "Dequantize" || op_kind == "Quantize") {


### PR DESCRIPTION
Fixes the coverity issues in graph component.
Will need to backport them to rls-v3.7 branch.