### PR TITLE
common: align verbose level interface

### DIFF
--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -181,9 +181,8 @@ uint32_t get_verbose(verbose_t::flag_kind verbosity_kind,
             // Legacy: we accept values 0,1,2
             // 0 and none erase previously set flags, including error
             if (s == "0" || s == "none") k = verbose_t::none;
-            if (s == "1") k |= verbose_t::exec_profile;
-            if (s == "2")
-                k |= verbose_t::exec_profile | verbose_t::create_profile;
+            if (s == "1") k |= verbose_t::level1;
+            if (s == "2") k |= verbose_t::level2;
             if (s == "all" || s == "-1") k |= verbose_t::all;
             if (s == "error") k |= verbose_t::error;
             if (s == "check")
@@ -1824,12 +1823,8 @@ dnnl_status_t dnnl_set_verbose(int level) {
     if (level < 0 || level > 2) return invalid_arguments;
 
     uint32_t verbose_level = verbose_t::none;
-    if (level == 1)
-        verbose_level
-                = verbose_t::error | verbose_t::exec_profile | verbose_t::warn;
-    if (level == 2)
-        verbose_level = verbose_t::error | verbose_t::exec_profile
-                | verbose_t::create_profile | verbose_t::warn;
+    if (level == 1) verbose_level = verbose_t::level1;
+    if (level == 2) verbose_level = verbose_t::level2;
     // we put the lower byte of level as devinfo to preserve backward
     // compatibility with historical VERBOSE={1,2}
     if (level == 1 || level == 2) verbose_level |= (level << 24);

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 * Copyright 2023 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -175,6 +175,9 @@ struct verbose_t {
         // the upper 8 bits are reserved for devinfo levels
         debuginfo = 1 << 24,
         //
+        level1 = error | exec_profile | warn,
+        level2 = error | exec_profile | warn | create_profile,
+
         all = (uint32_t)-1,
     };
 
@@ -254,6 +257,8 @@ get_verbose_to_log_level_map() {
             verbose_to_log_map {
                     {verbose_t::all, log_manager_t::trace},
                     {verbose_t::debuginfo, log_manager_t::debug},
+                    {verbose_t::level1, log_manager_t::info},
+                    {verbose_t::level2, log_manager_t::info},
                     {verbose_t::create_dispatch, log_manager_t::info},
                     {verbose_t::create_check, log_manager_t::info},
                     {verbose_t::create_profile, log_manager_t::info},


### PR DESCRIPTION
Align dnnl_set_verbose(int level) and DNNL_VERBOSE=level handling of verbose_t::warn.