### PR TITLE
xe: jit: gemm: fix invalid use of 2d messages

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -342,7 +342,8 @@ status_t gen_gemm_t::execute(const gemm_exec_ctx_t &ctx) const {
     int32_t po_offsets0[GEMM_MAX_PO] = {0}, po_offsets[GEMM_MAX_PO] = {0};
     for (int i = 0; i < po_count; i++)
         if (po_srcs[i])
-            po_offsets0[i] = po_srcs[i]->offset() / problem.Tbinary[i];
+            po_offsets0[i]
+                    = into<int32_t>(po_srcs[i]->offset() / problem.Tbinary[i]);
 
     int cmask = 0;
     if (pd()->with_c_zero_points()) {

--- a/src/gpu/intel/jit/gemm/include/type.hpp
+++ b/src/gpu/intel/jit/gemm/include/type.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -99,13 +99,13 @@ public:
     }
     constexpr Type baseType() const { return *this; }
 
-    template <typename U> constexpr friend int operator*(U a, Type t) {
-        return t.isInt4() ? int((unsigned(a) + 1) >> 1) : int(a * (U(1) << t.log2Size()));
+    template <typename U> constexpr friend decltype(std::declval<U>()*1) operator*(U a, Type t) {
+        return t.isInt4() ?(a + 2 * (a >= 0) - 1) / 2 : a * int(1u << t.log2Size());
     }
-    template <typename U> constexpr friend int operator*(Type t, U a) { return a * t; }
-    template <typename U>           friend int operator*=(U &a, Type t) { a = a * t; return a; }
-    template <typename U> constexpr friend int operator/(U a, Type t) {
-        return t.isInt4() ? int(a * 2) : int(a / (U(1) << t.log2Size()));
+    template <typename U> constexpr friend decltype(std::declval<U>()*1) operator*(Type t, U a) { return a * t; }
+    template <typename U>           friend U operator*=(U &a, Type t) { a = a * t; return a; }
+    template <typename U> constexpr friend decltype(std::declval<U>()/1) operator/(U a, Type t) {
+        return t.isInt4() ? a * 2 : a / int(1u << t.log2Size());
     }
 
     ngen::DataType ngen() const
@@ -139,6 +139,8 @@ public:
         }
     }
 };
+
+static_assert((-9 * Type(Type::s4) == -5) && (9 * Type(Type::s4) == 5), "Round away from zero is required non-integer type sizes");
 
 inline char typeToChar(Type T)
 {

--- a/src/gpu/intel/jit/gemm/xe_hp_systolic_gemm.cpp
+++ b/src/gpu/intel/jit/gemm/xe_hp_systolic_gemm.cpp
@@ -1008,7 +1008,8 @@ status_t xe_hp_systolic_gemm_t::execute(const gemm_exec_ctx_t &ctx) const {
     int32_t po_offsets0[GEMM_MAX_PO] = {0}, po_offsets[GEMM_MAX_PO] = {0};
     for (int i = 0; i < po_count; i++)
         if (po_srcs[i])
-            po_offsets0[i] = po_srcs[i]->offset() / problem_.Tbinary[i];
+            po_offsets0[i]
+                    = into<int32_t>(po_srcs[i]->offset() / problem_.Tbinary[i]);
 
     if (pd()->with_ab_zero_points()) {
         ao = &GEMM_CTX_ARG_STORAGE(a_zero_point);


### PR DESCRIPTION
Fixes the following failure observed on PVC:
```
$./benchdnn --engine=gpu --matmul --stag=any --wtag=any --dtag=any --dt=bf16:u8:bf16 --attr-fpmath=bf16:true 1x2:2x1789201856
[   0][DST][0:0] exp_f32:          26 exp:          26 got:          18 diff:       8 rdiff:0.307692
[   1][DST][0:1] exp_f32:          14 exp:          14 got:          30 diff:      16 rdiff: 1.14286
[   2][DST][0:2] exp_f32:           7 exp:           7 got:          35 diff:      28 rdiff:       4
[   3][DST][0:3] exp_f32:          20 exp:          20 got:           8 diff:      12 rdiff:     0.6
[   4][DST][0:4] exp_f32:          27 exp:          27 got:          23 diff:       4 rdiff:0.148148
[   5][DST][0:5] exp_f32:          26 exp:          26 got:           6 diff:      20 rdiff:0.769231
[   7][DST][0:7] exp_f32:          33 exp:          33 got:           5 diff:      28 rdiff:0.848485
[   8][DST][0:8] exp_f32:          17 exp:          17 got:          21 diff:       4 rdiff:0.235294
[  10][DST][0:10] exp_f32:           1 exp:           1 got:          21 diff:      20 rdiff:      20
[  11][DST][0:11] exp_f32:          31 exp:          31 got:          27 diff:       4 rdiff:0.129032
[COMPARE_STATS][DST]: trh=0 err_max_diff:      32 err_max_rdiff:      32 all_max_diff:      32 all_max_rdiff:      32
[PRIM_REF][INFO]: L2_size:2097152 bytes; per_core_L3_size:1966080 bytes; nthr:224; impl_name:brg_matmul:avx512_core_bf16
[PRIM_REF][REPRO]: --matmul --engine=cpu --dt=bf16:u8:bf16 --attr-fpmath=bf16:true 1x2:2x1789201856
0:FAILED (errors:1574188085 total:1789201856) __REPRO: --matmul --engine=gpu --dt=bf16:u8:bf16 --attr-fpmath=bf16:true 1x2:2x1789201856
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 269.24s; fill: 251.95s (94%); compute_ref: 0.56s (0%); compare: 11.55s (4%);
```

The root cause was using the unset `Ta_ext` type (which defaults to f32), so stride was calculated as `4 * 1789201856` followed by a down-conversion to `int` resulting in a negative pitch, which passed the check.