### PR TITLE
ci: linters: OS fix for clang-format 

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   pr-formatting:
     name: Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Formatting job uses ubuntu-latest version which is ubuntu 24.04. This version doesn't have clang-format 11 in default packages. Changed os version to 22.04.