### PR TITLE
benchdnn: graph: input_displacer: fix fp8 displacement

### DIFF
--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -337,7 +337,7 @@ int partition_data_displacer_t::gen_quantize_filling(
             // data overflow due to the specific driver logic.
             op.out_lts_[0].data_type_ = "u8";
         } else if (is_f8_quantization) {
-            op.out_lts_[0].data_type_ = "f8_e5m2";
+            op.out_lts_[0].data_type_ = op.in_lts_[0].data_type_;
         } else {
             // Use f32 as output data type since not all primitives support
             // different data types for input and output.


### PR DESCRIPTION
For fp8 quantization, change output data type from the fixed `f8_e5m2` to the input data type (may be `f8_e4m3`) to create the primitive for input displacement. Before this change, the below case will be skipped on SPR due to the failure of displacement primitive creation. Now it will pass.

```
./benchdnn --graph --case=pattern/f8/f8_conv_fwd.json
```