### PR TITLE
xe: softmax: enable half-precision softmax reusable 

### DIFF
--- a/src/gpu/intel/ocl/reusable_softmax.cl
+++ b/src/gpu/intel/ocl/reusable_softmax.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include "gpu/intel/ocl/ocl_types.h"
 #include "gpu/intel/ocl/types_interop.h"
 
+#ifndef USE_VECTORIZED_KERNEL
 #if ONE_REDUCTION_PER_SUBGROUP == 1
 __attribute__((reqd_work_group_size(16, 1, 1)))
 __attribute__((intel_reqd_sub_group_size(16)))
@@ -70,3 +71,113 @@ reusable_softmax_fwd_generic(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
         dst[c - begin] = TO_DST(unscaled * scale);
     }
 }
+#endif
+
+#ifdef USE_VECTORIZED_KERNEL
+
+#define VECT_SIZE 8
+#define DIVUP(a, b) (((a) + (b)-1) / (b))
+
+#define STORE_FLOAT8(prefix, ptr, val) \
+    WRITE_BLOCK8(prefix, (__global BLOCK_T(ALIAS(prefix)) *)(ptr), \
+            DATA_TO_BLOCK8(prefix, FLOAT_TO_DATA8(prefix, val)))
+
+#define STORE_DOUBLE8(prefix, ptr, val) \
+    WRITE_BLOCK8(prefix, (__global BLOCK_T(ALIAS(prefix)) *)(ptr), \
+            DATA_TO_BLOCK8(prefix, DOUBLE_TO_DATA8(prefix, val)))
+
+#if DST_DT_F64
+#define UP_CASE_DATA DOUBLE
+#define COMMON_DATA_T double
+#define COMMON_DATA_MAX DBL_MAX
+#define COMMON_DATA_ZERO 0.0
+#else
+#define UP_CASE_DATA FLOAT
+#define COMMON_DATA_T float
+#define COMMON_DATA_MAX FLT_MAX
+#define COMMON_DATA_ZERO 0.0f
+#endif
+
+#define COMMON_DATA_TO_X(x, y) CONCAT2(DATA_TO_, UP_CASE_DATA)(x, y)
+#define COMMON_STORE_DATA8(x, y, z) CONCAT3(STORE_, UP_CASE_DATA, 8)(x, y, z)
+
+__attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) __kernel void
+reusable_softmax_fwd_generic(__global DATA_T *src, __global DST_DATA_T *dst,
+        __global float *src_scale, __global float *dst_scale,
+        dim_t SOFTMAX_AXIS_SIZE, dim_t softmax_axis_stride,
+        dim_t softmax_axis_chunk_size, dispatch_gws_rt_params_t gws_params) {
+    float scale = 1.0f;
+    const int data_off = (get_global_id(0) / 16) * SOFTMAX_AXIS_SIZE;
+    VECT_FLOAT_T dk;
+    float max_ = -FLT_MAX;
+    float denom_ = 0.0f;
+    const bool has_tail = SOFTMAX_AXIS_SIZE % (16 * 8);
+    int last_buf = DIVUP(SOFTMAX_AXIS_SIZE, (16 * 8));
+    if (has_tail) last_buf--;
+    src += data_off;
+    for (int k = 0; k < last_buf; ++k) {
+        int idx = k * 16;
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx * 8])));
+        for (int i = 0; i < 8; ++i) {
+            max_ = max(dk[i], max_);
+        }
+    }
+    if (has_tail) {
+        int k = last_buf;
+        for (int i = 0; i < 8; ++i) {
+            int off = k * 8 * 16 + i * 16 + get_sub_group_local_id();
+            float d = (off < SOFTMAX_AXIS_SIZE ? COMMON_DATA_TO_X(SRC, src[off])
+                                               : -COMMON_DATA_MAX);
+            max_ = max(d, max_);
+        }
+    }
+    max_ = sub_group_reduce_max(max_);
+
+    for (int k = 0; k < last_buf; ++k) {
+        int idx = k * 16;
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx * 8])));
+        dk = exp(dk - max_);
+        for (int i = 0; i < 8; ++i)
+            denom_ += dk[i];
+    }
+    if (has_tail) {
+        int k = last_buf;
+        int idx = k * 16;
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx * 8])));
+        dk = exp(dk - max_);
+        for (int i = 0; i < 8; ++i) {
+            int off = k * 8 * 16 + i * 16 + get_sub_group_local_id();
+            if (off < SOFTMAX_AXIS_SIZE) denom_ += dk[i];
+        }
+    }
+    denom_ = sub_group_reduce_add(denom_);
+    denom_ = LOGSOFTMAX ? log(denom_) : 1.0f / denom_;
+
+    dst += data_off;
+
+    for (int k = 0; k < last_buf; ++k) {
+        int idx = k * 16;
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx * 8])));
+        dk = LOGSOFTMAX ? dk - max_ - denom_ : exp(dk - max_) * denom_;
+
+        COMMON_STORE_DATA8(DST, &dst[idx * VECT_SIZE], scale * dk);
+    }
+    if (has_tail) {
+        int k = last_buf;
+        int idx = k * 16;
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx * 8])));
+        dk = LOGSOFTMAX ? dk - max_ - denom_ : exp(dk - max_) * denom_;
+
+        for (int i = 0; i < 8; i++) {
+            int off = k * 8 * 16 + i * 16 + get_sub_group_local_id();
+            if (off < SOFTMAX_AXIS_SIZE)
+                dst[off] = convert_float(scale * dk[i]);
+        }
+    }
+}
+#endif

