### PR TITLE
[MHA][CPU] common: fix for mha cpu regression

### DIFF
--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -177,7 +177,7 @@ public:
         dnnl_graph_allocator_t a = nullptr;
         error::wrap_c_api(
                 dnnl_graph_allocator_create(&a, host_malloc, host_free),
-                dnnl::err_message_list::init_error("allocator for cpu"));
+                "could not create allocator for cpu");
         reset(a);
     }
 
@@ -185,7 +185,7 @@ public:
     allocator() {
         dnnl_graph_allocator_t a = nullptr;
         error::wrap_c_api(dnnl_graph_allocator_create(&a, nullptr, nullptr),
-                dnnl::err_message_list::init_error("allocator"));
+                "could not create allocator");
         reset(a);
     }
 };
@@ -202,7 +202,7 @@ inline engine make_engine_with_allocator(
     error::wrap_c_api(
             dnnl_graph_make_engine_with_allocator(&c_engine,
                     static_cast<dnnl_engine_kind_t>(kind), index, alloc.get()),
-            dnnl::err_message_list::init_error("engine with allocator"));
+            "could not make an engine with allocator");
     return engine(c_engine);
 }
 
@@ -336,8 +336,7 @@ public:
         error::wrap_c_api(
                 dnnl_graph_logical_tensor_init(&val, tid, convert_to_c(dtype),
                         ndims, convert_to_c(ltype), convert_to_c(ptype)),
-                dnnl::err_message_list::init_error(
-                        "logical_tensor with property"));
+                "could not create logical_tensor with property");
         data = val;
     }
 
@@ -369,16 +368,14 @@ public:
             error::wrap_c_api(dnnl_graph_logical_tensor_init(&val, tid,
                                       convert_to_c(dtype), 0,
                                       convert_to_c(ltype), convert_to_c(ptype)),
-                    dnnl::err_message_list::init_error(
-                            "logical_tensor with property"));
+                    "could not create logical_tensor with property");
         else
             error::wrap_c_api(
                     dnnl_graph_logical_tensor_init_with_dims(&val, tid,
                             convert_to_c(dtype),
                             static_cast<int32_t>(adims.size()), adims.data(),
                             convert_to_c(ltype), convert_to_c(ptype)),
-                    dnnl::err_message_list::init_error(
-                            "logical_tensor with dims and property"));
+                    "could not create logical_tensor with dims and property");
         data = val;
     }
 
@@ -403,8 +400,7 @@ public:
                 dnnl_graph_logical_tensor_init_with_strides(&val, tid,
                         convert_to_c(dtype), static_cast<int32_t>(adims.size()),
                         adims.data(), strides.data(), convert_to_c(ptype)),
-                dnnl::err_message_list::init_error(
-                        "logical_tensor with strides and property"));
+                "could not create logical_tensor with strides and property");
         data = val;
     }
 
@@ -428,7 +424,7 @@ public:
                                       convert_to_c(dtype), 0,
                                       convert_to_c(layout_type::opaque),
                                       convert_to_c(ptype)),
-                    dnnl::err_message_list::init_error("logical_tensor"));
+                    "could not create logical_tensor");
         } else {
             error::wrap_c_api(
                     dnnl_graph_logical_tensor_init_with_dims(&val, tid,
@@ -436,8 +432,7 @@ public:
                             static_cast<int32_t>(adims.size()), adims.data(),
                             convert_to_c(layout_type::opaque),
                             convert_to_c(ptype)),
-                    dnnl::err_message_list::init_error(
-                            "logical_tensor with dims"));
+                    "could not create logical_tensor with dims");
         }
 
         val.layout.layout_id = lid;
@@ -521,8 +516,7 @@ public:
     size_t get_mem_size() const {
         size_t size = 0;
         error::wrap_c_api(dnnl_graph_logical_tensor_get_mem_size(&data, &size),
-                dnnl::err_message_list::desc_query(
-                        "memory size", "logical_tensor"));
+                "could not get memory size from the logical_tensor");
         return size;
     }
 
@@ -596,9 +590,8 @@ public:
         dnnl_graph_tensor_t t = nullptr;
         error::wrap_c_api(
                 dnnl_graph_tensor_create(&t, &(lt.data), aengine.get(), handle),
-                dnnl::err_message_list::init_error(
-                        "tensor object with the logical_tensor, "
-                        "engine, and handle"));
+                "could not create tensor object with the logical_tensor, "
+                "engine, and handle");
         reset(t);
     }
 
@@ -617,7 +610,7 @@ public:
     void *get_data_handle() const {
         void *handle = nullptr;
         error::wrap_c_api(dnnl_graph_tensor_get_data_handle(get(), &handle),
-                dnnl::err_message_list::desc_query("data handle", "tensor"));
+                "could not get data handle from the tensor");
         return handle;
     }
 
