### PR TITLE
x64: cumulative backport: fixes in brgemm matmul and convolution 

### DIFF
--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1133,6 +1133,14 @@ status_t init_conf(conv_gemm_conf_t &jcp,
     const bool is_bwd_d = jcp.prop_kind == backward_data;
     const bool is_bwd_w = jcp.prop_kind == backward_weights;
     const bool is_fwd = !is_bwd_d && !is_bwd_w;
+
+    const auto dst_max_size
+            = static_cast<size_t>(jcp.iw) * jcp.ih * jcp.id * jcp.ic * 4;
+    const auto src_max_size
+            = static_cast<size_t>(jcp.ow) * jcp.oh * jcp.od * jcp.oc * 4;
+    VDISPATCH_CONV_IC(dst_max_size <= INT_MAX && src_max_size <= INT_MAX,
+            VERBOSE_UNSUPPORTED_FEATURE,
+            "dst/scr size > INT_MAX is not supported");
 
     bool is_int8_conv = (is_fwd ? utils::one_of(src_d.data_type(), s8, u8)
                                 : utils::one_of(dst_d.data_type(), s8, u8))

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -5396,12 +5396,23 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
         jcp.nthr_ic_b = nthr_ic_b;
 
         // TODO: Optimize memory allocation when threaded on height and depth
-        jcp.tr_src_buf_size = jcp.tr_iw * jcp.ic_block * jcp.ih * jcp.id;
+        jcp.tr_src_buf_size = static_cast<size_t>(jcp.tr_iw) * jcp.ic_block
+                * jcp.ih * jcp.id;
+        const auto src_max_size = jcp.tr_src_buf_size * jcp.typesize_in;
+        VDISPATCH_CONV_IC(src_max_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
+                "scr size > INT_MAX is not supported");
+
         jcp.tr_src_buf_count = jcp.global_transpose
                 ? jcp.nthr_mb * jcp.nb_ic * jcp.ngroups
                 : jcp.nthr;
 
-        jcp.tr_diff_dst_buf_size = jcp.tr_ow * jcp.oc_block * jcp.oh * jcp.od;
+        jcp.tr_diff_dst_buf_size = static_cast<size_t>(jcp.tr_ow) * jcp.oc_block
+                * jcp.oh * jcp.od;
+        const auto diff_dst_max_size
+                = jcp.tr_diff_dst_buf_size * jcp.typesize_in;
+        VDISPATCH_CONV_IC(diff_dst_max_size <= INT_MAX,
+                VERBOSE_UNSUPPORTED_FEATURE,
+                "diff_dst size > INT_MAX is not supported");
         jcp.tr_diff_dst_buf_count = jcp.global_transpose
                 ? jcp.nthr_mb * jcp.nb_oc * jcp.ngroups
                 : jcp.nthr;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -2102,7 +2102,8 @@ protected:
 
     constexpr static int reg_src_offs_ = 0;
     constexpr static int reg_tr_src_offs_ = 8;
-    constexpr static int stack_space_needed_ = 16;
+    constexpr static int reg_current_K_pad_offs_ = 16;
+    constexpr static int stack_space_needed_ = 24;
 
     const int comp_acc_idx_;
 
@@ -2708,9 +2709,14 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
 
     auto compute_K_loop = [&](bool is_N_tail) {
         int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
+        // 'param1' register (rcx on Windows) re-written in compute_K_loop_body
+        // so we need to read and keep 'current_K_pad' parameter in stack before
+        // the call
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+        mov(ptr[rsp + reg_current_K_pad_offs_], reg_K_iters);
         mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
         compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, false);
-        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+        mov(reg_K_iters, ptr[rsp + reg_current_K_pad_offs_]);
         compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, true);
     };
 
@@ -2900,7 +2906,8 @@ private:
     constexpr static int reg_src_offs = 0;
 
     constexpr static int reg_tr_src_offs = 8;
-    constexpr static int stack_space_needed = 16;
+    constexpr static int reg_current_K_pad_offs_ = 16;
+    constexpr static int stack_space_needed = 24;
 
     opmask_t kTail = k7;
     opmask_t kFFFF = k6;
@@ -3301,9 +3308,14 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
 
     auto compute_K_loop = [&](bool is_N_tail) {
         int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
+        // 'param1' register (rcx on Windows) re-written in compute_K_loop_body
+        // so we need to read and keep 'current_K_pad' parameter in stack before
+        // the call
+        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+        mov(ptr[rsp + reg_current_K_pad_offs_], reg_K_iters);
         mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_iters)]);
         compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, false);
-        mov(reg_K_iters, ptr[param1 + GET_OFF(current_K_pad)]);
+        mov(reg_K_iters, ptr[rsp + reg_current_K_pad_offs_]);
         compute_K_loop_body(reg_K_iters, ncolumns, is_N_tail, true);
     };
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2037,8 +2037,10 @@ void matmul_amx_blocking_params_t::set_blocking_parameters(
 
         const dim_t current_k_tail = K % k_blk_;
 
-        extendable_k_ = !use_buffer_a && K % wei_k_blk
-                && k_chunk_elems_ > wei_k_blk && !packed_sparse_weights;
+        // TODO: review extendable_k_ condition to cover more cases
+        extendable_k_ = (K % wei_k_blk != 0) && (k_chunk_elems_ > wei_k_blk)
+                && wei_zp_type == none && !use_buffer_a
+                && !packed_sparse_weights;
 
         if (extendable_k_) {
             if (k_chunk_elems_ >= K) {


### PR DESCRIPTION
This is a cumulative backport of:
#2379 :  x64: brgemm matmul copy routines: fix parameters reading
#2387 :  x64: conv: limitations for huge spatial sizes
#2392 :  x64: brgemm matmul: update condition for extendable_k 