### PR TITLE
benchdnn: softmax: update setup_cmp

### DIFF
--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -603,11 +603,12 @@ std::vector<std::pair<int, int>> attr_t::post_ops_t::get_po_masks(
     return v_masks;
 }
 
-bool attr_t::is_def(bool skip_fpmath) const {
+bool attr_t::is_def(bool skip_fpmath, bool skip_acc_mode) const {
     return scales.is_def() && zero_points.is_def() && post_ops.is_def()
             && scratchpad_mode == get_default_scratchpad_mode()
             && IMPLICATION(!skip_fpmath, fpmath_mode.is_def())
-            && acc_mode == dnnl_accumulation_mode_strict
+            && IMPLICATION(
+                    !skip_acc_mode, acc_mode == dnnl_accumulation_mode_strict)
             && rounding_mode.is_def() && deterministic.is_def()
             && dropout.is_def();
 }

--- a/tests/benchdnn/dnn_types.hpp
+++ b/tests/benchdnn/dnn_types.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -441,7 +441,7 @@ struct attr_t {
     dropout_t dropout;
     rounding_mode_t rounding_mode;
 
-    bool is_def(bool skip_fpmath = false) const;
+    bool is_def(bool skip_fpmath = false, bool skip_acc_mode = false) const;
 };
 
 struct isa_hints_t {

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 * Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -258,9 +258,11 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
 #endif
     cmp.set_threshold(trh);
 
-    // LogSoftMax is unstable enough when there are attributes on top.
-    const bool compare_with_norm
-            = (prb->alg == alg_t::LOGSOFTMAX && !prb->attr.is_def());
+    // LogSoftMax is unstable enough when there are compute attributes (such as
+    // post-ops or scales) on top of it.
+    const bool compare_with_norm = (prb->alg == alg_t::LOGSOFTMAX
+            && !prb->attr.is_def(
+                    /* skip_fpmath = */ true, /* skip_acc_mode = */ true));
     cmp.set_norm_validation_mode(compare_with_norm);
 
     const int64_t axis_size = prb->dims[prb->axis];


### PR DESCRIPTION
Way of checking softmax type of comparison did take into account acc_mode (by mistake).
This PR adds an argument to skip acc_mode (as it shouldn't be considered as an attribute) and updates softmax comparison to become p2p back again for logsoftmax.