@@ -626,8 +619,7 @@ public:
     /// @param handle Memory handle.
     void set_data_handle(void *handle) {
         error::wrap_c_api(dnnl_graph_tensor_set_data_handle(get(), handle),
-                dnnl::err_message_list::set_failure(
-                        "data handle to the tensor"));
+                "setting data handle to the tensor failed");
     }
 
     /// Returns the associated engine.
@@ -636,7 +628,7 @@ public:
     engine get_engine() const {
         dnnl_engine_t c_engine = nullptr;
         error::wrap_c_api(dnnl_graph_tensor_get_engine(get(), &c_engine),
-                dnnl::err_message_list::desc_query("engine", "tensor object"));
+                "could not get an engine from a tensor object");
         return engine(c_engine, true);
     }
 
@@ -646,8 +638,7 @@ public:
     logical_tensor get_logical_tensor() const {
         dnnl_graph_logical_tensor_t lt;
         error::wrap_c_api(dnnl_graph_tensor_get_logical_tensor(get(), &lt),
-                dnnl::err_message_list::desc_query(
-                        "logical tensor", "tensor object"));
+                "could not get logical tensor from a tensor object");
         return logical_tensor(lt);
     }
 };
@@ -704,8 +695,7 @@ public:
 
         error::wrap_c_api(dnnl_graph_compiled_partition_get_inplace_ports(
                                   get(), &num, &inplace_pairs),
-                dnnl::err_message_list::desc_query(
-                        "in-place pairs", "compiled partition"));
+                "could not get the in-place pairs from a compiled partition");
         if (num == 0) return {};
 
         std::vector<std::pair<size_t, size_t>> inplace_options;
@@ -740,7 +730,7 @@ public:
                 dnnl_graph_compiled_partition_execute(get(), astream.get(),
                         c_inputs.size(), c_inputs.data(), c_outputs.size(),
                         c_outputs.data()),
-                dnnl::err_message_list::execute_error("compiled_partition"));
+                "could not execute the compiled_partition");
     }
 };
 
@@ -998,7 +988,7 @@ public:
         dnnl_graph_op_t op = nullptr;
         error::wrap_c_api(dnnl_graph_op_create(&op, id, convert_to_c(akind),
                                   verbose_name.c_str()),
-                dnnl::err_message_list::init_error("op with id and op kind"));
+                "could not create op with id and op kind");
         reset(op);
     }
 
@@ -1071,7 +1061,7 @@ public:
     op &set_attr(attr name, const Type_i &value) {
         dnnl_graph_op_attr_t attr = convert_to_c(name);
         error::wrap_c_api(dnnl_graph_op_set_attr_s64(get(), attr, &value, 1),
-                dnnl::err_message_list::set_failure("attribute to the op"));
+                "could not set attribute to the op");
         return *this;
     }
 
@@ -1085,7 +1075,7 @@ public:
     op &set_attr(attr name, const Type_f &value) {
         dnnl_graph_op_attr_t attr = convert_to_c(name);
         error::wrap_c_api(dnnl_graph_op_set_attr_f32(get(), attr, &value, 1),
-                dnnl::err_message_list::set_failure("attribute to the op"));
+                "could not set attribute to the op");
         return *this;
     }
 
@@ -1100,7 +1090,7 @@ public:
         dnnl_graph_op_attr_t attr = convert_to_c(name);
         const uint8_t val = value;
         error::wrap_c_api(dnnl_graph_op_set_attr_bool(get(), attr, &val, 1),
-                dnnl::err_message_list::set_failure("attribute to the op"));
+                "could not set attribute to the op");
         return *this;
     }
 
@@ -1116,7 +1106,7 @@ public:
         dnnl_graph_op_attr_t attr = convert_to_c(name);
         error::wrap_c_api(dnnl_graph_op_set_attr_str(
                                   get(), attr, value.c_str(), value.size()),
-                dnnl::err_message_list::set_failure("attribute to the op"));
+                "could not set attribute to the op");
         return *this;
     }
 
@@ -1133,7 +1123,7 @@ public:
         dnnl_graph_op_attr_t attr = convert_to_c(name);
         error::wrap_c_api(dnnl_graph_op_set_attr_s64(
                                   get(), attr, value.data(), value.size()),
-                dnnl::err_message_list::set_failure("attribute to the op"));
+                "could not set attribute to the op");
         return *this;
     }
 
@@ -1149,7 +1139,7 @@ public:
         dnnl_graph_op_attr_t attr = convert_to_c(name);
         error::wrap_c_api(dnnl_graph_op_set_attr_f32(
                                   get(), attr, value.data(), value.size()),
-                dnnl::err_message_list::set_failure("attribute to the op"));
+                "could not set attribute to the op");
         return *this;
     }
 
