### PR TITLE
x64: updates for brgemm kernel and avx2 brgemm convolutions

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2023-2024 FUJITSU LIMITED
 * Copyright 2024 Arm Ltd. and affiliates
 *
@@ -414,6 +414,11 @@ status_t brgemm_desc_set_attr(brgemm_t *brg, const brgemm_attr_t &brgattr) {
             && brg->prfC.dist2 < 0)
         brg->prfC.dist2 = 0;
 
+    return status::success;
+}
+
+status_t brgemm_desc_finalize(brgemm_t *brg) {
+    // TODO: implement functionality here similar to corresponding one in x64
     return status::success;
 }
 

--- a/src/cpu/aarch64/brgemm/brgemm.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,6 +120,11 @@ status_t DNNL_API brgemm_desc_set_postops(brgemm_t *brg,
 ///
 status_t DNNL_API brgemm_desc_set_attr(
         brgemm_t *brg, const brgemm_attr_t &brgattr);
+
+/// Finalize BRGEMM descriptor.
+///
+/// @param brg Output BRGEMM descriptor
+status_t DNNL_API brgemm_desc_finalize(brgemm_t *brg);
 
 /// Generates a BRGEMM kernel based on descriptor
 ///

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -115,6 +115,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
         brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, jcp_.bia_dt));
