### PR TITLE
Fix accuracy of max-pooling backpropagation for bfloat16 data

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -271,6 +271,7 @@ enum {
     key_pool_dst_plain2blocked_cvt,
     key_pool_ind_plain2blocked_cvt,
     key_pool_src_bf16cvt,
+    key_pool_src_f32_accum,
     key_pool_src_plain2blocked_cvt,
     key_pool_reduction,
     key_precomputed_scales,

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -526,6 +526,8 @@ struct jit_pool_conf_t {
     bool with_binary;
     int nthr;
     memory_desc_t tmp_md;
+    bool needs_f32_accum_for_bf16;
+    dim_t f32_accum_block_size;
 };
 
 struct jit_pool_call_s {

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -388,6 +388,11 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
     }
     assert(jpp.ur > 0);
 
+    jpp.needs_f32_accum_for_bf16 = jpp.is_bf16
+            && jpp.alg == alg_kind::pooling_max && jpp.is_backward
+            && (jpp.stride_d < jpp.kd || jpp.stride_h < jpp.kh
+                    || jpp.stride_w < jpp.kw);
+
     // select jpp.ur_bc
     if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
         auto min_ur_w = nstl::max(1, utils::div_up(jpp.l_pad, jpp.stride_w));
@@ -413,9 +418,8 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
         }
 
         //take into account cache re-usage after zeroing on backward
-        if (jpp.is_backward && ndims < 5) {
-            const int L2 = platform::get_per_core_cache_size(2)
-                    / sizeof(jpp.dt_size);
+        if (jpp.is_backward && ndims < 5 && !jpp.needs_f32_accum_for_bf16) {
+            const int L2 = platform::get_per_core_cache_size(2) / jpp.dt_size;
             int ur_bc = nstl::max(1, L2 / (jpp.kh * jpp.iw * jpp.c_block));
             jpp.ur_bc = nstl::min(jpp.ur_bc, ur_bc);
         }
@@ -443,10 +447,6 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
                         * nscr);
     }
 
-    jpp.needs_f32_accum_for_bf16 = jpp.is_bf16
-            && jpp.alg == alg_kind::pooling_max && jpp.is_backward
-            && (jpp.stride_d < jpp.kd || jpp.stride_h < jpp.kh
-                    || jpp.stride_w < jpp.kw);
     jpp.f32_accum_block_size = jpp.ur_bc * jpp.c_block;
     if (jpp.needs_f32_accum_for_bf16) {
         auto tmp_d = memory_desc_wrapper(jpp.tmp_md);

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -258,7 +258,8 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
         jpp.is_bf16 = false;
         jpp.is_f16 = false;
         jpp.is_fp8 = false;
-        jpp.dt_size = types::data_type_size(data_type::f32);
+        jpp.src_dt = jpp.dst_dt = data_type::f32;
+        jpp.dt_size = types::data_type_size(jpp.src_dt);
         jpp.tag_kind = jit_memory_tag_kind_t::ncsp;
 
         // used to initialize binary post-ops
@@ -442,6 +443,29 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
                         * nscr);
     }
 
+    jpp.needs_f32_accum_for_bf16 = jpp.is_bf16
+            && jpp.alg == alg_kind::pooling_max && jpp.is_backward
+            && (jpp.stride_d < jpp.kd || jpp.stride_h < jpp.kh
+                    || jpp.stride_w < jpp.kw);
+    jpp.f32_accum_block_size = jpp.ur_bc * jpp.c_block;
+    if (jpp.needs_f32_accum_for_bf16) {
+        auto tmp_d = memory_desc_wrapper(jpp.tmp_md);
+        assert(tmp_d.is_zero()
+                && (fmt_tag == nspc_fmt_tag || fmt_tag == blocked_fmt_tag));
+
+        dims_t dims {};
+        utils::array_copy(dims, src_d.dims(), ndims);
+
+        const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+        dims[0] = nstl::min(dnnl_get_max_threads(), jpp.mb * nb2_c);
+        dims[1] = jpp.f32_accum_block_size;
+
+        CHECK(memory_desc_init_by_tag(
+                jpp.tmp_md, ndims, dims, data_type::f32, fmt_tag));
+
+        scratchpad.book<char>(key_pool_src_f32_accum, tmp_d.size());
+    }
+
     jpp.post_ops = attr.post_ops_;
 
     return status::success;