@@ -1206,8 +1196,7 @@ public:
         dnnl_graph_partition_t p = nullptr;
         error::wrap_c_api(dnnl_graph_partition_create_with_op(&p, aop.get(),
                                   static_cast<dnnl_engine_kind_t>(ekind)),
-                dnnl::err_message_list::init_error(
-                        "partition with op and engine kind"));
+                "could not create a partition with the op and engine kind");
         reset(p);
     }
 
@@ -1217,8 +1206,7 @@ public:
     size_t get_ops_num() const {
         size_t num {0};
         error::wrap_c_api(dnnl_graph_partition_get_op_num(get(), &num),
-                dnnl::err_message_list::desc_query(
-                        "number of ops", "partition"));
+                "could not get number of ops from the partition");
         return num;
     }
 
@@ -1230,7 +1218,7 @@ public:
         std::vector<size_t> ops(num);
 
         error::wrap_c_api(dnnl_graph_partition_get_ops(get(), num, ops.data()),
-                dnnl::err_message_list::desc_query("op ids", "partition"));
+                "could not get op ids from the partition");
         return ops;
     }
 
@@ -1241,7 +1229,7 @@ public:
     size_t get_id() const {
         size_t id {};
         error::wrap_c_api(dnnl_graph_partition_get_id(get(), &id),
-                dnnl::err_message_list::get_failure("id of the partition"));
+                "could not get id of the partition");
         return id;
     }
 
@@ -1279,8 +1267,7 @@ public:
     bool is_supported() const {
         uint8_t supported {0};
         error::wrap_c_api(dnnl_graph_partition_is_supported(get(), &supported),
-                dnnl::err_message_list::get_failure(
-                        "supporting status of the partition"));
+                "could not get supporting status of the partition");
         return supported != 0;
     }
 
@@ -1290,15 +1277,13 @@ public:
     std::vector<logical_tensor> get_input_ports() const {
         size_t num = 0;
         error::wrap_c_api(dnnl_graph_partition_get_input_ports_num(get(), &num),
-                dnnl::err_message_list::get_failure(
-                        "number of inputs of the partition"));
+                "could not get number of inputs of the partition");
         if (num == 0) return {};
 
         std::vector<dnnl_graph_logical_tensor_t> c_inputs(num);
         error::wrap_c_api(dnnl_graph_partition_get_input_ports(
                                   get(), num, c_inputs.data()),
-                dnnl::err_message_list::get_failure(
-                        "input logical tensors of the partition"));
+                "could not get input logical tensors of the partition");
 
         std::vector<logical_tensor> inputs;
         inputs.reserve(num);
@@ -1314,15 +1299,13 @@ public:
         size_t num = 0;
         error::wrap_c_api(
                 dnnl_graph_partition_get_output_ports_num(get(), &num),
-                dnnl::err_message_list::get_failure(
-                        "number of outputs of the partition"));
+                "cannot get number of outputs of the partition");
         if (num == 0) return {};
 
         std::vector<dnnl_graph_logical_tensor_t> c_outputs(num);
         error::wrap_c_api(dnnl_graph_partition_get_output_ports(
                                   get(), num, c_outputs.data()),
-                dnnl::err_message_list::get_failure(
-                        "output logical tensors of the partition"));
+                "could not get output logical tensors of the partition");
 
         std::vector<logical_tensor> outputs;
         outputs.reserve(num);
@@ -1337,7 +1320,7 @@ public:
     engine::kind get_engine_kind() const {
         dnnl_engine_kind_t akind;
         error::wrap_c_api(dnnl_graph_partition_get_engine_kind(get(), &akind),
-                dnnl::err_message_list::desc_query("engine kind", "partition"));
+                "cannot get the engine kind from the partition");
 
         return static_cast<engine::kind>(akind);
     }
@@ -1361,7 +1344,7 @@ private:
         dnnl_graph_compiled_partition_t cpartitions = nullptr;
         error::wrap_c_api(
                 dnnl_graph_compiled_partition_create(&cpartitions, get()),
-                dnnl::err_message_list::init_error("compiled_partition"));
+                "could not create compiled_partition");
         error::wrap_c_api(dnnl_graph_partition_compile(get(), cpartitions,
                                   c_inputs.size(), c_inputs.data(),
                                   c_outputs.size(), c_outputs.data(), e.get()),
@@ -1394,7 +1377,7 @@ public:
         dnnl_graph_graph_t g = nullptr;
         error::wrap_c_api(
                 dnnl_graph_graph_create(&g, convert_to_c(engine_kind)),
-                dnnl::err_message_list::init_error("graph with engine kind"));
+                "could not create graph with engine kind");
         reset(g);
     }
 
@@ -1413,8 +1396,7 @@ public:
         error::wrap_c_api(
                 dnnl_graph_graph_create_with_fpmath_mode(
                         &g, convert_to_c(engine_kind), convert_to_c(mode)),
-                dnnl::err_message_list::init_error(
-                        "graph with engine kind and math mode"));
+                "could not create graph with engine kind and math mode");
         reset(g);
     }
 
