### PR TITLE
graph: backend: graph compiler: fix build

### DIFF
--- a/src/graph/backend/graph_compiler/core/src/compiler/jit/xbyak/debug/vtune/vtune.cpp
+++ b/src/graph/backend/graph_compiler/core/src/compiler/jit/xbyak/debug/vtune/vtune.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2023 Intel Corporation
+ * Copyright 2023-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 #include <map>
 #include <memory>
-#include <common/ittnotify/jitprofiling.h>
+
 #include <compiler/jit/xbyak/debug/debug_info_mgr.hpp>
+#include <ittnotify/jitprofiling.h>
 #include <util/utils.hpp>
 
 namespace dnnl {

--- a/src/graph/backend/graph_compiler/core/src/runtime/microkernel/cpu/brgemm_onednn.cpp
+++ b/src/graph/backend/graph_compiler/core/src/runtime/microkernel/cpu/brgemm_onednn.cpp
@@ -125,7 +125,7 @@ static brgemm_attr_t get_dnnl_brgemm_attrs(const attrs_setting_t &attrs) {
                         = static_cast<brgemm_kernel_prefetching_t>(it.second);
                 break;
             case attr_key::wary_tail_read:
-                dnnl_attrs.wary_tail_read = static_cast<bool>(it.second);
+                dnnl_attrs.wary_A_k_tail_read = static_cast<bool>(it.second);
                 break;
             case attr_key::generate_skip_accumulation:
                 dnnl_attrs.generate_skip_accumulation

--- a/tests/gtests/graph/unit/backend/graph_compiler/CMakeLists.txt
+++ b/tests/gtests/graph/unit/backend/graph_compiler/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2021-2024 Intel Corporation
+# Copyright 2021-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,7 +50,8 @@ add_library(${OBJ_LIB} OBJECT ${TEST_SRC})
 
 include_directories_with_host_compiler(${OBJ_LIB}
     PRIVATE
-    ${PROJECT_SOURCE_DIR}/tests/gtests/graph # gtest related headers
+    ${PROJECT_SOURCE_DIR}/third_party/gtest # gtest related headers
+    ${PROJECT_SOURCE_DIR}/tests/gtests/graph
     ${PROJECT_SOURCE_DIR}/src/
     ${PROJECT_SOURCE_DIR}/src/graph/backend/graph_compiler/core/src # for context
     ${CMAKE_CURRENT_SOURCE_DIR}/core


### PR DESCRIPTION
- Fix the include paths of itt and gtest after they are moved into `third_party`.
- Fix a variable name change in brgemm.