@@ -503,10 +527,10 @@ inline void jit_uni_pool_kernel<isa>::pop_vmm_val(const int idx) {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel<isa>::load(const int idx,
+inline void jit_uni_pool_kernel<isa>::load(const data_type_t dt, const int idx,
         const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
-    if (jpp.is_bf16) {
+    if (dt == data_type::bf16) {
         /*TODO: maybe use vpmovzxwd + vpslld,
              * in order to free up vmm_idx() register */
         if (is_c_tail_proccessing && !jpp.is_c_padded) {
@@ -517,18 +541,18 @@ inline void jit_uni_pool_kernel<isa>::load(const int idx,
             vmovups(Ymm(idx), ptr[reg_ptr + offset]);
             vpermw(Vmm(idx) | k_mask_cvt | T_z, vmm_idx(), Vmm(idx));
         }
-    } else if (jpp.is_f16) {
+    } else if (dt == data_type::f16) {
         Vmm vmm_to_load = is_c_tail_proccessing && !jpp.is_c_padded
                 ? Vmm(idx) | k_c_tail_mask | T_z
                 : Vmm(idx);
         vcvtph2psx(vmm_to_load, ptr[reg_ptr + offset]);
-    } else if (jpp.is_fp8) {
+    } else if (utils::one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
         Vmm vmm_to_load = is_c_tail_proccessing && !jpp.is_c_padded
                 ? Vmm(idx) | k_c_tail_mask | T_z
                 : Vmm(idx);
-        if (jpp.src_dt == data_type::f8_e5m2)
+        if (dt == data_type::f8_e5m2)
             f8_e5m2_emu_->vcvt_f8_to_f32(vmm_to_load, ptr[reg_ptr + offset]);
-        else if (jpp.src_dt == data_type::f8_e4m3)
+        else if (dt == data_type::f8_e4m3)
             f8_e4m3_emu_->vcvt_f8_to_f32(vmm_to_load, ptr[reg_ptr + offset]);
     } else {
         if (is_c_tail_proccessing && !jpp.is_c_padded) {
@@ -544,8 +568,8 @@ inline void jit_uni_pool_kernel<isa>::load(const int idx,
 }
 
 template <>
-inline void jit_uni_pool_kernel<avx2_vnni_2>::load(const int idx,
-        const reg64_t &reg_ptr, const int offset,
+inline void jit_uni_pool_kernel<avx2_vnni_2>::load(const data_type_t dt,
+        const int idx, const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
     if (is_c_tail_proccessing) {
         vmaskmovps(Xmm(idx), xmm_c_tail_mask, ptr[reg_ptr + offset]);
@@ -556,13 +580,13 @@ inline void jit_uni_pool_kernel<avx2_vnni_2>::load(const int idx,
             vpinsrw(Xmm(idx), Xmm(idx), word_addr, tail_pos);
         }
     }
-    if (jpp.is_bf16) {
+    if (dt == data_type::bf16) {
         if (is_c_tail_proccessing)
             vpmovzxwd(Ymm(idx), Xmm(idx));
         else
             vpmovzxwd(Ymm(idx), ptr[reg_ptr + offset]);
         vpslld(Ymm(idx), Ymm(idx), 16);
-    } else if (jpp.is_f16) {
+    } else if (dt == data_type::f16) {
         if (is_c_tail_proccessing)
             vcvtph2ps(Ymm(idx), Xmm(idx));
         else
@@ -572,21 +596,22 @@ inline void jit_uni_pool_kernel<avx2_vnni_2>::load(const int idx,
 }
 
 template <>
-inline void jit_uni_pool_kernel<sse41>::load(const int idx,
-        const reg64_t &reg_ptr, const int offset,
+inline void jit_uni_pool_kernel<sse41>::load(const data_type_t dt,
+        const int idx, const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
     if (is_c_tail_proccessing && !jpp.is_c_padded) {
+        const auto dt_size = types::data_type_size(dt);
         for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-            pinsrd(Xmm(idx), ptr[reg_ptr + offset + i * jpp.dt_size], i);
+            pinsrd(Xmm(idx), ptr[reg_ptr + offset + i * dt_size], i);
     } else
         uni_vmovups(Vmm(idx), ptr[reg_ptr + offset]);
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel<isa>::store(const int idx,
+inline void jit_uni_pool_kernel<isa>::store(const data_type_t dt, const int idx,
         const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
-    if (jpp.is_bf16 || jpp.is_f16) {
+    if (utils::one_of(dt, data_type::bf16, data_type::f16)) {
         if (is_c_tail_proccessing) {
             if (jpp.is_c_padded) {
                 vmovdqu16(Ymm(idx) | k_c_tail_mask | T_z, Ymm(idx));
@@ -595,7 +620,7 @@ inline void jit_uni_pool_kernel<isa>::store(const int idx,
                 vmovdqu16(ptr[reg_ptr + offset] | k_c_tail_mask, Ymm(idx));
         } else
             vmovups(yword[reg_ptr + offset], Ymm(idx));
-    } else if (jpp.is_fp8) {
+    } else if (utils::one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
         if (is_c_tail_proccessing) {
             if (jpp.is_c_padded) {
                 vmovdqu8(Xmm(idx) | k_c_tail_mask | T_z, Xmm(idx));
@@ -629,10 +654,10 @@ inline void jit_uni_pool_kernel<isa>::store(const int idx,
 }
 
 template <>
-inline void jit_uni_pool_kernel<avx2_vnni_2>::store(const int idx,
-        const reg64_t &reg_ptr, const int offset,
+inline void jit_uni_pool_kernel<avx2_vnni_2>::store(const data_type_t dt,
+        const int idx, const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
-    if (jpp.is_bf16 || jpp.is_f16) {
+    if (utils::one_of(dt, data_type::bf16, data_type::f16)) {
         if (is_c_tail_proccessing) {
             vmaskmovps(ptr[reg_ptr + offset], xmm_c_tail_mask, Xmm(idx));
             if (jpp.c_tail % 2 != 0) {
@@ -647,13 +672,14 @@ inline void jit_uni_pool_kernel<avx2_vnni_2>::store(const int idx,
 }
 
 template <>
-inline void jit_uni_pool_kernel<sse41>::store(const int idx,
-        const reg64_t &reg_ptr, const int offset,
+inline void jit_uni_pool_kernel<sse41>::store(const data_type_t dt,
+        const int idx, const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
     if (is_c_tail_proccessing) {
         if (!jpp.is_c_padded) {
+            const auto dt_size = types::data_type_size(dt);
             for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-                pextrd(ptr[reg_ptr + offset + i * jpp.dt_size], Xmm(idx), i);
+                pextrd(ptr[reg_ptr + offset + i * dt_size], Xmm(idx), i);
         } else {
             if (jpp.with_postops) {
                 static constexpr auto xmm_half = 4;
@@ -834,7 +860,7 @@ inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
             auto accvr = vreg(accr_i);
             if (jpp.is_backward) {
                 auto output_offset = dt_size * (jj * c_off + bci * c_block);
-                load(accvr.getIdx(), reg_output, output_offset,
+                load(jpp.dst_dt, accvr.getIdx(), reg_output, output_offset,
                         is_tail_processing(bci));
                 uni_vdivps(accvr, accvr, vmm_tmp);
             } else {
@@ -874,8 +900,8 @@ inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
                 int input_offset = dt_size * aux_input_offset;
                 if (jpp.is_backward) {
                     auto inpyr = yreg(inpr_i);
-                    load(reg_idx(inpr_i), aux_reg_input, input_offset,
-                            is_tail_processing(bci));
+                    load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
+                            input_offset, is_tail_processing(bci));
                     uni_vaddps(inpvr, inpvr, accvr);
                     if (jpp.is_bf16) {
                         if (!isa_has_bf16(jpp.isa))
@@ -891,15 +917,15 @@ inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
                         else if (jpp.src_dt == data_type::f8_e4m3)
                             f8_e4m3_emu_->vcvt_f32_to_f8(inpxr, zreg(inpr_i));
                     }
-                    store(reg_idx(inpr_i), aux_reg_input, input_offset,
-                            is_tail_processing(bci));
+                    store(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
+                            input_offset, is_tail_processing(bci));
                 } else {
                     if (jpp.is_bf16 || jpp.is_f16 || jpp.is_fp8
                             || is_tail_processing(bci)
                             || (isa == sse41
                                     && c_off % (jpp.c_block / 2) != 0)) {
-                        load(vmm_tmp_1.getIdx(), aux_reg_input, input_offset,
-                                is_tail_processing(bci));
+                        load(jpp.src_dt, vmm_tmp_1.getIdx(), aux_reg_input,
+                                input_offset, is_tail_processing(bci));
 
                         uni_vaddps(accvr, accvr, vmm_tmp_1);
                     } else {
@@ -969,7 +995,7 @@ inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
                     else if (jpp.src_dt == data_type::f8_e4m3)
                         f8_e4m3_emu_->vcvt_f32_to_f8(accxr, accvr);
                 }
-                store(reg_idx(accr_i), reg_output, output_offset,
+                store(jpp.dst_dt, reg_idx(accr_i), reg_output, output_offset,
                         is_tail_processing(bci));
             }
         }
@@ -1043,7 +1069,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
                         = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
                 if (aux_input_offset >= iw * c_off) continue;
                 int input_offset = jpp.dt_size * aux_input_offset;
-                load(reg_idx(inpr_i), aux_reg_input, input_offset,
+                load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input, input_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
                     movups(vmm_mask, accvr);
@@ -1143,7 +1169,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
             else if (jpp.src_dt == data_type::f8_e4m3)
                 f8_e4m3_emu_->vcvt_f32_to_f8(accxr, acczr);
         }
-        store(reg_idx(accr_i), reg_output, output_offset,
+        store(jpp.dst_dt, reg_idx(accr_i), reg_output, output_offset,
                 is_tail_processing(bci));
 
         if (jpp.is_training) {
@@ -1242,7 +1268,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
                     }
                 }
             } else {
-                store(vr.getIdx(), reg_index, step_index,
+                store(jpp.ind_dt, vr.getIdx(), reg_index, step_index,
                         is_tail_processing(bci));
             }
         }
@@ -1257,8 +1283,17 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
     int kw = jpp.kw;
     int stride_w = jpp.stride_w;
     int c_block = jpp.c_block;
-    const int c_off
+    const int output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
+    const int input_c_off = jpp.needs_f32_accum_for_bf16
+            ? jpp.f32_accum_block_size
+            : output_c_off;
+    const auto input_dt
+            = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
+    const size_t input_dt_size = types::data_type_size(input_dt);
+    const size_t output_dt_size = jpp.dt_size;
+    assert(output_dt_size == types::data_type_size(jpp.dst_dt));
+
     Label kd_label, kh_label;
 
     const auto is_tail_processing = [&](int bc) {
@@ -1276,9 +1311,10 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
     for_(int jj = 0; jj < ur_w; jj++)
     for (int bci = 0; bci < ur_bc; bci++) {
         const auto outr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
-        auto out_offset = jpp.dt_size * (jj * c_off + bci * c_block);
-        load(reg_idx(outr_i), reg_output, out_offset, is_tail_processing(bci));
-        const size_t step_index = (jj * c_off + bci * c_block)
+        auto out_offset = output_dt_size * (jj * output_c_off + bci * c_block);
+        load(jpp.dst_dt, reg_idx(outr_i), reg_output, out_offset,
+                is_tail_processing(bci));
+        const size_t step_index = (jj * output_c_off + bci * c_block)
                 * types::data_type_size(jpp.ind_dt);
 
         const auto indr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
@@ -1315,7 +1351,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
                 }
             }
         } else {
-            load(indvr.getIdx(), reg_index, step_index,
+            load(jpp.ind_dt, indvr.getIdx(), reg_index, step_index,
                     is_tail_processing(bci));
         }
     }
@@ -1354,11 +1390,11 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
                 const auto inpr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
                 const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
-                int aux_inp_offset
-                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
-                if (aux_inp_offset >= iw * c_off) continue;
-                int inp_offset = jpp.dt_size * aux_inp_offset;
-                load(reg_idx(inpr_i), aux_reg_input, inp_offset,
+                int aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
+                        + bci * c_block;
+                if (aux_inp_offset >= iw * input_c_off) continue;
+                int inp_offset = input_dt_size * aux_inp_offset;
+                load(input_dt, reg_idx(inpr_i), aux_reg_input, inp_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
                     mov(dst_ptr, aux_reg_input);
@@ -1397,7 +1433,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
                     vpcmpeqd(k_store_mask, indvr, vmm_k_offset);
                     vblendmps(vmm_tmp | k_store_mask | T_z, outvr, outvr);
                     vaddps(inpvr, inpvr, vmm_tmp);
-                    if (jpp.is_bf16) {
+                    if (jpp.is_bf16 && !jpp.needs_f32_accum_for_bf16) {
                         if (!isa_has_bf16(jpp.isa))
                             bf16_emu_->vcvtneps2bf16(indyr, indzr);
                         else
@@ -1405,7 +1441,7 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
                     } else if (jpp.is_f16) {
                         vcvtps2ph(indyr, inpvr, _op_mxcsr);
                     }
-                    store(inpvr.getIdx(), aux_reg_input, inp_offset,
+                    store(input_dt, inpvr.getIdx(), aux_reg_input, inp_offset,
                             is_tail_processing(bci));
                 }
             }
@@ -1424,13 +1460,13 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
             if (with_c_tail_proccessing && (isa == avx || isa == avx2))
                 pop_vmm_val(vmm_c_tail_mask.getIdx());
         }
-        add(aux_reg_input, jpp.dt_size * iw * c_off);
+        add(aux_reg_input, input_dt_size * iw * input_c_off);
         inc(kj);
         cmp(kj, reg_kh);
         jl(kh_label, T_NEAR);
     }
     if (jpp.simple_alg && jpp.ndims == 5) {
-        add(aux_reg_input_d, jpp.dt_size * jpp.ih * iw * c_off);
+        add(aux_reg_input_d, input_dt_size * jpp.ih * iw * input_c_off);
 
         mov(tmp_gpr, reg_kd_pad_shift);
         uni_vmovq(xmm_tmp, tmp_gpr);
@@ -1458,9 +1494,10 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
 template <cpu_isa_t isa>
 void jit_uni_pool_kernel<isa>::zero_diff_src(
         int ur_bc, bool with_c_tail_proccessing) {
-    const int c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
-            ? jpp.c
-            : jpp.c_block;
+    const int c_off = jpp.needs_f32_accum_for_bf16
+            ? jpp.f32_accum_block_size
+            : ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c
+                                                             : jpp.c_block);
 
     Label l_skip, l_ih_loop, l_id_loop;
 
@@ -1481,7 +1518,10 @@ void jit_uni_pool_kernel<isa>::zero_diff_src(
     Vmm vzero = vmm_tmp;
     uni_vpxor(vzero, vzero, vzero);
 
-    const int width_size = jpp.iw * c_off * jpp.dt_size;
+    const auto src_dt
+            = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
+    const auto dt_size = types::data_type_size(src_dt);
+    const int width_size = jpp.iw * c_off * dt_size;
 
     auto aux_reg_zero_ptr = tmp_gpr;
 
@@ -1492,30 +1532,30 @@ void jit_uni_pool_kernel<isa>::zero_diff_src(
         L(l_ih_loop);
         {
             const auto vlen = cpu_isa_traits<isa>::vlen;
-            const int step = c_off * jpp.dt_size;
+            const int step = c_off * dt_size;
 
             // TODO: maybe a big code generated here
             for_(int i = 0; i < width_size; i += step)
             for (int bci = 0; bci < ur_bc; bci++) {
-                const int offs = i + bci * jpp.c_block * jpp.dt_size;
+                const int offs = i + bci * jpp.c_block * dt_size;
                 if (isa == sse41) {
                     bool is_needed_c_tail_processing = false;
                     if (is_tail_processing(bci)
                             && jpp.c_tail < (jpp.c_block / 2))
                         is_needed_c_tail_processing = true;
-                    store(vzero.getIdx(), reg_zero_ptr, offs,
+                    store(src_dt, vzero.getIdx(), reg_zero_ptr, offs,
                             is_needed_c_tail_processing);
                     if (!is_tail_processing(bci)
                             || (is_tail_processing(bci)
                                     && (jpp.is_c_padded
                                             || jpp.c_tail
                                                     > (jpp.c_block / 2)))) {
-                        store(vzero.getIdx(), reg_zero_ptr, offs + vlen,
+                        store(src_dt, vzero.getIdx(), reg_zero_ptr, offs + vlen,
                                 is_tail_processing(bci));
                     }
 
                 } else {
-                    store(vzero.getIdx(), reg_zero_ptr, offs,
+                    store(src_dt, vzero.getIdx(), reg_zero_ptr, offs,
                             is_tail_processing(bci));
                 }
             }
@@ -1546,10 +1586,16 @@ void jit_uni_pool_kernel<isa>::generate() {
     int c_block = jpp.c_block;
     int stride_w = jpp.stride_w;
     int l_pad = jpp.l_pad;
-    const int c_off
+    const int output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
+    const int input_c_off = jpp.needs_f32_accum_for_bf16
+            ? jpp.f32_accum_block_size
+            : output_c_off;
 
     int vlen = cpu_isa_traits<isa>::vlen;
+
+    const size_t input_dt_size
+            = jpp.needs_f32_accum_for_bf16 ? sizeof(float) : jpp.dt_size;
 
 #if defined(_WIN32)
     // Always mimic the Unix ABI (see the note about maskmovdqu in the header
@@ -1607,15 +1653,17 @@ void jit_uni_pool_kernel<isa>::generate() {
 
         if (!inc_reg) return;
 
-        auto dt_size = jpp.dt_size;
+        auto output_dt_size = jpp.dt_size;
         auto shift = (isa == sse41) ? vlen : 0;
         add(reg_input,
-                dt_size * nstl::max(0, ur_w * stride_w - lpad) * c_off - shift);
-        add(reg_output, dt_size * ur_w * c_off - shift);
+                input_dt_size * nstl::max(0, ur_w * stride_w - lpad)
+                                * input_c_off
+                        - shift);
+        add(reg_output, output_dt_size * ur_w * output_c_off - shift);
         if (jpp.alg == pooling_max && (jpp.is_training || jpp.is_backward)) {
             auto ishift = (isa == sse41) ? jpp.c_block / 2 : 0;
             auto ind_dt_size = types::data_type_size(jpp.ind_dt);
-            add(reg_index, (ur_w * c_off - ishift) * ind_dt_size);
+            add(reg_index, (ur_w * output_c_off - ishift) * ind_dt_size);
         }
     };
 

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -34,6 +34,9 @@ using namespace alg_kind;
 
 #define GET_OFF(field) offsetof(jit_pool_call_s, field)
 
+constexpr int sse41_single_block_size
+        = cpu_isa_traits<sse41>::vlen / sizeof(float);
+
 static bcast_set_t get_supported_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
             broadcasting_strategy_t::no_broadcast};
@@ -45,11 +48,7 @@ jit_uni_pool_kernel<isa>::~jit_uni_pool_kernel() = default;
 template <cpu_isa_t isa>
 jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
         const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md)
-    : jit_generator(jit_name(), isa), jpp(ajpp), bf16_emu_(nullptr) {
-    if (use_bf16_emulation())
-        bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,
-                bf16_emu_reserv_1, bf16_emu_reserv_2, bf16_emu_reserv_3,
-                bf16_emu_reserv_4, bf16_emu_reserv_5);
+    : jit_generator(jit_name(), isa), jpp(ajpp) {
 
     bool has_f8_e5m2_binary_postops = false;
     bool has_f8_e4m3_binary_postops = false;
@@ -81,16 +80,13 @@ jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
                     fp8_emu_reserv_4, fp8_emu_reserv_5, fp8_emu_reg64);
     }
 
+    const auto tail_size
+            = isa == sse41 ? jpp.c_tail % sse41_single_block_size : jpp.c_tail;
+
     if (jpp.with_postops) {
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        static constexpr int sse41_single_block_size
-                = cpu_isa_traits<sse41>::vlen / sizeof(float);
-        size_t postop_tail = static_cast<size_t>(jpp.c_tail);
-        const bool high_half_block_empty = isa == sse41
-                && static_cast<size_t>(jpp.c_tail) > sse41_single_block_size;
-        if (high_half_block_empty) postop_tail -= sse41_single_block_size;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
                 static_cast<std::size_t>(this->xmm4.getIdx()), this->r14,
@@ -99,7 +95,8 @@ jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
                 memory_desc_wrapper(jpp.tag_kind == jit_memory_tag_kind_t::ncsp
                                 ? jpp.tmp_md
                                 : *dst_md),
-                postop_tail, k_c_tail_mask, use_exact_tail_scalar_bcast};
+                static_cast<size_t>(tail_size), k_c_tail_mask,
+                use_exact_tail_scalar_bcast};
 
         const binary_injector::static_params_t bsp {reg_param,
                 get_supported_bcast_strategies(), rhs_sp, f8_e5m2_emu_.get(),
@@ -109,6 +106,34 @@ jit_uni_pool_kernel<isa>::jit_uni_pool_kernel(
                 = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
                         this, jpp.post_ops, bsp);
     }
+
+    io::io_tail_conf_t io_tail_conf(jpp.c_block, tail_size,
+            k_c_tail_mask.getIdx(), vmm_c_tail_mask.getIdx(), tmp_gpr);
+
+    utils::optional_t<io::io_emu_bf16_conf_t> io_bf16_conf;
+    if (use_bf16_emulation())
+        io_bf16_conf = io::io_emu_bf16_conf_t(bf16_emu_reserv_1,
+                bf16_emu_reserv_2, bf16_emu_reserv_3, bf16_emu_reserv_4,
+                bf16_emu_reserv_5);
+
+    utils::optional_t<io::io_emu_fp8_conf_t> io_fp8_conf;
+    if (use_fp8_emulation() || has_f8_e5m2_binary_postops
+            || has_f8_e4m3_binary_postops)
+        io_fp8_conf = io::io_emu_fp8_conf_t(fp8_emu_reserv_1, fp8_emu_reserv_2,
+                fp8_emu_reserv_3, fp8_emu_reserv_4, fp8_emu_reserv_5,
+                fp8_tmp_mask, fp8_emu_reg64);
+
+    using io_mdt_helper = io::jit_io_multi_dt_helper_t<Vmm>;
+
+    typename io_mdt_helper::data_types_t dtypes = {jpp.src_dt, jpp.dst_dt};
+    // Indices of type s32 will be stored/loaded as f32 as jit_io_helper_t does not
+    // support integers but stores/loads f32 without additional conversions of those
+    // 4 bytes. jit_io_helper_t is not used for processing indices of type u8.
+    if (jpp.ind_dt == data_type::s32) dtypes.insert(data_type::f32);
+    if (jpp.needs_f32_accum_for_bf16) dtypes.insert(data_type::f32);
+
+    io_ = io_mdt_helper(this, jpp.isa, dtypes, {}, io_tail_conf, io_bf16_conf,
+            {}, utils::nullopt, io_fp8_conf);
 }
 
 static status_t set_binary_postops_formats(
@@ -484,30 +509,6 @@ static int reg_ind(int shift, int bc, int j, int ur_bc, int ur_w) noexcept {
 };
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel<isa>::prepare_tail_mask() {
-    if (is_superset(isa, avx512_core)) {
-        size_t c_tail_mask = (1ULL << jpp.c_tail) - 1ULL;
-        mov(tmp_gpr.cvt32(), c_tail_mask);
-        kmovw(k_c_tail_mask, tmp_gpr.cvt32());
-    } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
-        constexpr int max_words_in_ymm = 8;
-
-        // for 'avx2_vnni_2' mask works with 2 x xf16 elements,
-        // in case of 'c_tail % 2 != 0' load/store an additional word
-        // for the remaining element.
-        auto dt_elem_div = isa == avx2_vnni_2 ? 2 : 1;
-        auto mask_offset = max_words_in_ymm - (jpp.c_tail / dt_elem_div);
-        auto mask_register
-                = isa == avx2_vnni_2 ? xmm_c_tail_mask : vmm_c_tail_mask;
-        static const uint32_t mask[16] = {0xffffffff, 0xffffffff, 0xffffffff,
-                0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0,
-                0, 0, 0, 0, 0, 0, 0};
-        mov(tmp_gpr, reinterpret_cast<size_t>(&mask[mask_offset]));
-        vmovups(mask_register, ptr[tmp_gpr]);
-    }
-}
-
-template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel<isa>::put_one_in_vmm() {
     mov(tmp_gpr, 1);
     uni_broadcast_reg_val(tmp_gpr.getIdx(), vmm_one.getIdx());
@@ -538,184 +539,180 @@ template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel<isa>::load(const data_type_t dt, const int idx,
         const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
-    if (dt == data_type::bf16) {
-        /*TODO: maybe use vpmovzxwd + vpslld,
-             * in order to free up vmm_idx() register */
-        if (is_c_tail_proccessing && !jpp.is_c_padded) {
-            Vmm vmm_to_load = Vmm(idx) | k_c_tail_mask | T_z;
-            vpmovzxwd(vmm_to_load, ptr[reg_ptr + offset]);
-            vpslld(vmm_to_load, vmm_to_load, 16);
-        } else {
-            vmovups(Ymm(idx), ptr[reg_ptr + offset]);
-            vpermw(Vmm(idx) | k_mask_cvt | T_z, vmm_idx(), Vmm(idx));
-        }
-    } else if (dt == data_type::f16) {
-        Vmm vmm_to_load = is_c_tail_proccessing && !jpp.is_c_padded
-                ? Vmm(idx) | k_c_tail_mask | T_z
-                : Vmm(idx);
-        vcvtph2psx(vmm_to_load, ptr[reg_ptr + offset]);
-    } else if (utils::one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
-        Vmm vmm_to_load = is_c_tail_proccessing && !jpp.is_c_padded
-                ? Vmm(idx) | k_c_tail_mask | T_z
-                : Vmm(idx);
-        if (dt == data_type::f8_e5m2)
-            f8_e5m2_emu_->vcvt_f8_to_f32(vmm_to_load, ptr[reg_ptr + offset]);
-        else if (dt == data_type::f8_e4m3)
-            f8_e4m3_emu_->vcvt_f8_to_f32(vmm_to_load, ptr[reg_ptr + offset]);
-    } else {
-        if (is_c_tail_proccessing && !jpp.is_c_padded) {
-            if (isa == avx || isa == avx2) {
-                vmaskmovps(Vmm(idx), vmm_c_tail_mask, ptr[reg_ptr + offset]);
-            } else {
-                vmovups(Zmm(idx) | k_c_tail_mask | T_z, ptr[reg_ptr + offset]);
-            }
-        } else {
-            uni_vmovups(Vmm(idx), ptr[reg_ptr + offset]);
-        }
-    }
-}
-
-template <>
-inline void jit_uni_pool_kernel<avx2_vnni_2>::load(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
-        const bool is_c_tail_proccessing) {
-    if (is_c_tail_proccessing) {
-        vmaskmovps(Xmm(idx), xmm_c_tail_mask, ptr[reg_ptr + offset]);
-        if (jpp.c_tail % 2 != 0) {
-            const int tail_pos = jpp.c_tail - 1;
-            auto word_addr
-                    = ptr[reg_ptr + offset + tail_pos * sizeof(bfloat16_t)];
-            vpinsrw(Xmm(idx), Xmm(idx), word_addr, tail_pos);
-        }
-    }
-    if (dt == data_type::bf16) {
-        if (is_c_tail_proccessing)
-            vpmovzxwd(Ymm(idx), Xmm(idx));
-        else
-            vpmovzxwd(Ymm(idx), ptr[reg_ptr + offset]);
-        vpslld(Ymm(idx), Ymm(idx), 16);
-    } else if (dt == data_type::f16) {
-        if (is_c_tail_proccessing)
-            vcvtph2ps(Ymm(idx), Xmm(idx));
-        else
-            vcvtph2ps(Ymm(idx), ptr[reg_ptr + offset]);
-    } else
-        assert(!"invalid data type");
-}
-
-template <>
-inline void jit_uni_pool_kernel<sse41>::load(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
-        const bool is_c_tail_proccessing) {
-    if (is_c_tail_proccessing && !jpp.is_c_padded) {
-        const auto dt_size = types::data_type_size(dt);
-        for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-            pinsrd(Xmm(idx), ptr[reg_ptr + offset + i * dt_size], i);
-    } else
-        uni_vmovups(Vmm(idx), ptr[reg_ptr + offset]);
+    io_[dt]->load(vmmword[reg_ptr + offset], Vmm(idx),
+            is_c_tail_proccessing && !jpp.is_c_padded);
 }
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel<isa>::store(const data_type_t dt, const int idx,
         const reg64_t &reg_ptr, const int offset,
         const bool is_c_tail_proccessing) {
-    if (utils::one_of(dt, data_type::bf16, data_type::f16)) {
-        if (is_c_tail_proccessing) {
-            if (jpp.is_c_padded) {
-                vmovdqu16(Ymm(idx) | k_c_tail_mask | T_z, Ymm(idx));
-                vmovups(yword[reg_ptr + offset], Ymm(idx));
-            } else
-                vmovdqu16(ptr[reg_ptr + offset] | k_c_tail_mask, Ymm(idx));
-        } else
-            vmovups(yword[reg_ptr + offset], Ymm(idx));
-    } else if (utils::one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
-        if (is_c_tail_proccessing) {
-            if (jpp.is_c_padded) {
-                vmovdqu8(Xmm(idx) | k_c_tail_mask | T_z, Xmm(idx));
-                vmovdqu8(yword[reg_ptr + offset], Xmm(idx));
-            } else
-                vmovdqu8(ptr[reg_ptr + offset] | k_c_tail_mask, Xmm(idx));
-        } else
-            vmovdqu8(yword[reg_ptr + offset], Xmm(idx));
-    } else {
-        if (is_c_tail_proccessing) {
-            if (!jpp.is_c_padded) {
-                if (isa == avx || isa == avx2)
-                    vmaskmovps(
-                            ptr[reg_ptr + offset], vmm_c_tail_mask, Vmm(idx));
-                else
-                    vmovups(ptr[reg_ptr + offset] | k_c_tail_mask, Zmm(idx));
+    if (is_c_tail_proccessing && jpp.is_c_padded && jpp.with_postops)
+        pad_with_zeros(idx);
+    io_[dt]->store(Vmm(idx), vmmword[reg_ptr + offset],
+            is_c_tail_proccessing && !jpp.is_c_padded);
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::pad_with_zeros(const int idx) {
+    if (isa == sse41) {
+        uni_vxorps(xmm_tmp_1, xmm_tmp_1, xmm_tmp_1);
+        if (jpp.c_tail <= sse41_single_block_size && sse_high_half) {
+            uni_vmovups(Vmm(idx), xmm_tmp_1);
+        } else if ((jpp.c_tail < sse41_single_block_size && !sse_high_half)
+                || (jpp.c_tail > sse41_single_block_size && sse_high_half)) {
+            const auto c_tail = jpp.c_tail % sse41_single_block_size;
+            std::bitset<8> tail_mask((1 << c_tail) - 1);
+            tail_mask.flip();
+            uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1, tail_mask.to_ulong());
+        }
+    } else if (isa == avx || isa == avx2) {
+        uni_vxorps(ymm_tmp_1, ymm_tmp_1, ymm_tmp_1);
+        uni_vblendvps(Vmm(idx), ymm_tmp_1, Vmm(idx), vmm_c_tail_mask);
+    } else
+        uni_vmovups(Vmm(idx) | k_c_tail_mask | T_z, Vmm(idx));
+}
+
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::load_indices(
+        const int indr_i, const int step_index, bool is_c_tail_processing) {
+    if (jpp.ind_dt == data_type::u8) {
+        auto indvr = vreg(indr_i);
+        auto indxr = xreg(indr_i);
+        if (isa == sse41) {
+            if (is_c_tail_processing && !jpp.is_c_padded) {
+                for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
+                    pinsrb(indxr, ptr[reg_index + step_index + i], i);
             } else {
-                if (jpp.with_postops) {
-                    if (isa == avx || isa == avx2) {
-                        uni_vxorps(ymm_tmp_1, ymm_tmp_1, ymm_tmp_1);
-                        uni_vblendvps(
-                                Vmm(idx), ymm_tmp_1, Vmm(idx), vmm_c_tail_mask);
-                    } else
-                        uni_vmovups(Vmm(idx) | k_c_tail_mask | T_z, Vmm(idx));
-                }
-                uni_vmovups(vmmword[reg_ptr + offset], Vmm(idx));
+                movd(indxr, ptr[reg_index + step_index]);
             }
-        } else
-            uni_vmovups(vmmword[reg_ptr + offset], Vmm(idx));
+            pmovzxbd(indvr, indxr);
+        } else if (isa == avx || isa == avx2) {
+            if (is_c_tail_processing && !jpp.is_c_padded) {
+                for (int i = 0; i < jpp.c_tail; i++)
+                    vpinsrb(indxr, indxr, ptr[reg_index + step_index + i], i);
+            } else {
+                vmovq(indxr, ptr[reg_index + step_index]);
+            }
+            if (!mayiuse(avx2)) {
+                avx_pmovzxbd(indvr, indxr, xmm_tmp);
+            } else {
+                vpmovzxbd(indvr, indxr);
+            }
+        } else {
+            if (is_c_tail_processing && !jpp.is_c_padded) {
+                vpmovzxbd(indvr | k_c_tail_mask | T_z,
+                        ptr[reg_index + step_index]);
+            } else {
+                vpmovzxbd(indvr, ptr[reg_index + step_index]);
+            }
+        }
+    } else {
+        assert(jpp.ind_dt == data_type::s32);
+
+        // Load 4-byte values without conversion. The values are actually integers.
+        auto indvr = vreg(indr_i);
+        io_[data_type::f32]->load(vmmword[reg_index + step_index], indvr,
+                is_c_tail_processing && !jpp.is_c_padded);
     }
 }
 
-template <>
-inline void jit_uni_pool_kernel<avx2_vnni_2>::store(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
-        const bool is_c_tail_proccessing) {
-    if (utils::one_of(dt, data_type::bf16, data_type::f16)) {
-        if (is_c_tail_proccessing) {
-            vmaskmovps(ptr[reg_ptr + offset], xmm_c_tail_mask, Xmm(idx));
-            if (jpp.c_tail % 2 != 0) {
-                const int tail_pos = jpp.c_tail - 1;
-                auto word_addr = ptr[reg_ptr + offset + tail_pos * 2];
-                vpextrw(word_addr, Xmm(idx), tail_pos);
+template <cpu_isa_t isa>
+inline void jit_uni_pool_kernel<isa>::store_indices(const int indr_i,
+        const int step_index, const bool is_c_tail_processing,
+        const bool is_first_w_block) {
+    if (jpp.ind_dt == data_type::u8) {
+        auto xr = xreg(indr_i);
+        if (isa == sse41) {
+            for (int i = 0; i < (jpp.c_block / 2); ++i) {
+                if (is_c_tail_processing
+                        && i + (sse_high_half ? (jpp.c_block / 2) : 0)
+                                >= jpp.c_tail) {
+                    if (jpp.is_c_padded)
+                        mov(ptr[reg_index + step_index + i],
+                                tmp_gpr.cvt8()); // fill padded tail with zeros
+                    else
+                        break; // tail end
+                } else {
+                    // bytes which should be stored are located in
+                    // least significant bits(8 to be precise) of 32 bits parts
+                    // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
+                    pextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                }
             }
-        } else
-            vmovups(xword[reg_ptr + offset], Xmm(idx));
-    } else
-        assert(!"datatype not supported");
-}
+        } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
+            auto yr = yreg(indr_i);
+            if (is_c_tail_processing && !jpp.is_c_padded) {
+                const int max_nr_of_vals = jpp.c_tail > (jpp.c_block / 2)
+                        ? (jpp.c_block / 2)
+                        : jpp.c_tail;
+                for (int i = 0; i < max_nr_of_vals; ++i) {
+                    // bytes which should be stored are located in
+                    // least significant bits(8 to be precise) of 32 bits parts
+                    // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
+                    vpextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                }
 
-template <>
-inline void jit_uni_pool_kernel<sse41>::store(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
-        const bool is_c_tail_proccessing) {
-    if (is_c_tail_proccessing) {
-        if (!jpp.is_c_padded) {
-            const auto dt_size = types::data_type_size(dt);
-            for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-                pextrd(ptr[reg_ptr + offset + i * dt_size], Xmm(idx), i);
+                if (jpp.c_tail > (jpp.c_block / 2)) {
+                    Xmm higher_128bits(vmm_mask.getIdx());
+                    vextractf128(higher_128bits, yr, 1);
+                    for (int i = 0; i < jpp.c_tail - (jpp.c_block / 2); ++i) {
+                        // bytes which should be stored are located in
+                        // least significant bits(8 to be precise) of 32 bits parts
+                        // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
+                        vpextrb(ptr[reg_index + step_index + (jpp.c_block / 2)
+                                        + i],
+                                higher_128bits, 4 * i);
+                    }
+                }
+            } else {
+                if (is_c_tail_processing) {
+                    assert(jpp.is_c_padded);
+                    vandps(yr, yr, vmm_c_tail_mask);
+                }
+                if (is_first_w_block) {
+                    vmovd(xmm_tmp, reg_shuf_mask);
+                    uni_vpbroadcastd(vmm_tmp, xmm_tmp);
+                }
+                if (mayiuse(avx2)) {
+                    vpshufb(yr, yr, vmm_tmp);
+                    vmovd(ptr[reg_index + step_index], xr);
+                    vperm2i128(yr, yr, yr, 0x1u);
+                    vmovd(ptr[reg_index + step_index + (jpp.c_block / 2)], xr);
+                } else {
+                    Xmm t(vmm_mask.getIdx());
+                    vextractf128(t, yr, 0);
+                    vpshufb(t, t, xmm_tmp);
+                    vmovd(ptr[reg_index + step_index], t);
+                    vextractf128(t, yr, 1);
+                    vpshufb(t, t,
+                            xmm_tmp); // ymm_tmp[:128]==ymm_tmp[127:0]
+                    vmovd(ptr[reg_index + step_index + (jpp.c_block / 2)], t);
+                }
+            }
         } else {
-            if (jpp.with_postops) {
-                static constexpr auto xmm_half = 4;
-                const auto tail_size = (jpp.c_without_padding > jpp.c_block)
-                        ? jpp.c_without_padding % (jpp.c - jpp.c_block)
-                        : jpp.c_without_padding;
-                const auto tail_size_real = (tail_size >= xmm_half)
-                        ? tail_size - xmm_half
-                        : tail_size;
-                uni_vxorps(xmm_tmp_1, xmm_tmp_1, xmm_tmp_1);
-                if (tail_size <= xmm_half && sse_high_half) {
-                    // just zero out upper half padding and don't write anything else
-                    uni_vmovups(vmmword[reg_ptr + offset], xmm_tmp_1);
-                    return;
-                }
-
-                if ((tail_size < xmm_half && !sse_high_half)
-                        || (tail_size > xmm_half && sse_high_half)) {
-                    std::bitset<8> tail_mask((1 << tail_size_real) - 1);
-                    tail_mask.flip();
-                    uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1,
-                            tail_mask.to_ulong());
-                }
+            auto vr = vreg(indr_i);
+            if (is_c_tail_processing) {
+                if (jpp.is_c_padded) {
+                    knotw(k_c_tail_mask, k_c_tail_mask);
+                    vpxord(vr | k_c_tail_mask, vr, vr);
+                    knotw(k_c_tail_mask, k_c_tail_mask);
+                    vpmovusdb(ptr[reg_index + step_index], vr);
+                } else
+                    vpmovusdb(ptr[reg_index + step_index], vr | k_c_tail_mask);
+            } else {
+                vpmovusdb(ptr[reg_index + step_index], vr);
             }
-            uni_vmovups(vmmword[reg_ptr + offset], Vmm(idx));
         }
-    } else
-        uni_vmovups(vmmword[reg_ptr + offset], Vmm(idx));
+    } else {
+        assert(jpp.ind_dt == data_type::s32);
+
+        // Store 4-byte values without conversion. The values are actually integers.
+        auto idx = reg_idx(indr_i);
+        if (is_c_tail_processing && jpp.is_c_padded) pad_with_zeros(idx);
+        io_[data_type::f32]->store(Vmm(idx), vmmword[reg_index + step_index],
+                is_c_tail_processing && !jpp.is_c_padded);
+    }
 }
 
 template <cpu_isa_t isa>
@@ -907,39 +904,15 @@ inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
                 if (aux_input_offset >= iw * c_off) continue;
                 int input_offset = dt_size * aux_input_offset;
                 if (jpp.is_backward) {
-                    auto inpyr = yreg(inpr_i);
                     load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
                             input_offset, is_tail_processing(bci));
                     uni_vaddps(inpvr, inpvr, accvr);
-                    if (jpp.is_bf16) {
-                        if (!isa_has_bf16(jpp.isa))
-                            bf16_emu_->vcvtneps2bf16(inpyr, zreg(inpr_i));
-                        else
-                            vcvtneps2bf16(inpyr, inpvr);
-                    } else if (jpp.is_f16) {
-                        vcvtps2ph(inpyr, inpvr, _op_mxcsr);
-                    } else if (jpp.is_fp8) {
-                        auto inpxr = xreg(inpr_i);
-                        if (jpp.src_dt == data_type::f8_e5m2)
-                            f8_e5m2_emu_->vcvt_f32_to_f8(inpxr, zreg(inpr_i));
-                        else if (jpp.src_dt == data_type::f8_e4m3)
-                            f8_e4m3_emu_->vcvt_f32_to_f8(inpxr, zreg(inpr_i));
-                    }
                     store(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
                             input_offset, is_tail_processing(bci));
                 } else {
-                    if (jpp.is_bf16 || jpp.is_f16 || jpp.is_fp8
-                            || is_tail_processing(bci)
-                            || (isa == sse41
-                                    && c_off % (jpp.c_block / 2) != 0)) {
-                        load(jpp.src_dt, vmm_tmp_1.getIdx(), aux_reg_input,
-                                input_offset, is_tail_processing(bci));
-
-                        uni_vaddps(accvr, accvr, vmm_tmp_1);
-                    } else {
-                        uni_vaddps(accvr, accvr,
-                                ptr[aux_reg_input + input_offset]);
-                    }
+                    load(jpp.src_dt, vmm_tmp_1.getIdx(), aux_reg_input,
+                            input_offset, is_tail_processing(bci));
+                    uni_vaddps(accvr, accvr, vmm_tmp_1);
                 }
             }
         }
@@ -975,34 +948,8 @@ inline void jit_uni_pool_kernel<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
         for (int jj = 0; jj < ur_w; jj++) {
             for (int bci = 0; bci < ur_bc; bci++) {
                 const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
-                const auto accvr = vreg(accr_i);
                 const auto output_offset
                         = dt_size * (jj * c_off + bci * c_block);
-                const auto accyr = yreg(accr_i);
-                if (jpp.is_bf16) {
-                    if (isa == avx2_vnni_2) {
-                        auto accxr = xreg(accr_i);
-                        vcvtneps2bf16(accxr, accyr, Xbyak::VexEncoding);
-                    } else {
-                        const auto acczr = zreg(accr_i);
-                        if (!isa_has_bf16(jpp.isa))
-                            bf16_emu_->vcvtneps2bf16(accyr, acczr);
-                        else
-                            vcvtneps2bf16(accyr, accvr);
-                    }
-                } else if (jpp.is_f16) {
-                    if (isa == avx2_vnni_2) {
-                        auto accxr = xreg(accr_i);
-                        vcvtps2ph(accxr, accyr, _op_mxcsr);
-                    } else
-                        vcvtps2ph(accyr, accvr, _op_mxcsr);
-                } else if (jpp.is_fp8) {
-                    const auto accxr = xreg(accr_i);
-                    if (jpp.src_dt == data_type::f8_e5m2)
-                        f8_e5m2_emu_->vcvt_f32_to_f8(accxr, accvr);
-                    else if (jpp.src_dt == data_type::f8_e4m3)
-                        f8_e4m3_emu_->vcvt_f32_to_f8(accxr, accvr);
-                }
                 store(jpp.dst_dt, reg_idx(accr_i), reg_output, output_offset,
                         is_tail_processing(bci));
             }
@@ -1149,136 +1096,19 @@ inline void jit_uni_pool_kernel<isa>::max_step_fwd(int ur_w, int ur_bc,
     for_(int jj = 0; jj < ur_w; jj++)
     for (int bci = 0; bci < ur_bc; bci++) {
         const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
-        const auto accvr = vreg(accr_i);
         const auto output_offset = jpp.dt_size * (jj * c_off + bci * c_block);
-        auto accyr = yreg(accr_i);
-        if (jpp.is_bf16) {
-            if (isa == avx2_vnni_2) {
-                auto accxr = xreg(accr_i);
-                vcvtneps2bf16(accxr, accyr, Xbyak::VexEncoding);
-            } else {
-                auto acczr = zreg(accr_i);
-                if (!isa_has_bf16(jpp.isa))
-                    bf16_emu_->vcvtneps2bf16(accyr, acczr);
-                else
-                    vcvtneps2bf16(accyr, accvr);
-            }
-        } else if (jpp.is_f16) {
-            if (isa == avx2_vnni_2) {
-                auto accxr = xreg(accr_i);
-                vcvtps2ph(accxr, accyr, _op_mxcsr);
-            } else
-                vcvtps2ph(accyr, accvr, _op_mxcsr);
-        } else if (jpp.is_fp8) {
-            auto accxr = xreg(accr_i);
-            auto acczr = zreg(accr_i);
-            if (jpp.src_dt == data_type::f8_e5m2)
-                f8_e5m2_emu_->vcvt_f32_to_f8(accxr, acczr);
-            else if (jpp.src_dt == data_type::f8_e4m3)
-                f8_e4m3_emu_->vcvt_f32_to_f8(accxr, acczr);
-        }
+        const bool is_c_tail_processing = is_tail_processing(bci);
         store(jpp.dst_dt, reg_idx(accr_i), reg_output, output_offset,
-                is_tail_processing(bci));
+                is_c_tail_processing);
 
         if (jpp.is_training) {
             const size_t step_index = (jj * c_off + bci * c_block)
                     * types::data_type_size(jpp.ind_dt);
 
             const auto indr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
-            auto vr = vreg(indr_i);
-            if (jpp.ind_dt == data_type::u8) {
-                auto xr = xreg(indr_i);
-                if (isa == sse41) {
-                    for (int i = 0; i < (jpp.c_block / 2); ++i) {
-                        if (is_tail_processing(bci)
-                                && i + (sse_high_half ? (jpp.c_block / 2) : 0)
-                                        >= jpp.c_tail) {
-                            if (jpp.is_c_padded)
-                                mov(ptr[reg_index + step_index + i],
-                                        tmp_gpr.cvt8()); // fill padded tail with zeros
-                            else
-                                break; // tail end
-                        } else {
-                            // bytes which should be stored are located in
-                            // least significant bits(8 to be precise) of 32 bits parts
-                            // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                            pextrb(ptr[reg_index + step_index + i], xr, 4 * i);
-                        }
-                    }
-                } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
-                    auto yr = yreg(indr_i);
-                    if (is_tail_processing(bci) && !jpp.is_c_padded) {
-                        const int max_nr_of_vals
-                                = jpp.c_tail > (jpp.c_block / 2)
-                                ? (jpp.c_block / 2)
-                                : jpp.c_tail;
-                        for (int i = 0; i < max_nr_of_vals; ++i) {
-                            // bytes which should be stored are located in
-                            // least significant bits(8 to be precise) of 32 bits parts
-                            // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                            vpextrb(ptr[reg_index + step_index + i], xr, 4 * i);
-                        }
-
-                        if (jpp.c_tail > (jpp.c_block / 2)) {
-                            Xmm higher_128bits(vmm_mask.getIdx());
-                            vextractf128(higher_128bits, yr, 1);
-                            for (int i = 0; i < jpp.c_tail - (jpp.c_block / 2);
-                                    ++i) {
-                                // bytes which should be stored are located in
-                                // least significant bits(8 to be precise) of 32 bits parts
-                                // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                                vpextrb(ptr[reg_index + step_index
-                                                + (jpp.c_block / 2) + i],
-                                        higher_128bits, 4 * i);
-                            }
-                        }
-                    } else {
-                        if (is_tail_processing(bci)) {
-                            assert(jpp.is_c_padded);
-                            vandps(yr, yr, vmm_c_tail_mask);
-                        }
-                        if (jj == 0) {
-                            vmovd(xmm_tmp, reg_shuf_mask);
-                            uni_vpbroadcastd(vmm_tmp, xmm_tmp);
-                        }
-                        if (mayiuse(avx2)) {
-                            vpshufb(yr, yr, vmm_tmp);
-                            vmovd(ptr[reg_index + step_index], xr);
-                            vperm2i128(yr, yr, yr, 0x1u);
-                            vmovd(ptr[reg_index + step_index
-                                          + (jpp.c_block / 2)],
-                                    xr);
-                        } else {
-                            Xmm t(vmm_mask.getIdx());
-                            vextractf128(t, yr, 0);
-                            vpshufb(t, t, xmm_tmp);
-                            vmovd(ptr[reg_index + step_index], t);
-                            vextractf128(t, yr, 1);
-                            vpshufb(t, t,
-                                    xmm_tmp); // ymm_tmp[:128]==ymm_tmp[127:0]
-                            vmovd(ptr[reg_index + step_index
-                                          + (jpp.c_block / 2)],
-                                    t);
-                        }
-                    }
-                } else {
-                    if (is_tail_processing(bci)) {
-                        if (jpp.is_c_padded) {
-                            knotw(k_c_tail_mask, k_c_tail_mask);
-                            vpxord(vr | k_c_tail_mask, vr, vr);
-                            knotw(k_c_tail_mask, k_c_tail_mask);
-                            vpmovusdb(ptr[reg_index + step_index], vr);
-                        } else
-                            vpmovusdb(ptr[reg_index + step_index],
-                                    vr | k_c_tail_mask);
-                    } else {
-                        vpmovusdb(ptr[reg_index + step_index], vr);
-                    }
-                }
-            } else {
-                store(jpp.ind_dt, vr.getIdx(), reg_index, step_index,
-                        is_tail_processing(bci));
-            }
+            const bool is_first_w_block = jj == 0;
+            store_indices(
+                    indr_i, step_index, is_c_tail_processing, is_first_w_block);
         }
     }
 }
@@ -1320,48 +1150,14 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
     for (int bci = 0; bci < ur_bc; bci++) {
         const auto outr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
         auto out_offset = output_dt_size * (jj * output_c_off + bci * c_block);
+        const bool is_c_tail_processing = is_tail_processing(bci);
         load(jpp.dst_dt, reg_idx(outr_i), reg_output, out_offset,
-                is_tail_processing(bci));
+                is_c_tail_processing);
         const size_t step_index = (jj * output_c_off + bci * c_block)
                 * types::data_type_size(jpp.ind_dt);
 
         const auto indr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
-        auto indvr = vreg(indr_i);
-        if (jpp.ind_dt == data_type::u8) {
-            auto indxr = xreg(indr_i);
-            if (isa == sse41) {
-                if (is_tail_processing(bci) && !jpp.is_c_padded) {
-                    for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-                        pinsrb(indxr, ptr[reg_index + step_index + i], i);
-                } else {
-                    movd(indxr, ptr[reg_index + step_index]);
-                }
-                pmovzxbd(indvr, indxr);
-            } else if (isa == avx || isa == avx2) {
-                if (is_tail_processing(bci) && !jpp.is_c_padded) {
-                    for (int i = 0; i < jpp.c_tail; i++)
-                        vpinsrb(indxr, indxr, ptr[reg_index + step_index + i],
-                                i);
-                } else {
-                    vmovq(indxr, ptr[reg_index + step_index]);
-                }
-                if (!mayiuse(avx2)) {
-                    avx_pmovzxbd(indvr, indxr, xmm_tmp);
-                } else {
-                    vpmovzxbd(indvr, indxr);
-                }
-            } else {
-                if (is_tail_processing(bci) && !jpp.is_c_padded) {
-                    vpmovzxbd(indvr | k_c_tail_mask | T_z,
-                            ptr[reg_index + step_index]);
-                } else {
-                    vpmovzxbd(indvr, ptr[reg_index + step_index]);
-                }
-            }
-        } else {
-            load(jpp.ind_dt, indvr.getIdx(), reg_index, step_index,
-                    is_tail_processing(bci));
-        }
+        load_indices(indr_i, step_index, is_c_tail_processing);
     }
     uni_vmovq(xmm_tmp, reg_k_shift);
     uni_vpbroadcastd(vmm_k_offset, xmm_tmp);
@@ -1369,11 +1165,6 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
     if (jpp.simple_alg && jpp.ndims == 5) {
         push(reg_input);
         push(reg_output);
-        if (isa == sse41) {
-            // Save rdi since it is used in maskmovdqu
-            assert(dst_ptr == rdi);
-            push(dst_ptr);
-        }
         mov(aux_reg_input_d, reg_input);
         mov(ki, ptr[reg_param + GET_OFF(kd_padding)]);
         mov(reg_kd_pad_shift, ptr[reg_param + GET_OFF(kd_padding_shift)]);
@@ -1405,50 +1196,27 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
                 load(input_dt, reg_idx(inpr_i), aux_reg_input, inp_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
-                    mov(dst_ptr, aux_reg_input);
-                    add(dst_ptr, inp_offset);
-
                     movups(cvtvr, indvr);
                     pcmpeqd(cvtvr, vmm_k_offset);
-                    addps(inpvr, outvr);
-                    if (is_tail_processing(bci)) {
-                        Label end_cond_move[4];
-                        for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2);
-                                i++) {
-                            pextrd(tmp_gpr.cvt32(), cvtvr, i);
-                            cmp(tmp_gpr, 0);
-                            je(end_cond_move[i], T_NEAR);
-                            pextrd(ptr[dst_ptr + i * jpp.dt_size], inpvr, i);
-                            L(end_cond_move[i]);
-                        }
-                    } else
-                        maskmovdqu(inpvr, cvtvr);
+                    vandps(cvtvr, cvtvr, outvr);
+                    addps(inpvr, cvtvr);
+                    store(input_dt, inpvr.getIdx(), aux_reg_input, inp_offset,
+                            is_tail_processing(bci));
                 } else if (isa == avx || isa == avx2) {
                     if (mayiuse(avx2)) {
                         vpcmpeqd(cvtvr, indvr, vmm_k_offset);
                     } else {
                         avx_pcmpeqd(cvtvr, indvr, vmm_k_offset, xmm_tmp);
                     }
-                    vaddps(inpvr, inpvr, outvr);
-                    if (is_tail_processing(bci)) {
-                        vandps(cvtvr, cvtvr, vmm_c_tail_mask);
-                    }
-                    vmaskmovps(
-                            vmmword[aux_reg_input + inp_offset], cvtvr, inpvr);
+                    uni_vpxor(vmm_tmp, vmm_tmp, vmm_tmp);
+                    vblendvps(vmm_tmp, vmm_tmp, outvr, cvtvr);
+                    vaddps(inpvr, inpvr, vmm_tmp);
+                    store(input_dt, inpvr.getIdx(), aux_reg_input, inp_offset,
+                            is_tail_processing(bci));
                 } else {
-                    auto indzr = zreg(inpr_i);
-                    auto indyr = yreg(inpr_i);
                     vpcmpeqd(k_store_mask, indvr, vmm_k_offset);
                     vblendmps(vmm_tmp | k_store_mask | T_z, outvr, outvr);
                     vaddps(inpvr, inpvr, vmm_tmp);
-                    if (jpp.is_bf16 && !jpp.needs_f32_accum_for_bf16) {
-                        if (!isa_has_bf16(jpp.isa))
-                            bf16_emu_->vcvtneps2bf16(indyr, indzr);
-                        else
-                            vcvtneps2bf16(indyr, inpvr);
-                    } else if (jpp.is_f16) {
-                        vcvtps2ph(indyr, inpvr, _op_mxcsr);
-                    }
                     store(input_dt, inpvr.getIdx(), aux_reg_input, inp_offset,
                             is_tail_processing(bci));
                 }
@@ -1489,11 +1257,6 @@ inline void jit_uni_pool_kernel<isa>::max_step_bwd(int ur_w, int ur_bc,
         dec(ki);
         cmp(ki, 0);
         jg(kd_label, T_NEAR);
-        if (isa == sse41) {
-            // Save rdi since it is used in maskmovdqu
-            assert(dst_ptr == rdi);
-            pop(dst_ptr);
-        }
         pop(reg_output);
         pop(reg_input);
     }
@@ -1585,8 +1348,6 @@ void jit_uni_pool_kernel<isa>::generate() {
 
     this->preamble();
 
-    Label idx_table;
-
     int ow = jpp.ow;
     int iw = jpp.iw;
     int kw = jpp.kw;
@@ -1605,14 +1366,7 @@ void jit_uni_pool_kernel<isa>::generate() {
     const size_t input_dt_size
             = jpp.needs_f32_accum_for_bf16 ? sizeof(float) : jpp.dt_size;
 
-#if defined(_WIN32)
-    // Always mimic the Unix ABI (see the note about maskmovdqu in the header
-    // file).
-    xor_(rdi, rcx);
-    xor_(rcx, rdi);
-    xor_(rdi, rcx);
-#endif
-    if (use_bf16_emulation()) bf16_emu_->init_vcvtneps2bf16();
+    if (use_bf16_emulation()) io_.init_bf16();
 
     mov(reg_input, ptr[reg_param + GET_OFF(src)]);
     mov(reg_output, ptr[reg_param + GET_OFF(dst)]);
@@ -1622,14 +1376,6 @@ void jit_uni_pool_kernel<isa>::generate() {
     mov(reg_k_shift, ptr[reg_param + GET_OFF(kh_padding_shift)]);
     mov(reg_ker_area_h, ptr[reg_param + GET_OFF(ker_area_h)]);
     mov(reg_nbc, ptr[reg_param + GET_OFF(ur_bc)]);
-
-    if ((jpp.is_bf16 || jpp.is_f16) && isa != avx2_vnni_2) {
-        mov(tmp_gpr.cvt32(), 0xAAAAAAAA);
-        kmovd(k_mask_cvt, tmp_gpr.cvt32());
-
-        mov(tmp_gpr, idx_table);
-        vmovups(vmm_idx(), ptr[tmp_gpr]);
-    }
 
     auto process_oi = [&](int ur_w, int ur_bc, int lpad, int rpad,
                               bool with_c_tail_proccessing,
@@ -1783,7 +1529,7 @@ void jit_uni_pool_kernel<isa>::generate() {
         // care of c tail processing if number of channels
         // is not divided by number of channels in block
         L(ur_bc_tail_label);
-        if (jpp.c_tail != 0) prepare_tail_mask();
+        if (jpp.c_tail != 0) io_.prepare_tail_mask();
         perform_ker(jpp.ur_bc_tail, jpp.c_tail != 0);
 
         L(finish_label);
@@ -1791,7 +1537,7 @@ void jit_uni_pool_kernel<isa>::generate() {
         jmp(finish_label, T_NEAR);
 
         L(c_tail_processing_label);
-        prepare_tail_mask();
+        io_.prepare_tail_mask();
         perform_ker(jpp.ur_bc, true);
 
         L(finish_label);
@@ -1801,17 +1547,9 @@ void jit_uni_pool_kernel<isa>::generate() {
 
     if (jpp.with_eltwise && postops_injector_)
         postops_injector_->prepare_table(/* generate = */ true);
-
-    if ((jpp.is_bf16 || jpp.is_f16) && isa != avx2_vnni_2) {
-        align(64);
-        L(idx_table);
-        const uint16_t _idx[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7,
-                8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15};
-        for (size_t i = 0; i < sizeof(_idx) / sizeof(_idx[0]); ++i)
-            dw(_idx[i]);
-    }
     if (f8_e5m2_emu_) f8_e5m2_emu_->prepare_table();
     if (f8_e4m3_emu_) f8_e4m3_emu_->prepare_table();
+    io_.prepare_table_fp8();
 }
 
 template struct jit_uni_pool_kernel<sse41>;

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -387,7 +387,9 @@ status_t jit_uni_pool_kernel<isa>::init_conf(
     }
     assert(jpp.ur > 0);
 
-    jpp.needs_f32_accum_for_bf16 = jpp.is_bf16
+    const bool is_relaxed_acc = utils::one_of(
+            attr.acc_mode_, accumulation_mode::relaxed, accumulation_mode::any);
+    jpp.needs_f32_accum_for_bf16 = !is_relaxed_acc && jpp.is_bf16
             && jpp.alg == alg_kind::pooling_max && jpp.is_backward
             && (jpp.stride_d < jpp.kd || jpp.stride_h < jpp.kh
                     || jpp.stride_w < jpp.kw);

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -154,9 +154,8 @@ bool jit_uni_pool_kernel<isa>::has_large_buffers(const pooling_pd_t *ppd) {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
-        memory_tracking::registrar_t &scratchpad, primitive_attr_t &attr,
-        const pooling_pd_t *ppd) {
+status_t jit_uni_pool_kernel<isa>::init_conf(
+        jit_pool_conf_t &jpp, primitive_attr_t &attr, const pooling_pd_t *ppd) {
 
     const auto &pd = *ppd->desc();
     const memory_desc_wrapper src_d(
@@ -430,6 +429,31 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
         jpp.ur_bc_tail = 0;
     }
 
+    jpp.f32_accum_block_size = jpp.ur_bc * jpp.c_block;
+    if (jpp.needs_f32_accum_for_bf16) {
+        assert(memory_desc_wrapper(jpp.tmp_md).is_zero()
+                && (fmt_tag == nspc_fmt_tag || fmt_tag == blocked_fmt_tag));
+
+        dims_t dims {};
+        utils::array_copy(dims, src_d.dims(), ndims);
+
+        const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+        dims[0] = nstl::min(dnnl_get_max_threads(), jpp.mb * nb2_c);
+        dims[1] = jpp.f32_accum_block_size;
+
+        CHECK(memory_desc_init_by_tag(
+                jpp.tmp_md, ndims, dims, data_type::f32, fmt_tag));
+    }
+
+    jpp.post_ops = attr.post_ops_;
+
+    return status::success;
+}
+
+template <cpu_isa_t isa>
+void jit_uni_pool_kernel<isa>::init_scratchpad(
+        const jit_pool_conf_t &jpp, memory_tracking::registrar_t &scratchpad) {
+
     // scratchpad for c_block slice of input and/or output
     using namespace memory_tracking::names;
     const int nscr = nstl::min(dnnl_get_max_threads(), jpp.mb * jpp.nb_c);
@@ -447,28 +471,10 @@ status_t jit_uni_pool_kernel<isa>::init_conf(jit_pool_conf_t &jpp,
                         * nscr);
     }
 
-    jpp.f32_accum_block_size = jpp.ur_bc * jpp.c_block;
     if (jpp.needs_f32_accum_for_bf16) {
         auto tmp_d = memory_desc_wrapper(jpp.tmp_md);
-        assert(tmp_d.is_zero()
-                && (fmt_tag == nspc_fmt_tag || fmt_tag == blocked_fmt_tag));
-
-        dims_t dims {};
-        utils::array_copy(dims, src_d.dims(), ndims);
-
-        const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
-        dims[0] = nstl::min(dnnl_get_max_threads(), jpp.mb * nb2_c);
-        dims[1] = jpp.f32_accum_block_size;
-
-        CHECK(memory_desc_init_by_tag(
-                jpp.tmp_md, ndims, dims, data_type::f32, fmt_tag));
-
         scratchpad.book<char>(key_pool_src_f32_accum, tmp_d.size());
     }
-
-    jpp.post_ops = attr.post_ops_;
-
-    return status::success;
 }
 
 static int reg_ind(int shift, int bc, int j, int ur_bc, int ur_w) noexcept {

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -161,10 +161,10 @@ private:
     void uni_broadcast_reg_val(const int reg_idx, const int vmm_idx);
     void push_vmm_val(const int idx);
     void pop_vmm_val(const int idx);
-    void load(const int idx, const reg64_t &reg_ptr, const int offset,
-            const bool is_c_tail_proccessing);
-    void store(const int idx, const reg64_t &reg_ptr, const int offset,
-            const bool is_c_tail_proccessing);
+    void load(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
+            const int offset, const bool is_c_tail_proccessing);
+    void store(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
+            const int offset, const bool is_c_tail_proccessing);
 
     void maybe_recalculate_divisor(int jj, int ur_w, int pad_l, int pad_r,
             bool with_c_tail_proccessing);

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -45,9 +45,11 @@ struct jit_uni_pool_kernel : public jit_generator {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_pool_kernel)
 
-    static status_t init_conf(jit_pool_conf_t &jbp,
-            memory_tracking::registrar_t &scratchpad, primitive_attr_t &attr,
+    static status_t init_conf(jit_pool_conf_t &jpp, primitive_attr_t &attr,
             const pooling_pd_t *ppd);
+
+    static void init_scratchpad(const jit_pool_conf_t &jpp,
+            memory_tracking::registrar_t &scratchpad);
 
 private:
     using Xmm = Xbyak::Xmm;

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -27,13 +27,12 @@
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/x64/jit_generator.hpp"
 #include "cpu/x64/jit_primitive_conf.hpp"
+#include "cpu/x64/utils/jit_io_helper.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace x64 {
-
-struct bf16_emulation_t;
 
 template <cpu_isa_t isa>
 struct jit_uni_pool_kernel : public jit_generator {
@@ -81,9 +80,8 @@ private:
     Ymm ymm_tmp_1 = Ymm(0);
     Vmm vmm_tmp_1 = Vmm(0);
 
-    // Used only for avx and if c tail is present
+    // Used only for avx and if c tail is present; is shared with jit_io_multi_dt_helper_t
     Vmm vmm_c_tail_mask = Vmm(2);
-    Xmm xmm_c_tail_mask = Xmm(2);
 
     Vmm vmm_ker_area_h = Vmm(2);
     Vmm vmm_one = Vmm(2);
@@ -91,14 +89,6 @@ private:
     Xmm xmm_tmp = Xmm(3);
 
     Vmm vmm_k_offset = Vmm(1);
-
-    // Used only for avx512 when bf16 is present
-    inline Vmm vmm_idx() {
-        if (!jpp.is_backward) {
-            return (jpp.is_training) ? Vmm(4) : Vmm(1);
-        } else
-            return Vmm(4);
-    }
 
     Zmm bf16_emu_reserv_1 = Zmm(5);
     Zmm bf16_emu_reserv_2 = Zmm(6);
@@ -114,33 +104,23 @@ private:
     Reg64 fp8_emu_reg64 = bf16_emu_reserv_4;
     Xbyak::Opmask fp8_tmp_mask = Xbyak::Opmask(3);
 
+    // k_c_tail_mask is shared with jit_io_multi_dt_helper_t and jit_uni_postops_injector_t
     Opmask k_c_tail_mask = Opmask(4);
-    Opmask k_mask_cvt = Opmask(5);
-    Opmask k_store_mask = Opmask(6);
-
-    // Here be some (tame) dragons. This kernel does not follow the regular
-    // OS-agnostic ABI pattern because when isa is sse41 it uses maskmovdqu
-    // instruction which has its destination hardcoded in rdi. Therefore:
-    // - all registers are hardcoded
-    // - on Windows rdi and rcx are swapped to mimic the Unix x86_64 ABI
-    //
-    // While this is only required by the backward pass, the quirk above
-    // is applied to the forward pass as well to keep things simpler.
+    Opmask k_store_mask = Opmask(5);
 
     using reg64_t = const Reg64;
-    reg64_t reg_param = rdi; // Always mimic the Unix ABI
+    reg64_t reg_param = abi_param1;
     reg64_t reg_input = r8;
     reg64_t aux_reg_input = r9;
     reg64_t reg_index = r10;
     reg64_t reg_output = r12;
     reg64_t reg_kd_pad_shift = r13;
-    reg64_t dst_ptr = rdi; // Must be rdi due to maskmovdqu
 
     reg64_t kj = r14;
     reg64_t oi_iter = r15;
     reg64_t reg_kh = rax;
     reg64_t reg_k_shift = rbx;
-    reg64_t tmp_gpr = rcx; // Must be rcx because rdi is used above
+    reg64_t tmp_gpr = abi_not_param1;
     reg64_t reg_ker_area_h = rdx;
     reg64_t reg_nbc = rsi;
 
@@ -158,7 +138,6 @@ private:
 
     int prev_kw;
 
-    void prepare_tail_mask();
     void put_one_in_vmm();
     void uni_broadcast_reg_val(const int reg_idx, const int vmm_idx);
     void push_vmm_val(const int idx);
@@ -167,6 +146,10 @@ private:
             const int offset, const bool is_c_tail_proccessing);
     void store(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
             const int offset, const bool is_c_tail_proccessing);
+    void pad_with_zeros(int idx);
+    void load_indices(int indr_i, int step_index, bool is_c_tail_processing);
+    void store_indices(int indr_i, int step_index, bool is_c_tail_processing,
+            bool is_first_w_block);
 
     void maybe_recalculate_divisor(int jj, int ur_w, int pad_l, int pad_r,
             bool with_c_tail_proccessing);
@@ -273,11 +256,11 @@ private:
 
     static bool has_large_buffers(const pooling_pd_t *ppd);
 
-    std::unique_ptr<bf16_emulation_t> bf16_emu_;
     std::unique_ptr<fp8_emulation_e5m2_t> f8_e5m2_emu_;
     std::unique_ptr<fp8_emulation_e4m3_t> f8_e4m3_emu_;
     std::unique_ptr<injector::jit_uni_postops_injector_t<isa>>
             postops_injector_;
+    io::jit_io_multi_dt_helper_t<Vmm> io_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -483,6 +483,151 @@ private:
     const dim_t c_tail_;
 };
 
+struct bwd_f32_accum_for_bf16_t {
+    using value_type = typename prec_traits_t<data_type::f32>::type;
+
+    bwd_f32_accum_for_bf16_t(const jit_pool_conf_t &jpp, const exec_ctx_t &ctx);
+
+    value_type *get_addr_2d(int ithr, dim_t ih) const {
+        return blk_data(ithr, 0, ih, 0);
+    }
+
+    value_type *get_addr_3d(int ithr, dim_t id, dim_t ih) const {
+        return blk_data(ithr, 0, id, ih, 0);
+    }
+
+    void zero_data(int ithr);
+
+    void cvt_to_bf16_slice_2d(int ithr, bfloat16_t *dst,
+            memory_desc_wrapper const &dst_d, dim_t n, dim_t b_c,
+            dim_t ur_bc) const;
+
+    void cvt_to_bf16_slice_3d(int ithr, bfloat16_t *dst,
+            memory_desc_wrapper const &dst_d, dim_t n, dim_t b_c,
+            dim_t ur_bc) const;
+
+private:
+    template <typename... Args>
+    value_type *blk_data(Args... args) const {
+        assert(wsp_);
+        return wsp_ + accum_d_.blk_off(std::forward<Args>(args)...);
+    }
+
+    const jit_pool_conf_t &jpp_;
+    value_type *wsp_ {nullptr};
+    memory_desc_wrapper accum_d_ {nullptr};
+};
+
+bwd_f32_accum_for_bf16_t::bwd_f32_accum_for_bf16_t(
+        const jit_pool_conf_t &jpp, const exec_ctx_t &ctx)
+    : jpp_ {jpp} {
+    if (jpp_.needs_f32_accum_for_bf16) {
+        accum_d_ = memory_desc_wrapper(jpp_.tmp_md);
+        auto &scratchpad = ctx.get_scratchpad_grantor();
+        wsp_ = scratchpad.template get<value_type>(
+                memory_tracking::names::key_pool_src_f32_accum);
+        assert(wsp_);
+    }
+}
+
+void bwd_f32_accum_for_bf16_t::zero_data(int ithr) {
+    auto *data = blk_data(ithr);
+    memset(data, 0,
+            jpp_.tmp_md.format_desc.blocking.strides[0] * sizeof(value_type));
+}
+
+void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_2d(int ithr, bfloat16_t *dst,
+        memory_desc_wrapper const &dst_d, dim_t n, dim_t b_c,
+        dim_t ur_bc) const {
+
+    assert(wsp_ && (jpp_.ndims == 3 || jpp_.ndims == 4)
+            && (jpp_.tag_kind == jit_memory_tag_kind_t::nspc
+                    || jpp_.tag_kind == jit_memory_tag_kind_t::blocked));
+
+    if (jpp_.tag_kind == jit_memory_tag_kind_t::nspc) {
+        if (jpp_.tmp_md.dims[1] == jpp_.c && b_c == 0
+                && jpp_.c == ur_bc * jpp_.c_block) {
+            // all channels
+            const size_t nelems = jpp_.ih * jpp_.iw * jpp_.c;
+            const auto *cur_src = blk_data(ithr);
+            auto *cur_dst = dst + dst_d.blk_off(n);
+            cvt_float_to_bfloat16(cur_dst, cur_src, nelems);
+        } else {
+            const auto c_b = jpp_.c_block * b_c;
+            const auto c_e = nstl::min(
+                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+
+            if (c_b >= c_e) return;
+
+            const size_t nelems = c_e - c_b;
+            if (jpp_.ndims == 4) {
+                for (dim_t h = 0; h < jpp_.ih; ++h) {
+                    for (dim_t w = 0; w < jpp_.iw; ++w) {
+                        const auto *cur_src = blk_data(ithr, 0, h, w);
+                        auto *cur_dst = dst + dst_d.blk_off(n, c_b, h, w);
+                        cvt_float_to_bfloat16(cur_dst, cur_src, nelems);
+                    }
+                }
+            } else {
+                for (dim_t w = 0; w < jpp_.iw; ++w) {
+                    const auto *cur_src = blk_data(ithr, 0, w);
+                    auto *cur_dst = dst + dst_d.blk_off(n, c_b, w);
+                    cvt_float_to_bfloat16(cur_dst, cur_src, nelems);
+                }
+            }
+        }
+    } else if (jpp_.tag_kind == jit_memory_tag_kind_t::blocked) {
+        assert(ur_bc == 1);
+
+        const size_t nelems = jpp_.ih * jpp_.iw * jpp_.c_block;
+        const auto *src_b = blk_data(ithr);
+        auto *dst_b = dst + dst_d.blk_off(n, b_c);
+        cvt_float_to_bfloat16(dst_b, src_b, nelems);
+    }
+}
+
+void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_3d(int ithr, bfloat16_t *dst,
+        memory_desc_wrapper const &dst_d, dim_t n, dim_t b_c,
+        dim_t ur_bc) const {
+
+    assert(wsp_ && jpp_.ndims == 5
+            && (jpp_.tag_kind == jit_memory_tag_kind_t::nspc
+                    || jpp_.tag_kind == jit_memory_tag_kind_t::blocked));
+
+    if (jpp_.tag_kind == jit_memory_tag_kind_t::blocked) {
+        assert(ur_bc == 1);
+        const size_t nelems = jpp_.id * jpp_.ih * jpp_.iw * jpp_.c_block;
+        const auto *src_b = blk_data(ithr);
+        auto *dst_b = dst + dst_d.blk_off(n, b_c);
+        cvt_float_to_bfloat16(dst_b, src_b, nelems);
+    } else if (jpp_.tag_kind == jit_memory_tag_kind_t::nspc) {
+        if (jpp_.tmp_md.dims[1] == jpp_.c && b_c == 0
+                && jpp_.c == ur_bc * jpp_.c_block) {
+            // all channels
+            const size_t nelems = jpp_.id * jpp_.ih * jpp_.iw * jpp_.c;
+            cvt_float_to_bfloat16(
+                    dst + dst_d.blk_off(n), blk_data(ithr), nelems);
+        } else {
+            const auto c_b = jpp_.c_block * b_c;
+            const auto c_e = nstl::min(
+                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+
+            if (c_b >= c_e) return;
+
+            const size_t nelems = c_e - c_b;
+            for (dim_t id = 0; id < jpp_.id; ++id) {
+                for (dim_t h = 0; h < jpp_.ih; ++h) {
+                    for (dim_t w = 0; w < jpp_.iw; ++w) {
+                        const auto *cur_src = blk_data(ithr, 0, id, h, w);
+                        auto *cur_dst = dst + dst_d.blk_off(n, c_b, id, h, w);
+                        cvt_float_to_bfloat16(cur_dst, cur_src, nelems);
+                    }
+                }
+            }
+        }
+    }
+}
+
 } // namespace jit_uni_pooling_utils
 
 template <cpu_isa_t isa, impl::data_type_t d_type>
@@ -906,6 +1051,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
                     diff_dst_d, indices_d, wsp_dt_, diff_src, diff_dst, indices,
                     ctx);
 
+    bwd_f32_accum_for_bf16_t f32_accum(jpp, ctx);
+
     auto get_first_ih = [&](int oh) {
         return nstl::min(nstl::max(oh * jpp.stride_h - jpp.t_pad, 0), jpp.ih);
     };
@@ -924,6 +1071,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
         const auto c_off = jpp.is_plain() ? b_c * jpp.c_block : b_c;
         if (transpose_facade.should_transpose_src())
             arg.src = transpose_facade.get_src_addr(ithr, ih, jpp);
+        else if (jpp.needs_f32_accum_for_bf16)
+            arg.src = f32_accum.get_addr_2d(ithr, ih);
         else
             arg.src = &diff_src[diff_src_d.blk_off(n, c_off, ih)];
 
@@ -950,6 +1099,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
         if (transpose_facade.should_transpose_src())
             arg.zero_ptr
                     = transpose_facade.get_src_addr(ithr, zero_ih_start, jpp);
+        else if (jpp.needs_f32_accum_for_bf16)
+            arg.zero_ptr = f32_accum.get_addr_2d(ithr, zero_ih_start);
         else
             arg.zero_ptr
                     = &diff_src[diff_src_d.blk_off(n, c_off, zero_ih_start, 0)];
@@ -978,6 +1129,10 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
 
         if (transpose_facade.should_transpose_src())
             transpose_facade.execute_transpose_output(ithr, n, b_c);
+
+        if (jpp.needs_f32_accum_for_bf16)
+            f32_accum.cvt_to_bf16_slice_2d(
+                    ithr, (bfloat16_t *)diff_src, diff_src_d, n, b_c, ur_bc);
     };
 
     const int nthr = jpp.nthr;
@@ -1029,6 +1184,12 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
     const auto trans_src = transpose_facade.should_transpose_src();
     const auto trans_dst = transpose_facade.should_transpose_dst();
 
+    bwd_f32_accum_for_bf16_t f32_accum(jpp, ctx);
+
+    const size_t input_dt_size = jpp.needs_f32_accum_for_bf16
+            ? sizeof(bwd_f32_accum_for_bf16_t::value_type)
+            : jpp.dt_size;
+
     auto get_last_ih = [&](int oh) {
         return nstl::min(
                 nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
@@ -1056,6 +1217,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
 
         if (trans_src)
             arg.src = transpose_facade.get_src_addr_3d(ithr, id + kd, ih, jpp);
+        else if (jpp.needs_f32_accum_for_bf16)
+            arg.src = f32_accum.get_addr_3d(ithr, id + kd, ih);
         else
             arg.src = (const void *)&diff_src[diff_src_d.blk_off(
                     n, c_off, id + kd, ih)];
@@ -1091,6 +1254,9 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             if (trans_src)
                 arg.zero_ptr = transpose_facade.get_src_addr_3d(
                         ithr, zero_id_start, zero_ih_start, jpp);
+            else if (jpp.needs_f32_accum_for_bf16)
+                arg.zero_ptr = f32_accum.get_addr_3d(
+                        ithr, zero_id_start, zero_ih_start);
             else
                 arg.zero_ptr = &diff_src[diff_src_d.blk_off(
                         n, c_off, zero_id_start, zero_ih_start, 0)];
@@ -1135,18 +1301,34 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
     const int nthr = jpp.nthr;
 
     if (jpp.simple_alg) {
+        const dim_t nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
+
         if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
-            const dim_t nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
-            parallel_nd(
-                    jpp.mb, jpp.od, nb2_c, [&](dim_t n, dim_t od, dim_t b2_c) {
-                        const dim_t b_c = b2_c * jpp.ur_bc;
-                        const dim_t ur_bc
-                                = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                        process_simple(n, b_c, od, ur_bc, first_ithr);
-                    });
+            if (!jpp.needs_f32_accum_for_bf16) {
+                parallel_nd(jpp.mb, jpp.od, nb2_c,
+                        [&](dim_t n, dim_t od, dim_t b2_c) {
+                            const dim_t b_c = b2_c * jpp.ur_bc;
+                            const dim_t ur_bc = nstl::min(
+                                    dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+                            process_simple(n, b_c, od, ur_bc, first_ithr);
+                        });
+            } else {
+                parallel_nd_ext(nthr, jpp.mb, nb2_c,
+                        [&](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
+                            const dim_t b_c = b2_c * jpp.ur_bc;
+                            const dim_t ur_bc = nstl::min(
+                                    dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+                            for (int od = 0; od < jpp.od; ++od) {
+                                process_simple(n, b_c, od, ur_bc, ithr);
+                            }
+                            f32_accum.cvt_to_bf16_slice_3d(ithr,
+                                    (bfloat16_t *)diff_src, diff_src_d, n, b_c,
+                                    ur_bc);
+                        });
+            }
         } else {
             assert(jpp.ur_bc == 1);
-            if (trans_src || trans_dst) {
+            if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
                 parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
                         [&](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
                             if (trans_src)
@@ -1158,6 +1340,10 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                             if (trans_dst)
                                 transpose_facade.execute_transpose_output(
                                         ithr, n, b_c);
+                            if (jpp.needs_f32_accum_for_bf16)
+                                f32_accum.cvt_to_bf16_slice_3d(ithr,
+                                        (bfloat16_t *)diff_src, diff_src_d, n,
+                                        b_c, 1);
                         });
             } else {
                 parallel_nd(jpp.mb, jpp.nb_c, jpp.od,
@@ -1168,31 +1354,35 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         }
     } else {
         const data_t zero_val = 0;
-        if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
-            const size_t chunk_size = (size_t)jpp.ih * jpp.iw * jpp.c;
-            parallel_nd(jpp.mb, jpp.id, [&](dim_t n, dim_t id) {
-                const size_t offset = ((size_t)n * jpp.id + id) * chunk_size;
-                PRAGMA_OMP_SIMD()
-                for (size_t idx = 0; idx < chunk_size; ++idx)
-                    diff_src[offset + idx] = zero_val;
-            });
-        } else {
-            if (!trans_src) {
-                const size_t chunk_size
-                        = (size_t)jpp.id * jpp.ih * jpp.iw * jpp.c_block;
-                parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                        [&](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
-                            const size_t offset
-                                    = ((size_t)n * jpp.nb_c + b_c) * chunk_size;
-                            PRAGMA_OMP_SIMD()
-                            for (size_t idx = 0; idx < chunk_size; ++idx)
-                                diff_src[offset + idx] = zero_val;
-                        });
+        if (!jpp.needs_f32_accum_for_bf16) {
+            if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
+                const size_t chunk_size = (size_t)jpp.ih * jpp.iw * jpp.c;
+                parallel_nd(jpp.mb, jpp.id, [&](dim_t n, dim_t id) {
+                    const size_t offset
+                            = ((size_t)n * jpp.id + id) * chunk_size;
+                    PRAGMA_OMP_SIMD()
+                    for (size_t idx = 0; idx < chunk_size; ++idx)
+                        diff_src[offset + idx] = zero_val;
+                });
+            } else {
+                if (!trans_src) {
+                    const size_t chunk_size
+                            = (size_t)jpp.id * jpp.ih * jpp.iw * jpp.c_block;
+                    parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
+                            [&](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                                const size_t offset
+                                        = ((size_t)n * jpp.nb_c + b_c)
+                                        * chunk_size;
+                                PRAGMA_OMP_SIMD()
+                                for (size_t idx = 0; idx < chunk_size; ++idx)
+                                    diff_src[offset + idx] = zero_val;
+                            });
+                }
             }
         }
 
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
-        if (trans_src || trans_dst) {
+        if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
             parallel_nd_ext(nthr, jpp.mb, nb2_c,
                     [&](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
                         const dim_t b_c = b2_c * jpp.ur_bc;
@@ -1202,16 +1392,19 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                                     ithr, n, b_c);
 
                             size_t block_size = jpp.c_block * jpp.id * jpp.ih
-                                    * jpp.iw * jpp.dt_size;
+                                    * jpp.iw * input_dt_size;
 
                             const void *src = transpose_facade.get_src_addr_3d(
                                     ithr, 0, 0, jpp);
                             std::memset((void *)src, zero_val, block_size);
                         }
 
+                        if (jpp.needs_f32_accum_for_bf16)
+                            f32_accum.zero_data(ithr);
+
+                        const dim_t ur_bc
+                                = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
                         for (dim_t kd = 0; kd < jpp.kd; ++kd) {
-                            const dim_t ur_bc = nstl::min(
-                                    dim_t(jpp.ur_bc), jpp.nb_c - b_c);
                             for (int od = 0; od < jpp.od; ++od) {
                                 const dim_t ik
                                         = static_cast<dim_t>(od) * jpp.stride_d;
@@ -1236,6 +1429,11 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                         if (trans_src)
                             transpose_facade.execute_transpose_output(
                                     ithr, n, b_c);
+
+                        if (jpp.needs_f32_accum_for_bf16)
+                            f32_accum.cvt_to_bf16_slice_3d(ithr,
+                                    (bfloat16_t *)diff_src, diff_src_d, n, b_c,
+                                    ur_bc);
                     });
         } else {
             for (dim_t kd = 0; kd < jpp.kd; ++kd) {

--- a/src/cpu/x64/jit_uni_pooling.hpp
+++ b/src/cpu/x64/jit_uni_pooling.hpp
@@ -70,10 +70,10 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
             if (desc()->alg_kind == alg_kind::pooling_max && is_training)
                 init_default_ws();
 
-            auto scratchpad = scratchpad_registry().registrar();
+            CHECK(jit_uni_pool_kernel<isa>::init_conf(jpp_, attr_, this));
 
-            CHECK(jit_uni_pool_kernel<isa>::init_conf(
-                    jpp_, scratchpad, attr_, this));
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_uni_pool_kernel<isa>::init_scratchpad(jpp_, scratchpad);
 
             return status::success;
         }
@@ -146,10 +146,10 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
                         compare_ws(hint_fwd_pd_), VERBOSE_WS_MISMATCH);
             }
 
-            auto scratchpad = scratchpad_registry().registrar();
+            CHECK(jit_uni_pool_kernel<isa>::init_conf(jpp_, attr_, this));
 
-            CHECK(jit_uni_pool_kernel<isa>::init_conf(
-                    jpp_, scratchpad, attr_, this));
+            auto scratchpad = scratchpad_registry().registrar();
+            jit_uni_pool_kernel<isa>::init_scratchpad(jpp_, scratchpad);
 
             return status::success;
         }

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -206,7 +206,7 @@ bool jit_io_helper_t<Vmm>::is_data_type_supported(const data_type_t dt) {
         case data_type::f16:
             return is_superset(isa_, avx512_core_fp16) || isa_ == avx2_vnni_2;
         case data_type::f8_e4m3:
-        case data_type::f8_e5m2: return is_superset(isa_, avx512_core_amx);
+        case data_type::f8_e5m2: return is_superset(isa_, avx512_core_fp16);
         default: assert(!"Unsupported data type");
     }
     return false;

--- a/tests/benchdnn/inputs/pool/test_pool_bfloat16
+++ b/tests/benchdnn/inputs/pool/test_pool_bfloat16
@@ -22,3 +22,13 @@
 
 --attr-post-ops=add:bf16,linear:0.5:-1
 --batch=set_all_small
+
+# Backward propagation without f32 accumulator
+--attr-post-ops=
+
+--alg=max
+--tag=axb,aBx16b
+
+--dir=BWD_D
+--attr-acc-mode=relaxed
+--batch=set_topologies

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -192,9 +192,13 @@ bool cuda_check_correctness(const prb_t *prb,
 
 void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
         const args_t &ref_args) {
+    const bool is_strict_acc
+            = prb->attr.acc_mode == dnnl_accumulation_mode_strict
+            || prb->attr.acc_mode == dnnl_accumulation_mode_f32;
     // Threshold to compensate division error. CPU could live with 6.f coeff.
-    const float trh
-            = prb->alg == alg_t::max ? 0.f : 10.f * epsilon_dt(prb->dt[1]);
+    const float trh = (prb->alg == alg_t::max && is_strict_acc)
+            ? 0.f
+            : 10.f * epsilon_dt(prb->dt[1]);
     cmp.set_threshold(trh);
     // Backward may have most zeroes for ker_in_pad with huge kernels problems.
     const float zero_percent = (prb->dir & FLAG_FWD) ? 99.f : 100.f;

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -193,7 +193,8 @@ bool cuda_check_correctness(const prb_t *prb,
 void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
         const args_t &ref_args) {
     // Threshold to compensate division error. CPU could live with 6.f coeff.
-    const float trh = 10.f * epsilon_dt(prb->dt[1]);
+    const float trh
+            = prb->alg == alg_t::max ? 0.f : 10.f * epsilon_dt(prb->dt[1]);
     cmp.set_threshold(trh);
     // Backward may have most zeroes for ker_in_pad with huge kernels problems.
     const float zero_percent = (prb->dir & FLAG_FWD) ? 99.f : 100.f;


### PR DESCRIPTION
[MFDNN-11050](https://jira.devtools.intel.com/browse/MFDNN-11050) bf16 backward max pooling returns incorrect results
[MFDNN-11396](https://jira.devtools.intel.com/browse/MFDNN-11396) BF16 pooling_backward performance regression on SPR

As a result of a refactoring,  [MFDNN-12863](https://jira.devtools.intel.com/browse/MFDNN-12863) (JIT max pool implementation works incorrectly for small data types and large kernels) was also fixed.
Also, as it was recommended during the review, io injector is used to load/store tensor data.


It was found earlier ([MFDNN-11050](https://jira.devtools.intel.com/browse/MFDNN-11050)) that bf16 backward max pooling returns incorrect results. An initial fix of an accuracy led to significant performance regression ([MFDNN-11396](https://jira.devtools.intel.com/browse/MFDNN-11396)). That initial fix was rolled back.

The reason of an accuracy issue is that even a sum of relatively small numbers is not accurate, e.g. bf16(256.0)+bf16(1.0) is bf16(256.0). Summation can take place if some pooling strides are less than corresponding kernel sizes.

The current fix uses additional accumulation arrays of f32's, with one array per thread. The size of those arrays for src_diff is the same as for existing ncsp implementation (ncsp implementation creates arrays of f32's for dst_diff, src_diff and indices, reorders data and uses those arrays during calculations). The ncsp case is not affected by this PR (except changed load/store functions).

I have done some manual measurements on a machine with SPR processor. In some cases this implementation works faster than the original version, sometimes slower, but significantly better than not-optimized implementation (that was used after the first fix of [MFDNN-11050](https://jira.devtools.intel.com/browse/MFDNN-11050)).

The following tables contain performance data for axb and aBx16b layouts for the original implementation (main branch), the fixed version (this PR), and another implementation (that is used if the optimized implementation is skipped).

#### Scratch of a script used to run tests:
```
export KMP_AFFINITY=granularity=fine,compact,1,0
export OMP_NUM_THREADS=56
...
export LD_PRELOAD=${libiomp5_loc}/libiomp5.so
numactl --physcpubind=0-59 --membind=0 ./benchdnn -v5 --mode=p --pool --reset --allow-enum-tags-only=0 --engine=cpu --dir=BWD_D --alg=pooling_max --dt=bf16:bf16 --tag=<tag> <problem>

```
### axb
| problem | original (ms) | fixed (ms) | other (simple_nhwc) (ms) |
| --- | --- | --- | --- |
| mb200_ic32_id20ih40iw30_od18oh38ow28_kd3kh3kw3 | 13 | 13 | 451 |
| mb200_ic35_id20ih40iw30_od18oh38ow28_kd3kh3kw3 | 29 | 22 |1685 |
| mb200_ic32_id40ih40iw30_od10oh35ow25_kd4kh6kw6_sd4sh1sw1 | 16 | 19 | 857 |
| mb200_ic35_id40ih40iw30_od10oh35ow25_kd4kh6kw6_sd4sh1sw1 | 55 | 33 | 3960 |
| mb128ic128_ih112oh56kh3sh2_iw112ow56kw3sw2 | 6.7 | 14 | 117 |
| mb512_ic512_iw2048kw129sw1ow1920 | 142 | 88 | 2480 |
| mb128ic64_ih112oh56kh3sh2dh0ph0_iw112ow56kw3sw2dw0pw0  _(from MFDNN-11396)_ | 1.85 | 5.34 | 67 |

### aBx16b
| problem | original (ms) | fixed (ms) | other (ref) (ms) |
| --- | --- | --- | --- |
| mb200_ic32_id20ih40iw30_od18oh38ow28_kd3kh3kw3 | 13 | 7 | 310 |
| mb200_ic35_id20ih40iw30_od18oh38ow28_kd3kh3kw3 | 20 | 10 | 338 |
| mb200_ic32_id40ih40iw30_od10oh35ow25_kd4kh6kw6_sd4sh1sw1 | 16 | 14 | 155 |
| mb200_ic35_id40ih40iw30_od10oh35ow25_kd4kh6kw6_sd4sh1sw1 | 25 | 19 | 177 |
| mb128ic128_ih112oh56kh3sh2_iw112ow56kw3sw2 | 3.6 | 3.7 | 147 |
| mb512_ic512_iw2048kw129sw1ow1920 | 121 | 60 | 1310 |
| mb128ic64_ih112oh56kh3sh2dh0ph0_iw112ow56kw3sw2dw0pw0  _(from MFDNN-11396)_ | 1.33 | 1.55 | 73 |