@@ -1484,8 +1466,7 @@ public:
     bool is_finalized() const {
         uint8_t ret = 0;
         error::wrap_c_api(dnnl_graph_graph_is_finalized(get(), &ret),
-                dnnl::err_message_list::get_failure(
-                        "finalization status of the graph"));
+                "could not get the finalization status of the graph");
 
         return ret != 0;
     }
@@ -1511,8 +1492,7 @@ public:
 
         size_t num = 0;
         error::wrap_c_api(dnnl_graph_graph_get_partition_num(get(), &num),
-                dnnl::err_message_list::desc_query(
-                        "number of partitions", "graph"));
+                "could not get number of partitions from the graph");
 
         // return early if there is no partitions in the graph.
         if (num == 0) return {};
@@ -1523,7 +1503,7 @@ public:
         std::vector<dnnl_graph_partition_t> partitions(num);
         error::wrap_c_api(
                 dnnl_graph_graph_get_partitions(get(), num, partitions.data()),
-                dnnl::err_message_list::desc_query("partitions", "graph"));
+                "could not get partitions from the graph");
 
         for (auto p : partitions) {
             out_list.emplace_back(p);
@@ -1555,8 +1535,7 @@ private:
 inline int get_compiled_partition_cache_capacity() {
     int result = 0;
     error::wrap_c_api(dnnl_graph_get_compiled_partition_cache_capacity(&result),
-            dnnl::err_message_list::get_failure(
-                    "compiled partition cache capacity"));
+            "could not get compiled partition cache capacity");
     return result;
 }
 
@@ -1564,8 +1543,7 @@ inline int get_compiled_partition_cache_capacity() {
 inline void set_compiled_partition_cache_capacity(int capacity) {
     error::wrap_c_api(
             dnnl_graph_set_compiled_partition_cache_capacity(capacity),
-            dnnl::err_message_list::set_failure(
-                    "compiled partition cache capacity"));
+            "could not set compiled partition cache capacity");
 }
 
 /// @} dnnl_graph_api_compiled_partition_cache
@@ -1587,7 +1565,7 @@ inline void set_compiled_partition_cache_capacity(int capacity) {
 /// disable the cache. Negative values are invalid.
 inline void set_constant_tensor_cache(int flag) {
     error::wrap_c_api(dnnl_graph_set_constant_tensor_cache(flag),
-            dnnl::err_message_list::set_failure("constant tensor cache"));
+            "fail to set constant tensor cache");
 }
 
 /// Return the enabling status of constant tensor cache.
@@ -1597,7 +1575,7 @@ inline void set_constant_tensor_cache(int flag) {
 inline int get_constant_tensor_cache() {
     int result = 0;
     error::wrap_c_api(dnnl_graph_get_constant_tensor_cache(&result),
-            dnnl::err_message_list::get_failure("constant tensor cache"));
+            "fail to get constant tensor cache");
     return result;
 }
 
@@ -1615,8 +1593,7 @@ inline int get_constant_tensor_cache() {
 inline void set_constant_tensor_cache_capacity(engine::kind kind, size_t size) {
     error::wrap_c_api(dnnl_graph_set_constant_tensor_cache_capacity(
                               static_cast<dnnl_engine_kind_t>(kind), size),
-            dnnl::err_message_list::set_failure(
-                    "constant tensor cache capacity"));
+            "fail to set constant tensor cache capacity");
 }
 
 /// Return the current capacity of constant tensor cache.
@@ -1626,8 +1603,7 @@ inline size_t get_constant_tensor_cache_capacity(engine::kind kind) {
     size_t size = 0;
     error::wrap_c_api(dnnl_graph_get_constant_tensor_cache_capacity(
                               static_cast<dnnl_engine_kind_t>(kind), &size),
-            dnnl::err_message_list::get_failure(
-                    "constant tensor cache capacity"));
+            "fail to get constant tensor cache capacity");
     return size;
 }
 

--- a/include/oneapi/dnnl/dnnl_graph_ocl.hpp
+++ b/include/oneapi/dnnl/dnnl_graph_ocl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ inline allocator make_allocator(dnnl_graph_ocl_allocate_f ocl_malloc,
     dnnl_graph_allocator_t c_allocator = nullptr;
     error::wrap_c_api(dnnl_graph_ocl_interop_allocator_create(
                               &c_allocator, ocl_malloc, ocl_free),
-            err_message_list::init_error("allocator for opencl device"));
+            "could not create allocator for opencl device");
     return allocator(c_allocator);
 }
 
@@ -79,7 +79,7 @@ inline engine make_engine_with_allocator(
     dnnl_engine_t c_engine;
     error::wrap_c_api(dnnl_graph_ocl_interop_make_engine_with_allocator(
                               &c_engine, device, context, alloc.get()),
-            err_message_list::init_error("engine with allocator"));
+            "could not make an engine with allocator");
     return engine(c_engine);
 }
 
