### PR TITLE
Build acl cache sequentially

### DIFF
--- a/.github/automation/build_acl.sh
+++ b/.github/automation/build_acl.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # *******************************************************************************
-# Copyright 2020-2024 Arm Limited and affiliates.
+# Copyright 2020-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # Defines MP, CC, CXX and OS.
 source ${SCRIPT_DIR}/common_aarch64.sh
 
-CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
+ACL_BUILD_TYPE=${ACL_BUILD_TYPE:-"Release"}
 ACL_ROOT_DIR=${ACL_ROOT_DIR:-"${PWD}/ComputeLibrary"}
 ACL_REPO="https://github.com/ARM-software/ComputeLibrary.git"
 
@@ -36,24 +36,44 @@ elif [[ "$ACL_THREADING" == "SEQ" ]]; then
     ACL_OPENMP=0
 fi
 
+if [[ "$OS" == "Linux" ]]; then
+    ACL_MULTI_ISA_SUPPORT=1
+    if [[ "$ACL_THREADING" == "OMP" ]]; then
+        ACL_OPENMP=1
+    elif [[ "$ACL_THREADING" == "SEQ" ]]; then
+        ACL_OPENMP=0
+    fi
+    ACL_OS="linux"
+elif [[ "$OS" == "Darwin" ]]; then
+    ACL_MULTI_ISA_SUPPORT=0
+    ACL_OPENMP=0
+    ACL_OS="macos"
+else
+    echo "Unknown OS: $OS"
+    exit 1
+fi
+
+if [[ "$ACL_BUILD_TYPE" == "Release" ]]; then
+    ACL_DEBUG=0
+elif [[ "$ACL_BUILD_TYPE" == "Debug" ]]; then
+    ACL_DEBUG=1
+else
+    echo "Unknown build config: $ACL_BUILD_TYPE"
+    exit 1
+fi
+
 if [[ "$ACL_ACTION" == "clone" ]]; then
     set -x
     git clone --branch $ACL_VERSION --depth 1 $ACL_REPO $ACL_ROOT_DIR
     set +x
-elif [[ "$ACL_ACTION" == "configure" ]]; then
-    set -x
-    cmake \
-    -S$ACL_ROOT_DIR -B$ACL_ROOT_DIR/build \
-	-DARM_COMPUTE_OPENMP=$ACL_OPENMP \
-	-DARM_COMPUTE_CPPTHREADS=0 \
-	-DARM_COMPUTE_WERROR=0 \
-	-DARM_COMPUTE_BUILD_EXAMPLES=1 \
-	-DARM_COMPUTE_BUILD_TESTING=1 \
-    -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
-    set +x
 elif [[ "$ACL_ACTION" == "build" ]]; then
     set -x
-    cmake --build $ACL_ROOT_DIR/build 
+    cd $ACL_ROOT_DIR
+    set -x
+    scons $MP Werror=0 debug=$ACL_DEBUG neon=1 opencl=0 embed_kernels=0 \
+        os=$ACL_OS arch=armv8.2-a build=native multi_isa=$ACL_MULTI_ISA_SUPPORT \
+        fixed_format_kernels=1 cppthreads=0 openmp=$ACL_OPENMP examples=0 \
+        validation_tests=0
     set +x
 else
     echo "Unknown action: $ACL_ACTION"

--- a/.github/automation/ci-aarch64.json
+++ b/.github/automation/ci-aarch64.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "acl": "v24.11.1",
+        "gcc": "13",
+        "clang": "17"
+    }
+}

