### PR TITLE
[GPU] Address clang-tidy complaints

### DIFF
--- a/src/gpu/generic/ref_sum.hpp
+++ b/src/gpu/generic/ref_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ struct ref_sum_t : public gpu::primitive_t {
         using gpu_sum_pd_t::gpu_sum_pd_t;
 
         pd_t(const pd_t &rhs) = default;
-        ~pd_t() = default;
+        ~pd_t() override = default;
 
         DECLARE_SUM_PD_T("ref:any", ref_sum_t);
 

--- a/src/gpu/gpu_binary_list.cpp
+++ b/src/gpu/gpu_binary_list.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ namespace {
 
 // clang-format off
 constexpr impl_list_item_t impl_list[] = REG_BINARY_P({
-        GPU_INSTANCE_INTEL(intel::ocl::multi_po_reorder_binary)
+        GPU_INSTANCE_INTEL(intel::ocl::multi_po_reorder_binary_t)
         GPU_INSTANCE_INTEL(intel::ocl::gen9_binary_t)
         GPU_INSTANCE_INTEL(intel::ocl::simple_binary_t)
         GPU_INSTANCE_NVIDIA(nvidia::cudnn_binary_t)

--- a/src/gpu/gpu_inner_product_pd.hpp
+++ b/src/gpu/gpu_inner_product_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ inline bool dense_gemm_consistency_check(const memory_desc_wrapper &src_d,
             && src_d.is_dense(true) && dst_d.is_dense() && wei_d.is_dense(true);
 }
 
-status_t template_set_default_params(memory_desc_t &src_md,
+inline status_t template_set_default_params(memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t *bias_md, int ndims, bool is_conv = false) {
     using namespace format_tag;

--- a/src/gpu/gpu_sum_list.cpp
+++ b/src/gpu/gpu_sum_list.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ namespace {
 
 // clang-format off
 constexpr impl_list_item_t impl_list[] = REG_SUM_P({
-        GPU_SUM_INSTANCE_INTEL(intel::ocl::multi_po_reorder_sum)
+        GPU_SUM_INSTANCE_INTEL(intel::ocl::multi_po_reorder_sum_t)
         GPU_SUM_INSTANCE_INTEL(intel::ocl::gen9_sum_t)
         GPU_SUM_INSTANCE_INTEL(intel::ocl::many_inputs_sum_t)
         GPU_SUM_INSTANCE_INTEL(intel::ocl::simple_sum_t<data_type::f32>)

--- a/src/gpu/gpu_utils.hpp
+++ b/src/gpu/gpu_utils.hpp
@@ -75,10 +75,10 @@ public:
     scales_query_t() = default;
     scales_query_t(const primitive_attr_t *attr, const memory_desc_wrapper &mdw,
             int arg)
-        : arg_(arg), ndims_(mdw.ndims()) {
-        scales_ = attr->scales_.get(arg);
-        count_ = get_attr_oscales_count(scales_.mask_, mdw);
-    }
+        : scales_(attr->scales_.get(arg))
+        , count_(get_attr_oscales_count(scales_.mask_, mdw))
+        , arg_(arg)
+        , ndims_(mdw.ndims()) {}
 
 private:
     runtime_scales_t scales_;
@@ -123,11 +123,10 @@ public:
     zero_points_query_t() = default;
     zero_points_query_t(const primitive_attr_t *attr,
             const memory_desc_wrapper &mdw, int arg)
-        : arg_(arg), ndims_(mdw.ndims()) {
-        zps_ = attr->zero_points_;
-        int mask = zps_.get(arg);
-        count_ = get_attr_oscales_count(mask, mdw);
-    }
+        : zps_(attr->zero_points_)
+        , count_(get_attr_oscales_count(zps_.get(arg), mdw))
+        , arg_(arg)
+        , ndims_(mdw.ndims()) {}
 
 private:
     zero_points_t zps_;

--- a/src/gpu/gpu_zero_pad_pd.hpp
+++ b/src/gpu/gpu_zero_pad_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ namespace gpu {
 
 struct gpu_zero_pad_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::zero_pad;
-    typedef gpu_zero_pad_pd_t hint_class;
+    using hint_class = gpu_zero_pad_pd_t;
 
     gpu_zero_pad_pd_t(const op_desc_t *adesc, const primitive_attr_t *attr,
             const hint_class *hint_fwd_pd)

--- a/src/gpu/intel/block_structure.hpp
+++ b/src/gpu/intel/block_structure.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ private:
 
 namespace compute {
 template <>
-struct scalar_type_traits<stride_t> {
+struct scalar_type_traits_t<stride_t> {
     static const auto type = scalar_type_t::_long;
 };
 } // namespace compute

--- a/src/gpu/intel/compute/kernel_arg_list.hpp
+++ b/src/gpu/intel/compute/kernel_arg_list.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -103,56 +103,56 @@ inline std::string to_string(scalar_type_t type) {
 }
 
 template <typename T>
-struct scalar_type_traits {};
+struct scalar_type_traits_t {};
 
 template <>
-struct scalar_type_traits<float16_t> {
+struct scalar_type_traits_t<float16_t> {
     static const auto type = scalar_type_t::_half;
 };
 template <>
-struct scalar_type_traits<bfloat16_t> {
+struct scalar_type_traits_t<bfloat16_t> {
     static const auto type = scalar_type_t::_bfloat16;
 };
 template <>
-struct scalar_type_traits<float> {
+struct scalar_type_traits_t<float> {
     static const auto type = scalar_type_t::_float;
 };
 template <>
-struct scalar_type_traits<double> {
+struct scalar_type_traits_t<double> {
     static const auto type = scalar_type_t::_double;
 };
 
 template <>
-struct scalar_type_traits<uint8_t> {
+struct scalar_type_traits_t<uint8_t> {
     static const auto type = scalar_type_t::_uchar;
 };
 template <>
-struct scalar_type_traits<uint16_t> {
+struct scalar_type_traits_t<uint16_t> {
     static const auto type = scalar_type_t::_ushort;
 };
 template <>
-struct scalar_type_traits<uint32_t> {
+struct scalar_type_traits_t<uint32_t> {
     static const auto type = scalar_type_t::_uint;
 };
 template <>
-struct scalar_type_traits<uint64_t> {
+struct scalar_type_traits_t<uint64_t> {
     static const auto type = scalar_type_t::_ulong;
 };
 
 template <>
-struct scalar_type_traits<int8_t> {
+struct scalar_type_traits_t<int8_t> {
     static const auto type = scalar_type_t::_char;
 };
 template <>
-struct scalar_type_traits<int16_t> {
+struct scalar_type_traits_t<int16_t> {
     static const auto type = scalar_type_t::_short;
 };
 template <>
-struct scalar_type_traits<int32_t> {
+struct scalar_type_traits_t<int32_t> {
     static const auto type = scalar_type_t::_int;
 };
 template <>
-struct scalar_type_traits<int64_t> {
+struct scalar_type_traits_t<int64_t> {
     static const auto type = scalar_type_t::_long;
 };
 
@@ -184,7 +184,7 @@ public:
             data_pool = static_cast<char *>(data_pool) + size_;
         }
         kind_ = kernel_arg_kind_t::scalar;
-        scalar_type_ = scalar_type_traits<T>::type;
+        scalar_type_ = scalar_type_traits_t<T>::type;
         new (const_cast<void *>(value_)) T(value);
         return *this;
     }
@@ -211,7 +211,7 @@ public:
     template <typename T>
     T as() const {
         assert(kind() == kernel_arg_kind_t::scalar);
-        assert(scalar_type() == scalar_type_traits<T>::type);
+        assert(scalar_type() == scalar_type_traits_t<T>::type);
         return *(const T *)value();
     }
 
@@ -308,7 +308,7 @@ private:
 template <typename T>
 void set_scalar_arg_cvt(kernel_arg_list_t &arg_list, int index, T scalar,
         scalar_type_t requested_type) {
-    if (scalar_type_traits<T>::type == requested_type) {
+    if (scalar_type_traits_t<T>::type == requested_type) {
         arg_list.set(index, scalar);
         return;
     }

--- a/src/gpu/intel/compute/zero_pool.cpp
+++ b/src/gpu/intel/compute/zero_pool.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -138,10 +138,10 @@ zero_pool_t::zero_pool_t(compute::compute_engine_t *engine, size_t chunk_size,
         bool stream_private, bool in_order)
     : engine_(engine)
     , chunk_size_(chunk_size)
+    , chunk_count_(stream_private ? 1 : 16)
     , stream_private_(stream_private)
     , in_order_(in_order) {
 
-    chunk_count_ = stream_private ? 1 : 16;
     assert(chunk_count_ <= max_chunks);
 }
 

--- a/src/gpu/intel/gpu_primitive.hpp
+++ b/src/gpu/intel/gpu_primitive.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ struct gpu_primitive_t : public gpu::primitive_t {
     private:
         bool empty_impl() const override { return !bool(kernel_); }
 
-        virtual status_t get_cache_blob_size_impl(
+        status_t get_cache_blob_size_impl(
                 impl::engine_t *engine, size_t *size) const override {
             if (empty()) return status::success;
             size_t sz = 0;
@@ -62,7 +62,7 @@ struct gpu_primitive_t : public gpu::primitive_t {
             return status::success;
         }
 
-        virtual status_t get_cache_blob_impl(
+        status_t get_cache_blob_impl(
                 impl::engine_t *engine, cache_blob_t &blob) const override {
             if (empty()) return status::success;
             xpu::binary_t binary;

--- a/src/gpu/intel/jit/gemm/include/kernel_selector.hpp
+++ b/src/gpu/intel/jit/gemm/include/kernel_selector.hpp
@@ -52,7 +52,7 @@ struct MatchParamsBase
     int nExtraReqs = 0;
     const StrategyRequirement *extraReqs = nullptr;
 
-    MatchParamsBase() {}
+    MatchParamsBase() = default;
     MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isIntegrated, const GEMMProblem &problem);
 
 protected:
@@ -61,7 +61,7 @@ protected:
 
 struct MatchParams : public MatchParamsBase
 {
-    MatchParams() : MatchParamsBase() {}
+    MatchParams() = default;
     MatchParams(ngen::HW hw, bool systolicAvailable, bool isIntegrated, const GEMMProblem &problem)
             : MatchParamsBase(hw, systolicAvailable, isIntegrated, problem) {}
 

--- a/src/gpu/intel/jit/gemm/include/kernel_selector.hpp
+++ b/src/gpu/intel/jit/gemm/include/kernel_selector.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -100,10 +100,8 @@ const kcatalog::Entry *upper_bound(const kcatalog::Catalog &catalog, const kcata
 
 class EntryIterator {
 public:
-    EntryIterator(const kcatalog::Catalog &catalog_, const MatchParams &pattern_): catalog(catalog_), pattern(pattern_) {
-        begin = lower_bound(catalog_, pattern_.selector);
-        end   = upper_bound(catalog_, pattern_.selector);
-        current = begin;
+    EntryIterator(const kcatalog::Catalog &catalog_, const MatchParams &pattern_)
+        : catalog(catalog_), pattern(pattern_), begin(lower_bound(catalog_, pattern_.selector)), end(upper_bound(catalog_, pattern_.selector)), current(begin) {
         findNextMatch();
     }
 

--- a/src/gpu/intel/jit/gemm/include/strategy.hpp
+++ b/src/gpu/intel/jit/gemm/include/strategy.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -173,7 +173,7 @@ struct CommonStrategy {
     EmulationStrategy emulate;
                                     ZPAD(C, 2)
 
-    CommonStrategy() {}
+    CommonStrategy() = default;
     CommonStrategy(ngen::HW hw, int stepping = 0);
     void preflight(ngen::HW hw, const CommonProblem &problem);
 };
@@ -315,7 +315,7 @@ struct GEMMStrategyPOD : public CommonStrategy {
     bool insideSK = false;                       // Inside a superkernel?
                                     ZPAD(P, 3)
 
-    GEMMStrategyPOD() {}
+    GEMMStrategyPOD() = default;
     GEMMStrategyPOD(ngen::HW hw, int stepping = 0) : CommonStrategy(hw, stepping) {}
 };
 
@@ -325,7 +325,7 @@ struct GEMMStrategy : public GEMMStrategyPOD
 {
     std::vector<MatrixAddressingStrategy> binary; // Strategies for accessing binary postop data.
 
-    GEMMStrategy() {}
+    GEMMStrategy() = default;
     GEMMStrategy(ngen::HW hw, int stepping = 0) : GEMMStrategyPOD(hw, stepping) {}
 
     void preflight(ngen::HW hw, const GEMMProblem &problem);

--- a/src/gpu/intel/jit/gemm/xe_hp_systolic_gemm.hpp
+++ b/src/gpu/intel/jit/gemm/xe_hp_systolic_gemm.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ struct xe_hp_systolic_gemm_t : public gpu_gemm_t {
 public:
     xe_hp_systolic_gemm_t(const pd_t *apd) : gpu_gemm_t(apd) {}
 
-    virtual status_t execute(const gemm_exec_ctx_t &ctx) const override;
+    status_t execute(const gemm_exec_ctx_t &ctx) const override;
 
 private:
     status_t init_compute(impl::engine_t *engine);

--- a/src/gpu/intel/jit/gen9_simple_sum.hpp
+++ b/src/gpu/intel/jit/gen9_simple_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -63,9 +63,9 @@ struct gen9_simple_sum_t : public gpu_primitive_t {
 
     gen9_simple_sum_t(const pd_t *apd) : gpu_primitive_t(apd) {}
 
-    virtual status_t init(impl::engine_t *engine);
+    status_t init(impl::engine_t *engine) override;
 
-    virtual status_t execute(const exec_ctx_t &ctx) const {
+    status_t execute(const exec_ctx_t &ctx) const override {
         status_t status = status::success;
         auto &output = CTX_OUT_CLEAN_STORAGE(DNNL_ARG_DST, status);
         CHECK(status);

--- a/src/gpu/intel/jit/ir/blocking.hpp
+++ b/src/gpu/intel/jit/ir/blocking.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public:
         return loop_.is_empty() && thread_group_.is_empty() && iter_.is_empty();
     }
     bool is_spatial() const {
-        for (auto d : {pvars::iw, pvars::ow}) {
+        for (const auto &d : {pvars::iw, pvars::ow}) {
             if (iter_.has(d) && iter_[d] != 1) return true;
         }
         return false;

--- a/src/gpu/intel/jit/ir/config.hpp
+++ b/src/gpu/intel/jit/ir/config.hpp
@@ -130,11 +130,7 @@ public:
     }
 
     std::vector<std::string> accepted_keys() const override {
-        std::vector<std::string> ret;
-        ret.push_back("regs");
-        ret.push_back("simd");
-        ret.push_back("vec");
-        return ret;
+        return {"regs", "simd", "vec"};
     }
 
     void set_from_str(

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -395,8 +395,7 @@ public:
 
     type_t(type_kind_t kind, uint32_t elems = 1) : kind_(kind), elems_(elems) {}
 
-    type_t(const std::string &s) {
-        elems_ = 1;
+    type_t(const std::string &s) : elems_(1) {
 #define CASE(x) \
     if (to_string(type_kind_t::x) == s) { \
         kind_ = type_kind_t::x; \

--- a/src/gpu/intel/jit/ir/gemm_schedule.hpp
+++ b/src/gpu/intel/jit/ir/gemm_schedule.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -364,9 +364,9 @@ public:
         oss << " kind: " << kind_;
         if (unroll_factor_ != 1) oss << " unroll: " << unroll_factor_;
         std::vector<std::string> props;
-        if (is_root()) props.push_back("root");
-        if (is_fused_child()) props.push_back("fused");
-        if (is_split_parent()) props.push_back("split");
+        if (is_root()) props.emplace_back("root");
+        if (is_fused_child()) props.emplace_back("fused");
+        if (is_split_parent()) props.emplace_back("split");
         oss << "(" << make_seq_print_helper(props, ", ") << ")";
         return oss.str();
     }
@@ -623,8 +623,9 @@ public:
         }
         auto &fused_loop = create_loop(fused_var, fused_bound);
         std::vector<std::reference_wrapper<loop_t>> loop_refs;
+        loop_refs.reserve(vars.size());
         for (auto &v : vars) {
-            loop_refs.push_back(find_loop(v));
+            loop_refs.emplace_back(find_loop(v));
         }
         fused_loop.set_fuse(loop_refs);
         set_bmnk_kind(fused_var, bmnk_kind(vars));

--- a/src/gpu/intel/jit/ir/ir.hpp
+++ b/src/gpu/intel/jit/ir/ir.hpp
@@ -326,6 +326,7 @@ struct expr_cast_helper_t {
 
     static std::vector<T> call(const std::vector<expr_t> &exprs) {
         std::vector<T> ret;
+        ret.reserve(exprs.size());
         for (auto &e : exprs)
             ret.push_back(to_cpp<T>(e));
         return ret;
@@ -345,6 +346,7 @@ struct expr_cast_helper_t<expr_t> {
             = typename std::enable_if<std::is_arithmetic<U>::value>::type>
     static std::vector<expr_t> call(const std::vector<U> &vec) {
         std::vector<expr_t> ret;
+        ret.reserve(vec.size());
         for (auto &v : vec)
             ret.push_back(to_expr(v));
         return ret;

--- a/src/gpu/intel/jit/ir/kernel_info.hpp
+++ b/src/gpu/intel/jit/ir/kernel_info.hpp
@@ -63,7 +63,7 @@ public:
 
     const memory_storage_t *get() const {
         if (!ptr_) return nullptr;
-        return ptr_.get()->get();
+        return ptr_->get();
     }
 
 private:

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -553,7 +553,8 @@ public:
                     b_str.append(1, '*');
                 }
             }
-            ret = b_str + ret;
+            b_str += ret;
+            std::swap(ret, b_str);
             dense_stride = b.stride * b.block;
             seen[b.dim_idx] = true;
         }

--- a/src/gpu/intel/jit/utils/utils.hpp
+++ b/src/gpu/intel/jit/utils/utils.hpp
@@ -337,8 +337,7 @@ public:
         return false;
 #endif
     }
-    ir_check_log_level_t(int new_level) {
-        old_level_ = level_;
+    ir_check_log_level_t(int new_level) : old_level_(level_) {
         level_ = new_level;
     }
     ~ir_check_log_level_t() { level_ = old_level_; }

--- a/src/gpu/intel/kernel_cache.hpp
+++ b/src/gpu/intel/kernel_cache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ template <typename T>
 struct trivial_key_validator_t {
 
     template <typename V>
-    struct is_trivially_validatable {
+    struct is_trivially_validatable_t {
         using yes_t = uint8_t;
         using no_t = uint16_t;
 
@@ -49,7 +49,7 @@ struct trivial_key_validator_t {
     };
 
     template <typename U,
-            gpu_utils::enable_if_t<is_trivially_validatable<U>::value,
+            gpu_utils::enable_if_t<is_trivially_validatable_t<U>::value,
                     bool> = true>
     static bool is_valid(const U &t) {
         static_assert(std::is_same<T, U>::value,
@@ -58,7 +58,7 @@ struct trivial_key_validator_t {
     }
 
     template <typename U,
-            gpu_utils::enable_if_t<!is_trivially_validatable<U>::value,
+            gpu_utils::enable_if_t<!is_trivially_validatable_t<U>::value,
                     bool> = true>
     static bool is_valid(const U &t) {
         // Runtime validation only occurs in C++20 as default comparisons
@@ -84,10 +84,10 @@ template <typename T>
 struct trivial_key_t : public T {
     // helper for extracting the value type associated with the key
     template <typename S>
-    struct create_signature {};
+    struct create_signature_t {};
 
     template <typename R, typename C, typename A1, typename A2>
-    struct create_signature<R (C::*)(A1, A2) const> {
+    struct create_signature_t<R (C::*)(A1, A2) const> {
         using result_type = R;
         using class_type = C;
         using arg1_type = A1;
@@ -95,7 +95,7 @@ struct trivial_key_t : public T {
     };
 
     using value_type =
-            typename std::remove_reference<typename create_signature<decltype(
+            typename std::remove_reference<typename create_signature_t<decltype(
                     &T::create_generator)>::arg2_type>::type;
 
     trivial_key_t() = delete;

--- a/src/gpu/intel/ocl/gen9_concat.hpp
+++ b/src/gpu/intel/ocl/gen9_concat.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ struct gen9_concat_t : public gpu_primitive_t {
             : gpu_concat_pd_t(attr, dst_md, n, concat_dim, src_mds) {}
 
         pd_t(const pd_t &rhs) = default;
-        ~pd_t() = default;
+        ~pd_t() override = default;
 
         DECLARE_CONCAT_PD_T("gen9:any", gen9_concat_t);
 
@@ -87,7 +87,7 @@ struct gen9_concat_t : public gpu_primitive_t {
         return status::success;
     }
 
-    virtual status_t execute(const exec_ctx_t &ctx) const override {
+    status_t execute(const exec_ctx_t &ctx) const override {
         return execute_concat(ctx);
     }
 

--- a/src/gpu/intel/ocl/multi_concat.hpp
+++ b/src/gpu/intel/ocl/multi_concat.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ struct multi_concat_t : public gpu_primitive_t {
         using gpu_concat_pd_t::gpu_concat_pd_t;
 
         pd_t(const pd_t &rhs) = default;
-        ~pd_t() = default;
+        ~pd_t() override = default;
 
         DECLARE_CONCAT_PD_T("multi:any", multi_concat_t);
 

--- a/src/gpu/intel/ocl/multi_po_reorder_binary.hpp
+++ b/src/gpu/intel/ocl/multi_po_reorder_binary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,12 +33,13 @@ namespace gpu {
 namespace intel {
 namespace ocl {
 
-struct multi_po_reorder_binary : public gpu_primitive_t {
+struct multi_po_reorder_binary_t : public gpu_primitive_t {
     using gpu_primitive_t::gpu_primitive_t;
     struct pd_t : public gpu_binary_pd_t {
         using gpu_binary_pd_t::gpu_binary_pd_t;
 
-        DECLARE_COMMON_PD_T("multi_po_reorder_binary", multi_po_reorder_binary);
+        DECLARE_COMMON_PD_T(
+                "multi_po_reorder_binary", multi_po_reorder_binary_t);
 
         status_t init(impl::engine_t *engine) {
             if (attr()->scales_.get(DNNL_ARG_SRC_0).is_set_

--- a/src/gpu/intel/ocl/multi_po_reorder_sum.hpp
+++ b/src/gpu/intel/ocl/multi_po_reorder_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ struct multi_po_reorder_sum : public gpu_primitive_t {
         using gpu_sum_pd_t::gpu_sum_pd_t;
 
         pd_t(const pd_t &rhs) = default;
-        ~pd_t() = default;
+        ~pd_t() override = default;
 
         DECLARE_SUM_PD_T("multi_po_reorder_sum", multi_po_reorder_sum);
 

--- a/src/gpu/intel/ocl/multi_po_reorder_sum.hpp
+++ b/src/gpu/intel/ocl/multi_po_reorder_sum.hpp
@@ -33,7 +33,7 @@ namespace gpu {
 namespace intel {
 namespace ocl {
 
-struct multi_po_reorder_sum : public gpu_primitive_t {
+struct multi_po_reorder_sum_t : public gpu_primitive_t {
     using gpu_primitive_t::gpu_primitive_t;
     struct pd_t : public gpu_sum_pd_t {
         using gpu_sum_pd_t::gpu_sum_pd_t;
@@ -41,7 +41,7 @@ struct multi_po_reorder_sum : public gpu_primitive_t {
         pd_t(const pd_t &rhs) = default;
         ~pd_t() override = default;
 
-        DECLARE_SUM_PD_T("multi_po_reorder_sum", multi_po_reorder_sum);
+        DECLARE_SUM_PD_T("multi_po_reorder_sum", multi_po_reorder_sum_t);
 
         status_t init(impl::engine_t *engine) {
             VDISPATCH_SUM_SC(

--- a/src/gpu/intel/ocl/ocl_gpu_device_info.hpp
+++ b/src/gpu/intel/ocl/ocl_gpu_device_info.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,11 +35,11 @@ public:
     std::string get_cl_ext_options() const;
 
 protected:
-    status_t init_device_name(impl::engine_t *engine);
-    status_t init_arch(impl::engine_t *engine);
-    status_t init_runtime_version(impl::engine_t *engine);
-    status_t init_extensions(impl::engine_t *engine);
-    status_t init_attributes(impl::engine_t *engine);
+    status_t init_device_name(impl::engine_t *engine) override;
+    status_t init_arch(impl::engine_t *engine) override;
+    status_t init_runtime_version(impl::engine_t *engine) override;
+    status_t init_extensions(impl::engine_t *engine) override;
+    status_t init_attributes(impl::engine_t *engine) override;
 };
 
 } // namespace ocl

--- a/src/gpu/intel/ocl/reduction/ref_reduction.hpp
+++ b/src/gpu/intel/ocl/reduction/ref_reduction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ struct ref_reduction_t : public gpu_primitive_t {
         return status::success;
     }
 
-    virtual status_t execute(const exec_ctx_t &ctx) const override {
+    status_t execute(const exec_ctx_t &ctx) const override {
         return execute_ref(ctx);
     }
 

--- a/src/gpu/intel/ocl/ref_prelu.hpp
+++ b/src/gpu/intel/ocl/ref_prelu.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ struct ref_prelu_fwd_t : public gpu_primitive_t {
         return status::success;
     }
 
-    virtual status_t execute(const exec_ctx_t &ctx) const override {
+    status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
     }
 

--- a/src/gpu/intel/ocl/rnn/cell_common.cpp
+++ b/src/gpu/intel/ocl/rnn/cell_common.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ status_t compute_cell_fwd(const exec_ctx_t &ctx,
 }
 
 template <prop_kind_t aprop>
-cell_execution_sig((_simple_rnn_common_t<aprop>::cell_execution)) {
+cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution)) {
     const conf_t &rnn = this->pd()->rnn_conf;
     const ocl_conf_t &ocl_conf = this->pd()->ocl_conf;
     const rnn_offsets_t &offsets = this->pd()->off;

--- a/src/gpu/intel/ocl/rnn/cell_gru.cpp
+++ b/src/gpu/intel/ocl/rnn/cell_gru.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ using namespace dnnl::impl::utils;
 using namespace rnn_utils;
 
 template <prop_kind_t aprop>
-cell_execution_sig((_simple_rnn_common_t<aprop>::cell_execution_gru)) {
+cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution_gru)) {
     const conf_t &rnn = this->pd()->rnn_conf;
     const ocl_conf_t &ocl_conf = this->pd()->ocl_conf;
     const rnn_offsets_t &offsets = this->pd()->off;

--- a/src/gpu/intel/ocl/rnn/cell_gru_lbr.cpp
+++ b/src/gpu/intel/ocl/rnn/cell_gru_lbr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ template cell_execution_sig(simple_rnn_fwd_t::cell_execution_gru_lbr);
 template cell_execution_sig(simple_rnn_bwd_t::cell_execution_gru_lbr);
 
 template <prop_kind_t aprop>
-cell_execution_sig((_simple_rnn_common_t<aprop>::cell_execution_gru_lbr)) {
+cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution_gru_lbr)) {
     const conf_t &rnn = this->pd()->rnn_conf;
     const ocl_conf_t &ocl_conf = this->pd()->ocl_conf;
     const rnn_offsets_t &offsets = this->pd()->off;

--- a/src/gpu/intel/ocl/rnn/rnn_grid.cpp
+++ b/src/gpu/intel/ocl/rnn/rnn_grid.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -461,7 +461,7 @@ status_t ocl_conf_t::init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const {
 }
 
 template <>
-status_t _simple_rnn_common_t<prop_kind::forward>::pd_t::set_default_params() {
+status_t simple_rnn_common_t<prop_kind::forward>::pd_t::set_default_params() {
     using namespace format_tag;
     if (src_layer_md_.format_kind == format_kind::any)
         CHECK(memory_desc_init_by_tag(src_layer_md_, tnc));
@@ -489,7 +489,7 @@ status_t _simple_rnn_common_t<prop_kind::forward>::pd_t::set_default_params() {
 }
 
 template <>
-status_t _simple_rnn_common_t<prop_kind::backward>::pd_t::set_default_params() {
+status_t simple_rnn_common_t<prop_kind::backward>::pd_t::set_default_params() {
     using namespace format_tag;
     int arch_ld = is_xe_hpc ? 128 : 64;
     if (src_layer_md_.format_kind == format_kind::any)
@@ -564,7 +564,7 @@ status_t _simple_rnn_common_t<prop_kind::backward>::pd_t::set_default_params() {
 }
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
+status_t simple_rnn_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
     using namespace prop_kind;
     using namespace utils;
     using namespace rnn_utils;
@@ -948,7 +948,7 @@ status_t _simple_rnn_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
 }
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::init(impl::engine_t *engine) {
+status_t simple_rnn_common_t<aprop>::init(impl::engine_t *engine) {
     using namespace rnn_utils;
 
     switch (pd()->cell_kind()) {
@@ -1043,7 +1043,7 @@ status_t _simple_rnn_common_t<aprop>::init(impl::engine_t *engine) {
 }
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::init_res_storage(
+status_t simple_rnn_common_t<aprop>::init_res_storage(
         impl::engine_t *engine, gpu_resource_t *r) const {
     if (pd()->rnn_conf.is_int8 && pd()->rnn_conf.copy_bias) {
         dim_t size = pd()->rnn_conf.n_gates * pd()->rnn_conf.dhc
@@ -1086,7 +1086,7 @@ status_t _simple_rnn_common_t<aprop>::init_res_storage(
 }
 
 template <prop_kind_t aprop>
-gemm_sig((_simple_rnn_common_t<aprop>::gemm_primitive)) {
+gemm_sig((simple_rnn_common_t<aprop>::gemm_primitive)) {
     // We flip A and B here since the GEMM API is row major but the
     // RNN code describes GEMM in column major fashion
     gemm_exec_args_t gemm_args;
@@ -1171,7 +1171,7 @@ gemm_sig((_simple_rnn_common_t<aprop>::gemm_primitive)) {
 
 //*************** Grid computations strategy: linear ***************//
 template <prop_kind_t aprop>
-grid_execution_sig((_simple_rnn_common_t<aprop>::linear_execution)) {
+grid_execution_sig((simple_rnn_common_t<aprop>::linear_execution)) {
     const conf_t &rnn = pd()->rnn_conf;
     dim_t n_layer = rnn.n_layer;
     dim_t n_dir = rnn.n_dir;
@@ -1257,7 +1257,7 @@ grid_execution_sig((_simple_rnn_common_t<aprop>::linear_execution)) {
 //********* GRID computations strategy: utility functions **********//
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::bias_prepare(const exec_ctx_t &ctx,
+status_t simple_rnn_common_t<aprop>::bias_prepare(const exec_ctx_t &ctx,
         compute::compute_stream_t *compute_stream, dim_t n_layer, dim_t n_dir,
         dim_t n_bias, dim_t n_gates, dim_t dhc, const memory_storage_t &ws_bias,
         const memory_storage_t &scales, const memory_storage_t &wei_layer,
@@ -1289,7 +1289,7 @@ status_t _simple_rnn_common_t<aprop>::bias_prepare(const exec_ctx_t &ctx,
 }
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::copy_init_layer(const exec_ctx_t &ctx,
+status_t simple_rnn_common_t<aprop>::copy_init_layer(const exec_ctx_t &ctx,
         compute::compute_stream_t *compute_stream, bool lr, bool rl,
         dim_t batch, dim_t dhc, dim_t slc, dim_t n_iter, dim_t n_layer,
         dim_t n_dir, dim_t n_states, dim_t states_ws_ld,
@@ -1348,7 +1348,7 @@ status_t _simple_rnn_common_t<aprop>::copy_init_layer(const exec_ctx_t &ctx,
 }
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::copy_init_iter(const exec_ctx_t &ctx,
+status_t simple_rnn_common_t<aprop>::copy_init_iter(const exec_ctx_t &ctx,
         compute::compute_stream_t *compute_stream, dim_t batch, dim_t dhc,
         dim_t sic, dim_t n_iter, dim_t n_layer, dim_t n_dir, dim_t n_states,
         dim_t states_ws_ld, dim_t scratch_diff_states_ld,
@@ -1420,7 +1420,7 @@ status_t _simple_rnn_common_t<aprop>::copy_init_iter(const exec_ctx_t &ctx,
 }
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::copy_res_layer(const exec_ctx_t &ctx,
+status_t simple_rnn_common_t<aprop>::copy_res_layer(const exec_ctx_t &ctx,
         compute::compute_stream_t *compute_stream, bool lr, bool rl,
         dim_t batch, dim_t dhc, dim_t slc, dim_t n_iter, dim_t n_layer,
         dim_t n_dir, dim_t n_states, dim_t states_ws_ld,
@@ -1482,7 +1482,7 @@ status_t _simple_rnn_common_t<aprop>::copy_res_layer(const exec_ctx_t &ctx,
 }
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::copy_res_iter(const exec_ctx_t &ctx,
+status_t simple_rnn_common_t<aprop>::copy_res_iter(const exec_ctx_t &ctx,
         compute::compute_stream_t *compute_stream, dim_t batch, dim_t dhc,
         dim_t sic, dim_t n_iter, dim_t n_layer, dim_t n_dir, dim_t n_states,
         dim_t states_ws_ld, dim_t scratch_diff_states_ld,
@@ -1557,7 +1557,7 @@ status_t _simple_rnn_common_t<aprop>::copy_res_iter(const exec_ctx_t &ctx,
 //********************* Execution function *********************//
 
 template <prop_kind_t aprop>
-status_t _simple_rnn_common_t<aprop>::execute_(const exec_ctx_t &ctx) const {
+status_t simple_rnn_common_t<aprop>::execute_(const exec_ctx_t &ctx) const {
 
     impl::engine_t *engine = ctx.stream()->engine();
     auto *compute_stream
@@ -1722,8 +1722,8 @@ elemwise_sig_gru(simple_rnn_fwd_t::gru_elemwise);
 template <>
 elemwise_sig_gru(simple_rnn_bwd_t::gru_elemwise);
 
-template struct _simple_rnn_common_t<prop_kind::forward>;
-template struct _simple_rnn_common_t<prop_kind::backward>;
+template struct simple_rnn_common_t<prop_kind::forward>;
+template struct simple_rnn_common_t<prop_kind::backward>;
 
 } // namespace ocl
 } // namespace intel

--- a/src/gpu/intel/ocl/rnn/rnn_grid.hpp
+++ b/src/gpu/intel/ocl/rnn/rnn_grid.hpp
@@ -55,10 +55,10 @@ enum gemm_kind_t {
 };
 
 template <prop_kind_t aprop>
-struct _simple_rnn_common_t : public gpu_primitive_t {
+struct simple_rnn_common_t : public gpu_primitive_t {
     using gpu_primitive_t::gpu_primitive_t;
 
-    using class_name = _simple_rnn_common_t<aprop>;
+    using class_name = simple_rnn_common_t<aprop>;
 
     using elemwise_f = elemwise_sig((class_name::*));
     using elemwise_gru_f = elemwise_sig_gru((class_name::*));
@@ -263,8 +263,8 @@ private:
 
     enum { SCALES_ = 0, TM_SCALES_ = 1 };
 };
-using simple_rnn_fwd_t = _simple_rnn_common_t<prop_kind::forward>;
-using simple_rnn_bwd_t = _simple_rnn_common_t<prop_kind::backward>;
+using simple_rnn_fwd_t = simple_rnn_common_t<prop_kind::forward>;
+using simple_rnn_bwd_t = simple_rnn_common_t<prop_kind::backward>;
 } // namespace ocl
 } // namespace intel
 } // namespace gpu

--- a/src/gpu/intel/ocl/rnn/rnn_grid.hpp
+++ b/src/gpu/intel/ocl/rnn/rnn_grid.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,12 +60,12 @@ struct _simple_rnn_common_t : public gpu_primitive_t {
 
     using class_name = _simple_rnn_common_t<aprop>;
 
-    typedef elemwise_sig((class_name::*elemwise_f));
-    typedef elemwise_sig_gru((class_name::*elemwise_gru_f));
-    typedef elemwise_sig_gru_lbr((class_name::*elemwise_gru_lbr_f));
-    typedef cell_execution_sig((class_name::*cell_execution_f));
-    typedef grid_execution_sig((class_name::*grid_execution_f));
-    typedef gemm_sig((class_name::*gemm_t));
+    using elemwise_f = elemwise_sig((class_name::*));
+    using elemwise_gru_f = elemwise_sig_gru((class_name::*));
+    using elemwise_gru_lbr_f = elemwise_sig_gru_lbr((class_name::*));
+    using cell_execution_f = cell_execution_sig((class_name::*));
+    using grid_execution_f = grid_execution_sig((class_name::*));
+    using gemm_t = gemm_sig((class_name::*));
 
     using base_pd_t =
             typename utils::conditional<false || aprop == prop_kind::forward,

--- a/src/gpu/intel/ocl/rnn/rnn_utils.hpp
+++ b/src/gpu/intel/ocl/rnn/rnn_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -805,7 +805,7 @@ struct scratch_t : public data_helper_t {
         diff_ht_ = scratchpad.get_memory_storage(key_rnn_diff_ht);
     }
 
-    struct gemm_pds {
+    struct gemm_pds_t {
         const primitive_desc_t *iter_fwd_pd;
         const primitive_desc_t *iter_fwd_2_pd;
         const primitive_desc_t *layer_fwd_pd;
@@ -821,7 +821,7 @@ struct scratch_t : public data_helper_t {
     };
 
     static void book(memory_tracking::registrar_t &scratchpad,
-            const conf_t &rnn_conf, const gemm_pds &gemms) {
+            const conf_t &rnn_conf, const gemm_pds_t &gemms) {
         using namespace memory_tracking::names;
         if (rnn_conf.scratch_gates_size > 0)
             scratchpad.book(key_rnn_gates, rnn_conf.scratch_gates_size, 1,

--- a/src/gpu/intel/ocl/rnn/simple_rnn_postgemm.cpp
+++ b/src/gpu/intel/ocl/rnn/simple_rnn_postgemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ using namespace dnnl::impl::gpu::intel::gpu_utils;
 using namespace rnn_utils;
 
 template <prop_kind_t aprop>
-elemwise_sig((_simple_rnn_common_t<aprop>::rnn_elemwise)) {
+elemwise_sig((simple_rnn_common_t<aprop>::rnn_elemwise)) {
     auto nd_range = get_nd_range({dhc,
             utils::div_up(
                     batch, aprop == prop_kind::forward ? 1 : bwd_batch_block)});
@@ -101,7 +101,7 @@ template elemwise_sig(simple_rnn_fwd_t::rnn_elemwise);
 template elemwise_sig(simple_rnn_bwd_t::rnn_elemwise);
 
 template <prop_kind_t aprop>
-elemwise_sig((_simple_rnn_common_t<aprop>::lstm_elemwise)) {
+elemwise_sig((simple_rnn_common_t<aprop>::lstm_elemwise)) {
     auto nd_range = get_nd_range({dhc,
             utils::div_up(
                     batch, aprop == prop_kind::forward ? 1 : bwd_batch_block)});
@@ -176,7 +176,7 @@ template elemwise_sig(simple_rnn_fwd_t::lstm_elemwise);
 template elemwise_sig(simple_rnn_bwd_t::lstm_elemwise);
 
 template <prop_kind_t aprop>
-elemwise_sig((_simple_rnn_common_t<aprop>::lstm_elemwise_u8s8)) {
+elemwise_sig((simple_rnn_common_t<aprop>::lstm_elemwise_u8s8)) {
     auto nd_range = get_nd_range({dhc,
             utils::div_up(
                     batch, aprop == prop_kind::forward ? 1 : bwd_batch_block)});
@@ -235,7 +235,7 @@ template elemwise_sig(simple_rnn_fwd_t::lstm_elemwise_u8s8);
 template elemwise_sig(simple_rnn_bwd_t::lstm_elemwise_u8s8);
 
 template <prop_kind_t aprop>
-elemwise_sig_gru_lbr((_simple_rnn_common_t<aprop>::gru_lbr_elemwise)) {
+elemwise_sig_gru_lbr((simple_rnn_common_t<aprop>::gru_lbr_elemwise)) {
     auto nd_range = get_nd_range({dhc,
             utils::div_up(
                     batch, aprop == prop_kind::forward ? 1 : bwd_batch_block)});
@@ -311,7 +311,7 @@ template elemwise_sig_gru_lbr(simple_rnn_fwd_t::gru_lbr_elemwise);
 template elemwise_sig_gru_lbr(simple_rnn_bwd_t::gru_lbr_elemwise);
 
 template <prop_kind_t aprop>
-elemwise_sig_gru((_simple_rnn_common_t<aprop>::gru_elemwise)) {
+elemwise_sig_gru((simple_rnn_common_t<aprop>::gru_elemwise)) {
     auto nd_range = get_nd_range({dhc,
             utils::div_up(
                     batch, aprop == prop_kind::forward ? 1 : bwd_batch_block)});

--- a/src/gpu/intel/ocl/simple_sum.hpp
+++ b/src/gpu/intel/ocl/simple_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ struct simple_sum_t : public gpu_primitive_t {
     status_t execute(const exec_ctx_t &ctx) const override;
 
     enum { max_num_arrs = 16 };
-    typedef typename prec_traits<data_type>::type data_t;
+    using data_t = typename prec_traits<data_type>::type;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/gpu/intel/ocl/types_interop.hpp
+++ b/src/gpu/intel/ocl/types_interop.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2024 Intel Corporation
+ * Copyright 2024-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,37 +27,37 @@ namespace intel {
 namespace compute {
 
 template <>
-struct scalar_type_traits<int64x2_t> {
+struct scalar_type_traits_t<int64x2_t> {
     static const auto type = scalar_type_t::_int64x3_t;
 };
 
 template <>
-struct scalar_type_traits<int64x3_t> {
+struct scalar_type_traits_t<int64x3_t> {
     static const auto type = scalar_type_t::_int64x3_t;
 };
 
 template <>
-struct scalar_type_traits<int64x4_t> {
+struct scalar_type_traits_t<int64x4_t> {
     static const auto type = scalar_type_t::_int64x4_t;
 };
 
 template <>
-struct scalar_type_traits<int64x5_t> {
+struct scalar_type_traits_t<int64x5_t> {
     static const auto type = scalar_type_t::_int64x5_t;
 };
 
 template <>
-struct scalar_type_traits<int64x6_t> {
+struct scalar_type_traits_t<int64x6_t> {
     static const auto type = scalar_type_t::_int64x6_t;
 };
 
 template <>
-struct scalar_type_traits<dispatch_gws_rt_params_t> {
+struct scalar_type_traits_t<dispatch_gws_rt_params_t> {
     static const auto type = scalar_type_t::_dispatch_gws_rt_params_t;
 };
 
 template <>
-struct scalar_type_traits<zero_pad_mask_t> {
+struct scalar_type_traits_t<zero_pad_mask_t> {
     static const auto type = scalar_type_t::_zero_pad_mask_t;
 };
 

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -104,23 +104,23 @@ struct attr_info_t {
 template <size_t ndims>
 using strides_t = std::array<dim_t, ndims>;
 template <>
-struct compute::scalar_type_traits<strides_t<2>> {
+struct compute::scalar_type_traits_t<strides_t<2>> {
     static const auto type = scalar_type_t::_int64x3_t;
 };
 template <>
-struct compute::scalar_type_traits<strides_t<3>> {
+struct compute::scalar_type_traits_t<strides_t<3>> {
     static const auto type = scalar_type_t::_int64x3_t;
 };
 template <>
-struct compute::scalar_type_traits<strides_t<4>> {
+struct compute::scalar_type_traits_t<strides_t<4>> {
     static const auto type = scalar_type_t::_int64x4_t;
 };
 template <>
-struct compute::scalar_type_traits<strides_t<5>> {
+struct compute::scalar_type_traits_t<strides_t<5>> {
     static const auto type = scalar_type_t::_int64x5_t;
 };
 template <>
-struct compute::scalar_type_traits<strides_t<6>> {
+struct compute::scalar_type_traits_t<strides_t<6>> {
     static const auto type = scalar_type_t::_int64x5_t;
 };
 

--- a/src/gpu/intel/serialization.hpp
+++ b/src/gpu/intel/serialization.hpp
@@ -59,7 +59,7 @@ struct serialized_data_t {
     void set_data(std::vector<uint8_t> d) { this->data = std::move(d); }
 
     template <typename T>
-    struct has_serialize {
+    struct has_serialize_t {
         using yes_t = uint8_t;
         using no_t = uint16_t;
 
@@ -77,7 +77,7 @@ struct serialized_data_t {
     // Append helper function for structures with the member function
     // void serialize(serialized_data_t &) const
     template <typename T,
-            gpu_utils::enable_if_t<has_serialize<T>::value, bool> = true>
+            gpu_utils::enable_if_t<has_serialize_t<T>::value, bool> = true>
     void append(const T &t) {
         t.serialize(*this);
     }
@@ -85,7 +85,7 @@ struct serialized_data_t {
     // Append helper function for trivially serialized objects
     template <typename T,
             gpu_utils::enable_if_t<is_trivially_serialized<T>::value
-                            && !has_serialize<T>::value,
+                            && !has_serialize_t<T>::value,
                     bool> = true>
     void append(const T &t) {
         std::array<uint8_t, sizeof(T)> type_data;
@@ -176,7 +176,7 @@ struct deserializer_t {
     deserializer_t(const serialized_data_t &s) : idx(0), s(s) {}
 
     template <typename T>
-    struct has_deserialize {
+    struct has_deserialize_t {
         using yes_t = uint8_t;
         using no_t = uint16_t;
 
@@ -194,12 +194,12 @@ struct deserializer_t {
     // Helper function for structures with the static member function
     // void deserialize(deserializer_t&)
     template <typename T,
-            gpu_utils::enable_if_t<has_deserialize<T>::value, bool> = true>
+            gpu_utils::enable_if_t<has_deserialize_t<T>::value, bool> = true>
     void pop(T &t) {
         t = T::deserialize(*this);
     }
     template <typename T,
-            gpu_utils::enable_if_t<has_deserialize<T>::value, bool> = true>
+            gpu_utils::enable_if_t<has_deserialize_t<T>::value, bool> = true>
     T pop() {
         return T::deserialize(*this);
     }
@@ -207,7 +207,7 @@ struct deserializer_t {
     template <typename T,
             gpu_utils::enable_if_t<
                     serialized_data_t::is_trivially_serialized<T>::value
-                            && !has_deserialize<T>::value,
+                            && !has_deserialize_t<T>::value,
                     bool> = true>
     void pop(T &t) {
         t = s.get<T>(idx);
@@ -216,7 +216,7 @@ struct deserializer_t {
     template <typename T,
             gpu_utils::enable_if_t<
                     serialized_data_t::is_trivially_serialized<T>::value
-                            && !has_deserialize<T>::value,
+                            && !has_deserialize_t<T>::value,
                     bool> = true>
     T pop() {
         auto idx_start = idx;


### PR DESCRIPTION
Addresses most of the clang-tidy hits in [MFDNN-13007](https://jira.devtools.intel.com/browse/MFDNN-13007). Missing are fixes for macro warnings and emulation.hpp class name styling.

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?