@@ -99,8 +99,7 @@ inline engine make_engine_with_allocator(cl_device_id device,
             dnnl_graph_ocl_interop_make_engine_from_cache_blob_with_allocator(
                     &c_engine, device, context, alloc.get(), cache_blob.size(),
                     cache_blob.data()),
-            err_message_list::init_error(
-                    "engine with allocator from cache blob"));
+            "could not make an engine with allocator from cache blob");
     return engine(c_engine);
 }
 
@@ -135,9 +134,8 @@ inline cl_event execute(compiled_partition &c_partition, stream &astream,
                     astream.get(), c_inputs.size(), c_inputs.data(),
                     c_outputs.size(), c_outputs.data(), c_deps,
                     (int)deps.size(), &ocl_event),
-            err_message_list::execute_error(
-                    "compiled_partition on a specified opencl "
-                    "stream"));
+            "could not execute the compiled_partition on a specified opencl "
+            "stream");
     return ocl_event;
 }
 

--- a/include/oneapi/dnnl/dnnl_graph_sycl.hpp
+++ b/include/oneapi/dnnl/dnnl_graph_sycl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ inline allocator make_allocator(dnnl_graph_sycl_allocate_f sycl_malloc,
     dnnl_graph_allocator_t c_allocator = nullptr;
     error::wrap_c_api(dnnl_graph_sycl_interop_allocator_create(
                               &c_allocator, sycl_malloc, sycl_free),
-            err_message_list::init_error("allocator for sycl device"));
+            "could not create allocator for sycl device");
     return allocator(c_allocator);
 }
 
@@ -77,7 +77,7 @@ inline engine make_engine_with_allocator(const sycl::device &adevice,
             dnnl_graph_sycl_interop_make_engine_with_allocator(&c_engine,
                     static_cast<const void *>(&adevice),
                     static_cast<const void *>(&acontext), alloc.get()),
-            err_message_list::init_error("engine with allocator"));
+            "could not make an engine with allocator");
     return engine(c_engine);
 }
 
@@ -109,9 +109,8 @@ inline sycl::event execute(compiled_partition &c_partition, stream &astream,
                               c_partition.get(), astream.get(), c_inputs.size(),
                               c_inputs.data(), c_outputs.size(),
                               c_outputs.data(), &deps, &sycl_event),
-            err_message_list::execute_error(
-                    "compiled_partition on a specified sycl "
-                    "stream"));
+            "could not execute the compiled_partition on a specified sycl "
+            "stream");
     return sycl_event;
 }
 

--- a/include/oneapi/dnnl/dnnl_ocl.hpp
+++ b/include/oneapi/dnnl/dnnl_ocl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,12 +87,12 @@ inline std::vector<uint8_t> get_engine_cache_blob_id(cl_device_id device) {
     size_t size = 0;
     error::wrap_c_api(
             dnnl_ocl_interop_engine_get_cache_blob_id(device, &size, nullptr),
-            err_message_list::get_failure("engine cache blob id size"));
+            "could not get an engine cache blob id size");
 
     std::vector<uint8_t> cache_blob_id(size);
     error::wrap_c_api(dnnl_ocl_interop_engine_get_cache_blob_id(
                               device, &size, cache_blob_id.data()),
-            err_message_list::get_failure("engine cache blob id"));
+            "could not get an engine cache blob id");
     return cache_blob_id;
 }
 
@@ -109,12 +109,12 @@ inline std::vector<uint8_t> get_engine_cache_blob(const engine &aengine) {
     size_t size = 0;
     error::wrap_c_api(dnnl_ocl_interop_engine_get_cache_blob(
                               aengine.get(), &size, nullptr),
-            err_message_list::get_failure("engine cache blob size"));
+            "could not get an engine cache blob size");
 
     std::vector<uint8_t> cache_blob(size);
     error::wrap_c_api(dnnl_ocl_interop_engine_get_cache_blob(
                               aengine.get(), &size, cache_blob.data()),
-            err_message_list::get_failure("engine cache blob"));
+            "could not get an engine cache blob");
     return cache_blob;
 }
 
@@ -131,7 +131,7 @@ inline engine make_engine(cl_device_id device, cl_context context,
     error::wrap_c_api(
             dnnl_ocl_interop_engine_create_from_cache_blob(&c_engine, device,
                     context, cache_blob.size(), cache_blob.data()),
-            err_message_list::init_error("engine from cache blob"));
+            "could not create an engine from cache blob");
     return engine(c_engine);
 }
 
@@ -145,7 +145,7 @@ inline engine make_engine(cl_device_id device, cl_context context) {
     dnnl_engine_t c_engine;
     error::wrap_c_api(
             dnnl_ocl_interop_engine_create(&c_engine, device, context),
-            err_message_list::init_error("engine"));
+            "could not create an engine");
     return engine(c_engine);
 }
 