+        CHECK(brgemm_desc_finalize(&brg));
         brgs_->insert(brg_idx, brg);
     }
 

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -280,6 +280,8 @@ status_t brgemm_convolution_fwd_t<isa, use_inversion>::pd_t::add_brg_descriptor(
     brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
     CHECK(brgemm_desc_set_postops(&brg, attr(), &dst_md_, LDD, jcp_.bia_dt));
 
+    CHECK(brgemm_desc_finalize(&brg));
+
     brgemm_descriptors_->insert(brg_idx, brg, bd_mask, stoffs);
 
     return status::success;

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -159,6 +159,9 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                 = bgmmc_.post_ops_applicable && bgmmc_.nthr_k > 1;
 
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
+
+        CHECK(brgemm_desc_finalize(&brg));
+
         bgmmc_.wsp_tile_per_thr_bytes = nstl::max(
                 brg.get_wsp_buffer_size(), bgmmc_.wsp_tile_per_thr_bytes);
     }

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -129,6 +129,15 @@ status_t DNNL_API brgemm_desc_set_postops(brgemm_desc_t *brg,
 ///
 status_t DNNL_API brgemm_desc_set_attr(
         brgemm_desc_t *brg, const brgemm_attr_t &brgattr);
+
+/// Finalize BRGEMM descriptor.
+///
+/// @param brg Output BRGEMM descriptor
+/// This function must be called after all the fields of the descriptor are set.
+/// It finalizes the descriptor including internal blocking parameters to
+/// prepare it for the kernel creation.
+///
+status_t DNNL_API brgemm_desc_finalize(brgemm_desc_t *brg);
 
 /// Generates a BRGEMM kernel based on descriptor
 ///

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -252,6 +252,7 @@ struct brgemm_desc_t {
     bool with_scales = false;
     bool skip_zp_b_compensation = false;
     bool skip_scales = false;
+    bool n_bcast_1_load = false;
 
     brgemm_broadcast_t zp_type_a = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -252,7 +252,7 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     return max_bcast_block;
 }
 
-status_t brgemm_blocking(brgemm_desc_t *brg, bool attr_blocking) {
+status_t brgemm_blocking(brgemm_desc_t *brg) {
     const data_type_t ld_step_compute_dt
             = get_mac_emu_data_type(brg->dt_b, brg->isa_impl,
                     brg->isa_impl != avx2_vnni_2 && !brg->is_fp8_via_convert());
@@ -753,19 +753,16 @@ status_t brgemm_blocking(brgemm_desc_t *brg, bool attr_blocking) {
         // Remove these guards in the future (add tail processing by reduction
         // dimension)
         // TODO: these checks do not work for fp8-f16 and f16-fp8 cfgs
-        if (attr_blocking
-                && !IMPLICATION(brg->rdb > 0 && brg->rdb_tail,
-                        brg->is_input_convert() || brg->amx_wary_k_tail())) {
+        if (!IMPLICATION(brg->rdb > 0 && brg->rdb_tail,
+                    brg->is_input_convert() || brg->amx_wary_k_tail())) {
             return status::unimplemented;
         }
 
-        if (attr_blocking
-                && !IMPLICATION(
-                        (brg->rdb_tail
-                                % ((brg->is_bf16_tmm || brg->is_f16_tmm) ? 2
-                                                                         : 4))
-                                != 0,
-                        brg->is_input_convert() || brg->amx_wary_k_tail())) {
+        if (!IMPLICATION(
+                    (brg->rdb_tail
+                            % ((brg->is_bf16_tmm || brg->is_f16_tmm) ? 2 : 4))
+                            != 0,
+                    brg->is_input_convert() || brg->amx_wary_k_tail())) {
             return status::unimplemented;
         }
 
@@ -777,6 +774,23 @@ status_t brgemm_blocking(brgemm_desc_t *brg, bool attr_blocking) {
                 ? true
                 : false;
     }
+
+    // avx2_vnni_2 kernel with xf16 data type requires blocked weights.
+    if (brg->isa_impl == avx2_vnni_2 && brg->is_xf16()
+            && brg->LDB % brg->ld_block > 0)
+        return status::unimplemented;
+
+    brg->LDA2 = (brg->brgattr.LDA2 != 0) ? brg->brgattr.LDA2 : brg->LDA;
+    brg->LDB2 = (brg->brgattr.LDB2 != 0) ? brg->brgattr.LDB2 : brg->LDB;
+    brg->LDC2_M = (brg->brgattr.LDC2_M != 0) ? brg->brgattr.LDC2_M : brg->LDC;
+    brg->LDC2_N
+            = (brg->brgattr.LDC2_N != 0) ? brg->brgattr.LDC2_N : brg->ld_block;
+
+    brg->is_blocked = (brg->LDA2 != brg->LDA || brg->LDB2 != brg->LDB
+            || brg->LDC2_M != brg->LDC || brg->LDC2_N != brg->ld_block);
+
+    if (!IMPLICATION(brg->is_blocked, brg->layout == brgemm_row_major))
+        return status::invalid_arguments;
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.hpp
@@ -34,7 +34,7 @@ bool can_dispatch_uker(const brgemm_desc_t *brg);
 
 void maybe_try_bf32(brgemm_desc_t *brg);
 
-status_t brgemm_blocking(brgemm_desc_t *brg, bool attr_blocking = false);
+status_t brgemm_blocking(brgemm_desc_t *brg);
 
 status_t brdgmm_blocking(brgemm_desc_t *brg);
 

--- a/src/cpu/x64/brgemm/capi/brgemm_api.cpp
+++ b/src/cpu/x64/brgemm/capi/brgemm_api.cpp
@@ -144,6 +144,11 @@ status_t brgemm_t::finalize() {
         VCHECK_BRGEMM_STATUS(status, false, "brgemm_desc_set_attr failed");
     }
 
+    status = brgemm_desc_finalize(&brgemm_desc_);
+    if (status != status::success) {
+        VCHECK_BRGEMM_STATUS(status, false, "brgemm_desc_finalize failed");
+    }
+
     // Note: API can't take a compensation buffer externally. Users must add
     // compensation on their own as a binary post-op.
     brgemm_desc_.req_s8s8_compensation = false;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -295,7 +295,7 @@ private:
     }
 
     Vmm bcst(int bd = 0) {
-        if (n_bcast_1_load) {
+        if (brg.n_bcast_1_load) {
             int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - bd;
             assert(idx > 0);
@@ -305,7 +305,7 @@ private:
     }
 
     Vmm load(int ld = 0) {
-        if (n_bcast_1_load) {
+        if (brg.n_bcast_1_load) {
             return Vmm(0);
         } else {
             int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
@@ -452,7 +452,6 @@ private:
     int bdb_zp_comp_b_offset(int bd_block2) const noexcept;
     int zp_c_values_offset(int ld, bool is_tail = false) const noexcept;
 
-    bool n_bcast_1_load = false;
     bool vpad_exist = false;
     bool need_comp_pads = false;
     palette_config_t palette_;
@@ -2158,7 +2157,7 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(int rd_loop, int bd_b,
         }
     };
 
-    if (n_bcast_1_load && brg.zp_type_a != brgemm_broadcast_t::none) {
+    if (brg.n_bcast_1_load && brg.zp_type_a != brgemm_broadcast_t::none) {
         mov(ptr[rsp + reg_bdb_loop_offs_], reg_bdb_loop);
         const auto reg32_scratch = reg_zp_a_input_shift.cvt32();
         mov(reg32_scratch, 0x1010101);
@@ -2257,7 +2256,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
     bool maybe_load_bytes
             = (rows_for_rd_tail > 0 || brg.brgattr.wary_A_k_tail_read)
             && is_rd_tail && rd_tail_size != 0 && (brg.is_bf16 || brg.is_int8);
-    if (n_bcast_1_load) {
+    if (brg.n_bcast_1_load) {
         for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
             bool have_to_load_bytes
                     = maybe_load_bytes && (rd == rd_loop - brg.rd_step);
@@ -2673,7 +2672,6 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
     if (brg.is_tmm) {
         rows_for_rd_tail = 0;
         bd_blocks_for_rd_tail = 0;
-        n_bcast_1_load = false;
     } else {
         rows_for_rd_tail = 0;
         if (brg.rdb_tail != 0 && (brg.is_bf16 || brg.is_int8)) {
@@ -2687,19 +2685,6 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                                  rows_for_rd_tail - brg.bdb_tail
                                          + brg.brgattr.max_bottom_vpad),
                         brg.bd_block);
-
-        auto ld_block2 = (brg.ldb2 > 0)
-                ? brg.ld_block2
-                : ((brg.ldb2_tail > 0) ? brg.ldb2_tail : 1);
-        const int free_vregs = max_effective_vregs - brg.req_s8s8_compensation;
-        n_bcast_1_load = brg.is_int8
-                && ((brg.bd_block * (ld_block2 + 1) < free_vregs)
-                        && (bd_blocks_for_rd_tail == 0)
-                        && (rows_for_rd_tail == 0));
-        if (brg.brgattr.hint_loop_order != brgemm_lo_default)
-            n_bcast_1_load = (brg.brgattr.hint_loop_order == brgemm_lo_bl_1load)
-                    ? true
-                    : false;
     }
 
     auto bdb_loop_avx512 = [&](bool skip_accumulation) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2463,8 +2463,10 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
             L_aligned(BS_loop_label, 64);
             {
                 if (first_bdb || last_bdb) {
-                    const auto vpad_first = -brg.brgattr.max_bottom_vpad;
-                    const auto vpad_last = brg.brgattr.max_top_vpad;
+                    const auto vpad_first
+                            = last_bdb ? (-brg.brgattr.max_bottom_vpad) : 1;
+                    const auto vpad_last
+                            = first_bdb ? brg.brgattr.max_top_vpad : -1;
                     const auto n_vpads = vpad_last - vpad_first + 2;
                     constexpr auto MAX_N_VPADS = 2 * brgemm_desc_t::MAX_VPAD;
                     assert(n_vpads < MAX_N_VPADS);

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -429,6 +429,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                 LDA, LDC, M, N, &strides));
         CHECK(brgemm_desc_set_attr(&bcp, brg_attr));
         CHECK(brgemm_desc_set_postops(&bcp, attr(), dst_md(), LDD, jcp.bia_dt));
+        CHECK(brgemm_desc_finalize(&bcp));
         ++idx;
         return status::success;
     };

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -221,6 +221,8 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
         CHECK(brgemm_desc_set_postops(
                 &brg, attr(), &dst_md_, LDD, jcp_.bia_dt));
+        CHECK(brgemm_desc_finalize(&brg));
+
         jcp_.amx_buf_size_per_thread = nstl::max(
                 brg.get_wsp_buffer_size(), jcp_.amx_buf_size_per_thread);
         brgs_->insert(brg_idx, brg);

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -319,6 +319,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
     brg.with_sum = with_sum_;
     brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
     CHECK(brgemm_desc_set_postops(&brg, attr(), &dst_md_, LDD, jcp_.bia_dt));
+    CHECK(brgemm_desc_finalize(&brg));
+
     jcp_.amx_buf_size_per_thread = nstl::max(
             brg.get_wsp_buffer_size(), jcp_.amx_buf_size_per_thread);
 

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -284,6 +284,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
     brgattr.hint_innermost_loop = jcp_.brgemm_bd_loop_innermost
             ? brgemm_bd_loop_innermost
             : brgemm_innermost_undef;
+    brgattr.hint_loop_order = jcp_.brgemm_kernel_loop_order;
+
     if (jcp_.amx_tile_load_xx) {
         // assuming 2x2 decomposition in amx brgemm kernel
         // and overlap of input by kw

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -572,7 +572,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     if (jcp_.K > 0) Kv.push_back(false);
     if (has_K_tail) Kv.push_back(true);
 
-    const auto first_K_init_only = jcp_.exec_type == exec_trans
+    const auto first_K_init_only = one_of(jcp_.exec_type, exec_trans, exec_vpad)
             && (jcp_.ic / jcp_.ic_block <= 1)
             && (KD_BLOCK == KD && KH_BLOCK == KH);
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -295,6 +295,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(
     brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
     CHECK(brgemm_desc_set_postops(
             &brg, attr(), &diff_src_md_, LDD, jcp_.bia_dt));
+    CHECK(brgemm_desc_finalize(&brg));
+
     jcp_.amx_buf_size_per_thread = nstl::max(
             brg.get_wsp_buffer_size(), jcp_.amx_buf_size_per_thread);
     brg_idx = brgs_->insert(brg);

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -147,6 +147,7 @@ status_t brgemm_convolution_bwd_weights_t::pd_t::init(engine_t *engine) {
                         * jcp_.kd * jcp_.kh * jcp_.kw;
 
                 CHECK(brgemm_desc_set_attr(&brg, brgattr));
+                CHECK(brgemm_desc_finalize(&brg));
 
                 brgs_->insert(brg_idx, brg);
             }

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1956,6 +1956,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             * jcp.wei_dsz;
 
     jcp.loop_order = (bcast_amount < wei_amount) ? loop_ngcdhw : loop_ndhwgc;
+    jcp.brgemm_kernel_loop_order
+            = brgemm_kernel_loop_order_t::brgemm_lo_default;
 
     const int min_oc_block = jcp.acc_simd_w;
 

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1971,12 +1971,17 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     using namespace data_type;
     // ======================= blocking =================================
 
-    auto bcast_amount
-            = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw * jcp.src_dsz;
+    auto bcast_amount = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw
+            * jcp.src_dsz * jcp.ic;
     auto wei_amount = static_cast<size_t>(jcp.oc) * jcp.kd * jcp.kh * jcp.kw
-            * jcp.wei_dsz;
+            * jcp.wei_dsz * jcp.ic;
 
-    jcp.loop_order = (bcast_amount < wei_amount) ? loop_ngcdhw : loop_ndhwgc;
+    jcp.loop_order
+            = (one_of(isa, avx2, avx2_vnni, avx2_vnni_2) && jcp.mb > jcp.nthr
+                      && bcast_amount > brg_blocking_t::L2
+                      && wei_amount > brg_blocking_t::L2)
+            ? loop_gcndhw
+            : ((bcast_amount < wei_amount) ? loop_ngcdhw : loop_ndhwgc);
     jcp.brgemm_kernel_loop_order
             = brgemm_kernel_loop_order_t::brgemm_lo_default;
 
@@ -1994,6 +1999,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         const bool small_amx_job = est_amx_job < 64 || jcp.oc < 256;
         auto start_ocb
                 = (is_amx(isa) && jcp.is_os_blocking && small_amx_job) ? 2 : 4;
+        if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)
+                && jcp.loop_order == loop_gcndhw)
+            start_ocb = 2;
+        if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)
+                && jcp.oh * jcp.ow >= 150 * 150)
+            start_ocb = 2;
+
         start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
 
         auto finish_ocb = 1;
@@ -2248,7 +2260,6 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 #endif
 
     // ============ end blocking ===========================================
-
     jcp.brg_type
             = (jcp.use_uker && one_of(jcp.exec_type, exec_base, exec_trans))
             ? brgemm_static_offs

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -754,6 +754,7 @@ bool brg_blocking_t::fast_check_oc_block() const {
 }
 
 float brg_blocking_t::est_eff() {
+    const auto jcp = *this;
     const auto ocblock = oc_block / acc_simd_w;
 
     const auto brgemm_microkernel_eff
@@ -786,28 +787,18 @@ float brg_blocking_t::est_eff() {
             dim_t thr_job = 0;
             int start {0}, end {0};
             balance211(work_amount, nthr, ithr, start, end);
-            int n {0}, g {0}, ocb {0}, odp {0}, ohp {0}, spb {0};
-            if (loop_order == loop_ndhwgc)
-                nd_iterator_init(start, n, mb, odp, od, ohp, oh, spb, nb_sp, g,
-                        ngroups, ocb, nb_oc);
-            else if (loop_order == loop_ngcdhw)
-                nd_iterator_init(start, n, mb, g, ngroups, ocb, nb_oc, odp, od,
-                        ohp, oh, spb, nb_sp);
+            int n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
+            BRGEMM_CONV_ITERATOR_INIT;
 
             for (auto work = start; work < end; work++) {
                 const int ocp = ocb * oc_block;
                 const auto oc_sz = nstl::min(oc - ocp, oc_block);
                 int sp_sz = 0;
-                const int spp = spb * sp_block;
+                const int spp = owb * sp_block;
                 sp_sz = nstl::min(sp - spp, sp_block);
                 thr_job += sp_sz * oc_sz;
 
-                if (loop_order == loop_ndhwgc)
-                    nd_iterator_step(n, mb, odp, od, ohp, oh, spb, nb_sp, g,
-                            ngroups, ocb, nb_oc);
-                else if (loop_order == loop_ngcdhw)
-                    nd_iterator_step(n, mb, g, ngroups, ocb, nb_oc, odp, od,
-                            ohp, oh, spb, nb_sp);
+                BRGEMM_CONV_ITERATOR_STEP;
             }
             thr_jobs[ithr] = thr_job;
         }

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -118,13 +118,10 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     // These are rough estimates of the latency (relative) of access to various
     // cache levels. This is enough for an estimation of data access cost.
     // TODO: Improve memory access estimates
-    static constexpr float L1_k = 1.f;
-    static constexpr float L2_k = 3.f;
-    static constexpr float L3_k = 15.f;
-    // TODO: At the moment, we are primarily evaluating the fit of the data into
-    // the L1/L2. Need to take into account the difference between the L3 and
-    // memory.
-    static constexpr float mem_k = 15.f;
+    static float L1_k;
+    static float L2_k;
+    static float L3_k;
+    static float mem_k;
     static constexpr int bench_iterations = 1;
 
     int sp, sp_block, nb_sp;
@@ -172,11 +169,22 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         return (k > 1.f) ? (k - 1 + eff) / k : eff * koeff;
     }
 
-    static int estimate_ur(int oc_block) {
-        const auto est_ur = (oc_block == 64)
-                ? 6
-                : ((oc_block == 48) ? 9 : ((oc_block == 32) ? 14 : 28));
-        return est_ur;
+    static int estimate_ur(cpu_isa_t isa, int oc_block) {
+        if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)) {
+            switch (oc_block) {
+                case 32: return 3;
+                case 24: return 4;
+                case 16: return 6;
+                default: return 14;
+            }
+        } else {
+            switch (oc_block) {
+                case 64: return 6;
+                case 48: return 9;
+                case 32: return 14;
+                default: return 28;
+            }
+        }
     }
 
     int inp_w(int out_w, int ker_w) const {
@@ -378,6 +386,10 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
 
 unsigned brg_blocking_t::L1;
 unsigned brg_blocking_t::L2;
+float brg_blocking_t::L1_k;
+float brg_blocking_t::L2_k;
+float brg_blocking_t::L3_k;
+float brg_blocking_t::mem_k;
 
 float brg_blocking_t::io_k(dim_t src, dim_t wei, dim_t dst, float n, float pk,
         bool is_broadcast, bool is_shared) const {
@@ -458,8 +470,8 @@ void brg_blocking_t::select_ic_block() {
         }
     } else {
         const auto est_ur = sp_block > 0
-                ? nstl::min(sp_block, estimate_ur(oc_block))
-                : estimate_ur(oc_block);
+                ? nstl::min(sp_block, estimate_ur(isa, oc_block))
+                : estimate_ur(isa, oc_block);
         const auto inp_ur = is_os_blocking ? est_ur : inp_w(est_ur, kw_block);
 
         if (kw_block > 1) {
@@ -1607,8 +1619,26 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
     using namespace prop_kind;
 
-    brg_blocking_t::L1 = platform::get_per_core_cache_size(1);
+    // take L1 as 7/8 of the real size for L1
+    brg_blocking_t::L1 = (platform::get_per_core_cache_size(1) * 7) / 8;
     brg_blocking_t::L2 = platform::get_per_core_cache_size(2);
+    // here is hard-coded L2 size for avx2 performance cores
+    // TODO: get L2 size from the platform
+    if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2))
+        brg_blocking_t::L2 = 2 * 1024 * 1024;
+    // take L2 as 3/4 of the real size for L2
+    brg_blocking_t::L2 = (brg_blocking_t::L2 * 3) / 4;
+
+    // These are rough estimates of the latency (relative) of access to various
+    // cache levels. This is enough for an estimation of data access cost.
+    // TODO: Improve memory access estimates
+    brg_blocking_t::L1_k = 1.f;
+    brg_blocking_t::L2_k = 2.3f;
+    brg_blocking_t::L3_k = 17.f;
+    // TODO: At the moment, we are primarily evaluating the fit of the data into
+    // the L1/L2. Need to take into account the difference between the L3 and
+    // memory.
+    brg_blocking_t::mem_k = 17.f;
 
     const memory_desc_wrapper src_d(&src_md);
     const memory_desc_wrapper weights_d(&weights_md);

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -690,7 +690,6 @@ status_t brg_blocking_t::get_brgemm_ur(
         brgemm_utils::init_brgemm_conf(&brg, isa, brg_type, src_dt, wei_dt,
                 brgemm_row_major, alpha, vbeta, LDA, LDB, LDC, vM, vN, vK,
                 strides_ptr, is_bf32);
-        CHECK(brgemm_utils::brgemm_blocking(&brg));
 
         brgemm_attr_t brgattr;
         brgattr.max_bs = max_batch;
@@ -702,6 +701,7 @@ status_t brg_blocking_t::get_brgemm_ur(
 
         brg.with_sum = with_sum;
         CHECK(brgemm_desc_set_postops(&brg, attr, &dst_md, LDD, bia_dt));
+        CHECK(brgemm_utils::brgemm_blocking(&brg));
     }
 
     return status::success;

--- a/src/cpu/x64/jit_brgemm_conv_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.hpp
@@ -71,6 +71,36 @@ void get_ow_range(const jit_brgemm_conv_conf_t &jcp, int ow, int kw, int &ow_s,
 void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int ow, int &kw_s,
         int &kw_full_s, int &kw_full_f, int &kw_f);
 
+#define BRGEMM_CONV_NDHWGC_ORDER \
+    n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh, owb, jcp.nb_ow, g, jcp.ngroups, \
+            ocb, jcp.nb_oc
+#define BRGEMM_CONV_NGCDHW_ORDER \
+    n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc, odb, jcp.nb_od, ohb, jcp.nb_oh, \
+            owb, jcp.nb_ow
+#define BRGEMM_CONV_GCNDHW_ORDER \
+    g, jcp.ngroups, ocb, jcp.nb_oc, n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh, \
+            owb, jcp.nb_ow
+
+#define BRGEMM_CONV_ITERATOR_INIT \
+    if (jcp.loop_order == loop_ndhwgc) \
+        nd_iterator_init(start, BRGEMM_CONV_NDHWGC_ORDER); \
+    else if (jcp.loop_order == loop_ngcdhw) \
+        nd_iterator_init(start, BRGEMM_CONV_NGCDHW_ORDER); \
+    else if (jcp.loop_order == loop_gcndhw) \
+        nd_iterator_init(start, BRGEMM_CONV_GCNDHW_ORDER); \
+    else \
+        assert(!"Unknown loop order");
+
+#define BRGEMM_CONV_ITERATOR_STEP \
+    if (jcp.loop_order == loop_ndhwgc) \
+        nd_iterator_step(BRGEMM_CONV_NDHWGC_ORDER); \
+    else if (jcp.loop_order == loop_ngcdhw) \
+        nd_iterator_step(BRGEMM_CONV_NGCDHW_ORDER); \
+    else if (jcp.loop_order == loop_gcndhw) \
+        nd_iterator_step(BRGEMM_CONV_GCNDHW_ORDER); \
+    else \
+        assert(!"Unknown loop order");
+
 } // namespace brgemm_convolution_utils
 
 } // namespace x64

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -143,6 +143,7 @@ struct brgemm_inner_product_fwd_t : public primitive_t {
                 }
 
                 CHECK(brgemm_desc_set_attr(&brg, brgattr));
+                CHECK(brgemm_desc_finalize(&brg));
 
                 if (jbgp_.is_amx)
                     jbgp_.amx_buf_size_per_thread
@@ -334,6 +335,9 @@ struct brgemm_inner_product_bwd_data_t : public primitive_t {
                     brgattr.fpmath_mode = attr()->fpmath_.mode_;
 
                     CHECK(brgemm_desc_set_attr(&brg, brgattr));
+                }
+                CHECK(brgemm_desc_finalize(&brg));
+                if (jbgp_.is_amx) {
                     jbgp_.amx_buf_size_per_thread
                             = nstl::max(brg.get_wsp_buffer_size(),
                                     jbgp_.amx_buf_size_per_thread);
@@ -510,6 +514,9 @@ struct brgemm_inner_product_bwd_weights_t : public primitive_t {
                     brgattr.fpmath_mode = attr()->fpmath_.mode_;
 
                     CHECK(brgemm_desc_set_attr(&brg, brgattr));
+                }
+                CHECK(brgemm_desc_finalize(&brg));
+                if (jbgp_.is_amx) {
                     jbgp_.amx_buf_size_per_thread
                             = nstl::max(brg.get_wsp_buffer_size(),
                                     jbgp_.amx_buf_size_per_thread);

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -703,6 +703,7 @@ status_t jit_brgemm_ip_fwd_conf_t::init_conf(cpu_isa_t isa,
                 jbgp.src_dt, jbgp.wei_dt, false, false, brgemm_row_major, 1.0f,
                 1.0f, jbgp.ic_without_padding, jbgp.oc_block,
                 jbgp.oc_without_padding, jbgp.os_block, jbgp.oc_block, jbgp.K);
+        if (st == success) st = brgemm_desc_finalize(&brg_desc);
 
         if (st == success) {
             int bd_block = brg_desc.bd_block;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -661,6 +661,7 @@ struct jit_brdgmm_conv_conf_t {
 enum conv_brgemm_loop_order_t {
     loop_ndhwgc,
     loop_ngcdhw,
+    loop_gcndhw,
 };
 
 enum conv_brgemm_exec_type_t {

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -817,6 +817,7 @@ struct jit_brgemm_conv_conf_t {
     bool has_uneven_iw;
     int trans_dim_koef {1};
     bool extendable_k = false;
+    brgemm_kernel_loop_order_t brgemm_kernel_loop_order {brgemm_lo_default};
 };
 
 struct jit_shuffle_conf_t {

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -246,6 +246,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         }
 
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
+        CHECK(brgemm_desc_finalize(&brg));
+
         bgmmc_.wsp_tile_per_thr_bytes = nstl::max(
                 brg.get_wsp_buffer_size(), bgmmc_.wsp_tile_per_thr_bytes);
     }

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -566,6 +566,7 @@ status_t init_brgemm_kernel(x64::brgemm_desc_t *desc, x64::cpu_isa_t isa,
     brgattr.max_bottom_vpad = 0;
     brgattr.b_is_vnni = true;
     CHECK(brgemm_desc_set_attr(desc, brgattr));
+    CHECK(brgemm_desc_finalize(desc));
 
     x64::brgemm_kernel_t *_t_ptr;
     CHECK(brgemm_kernel_create(&_t_ptr, *desc));

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -371,6 +371,9 @@ int init_kernel(kernel_args_t &kernel_args) {
             WARN);
     if (res->state == SKIPPED) return OK;
 
+    SAFE(check_dnnl_status(brgemm_desc_finalize(&brgemm_desc), prb, res), WARN);
+    if (res->state == SKIPPED) return OK;
+
     kernel_args.generate_skip_accumulation_
             = brgemm_attr.generate_skip_accumulation;
 

--- a/tests/gtests/internals/test_brgemm.cpp
+++ b/tests/gtests/internals/test_brgemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -193,12 +193,16 @@ private:
                 p.alpha, p.beta, p.lda, p.ldb, p.ldc, p.M, p.N, p.K);
         if (res != dnnl_success) return res;
 
-        if (desc.is_tmm) {
-            res = brgemm_init_tiles(desc, palette);
-            if (res != dnnl_success) return res;
-        }
         if (!desc.is_tmm) {
             res = brgemm_desc_set_attr(&desc, p.attrs);
+            if (res != dnnl_success) return res;
+        }
+
+        res = brgemm_desc_finalize(&desc);
+        if (res != dnnl_success) return res;
+
+        if (desc.is_tmm) {
+            res = brgemm_init_tiles(desc, palette);
             if (res != dnnl_success) return res;
         }
 


### PR DESCRIPTION
This request contains a few general brgemm code changes and some performance updates for avx2:

- brgemm: introduce brgemm_desc_finalize function  :  this function must be called after all the parameters of the brgemm descriptor are set.  As result brgemm blocking is called only once having all needed information
- brgemm conv: update to reduce the number of generated kernels: small update for brgemm non-amx convolutions 
- brgemm: update non-amx blocking: more careful distribution of available vmm registers. It's especially important for avx2.  It also determine which order of data loading in microkernel to choose - n_bcast_1_load or 1_bcast_n_load .
- brgemm kernel: update gemm microkernel: just update the kernel code
- brgemm kernel: reduce number of vpad variants: it reduces the size of generated kernel
- brgemm conv: knob for brgemm microkernel decomposition: we may want to tune microkernel decomposition
- brgemm conv: introduce loop order gcndhw: for some shapes such loop order makes sense in terms of performance
- brgemm conv: update cache constants and ur estimation: update platform values used in convolution blocking selection
- brgemm conv: heuristic for big convolution on avx2

Performance testing by openvino on MTL. Here are a ratio brgemm to jit implementation for rls-v3.5 and for this brgemm update over v3.5:

![image](https://github.com/user-attachments/assets/ea82ae80-52eb-4e6d-95de-815f2e15d4c4)