--- a/src/gpu/intel/ocl/reusable_softmax.hpp
+++ b/src/gpu/intel/ocl/reusable_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ namespace ocl {
 enum softmax_algorithm_id_t {
     many_reductions_per_workgroup = 1,
     one_reduction_per_workgroup,
-    one_reduction_per_subgroup
+    one_reduction_per_subgroup,
+    vectorized
 };
 
 struct reusable_softmax_params_t {
@@ -72,6 +73,7 @@ struct reusable_softmax_params_t {
     data_type_t dst_data_type;
     int algorithm_number;
     bool is_logsoftmax;
+    int subgroup_size;
 
     uint8_t padding[3] = {0};
 
@@ -106,9 +108,11 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
             VDISPATCH_SOFTMAX(is_fwd(), VERBOSE_BAD_PROPKIND);
 
             // reusable implementation still too slow for half-precision
-            VDISPATCH_SOFTMAX(utils::one_of(src_dt, f64, f32, u8, s8),
+            VDISPATCH_SOFTMAX(
+                    utils::one_of(src_dt, f64, f32, f16, bf16, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_SOFTMAX(utils::one_of(dst_dt, f64, f32, u8, s8),
+            VDISPATCH_SOFTMAX(
+                    utils::one_of(dst_dt, f64, f32, f16, bf16, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
 
             VDISPATCH_SOFTMAX(IMPLICATION(utils::one_of(f16, src_dt, dst_dt),
@@ -159,6 +163,7 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
             conf.is_logsoftmax = is_logsoftmax();
             conf.src_data_type = src_dt;
             conf.dst_data_type = dst_dt;
+            conf.subgroup_size = mayiuse_sg(32, compute_engine) ? 32 : 16;
 
             // run-time configuration setup
             rt_conf.softmax_axis_size = src_mdw.dims()[desc()->softmax_axis];
@@ -169,51 +174,64 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
                 }
             }
 
-            // empirically derived: select algorithm and parameters
             const auto nelems = src_mdw.nelems();
-            if (rt_conf.softmax_axis_size < 6 && nelems > 64000) {
-                conf.algorithm_number = many_reductions_per_workgroup;
-                CHECK(init_dispatch_default_reusable(compute_engine));
-            } else if (rt_conf.softmax_axis_size > 128) {
-                conf.algorithm_number = one_reduction_per_workgroup;
+            const bool use_vectorized = rt_conf.softmax_axis_size > 128
+                    && nelems > (1 << 19)
+                    && dnnl::impl::utils::div_up(rt_conf.softmax_axis_size, 16)
+                            <= 1024;
 
-                // select workgroup size/num works per reduction
-                int elements_per_worker;
-                if (nelems <= 64000)
-                    elements_per_worker = 1;
-                else if (rt_conf.softmax_axis_size <= 1024)
-                    elements_per_worker = 4;
-                else
-                    elements_per_worker = 15;
-                const size_t num_workers_per_workgroup
-                        = dnnl::impl::utils::div_up(
-                                rt_conf.softmax_axis_size, elements_per_worker);
+            if (use_vectorized) {
+                conf.algorithm_number = vectorized;
+                CHECK(init_dispatch_vectorized(compute_engine));
+            } else {
+                if (rt_conf.softmax_axis_size < 6 && nelems > 64000) {
+                    conf.algorithm_number = many_reductions_per_workgroup;
+                    CHECK(init_dispatch_default_reusable(compute_engine));
+                } else if (rt_conf.softmax_axis_size > 128) {
+                    conf.algorithm_number = one_reduction_per_workgroup;
 
-                // do not solve problems beyond hardware workgroup limit
-                auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
-                        attr()->gpu_attr_.get());
-                const bool large_grf_mode
-                        = gpu_attr && gpu_attr->threads_per_eu() == 4;
-                const size_t max_wg_size
-                        = compute_engine->device_info()->max_wg_size(
-                                large_grf_mode);
-                VDISPATCH_SOFTMAX(num_workers_per_workgroup <= max_wg_size,
-                        "softmax axis size too large");
+                    // select workgroup size/num works per reduction
+                    int elements_per_worker;
+                    if (nelems <= 64000)
+                        elements_per_worker = 1;
+                    else if (rt_conf.softmax_axis_size <= 1024)
+                        elements_per_worker = 4;
+                    else
+                        elements_per_worker = 15;
+                    const size_t num_workers_per_workgroup
+                            = dnnl::impl::utils::div_up(
+                                    rt_conf.softmax_axis_size,
+                                    elements_per_worker);
 
-                CHECK(init_dispatch_workgroup_per_reduction(
-                        compute_engine, num_workers_per_workgroup));
-            } else { // rt_conf.softmax_axis_size <= 128
-                conf.algorithm_number = one_reduction_per_subgroup;
-                CHECK(init_dispatch_workgroup_per_reduction(
-                        compute_engine, 16));
+                    // do not solve problems beyond hardware workgroup limit
+                    auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
+                            attr()->gpu_attr_.get());
+                    const bool large_grf_mode
+                            = gpu_attr && gpu_attr->threads_per_eu() == 4;
+                    const size_t max_wg_size
+                            = compute_engine->device_info()->max_wg_size(
+                                    large_grf_mode);
+                    VDISPATCH_SOFTMAX(num_workers_per_workgroup <= max_wg_size,
+                            "softmax axis size too large");
+
+                    CHECK(init_dispatch_workgroup_per_reduction(
+                            compute_engine, num_workers_per_workgroup));
+                } else { // rt_conf.softmax_axis_size <= 128
+                    conf.algorithm_number = one_reduction_per_subgroup;
+                    CHECK(init_dispatch_workgroup_per_reduction(
+                            compute_engine, 16));
+                }
             }
 
             return status::success;
         }
 
+        bool mayiuse_sg(const int sg_size, compute::compute_engine_t *engine);
+
         status_t init_dispatch_default_reusable(engine_t *engine);
         status_t init_dispatch_workgroup_per_reduction(
                 engine_t *engine, const size_t num_workers_per_workgroup);
+        status_t init_dispatch_vectorized(engine_t *engine);
 
         reusable_softmax_params_t conf;
         reusable_softmax_runtime_params_t rt_conf;

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -603,11 +603,12 @@ std::vector<std::pair<int, int>> attr_t::post_ops_t::get_po_masks(
     return v_masks;
 }
 
-bool attr_t::is_def(bool skip_fpmath) const {
+bool attr_t::is_def(bool skip_fpmath, bool skip_acc_mode) const {
     return scales.is_def() && zero_points.is_def() && post_ops.is_def()
             && scratchpad_mode == get_default_scratchpad_mode()
             && IMPLICATION(!skip_fpmath, fpmath_mode.is_def())
-            && acc_mode == dnnl_accumulation_mode_strict
+            && IMPLICATION(
+                    !skip_acc_mode, acc_mode == dnnl_accumulation_mode_strict)
             && rounding_mode.is_def() && deterministic.is_def()
             && dropout.is_def();
 }

--- a/tests/benchdnn/dnn_types.hpp
+++ b/tests/benchdnn/dnn_types.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -441,7 +441,7 @@ struct attr_t {
     dropout_t dropout;
     rounding_mode_t rounding_mode;
 
-    bool is_def(bool skip_fpmath = false) const;
+    bool is_def(bool skip_fpmath = false, bool skip_acc_mode = false) const;
 };
 
 struct isa_hints_t {

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 * Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -258,9 +258,11 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
 #endif
     cmp.set_threshold(trh);
 
-    // LogSoftMax is unstable enough when there are attributes on top.
-    const bool compare_with_norm
-            = (prb->alg == alg_t::LOGSOFTMAX && !prb->attr.is_def());
+    // LogSoftMax is unstable enough when there are compute attributes (such as
+    // post-ops or scales) on top of it.
+    const bool compare_with_norm = (prb->alg == alg_t::LOGSOFTMAX
+            && !prb->attr.is_def(
+                    /* skip_fpmath = */ true, /* skip_acc_mode = */ true));
     cmp.set_norm_validation_mode(compare_with_norm);
 
     const int64_t axis_size = prb->dims[prb->axis];


### PR DESCRIPTION
This adds support for half-precision within the reusable softmax implementation. Previously, reusable softmax skipped half-precision problems due to much longer runtimes than other implementations. This PR enables half-precision and accelerates the half-precision performance by incorporating vector loads/stores on applicable input shapes.