@@ -157,7 +157,7 @@ inline cl_context get_context(const engine &aengine) {
     cl_context context = nullptr;
     error::wrap_c_api(
             dnnl_ocl_interop_engine_get_context(aengine.get(), &context),
-            err_message_list::desc_query("OpenCL context", "engine"));
+            "could not get an OpenCL context from an engine");
     return context;
 }
 
@@ -168,7 +168,7 @@ inline cl_context get_context(const engine &aengine) {
 inline cl_device_id get_device(const engine &aengine) {
     cl_device_id device = nullptr;
     error::wrap_c_api(dnnl_ocl_interop_get_device(aengine.get(), &device),
-            err_message_list::desc_query("OpenCL device", "engine"));
+            "could not get an OpenCL device from an engine");
     return device;
 }
 
@@ -181,7 +181,7 @@ inline stream make_stream(const engine &aengine, cl_command_queue queue) {
     dnnl_stream_t c_stream;
     error::wrap_c_api(
             dnnl_ocl_interop_stream_create(&c_stream, aengine.get(), queue),
-            err_message_list::init_error("stream"));
+            "could not create a stream");
     return stream(c_stream);
 }
 
@@ -193,7 +193,7 @@ inline cl_command_queue get_command_queue(const stream &astream) {
     cl_command_queue queue = nullptr;
     error::wrap_c_api(
             dnnl_ocl_interop_stream_get_command_queue(astream.get(), &queue),
-            err_message_list::desc_query("OpenCL command queue", "stream"));
+            "could not get an OpenCL command queue from a stream");
     return queue;
 }
 
@@ -205,8 +205,7 @@ inline cl_mem get_mem_object(const memory &amemory) {
     cl_mem mem_object;
     error::wrap_c_api(
             dnnl_ocl_interop_memory_get_mem_object(amemory.get(), &mem_object),
-            err_message_list::desc_query(
-                    "OpenCL buffer object", "memory object"));
+            "could not get OpenCL buffer object from a memory object");
     return mem_object;
 }
 
@@ -221,8 +220,7 @@ inline cl_mem get_mem_object(const memory &amemory) {
 inline void set_mem_object(memory &amemory, cl_mem mem_object) {
     error::wrap_c_api(
             dnnl_ocl_interop_memory_set_mem_object(amemory.get(), mem_object),
-            err_message_list::set_failure(
-                    "OpenCL buffer object from a memory object"));
+            "could not set OpenCL buffer object from a memory object");
 }
 
 /// Returns the memory allocation kind associated with a memory object.
@@ -234,7 +232,7 @@ inline memory_kind get_memory_kind(const memory &amemory) {
     dnnl_ocl_interop_memory_kind_t ckind;
     error::wrap_c_api(
             dnnl_ocl_interop_memory_get_memory_kind(amemory.get(), &ckind),
-            err_message_list::get_failure("memory kind"));
+            "could not get memory kind");
     return static_cast<memory_kind>(ckind);
 }
 
@@ -276,7 +274,7 @@ inline memory make_memory(const memory::desc &memory_desc,
             dnnl_ocl_interop_memory_create_v2(&c_memory, memory_desc.get(),
                     aengine.get(), convert_to_c(kind), (int)handles.size(),
                     handles.data()),
-            err_message_list::init_error("memory"));
+            "could not create a memory");
     return memory(c_memory);
 }
 
@@ -379,7 +377,7 @@ inline memory make_memory(const memory::desc &memory_desc,
     error::wrap_c_api(
             dnnl_ocl_interop_memory_create(&c_memory, memory_desc.get(),
                     aengine.get(), convert_to_c(kind), handle),
-            err_message_list::init_error("memory"));
+            "could not create a memory");
     return memory(c_memory);
 }
 
@@ -430,7 +428,7 @@ inline cl_event execute(const dnnl::primitive &aprimitive,
     error::wrap_c_api(dnnl_ocl_interop_primitive_execute(aprimitive.get(),
                               astream.get(), (int)c_args.size(), c_args.data(),
                               c_deps, (int)deps.size(), &return_event),
-            err_message_list::execute_error("primitive"));
+            "could not execute a primitive");
     return return_event;
 }
 

--- a/include/oneapi/dnnl/dnnl_threadpool.hpp
+++ b/include/oneapi/dnnl/dnnl_threadpool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ inline dnnl::stream make_stream(
     dnnl_stream_t c_stream;
     dnnl::error::wrap_c_api(dnnl_threadpool_interop_stream_create(
                                     &c_stream, aengine.get(), threadpool),
-            err_message_list::init_error("stream"));
+            "could not create stream");
     return dnnl::stream(c_stream);
 }
 
@@ -66,7 +66,7 @@ inline threadpool_iface *get_threadpool(const dnnl::stream &astream) {
     void *tp;
     dnnl::error::wrap_c_api(
             dnnl_threadpool_interop_stream_get_threadpool(astream.get(), &tp),
-            err_message_list::get_failure("stream threadpool"));
+            "could not get stream threadpool");
     return static_cast<threadpool_iface *>(tp);
 }
 

