### PR TITLE
gpu: nvidia: amd: generic: ignore check-ref-impl

### DIFF
--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -832,6 +832,10 @@ int check_same_pd(const dnnl_primitive_desc_t &pd_no_attr, res_t *res) {
 int check_ref_impl_hit(res_t *res) {
     if (!check_ref_impl) return OK;
 
+    // Nvidia, AMD and Generic backends use reference implementations to fill
+    // gaps in feature support.
+    if (is_nvidia_gpu() || is_amd_gpu() || is_generic_gpu()) return OK;
+
     const auto &impl_name = res->impl_name;
     if (impl_name.find("ref") != std::string::npos) {
         res->state = FAILED;
@@ -883,6 +887,14 @@ bool is_amd_gpu(const dnnl_engine_t &engine) {
             = device.get_info<::sycl::info::device::vendor_id>();
     return eng_vendor_id == amd_vendor_id;
 #endif
+    return false;
+}
+
+bool is_generic_gpu(const dnnl_engine_t &engine) {
+#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR == DNNL_VENDOR_GENERIC
+    return is_gpu(engine);
+#endif
+
     return false;
 }
 

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -146,6 +146,7 @@ bool is_opencl_engine(const dnnl_engine_t &engine = get_test_engine());
 bool is_nvidia_gpu(const dnnl_engine_t &engine = get_test_engine());
 bool is_f64_supported(const dnnl_engine_t &engine = get_test_engine());
 bool is_amd_gpu(const dnnl_engine_t &engine = get_test_engine());
+bool is_generic_gpu(const dnnl_engine_t &engine = get_test_engine());
 
 // Extended version of dnnl_sycl_interop_memory_kind_t enumeration.
 enum class memory_kind_ext_t {

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -161,7 +161,8 @@ changes the implementation dispatching which is an undesired behavior. When
 string against the `ref` string pattern. When `BOOL` is set to `true`, the check
 returns an error if the name matches the reference pattern. By default, the
 check is disabled. It's useful to catch unexpected fallbacks to slow reference
-implementations from a big batch of problems.
+implementations from a big batch of problems. This option is always disabled on
+NVIDIA, AMD, and Generic vendors.
 
 ### --fast-ref
 `--fast-ref=BOOL` instructs the driver to use an optimized implementation


### PR DESCRIPTION
# Description

This PR disables the `check-ref-impl` benchdnn flag when used on nvidia, amd or generic vendors. The nvidia and amd vendors use reference implementations to fill gaps in feature support and therefore this change will remove some false positives when testing.   

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
