### PR TITLE
x64: brgemm matmul: update condition for extendable_k

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2037,8 +2037,10 @@ void matmul_amx_blocking_params_t::set_blocking_parameters(
 
         const dim_t current_k_tail = K % k_blk_;
 
-        extendable_k_ = !use_buffer_a && K % wei_k_blk
-                && k_chunk_elems_ > wei_k_blk && !packed_sparse_weights;
+        // TODO: review extendable_k_ condition to cover more cases
+        extendable_k_ = (K % wei_k_blk != 0) && (k_chunk_elems_ > wei_k_blk)
+                && wei_zp_type == none && !use_buffer_a
+                && !packed_sparse_weights;
 
         if (extendable_k_) {
             if (k_chunk_elems_ >= K) {


### PR DESCRIPTION
This is a quick fix to prevent failures for some brgemm matmul on GNR