--- a/include/oneapi/dnnl/dnnl_ukernel.hpp
+++ b/include/oneapi/dnnl/dnnl_ukernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -94,8 +94,8 @@ struct attr_params : public handle<dnnl_ukernel_attr_params_t> {
     attr_params() {
         dnnl_ukernel_attr_params_t c_params = nullptr;
         dnnl_status_t status = dnnl_ukernel_attr_params_create(&c_params);
-        error::wrap_c_api(status,
-                err_message_list::init_error("attributes memory storage"));
+        error::wrap_c_api(
+                status, "could not create an attributes memory storage");
         reset(c_params);
     }
 
@@ -107,8 +107,8 @@ struct attr_params : public handle<dnnl_ukernel_attr_params_t> {
         dnnl_status_t status = dnnl_ukernel_attr_params_set_post_ops_args(
                 get(), post_ops_args);
         if (status != dnnl_success)
-            error::wrap_c_api(status,
-                    err_message_list::set_failure("post operations arguments"));
+            error::wrap_c_api(
+                    status, "could not set post operations arguments");
     }
 
     /// Sets tensor A scales arguments to a storage.
@@ -118,8 +118,7 @@ struct attr_params : public handle<dnnl_ukernel_attr_params_t> {
         dnnl_status_t status
                 = dnnl_ukernel_attr_params_set_A_scales(get(), a_scales);
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("A scales argument"));
+            error::wrap_c_api(status, "could not set A scales argument");
     }
 
     /// Sets tensor B scales arguments to a storage.
@@ -132,8 +131,7 @@ struct attr_params : public handle<dnnl_ukernel_attr_params_t> {
         dnnl_status_t status
                 = dnnl_ukernel_attr_params_set_B_scales(get(), b_scales);
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("B scales argument"));
+            error::wrap_c_api(status, "could not set B scales argument");
     }
 
     /// Sets tensor D scales arguments to a storage.
@@ -143,8 +141,7 @@ struct attr_params : public handle<dnnl_ukernel_attr_params_t> {
         dnnl_status_t status
                 = dnnl_ukernel_attr_params_set_D_scales(get(), d_scales);
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("D scales argument"));
+            error::wrap_c_api(status, "could not set D scales argument");
     }
 };
 /// @} dnnl_api_ukernel_utils
@@ -186,8 +183,8 @@ struct brgemm : public handle<dnnl_brgemm_t> {
                 memory::convert_to_c(b_dt), memory::convert_to_c(c_dt));
 
         if (!allow_empty)
-            error::wrap_c_api(status,
-                    err_message_list::init_error("BRGeMM ukernel object"));
+            error::wrap_c_api(
+                    status, "could not create a BRGeMM ukernel object");
         reset(brgemm);
     }
 
@@ -200,8 +197,7 @@ struct brgemm : public handle<dnnl_brgemm_t> {
         dnnl_status_t status
                 = dnnl_brgemm_set_add_C(get(), static_cast<int>(add_C));
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("add_C attribute"));
+            error::wrap_c_api(status, "could not set add_C attribute");
     }
 
     /// Sets post-operations to a BRGeMM ukernel object:
@@ -221,8 +217,7 @@ struct brgemm : public handle<dnnl_brgemm_t> {
         dnnl_status_t status = dnnl_brgemm_set_post_ops(
                 get(), ldd, memory::convert_to_c(d_dt), po.get());
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("post operations"));
+            error::wrap_c_api(status, "could not set post operations");
     }
 
     /// Sets tensor A scales mask to a BRGeMM ukernel object.
@@ -234,8 +229,7 @@ struct brgemm : public handle<dnnl_brgemm_t> {
     void set_A_scales(int a_scale_mask) {
         dnnl_status_t status = dnnl_brgemm_set_A_scales(get(), a_scale_mask);
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("A scales"));
+            error::wrap_c_api(status, "could not set A scales");
     }
 
     /// Sets tensor B scales mask to a BRGeMM ukernel object.
@@ -247,8 +241,7 @@ struct brgemm : public handle<dnnl_brgemm_t> {
     void set_B_scales(int b_scale_mask) {
         dnnl_status_t status = dnnl_brgemm_set_B_scales(get(), b_scale_mask);
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("B scales"));
+            error::wrap_c_api(status, "could not set B scales");
     }
 
     /// Sets tensor D scales mask to a BRGeMM ukernel object.
@@ -260,8 +253,7 @@ struct brgemm : public handle<dnnl_brgemm_t> {
     void set_D_scales(int d_scale_mask) {
         dnnl_status_t status = dnnl_brgemm_set_D_scales(get(), d_scale_mask);
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("D scales"));
+            error::wrap_c_api(status, "could not set D scales");
     }
 
     /// Finalizes initialization of a BRGeMM ukernel object.