--- a/.github/workflows/aarch64-acl.yml
+++ b/.github/workflows/aarch64-acl.yml
@@ -1,0 +1,123 @@
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+name: "Build ACL cache"
+
+#* To avoid duplicate jobs running when both push and PR is satisfied, we use this:
+#* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
+on:
+  workflow_call:
+  workflow_dispatch:
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  # Cache is built sequentially to avoid cache-hit race conditions
+  build-cache:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config: [
+          { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release },
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug },
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: gcc, build: Release }
+        ]
+
+    name: ${{ matrix.config.name }}, ${{ matrix.config.toolset }}, ${{ matrix.config.threading }}, ${{ matrix.config.build }}
+    runs-on: ${{ matrix.config.label }}
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: oneDNN
+
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/ci-aarch64.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
+
+      - name: Clone ACL
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        env:
+          ACL_ACTION: clone
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          ACL_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.acl }}
+
+      - name: Get ACL commit hash for cache key
+        id: get_acl_commit_hash
+        run: (cd ${{ github.workspace }}/ComputeLibrary && echo "ACLCommitHash=$(git rev-parse --short HEAD)") >> $GITHUB_OUTPUT
+
+      - name: Get system name
+        id: get_system_name
+        run: (echo "SystemName=$(uname)") >> $GITHUB_OUTPUT
+
+      - name: Restore cached ACL
+        id: cache-acl-restore
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
+          path: ${{ github.workspace }}/ComputeLibrary/build
+
+      - name: Install Scons (MacOS)
+        if: ${{ matrix.config.name == 'MacOS' && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        run: brew install scons
+
+      - name: Install scons (Linux)
+        if: ${{ matrix.config.name != 'MacOS' && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        run: |
+          sudo apt update -y
+          sudo apt install -y scons
+
+      - if: ${{ startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.threading == 'OMP') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        name: Install openmp
+        run: |
+          sudo apt install -y libomp-dev
+
+      - if: ${{ startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'gcc') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        name: Install gcc
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt update -y
+          sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
+
+      - if: ${{ startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'clang') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        name: Install clang
+        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
+        with:
+          version: ${{ fromJson(steps.get-versions.outputs.output).dependencies.clang }}
+
+      - name: Build ACL
+        if: ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
+        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        env:
+          ACL_ACTION: build
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          ACL_THREADING: ${{ matrix.config.threading }}
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          ACL_BUILD_TYPE: ${{ matrix.config.build }}
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
+
+      - name: Save ACL in cache
+        id: cache-acl_build-save
+        if: ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
+          path: ${{ github.workspace }}/ComputeLibrary/build

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2024-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,29 +21,29 @@ name: "CI AArch64"
 #* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
 on:
   push:
-    branches: [ main, 'rls-*' ]
+    branches: [main, "rls-*"]
     paths:
-      - '.github/**'
-      - 'cmake/**'
-      - 'examples/**'
-      - 'include/**'
-      - 'src/common/**'
-      - 'src/cpu/*'
-      - 'src/cpu/aarch64/**'
-      - 'tests/**'
-      - 'CMakeLists.txt'
+      - ".github/**"
+      - "cmake/**"
+      - "examples/**"
+      - "include/**"
+      - "src/common/**"
+      - "src/cpu/*"
+      - "src/cpu/aarch64/**"
+      - "tests/**"
+      - "CMakeLists.txt"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - '.github/**'
-      - 'cmake/**'
-      - 'examples/**'
-      - 'include/**'
-      - 'src/common/**'
-      - 'src/cpu/*'
-      - 'src/cpu/aarch64/**'
-      - 'tests/**'
-      - 'CMakeLists.txt'
+      - ".github/**"
+      - "cmake/**"
+      - "examples/**"
+      - "include/**"
+      - "src/common/**"
+      - "src/cpu/*"
+      - "src/cpu/aarch64/**"
+      - "tests/**"
+      - "CMakeLists.txt"
 
 #* Stop stale workflows when pull requests are updated: https://stackoverflow.com/a/70972844
 #* Does not apply to the main branch.
@@ -55,7 +55,11 @@ concurrency:
 permissions: read-all
 
 jobs:
+  build-acl-cache:
+    uses: ./.github/workflows/aarch64-acl.yml
+
   build-and-test:
+    needs: build-acl-cache
     strategy:
       matrix:
         config: [
@@ -68,11 +72,17 @@ jobs:
     name: ${{ matrix.config.name }}, ${{ matrix.config.toolset }}, ${{ matrix.config.threading }}, ${{ matrix.config.build }}
     runs-on: ${{ matrix.config.label }}
     steps:
-
       - name: Checkout oneDNN
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: oneDNN
+
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/ci-aarch64.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
 
       - name: Get latest CMake and Ninja
         uses: lukka/get-cmake@acb35cf920333f4dc3fc4f424f1b30d5e7d561b4 # v3.31.4
@@ -90,20 +100,20 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt update -y
-          sudo apt install -y g++-13
+          sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
 
       - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'clang')) }}
         name: Install clang
         uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
         with:
-          version: "17"
+          version: ${{ fromJson(steps.get-versions.outputs.output).dependencies.clang }}
 
       - name: Clone ACL
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
         env:
           ACL_ACTION: clone
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_VERSION: v24.11.1
+          ACL_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.acl }}
 
       - name: Get ACL commit hash for cache key
         id: get_acl_commit_hash
@@ -120,32 +130,6 @@ jobs:
           key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
           path: ${{ github.workspace }}/ComputeLibrary/build
 
-      - name: Configure ACL
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: configure
-          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_THREADING: ${{ matrix.config.threading }}
-          BUILD_TOOLSET: ${{ matrix.config.toolset }}
-          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
-          CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
-
-      - name: Build ACL
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: build
-
-      - name: Save ACL in cache
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        id: cache-acl_build-save
-        uses: actions/cache/save@v4
-        with:
-          key: ${{ steps.cache-acl-restore.outputs.cache-primary-key }}
-          path: ${{ github.workspace }}/ComputeLibrary/build
-
       - name: Configure oneDNN
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
         working-directory: ${{ github.workspace }}/oneDNN
@@ -154,7 +138,7 @@ jobs:
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
           ONEDNN_ACTION: configure
           ONEDNN_TEST_SET: ${{ matrix.config.testset }}
           ONEDNN_THREADING: ${{ matrix.config.threading }}

--- a/.github/workflows/nightly-aarch64.yml
+++ b/.github/workflows/nightly-aarch64.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2024-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,18 +63,25 @@ jobs:
         run: |
           sudo apt install -y libomp-dev
 
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/ci-aarch64.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
+
       - name: Install gcc
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt update -y
-          sudo apt install -y g++-13
+          sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
 
       - name: Clone ACL
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
         env:
           ACL_ACTION: clone
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_VERSION: v24.11.1
+          ACL_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.acl }}
 
       - name: Configure ACL
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
@@ -85,7 +92,7 @@ jobs:
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
 
       - name: Build ACL
         run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
@@ -100,7 +107,7 @@ jobs:
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
           ONEDNN_ACTION: configure
           ONEDNN_TEST_SET: ${{ matrix.config.testset }}
           ONEDNN_THREADING: ${{ matrix.config.threading }}


### PR DESCRIPTION
When using github actions caches with the matrix strategy, the `cache-hit` variable is shared amongst all the strategies, potentially causing a race condition when run in parallel. This work creates just the caches sequentially, avoiding this problem