### PR TITLE
brgconv: fix long pd time for problems with dilation (fixed MFDNN-12916)

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -604,10 +604,9 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             for (int kw = kw_s; kw < kw_f; kw++) {
                 brgemm_convolution_utils::get_ow_range(
                         jcp_, ow, kw, ow_s, ow_f);
-                if (ow_f - ow_s <= 0) continue;
-
-                auto M = ow_f - ow_s;
+                const auto M = ow_f - ow_s;
                 if (M <= 0) continue;
+
                 for (const auto &key_value_pair : batchsizes) {
                     const int kd_b = key_value_pair.first[0];
                     const int kd_e = key_value_pair.first[1];

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -93,10 +93,6 @@ struct brgemm_convolution_fwd_t : public primitive_t {
         Arrmap<4> batchsizes;
         int brg_indices_c {0};
         Arrmap<8> brg_indices;
-
-        void get_kw_range(int ow, int &kw_s, int &kw_full_s, int &kw_full_e,
-                int &kw_e) const;
-        void get_ow_range(int ow, int kw, int &ow_s, int &ow_e) const;
 
         int get_brg_idx(int m, bool do_initialization, bool is_N_tail,
                 bool is_K_tail, int kd_b, int kd_e, int kh_b, int kh_e) const;

--- a/src/cpu/x64/jit_brgemm_conv_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,6 +64,12 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
 status_t init_scratchpad_bwd_w(memory_tracking::registrar_t &scratchpad,
         const jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
         memory_desc_t &diff_weights_md, memory_desc_t &diff_dst_md);
+
+// TODO: make a part of `jit_brgemm_conv_conf_t` instead?
+void get_ow_range(const jit_brgemm_conv_conf_t &jcp, int ow, int kw, int &ow_s,
+        int &ow_f);
+void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int ow, int &kw_s,
+        int &kw_full_s, int &kw_full_f, int &kw_f);
 
 } // namespace brgemm_convolution_utils
 


### PR DESCRIPTION
MFDNN-12916

The reason for slowdown is executing a really long cycle where a full brgemm descriptor as going to be created. In the reality, only a short set of M values must be check.
The reason why this loop is called is dilated convolution can fail the condition for exec_vpad type (left a TODO comment there). This type would only call verification for two M values and that's it.

The solution was to adopt the approach for exec_base type from the actual initialization step.

Measured on sdpdal774583
Timing before (cpdtime is a primitive descriptor creation time):
```
run: --mode=P --conv --dir=FWD_I --dt=u8:s8:u8 --stag=acb --dtag=acb --attr-scales=wei:per_oc --attr-post-ops=relu:0.1+linear:350.855:35 mb1ic32iw129024oc32ow129024kw3pw5dw4
Output template: %impl%,%+cpdtime%
brg_conv_fwd:avx2_vnni_2,37.1177
```

Timing after:
```
run: --mode=P --conv --dir=FWD_I --dt=u8:s8:u8 --stag=acb --dtag=acb --attr-scales=wei:per_oc --attr-post-ops=relu:0.1+linear:350.855:35 mb1ic32iw129024oc32ow129024kw3pw5dw4
Output template: %impl%,%+cpdtime%
brg_conv_fwd:avx2_vnni_2,1.89819
```