@@ -317,8 +309,7 @@ struct brgemm : public handle<dnnl_brgemm_t> {
     void set_hw_context() const {
         dnnl_status_t status = dnnl_brgemm_set_hw_context(get());
         if (status != dnnl_success)
-            error::wrap_c_api(
-                    status, err_message_list::set_failure("hardware context"));
+            error::wrap_c_api(status, "could not set hardware context");
     }
 
     /// Releases the hardware-specific context. Affects the global state for
@@ -354,8 +345,8 @@ struct brgemm : public handle<dnnl_brgemm_t> {
         dnnl_status_t status = dnnl_brgemm_execute(get(), A, B,
                 (const dnnl_dim_t *)A_B_offsets.data(), C, scratchpad);
         if (status != dnnl_success)
-            error::wrap_c_api(status,
-                    err_message_list::execute_error("BRGeMM ukernel object"));
+            error::wrap_c_api(
+                    status, "could not execute a BRGeMM ukernel object");
     }
 
     /// Executes a BRGeMM ukernel object with post operations.
@@ -380,8 +371,8 @@ struct brgemm : public handle<dnnl_brgemm_t> {
                 (const dnnl_dim_t *)A_B_offsets.data(), C, D, scratchpad,
                 params.get());
         if (status != dnnl_success)
-            error::wrap_c_api(status,
-                    err_message_list::execute_error("BRGeMM ukernel object"));
+            error::wrap_c_api(
+                    status, "could not execute a BRGeMM ukernel object");
     }
 
     /// Returns a constant reference to a static instance of default constructed
@@ -435,8 +426,7 @@ struct transform : public handle<dnnl_transform_t> {
 
         if (!allow_empty)
             error::wrap_c_api(status,
-                    err_message_list::init_error(
-                            "BRGeMM ukernel packing B object"));
+                    "could not create a BRGeMM ukernel packing B object");
         reset(transform);
     }
 
@@ -456,8 +446,7 @@ struct transform : public handle<dnnl_transform_t> {
         dnnl_status_t status = dnnl_transform_execute(get(), in, out);
         if (status != dnnl_success)
             error::wrap_c_api(status,
-                    err_message_list::execute_error(
-                            "BRGeMM ukernel packing B object"));
+                    "could not execute a BRGeMM ukernel packing B object");
     }
 };
 

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -450,7 +450,7 @@ dnnl::graph::graph deserialized_graph::to_graph(
             g.add_op(aop.create());
         } catch (const dnnl::error &e) {
             BENCHDNN_PRINT(0, "Error: Adding op %s failed: %s\n",
-                    aop.name_.c_str(), e.message.c_str());
+                    aop.name_.c_str(), e.message);
             SAFE_V(FAIL);
         }
     }


### PR DESCRIPTION
# Description

Fixes [MFDNN-12814](https://jira.devtools.intel.com/browse/MFDNN-12814). 

Implementation handles regression by removing string-based error message construction for exception messages. The PR removes the message construction mechanism introduced in commit [e9d8e12](https://github.com/oneapi-src/oneDNN/commit/e9d8e126c8969513f1825ed23913ae210cc0b469). 

#### Test Command:
```
KMP_AFFINITY=compact,1,0,granularity=fine OMP_NUM_THREADS=4 OMP_PLACES=threads OMP_PROC_BIND=close numactl --membind=0 --physcpubind=0-3 ./tests/benchdnn/benchdnn --mode=P --graph --in-shapes=0:1x16x12x64+1:1x16x12x64+2:1x16x64x12+6:1x1x1x12 --case=$WORKDIR/projects/mfdnn12814/graph-mha-v2-head_16-dt_f32.json
```

#### Output:

Error Commits:  [e9d8e12](https://github.com/oneapi-src/oneDNN/commit/e9d8e126c8969513f1825ed23913ae210cc0b469), [f2251f0](https://github.com/oneapi-src/oneDNN/commit/f2251f0fad775c554cfdce08081e866ea31a6396)

| Before Fix (Min, Avg)     | After Fix (Min, Avg)                  | Before Error Commits (Min, Avg)    |
| -------------------------- | -------------------------------- | -------------------------------------- | 
| (0.03125,	0.0333039) |	(0.0229492,	0.0246163) |	(0.0222168,	0.0240998) |
| (0.03125,  	0.0333095) |	(0.0229492,	0.0248023) |	(0.0224609,	0.0241914) |
| (0.0314941,  	0.0336628) |	(0.0229492,	0.0248049) |	(0.0224609,	0.0242241) |
| (0.03125,      	0.0334094) |	(0.0227051,	0.0246843) |	(0.0227051,	0.0245072) |
| (0.0324707, 	0.0343265) |	(0.0229492,	0.0248256) |	(0.0222168,	0.0239901) |


