### PR TITLE
[GPU] Logging cleanup

### DIFF
--- a/src/gpu/intel/jit/codegen/bank_conflict_allocation.cpp
+++ b/src/gpu/intel/jit/codegen/bank_conflict_allocation.cpp
@@ -779,12 +779,12 @@ bank_conflict_allocation_t bank_conflict_allocation_t::create(
         found = search(ctx);
 #ifdef DNNL_DEV_MODE
         search_time = get_msec() - search_time;
-        ir_trace() << "Bank conflict allocation:" << std::endl;
-        ir_trace() << "    Search time: " << search_time << " ms" << std::endl;
-        ir_trace() << "    Status: " << (found ? "OK" : "FAIL") << std::endl;
-        ir_trace() << "    Steps: " << ctx.steps << std::endl;
+        ir_trace() << "Bank conflict allocation:";
+        ir_trace() << "    Search time: " << search_time << " ms";
+        ir_trace() << "    Status: " << (found ? "OK" : "FAIL");
+        ir_trace() << "    Steps: " << ctx.steps;
         ir_trace() << "    Bundle check: "
-                   << ir_utils::to_string(ctx.check_bundles) << std::endl;
+                   << ir_utils::to_string(ctx.check_bundles);
 #endif
         if (found) break;
     }

--- a/src/gpu/intel/jit/codegen/bank_conflict_allocation.hpp
+++ b/src/gpu/intel/jit/codegen/bank_conflict_allocation.hpp
@@ -40,15 +40,15 @@ public:
     int refs() const { return refs_; }
 
     void retain() {
-        ir_assert(refs_ > 0);
+        gpu_assert(refs_ > 0);
         refs_++;
     }
 
     void release(const expr_t &buf) {
-        ir_assert(refs_ > 0);
+        gpu_assert(refs_ > 0);
         refs_--;
         auto it = buf_map_.find(buf);
-        ir_assert(it != buf_map_.end()) << "Buffer not found: " << buf;
+        gpu_assert(it != buf_map_.end()) << "Buffer not found: " << buf;
         it->second.release(*ra_);
         buf_map_.erase(it);
     }
@@ -60,7 +60,7 @@ public:
     void set_reg_buf(const expr_t &buf, const reg_buf_t &reg_buf) {
         auto ret = buf_map_.emplace(buf, reg_buf);
         reg_buf.claim(*ra_);
-        ir_assert(ret.second) << "Buffer already exists: " << buf;
+        gpu_assert(ret.second) << "Buffer already exists: " << buf;
     }
 
     static bank_conflict_allocation_t create(

--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -64,11 +64,9 @@ public:
     ~ir_to_ngen_t() {
 #ifdef DNNL_DEV_MODE
         if (bank_conflicts_ > 0)
-            ir_warning() << "Found bank conflicts: " << bank_conflicts_
-                         << std::endl;
+            ir_warning() << "Found bank conflicts: " << bank_conflicts_;
         if (bundle_conflicts_ > 0)
-            ir_warning() << "Found bundle conflicts: " << bundle_conflicts_
-                         << std::endl;
+            ir_warning() << "Found bundle conflicts: " << bundle_conflicts_;
 #endif
     }
 
@@ -95,7 +93,7 @@ public:
             expr_binding_.bind(obj.buf, rbd);
         }
         ir_trace() << "codegen:bind " << obj.buf << " -> "
-                   << expr_binding_.get(obj.buf) << std::endl;
+                   << expr_binding_.get(obj.buf);
         visit(obj.body);
         if (do_alloc) expr_binding_.unbind(obj.buf);
         if (use_bc_alloc) release_bank_conflict_allocation(obj);
@@ -112,7 +110,7 @@ public:
         host_->emov(1, var_op, init_op);
         expr_binding_.bind(obj.var, var_op);
         ir_trace() << "codegen:bind " << obj.var << " -> "
-                   << expr_binding_.get(obj.var) << std::endl;
+                   << expr_binding_.get(obj.var);
         // For dynamic loops use standard format otherwise
         // use do-while format.
         if (dynamic_loop) {
@@ -221,8 +219,7 @@ public:
     void _visit(const let_t &obj) override {
         if (obj.value.is_empty()) {
             auto var_op = expr_binding_.get(obj.var);
-            ir_trace() << "codegen:bind " << obj.var << " -> " << var_op
-                       << std::endl;
+            ir_trace() << "codegen:bind " << obj.var << " -> " << var_op;
             // External variable, must be already bound.
             ir_assert(expr_binding_.is_bound(obj.var))
                     << "Variable is not defined: " << obj.var;
@@ -245,8 +242,7 @@ public:
         }
 
         auto var_op = expr_binding_.get(obj.var);
-        ir_trace() << "codegen:bind " << obj.var << " -> " << var_op
-                   << std::endl;
+        ir_trace() << "codegen:bind " << obj.var << " -> " << var_op;
 
         // At this point the scope contains allocations for temporary
         // expressions. We need to 1) query and later re-claim the allocation

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -324,7 +324,7 @@ public:
                 auto alloc_buf
                         = alloc_mgr.find_buffer(name, /*allow_empty=*/true);
                 if (alloc_buf.is_empty()) {
-                    ir_warning() << "Unused argument: " << arg_var << std::endl;
+                    ir_warning() << "Unused argument: " << arg_var;
                     continue;
                 }
                 ir_assert(alloc_buf.is_same(arg_var));

--- a/src/gpu/intel/jit/codegen/ngen_helpers.hpp
+++ b/src/gpu/intel/jit/codegen/ngen_helpers.hpp
@@ -44,14 +44,14 @@ T to_cpp(const ngen::Immediate &imm) {
         case ngen::DataType::uq: return (T)utils::bit_cast<uint64_t>(u64);
         case ngen::DataType::f:
             return (T)utils::bit_cast<std::array<float, 2>>(u64)[0];
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return 0;
 }
 
 // type_t to ngen::DataType convertor.
 inline ngen::DataType to_ngen(const type_t &type) {
-    ir_assert(type.is_scalar()) << "Expected scalar type.";
+    gpu_assert(type.is_scalar()) << "Expected scalar type.";
 
 #define CASE(_kind, ngen_enum) \
     if (type.kind() == type_kind_t::_kind) return ngen::DataType::ngen_enum
@@ -75,7 +75,7 @@ inline ngen::DataType to_ngen(const type_t &type) {
     if (type == type_t::byte_ptr()) return ngen::DataType::uq;
 
 #undef CASE
-    ir_error_not_expected();
+    gpu_error_not_expected();
     return ngen::DataType::invalid;
 }
 
@@ -100,13 +100,13 @@ inline type_t to_ir(ngen::DataType type) {
     CASE(u8, ub);
 
 #undef CASE
-    ir_error_not_expected();
+    gpu_error_not_expected();
     return type_t::undef();
 }
 
 inline ngen::Immediate to_ngen(
         const expr_t &expr, const type_t &type = type_t::undef()) {
-    ir_assert(expr.type().is_scalar()) << "Vector types are not supported.";
+    gpu_assert(expr.type().is_scalar()) << "Vector types are not supported.";
     if (expr.is<int_imm_t>()) {
         auto &imm = expr.as<int_imm_t>();
         // No conversion.
@@ -124,15 +124,15 @@ inline ngen::Immediate to_ngen(
         CASE(uint64_t);
 
 #undef CASE
-        ir_error_not_expected() << "Can't convert expression: " << expr;
+        gpu_error_not_expected() << "Can't convert expression: " << expr;
     } else if (expr.is<float_imm_t>()) {
-        ir_assert(utils::one_of(type, type_t::undef(), type_t::f32()))
+        gpu_assert(utils::one_of(type, type_t::undef(), type_t::f32()))
                 << "Conversion is not supported.";
         auto &imm = expr.as<float_imm_t>();
         if (imm.type.is_f32()) { return ngen::Immediate((float)imm.value); }
         return ngen::Immediate(imm.value);
     }
-    ir_error_not_expected() << "Can't convert expression: " << expr;
+    gpu_error_not_expected() << "Can't convert expression: " << expr;
     return ngen::Immediate();
 }
 
@@ -151,7 +151,7 @@ inline ngen::InstructionModifier to_ngen(
 inline ngen::AtomicOp to_ngen(ngen_proxy::AtomicOp atomic_op) {
     switch (atomic_op) {
         case ngen_proxy::AtomicOp::fadd: return ngen::AtomicOp::fadd;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return ngen::AtomicOp(std::numeric_limits<uint16_t>::max());
 }
@@ -161,7 +161,7 @@ inline ngen::Immediate ngen_negate(const ngen::Immediate &imm) {
         case ngen::DataType::w: return ngen::Immediate(-to_cpp<int16_t>(imm));
         case ngen::DataType::d: return ngen::Immediate(-to_cpp<int32_t>(imm));
         case ngen::DataType::f: return ngen::Immediate(-to_cpp<float>(imm));
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return ngen::Immediate();
 }

--- a/src/gpu/intel/jit/codegen/operand.cpp
+++ b/src/gpu/intel/jit/codegen/operand.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,8 +60,8 @@ std::string ngen_operand_t::str() const {
     auto &rb = rbd.reg_buf();
     std::ostringstream oss;
     if (rbd.type() != ngen::DataType::invalid) {
-        ir_assert(rb.blocks() == 1);
-        ir_assert(!rb.with_permute());
+        gpu_assert(rb.blocks() == 1);
+        gpu_assert(!rb.with_permute());
         oss << "r" << rbd.base() << ".";
         oss << rbd.offset() << ":";
         oss << to_string(rbd.type());

--- a/src/gpu/intel/jit/codegen/operand.hpp
+++ b/src/gpu/intel/jit/codegen/operand.hpp
@@ -62,12 +62,12 @@ public:
     }
 
     const ngen::Immediate &immediate() const {
-        ir_assert(is_immediate());
+        gpu_assert(is_immediate());
         return *(const ngen::Immediate *)ptr_.get();
     }
 
     const reg_buf_data_t &reg_buf_data() const {
-        ir_assert(is_reg_buf_data());
+        gpu_assert(is_reg_buf_data());
         return *(const reg_buf_data_t *)ptr_.get();
     }
 
@@ -77,7 +77,7 @@ public:
     }
 
     const ngen::FlagRegister &flag_register() const {
-        ir_assert(is_flag_register());
+        gpu_assert(is_flag_register());
         return *(const ngen::FlagRegister *)ptr_.get();
     }
 
@@ -110,7 +110,7 @@ public:
     ngen::DataType type() const {
         if (is_immediate()) return immediate().getType();
         if (is_reg_buf_data()) return reg_buf_data().type();
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return ngen::DataType::invalid;
     }
 
@@ -121,12 +121,12 @@ public:
             ret.is_negated_ = !ret.is_negated_;
             return ret;
         }
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return ngen_operand_t();
     }
 
     ngen_operand_t reinterpret(const type_t &new_type) const {
-        ir_assert(new_type.is_scalar());
+        gpu_assert(new_type.is_scalar());
         return ngen_operand_t(
                 reg_buf_data().reinterpret(to_ngen(new_type)), mod_);
     }
@@ -155,7 +155,7 @@ public:
                 return flag_register() == other.flag_register();
             case ngen_operand_kind_t::reg_buf_data:
                 return reg_buf_data() == other.reg_buf_data();
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return false;
     }
@@ -179,7 +179,7 @@ private:
             case ngen_operand_kind_t::flag_register:
                 delete (ngen::FlagRegister *)ptr;
                 break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
     }
 
@@ -195,7 +195,7 @@ private:
 
 template <typename T>
 T to_cpp(ngen::HW hw, const ngen_operand_t &op) {
-    ir_assert(op.is_immediate());
+    gpu_assert(op.is_immediate());
     return to_cpp<T>(op.immediate());
 }
 

--- a/src/gpu/intel/jit/codegen/reduce.hpp
+++ b/src/gpu/intel/jit/codegen/reduce.hpp
@@ -45,7 +45,7 @@ public:
         bool is_inplace = (src_rd.base() == dst_rd.base()
                 && src_rd.byte_offset() == dst_rd.byte_offset());
         if (is_inplace) {
-            ir_assert(src_type == dst_type)
+            gpu_assert(src_type == dst_type)
                     << "Inplace operation is supported for the same type only.";
         }
 
@@ -55,7 +55,7 @@ public:
         int tile_elems = (int)tile.elems();
         auto src_tile_layout = src_layout_.map(tile);
         auto src_tile_blocks = src_tile_layout.blocks();
-        ir_assert(src_tile_blocks.size() <= 1);
+        gpu_assert(src_tile_blocks.size() <= 1);
         ngen_register_scope_t block_scope(scope.register_allocator());
         int src_stride
                 = src_tile_blocks.empty() ? 1 : (int)src_tile_blocks[0].stride;
@@ -74,7 +74,7 @@ public:
                     if (is_inplace) {
                         bool same_src_dst = (dst_off == src_off);
                         if (!seen[dst_off] && !same_src_dst) {
-                            ir_error_not_expected()
+                            gpu_error_not_expected()
                                     << "Invalid inplace reduction.";
                         }
                         seen[dst_off] = true;
@@ -119,7 +119,7 @@ private:
     tensor_t find_1d_tile(layout_t a, layout_t b) const {
         layout_t::align_layouts(a, b);
 
-        ir_assert(!a.blocks().empty());
+        gpu_assert(!a.blocks().empty());
         // Allow trivial tile for scalar dst.
         if (b.blocks().empty()) { return tensor_t(dst_layout_.dims()); }
 
@@ -138,7 +138,7 @@ private:
             return tensor_t(std::vector<dim_t>(b.ndims(), 1));
         }
 
-        ir_assert(dim_t(b0.stride) == 1)
+        gpu_assert(dim_t(b0.stride) == 1)
                 << "Reduction is not supported for non-unit dst stride.";
 
         int grf_size = ngen::GRF::bytes(hw_);
@@ -154,7 +154,7 @@ private:
 
         if (a0.block % min_step != 0) {
             // TODO: Extend implementation to support this case.
-            ir_except_not_implemented("Reduction is not supported.");
+            gpu_except_not_implemented("Reduction is not supported.");
         }
 
         std::vector<dim_t> tile_dims(src_layout_.ndims(), 1);

--- a/src/gpu/intel/jit/codegen/register_allocator.hpp
+++ b/src/gpu/intel/jit/codegen/register_allocator.hpp
@@ -42,7 +42,7 @@ public:
     }
     ~reg_allocator_t() {
 #ifdef DNNL_DEV_MODE
-        ir_assert(!is_speculate) << "Speculative allocation never finished\n";
+        gpu_assert(!is_speculate) << "Speculative allocation never finished\n";
 #endif
     }
 

--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -384,8 +384,8 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
     // - int -> hf must be DW-aligned & strided: use f temporary
     // - Use b -> w -> f -> hf
     if (src_b && dst_hf) {
-        ir_assert(utils::one_of(dst_stride_bytes, 2, 4));
-        ir_assert(utils::one_of(src_stride_bytes, 1, 4));
+        gpu_assert(utils::one_of(dst_stride_bytes, 2, 4));
+        gpu_assert(utils::one_of(src_stride_bytes, 1, 4));
         int step = get_step();
         const int align_boundary = grf_size / 2;
         const int step_size = step * (int)sizeof(uint32_t);
@@ -795,8 +795,8 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
 
     // hf -> b
     if (src_hf && dst_b) {
-        ir_assert(utils::one_of(src_stride_bytes, 2, 4));
-        ir_assert(utils::one_of(dst_stride_bytes, 1, 4));
+        gpu_assert(utils::one_of(src_stride_bytes, 2, 4));
+        gpu_assert(utils::one_of(dst_stride_bytes, 1, 4));
         int step = get_step();
         const int tmp_stride = 4;
         const int tmp_stride_bytes = tmp_stride * dst_type_size;
@@ -835,7 +835,7 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
                 if (hw != ngen::HW::Gen9) {
                     plan(mov, esize | host->sat, d(dst_stride), s(src_stride));
                 } else {
-                    ir_assert(dst_stride_bytes % tmp_stride_bytes == 0);
+                    gpu_assert(dst_stride_bytes % tmp_stride_bytes == 0);
                     auto d_f = dst.format(i * ngen::getBytes(ngen::DataType::f),
                             ngen::DataType::f, esize,
                             dst_stride_bytes / tmp_stride_bytes);
@@ -993,9 +993,9 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
     bool d_or_f_to_b = (src_d || src_f) && dst_b;
     bool b_to_d_or_f = (dst_d || dst_f) && src_b;
     if (d_or_f_to_b || b_to_d_or_f) {
-        if (dst_d || dst_f) ir_assert(dst_stride_bytes == 4);
-        if (src_d || src_f) ir_assert(src_stride_bytes == 4);
-        if (dst_b) ir_assert(utils::one_of(dst_stride_bytes, 1, 4, 8));
+        if (dst_d || dst_f) gpu_assert(dst_stride_bytes == 4);
+        if (src_d || src_f) gpu_assert(src_stride_bytes == 4);
+        if (dst_b) gpu_assert(utils::one_of(dst_stride_bytes, 1, 4, 8));
         int step = get_step();
         const int step_size = step * (int)sizeof(uint32_t);
         const int nregs = 1 + utils::div_up(step_size, grf_size);
@@ -1100,7 +1100,7 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
             step = std::min(step, width - i);
             step = utils::rnd_down_pow2(step);
             int esize = step;
-            ir_assert(math::is_pow2(esize));
+            gpu_assert(math::is_pow2(esize));
             auto s = src.format(i * src_stride_bytes, ngen::DataType::invalid,
                     esize, src_stride);
             auto d = dst.format(i * dst_stride_bytes, ngen::DataType::invalid,
@@ -1259,7 +1259,7 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
             step = std::min(step, width - i);
             step = utils::rnd_down_pow2(step);
             int esize = step;
-            ir_assert(math::is_pow2(esize));
+            gpu_assert(math::is_pow2(esize));
             auto s = src.format(i * src_stride_bytes, dst_type, esize,
                     src_stride * src_type_size / dst_type_size);
             auto d = dst.format(i * dst_stride_bytes, ngen::DataType::invalid,
@@ -1275,7 +1275,7 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
         step = std::min(step, width - i);
         step = utils::rnd_down_pow2(step);
         int esize = step;
-        ir_assert(math::is_pow2(esize));
+        gpu_assert(math::is_pow2(esize));
         auto s = src.format(i * src_stride_bytes, ngen::DataType::invalid,
                 esize, src_stride);
         auto d = dst.format(i * dst_stride_bytes, ngen::DataType::invalid,
@@ -1367,7 +1367,7 @@ public:
     reorder_2d_impl_t(ngen::HW hw, tensor_t tile, const layout_t &src_layout,
             const layout_t &dst_layout)
         : hw_(hw), src_(src_layout), dst_(dst_layout), tile_(std::move(tile)) {
-        ir_assert(src_.type() == dst_.type());
+        gpu_assert(src_.type() == dst_.type());
     }
 
     const tensor_t &tile() const { return tile_; }
@@ -1416,8 +1416,8 @@ public:
             auto next_rd = (use_dst ? dst_rd : tmp);
             auto &x_blocks = x.blocks();
             auto &y_blocks = y.blocks();
-            ir_assert(x_blocks.size() <= 1);
-            ir_assert(y_blocks.size() <= 1);
+            gpu_assert(x_blocks.size() <= 1);
+            gpu_assert(y_blocks.size() <= 1);
             int x_stride = (x_blocks.empty() ? 1 : int(x_blocks[0].stride));
             int y_stride = (y_blocks.empty() ? 1 : int(y_blocks[0].stride));
             int width = int(tile.elems()) * orig_type.size() / type.size();
@@ -1546,8 +1546,8 @@ private:
             for (int i = min_log_bytes; i <= max_log_bytes; i++) {
                 if ((mask & (1 << i)) == 0) continue;
                 if (i > min_log_bytes) {
-                    ir_assert(!layout.blocks().empty());
-                    ir_assert(!v.layout.blocks().empty());
+                    gpu_assert(!layout.blocks().empty());
+                    gpu_assert(!v.layout.blocks().empty());
                     int dim_idx0 = layout.blocks()[0].dim_idx;
                     int dim_idx1 = v.layout.blocks()[0].dim_idx;
                     if (dim_idx0 != dim_idx1) continue;
@@ -1597,7 +1597,7 @@ private:
                 b_idx = i;
                 continue;
             }
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
 
         for (dim_idx_t i = 0; i < tile.ndims(); i++) {
@@ -1688,8 +1688,8 @@ private:
                 dst_idx = i;
         }
 
-        ir_assert(src_idx != -1);
-        ir_assert(dst_idx != -1);
+        gpu_assert(src_idx != -1);
+        gpu_assert(dst_idx != -1);
 
         // Layouts are the same, just copy.
         if (src_idx == dst_idx) {
@@ -1737,7 +1737,7 @@ private:
         // Sanity check, ensure the reorder sequence is not too long.
         int max_cost = 256;
         if (cost[dst_idx] > max_cost)
-            ir_warning() << "High cost reorder generated";
+            gpu_warning() << "High cost reorder generated";
 
         // Restore the shortest reorder path.
         std::vector<reorder_step_t> ret;

--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -1737,7 +1737,7 @@ private:
         // Sanity check, ensure the reorder sequence is not too long.
         int max_cost = 256;
         if (cost[dst_idx] > max_cost)
-            ir_warning() << "High cost reorder generated\n";
+            ir_warning() << "High cost reorder generated";
 
         // Restore the shortest reorder path.
         std::vector<reorder_step_t> ret;

--- a/src/gpu/intel/jit/codegen/send.hpp
+++ b/src/gpu/intel/jit/codegen/send.hpp
@@ -35,7 +35,7 @@ struct atomic_helper_t {
     static void call(GeneratorT *, ngen::AtomicOp,
             const ngen::InstructionModifier &, const DataSpecT &,
             ngen::AddressBase, const ngen::RegData &, const ngen::RegData &) {
-        ir_error_not_expected()
+        gpu_error_not_expected()
                 << "Unknown DataSpec: atomics are not supported.";
     }
 };
@@ -106,7 +106,7 @@ public:
                 emit_load_or_store(host, mod, ngen::block_hword(elems),
                         address_base, header, data);
                 break;
-            default: ir_error_not_expected() << send_.type;
+            default: gpu_error_not_expected() << send_.type;
         }
     }
 
@@ -125,7 +125,7 @@ public:
                         ngen::scattered_qword(send_.type.elems()),
                         to_address_base(send_.address), header, data);
                 break;
-            default: ir_error_not_expected() << send_.type;
+            default: gpu_error_not_expected() << send_.type;
         }
         return;
     }
@@ -144,7 +144,7 @@ private:
         } else if (send_.is_store()) {
             host->store(mod, spec, base, addr, data);
         } else {
-            ir_error_not_expected() << "Can't emit send: " << send_;
+            gpu_error_not_expected() << "Can't emit send: " << send_;
         }
     }
     template <typename GeneratorT, typename DataSpecT>
@@ -166,12 +166,12 @@ private:
             for (auto &t : {type_t::qword(), type_t::dword()}) {
                 if (type.size() % t.size() == 0) {
                     int elems = type.size() / t.size();
-                    ir_assert(math::is_pow2(elems));
-                    ir_assert(elems >= 1 && elems <= 64);
+                    gpu_assert(math::is_pow2(elems));
+                    gpu_assert(elems >= 1 && elems <= 64);
                     return t.with_elems(elems);
                 }
             }
-            ir_error_not_expected();
+            gpu_error_not_expected();
             return type;
         };
 
@@ -184,7 +184,7 @@ private:
             lsc_spec = utils::make_unique<ngen::DataSpecLSC>(
                     ngen::block(lsc_type.first, lsc_type.second));
         } else {
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
 
         if (send_.is_slm()) {
@@ -193,7 +193,7 @@ private:
             } else if (send_.is_store()) {
                 host->store.slm(mod, *lsc_spec, host->SLM, header, data);
             } else {
-                ir_error_not_expected();
+                gpu_error_not_expected();
             }
         } else if (send_.is_a64()) {
             *lsc_spec |= get_cache_settings(send_, host->exec_cfg_.hw());
@@ -206,7 +206,7 @@ private:
                         to_address_base(send_.address), header, data);
             }
         } else {
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
     }
 
@@ -219,7 +219,7 @@ private:
             case 1: data_size = ngen::DataSizeLSC::D8; break;
             case 2: data_size = ngen::DataSizeLSC::D16; break;
             case 4: data_size = ngen::DataSizeLSC::D32; break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         ngen::DataSpecLSC data_spec(data_size);
         if (info.vnni) data_spec |= host->vnni;
@@ -231,7 +231,7 @@ private:
         } else if (send_.is_store_2d()) {
             host->store(mod, spec, host->A64, header, data);
         } else {
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
     }
 
@@ -261,7 +261,7 @@ private:
             case 8: return std::make_pair(ngen::DataSizeLSC::D64, type.elems());
             default: break;
         }
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return std::make_pair(ngen::DataSizeLSC::D8, 1);
     }
 
@@ -269,7 +269,7 @@ private:
         switch (address) {
             case send_address_t::a64: return ngen::AddressBase::createA64(true);
             case send_address_t::slm: return ngen::AddressBase::createSLM();
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return ngen::AddressBase();
     }
@@ -279,7 +279,7 @@ private:
             case send_op_t::atomic_add: return ngen::AtomicOp::add;
             case send_op_t::atomic_fadd: return ngen::AtomicOp::fadd;
             case send_op_t::atomic_cmpwr: return ngen::AtomicOp::cmpwr;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return ngen::AtomicOp();
     }

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -1263,7 +1263,7 @@ send_pattern_t<pvar_t> validate_blocking(const conv_config_t &cfg,
         return all_hints;
     }();
     if (hints.empty()) {
-        ir_suggestion() << "No hints generated! ";
+        ir_suggestion() << "No hints generated!";
         return send_pattern();
     }
 
@@ -1273,9 +1273,9 @@ send_pattern_t<pvar_t> validate_blocking(const conv_config_t &cfg,
 
     ir_suggestion() << "blocking disables " << send_pattern(hints[0])
                     << " load of the " << tensor
-                    << " tensor. Try a multiple of:\n";
+                    << " tensor. Try a multiple of:";
     for (auto &hint : hints) {
-        ir_suggestion() << "\t" << hint.str() << "\n";
+        ir_suggestion() << "\t" << hint.str();
     }
 
     return send_pattern();
@@ -1847,12 +1847,12 @@ void validate_config_and_plan(conv_config_t &cfg) {
     if (!a_load_pattern.matches(
                 plan.x2r.a_load.create_stmt(dummy_mem, dummy_reg))) {
         ir_warning() << "Generated load for tensor A does not match "
-                     << a_load_pattern << " load idiom\n";
+                     << a_load_pattern << " load idiom";
     }
     if (!b_load_pattern.matches(
                 plan.x2r.b_load.create_stmt(dummy_mem, dummy_reg))) {
         ir_warning() << "Generated load for tensor B does not match "
-                     << a_load_pattern << " load idiom\n";
+                     << a_load_pattern << " load idiom";
     }
 #endif
 }

--- a/src/gpu/intel/jit/conv/config.hpp
+++ b/src/gpu/intel/jit/conv/config.hpp
@@ -85,7 +85,7 @@ inline std::string to_string(bwd_d_optimize_kind_t kind) {
         CASE(skip_strided_dh);
         CASE(skip_strided_dhw);
 #undef CASE
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return "unknown";
 }
@@ -98,7 +98,7 @@ inline bwd_d_optimize_kind_t to_bwd_d_optimize_kind(const std::string &s) {
     CASE(skip_strided_dh);
     CASE(skip_strided_dhw);
 #undef CASE
-    ir_error_not_expected();
+    gpu_error_not_expected();
     return bwd_d_optimize_kind_t::undef;
 }
 
@@ -183,7 +183,7 @@ public:
             switch (c) {
                 case 'u': do_unroll_ = true; break;
                 case 'r': reuse_headers_ = true; break;
-                default: ir_error_not_expected() << s;
+                default: gpu_error_not_expected() << s;
             }
         }
     }
@@ -246,12 +246,12 @@ public:
                 b_ = p.find("b") != std::string::npos;
                 continue;
             }
-            ir_assert(p.size() >= 2) << p;
+            gpu_assert(p.size() >= 2) << p;
             char name = p[0];
             int value = std::stoi(p.substr(1));
             switch (name) {
                 case 'x': bufs_ = value; break;
-                default: ir_error_not_expected() << p;
+                default: gpu_error_not_expected() << p;
             }
         }
         if (!ab_set && bufs_ > 0) {
@@ -310,14 +310,14 @@ public:
                 b_ = p.find("b") != std::string::npos;
                 continue;
             }
-            ir_assert(p.size() >= 2) << p;
+            gpu_assert(p.size() >= 2) << p;
             char name = p[0];
             int value = std::stoi(p.substr(1));
             switch (name) {
                 case 'x': bufs_ = value; break;
                 case 'g': gmem_bufs_ = value; break;
                 case 'v': sync_version_ = value; break;
-                default: ir_error_not_expected() << p;
+                default: gpu_error_not_expected() << p;
             }
         }
         if (!ab_set && bufs_ > 0) {
@@ -400,7 +400,7 @@ public:
             } else if (kv.first == "b") {
                 b_ = kv.second;
             } else {
-                ir_error_not_expected() << kv.first;
+                gpu_error_not_expected() << kv.first;
             }
         }
     }
@@ -480,13 +480,13 @@ class conv_config_t : public prim_config_t {
 public:
 #define DECL_PARAM(name) \
     const name##_param_t &name##_param() const { \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         (void)name##_init_; \
         return name##_; \
     } \
     name##_param_t &name##_param() { return name##_; } \
     const name##_param_t::value_t &name() const { \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         return name##_.get(); \
     } \
     void set_##name(const name##_param_t::value_t &value) { \
@@ -496,7 +496,7 @@ public:
 #define DECL_PARAM2(name) \
     const name##_param_t &name() const { \
         (void)name##_init_; \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         return name##_; \
     } \
     name##_param_t &name() { return name##_; }

--- a/src/gpu/intel/jit/conv/conv_kernel.hpp
+++ b/src/gpu/intel/jit/conv/conv_kernel.hpp
@@ -105,12 +105,12 @@ conv_kernel_t<hw>::conv_kernel_t(const conv_config_t &cfg,
     profile.stop("Epilogue");
 
 #ifdef DNNL_DEV_MODE
-    ir_perf_no_trace() << profile;
+    gpu_perf_no_trace() << profile;
 
-    ir_trace() << "Actual register usage:           " << ra_.get_peak_regs();
+    gpu_trace() << "Actual register usage:           " << ra_.get_peak_regs();
     int estimated_peak_regs = estimate_register_count(cfg_);
     if (ra_.get_peak_regs() > estimated_peak_regs) {
-        ir_warning()
+        gpu_warning()
                 << "conv_kernel_t register usage underestimated: estimate = "
                 << estimated_peak_regs << ", actual = " << ra_.get_peak_regs();
     }

--- a/src/gpu/intel/jit/conv/conv_kernel.hpp
+++ b/src/gpu/intel/jit/conv/conv_kernel.hpp
@@ -105,16 +105,14 @@ conv_kernel_t<hw>::conv_kernel_t(const conv_config_t &cfg,
     profile.stop("Epilogue");
 
 #ifdef DNNL_DEV_MODE
-    ir_perf_no_trace() << profile << "\n";
+    ir_perf_no_trace() << profile;
 
-    ir_trace() << "Actual register usage:           " << ra_.get_peak_regs()
-               << std::endl;
+    ir_trace() << "Actual register usage:           " << ra_.get_peak_regs();
     int estimated_peak_regs = estimate_register_count(cfg_);
     if (ra_.get_peak_regs() > estimated_peak_regs) {
         ir_warning()
                 << "conv_kernel_t register usage underestimated: estimate = "
-                << estimated_peak_regs << ", actual = " << ra_.get_peak_regs()
-                << "\n";
+                << estimated_peak_regs << ", actual = " << ra_.get_peak_regs();
     }
 #endif
 }

--- a/src/gpu/intel/jit/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/conv/gen_convolution.cpp
@@ -154,7 +154,7 @@ public:
 
                 if (!tiler->is_grf_limit_ok(cfg)) continue;
 
-                ir_info() << "Configuration:" << std::endl;
+                ir_info() << "Configuration:";
                 ir_info() << cfg;
 
                 init_nd_ranges(primitive, cfg);

--- a/src/gpu/intel/jit/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/conv/gen_convolution.cpp
@@ -154,8 +154,8 @@ public:
 
                 if (!tiler->is_grf_limit_ok(cfg)) continue;
 
-                ir_info() << "Configuration:";
-                ir_info() << cfg;
+                gpu_info() << "Configuration:";
+                gpu_info() << cfg;
 
                 init_nd_ranges(primitive, cfg);
                 auto &kernel_infos = data.kernel_infos;
@@ -164,7 +164,7 @@ public:
                 // since it adds its own version mark to the cache blob
                 for (int i = 0; i < int(kernel_infos.size()); i++)
                     if (kernel_infos[i].id() == kernel_id_t::zp_precalc) {
-                        ir_assert(data.zp_pd);
+                        gpu_assert(data.zp_pd);
                         CHECK(primitive->create_nested_primitive(
                                 zp_prim_, data.zp_pd, engine));
                     }
@@ -220,7 +220,7 @@ public:
                             tmp_kernels.emplace_back();
                             continue;
 
-                        default: ir_error_not_expected();
+                        default: gpu_error_not_expected();
                     }
                     if (!tmp_kernels[i]) return status::runtime_error;
                 }
@@ -242,7 +242,7 @@ public:
             }
         }
         if (!ok) return status::runtime_error;
-        ir_assert(kernels_.size() == data.kernel_infos.size());
+        gpu_assert(kernels_.size() == data.kernel_infos.size());
         CHECK(primitive->register_kernels(kernels_));
 
         conv_tiler_t::after_create_hook(cfg, primitive);
@@ -284,7 +284,7 @@ public:
                                 new memory_t(ctx.stream()->engine(), md,
                                         std::move(s)));
                     };
-                    ir_assert(zp_prim_);
+                    gpu_assert(zp_prim_);
                     std::unique_ptr<memory_t, memory_deleter_t> zp_src, zp_dst;
                     CHECK(scratchpad_arg(
                             zp_src, "src_zero_points", zp_conv_md_in(data)));
@@ -328,7 +328,7 @@ private:
     template <typename T>
     static kernel_info_t &create_kernel_info(T *pd, kernel_id_t kernel_id) {
         auto &infos = pd->data->kernel_infos;
-        ir_assert((int)infos.size() + 1 <= max_kernels);
+        gpu_assert((int)infos.size() + 1 <= max_kernels);
         infos.emplace_back();
         auto &ret = infos.back();
         ret.set_id(kernel_id);
@@ -360,9 +360,9 @@ private:
             int compute_arg_key = t.arg_key;
 
             if (compute_arg_key == DNNL_ARG_UNDEF) {
-                ir_assert(!t.needs_reorder);
-                ir_assert(!t.needs_zero_out);
-                ir_error_not_expected();
+                gpu_assert(!t.needs_reorder);
+                gpu_assert(!t.needs_zero_out);
+                gpu_error_not_expected();
                 continue;
             }
 
@@ -471,14 +471,14 @@ private:
                     nd_ranges_[i] = info.nd_range();
                     break;
                 case kernel_id_t::zp_precalc: break;
-                default: ir_error_not_expected();
+                default: gpu_error_not_expected();
             }
         }
     }
 
     static bool can_skip_zero_out(
             const kernel_info_t &info, const conv_config_t &cfg) {
-        ir_assert(info.id() == kernel_id_t::zero_out);
+        gpu_assert(info.id() == kernel_id_t::zero_out);
         auto &buf_name = info.arg_var(1).as<var_t>().name;
         if (buf_name == "wei") return cfg.can_skip_wei_zero_out();
         if (buf_name == "bia") return cfg.can_skip_bia_zero_out();

--- a/src/gpu/intel/jit/conv/grf_usage.cpp
+++ b/src/gpu/intel/jit/conv/grf_usage.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -351,8 +351,8 @@ void compare(const grf_usage_t &est_usage, const grf_usage_t &ir_usage,
     table << "Total" << est_total << ir_total;
     table << (ir_total > est_total ? "FAIL" : "");
     table << std::endl;
-    ir_trace() << table << std::endl;
-    ir_trace() << ir_usage.buf_usage() << std::endl;
+    ir_trace() << table;
+    ir_trace() << ir_usage.buf_usage();
 }
 
 void verify_grf_usage(

--- a/src/gpu/intel/jit/conv/grf_usage.hpp
+++ b/src/gpu/intel/jit/conv/grf_usage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -72,13 +72,13 @@ public:
 
     grf_usage_label_t get_label(const expr_t &buf) const {
         auto it = buf_labels_.find(buf);
-        ir_assert(it != buf_labels_.end()) << "Buffer not found: " << buf;
+        gpu_assert(it != buf_labels_.end()) << "Buffer not found: " << buf;
         return it->second;
     }
 
     int get_size(const expr_t &buf) const {
         auto it = buf_sizes_.find(buf);
-        ir_assert(it != buf_sizes_.end()) << "Buffer not found: " << buf;
+        gpu_assert(it != buf_sizes_.end()) << "Buffer not found: " << buf;
         return it->second;
     }
 

--- a/src/gpu/intel/jit/conv/ir_builder.cpp
+++ b/src/gpu/intel/jit/conv/ir_builder.cpp
@@ -103,7 +103,7 @@ public:
         } else if (func.is<builtin_t>()) {
             // No buffers to check.
         } else {
-            ir_error_not_expected() << "Unhandled function: " << obj;
+            gpu_error_not_expected() << "Unhandled function: " << obj;
         }
 
         ir_visitor_t::_visit(obj);
@@ -134,10 +134,10 @@ private:
         auto &base = (is_var(buf) ? buf : buf.as<ptr_t>().base);
         dim_t off = (is_var(buf) ? 0 : to_cpp<dim_t>(buf.as<ptr_t>().off));
         auto it = buf_sizes_.find(base);
-        ir_assert(it != buf_sizes_.end())
+        gpu_assert(it != buf_sizes_.end())
                 << "Can't find allocation for buffer: " << buf;
         int buf_size = it->second;
-        ir_assert(off + size <= buf_size)
+        gpu_assert(off + size <= buf_size)
                 << "Invalid access:\n    " << obj << "\n    Buffer " << base
                 << " has size: " << buf_size;
     }
@@ -350,8 +350,8 @@ private:
     void build_x2r_mul() {
         auto &x2r = plan_.x2r;
         auto &fma = plan_.fma;
-        ir_assert(x2r.split_abc == fma.split_abc);
-        ir_assert(x2r.split_factor == fma.split_factor);
+        gpu_assert(x2r.split_abc == fma.split_abc);
+        gpu_assert(x2r.split_factor == fma.split_factor);
         for (int i = 0; i < x2r.split_factor; i++) {
             build_x2r(i);
             stmt_t mul_stmt;
@@ -443,7 +443,7 @@ private:
     void build_zp_apply(int subtile_idx, stmt_t &mul_stmt) {
         auto make_zp_fma = [&](const std::string &zp_buf, abc_kind_t kind,
                                    int size) {
-            ir_assert((kind == abc_kind_t::a) || (kind == abc_kind_t::b));
+            gpu_assert((kind == abc_kind_t::a) || (kind == abc_kind_t::b));
             buf_mgr_.get(zp_buf, size);
             return plan_.fma.create_stmt(ir_ctx_, buf_mgr_,
                     (kind == abc_kind_t::a) ? zp_buf : "a",
@@ -758,7 +758,7 @@ void conv_ir_builder_t::build() {
     verify_buffer_access(stmt_, ir_ctx);
 #endif
 
-    ir_trace() << "Convolution kernel body:\n" << stmt_;
+    gpu_trace() << "Convolution kernel body:\n" << stmt_;
     trace_perf();
 }
 

--- a/src/gpu/intel/jit/conv/ir_builder.cpp
+++ b/src/gpu/intel/jit/conv/ir_builder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -758,7 +758,7 @@ void conv_ir_builder_t::build() {
     verify_buffer_access(stmt_, ir_ctx);
 #endif
 
-    ir_trace() << "Convolution kernel body:\n" << stmt_ << std::endl;
+    ir_trace() << "Convolution kernel body:\n" << stmt_;
     trace_perf();
 }
 

--- a/src/gpu/intel/jit/conv/key.cpp
+++ b/src/gpu/intel/jit/conv/key.cpp
@@ -87,7 +87,7 @@ fma_kind_t to_key(fma_kind_t fma) {
         case fma_kind_t::dp4a:
         case fma_kind_t::dpas: return fma;
         case fma_kind_t::dpasw: return fma_kind_t::dpas;
-        default: ir_error_not_expected(); return fma_kind_t::undef;
+        default: gpu_error_not_expected(); return fma_kind_t::undef;
     }
 }
 
@@ -105,7 +105,7 @@ key_type_kind_t to_type_kind(data_type_t dt) {
         CASE(s32);
         CASE(tf32);
         CASE(f64);
-        default: ir_error_not_expected(); return key_type_kind_t::undef;
+        default: gpu_error_not_expected(); return key_type_kind_t::undef;
     }
 #undef CASE
 }
@@ -127,7 +127,7 @@ key_type_kind_t to_filter(key_type_kind_t kind) {
         case key_type_kind_t::bf8:
         case key_type_kind_t::hf8:
         case key_type_kind_t::xf8: return key_type_kind_t::xf8;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return key_type_kind_t::undef;
 }
@@ -135,7 +135,7 @@ key_type_kind_t to_filter(key_type_kind_t kind) {
 template <>
 struct key_kind_traits_t<key_type_kind_t> {
     static bool matches(key_type_kind_t filter, key_type_kind_t other) {
-        ir_assert(filter == to_filter(filter));
+        gpu_assert(filter == to_filter(filter));
         if (filter == key_type_kind_t::any) return true;
         return filter == to_filter(other);
     }
@@ -205,7 +205,7 @@ struct key_hw_t {
     void parse(std::istream &in) {
         auto s = stream_parse<std::string>(in);
         auto parts = gpu_utils::split(s, ":");
-        ir_assert(parts.size() <= 2);
+        gpu_assert(parts.size() <= 2);
         hw = to_enum<ngen::HW>(parts[0]);
         family = (parts.size() > 1 ? to_enum<ngen::ProductFamily>(parts[1])
                                    : ngen::ProductFamily::Unknown);
@@ -249,7 +249,7 @@ struct key_type_info_t {
             case prop_kind::forward: ret.dst = any_type; break;
             case prop_kind::backward_data: ret.src = any_type; break;
             case prop_kind::backward_weights: ret.wei = any_type; break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return ret;
     }
@@ -276,7 +276,7 @@ struct key_type_info_t {
     void parse(std::istream &in) {
         auto s = stream_parse<std::string>(in);
         auto parts = gpu_utils::split(s, ":");
-        ir_assert(parts.size() == 3);
+        gpu_assert(parts.size() == 3);
         src = key_type_t(to_enum<key_type_kind_t>(parts[0]));
         wei = key_type_t(to_enum<key_type_kind_t>(parts[1]));
         dst = key_type_t(to_enum<key_type_kind_t>(parts[2]));
@@ -317,7 +317,7 @@ struct key_mb_t {
             case prop_kind::backward_weights:
                 is_blocked = src_blocked && dst_blocked;
                 break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
     }
 
@@ -510,12 +510,12 @@ conv_key_t conv_key_t::to_filter() const {
 }
 
 const std::string &conv_key_t::desc() const {
-    ir_assert(impl_);
+    gpu_assert(impl_);
     return impl_->desc_str();
 }
 
 dim_t conv_key_t::distance(const conv_key_t &other) const {
-    ir_assert(impl_ && other.impl_);
+    gpu_assert(impl_ && other.impl_);
     return impl_->distance(*other.impl_);
 }
 
@@ -534,7 +534,7 @@ size_t conv_key_t::get_hash() const {
 }
 
 void conv_key_t::stringify(std::ostream &out) const {
-    ir_assert(impl_);
+    gpu_assert(impl_);
     impl_->stringify(out);
 }
 

--- a/src/gpu/intel/jit/conv/lookup_table.cpp
+++ b/src/gpu/intel/jit/conv/lookup_table.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ conv_lookup_table_t::conv_lookup_table_t(const char **entries) {
         {
             std::ostringstream oss;
             e.stringify(oss);
-            ir_assert(oss.str() == *entries)
+            gpu_assert(oss.str() == *entries)
                     << "parsed from:\n  " << *entries << "\nstringified to\n  "
                     << oss.str();
         }

--- a/src/gpu/intel/jit/conv/message_patterns.hpp
+++ b/src/gpu/intel/jit/conv/message_patterns.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,23 +46,23 @@ struct conv_stride_layout_t : public stride_layout_t<pvar_t> {
                 else if (type == input_tensor_t::wei)
                     return prb.b_md();
                 else
-                    ir_error_not_expected();
+                    gpu_error_not_expected();
             } else if (prb.is_bwd_d) {
                 if (type == input_tensor_t::dst)
                     return prb.a_md();
                 else if (type == input_tensor_t::wei)
                     return prb.b_md();
                 else
-                    ir_error_not_expected();
+                    gpu_error_not_expected();
             } else if (prb.is_bwd_w) {
                 if (type == input_tensor_t::src)
                     return prb.a_md();
                 else if (type == input_tensor_t::dst)
                     return prb.b_md();
                 else
-                    ir_error_not_expected();
+                    gpu_error_not_expected();
             } else {
-                ir_error_not_expected();
+                gpu_error_not_expected();
             }
             return prb.a_md();
         }();
@@ -105,14 +105,14 @@ struct conv_stride_layout_t : public stride_layout_t<pvar_t> {
                                       is_complex = true;
                                   }
                               }
-                              ir_assert(s != strides.end());
+                              gpu_assert(s != strides.end());
                               *s++ = stride_dim_t(conv_dim, blk_size, next,
                                       can_overflow, is_complex);
                               ndims++;
                           }
                           stride *= blk_size;
                       }
-                      ir_assert(s != strides.end());
+                      gpu_assert(s != strides.end());
                       *s++ = stride_dim_t(conv_dim, outer,
                               access_stride * blk.strides[desc_dim],
                               can_overflow, is_complex);

--- a/src/gpu/intel/jit/conv/model_bridge.cpp
+++ b/src/gpu/intel/jit/conv/model_bridge.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ type_t to_type(data_type_t dt) {
         case data_type::f32:
         case data_type::s32: return type_t::d32;
         case data_type::f64: return type_t::d64;
-        default: ir_error_not_expected() << "Unknown type: " << dt;
+        default: gpu_error_not_expected() << "Unknown type: " << dt;
     }
     return type_t::undef;
 }
@@ -55,7 +55,7 @@ hw_t to_hw(ngen::HW hw) {
         case ngen::HW::XeHPC: return hw_t::xehpc;
         case ngen::HW::Xe2: return hw_t::xehpc;
         case ngen::HW::Xe3: return hw_t::xehpc;
-        default: ir_error_not_expected() << "Unknown HW: " << to_string(hw);
+        default: gpu_error_not_expected() << "Unknown HW: " << to_string(hw);
     }
     return hw_t::undef;
 }
@@ -67,7 +67,7 @@ fma_t to_fma(fma_kind_t fma) {
         case fma_kind_t::dpas:
         case fma_kind_t::dpasw: return fma_t::dpas;
         default:
-            ir_error_not_expected() << "Unknown FMA kind: " << to_string(fma);
+            gpu_error_not_expected() << "Unknown FMA kind: " << to_string(fma);
     }
     return fma_t::undef;
 }

--- a/src/gpu/intel/jit/conv/plan.cpp
+++ b/src/gpu/intel/jit/conv/plan.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1515,8 +1515,7 @@ dim_t find_min_stride_without_conflicts(
         }
     }
 
-    ir_warning() << "Couldn't find stride without conflicts for SLM padding."
-                 << std::endl;
+    ir_warning() << "Couldn't find stride without conflicts for SLM padding.";
 
     return dense_stride_bytes;
 }
@@ -1539,7 +1538,7 @@ layout_t pad_slm_layout(
     auto l = layout.split_into_multi_blocks(multi_blocks);
 
     if (l.is_empty()) {
-        ir_warning() << "Couldn't split layout for SLM padding." << std::endl;
+        ir_warning() << "Couldn't split layout for SLM padding.";
         return layout;
     }
     auto padded_blocks = l.blocks();
@@ -1896,8 +1895,7 @@ public:
         if (status == plan_status_t::success) return status::success;
 
         if (a_direct_view_ || b_direct_view_) {
-            ir_trace() << "Retry plan initialization without direct view"
-                       << std::endl;
+            ir_trace() << "Retry plan initialization without direct view";
             enable_direct_view(false);
             status = try_init_plan();
             if (status == plan_status_t::success) return status::success;
@@ -1905,7 +1903,7 @@ public:
 
         if ((use_slm(abc_kind_t::a) || use_slm(abc_kind_t::b))
                 && !cfg_.slm().is_overridden()) {
-            ir_trace() << "Retry plan initialization without SLM" << std::endl;
+            ir_trace() << "Retry plan initialization without SLM";
             enable_slm(false);
             status = try_init_plan();
             if (status == plan_status_t::success) return status::success;
@@ -1932,7 +1930,7 @@ private:
                     = gmem_buf_size == 0 ? 0 : 1 + free / gmem_buf_size;
         }
 
-        ir_trace() << plan_ << std::endl;
+        ir_trace() << plan_;
         cfg_.set_plan(plan_ptr_);
     }
 

--- a/src/gpu/intel/jit/conv/plan.hpp
+++ b/src/gpu/intel/jit/conv/plan.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -238,7 +238,7 @@ struct conv_plan_t : public base_plan_t {
     const tensor_t &x_reduce_tile() const {
         if (!x2r.x_reduce_tile.is_empty()) return x2r.x_reduce_tile;
         if (!slm.x_reduce_tile.is_empty()) return slm.x_reduce_tile;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return x2r.x_reduce_tile;
     }
 

--- a/src/gpu/intel/jit/conv/plan_utils.hpp
+++ b/src/gpu/intel/jit/conv/plan_utils.hpp
@@ -34,7 +34,7 @@ struct base_plan_t {
     base_plan_t(const hw_t hw = hw_t()) : hw(hw) {}
 
     int grf_size() const {
-        ir_assert(!hw.is_undef());
+        gpu_assert(!hw.is_undef());
         return hw.grf_size();
     }
 

--- a/src/gpu/intel/jit/conv/problem.cpp
+++ b/src/gpu/intel/jit/conv/problem.cpp
@@ -74,7 +74,7 @@ const std::vector<pvar_t> &conv_index_dims(prop_kind_t prop) {
         case prop_kind::forward: return fwd_dims;
         case prop_kind::backward_data: return bwd_d_dims;
         case prop_kind::backward_weights: return bwd_w_dims;
-        default: ir_error_not_expected(); return fwd_dims;
+        default: gpu_error_not_expected(); return fwd_dims;
     }
 }
 
@@ -113,7 +113,7 @@ const std::vector<pvar_t> &conv_layout_dims(
             return src_dst_with_group ? dst_g_dims : dst_dims;
         case tensor_kind_t::bias:
             return src_dst_with_group ? bia_g_dims : bia_dims;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return src_dims;
 }
@@ -129,7 +129,7 @@ tensor_kind_t to_abc(prop_kind_t prop, tensor_kind_t tensor) {
         case tensor_kind_t::src: return kinds[0];
         case tensor_kind_t::wei: return kinds[1];
         case tensor_kind_t::dst: return kinds[2];
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return kinds[0];
 }
@@ -338,7 +338,7 @@ void normalize_conv_shape(dim_t &id, dim_t &od, dim_t &kd, dim_t &sd, dim_t &dd,
     if (is_1x1 && sd == 1 && sh == 1 && sw == 1 && is_eq_oi
             && can_flatten_spatial) {
         // Convert 3D to 1D convolution.
-        ir_assert(pd == 0 && ph == 0 && pw == 0);
+        gpu_assert(pd == 0 && ph == 0 && pw == 0);
         ow = od * oh * ow;
         iw = id * ih * iw;
         od = id = kd = 1;
@@ -390,7 +390,7 @@ pvar_t to_gemm(const pvar_t &d, prop_kind_t prop, bool is_transpose) {
         if (d == pvars::m) return pvars::n;
         if (d == pvars::n) return pvars::m;
         if (d == pvars::k) return pvars::k;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return pvar_t();
     };
     auto pick
@@ -403,7 +403,7 @@ pvar_t to_gemm(const pvar_t &d, prop_kind_t prop, bool is_transpose) {
                   if (is_fwd) return fwd;
                   if (is_bwd_d) return bwd_d;
                   if (is_bwd_w) return bwd_w;
-                  ir_error_not_expected();
+                  gpu_error_not_expected();
                   return pvar_t();
               };
     if (d == pvars::g) return pvars::b;

--- a/src/gpu/intel/jit/conv/problem.hpp
+++ b/src/gpu/intel/jit/conv/problem.hpp
@@ -53,7 +53,7 @@ T &&pick_abc(tensor_kind_t abc, prop_kind_t prop, T &&src, T &&wei, T &&dst) {
             if (is_fwd) return std::forward<T>(dst);
             if (is_bwd_d) return std::forward<T>(src);
             return std::forward<T>(wei);
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return std::forward<T>(src);
 }
@@ -128,7 +128,7 @@ public:
         if (is_fwd) return prop_kind::forward;
         if (is_bwd_d) return prop_kind::backward_data;
         if (is_bwd_w) return prop_kind::backward_weights;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return prop_kind::undef;
     }
 
@@ -236,7 +236,7 @@ public:
         if (prb_.is_fwd) return DNNL_ARG_SRC;
         if (prb_.is_bwd_d) return DNNL_ARG_DIFF_SRC;
         if (prb_.is_bwd_w) return DNNL_ARG_SRC;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return DNNL_ARG_UNDEF;
     }
 
@@ -247,7 +247,7 @@ public:
         if (prb_.is_fwd) return DNNL_ARG_WEIGHTS;
         if (prb_.is_bwd_d) return DNNL_ARG_WEIGHTS;
         if (prb_.is_bwd_w) return DNNL_ARG_DIFF_WEIGHTS;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return DNNL_ARG_UNDEF;
     }
 
@@ -258,7 +258,7 @@ public:
         if (prb_.is_fwd) return DNNL_ARG_BIAS;
         if (prb_.is_bwd_d) return DNNL_ARG_BIAS;
         if (prb_.is_bwd_w) return DNNL_ARG_DIFF_BIAS;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return DNNL_ARG_UNDEF;
     }
 
@@ -269,7 +269,7 @@ public:
         if (prb_.is_fwd) return DNNL_ARG_DST;
         if (prb_.is_bwd_d) return DNNL_ARG_DIFF_DST;
         if (prb_.is_bwd_w) return DNNL_ARG_DIFF_DST;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return DNNL_ARG_UNDEF;
     }
 

--- a/src/gpu/intel/jit/conv/tiler.cpp
+++ b/src/gpu/intel/jit/conv/tiler.cpp
@@ -1563,8 +1563,7 @@ private:
             case tiler_mode_t::lookup: {
                 const auto params = const_conv_lookup_table().find(cfg.key());
                 if (!params.is_empty() && chk.is_ok(params.blocking())) {
-                    gpu_info() << "[INFO] Using lookup table config: "
-                               << params.str();
+                    gpu_info() << "Using lookup table config: " << params.str();
                     params_gen_ = params_generator_t(tune_level, simd_size, chk,
                             level_tile_sets, params);
                 } else {

--- a/src/gpu/intel/jit/conv/tiler.cpp
+++ b/src/gpu/intel/jit/conv/tiler.cpp
@@ -1207,7 +1207,7 @@ void sort_by_model_scores(params_generator_t &params_gen,
         table << p.str() << (int)(score * 1000) / 1000.0 << eff << regs
               << slm_size << std::endl;
     }
-    ir_trace() << table.str() << std::endl;
+    ir_trace() << table.str();
 #endif
     MAYBE_UNUSED(&slm_usage_bytes_for_params);
 }
@@ -1383,9 +1383,8 @@ private:
         const int nbest = 5;
         auto best_ids = tune_data_.best_ids(nbest);
         std::unordered_map<int, float> dists;
-        ir_trace() << "[Tuning] Rescoring: " << (end - beg) << " configs left"
-                   << std::endl;
-        ir_trace() << "  Best config: " << best_params_dbg_ << std::endl;
+        ir_trace() << "[Tuning] Rescoring: " << (end - beg) << " configs left";
+        ir_trace() << "  Best config: " << best_params_dbg_;
         for (int i = beg; i < end; i++) {
             auto &p = params_gen_.at(i);
             dists[p.id()] = std::numeric_limits<float>::max();
@@ -1399,8 +1398,7 @@ private:
 
         for (int i = beg; i < end; i++) {
             auto &p = params_gen_.at(i);
-            ir_trace() << "  " << p << " [dist:" << dists[p.id()] << "]"
-                       << std::endl;
+            ir_trace() << "  " << p << " [dist:" << dists[p.id()] << "]";
         }
     }
 
@@ -1566,7 +1564,7 @@ private:
                 const auto params = const_conv_lookup_table().find(cfg.key());
                 if (!params.is_empty() && chk.is_ok(params.blocking())) {
                     ir_info() << "[INFO] Using lookup table config: "
-                              << params.str() << std::endl;
+                              << params.str();
                     params_gen_ = params_generator_t(tune_level, simd_size, chk,
                             level_tile_sets, params);
                 } else {
@@ -1616,10 +1614,10 @@ private:
     }
 
     void print_info(double init_time_ms) {
-        ir_info() << "Convolution tiler:" << std::endl;
-        ir_info() << "  Mode:              " << to_string(mode_) << std::endl;
-        ir_info() << "  Filtered configs:  " << configs() << std::endl;
-        ir_info() << "  Init time (ms):    " << init_time_ms << std::endl;
+        ir_info() << "Convolution tiler:";
+        ir_info() << "  Mode:              " << to_string(mode_);
+        ir_info() << "  Filtered configs:  " << configs();
+        ir_info() << "  Init time (ms):    " << init_time_ms;
     }
 
     tiler_mode_t mode_ = tiler_mode_t::undef;

--- a/src/gpu/intel/jit/conv/zero_out.cpp
+++ b/src/gpu/intel/jit/conv/zero_out.cpp
@@ -50,7 +50,7 @@ void zero_out_kernel_desc_t::init_kernel_info(kernel_info_t &kernel_info,
         auto &name = kernel_info.arg_name(i);
         auto &var = kernel_info.arg_var(i);
         if (var.type().is_ptr()) continue;
-        ir_assert(name == "size") << "Unknown scalar argument: " << name;
+        gpu_assert(name == "size") << "Unknown scalar argument: " << name;
         kernel_info.set_internal_arg(name, into<uint32_t>(params.size));
     }
     kernel_info.set_nd_range(nd_range(simd_, params.size));

--- a/src/gpu/intel/jit/ir/block_2d_utils.hpp
+++ b/src/gpu/intel/jit/ir/block_2d_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ inline int block_2d_base_alignment(const hw_t &hw) {
             return (hw.stepping_id() <= 6) ? 128 : 64;
         case ngen::HW::Xe2:
         case ngen::HW::Xe3: return 64;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return 0;
 }
@@ -61,7 +61,7 @@ inline int block_2d_pitch_alignment(const hw_t &hw) {
         case ngen::HW::XeHPC: return 8;
         case ngen::HW::Xe2: return 16;
         case ngen::HW::Xe3: return 16;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return 0;
 }

--- a/src/gpu/intel/jit/ir/blocking.cpp
+++ b/src/gpu/intel/jit/ir/blocking.cpp
@@ -138,7 +138,7 @@ void get_level_tiles(
 
 void params_generator_t::set_params(prim_config_t &cfg) {
     auto &params = params_vec_[cur_idx_];
-    ir_trace() << "set params #" << cur_idx_ << ": " << params << std::endl;
+    ir_trace() << "set params #" << cur_idx_ << ": " << params;
     cfg.set_params(params);
 }
 

--- a/src/gpu/intel/jit/ir/blocking.cpp
+++ b/src/gpu/intel/jit/ir/blocking.cpp
@@ -138,7 +138,7 @@ void get_level_tiles(
 
 void params_generator_t::set_params(prim_config_t &cfg) {
     auto &params = params_vec_[cur_idx_];
-    ir_trace() << "set params #" << cur_idx_ << ": " << params;
+    gpu_trace() << "set params #" << cur_idx_ << ": " << params;
     cfg.set_params(params);
 }
 
@@ -159,7 +159,7 @@ std::string to_string(tiler_mode_t mode) {
         CASE(tune);
 #undef CASE
     }
-    ir_error_not_expected();
+    gpu_error_not_expected();
     return "(unknown)";
 }
 
@@ -263,7 +263,7 @@ void blocking_generator_t::generate_all(int vec_size, blocking_checker_t &chk,
 
 void blocking_generator_t::generate_sample(int vec_size,
         const blocking_checker_t &chk, const level_tile_set_t &level_tile_set) {
-    ir_assert(false);
+    gpu_assert(false);
     int target_size = 1;
     auto is_ok = [&](const blocking_t &blk) { return chk.is_ok(blk); };
     auto ts_blockings = level_tile_set.sample(target_size, is_ok, vec_size);
@@ -289,7 +289,7 @@ params_generator_t::params_generator_t(int tune_level, int simd_size,
         const std::vector<level_tile_set_t> &level_tile_sets, int idx) {
     append_params(params_vec_, level_tile_sets, chk, tune_level, simd_size);
     if (idx != -1) {
-        ir_assert(idx >= 0 && idx < configs());
+        gpu_assert(idx >= 0 && idx < configs());
         std::vector<blocking_params_t> temp_vec;
         temp_vec.swap(params_vec_);
         append_params(params_vec_, temp_vec[idx]);
@@ -342,7 +342,7 @@ const tiler_params_t &tiler_params() {
                 continue;
             }
             auto sub_opts = gpu_utils::split(opt, ":");
-            ir_assert((int)sub_opts.size() == 2);
+            gpu_assert((int)sub_opts.size() == 2);
             auto &key = sub_opts[0];
             auto &value = sub_opts[1];
             if (key == "tune_iters") {
@@ -351,11 +351,11 @@ const tiler_params_t &tiler_params() {
                 ret.mode = tiler_mode_t::env_tiler;
                 ret.env_params_idx = std::stoi(value);
             } else {
-                ir_error_not_expected();
+                gpu_error_not_expected();
             }
         }
         bool do_tune = (ret.mode == tiler_mode_t::tune);
-        ir_assert(do_tune == (ret.tune_iters != 0));
+        gpu_assert(do_tune == (ret.tune_iters != 0));
         return ret;
     }();
     return params;
@@ -372,7 +372,7 @@ tile_to_vec_t::tile_to_vec_t(const std::vector<std::vector<pvar_tile_t>> &tiles,
         ids.resize(ntiles);
         std::iota(ids.begin(), ids.end(), 0);
     }
-    ir_assert(ids.size() == tiles.size());
+    gpu_assert(ids.size() == tiles.size());
     int max_id = 0;
     for (int i = 0; i < ntiles; i++) {
         for (int j = 0; j < nsubtiles; j++) {

--- a/src/gpu/intel/jit/ir/blocking.hpp
+++ b/src/gpu/intel/jit/ir/blocking.hpp
@@ -19,6 +19,7 @@
 
 #include "gpu/intel/jit/ir/core.hpp"
 #include "gpu/intel/jit/ir/problem.hpp"
+#include "gpu/intel/utils.hpp"
 
 #include <set>
 
@@ -248,7 +249,7 @@ public:
             case level_t::loop: return loop != 0;
             case level_t::thread_group: return thread_group != 0;
             case level_t::iter: return iter != 0;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return false;
     }
@@ -304,13 +305,13 @@ public:
     virtual ~blocking_scheme_t() = default;
     blocking_scheme_t() = default;
     blocking_scheme_t(const std::string &s) {
-        ir_assert(s[s.length() - 1] == ']');
+        gpu_assert(s[s.length() - 1] == ']');
         auto parts = gpu_utils::split(s.substr(0, s.length() - 1), "],");
         for (auto &p : parts) {
             auto p_parts = gpu_utils::split(p, ":");
             auto &key = p_parts[0];
             auto &vec = p_parts[1];
-            ir_assert(vec[0] == '[');
+            gpu_assert(vec[0] == '[');
             auto s_dims
                     = gpu_utils::split(vec.substr(1, vec.length() - 1), ",");
             for (auto &s : s_dims)
@@ -366,11 +367,11 @@ public:
 
 private:
     void set(const std::string &s_tile, const std::string &_s_dim) {
-        ir_assert(!_s_dim.empty());
+        gpu_assert(!_s_dim.empty());
         bool no_min_check = (_s_dim[0] == '#');
         auto s_dim = no_min_check ? _s_dim.substr(1) : _s_dim;
         auto d = pvar_t(s_dim);
-        if (no_min_check) ir_assert(s_tile == "i");
+        if (no_min_check) gpu_assert(s_tile == "i");
         if (s_tile == "i") {
             add_iter_dim(d);
             if (no_min_check) tile_info(d).set_min_iter_block(1);
@@ -383,7 +384,7 @@ private:
         } else if (s_tile == "li") {
             add_loop_dim_with_iter_unroll(d);
         } else {
-            ir_error_not_expected() << s_tile;
+            gpu_error_not_expected() << s_tile;
         }
     }
 
@@ -555,14 +556,14 @@ public:
     int cur_index() const { return cur_idx_; }
 
     void set_cur_index(int idx) {
-        ir_assert(idx < configs());
+        gpu_assert(idx < configs());
         cur_idx_ = idx;
     }
 
     const blocking_params_t &cur_params() const { return at(cur_idx_); }
 
     const blocking_params_t &at(int idx) const {
-        ir_assert(idx >= 0 && idx < configs());
+        gpu_assert(idx >= 0 && idx < configs());
         return params_vec_[idx];
     }
 
@@ -572,8 +573,8 @@ public:
 
     template <typename KeyFuncT>
     void sort(int beg, int end, const KeyFuncT &key_func) {
-        ir_assert(beg >= 0 && beg < configs());
-        ir_assert(end >= beg && end <= configs());
+        gpu_assert(beg >= 0 && beg < configs());
+        gpu_assert(end >= beg && end <= configs());
         std::sort(params_vec_.begin() + beg, params_vec_.begin() + end,
                 [&](const blocking_params_t &a, const blocking_params_t &b) {
                     return key_func(a) < key_func(b);
@@ -582,7 +583,7 @@ public:
 
     template <typename PredicateFuncT>
     void remove_if(const PredicateFuncT &func) {
-        ir_assert(cur_idx_ == -1);
+        gpu_assert(cur_idx_ == -1);
         params_vec_.erase(
                 std::remove_if(params_vec_.begin(), params_vec_.end(), func),
                 params_vec_.end());
@@ -596,7 +597,7 @@ public:
         table_t table("List of configs", headers);
         for (int i = 0; i < configs(); i++) {
             auto &params = params_vec_[i];
-            ir_trace() << "params #" << i << ": " << params;
+            gpu_trace() << "params #" << i << ": " << params;
         }
     }
 
@@ -692,7 +693,7 @@ private:
 
             dim_idx_t to_index(dim_t value) const {
                 auto it = values_.find(value);
-                ir_assert(it != values_.end());
+                gpu_assert(it != values_.end());
                 return it->second;
             }
 

--- a/src/gpu/intel/jit/ir/blocking.hpp
+++ b/src/gpu/intel/jit/ir/blocking.hpp
@@ -596,7 +596,7 @@ public:
         table_t table("List of configs", headers);
         for (int i = 0; i < configs(); i++) {
             auto &params = params_vec_[i];
-            ir_trace() << "params #" << i << ": " << params << std::endl;
+            ir_trace() << "params #" << i << ": " << params;
         }
     }
 

--- a/src/gpu/intel/jit/ir/config.hpp
+++ b/src/gpu/intel/jit/ir/config.hpp
@@ -62,7 +62,7 @@ public:
                 compute_unnormalized_tag_ = parts[0];
                 user_unnormalized_tag_ = parts[1];
                 break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
     }
 
@@ -125,7 +125,7 @@ public:
         if (key == "regs") return false;
         if (key == "simd") return false;
         if (key == "vec") return value_.vec_size() == value_.simd();
-        ir_error_not_expected() << key;
+        gpu_error_not_expected() << key;
         return false;
     }
 
@@ -142,7 +142,7 @@ public:
         } else if (key == "vec") {
             value_.set_vec_size(std::stoi(value));
         } else {
-            ir_error_not_expected() << key;
+            gpu_error_not_expected() << key;
         }
     }
 
@@ -306,7 +306,7 @@ public:
     }
 
     void set_params(const blocking_params_t &params) {
-        ir_assert(!params.is_empty());
+        gpu_assert(!params.is_empty());
         const auto &blocking = params.blocking();
         if (!loop_dims().is_overridden()) loop_dims().set(blocking.loop());
         if (!thread_group_dims().is_overridden())
@@ -351,7 +351,7 @@ public:
         int subslice_count = exec_cfg.hw().eu_count() / eus_per_subslice;
 
         int tgs_per_subslice = eus_per_subslice * threads_per_eu / tg_elems;
-        ir_assert(tgs_per_subslice > 0);
+        gpu_assert(tgs_per_subslice > 0);
         return subslice_count * tgs_per_subslice;
     }
 
@@ -382,12 +382,12 @@ public:
 #define DECL_PARAM(name) \
     const name##_param_t &name##_param() const { \
         (void)name##_init_; \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         return name##_; \
     } \
     name##_param_t &name##_param() { return name##_; } \
     const name##_param_t::value_t &name() const { \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         return name##_.get(); \
     } \
     void set_##name(const name##_param_t::value_t &value) { \
@@ -396,7 +396,7 @@ public:
 #define DECL_PARAM2(name) \
     const name##_param_t &name() const { \
         (void)name##_init_; \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         return name##_; \
     } \
     name##_param_t &name() { return name##_; }

--- a/src/gpu/intel/jit/ir/eltwise.hpp
+++ b/src/gpu/intel/jit/ir/eltwise.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public:
             // Note: `eltwise_stochastic_round` is not a part of `enum` which
             // forces `switch` to iterate over `int`, not `alg_kind_t`.
             case alg_kind::eltwise_stochastic_round: return "stochastic_round";
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return "unknown";
     }

--- a/src/gpu/intel/jit/ir/epilogue.cpp
+++ b/src/gpu/intel/jit/ir/epilogue.cpp
@@ -727,7 +727,7 @@ public:
         ir_trace() << "Creating epilogue with parameters"
                    << ": tile_size = " << tile_size_
                    << ", preload_max_size = " << preload_max_size
-                   << ", post_op_blk = " << post_op_blk << std::endl;
+                   << ", post_op_blk = " << post_op_blk;
 
         for (auto &po_tensor_info : post_op_ctx_.post_op_tensor_infos()) {
             post_op_tensor_t po_tensor(ir_ctx_, po_tensor_info);

--- a/src/gpu/intel/jit/ir/fma.cpp
+++ b/src/gpu/intel/jit/ir/fma.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ int get_simd_size(const hw_t &hw, const fma_kind_t kind, const type_t &a,
         case fma_kind_t::mad: ret = mad_t::get_simd_size(hw, a, b, c); break;
         default: break;
     }
-    ir_assert(ret != 0);
+    gpu_assert(ret != 0);
     return ret;
 }
 
@@ -75,7 +75,7 @@ type_t multiply_desc_t::get_c_type(
         return type_t::f16();
     }
 
-    ir_error_not_expected()
+    gpu_error_not_expected()
             << "Can't deduce C type. A type: " << a << " B type: " << b;
     return type_t::undef();
 }
@@ -86,7 +86,7 @@ bool dpas_t::is_src_type(type_t type) {
 }
 
 layout_t dpas_t::a_layout() const {
-    if (!is_src_type(src1_type)) ir_error_not_expected();
+    if (!is_src_type(src1_type)) gpu_error_not_expected();
 
     int m_blk = exec_size;
     int inner_blk = 4 / src1_type.size();
@@ -97,7 +97,7 @@ layout_t dpas_t::a_layout() const {
 }
 
 layout_t dpas_t::b_layout() const {
-    if (!is_src_type(src2_type)) ir_error_not_expected();
+    if (!is_src_type(src2_type)) gpu_error_not_expected();
 
     int n_blk = rcount;
     int k_blk = sdepth * 4 / src2_type.size();

--- a/src/gpu/intel/jit/ir/fma.hpp
+++ b/src/gpu/intel/jit/ir/fma.hpp
@@ -69,7 +69,7 @@ public:
     multiply_desc_t(const layout_t &a_layout, const layout_t &b_layout,
             bool force_c_upconvert)
         : a_layout_(a_layout), b_layout_(b_layout) {
-        ir_assert(a_layout.ndims() == dim_idx_t(2)
+        gpu_assert(a_layout.ndims() == dim_idx_t(2)
                 && b_layout.ndims() == dim_idx_t(2))
                 << "Expected 2D layouts, A layout: " << a_layout
                 << " B layout: " << b_layout;
@@ -281,12 +281,12 @@ private:
         , src1_stride(src1_stride)
         , src2_stride(src2_stride) {
         int max_exec_size_bytes = get_max_exec_size_bytes(hw);
-        ir_assert(math::is_pow2(exec_size));
+        gpu_assert(math::is_pow2(exec_size));
 
-        ir_assert(exec_size <= max_exec_size);
-        ir_assert(dst_size() <= max_exec_size_bytes);
-        ir_assert(src1_size() <= max_exec_size_bytes);
-        ir_assert(src2_size() <= max_exec_size_bytes);
+        gpu_assert(exec_size <= max_exec_size);
+        gpu_assert(dst_size() <= max_exec_size_bytes);
+        gpu_assert(src1_size() <= max_exec_size_bytes);
+        gpu_assert(src2_size() <= max_exec_size_bytes);
     }
 };
 

--- a/src/gpu/intel/jit/ir/gemm_schedule.cpp
+++ b/src/gpu/intel/jit/ir/gemm_schedule.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ layout_t bmnk_mapper_t::map_to_bmnk(abc_kind_t abc_kind,
                 break;
             }
         }
-        if (!found) ir_error_not_expected() << "MNK dimension not found.";
+        if (!found) gpu_error_not_expected() << "MNK dimension not found.";
     }
     return layout_t(layout.type(), int(bmnk_kinds.size()), 0, blocks);
 }
@@ -64,15 +64,15 @@ void bmnk_block_mapper_t::push_block(abc_kind_t abc_kind, const block_t &b) {
         case bmnk_kind_t::m: m_blocks_.emplace_back(abc_kind, b); break;
         case bmnk_kind_t::n: n_blocks_.emplace_back(abc_kind, b); break;
         case bmnk_kind_t::k: k_blocks_.emplace_back(abc_kind, b); break;
-        default: ir_error_not_expected() << "Unknown MNK kind.";
+        default: gpu_error_not_expected() << "Unknown MNK kind.";
     }
 }
 
 layout_t bmnk_block_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
         const std::vector<bmnk_kind_t> &bmnk_kinds,
         const layout_t &bmnk_layout) const {
-    ir_assert(bmnk_layout.ndims() <= 3);
-    ir_assert(bmnk_layout.has_zero_offset());
+    gpu_assert(bmnk_layout.ndims() <= 3);
+    gpu_assert(bmnk_layout.has_zero_offset());
     std::vector<block_t> blocks;
     std::vector<std::vector<block_t>> tmp_blocks(
             static_cast<int>(bmnk_kind_t::k) + 1);
@@ -87,13 +87,13 @@ layout_t bmnk_block_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
     for (auto &b : bmnk_layout.blocks()) {
         auto &bmnk_blocks = tmp_blocks[static_cast<int>(bmnk_kinds[b.dim_idx])];
         bool ok = pop_block(bmnk_blocks, blocks, b);
-        ir_assert(ok) << "Can't map from bmnk layout to problem layout.";
+        gpu_assert(ok) << "Can't map from bmnk layout to problem layout.";
         MAYBE_UNUSED(ok);
     }
     for (auto bmnk_kind : bmnk_kinds) {
         auto &bmnk_blocks = tmp_blocks[static_cast<int>(bmnk_kind)];
         pop_size_1_blocks(bmnk_blocks);
-        ir_assert(bmnk_blocks.empty());
+        gpu_assert(bmnk_blocks.empty());
     }
 
     // Fix strides to make them dense.

--- a/src/gpu/intel/jit/ir/grf_permutation.hpp
+++ b/src/gpu/intel/jit/ir/grf_permutation.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public:
     grf_permutation_t() { permutation_.fill(-1); }
 
     int map(int off) const {
-        ir_assert(off >= 0 && off < max_regs);
+        gpu_assert(off >= 0 && off < max_regs);
         if (permutation_[off] == -1) return off;
         return permutation_[off];
     }
@@ -42,10 +42,10 @@ public:
     bool is_empty() const { return is_empty_; }
 
     void set_permute(int old_off, int new_off) {
-        ir_assert(old_off >= 0 && old_off < max_regs);
+        gpu_assert(old_off >= 0 && old_off < max_regs);
         if (old_off == new_off || new_off == -1) return;
         is_empty_ = false;
-        ir_assert(utils::one_of(permutation_[old_off], -1, new_off))
+        gpu_assert(utils::one_of(permutation_[old_off], -1, new_off))
                 << "Already assigned to a different offset.";
         permutation_[old_off] = new_off;
     }

--- a/src/gpu/intel/jit/ir/hw.cpp
+++ b/src/gpu/intel/jit/ir/hw.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ int hw_t::cache_line_size() const {
         case ngen::HW::XeHPC:
         case ngen::HW::Xe2:
         case ngen::HW::Xe3: return 64;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return 0;
 }

--- a/src/gpu/intel/jit/ir/ir.hpp
+++ b/src/gpu/intel/jit/ir/ir.hpp
@@ -117,7 +117,7 @@ public:
         }
         // Ensure large GRF buffers are aligned to a register boundary.
         if (!entry_ptr->is_slm() && entry_ptr->size > ir_ctx_->grf_size()) {
-            ir_assert(entry_ptr->size % ir_ctx_->grf_size() == 0);
+            gpu_assert(entry_ptr->size % ir_ctx_->grf_size() == 0);
         }
         return entry_ptr->buf;
     }
@@ -129,7 +129,7 @@ public:
     entry_t find(const std::string &name, bool allow_empty = false) const {
         auto it = entries_.find(name);
         if (it != entries_.end()) return it->second;
-        if (!allow_empty) ir_error_not_expected() << "Not found: " << name;
+        if (!allow_empty) gpu_error_not_expected() << "Not found: " << name;
         return entry_t();
     }
 
@@ -139,7 +139,7 @@ public:
 
     const entry_t &find_ref(const std::string &name) const {
         auto it = entries_.find(name);
-        ir_assert(it != entries_.end());
+        gpu_assert(it != entries_.end());
         return it->second;
     }
 
@@ -149,7 +149,7 @@ public:
 
     entry_t &find_ref(const std::string &name) {
         auto it = entries_.find(name);
-        ir_assert(it != entries_.end());
+        gpu_assert(it != entries_.end());
         return it->second;
     }
 
@@ -194,19 +194,19 @@ class alloc_updater_t : public ir_mutator_t {
 public:
     void resize(const expr_t &buf, int new_size) {
         auto ret = resizes_.insert({buf, new_size});
-        ir_assert(ret.second) << buf;
+        gpu_assert(ret.second) << buf;
         MAYBE_UNUSED(ret);
     }
 
     void add_attr(const expr_t &buf, const alloc_attr_t &attr) {
         auto ret = attrs_.insert({buf, attr});
-        ir_assert(ret.second) << buf;
+        gpu_assert(ret.second) << buf;
         MAYBE_UNUSED(ret);
     }
 
     void remove(const expr_t &buf) {
         auto ret = removes_.insert(buf);
-        ir_assert(ret.second) << buf;
+        gpu_assert(ret.second) << buf;
         MAYBE_UNUSED(ret);
     }
 
@@ -223,7 +223,7 @@ public:
             } else if (!new_stmt.is_same(old_stmt)) {
                 auto &new_a = new_stmt.as<alloc_t>();
                 auto &entry = buf_mgr.find_ref(e.buf);
-                ir_assert(entry.attrs.empty());
+                gpu_assert(entry.attrs.empty());
                 entry.size = new_a.size;
                 entry.attrs = new_a.attrs;
                 continue;
@@ -416,7 +416,7 @@ public:
             auto &a = _a.as<alloc_t>();
             auto ret = buf2alloc_.insert({a.buf, _a});
             buffers_.push_back(a.buf);
-            ir_assert(ret.second) << "Buffer already exists: " << a.buf;
+            gpu_assert(ret.second) << "Buffer already exists: " << a.buf;
             MAYBE_UNUSED(ret);
         }
 
@@ -434,7 +434,7 @@ public:
         for (auto &b : buffers())
             if (b.as<var_t>().name == name) return b;
 
-        if (!allow_empty) ir_error_not_expected() << name;
+        if (!allow_empty) gpu_error_not_expected() << name;
         return expr_t();
     }
 
@@ -447,13 +447,13 @@ public:
 
     uint32_t alloc_size(const expr_t &buf) const {
         auto *a = find_alloc(buf);
-        ir_assert(a) << buf;
+        gpu_assert(a) << buf;
         return a->size;
     }
 
     alloc_kind_t alloc_kind(const expr_t &buf) const {
         auto *a = find_alloc(buf);
-        ir_assert(a) << buf;
+        gpu_assert(a) << buf;
         return a->kind;
     }
 
@@ -637,7 +637,7 @@ public:
     void pop() { path_.pop_back(); }
 
     const object_impl_t *back() const {
-        ir_assert(!is_empty());
+        gpu_assert(!is_empty());
         return path_.back();
     }
 
@@ -782,7 +782,7 @@ public:
     }
 
     bool implies(const modulus_info_t &other) const {
-        ir_assert(var().is_same(other.var()));
+        gpu_assert(var().is_same(other.var()));
 
         int64_t this_mod = to_cpp<int64_t>(mod());
         int64_t other_mod = to_cpp<int64_t>(other.mod());
@@ -841,7 +841,7 @@ public:
         : relations_(relations) {}
 
     int64_t get_var_bound(const expr_t &e, bool is_low) const override {
-        ir_assert(is_var(e));
+        gpu_assert(is_var(e));
         int64_t def_bound = unlimited_bound(is_low);
         auto it = relations_.find(e);
         if (it == relations_.end()) return def_bound;
@@ -953,12 +953,12 @@ private:
             case op_kind_t::_le: break;
             case op_kind_t::_gt:
                 op_kind = op_kind_t::_ge;
-                ir_assert(b < std::numeric_limits<int64_t>::max());
+                gpu_assert(b < std::numeric_limits<int64_t>::max());
                 b += 1;
                 break;
             case op_kind_t::_lt:
                 op_kind = op_kind_t::_le;
-                ir_assert(b > std::numeric_limits<int64_t>::min());
+                gpu_assert(b > std::numeric_limits<int64_t>::min());
                 b -= 1;
                 break;
             default: return false;

--- a/src/gpu/intel/jit/ir/ir.hpp
+++ b/src/gpu/intel/jit/ir/ir.hpp
@@ -397,6 +397,17 @@ std::vector<std::pair<KeyT, expr_t>> sort_var_map_by_value(
             });
 }
 
+template <typename ValueT, typename HashT, typename EqualT>
+std::vector<std::pair<expr_t, ValueT>> sort_var_map_by_key(
+        const std::unordered_map<expr_t, ValueT, HashT, EqualT> &map) {
+    return sort_var_map(map,
+            [](const std::pair<expr_t, ValueT> &a,
+                    const std::pair<expr_t, ValueT> &b) {
+                return a.first.template as<var_t>().name
+                        < b.first.template as<var_t>().name;
+            });
+}
+
 class alloc_manager_t {
 public:
     alloc_manager_t(const stmt_t &root) {
@@ -875,7 +886,7 @@ public:
     std::string str() const {
         std::ostringstream oss;
         oss << "relations:" << (relations_.empty() ? " (empty)\n" : "\n");
-        for (auto &r : relations_) {
+        for (auto &r : sort_var_map_by_key(relations_)) {
             oss << "\t" << r.first << ":";
             bool first = true;
             for (auto &s : r.second) {
@@ -887,7 +898,7 @@ public:
 
         oss << "modulus_info:"
             << (modulus_infos_.empty() ? " (empty)\n" : "\n");
-        for (auto &m : modulus_infos_) {
+        for (auto &m : sort_var_map_by_key(modulus_infos_)) {
             oss << "\t" << m.first << ":";
             bool first = true;
             for (auto &s : m.second) {

--- a/src/gpu/intel/jit/ir/kernel_info.hpp
+++ b/src/gpu/intel/jit/ir/kernel_info.hpp
@@ -74,7 +74,7 @@ class kernel_iface_t {
 public:
     int nargs() const { return int(args_.size()); }
     const expr_t &arg_var(int idx) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         return args_[idx].var;
     }
     const std::string &arg_name(int idx) const {
@@ -87,7 +87,7 @@ public:
         auto *arg = find_arg_impl(name);
         if (arg) return arg->var;
         if (!allow_empty)
-            ir_error_not_expected() << "Argument not found: " << name;
+            gpu_error_not_expected() << "Argument not found: " << name;
         return expr_t();
     }
 
@@ -149,7 +149,7 @@ public:
             case kernel_id_t::pre_reorder: return 2;
             case kernel_id_t::convolution: return 3;
             case kernel_id_t::post_reorder: return 4;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return -1;
     }
@@ -169,7 +169,7 @@ public:
 
     void set_internal_arg(const std::string &name, const expr_t &value) {
         auto *arg = find_arg_impl(name);
-        ir_assert(arg) << "Cannot find argument: " << name;
+        gpu_assert(arg) << "Cannot find argument: " << name;
         arg->value = value;
     }
 
@@ -183,12 +183,12 @@ public:
     }
 
     const std::string &arg_name(int idx) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         return args_[idx].name();
     }
 
     const expr_t &arg_var(int idx) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         return args_[idx].var;
     }
 
@@ -198,12 +198,12 @@ public:
         auto *arg = find_arg_impl(name);
         if (arg) return arg->var;
         if (!allow_empty)
-            ir_error_not_expected() << "Argument not found: " << name;
+            gpu_error_not_expected() << "Argument not found: " << name;
         return expr_t();
     }
 
     int key(int idx) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         return args_[idx].key;
     }
 
@@ -211,24 +211,24 @@ public:
         for (int i = 0; i < nargs(); i++) {
             if (arg_name(i) == name) return key(i);
         }
-        ir_error_not_expected() << "Argument not found: " << name;
+        gpu_error_not_expected() << "Argument not found: " << name;
         return -1;
     }
 
     int nargs() const { return int(args_.size()); }
 
     bool is_scratchpad(int idx) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         return args_[idx].kind == arg_kind_t::scratchpad;
     }
 
     bool is_user(int idx) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         return args_[idx].kind == arg_kind_t::user;
     }
 
     bool is_input(int idx) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         return args_[idx].is_input;
     }
 
@@ -244,7 +244,7 @@ public:
 
     memory_storage_wrapper_t arg_storage(int idx, const exec_ctx_t &ctx,
             const gpu_primitive_t *primitive) const {
-        ir_assert(idx >= 0 && idx < nargs());
+        gpu_assert(idx >= 0 && idx < nargs());
         bool is_input = args_[idx].is_input;
         int key = args_[idx].key;
         switch (args_[idx].kind) {
@@ -256,7 +256,7 @@ public:
             }
             // No storage for internal arguments.
             case arg_kind_t::internal: return memory_storage_wrapper_t();
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return memory_storage_wrapper_t();
     }
@@ -268,7 +268,7 @@ public:
                 return memory_desc_wrapper(md).size();
             }
             case arg_kind_t::scratchpad: return args_[idx].scratchpad_size;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return std::numeric_limits<size_t>::max();
     }
@@ -305,7 +305,7 @@ public:
                         CASE(u64, uint64_t)
 #undef CASE
 
-                        ir_error_not_expected() << type;
+                        gpu_error_not_expected() << type;
                     } while (false);
                     break;
                 }
@@ -314,7 +314,7 @@ public:
                     arg_list.set(i, *storage_list[i].get());
                     break;
                 }
-                default: ir_error_not_expected();
+                default: gpu_error_not_expected();
             }
         }
     }
@@ -343,7 +343,7 @@ private:
 
     void register_arg(const expr_t &var, arg_kind_t kind, int key,
             bool is_input, size_t scratchpad_size = 0) {
-        ir_assert(is_var(var)) << "Expected var, got: " << var;
+        gpu_assert(is_var(var)) << "Expected var, got: " << var;
         args_.emplace_back(var, kind, key, is_input, scratchpad_size);
     }
 

--- a/src/gpu/intel/jit/ir/message.cpp
+++ b/src/gpu/intel/jit/ir/message.cpp
@@ -498,8 +498,7 @@ void access_builder_t::build() {
     }
     if (!ok && send_op_ == send_op_t::prefetch) {
         // Do not treat as an error, skip prefetch messages during generation.
-        ir_warning() << "Can't generate send decomposition for prefetch."
-                     << std::endl;
+        ir_warning() << "Can't generate send decomposition for prefetch.";
         return;
     }
     ir_assert(ok) << "Can't generate send decomposition.";

--- a/src/gpu/intel/jit/ir/message.hpp
+++ b/src/gpu/intel/jit/ir/message.hpp
@@ -270,7 +270,7 @@ public:
     }
 
     int payload_type_stride() const {
-        ir_assert(!is_2d());
+        gpu_assert(!is_2d());
         return std::max(4, type.size());
     }
 
@@ -309,7 +309,7 @@ public:
 
         if (is_scattered()) return type.size();
 
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return 0;
     }
 
@@ -318,7 +318,7 @@ public:
         int masks = ir_utils::safe_divide(type.size() * slots, mask_size());
         if (hw < ngen::HW::XeHPC && is_block() && masks > 16) {
             // Round-robin masking, 16 bits are reused with dword granularity.
-            ir_assert(masks % 16 == 0);
+            gpu_assert(masks % 16 == 0);
             masks = 16;
         }
         return masks;
@@ -401,11 +401,11 @@ private:
         , fill_buf(zero_out)
         , block_2d_info(block_2d_info)
         , cache_hint(cache_hint) {
-        ir_assert(utils::one_of(op, send_op_t::load_2d, send_op_t::store_2d,
+        gpu_assert(utils::one_of(op, send_op_t::load_2d, send_op_t::store_2d,
                 send_op_t::prefetch_2d));
         if (is_store_2d()) {
-            ir_assert(!block_2d_info.vnni);
-            ir_assert(!block_2d_info.transpose);
+            gpu_assert(!block_2d_info.vnni);
+            gpu_assert(!block_2d_info.transpose);
         }
     }
 };

--- a/src/gpu/intel/jit/ir/message_patterns.hpp
+++ b/src/gpu/intel/jit/ir/message_patterns.hpp
@@ -111,11 +111,11 @@ struct stride_layout_t {
     }
 
     const stride_dim_t &operator[](int i) const {
-        ir_assert(i < max_ndims);
+        gpu_assert(i < max_ndims);
         return strides[i];
     }
     stride_dim_t &operator[](int i) {
-        ir_assert(i < max_ndims);
+        gpu_assert(i < max_ndims);
         return strides[i];
     }
 
@@ -202,7 +202,7 @@ struct send_hint_t {
     bool is_uniform_2d() const { return type_id_ == uniform_2d; }
     send_type_id_t get_type() const { return type_id_; }
     void set_type(send_type_id_t type) {
-        ir_assert(utils::one_of(type_id_, type, send_type_id_t::empty));
+        gpu_assert(utils::one_of(type_id_, type, send_type_id_t::empty));
         type_id_ = type;
     }
     dim_t ref_2d_width() const { return block_width / type_size_; }
@@ -502,7 +502,7 @@ struct uniform_send_idiom_t final {
                 });
         if (ret.size() && filtered_ret.size()
                 && ret[0].size() > filtered_ret[0].size())
-            ir_warning() << "Optimal send hint disabled: " << ret[0];
+            gpu_warning() << "Optimal send hint disabled: " << ret[0];
 
         return filtered_ret;
     }

--- a/src/gpu/intel/jit/ir/message_patterns.hpp
+++ b/src/gpu/intel/jit/ir/message_patterns.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -502,8 +502,7 @@ struct uniform_send_idiom_t final {
                 });
         if (ret.size() && filtered_ret.size()
                 && ret[0].size() > filtered_ret[0].size())
-            ir_warning() << "Optimal send hint disabled: " << ret[0]
-                         << std::endl;
+            ir_warning() << "Optimal send hint disabled: " << ret[0];
 
         return filtered_ret;
     }

--- a/src/gpu/intel/jit/ir/post_ops.cpp
+++ b/src/gpu/intel/jit/ir/post_ops.cpp
@@ -57,7 +57,7 @@ post_op_context_t::post_op_context_t(const primitive_attr_t &attr,
             view_t view;
             switch (key) {
                 case DNNL_ARG_SRC:
-                    ir_assert(mask == 0);
+                    gpu_assert(mask == 0);
                     src_scales_type = sc_type;
                     view = po_vm_.create_view(sc_type, mask);
                     src_scales = add_input_tensor(view, buf);
@@ -67,14 +67,14 @@ post_op_context_t::post_op_context_t(const primitive_attr_t &attr,
                     // Convert o/i weights mask to src/dst.
                     // XXX: per_oc for BWD_D is treated as per_ic assuming
                     // it's called from deconvolution.
-                    ir_assert(utils::one_of(mask, 0, 1, 3));
+                    gpu_assert(utils::one_of(mask, 0, 1, 3));
                     wei_scales_type = sc_type;
                     view = po_vm_.create_view(sc_type, (mask) ? 1 << 1 : 0);
                     wei_scales = add_input_tensor(view, buf);
                     wei_scales_mask = mask;
                     break;
                 case DNNL_ARG_DST: // Invert dst scales right after load.
-                    ir_assert(mask == 0);
+                    gpu_assert(mask == 0);
                     dst_scales_type = sc_type;
                     view = po_vm_.create_view(sc_type, mask);
                     dst_scales = add_input_tensor(view, buf);
@@ -185,7 +185,7 @@ post_op_context_t::post_op_context_t(const primitive_attr_t &attr,
             auto op_kind = alg_kind_to_op_kind(po.binary.alg);
             post_ops_.emplace_back(c, binary_op_t::make(op_kind, c, rhs));
         } else {
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
     }
 
@@ -286,7 +286,7 @@ bool post_op_context_t::init_need_to_restore_zero_padding(
         } else if (po.is_prelu()) {
             return false;
         } else {
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
     }
     if (zp_cfg.do_src_compensation && dst_md.dims[0] != dst_md.padded_dims[0])

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -185,12 +185,12 @@ private:
         auto *ptr = buf.as_ptr<ptr_t>();
         if (ptr) {
             auto prefix = make_op_var_name(ptr->base);
-            ir_assert(is_const(ptr->off));
+            gpu_assert(is_const(ptr->off));
             dim_t off = to_cpp<dim_t>(ptr->off);
             return prefix + "_" + std::to_string(off);
         }
 
-        ir_error_not_expected() << "Can't generate op var name: " << buf;
+        gpu_error_not_expected() << "Can't generate op var name: " << buf;
         return "unknown";
     }
     bool is_input_;
@@ -307,7 +307,7 @@ inline op_kind_t alg_kind_to_op_kind(alg_kind_t alg) {
         case alg_kind::binary_lt: return op_kind_t::_lt;
         case alg_kind::binary_eq: return op_kind_t::_eq;
         case alg_kind::binary_ne: return op_kind_t::_ne;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return op_kind_t::undef;
 }
@@ -364,7 +364,7 @@ private:
             const expr_t &buf, const expr_t &op_var,
             const expr_t &compute_expr = expr_t(),
             const bool do_convert = true) {
-        ir_assert(cp_ndims() == view.nvdims());
+        gpu_assert(cp_ndims() == view.nvdims());
         uint32_t mask = (buf.is_empty() && compute_expr.is_empty()
                         ? ~(1u << cp_ndims())
                         : compute_mask(view));
@@ -374,7 +374,7 @@ private:
     }
 
     uint32_t compute_mask(const view_t &view) const {
-        ir_assert(cp_ndims() == view.nvdims());
+        gpu_assert(cp_ndims() == view.nvdims());
         uint32_t mask = 0;
         for (dim_idx_t i = 0; i < cp_ndims(); i++) {
             if (view.vdims()[i] != 1) mask |= (1 << i);

--- a/src/gpu/intel/jit/ir/problem.cpp
+++ b/src/gpu/intel/jit/ir/problem.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ std::string to_string(tensor_kind_t tensor) {
         CASE(b);
         CASE(c);
 #undef CASE
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return {};
 }

--- a/src/gpu/intel/jit/ir/problem.hpp
+++ b/src/gpu/intel/jit/ir/problem.hpp
@@ -153,7 +153,7 @@ public:
     }
 
     const ValueT &operator[](const pvar_t &key) const {
-        ir_assert(has(key)) << "Key not found: " << key;
+        gpu_assert(has(key)) << "Key not found: " << key;
         return map_.at(key);
     }
 
@@ -184,7 +184,7 @@ public:
         for (auto &kv : other.map_) {
             auto it = map_.find(kv.first);
             if (it != map_.end()) {
-                ir_assert(it->second == kv.second);
+                gpu_assert(it->second == kv.second);
                 continue;
             }
             ret[kv.first] = kv.second;

--- a/src/gpu/intel/jit/ir/reduce.cpp
+++ b/src/gpu/intel/jit/ir/reduce.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
         uint32_t reduction_mask, bool drop_dims) {
     auto subtile = _subtile;
     if (subtile.is_empty()) subtile = tensor_t(src.dims());
-    ir_assert(src.ndims() == subtile.ndims());
+    gpu_assert(src.ndims() == subtile.ndims());
     dim_idx_t ndims = src.ndims();
 
     // Align dst layout with src layout according to the mask if needed.
@@ -45,7 +45,8 @@ stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
                 dst_dim_idx++;
             }
         }
-        ir_assert(dst_dim_idx == dst.ndims()) << "Incompatible reduction mask.";
+        gpu_assert(dst_dim_idx == dst.ndims())
+                << "Incompatible reduction mask.";
 
         auto dst_blocks = dst.blocks();
         for (auto &b : dst_blocks)
@@ -74,7 +75,7 @@ stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
 
 stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
         const expr_t &src_buf, const expr_t &dst_buf) {
-    ir_assert(src.ndims() == dst.ndims());
+    gpu_assert(src.ndims() == dst.ndims());
     uint32_t reduction_mask = 0;
     for (dim_idx_t i = 0; i < src.ndims(); i++) {
         if (dst.dims()[i] != 1 || src.dims()[i] == 1) {

--- a/src/gpu/intel/jit/ir/reorder.hpp
+++ b/src/gpu/intel/jit/ir/reorder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -57,8 +57,8 @@ private:
 
 inline stmt_t create_reorder_stmt(const layout_t &src, const layout_t &dst,
         const expr_t &src_buf, const expr_t &dst_buf) {
-    ir_assert(src.ndims() == dst.ndims()) << "Layouts are incompatible.";
-    ir_assert(src.elems() == dst.elems()) << "Layouts are incompatible.";
+    gpu_assert(src.ndims() == dst.ndims()) << "Layouts are incompatible.";
+    gpu_assert(src.elems() == dst.elems()) << "Layouts are incompatible.";
     auto func = reorder_t::make(src, dst);
     return func.call({dst_buf, src_buf});
 }

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -579,7 +579,7 @@ std::vector<T> slice(const std::vector<T> &v, int start, int stop) {
 }
 
 const char *fail_2d_header() {
-    return "INFO: can't use 2D send. ";
+    return "Cannot use 2D send. ";
 }
 
 template <typename T0>

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -584,19 +584,19 @@ const char *fail_2d_header() {
 
 template <typename T0>
 bool fail_2d(const T0 &t0) {
-    ir_trace() << fail_2d_header() << t0 << std::endl;
+    ir_trace() << fail_2d_header() << t0;
     return false;
 }
 
 template <typename T0, typename T1>
 bool fail_2d(const T0 &t0, const T1 &t1) {
-    ir_trace() << fail_2d_header() << t0 << t1 << std::endl;
+    ir_trace() << fail_2d_header() << t0 << t1;
     return false;
 }
 
 template <typename T0, typename T1, typename T2>
 bool fail_2d(const T0 &t0, const T1 &t1, const T2 &t2) {
-    ir_trace() << fail_2d_header() << t0 << t1 << t2 << std::endl;
+    ir_trace() << fail_2d_header() << t0 << t1 << t2;
     return false;
 }
 

--- a/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
+++ b/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
@@ -38,8 +38,8 @@ slm_reduce_builder_t::slm_reduce_builder_t(ir_context_t &ir_ctx,
     , reg_layout_(reg_layout)
     , thr_tile_(thr_tile)
     , dim_(dim) {
-    ir_assert((dim_ != dim_idx::invalid) && (dim_ <= 2));
-    ir_assert(tg_grid_.dim(dim_) > 1);
+    gpu_assert((dim_ != dim_idx::invalid) && (dim_ <= 2));
+    gpu_assert(tg_grid_.dim(dim_) > 1);
 
     tmp_reg_buf_ = ir_ctx.create_tmp_var(type_t::byte_ptr());
     slm_buf_ = ir_ctx.create_tmp_var(type_t::byte_ptr(), "reduce_slm");
@@ -75,7 +75,7 @@ void slm_reduce_builder_t::build() {
     store_stmt_ = write.stmt();
 
     auto &write_layout = write.reg_layout();
-    ir_assert(write_layout == reg_layout_) << "Incompatible layouts.";
+    gpu_assert(write_layout == reg_layout_) << "Incompatible layouts.";
 
     // Redistribute the layout to read/reduce all k-axis tiles from every
     // thread.

--- a/src/gpu/intel/jit/ir/tensor_config.cpp
+++ b/src/gpu/intel/jit/ir/tensor_config.cpp
@@ -39,7 +39,7 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
     };
     if (zp_cfg.do_src_compensation && zp_cfg.is_runtime_src_zero_points) {
         if (zp_cfg.needs_src_conv_precalc) {
-            ir_assert(zp_src);
+            gpu_assert(zp_src);
             int arg_key = DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC;
             tensor_cfg.add_tensor("src_zero_points", arg_key, /*is_input=*/true,
                     /*is_output=*/false, layout_t(zp_src, false), layout_t());
@@ -49,7 +49,7 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
         }
     }
     if (zp_cfg.do_wei_compensation && zp_cfg.is_runtime_wei_zero_points) {
-        ir_assert(zp_cfg.is_common_wei_zero_point);
+        gpu_assert(zp_cfg.is_common_wei_zero_point);
         add_zp_buffer(
                 "wei_zero_points", zp_cfg.wei_zp_type, DNNL_ARG_WEIGHTS, 1);
     }
@@ -85,7 +85,7 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
             tensor_cfg.add_tensor("prelu_rhs_" + std::to_string(i), arg_key,
                     /*is_input=*/true, /*is_output=*/false, layout);
         } else {
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
     }
 }

--- a/src/gpu/intel/jit/ir/tensor_config.hpp
+++ b/src/gpu/intel/jit/ir/tensor_config.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ private:
         for (auto &t : tensors_) {
             if (t.name == name) return t;
         }
-        ir_error_not_expected() << "Can't find tensor " << name;
+        gpu_error_not_expected() << "Can't find tensor " << name;
         return tensors_.front();
     }
 

--- a/src/gpu/intel/jit/ir/walk_order.hpp
+++ b/src/gpu/intel/jit/ir/walk_order.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public:
     walk_order_t() = default;
     walk_order_t(const std::string &s) {
         auto parts = gpu_utils::split(s, ",");
-        ir_assert(parts.size() <= 3);
+        gpu_assert(parts.size() <= 3);
         for (int i = 0; i < (int)parts.size(); i++) {
             for (auto &kv : ir_utils::to_string_int_pairs(parts[i])) {
                 add(pvar_t(kv.first), kv.second, i);
@@ -108,9 +108,9 @@ public:
         for (auto &b : blocks_) {
             if (b.dim != dim) continue;
             if (id == -1) id = b.grid_id;
-            ir_assert(b.grid_id == id);
+            gpu_assert(b.grid_id == id);
         }
-        ir_assert(id != -1);
+        gpu_assert(id != -1);
         return id;
     }
 
@@ -118,7 +118,7 @@ public:
         for (auto &info : dim_infos_) {
             if (info.dim == dim) return info.grid_var;
         }
-        ir_error_not_expected() << "Grid variable not found: " << dim;
+        gpu_error_not_expected() << "Grid variable not found: " << dim;
         return expr_t();
     }
 
@@ -126,7 +126,7 @@ public:
         for (auto &info : dim_infos_) {
             if (info.grid_var.is_same(grid_var)) return info.size;
         }
-        ir_error_not_expected() << "Grid variable not found: " << grid_var;
+        gpu_error_not_expected() << "Grid variable not found: " << grid_var;
         return -1;
     }
 

--- a/src/gpu/intel/jit/jit_generator.cpp
+++ b/src/gpu/intel/jit/jit_generator.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ void check_kernel_size(const std::string &kernel_name, size_t kernel_size,
     if (kernel_size > icache_size) {
         ir_warning() << kernel_name
                      << " larger than icache, kernel: " << kernel_size
-                     << " bytes, icache: " << icache_size << " bytes\n";
+                     << " bytes, icache: " << icache_size << " bytes";
     }
 }
 

--- a/src/gpu/intel/jit/jit_generator.cpp
+++ b/src/gpu/intel/jit/jit_generator.cpp
@@ -27,9 +27,9 @@ namespace jit {
 void check_kernel_size(const std::string &kernel_name, size_t kernel_size,
         size_t icache_size) {
     if (kernel_size > icache_size) {
-        ir_warning() << kernel_name
-                     << " larger than icache, kernel: " << kernel_size
-                     << " bytes, icache: " << icache_size << " bytes";
+        gpu_warning() << kernel_name
+                      << " larger than icache, kernel: " << kernel_size
+                      << " bytes, icache: " << icache_size << " bytes";
     }
 }
 

--- a/src/gpu/intel/jit/pass/alloc.cpp
+++ b/src/gpu/intel/jit/pass/alloc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public:
         for (auto &c : calls) {
             if (!is_func_call<send_t>(c)) continue;
             auto header_buf = send_t::arg_mem_off(c);
-            ir_assert(is_var(header_buf)) << header_buf;
+            gpu_assert(is_var(header_buf)) << header_buf;
             header_bufs_.insert(header_buf);
         }
     }
@@ -116,7 +116,7 @@ public:
     }
 
     object_t _mutate(const var_t &obj) override {
-        ir_assert(refs_.count(obj) == 1)
+        gpu_assert(refs_.count(obj) == 1)
                 << "Variable is not defined: " << expr_t(&obj);
         if (!skip_var_.is_same(obj)) refs_[&obj].update(increment_, level_);
         return ir_mutator_t::_mutate(obj);
@@ -142,7 +142,7 @@ private:
     template <typename T>
     object_t mutate_scope(const T &obj, const expr_t &var) {
         auto ret = refs_.insert({var, ref_info_t(level_)});
-        ir_assert(ret.second) << var;
+        gpu_assert(ret.second) << var;
         MAYBE_UNUSED(ret);
 
         auto new_obj = ir_mutator_t::_mutate(obj);
@@ -159,7 +159,7 @@ private:
     }
 
     object_t mutate_let(const let_t &obj, const ref_info_t &ref_info) {
-        ir_assert(ref_info.refs >= 1);
+        gpu_assert(ref_info.refs >= 1);
         if (ref_info.refs == 1) {
             // Variable is not used.
             remove_refs(obj);
@@ -177,7 +177,7 @@ private:
     }
 
     object_t mutate_alloc(const alloc_t &obj, const ref_info_t &ref_info) {
-        ir_assert(ref_info.refs >= 1);
+        gpu_assert(ref_info.refs >= 1);
         // Buffer is not used, single reference from alloc_t itself. Remove
         // stores to the buffer if any.
         if (ref_info.refs == 1) return remove_stores(obj.body, obj.buf);

--- a/src/gpu/intel/jit/pass/cse.cpp
+++ b/src/gpu/intel/jit/pass/cse.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,14 +46,14 @@ public:
         , path(path)
         , refs(refs)
         , cse_var(cse_var) {
-        ir_trace() << "cse_pass: add expression: " << expr << std::endl;
+        ir_trace() << "cse_pass: add expression: " << expr;
     }
 
     void add_usage(const ir_path_t &other_path, bool do_increment = true) {
         if (do_increment) refs++;
         path.merge(other_path);
         ir_trace() << "cse_pass: add usage: " << expr
-                   << ", total refs: " << refs << std::endl;
+                   << ", total refs: " << refs;
     }
 
     // Expression to eliminate via let.
@@ -214,8 +214,7 @@ public:
 
             ir_trace() << "cse_pass: skipping " << e.cse_expr()->expr
                        << " with cost " << e.cost() << ", size " << e.size()
-                       << ", and cost per byte " << (double)e.cost() / e.size()
-                       << "\n";
+                       << ", and cost per byte " << (double)e.cost() / e.size();
 
             e.set_unallocated();
             grf_usage_ -= e.size();
@@ -281,7 +280,7 @@ public:
                             ? bool_imm_t::get_packed_type(e.type().elems())
                             : e.type());
             ir_trace() << "cse_pass: assigning var: " << e << " -> "
-                       << cse_expr.cse_var << std::endl;
+                       << cse_expr.cse_var;
         }
         return cse_expr.cse_var;
     }
@@ -686,7 +685,7 @@ stmt_t eliminate_common_subexprs_impl(const stmt_t &_stmt, cse_context_t &ctx,
     int memory_usage = get_peak_regs(stmt, grf_size) * grf_size;
     ir_trace() << "CSE exceeded GRF usage limit. Usage: " << memory_usage
                << ", limit: " << memory_usage_limit
-               << ". Retry CSE and skip some expressions..." << std::endl;
+               << ". Retry CSE and skip some expressions...";
     ctx.reset_cse_exprs();
     return stmt_t();
 }

--- a/src/gpu/intel/jit/pass/dp4a.cpp
+++ b/src/gpu/intel/jit/pass/dp4a.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ private:
         if (type.is_x32()) return type;
         if (type.is_s8()) return type_t::s32();
         if (type.is_u8()) return type_t::u32();
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return type_t();
     };
 };

--- a/src/gpu/intel/jit/pass/dpasw.cpp
+++ b/src/gpu/intel/jit/pass/dpasw.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -298,8 +298,7 @@ private:
                 // loaded by the corresponding send message.
                 if (send_info.reg_buf_size() != dpas_info.src2_size()) {
                     ir_warning() << "Can't inject dpasw: different register "
-                                    "sizes in send and dpas."
-                                 << std::endl;
+                                    "sizes in send and dpas.";
                     return false;
                 }
                 dpas_info.send_producer = send_info.call;

--- a/src/gpu/intel/jit/pass/expr_scalarizer.hpp
+++ b/src/gpu/intel/jit/pass/expr_scalarizer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public:
         auto type = obj.type;
         auto expr = mutate(obj.expr);
         if (!type.is_scalar()) {
-            ir_assert(type.elems() == elems_) << expr;
+            gpu_assert(type.elems() == elems_) << expr;
             type = type.scalar();
         }
         return cast_t::make(type, expr, obj.saturate);
@@ -46,15 +46,15 @@ public:
         if (obj.type.is_scalar()) return obj;
 
         auto it = vec_vars_.find(obj);
-        ir_assert(it != vec_vars_.end()) << "Can't find variable: " << obj;
-        ir_assert(int(it->second.size()) == elems_);
+        gpu_assert(it != vec_vars_.end()) << "Can't find variable: " << obj;
+        gpu_assert(int(it->second.size()) == elems_);
         return it->second[idx_];
     }
 
     object_t _mutate(const shuffle_t &obj) override {
         expr_t new_obj = ir_mutator_t::_mutate(obj);
         auto &shuffle = new_obj.as<shuffle_t>();
-        ir_assert(shuffle.type.elems() == elems_) << new_obj;
+        gpu_assert(shuffle.type.elems() == elems_) << new_obj;
         return new_obj[idx_];
     }
 

--- a/src/gpu/intel/jit/pass/hoist.cpp
+++ b/src/gpu/intel/jit/pass/hoist.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public:
             const std::vector<expr_t> &args, const type_t &type) {
         auto maybe_bcast = [&](const expr_t &e) {
             if (e.type().elems() == type.elems()) return e;
-            ir_assert(e.type().is_scalar());
+            gpu_assert(e.type().is_scalar());
             return shuffle_t::make_broadcast(e, type.elems());
         };
         if (args.empty()) return cast(0, type);
@@ -77,7 +77,7 @@ public:
             int max_hoist_size = std::numeric_limits<int>::max())
         : ir_ctx_(ir_ctx), max_hoist_size_(max_hoist_size) {}
 
-    ~hoist_exprs_mutator_t() override { ir_assert(let_vars_.empty()); }
+    ~hoist_exprs_mutator_t() override { gpu_assert(let_vars_.empty()); }
 
     object_t _mutate(const func_call_t &obj) override {
         if (!obj.func.is<send_t>()) return ir_mutator_t::_mutate(obj);
@@ -338,7 +338,7 @@ public:
         auto hoisted_mask = hoist_mask(mask);
         if (hoisted_mask.is_same(mask)) return ir_mutator_t::_mutate(obj);
 
-        ir_assert(hoisted_mask.type().is_u16() || hoisted_mask.type().is_u32())
+        gpu_assert(hoisted_mask.type().is_u16() || hoisted_mask.type().is_u32())
                 << hoisted_mask;
 
         send_t::arg_mask(new_args) = cast(hoisted_mask, mask.type());
@@ -355,7 +355,7 @@ public:
         }
 
         if (in_stmt_group) {
-            ir_assert(!obj.value.is_empty());
+            gpu_assert(!obj.value.is_empty());
             let_values_.emplace(obj.var, expand(obj.value, value_vars));
         }
 
@@ -375,7 +375,7 @@ public:
 
 private:
     bool is_loop_dependency(const expr_t &v) const {
-        ir_assert(is_var(v)) << v;
+        gpu_assert(is_var(v)) << v;
         return loop_deps_.count(v) != 0;
     }
 
@@ -384,7 +384,7 @@ private:
     }
 
     expr_t hoist_mask(const expr_t &e) {
-        ir_assert(e.type().is_bool()) << e;
+        gpu_assert(e.type().is_bool()) << e;
 
         if (is_const(e) || is_shuffle_const(e)) return e;
 

--- a/src/gpu/intel/jit/pass/overflow.cpp
+++ b/src/gpu/intel/jit/pass/overflow.cpp
@@ -28,7 +28,7 @@ namespace jit {
 class overflow_bound_finder_t : public bound_finder_base_t {
 public:
     bool has_var(const expr_t &e) const {
-        ir_assert(is_var(e)) << "Expected variable, found: " << e;
+        gpu_assert(is_var(e)) << "Expected variable, found: " << e;
         auto it = var_bounds_.find(e);
         return it != var_bounds_.end();
     }
@@ -40,16 +40,16 @@ public:
     }
 
     int64_t get_var_bound(const expr_t &e, bool is_low) const override {
-        ir_assert(has_var(e)) << "Variable not found: " << e;
+        gpu_assert(has_var(e)) << "Variable not found: " << e;
         auto &lo_hi = var_bounds_.at(e);
         return is_low ? lo_hi.first : lo_hi.second;
     }
 
     void set_var_bounds(
             const expr_t &e, const std::pair<int64_t, int64_t> &lo_hi) {
-        ir_assert(is_good_bound(lo_hi.first))
+        gpu_assert(is_good_bound(lo_hi.first))
                 << "Can't compute low bound for " << e;
-        ir_assert(is_good_bound(lo_hi.second))
+        gpu_assert(is_good_bound(lo_hi.second))
                 << "Can't compute high bound for " << e;
         var_bounds_.emplace(e, lo_hi);
     }
@@ -124,7 +124,7 @@ private:
                 bool is_overflow = (lo < type_lo || hi > type_hi);
                 if (is_overflow) {
                     found_overflow = true;
-                    ir_warning()
+                    gpu_warning()
                             << "Found overflow: " << value
                             << " low bound: " << lo << " high bound: " << hi;
                     break;
@@ -142,7 +142,7 @@ private:
                     cast(binary->a, type_t::u64(e.type().elems())), binary->b);
         }
 
-        ir_error_not_expected() << "Can't fix overflow: " << e;
+        gpu_error_not_expected() << "Can't fix overflow: " << e;
         return e;
     }
 
@@ -174,13 +174,13 @@ public:
             for (auto &rel : kv.second) {
                 bool is_ge = (rel.op_kind() == op_kind_t::_ge);
                 bool is_le = (rel.op_kind() == op_kind_t::_le);
-                ir_assert(is_ge || is_le);
+                gpu_assert(is_ge || is_le);
                 if (rel.op_kind() == op_kind_t::_ge) {
                     lo = std::max(to_cpp<int64_t>(rel.rhs()), lo);
                 } else if (rel.op_kind() == op_kind_t::_le) {
                     hi = std::min(to_cpp<int64_t>(rel.rhs()), hi);
                 } else {
-                    ir_error_not_expected()
+                    gpu_error_not_expected()
                             << "Only >= or <= is expected, found: "
                             << to_string(rel.op_kind());
                 }

--- a/src/gpu/intel/jit/pass/overflow.cpp
+++ b/src/gpu/intel/jit/pass/overflow.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -124,9 +124,9 @@ private:
                 bool is_overflow = (lo < type_lo || hi > type_hi);
                 if (is_overflow) {
                     found_overflow = true;
-                    ir_warning() << "Found overflow: " << value
-                                 << " low bound: " << lo
-                                 << " high bound: " << hi << std::endl;
+                    ir_warning()
+                            << "Found overflow: " << value
+                            << " low bound: " << lo << " high bound: " << hi;
                     break;
                 }
             }

--- a/src/gpu/intel/jit/pass/pass.cpp
+++ b/src/gpu/intel/jit/pass/pass.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public:
         stmt_t new_stmt;
         for (int i = 0; i < elems; i += step) {
             int cur_elems = std::min(step, elems - i);
-            ir_assert(math::is_pow2(cur_elems));
+            gpu_assert(math::is_pow2(cur_elems));
             int off = i * stride * elem_size;
             auto store = store_t::make(obj.buf, obj.off + off,
                     split_expr(obj.value, i, i + cur_elems), obj.stride);
@@ -127,7 +127,7 @@ private:
             return load_t::make(load->type.with_elems(end - beg), load->buf,
                     load->off + beg * stride, load->stride);
         }
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return expr_t();
     }
 

--- a/src/gpu/intel/jit/pass/peephole.cpp
+++ b/src/gpu/intel/jit/pass/peephole.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public:
                 if (!ok) new_obj = old_obj;
                 break;
             }
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return std::move(new_obj);
     }

--- a/src/gpu/intel/jit/pass/send.cpp
+++ b/src/gpu/intel/jit/pass/send.cpp
@@ -71,7 +71,7 @@ public:
         expr_t pattern;
         if (obj.args.size() > 6) pattern = send_t::arg_fill_pattern(obj);
 
-        ir_assert(is_var(mem_buf)) << mem_buf;
+        gpu_assert(is_var(mem_buf)) << mem_buf;
 
         auto header_buf = ir_ctx_.create_tmp_var(type_t::byte_ptr(), "h");
         auto off_store = simplify_store(
@@ -146,7 +146,7 @@ public:
             if (!is_func_call<send_t>(c)) continue;
             if (!c.as<func_call_t>().func.as<send_t>().is_2d()) continue;
             auto header_buf = send_t::arg_mem_off(c);
-            ir_assert(is_var(header_buf)) << header_buf;
+            gpu_assert(is_var(header_buf)) << header_buf;
             header_bufs_.insert(header_buf);
         }
     }

--- a/src/gpu/intel/jit/pass/shuffle_splitter.cpp
+++ b/src/gpu/intel/jit/pass/shuffle_splitter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public:
         expr_t e = shuffle_t::make_broadcast(make_add(bcasts), elems);
         if (!non_bcasts.empty()) e = add(e, make_add(non_bcasts));
 
-        ir_assert(!e.is_empty());
+        gpu_assert(!e.is_empty());
         return std::move(e);
     }
 

--- a/src/gpu/intel/jit/pass/simplify.cpp
+++ b/src/gpu/intel/jit/pass/simplify.cpp
@@ -140,9 +140,9 @@ public:
     }
 
     void set(const expr_t &ptrn, const expr_t &e) {
-        ir_assert(ptrn.is<pexpr_t>());
+        gpu_assert(ptrn.is<pexpr_t>());
         auto ret = expr_matched_.insert({ptrn, e});
-        ir_assert(ret.second);
+        gpu_assert(ret.second);
         MAYBE_UNUSED(ret);
     }
 
@@ -314,7 +314,7 @@ expr_t simplify_rewrite_add(const expr_t &_e) {
     auto _0 = pint_imm_t::_0();
 
     auto &obj = _e.as<binary_op_t>();
-    ir_assert(obj.op_kind == op_kind_t::_add);
+    gpu_assert(obj.op_kind == op_kind_t::_add);
 
     auto e = _e;
 
@@ -330,7 +330,7 @@ expr_t simplify_rewrite_sub(const expr_t &_e) {
     auto _0 = pint_imm_t::_0();
 
     auto &obj = _e.as<binary_op_t>();
-    ir_assert(obj.op_kind == op_kind_t::_sub);
+    gpu_assert(obj.op_kind == op_kind_t::_sub);
 
     auto e = _e;
 
@@ -347,7 +347,7 @@ expr_t simplify_rewrite_mul(const expr_t &_e) {
     auto _1 = pint_imm_t::_1();
 
     auto &obj = _e.as<binary_op_t>();
-    ir_assert(obj.op_kind == op_kind_t::_mul);
+    gpu_assert(obj.op_kind == op_kind_t::_mul);
 
     auto e = _e;
 
@@ -366,7 +366,7 @@ expr_t simplify_rewrite_div(const expr_t &_e) {
     auto _1 = pint_imm_t::_1();
 
     auto &obj = _e.as<binary_op_t>();
-    ir_assert(obj.op_kind == op_kind_t::_div);
+    gpu_assert(obj.op_kind == op_kind_t::_div);
 
     auto e = _e;
 
@@ -383,7 +383,7 @@ expr_t simplify_rewrite_mod(const expr_t &_e) {
     auto _1 = pint_imm_t::_1();
 
     auto &obj = _e.as<binary_op_t>();
-    ir_assert(obj.op_kind == op_kind_t::_mod);
+    gpu_assert(obj.op_kind == op_kind_t::_mod);
 
     auto e = _e;
 
@@ -397,7 +397,7 @@ expr_t simplify_rewrite_and(const expr_t &_e) {
     auto x = pexpr_t::x();
 
     auto &obj = _e.as<binary_op_t>();
-    ir_assert(obj.op_kind == op_kind_t::_and);
+    gpu_assert(obj.op_kind == op_kind_t::_and);
 
     auto e = _e;
 
@@ -424,7 +424,7 @@ expr_t simplify_rewrite_or(const expr_t &_e) {
     auto x = pexpr_t::x();
 
     auto &obj = _e.as<binary_op_t>();
-    ir_assert(obj.op_kind == op_kind_t::_or);
+    gpu_assert(obj.op_kind == op_kind_t::_or);
 
     auto e = _e;
 
@@ -612,7 +612,7 @@ public:
                     new_op_kind = op_kind_t::_le;
                     div = (sign ? div + 1 : div);
                     break;
-                default: ir_error_not_expected();
+                default: gpu_error_not_expected();
             }
         }
 
@@ -633,7 +633,7 @@ public:
         if (!is_const(a_op.b)) return e;
 
         auto &c0 = a_op.b;
-        ir_assert(to_cpp<int64_t>(c0) > 0) << e;
+        gpu_assert(to_cpp<int64_t>(c0) > 0) << e;
 
         // Comparison against a constant is a continuous function, just check
         // boundary points.
@@ -709,8 +709,8 @@ expr_t cvt_mul_to_nary_op(const expr_t &a, const expr_t &b) {
     auto *a_nary = a.as_ptr<nary_op_t>();
     auto *b_nary = b.as_ptr<nary_op_t>();
 
-    if (a_nary) ir_assert(a_nary->op_kind == op_kind_t::_mul);
-    if (b_nary) ir_assert(b_nary->op_kind == op_kind_t::_mul);
+    if (a_nary) gpu_assert(a_nary->op_kind == op_kind_t::_mul);
+    if (b_nary) gpu_assert(b_nary->op_kind == op_kind_t::_mul);
 
     auto a_args = cvt_expr_to_nary_op_args(a);
     auto b_args = cvt_expr_to_nary_op_args(b);
@@ -799,7 +799,7 @@ public:
             if (arg.is<cast_t>()) arg = args[i].as<cast_t>().expr;
             auto *nary = arg.as_ptr<nary_op_t>();
             if (nary && nary->op_kind != op_kind_t::_add) {
-                ir_error_not_expected();
+                gpu_error_not_expected();
             }
             auto i_args = cvt_expr_to_nary_op_args(arg);
             if (arg.type() != args[i].type()) {
@@ -901,7 +901,7 @@ public:
     object_t _mutate(const nary_op_t &obj) override {
         auto new_obj = nary_op_mutator_t::_mutate(obj);
         auto &nary = new_obj.as<nary_op_t>();
-        ir_assert(!nary.args.empty()) << new_obj;
+        gpu_assert(!nary.args.empty()) << new_obj;
 
         if (nary.args.size() == 1) return nary.args[0];
 
@@ -916,7 +916,7 @@ public:
                 ret *= nary.args[i];
             return std::move(ret);
         }
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return expr_t();
     }
 };
@@ -1048,7 +1048,7 @@ public:
         auto f_common = intersect(other);
         auto diff_other = f_other.diff(f_common);
         // Other must be reducible.
-        ir_assert(diff_other.as<factored_expr_t>().is_one()) << diff_other;
+        gpu_assert(diff_other.as<factored_expr_t>().is_one()) << diff_other;
         return diff(f_common);
     }
 
@@ -1148,7 +1148,7 @@ private:
             factors = f_common.merge(rest).as<factored_expr_t>().factors;
             return;
         }
-        ir_error_not_expected();
+        gpu_error_not_expected();
     }
 
     expr_t intersect_impl(const expr_t &other, bool ignore_constants) const {
@@ -1320,7 +1320,7 @@ public:
             return mutate(lhs_div) + mutate(rhs_div);
         }
 
-        ir_error_not_expected() << expr;
+        gpu_error_not_expected() << expr;
 
         return expr_t();
     }
@@ -1376,7 +1376,7 @@ public:
 
         // max_gcd is the GCD for some summand so at least one summand must be
         // reducible.
-        ir_assert(!lhs_args.empty());
+        gpu_assert(!lhs_args.empty());
 
         if (rhs_args.empty()) return expr_t();
 
@@ -1399,7 +1399,7 @@ public:
             return lhs_div;
         }
 
-        ir_error_not_expected() << expr;
+        gpu_error_not_expected() << expr;
 
         return expr_t();
     }
@@ -1458,7 +1458,7 @@ public:
         auto args = mutate(obj.args);
         for (auto &a : args) {
             auto *nary = a.as_ptr<nary_op_t>();
-            if (nary) ir_assert(nary->op_kind == op_kind_t::_mul) << a;
+            if (nary) gpu_assert(nary->op_kind == op_kind_t::_mul) << a;
         }
 
         // Fold same factors (find exact match, ignore constants).
@@ -1694,13 +1694,13 @@ private:
             case op_kind_t::_le: return op_kind_t::_gt;
             case op_kind_t::_lt: return op_kind_t::_ge;
             case op_kind_t::_ne: return op_kind_t::_eq;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return op_kind_t::undef;
     }
 
     static expr_t flip_condition(const expr_t &cond) {
-        ir_assert(cond.type().is_bool());
+        gpu_assert(cond.type().is_bool());
 
         auto *binary_op = cond.as_ptr<binary_op_t>();
         if (binary_op) {
@@ -1716,7 +1716,7 @@ private:
                     flip_condition(shuffle->vec[0]), shuffle->elems());
         }
 
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return expr_t();
     }
 
@@ -1747,7 +1747,7 @@ stmt_t simplify_stmt(const stmt_t &s, const constraint_set_t &cset) {
 }
 
 int64_t get_max_const_factor(const expr_t &_e, const constraint_set_t &cset) {
-    ir_assert(_e.type().is_int());
+    gpu_assert(_e.type().is_int());
     auto e = _e;
     // Some complex expressions need more than one simplify() call.
     int max_tries = 3;
@@ -1816,7 +1816,7 @@ struct op_traits_t<op_kind_t::_div> {
     template <typename T,
             typename = typename std::enable_if<is_int_t<T>::value>::type>
     static auto compute(T a, T b) -> decltype(a / b) {
-        ir_assert(b > 0);
+        gpu_assert(b > 0);
         T r = a % b;
         T d = a / b;
         if (r < 0) d--;
@@ -1829,7 +1829,7 @@ struct op_traits_t<op_kind_t::_mod> {
     template <typename T,
             typename = typename std::enable_if<is_int_t<T>::value>::type>
     static auto compute(T a, T b) -> decltype(a % b) {
-        ir_assert(b > 0);
+        gpu_assert(b > 0);
         T r = a % b;
         if (r < 0) r += b;
         return r;
@@ -1892,7 +1892,7 @@ public:
             CASE(op_kind_t::_min)
             CASE(op_kind_t::_max)
 
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
 
 #undef CASE
         }
@@ -1924,7 +1924,7 @@ bool is_const_or_shuffle_const(const expr_t &e) {
 }
 
 expr_t const_fold_unary(op_kind_t op_kind, const expr_t &a) {
-    ir_assert(op_kind == op_kind_t::_minus);
+    gpu_assert(op_kind == op_kind_t::_minus);
     if (!a.type().is_scalar()) {
         int elems = a.type().elems();
         std::vector<expr_t> ret;
@@ -1947,7 +1947,7 @@ expr_t const_fold_unary(op_kind_t op_kind, const expr_t &a) {
 
 #undef CASE
 
-    ir_error_not_expected() << "Cannot handle type: " << a;
+    gpu_error_not_expected() << "Cannot handle type: " << a;
     return expr_t();
 }
 
@@ -1967,7 +1967,7 @@ expr_t const_fold_binary(const type_t &compute_type, op_kind_t op_kind,
     if (compute_type.is_unsigned()) {
         auto a_s64 = to_cpp<int64_t>(a);
         auto b_s64 = to_cpp<int64_t>(b);
-        ir_assert(a_s64 >= 0 && b_s64 >= 0)
+        gpu_assert(a_s64 >= 0 && b_s64 >= 0)
                 << "Overflow detected: fix data types.";
         MAYBE_UNUSED(a_s64);
         MAYBE_UNUSED(b_s64);
@@ -1991,14 +1991,14 @@ expr_t const_fold_binary(const type_t &compute_type, op_kind_t op_kind,
 
 #undef CASE
 
-    ir_error_not_expected() << "Unknown type.";
+    gpu_error_not_expected() << "Unknown type.";
     return expr_t();
 }
 
 object_t simplify(const object_t &obj, const constraint_set_t &cset) {
     if (obj.is_expr()) return simplify_expr(obj, cset);
     if (obj.is_stmt()) return simplify_stmt(obj, cset);
-    ir_assert(obj.is_empty());
+    gpu_assert(obj.is_empty());
     return object_t();
 }
 
@@ -2109,7 +2109,7 @@ expr_t simplify_cmp_reduce_lhs_rhs(const expr_t &e) {
                 new_op_kind = op_kind_t::_le;
                 div = (sign ? div + 1 : div);
                 break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
     }
 
@@ -2303,7 +2303,7 @@ expr_t nary_op_canonicalize(const expr_t &_e) {
     e = nary_op_transformer_t().mutate(e);
     e = mul_nary_op_expander_t().mutate(e);
 
-    ir_assert(is_nary_op_canonical(e)) << e;
+    gpu_assert(is_nary_op_canonical(e)) << e;
     MAYBE_UNUSED(is_nary_op_canonical(e));
 
     return e;
@@ -2313,7 +2313,7 @@ expr_t make_nary_op(op_kind_t op_kind, const std::vector<expr_t> &args) {
     if (args.empty()) {
         if (op_kind == op_kind_t::_add) return 0;
         if (op_kind == op_kind_t::_mul) return 1;
-        ir_error_not_expected() << to_string(op_kind);
+        gpu_error_not_expected() << to_string(op_kind);
     }
     if (args.size() == 1) return args[0];
 

--- a/src/gpu/intel/jit/pass/slm.cpp
+++ b/src/gpu/intel/jit/pass/slm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public:
         : hw_(hw), tg_grid_(tg_grid) {
         alloc_manager_t alloc_mgr(root);
         auto slm_buffers = alloc_mgr.find_buffers(alloc_kind_t::slm);
-        ir_assert(slm_buffers.size() == 1);
+        gpu_assert(slm_buffers.size() == 1);
         slm_base_ = slm_buffers[0];
         slm_size_ = alloc_mgr.total_size(alloc_kind_t::slm);
     }
@@ -163,7 +163,7 @@ private:
         int hword_size = type_t::hword().size();
         int hwords = tile_size / hword_size;
 
-        ir_assert(tile_size % hword_size == 0);
+        gpu_assert(tile_size % hword_size == 0);
 
         slm_size_ = std::max(
                 slm_size_, slm_thr_size * into<int>(tg_grid_.elems()));
@@ -207,8 +207,8 @@ private:
         auto &d1 = dst_blocks[1];
 
         if (s0.dim_idx != d1.dim_idx || s1.dim_idx != d0.dim_idx) return false;
-        ir_assert(s0.block == d1.block);
-        ir_assert(s1.block == d0.block);
+        gpu_assert(s0.block == d1.block);
+        gpu_assert(s1.block == d0.block);
 
         int simd = into<int>(s0.block);
         int vec_size = into<int>(s1.block);

--- a/src/gpu/intel/jit/pass/strength_reduce.cpp
+++ b/src/gpu/intel/jit/pass/strength_reduce.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public:
 
     ~loop_strength_reducer_t() override {
         // Sanity check, all stores must be applied.
-        ir_assert(post_inc_stores.empty());
+        gpu_assert(post_inc_stores.empty());
     }
 
     object_t _mutate(const for_t &obj) override {
@@ -47,7 +47,7 @@ public:
         int loop_level = int(loops_.size()) - 1;
         auto ret = lets_.insert(
                 {obj.var, let_info_t(obj.var, obj.value, loop_level)});
-        ir_assert(ret.second);
+        gpu_assert(ret.second);
         MAYBE_UNUSED(ret);
         auto new_obj = ir_mutator_t::_mutate(obj);
         lets_.erase(obj.var);
@@ -118,7 +118,7 @@ public:
         loops_[init_store_level].init_stores.push_back(init_store_stmt);
         if (!post_inc_store.is_empty()) {
             auto ret = post_inc_stores.insert({obj.buf, post_inc_store});
-            ir_assert(ret.second);
+            gpu_assert(ret.second);
             MAYBE_UNUSED(ret);
         }
         return stmt_t();
@@ -226,7 +226,7 @@ private:
         }
         loops_.pop_back();
         // The top-level dummy loop shouldn't be removed.
-        ir_assert(loops_.size() >= 1);
+        gpu_assert(loops_.size() >= 1);
         return std::move(s);
     }
 

--- a/src/gpu/intel/jit/pass/unroll.cpp
+++ b/src/gpu/intel/jit/pass/unroll.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -96,15 +96,15 @@ public:
         // No unrolling.
         if (_for.unroll == 1) return new_obj;
 
-        ir_assert(is_const(_for.init))
+        gpu_assert(is_const(_for.init))
                 << "Can't unroll loop with non-const bound: " << _for.init;
-        ir_assert(is_const(_for.bound))
+        gpu_assert(is_const(_for.bound))
                 << "Can't unroll loop with non-const bound: " << _for.bound;
 
         auto init = to_cpp<int>(_for.init);
         auto bound = to_cpp<int>(_for.bound);
 
-        ir_assert(_for.unroll == (bound - init))
+        gpu_assert(_for.unroll == (bound - init))
                 << "Only full loop unroll is supported.";
 
         stmt_t ret;

--- a/src/gpu/intel/jit/pooling/config.hpp
+++ b/src/gpu/intel/jit/pooling/config.hpp
@@ -259,7 +259,7 @@ public:
 
             const dim_t max_tg
                     = exec.hw().max_tg_size(exec.regs(), exec.simd());
-            ir_assert(max_tg == utils::rnd_up_pow2(max_tg));
+            gpu_assert(max_tg == utils::rnd_up_pow2(max_tg));
 
             const bool ow_pow2
                     = (ow > 1) && (utils::rnd_up_pow2(oh) * ow > max_tg);
@@ -396,7 +396,7 @@ public:
                             * utils::rnd_up(oh, max_tg / tgw);
                 };
                 int ok_tgw = sqrt(max_tg);
-                ir_assert(ok_tgw == utils::rnd_up_pow2(ok_tgw));
+                gpu_assert(ok_tgw == utils::rnd_up_pow2(ok_tgw));
                 for (int tgw = sqrt(max_tg); tgw > 0; tgw >>= 1) {
                     if (loss(tgw) < loss(ok_tgw)) ok_tgw = tgw;
                     if (loss(max_tg / tgw) <= loss(ok_tgw))
@@ -574,13 +574,13 @@ public:
 
 #define DECL_PARAM(name) \
     const name##_param_t &name##_param() const { \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         (void)name##_init_; \
         return name##_; \
     } \
     name##_param_t &name##_param() { return name##_; } \
     const name##_param_t::value_t &name() const { \
-        ir_assert(!name##_.is_undef()); \
+        gpu_assert(!name##_.is_undef()); \
         return name##_.get(); \
     } \
     void set_##name(const name##_param_t::value_t &value) { \
@@ -616,7 +616,7 @@ private:
             197, 199, 211, 223, 227, 229, 233, 239, 241, 251,
         };
         // clang-format on
-        ir_assert(dn % scale == 0);
+        gpu_assert(dn % scale == 0);
         for (int p : primes_up_to_256)
             if (dn % (p * scale) == 0) {
                 up *= p;

--- a/src/gpu/intel/jit/pooling/gen_pooling.cpp
+++ b/src/gpu/intel/jit/pooling/gen_pooling.cpp
@@ -136,8 +136,6 @@ status_t gen_pooling_fwd_t::init(impl::engine_t *engine) {
         gpu_assert(!t.needs_zero_out);
 
         if (t.arg_key == DNNL_ARG_UNDEF) {
-            gpu_assert(!t.needs_reorder);
-            gpu_assert(!t.needs_zero_out);
             gpu_error_not_expected();
             continue;
         }

--- a/src/gpu/intel/jit/pooling/gen_pooling.cpp
+++ b/src/gpu/intel/jit/pooling/gen_pooling.cpp
@@ -132,13 +132,13 @@ status_t gen_pooling_fwd_t::init(impl::engine_t *engine) {
 
     // Initialize kernel arguments.
     for (auto &t : tensor_cfg.tensors()) {
-        ir_assert(!t.needs_reorder);
-        ir_assert(!t.needs_zero_out);
+        gpu_assert(!t.needs_reorder);
+        gpu_assert(!t.needs_zero_out);
 
         if (t.arg_key == DNNL_ARG_UNDEF) {
-            ir_assert(!t.needs_reorder);
-            ir_assert(!t.needs_zero_out);
-            ir_error_not_expected();
+            gpu_assert(!t.needs_reorder);
+            gpu_assert(!t.needs_zero_out);
+            gpu_error_not_expected();
             continue;
         }
         kernel_info_.register_user_arg(make_buffer(t.name), t.arg_key,
@@ -152,14 +152,14 @@ status_t gen_pooling_fwd_t::init(impl::engine_t *engine) {
             break;
         } catch (const ngen::out_of_registers_exception &exc) {
             UNUSED(exc);
-            ir_warning() << "loop too large: cut and retry!";
+            gpu_warning() << "loop too large: cut and retry!";
             kernel_ = {};
             if (!cfg_.cut()) {
-                ir_error_not_expected() << "minimal loop too large!";
+                gpu_error_not_expected() << "minimal loop too large!";
                 break;
             }
         } catch (const std::exception &exc) {
-            ir_error_not_expected() << exc.what();
+            gpu_error_not_expected() << exc.what();
             kernel_ = {};
             break;
         }

--- a/src/gpu/intel/jit/pooling/gen_pooling.cpp
+++ b/src/gpu/intel/jit/pooling/gen_pooling.cpp
@@ -152,7 +152,7 @@ status_t gen_pooling_fwd_t::init(impl::engine_t *engine) {
             break;
         } catch (const ngen::out_of_registers_exception &exc) {
             UNUSED(exc);
-            ir_warning() << "loop too large: cut and retry!" << std::endl;
+            ir_warning() << "loop too large: cut and retry!";
             kernel_ = {};
             if (!cfg_.cut()) {
                 ir_error_not_expected() << "minimal loop too large!";

--- a/src/gpu/intel/jit/pooling/ir_builder.cpp
+++ b/src/gpu/intel/jit/pooling/ir_builder.cpp
@@ -549,8 +549,8 @@ stmt_t pooling_ir_builder_t::try_build(pooling_ir_builder_t &pb,
 
     const int regs = get_peak_regs(stmt, exec.grf_size());
 
-    ir_trace() << "Pooling kernel body:\n" << stmt << std::endl;
-    ir_trace() << "Pooling cfg (~" << regs << " regs):\n" << cfg << std::endl;
+    ir_trace() << "Pooling kernel body:\n" << stmt;
+    ir_trace() << "Pooling cfg (~" << regs << " regs):\n" << cfg;
 
     return (regs > exec.regs()) ? stmt_t() : std::move(stmt);
 }

--- a/src/gpu/intel/jit/pooling/ir_builder.hpp
+++ b/src/gpu/intel/jit/pooling/ir_builder.hpp
@@ -32,7 +32,7 @@ public:
     pooling_ir_builder_t(pooling_config_t &cfg, const kernel_info_t &ki,
             const primitive_desc_t &pd) {
         while ((stmt_ = try_build(*this, ki, cfg, pd)).is_empty()) {
-            ir_warning() << "loop too large: cut and retry!" << std::endl;
+            ir_warning() << "loop too large: cut and retry!";
             const bool cut_ok = cfg.cut();
             if (!cut_ok) ir_error_not_expected() << "minimal loop too large!";
         }

--- a/src/gpu/intel/jit/pooling/ir_builder.hpp
+++ b/src/gpu/intel/jit/pooling/ir_builder.hpp
@@ -32,9 +32,9 @@ public:
     pooling_ir_builder_t(pooling_config_t &cfg, const kernel_info_t &ki,
             const primitive_desc_t &pd) {
         while ((stmt_ = try_build(*this, ki, cfg, pd)).is_empty()) {
-            ir_warning() << "loop too large: cut and retry!";
+            gpu_warning() << "loop too large: cut and retry!";
             const bool cut_ok = cfg.cut();
-            if (!cut_ok) ir_error_not_expected() << "minimal loop too large!";
+            if (!cut_ok) gpu_error_not_expected() << "minimal loop too large!";
         }
     }
 

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -197,8 +197,6 @@ status_t gen_reorder_t::pd_t::init_kernel_info() {
         gpu_assert(!t.needs_zero_out);
 
         if (t.arg_key == DNNL_ARG_UNDEF) {
-            gpu_assert(!t.needs_reorder);
-            gpu_assert(!t.needs_zero_out);
             gpu_error_not_expected();
             continue;
         }

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -193,13 +193,13 @@ status_t gen_reorder_t::pd_t::init_kernel_info() {
 
     // Initialize kernel arguments.
     for (auto &t : tensor_cfg.tensors()) {
-        ir_assert(!t.needs_reorder);
-        ir_assert(!t.needs_zero_out);
+        gpu_assert(!t.needs_reorder);
+        gpu_assert(!t.needs_zero_out);
 
         if (t.arg_key == DNNL_ARG_UNDEF) {
-            ir_assert(!t.needs_reorder);
-            ir_assert(!t.needs_zero_out);
-            ir_error_not_expected();
+            gpu_assert(!t.needs_reorder);
+            gpu_assert(!t.needs_zero_out);
+            gpu_error_not_expected();
             continue;
         }
         kernel_info->register_user_arg(make_buffer(t.name), t.arg_key,

--- a/src/gpu/intel/jit/reorder/ir_builder.cpp
+++ b/src/gpu/intel/jit/reorder/ir_builder.cpp
@@ -606,20 +606,15 @@ void reorder_ir_builder_t::build() {
             = max_tile_size(cfg_.exec_cfg().hw(), dst_layout_, src_layout_);
     for (int i = 0; i < max_iters; i++) {
         if (try_build(iter_blocks, loop_blocks, tg_blocks)) {
-            ir_info() << "Reorder configuration:" << std::endl;
-            ir_info() << "  Source layout:              " << src_layout_
-                      << std::endl;
-            ir_info() << "  Destination layout:         " << dst_layout_
-                      << std::endl;
+            ir_info() << "Reorder configuration:";
+            ir_info() << "  Source layout:              " << src_layout_;
+            ir_info() << "  Destination layout:         " << dst_layout_;
             ir_info() << "  Iteration blocks:           "
-                      << ir_utils::make_seq_print_helper(iter_blocks, " x ")
-                      << std::endl;
+                      << ir_utils::make_seq_print_helper(iter_blocks, " x ");
             ir_info() << "  Loop blocks:                "
-                      << ir_utils::make_seq_print_helper(loop_blocks, " x ")
-                      << std::endl;
+                      << ir_utils::make_seq_print_helper(loop_blocks, " x ");
             ir_info() << "  Thread group blocks:        "
-                      << ir_utils::make_seq_print_helper(tg_blocks, " x ")
-                      << std::endl;
+                      << ir_utils::make_seq_print_helper(tg_blocks, " x ");
             return;
         }
 
@@ -820,13 +815,12 @@ bool reorder_ir_builder_t::try_build(const std::vector<int> &iter_blocks,
     if (regs > cfg_.exec_cfg().regs()) {
         ir_warning() << "Estimated GRF usage is " << regs
                      << " registers which exceeds available space, retry with "
-                        "a smaller tile."
-                     << std::endl;
+                        "a smaller tile.";
 
         return false;
     }
 
-    ir_trace() << "Reorder kernel body:\n" << stmt_ << std::endl;
+    ir_trace() << "Reorder kernel body:\n" << stmt_;
     return true;
 }
 

--- a/src/gpu/intel/jit/utils/trace.cpp
+++ b/src/gpu/intel/jit/utils/trace.cpp
@@ -36,8 +36,7 @@ ir_utils::debug_profiler_t &get_trace_profiler() {
 void trace_pass(
         const char *pass_name, const stmt_t &stmt, const ir_context_t &ir_ctx) {
     trace_stop(pass_name);
-    gpu_trace() << "=== After " << pass_name;
-    gpu_trace() << stmt;
+    gpu_trace() << "=== After " << pass_name << "\n" << stmt;
     auto grf_usage = get_grf_usage(stmt, ir_ctx.hw().grf_size());
     if (!grf_usage.is_empty()) gpu_trace() << grf_usage;
     gpu_trace() << ir_ctx.cset();

--- a/src/gpu/intel/jit/utils/trace.cpp
+++ b/src/gpu/intel/jit/utils/trace.cpp
@@ -36,11 +36,11 @@ ir_utils::debug_profiler_t &get_trace_profiler() {
 void trace_pass(
         const char *pass_name, const stmt_t &stmt, const ir_context_t &ir_ctx) {
     trace_stop(pass_name);
-    ir_trace() << "=== After " << pass_name;
-    ir_trace() << stmt;
+    gpu_trace() << "=== After " << pass_name;
+    gpu_trace() << stmt;
     auto grf_usage = get_grf_usage(stmt, ir_ctx.hw().grf_size());
-    if (!grf_usage.is_empty()) ir_trace() << grf_usage;
-    ir_trace() << ir_ctx.cset();
+    if (!grf_usage.is_empty()) gpu_trace() << grf_usage;
+    gpu_trace() << ir_ctx.cset();
 }
 #endif
 

--- a/src/gpu/intel/jit/utils/trace.cpp
+++ b/src/gpu/intel/jit/utils/trace.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,11 +36,11 @@ ir_utils::debug_profiler_t &get_trace_profiler() {
 void trace_pass(
         const char *pass_name, const stmt_t &stmt, const ir_context_t &ir_ctx) {
     trace_stop(pass_name);
-    ir_trace() << "=== After " << pass_name << std::endl;
-    ir_trace() << stmt << std::endl;
+    ir_trace() << "=== After " << pass_name;
+    ir_trace() << stmt;
     auto grf_usage = get_grf_usage(stmt, ir_ctx.hw().grf_size());
-    if (!grf_usage.is_empty()) ir_trace() << grf_usage << std::endl;
-    ir_trace() << ir_ctx.cset() << std::endl;
+    if (!grf_usage.is_empty()) ir_trace() << grf_usage;
+    ir_trace() << ir_ctx.cset();
 }
 #endif
 

--- a/src/gpu/intel/jit/utils/trace.hpp
+++ b/src/gpu/intel/jit/utils/trace.hpp
@@ -32,23 +32,27 @@ class ir_context_t;
 #ifdef DNNL_DEV_MODE
 ir_utils::debug_profiler_t &get_trace_profiler();
 inline void trace_start() {
-    if (get_verbose(verbose_t::debuginfo) >= ir_utils::LOG_PERF)
+    if (get_verbose(verbose_t::debuginfo)
+            >= static_cast<int>(log_level_t::perf))
         get_trace_profiler().start();
 }
 inline void trace_reset() {
-    if (get_verbose(verbose_t::debuginfo) >= ir_utils::LOG_PERF)
+    if (get_verbose(verbose_t::debuginfo)
+            >= static_cast<int>(log_level_t::perf))
         get_trace_profiler().reset();
 }
 inline void trace_stamp(const char *pass_name) {
-    if (get_verbose(verbose_t::debuginfo) >= ir_utils::LOG_PERF)
+    if (get_verbose(verbose_t::debuginfo)
+            >= static_cast<int>(log_level_t::perf))
         get_trace_profiler().stamp(pass_name);
 }
 inline void trace_stop(const char *pass_name) {
-    if (get_verbose(verbose_t::debuginfo) >= ir_utils::LOG_PERF)
+    if (get_verbose(verbose_t::debuginfo)
+            >= static_cast<int>(log_level_t::perf))
         get_trace_profiler().stop(pass_name);
 }
 inline void trace_perf() {
-    ir_perf() << get_trace_profiler();
+    gpu_perf() << get_trace_profiler();
 }
 #else
 inline void trace_start() {};

--- a/src/gpu/intel/jit/utils/trace.hpp
+++ b/src/gpu/intel/jit/utils/trace.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ inline void trace_stop(const char *pass_name) {
         get_trace_profiler().stop(pass_name);
 }
 inline void trace_perf() {
-    ir_perf() << get_trace_profiler() << std::endl;
+    ir_perf() << get_trace_profiler();
 }
 #else
 inline void trace_start() {};

--- a/src/gpu/intel/jit/utils/utils.cpp
+++ b/src/gpu/intel/jit/utils/utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,11 +21,6 @@ namespace impl {
 namespace gpu {
 namespace intel {
 namespace jit {
-namespace ir_utils {
-
-thread_local int ir_check_log_level_t::level_ = LOG_CHECK_DEFAULT;
-
-} // namespace ir_utils
 
 void stringify_to_cpp_file(const std::string &file_name,
         const std::string &var_name, const std::vector<std::string> &namespaces,

--- a/src/gpu/intel/jit/v2/conv/bench_data.cpp
+++ b/src/gpu/intel/jit/v2/conv/bench_data.cpp
@@ -84,7 +84,7 @@ std::vector<int> bench_data_set_t::find_best_idxs(int _nbest) const {
                 best_idx = i;
             }
         }
-        ir_assert(best_idx != -1);
+        gpu_assert(best_idx != -1);
         for (int j = 0; j < nprbs; j++) {
             cur_times[j]
                     = std::min(cur_times[j], vec_[best_idx].times[j].total);

--- a/src/gpu/intel/jit/v2/conv/builder.cpp
+++ b/src/gpu/intel/jit/v2/conv/builder.cpp
@@ -969,14 +969,14 @@ stmt_t build_ir(const exec_config_t &exec_cfg, const kernel_desc_t &desc,
     auto plan = create_conv_plan(desc, exec_cfg.hw());
     if (!plan) ir_except_not_implemented("Cannot create plan.");
 
-    ir_info() << desc << std::endl;
-    ir_trace() << plan << std::endl;
+    ir_info() << desc;
+    ir_trace() << plan;
 
     constraint_set_t cset;
     ir_context_t ir_ctx(exec_cfg, cset);
     conv_builder_t builder(ir_ctx, desc, var_mgr, plan);
     auto stmt = builder.get_stmt();
-    ir_trace() << "Convolution kernel body:\n" << stmt << std::endl;
+    ir_trace() << "Convolution kernel body:\n" << stmt;
     return stmt;
 }
 

--- a/src/gpu/intel/jit/v2/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/v2/conv/gen_convolution.cpp
@@ -114,7 +114,7 @@ public:
             auto &registry = const_plan_registry();
             _desc = registry.find_best(prb);
             if (_desc.is_empty()) {
-                ir_info() << "Cannot find kernels that can fit the problem.";
+                gpu_info() << "Cannot find kernels that can fit the problem.";
                 return status::unimplemented;
             }
         }
@@ -124,7 +124,7 @@ public:
         CHECK(pd->attr_.set_default_formats(out_md(pd)));
         CHECK(_desc.set_post_ops(pd->attr()->post_ops_, out_md(pd), pd));
         if (!finalize_conv_desc(_desc, prb)) {
-            ir_info() << "Cannot create kernel descriptor.";
+            gpu_info() << "Cannot create kernel descriptor.";
             return status::runtime_error;
         }
         pd->init_plan = std::make_shared<primitive_init_plan_t>();
@@ -151,7 +151,7 @@ private:
         if (pd->is_fwd()) return pd->dst_md();
         if (pd->is_bwd_d()) return pd->diff_src_md();
         if (pd->is_bwd_w()) return pd->diff_weights_md();
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return nullptr;
     }
 

--- a/src/gpu/intel/jit/v2/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/v2/conv/gen_convolution.cpp
@@ -114,7 +114,7 @@ public:
             auto &registry = const_plan_registry();
             _desc = registry.find_best(prb);
             if (_desc.is_empty()) {
-                ir_info() << "Cannot find kernels that can fit the problem.\n";
+                ir_info() << "Cannot find kernels that can fit the problem.";
                 return status::unimplemented;
             }
         }
@@ -124,7 +124,7 @@ public:
         CHECK(pd->attr_.set_default_formats(out_md(pd)));
         CHECK(_desc.set_post_ops(pd->attr()->post_ops_, out_md(pd), pd));
         if (!finalize_conv_desc(_desc, prb)) {
-            ir_info() << "Cannot create kernel descriptor.\n";
+            ir_info() << "Cannot create kernel descriptor.";
             return status::runtime_error;
         }
         pd->init_plan = std::make_shared<primitive_init_plan_t>();

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -230,7 +230,7 @@ void kernel_desc_t::set(const std::string &s) {
     iface.parse(s, *this, &result);
     if (!result.is_set("--iter") || !result.is_set("--tg")) {
         ir_info() << "Error: missing --iter and/or --tg parameters in kernel "
-                     "descriptor.\n";
+                     "descriptor.";
         ir_error_not_expected();
     }
     set_defaults();

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -320,7 +320,7 @@ public:
                 return pick_b(prop, src_tag, wei_tag, dst_tag);
             case tensor_kind_t::c:
                 return pick_c(prop, src_tag, wei_tag, dst_tag);
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return src_tag;
     }
@@ -363,7 +363,7 @@ public:
                 reqs.simplify();
                 break;
             case spec_strategy_t::none: break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         spec_strategy = spec_strategy_t::none;
     }
@@ -417,8 +417,8 @@ public:
     }
 
     void add_mapping(const pvar_t &dim, int idx) {
-        ir_assert(idx >= 0 && idx < N);
-        ir_assert(index_var(dim).is_empty());
+        gpu_assert(idx >= 0 && idx < N);
+        gpu_assert(index_var(dim).is_empty());
         entries_[idx].dims.push_back(dim);
     }
 
@@ -451,7 +451,7 @@ public:
     expr_t index_var(const pvar_t &dim) const { return index_var(index(dim)); }
 
     const std::vector<pvar_t> &dims(int idx) const {
-        ir_assert(idx >= 0 && idx < N);
+        gpu_assert(idx >= 0 && idx < N);
         return entries_[idx].dims;
     }
 
@@ -465,7 +465,7 @@ public:
     }
 
     size_t size(size_t idx, const pvar_tile_t &tile) const {
-        ir_assert(idx < N);
+        gpu_assert(idx < N);
         size_t ret = 1;
         for (auto &d : entries_[idx].dims) {
             ret *= into<size_t>(tile.get(d, 1));

--- a/src/gpu/intel/jit/v2/conv/plan.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan.cpp
@@ -356,8 +356,8 @@ private:
             const send_params_t &params, const view_t &view) {
         auto plan = create_send_plan(params, view, /*allow_fail=*/true);
         bool ok = [&]() {
-            ir_check(plan) << tag << ": cannot create send plan" << std::endl
-                           << params << std::endl
+            ir_check(plan) << tag << ": cannot create send plan\n"
+                           << params << "\n"
                            << ir_utils::add_tag("view", view.str());
             return true;
         }();

--- a/src/gpu/intel/jit/v2/conv/plan.hpp
+++ b/src/gpu/intel/jit/v2/conv/plan.hpp
@@ -147,7 +147,7 @@ class virt_grid_t {
 public:
     void add(const expr_t &var, const expr_t &expr) {
         auto ret = idxs_.emplace(var, expr);
-        ir_assert(ret.second);
+        gpu_assert(ret.second);
     }
 
     const object_map_t<expr_t, expr_t> &idxs() const { return idxs_; }

--- a/src/gpu/intel/jit/v2/conv/plan_preset.hpp
+++ b/src/gpu/intel/jit/v2/conv/plan_preset.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public:
     const kernel_desc_t &get() const {
         if (!env_desc_.is_empty()) return env_desc_;
         if (!tls_desc_.is_empty()) return tls_desc_;
-        ir_error_not_expected();
+        gpu_error_not_expected();
         return env_desc_;
     }
 

--- a/src/gpu/intel/jit/v2/conv/plan_registry.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan_registry.cpp
@@ -38,9 +38,8 @@ plan_registry_t::plan_registry_t(const char **entries) {
             std::ostringstream oss;
             e.stringify(oss);
             if (oss.str() != *entries) {
-                ir_warning()
-                        << "parsed from:\n  " << *entries
-                        << "\nstringified to\n  " << oss.str() << std::endl;
+                ir_warning() << "parsed from:\n  " << *entries
+                             << "\nstringified to\n  " << oss.str();
             }
         }
 #endif
@@ -117,8 +116,7 @@ struct plan_registry_instance_t {
             if (in.good()) {
                 registry.parse(in);
                 ir_info() << "Loaded kernel registry from " << registry_path
-                          << " with " << registry.size() << " entries"
-                          << std::endl;
+                          << " with " << registry.size() << " entries";
                 return;
             }
         }

--- a/src/gpu/intel/jit/v2/conv/plan_registry.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan_registry.cpp
@@ -38,8 +38,8 @@ plan_registry_t::plan_registry_t(const char **entries) {
             std::ostringstream oss;
             e.stringify(oss);
             if (oss.str() != *entries) {
-                ir_warning() << "parsed from:\n  " << *entries
-                             << "\nstringified to\n  " << oss.str();
+                gpu_warning() << "parsed from:\n  " << *entries
+                              << "\nstringified to\n  " << oss.str();
             }
         }
 #endif
@@ -89,7 +89,8 @@ void plan_registry_t::parse(std::istream &in) {
 }
 
 void plan_registry_t::entry_t::stringify(std::ostream &out) const {
-    ir_assert(desc.is_finalized) << "Cannot stringify non-finalized descriptor";
+    gpu_assert(desc.is_finalized)
+            << "Cannot stringify non-finalized descriptor";
     jit::stringify(out, desc);
     out << " model=";
     jit::stringify(out, model_set);
@@ -115,8 +116,8 @@ struct plan_registry_instance_t {
             std::ifstream in(registry_path);
             if (in.good()) {
                 registry.parse(in);
-                ir_info() << "Loaded kernel registry from " << registry_path
-                          << " with " << registry.size() << " entries";
+                gpu_info() << "Loaded kernel registry from " << registry_path
+                           << " with " << registry.size() << " entries";
                 return;
             }
         }

--- a/src/gpu/intel/jit/v2/conv/plan_registry.hpp
+++ b/src/gpu/intel/jit/v2/conv/plan_registry.hpp
@@ -46,7 +46,7 @@ public:
     plan_registry_t(const char **entries);
 
     void set(const kernel_desc_t &desc, const model_set_t &model_set) {
-        ir_assert(desc.is_finalized);
+        gpu_assert(desc.is_finalized);
         entries_.emplace_back(desc, model_set);
     }
     int size() const { return (int)entries_.size(); }

--- a/src/gpu/intel/jit/v2/conv/planner/bench.hpp
+++ b/src/gpu/intel/jit/v2/conv/planner/bench.hpp
@@ -71,7 +71,7 @@ struct bench_input_params_t {
     bench_input_params_t(const kernel_desc_t &kernel_desc, const hw_t &hw,
             int nprbs = default_nprbs)
         : hw(hw), nprbs(nprbs) {
-        ir_assert(kernel_desc.is_finalized);
+        gpu_assert(kernel_desc.is_finalized);
         prop = kernel_desc.prop;
         src_tag = kernel_desc.src_tag;
         wei_tag = kernel_desc.wei_tag;

--- a/src/gpu/intel/jit/v2/conv/planner/planner.cpp
+++ b/src/gpu/intel/jit/v2/conv/planner/planner.cpp
@@ -151,7 +151,7 @@ void DNNL_API planner_main(int argc, const char **argv) {
             search(bench_mger, params);
             break;
         }
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
 }
 

--- a/src/gpu/intel/jit/v2/conv/planner/search.cpp
+++ b/src/gpu/intel/jit/v2/conv/planner/search.cpp
@@ -163,7 +163,7 @@ private:
             auto dim = pvar_t(value);
             tile_infos_[dim].add(tile_flags_t::thread_group);
         } else {
-            ir_error_not_expected();
+            gpu_error_not_expected();
         }
     }
 
@@ -304,7 +304,7 @@ std::vector<tile_scheme_t> get_tile_schemes(const search_params_t &params) {
         schemes.emplace_back("tg=[oc,ic], iter=[mb,g,oc,ic]");
         schemes.emplace_back("tg=[oc,ic], iter=[ow,g,oc,ic]");
     } else {
-        ir_error_not_expected();
+        gpu_error_not_expected();
     }
     for (auto &s : schemes) {
         if (params.base_desc.is_dw) {
@@ -327,7 +327,7 @@ public:
     const std::vector<kernel_desc_t> &descs() const { return descs_; }
 
     void add_desc(const kernel_desc_t &desc) {
-        ir_assert(desc.reqs.str() == reqs_.str())
+        gpu_assert(desc.reqs.str() == reqs_.str())
                 << "Reqs mismatch:\n"
                 << desc.cmd_str() << "\ndesc.reqs:" << desc.reqs.str()
                 << "\nreqs:\n"
@@ -335,7 +335,7 @@ public:
         if (descs_.empty()) {
             is_dw_ = desc.is_dw;
         } else {
-            ir_assert(desc.is_dw == is_dw_);
+            gpu_assert(desc.is_dw == is_dw_);
         }
         descs_.push_back(desc);
     }
@@ -419,7 +419,7 @@ private:
                           << std::endl;
             }
         }
-        ir_info() << "gen_desc_groups(): descs.size() = " << descs.size();
+        gpu_info() << "gen_desc_groups(): descs.size() = " << descs.size();
         std::unordered_map<std::string, search_kernel_desc_group_t> desc_groups;
         std::vector<int> prefetch_dists;
         if (params_.is_prefetch_set) {
@@ -522,7 +522,7 @@ public:
     }
 
     std::pair<int, kernel_desc_t> next() {
-        ir_assert((bool)*this);
+        gpu_assert((bool)*this);
         auto &e = *entry_it_;
         ++entry_it_;
         return std::make_pair(e.id, e.desc);
@@ -674,7 +674,7 @@ void search(const bench_manager_t &bench_mger, const planner_params_t &params) {
         case planner_mode_t::auto_search:
             auto_search(bench_mger, params);
             break;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
 }
 

--- a/src/gpu/intel/jit/v2/conv/planner/search.cpp
+++ b/src/gpu/intel/jit/v2/conv/planner/search.cpp
@@ -419,8 +419,7 @@ private:
                           << std::endl;
             }
         }
-        ir_info() << "gen_desc_groups(): descs.size() = " << descs.size()
-                  << std::endl;
+        ir_info() << "gen_desc_groups(): descs.size() = " << descs.size();
         std::unordered_map<std::string, search_kernel_desc_group_t> desc_groups;
         std::vector<int> prefetch_dists;
         if (params_.is_prefetch_set) {

--- a/src/gpu/intel/jit/v2/conv/problem.cpp
+++ b/src/gpu/intel/jit/v2/conv/problem.cpp
@@ -25,7 +25,7 @@ namespace v2 {
 namespace conv {
 
 problem_t::problem_t(const std::string &line) {
-    ir_error_not_expected();
+    gpu_error_not_expected();
     auto s_desc = gpu_utils::split(line, " ").back();
     set_shape(s_desc);
 }
@@ -41,13 +41,13 @@ const type_t &problem_t::out_type() const {
         case prop_kind::forward: return dst_tag_.type();
         case prop_kind::backward_data: return src_tag_.type();
         case prop_kind::backward_weights: return wei_tag_.type();
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return src_tag_.type();
 }
 
 void problem_t::set_shape(const std::string &s) {
-    ir_assert(prop_ != prop_kind::undef);
+    gpu_assert(prop_ != prop_kind::undef);
     pvar_tile_t s_tile(s);
     bool has_d = has_spatial(s_tile, 'd');
     bool has_h = has_spatial(s_tile, 'h');
@@ -69,7 +69,7 @@ void problem_t::set_shape(const std::string &s) {
         s_tile[pvars::dw] = s_tile[pvars::dh];
         s_tile[pvars::pw] = s_tile[pvars::ph];
     } else {
-        ir_error_not_expected();
+        gpu_error_not_expected();
     }
     for (auto &d : default_shape()) {
         if (s_tile.has(d)) continue;

--- a/src/gpu/intel/jit/v2/conv/problem.hpp
+++ b/src/gpu/intel/jit/v2/conv/problem.hpp
@@ -47,7 +47,7 @@ public:
                 return pick_b(prop_, src_tag_, wei_tag_, dst_tag_);
             case tensor_kind_t::c:
                 return pick_c(prop_, src_tag_, wei_tag_, dst_tag_);
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
         return src_tag_;
     }

--- a/src/gpu/intel/jit/v2/conv/tensor_utils.cpp
+++ b/src/gpu/intel/jit/v2/conv/tensor_utils.cpp
@@ -49,7 +49,7 @@ layout_desc_t make_conv_layout_desc(
         CASE(ow, 'w');
         CASE(kw, is_wei ? 'w' : 'x');
 #undef CASE
-        ir_assert(c != ' ');
+        gpu_assert(c != ' ');
         letter_map[d] = c;
     }
     return layout_desc_t(letter_map);
@@ -67,7 +67,7 @@ layout_desc_t make_conv_algo_layout_desc(
         case tensor_kind_t::dst:
             if (prop != prop_kind::backward_data) return desc;
             break;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     pvar_map_t<char> letter_map;
     bool is_src = (tensor_kind == tensor_kind_t::src);
@@ -218,7 +218,7 @@ std::string blocked_to_str_tag(const memory_desc_t &md) {
                 break;
             }
         }
-        if (!found) ir_error_not_expected();
+        if (!found) gpu_error_not_expected();
     }
     std::ostringstream oss;
     for (int i = (int)parts.size() - 1; i >= 0; i--)
@@ -246,7 +246,7 @@ layout_tag_t make_conv_layout_tag(tensor_kind_t tensor_kind,
         dim_idx_t conv_ndims, const memory_desc_t &md) {
     bool is_any = (md.format_kind == format_kind::any);
     bool is_blocked = (md.format_kind == format_kind::blocked);
-    ir_assert(is_any || is_blocked);
+    gpu_assert(is_any || is_blocked);
     auto desc = make_conv_layout_desc(tensor_kind);
     type_t type(md.data_type);
     if (is_any) return layout_tag_t(desc, type, layout_raw_tag_t::any());
@@ -280,7 +280,7 @@ const dim_mapper_t &dim_mapper_manager_t::mapper(tensor_kind_t tensor) const {
             return mapper(pick_c(prop_, tensor_kind_t::src, tensor_kind_t::wei,
                     tensor_kind_t::dst));
         case tensor_kind_t::bias: return bias_mapper_;
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return src_mapper_;
 }
@@ -399,7 +399,7 @@ std::vector<pvar_t> skip_mask(
     auto dim_sizes = view.base_layout().dim_sizes();
     for (int i = 0; i < mask_desc.nmasks(); i++) {
         pvar_t dim = mask_desc[i].dim;
-        ir_assert(view.dim_mapper().has(dim));
+        gpu_assert(view.dim_mapper().has(dim));
         // Assume that dimensions with non-trivial mapping always require
         // masking.
         if (!view.dim_mapper().expr(dim).is_same(dim.index_var())) continue;

--- a/src/gpu/intel/jit/v2/ir/bridge.hpp
+++ b/src/gpu/intel/jit/v2/ir/bridge.hpp
@@ -37,7 +37,7 @@ inline jit::send_address_t to_ir(send_address_t address) {
         CASE(a64);
         CASE(slm);
 #undef CASE
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     return ret;
 }
@@ -53,7 +53,7 @@ inline jit::send_op_t to_ir(send_op_t op, bool is_2d = false) {
         CASE(prefetch);
         CASE(store);
 #undef CASE
-        default: ir_error_not_expected();
+        default: gpu_error_not_expected();
     }
     if (is_2d) {
         switch (ret) {
@@ -62,15 +62,15 @@ inline jit::send_op_t to_ir(send_op_t op, bool is_2d = false) {
                 ret = jit::send_op_t::prefetch_2d;
                 break;
             case jit::send_op_t::store: ret = jit::send_op_t::store_2d; break;
-            default: ir_error_not_expected();
+            default: gpu_error_not_expected();
         }
     }
     return ret;
 }
 
 inline jit::layout_t to_ir(const layout_t &layout) {
-    ir_assert(layout.has_const_sizes());
-    ir_assert(layout.has_const_strides());
+    gpu_assert(layout.has_const_sizes());
+    gpu_assert(layout.has_const_strides());
     std::vector<gpu::intel::block_t> blocks;
     for (auto &b : layout.blocks()) {
         int dim_idx = layout.desc().dim_index(b.dim);

--- a/src/gpu/intel/jit/v2/ir/builder.cpp
+++ b/src/gpu/intel/jit/v2/ir/builder.cpp
@@ -135,7 +135,7 @@ offset_t offset_scope_t::get_offset(int version, const expr_t &base0,
             && ret.type.is_scalar()) {
         for (auto &o : offsets_) {
             if (o.is_equal(ret, /*compare_shift=*/false)) {
-                ir_assert(o.type.is_scalar());
+                gpu_assert(o.type.is_scalar());
                 ret.inline_init = ret.store(o.load() + ret.shift);
                 ret.loop_incs.clear();
                 break;
@@ -155,7 +155,7 @@ stmt_t create_stmt(const send_1d_plan_t &plan, const expr_t &mem_buf,
         const expr_t &reg_buf, offset_ctx_t &off_ctx,
         const pvar_coord_t<dim_t> &coord, const pvar_tile_t &tile) {
     for (auto &d : plan.entry_tile) {
-        ir_assert(tile.at(d) % plan.entry_tile.at(d) == 0);
+        gpu_assert(tile.at(d) % plan.entry_tile.at(d) == 0);
     }
     auto op = to_ir(plan.desc.op);
     auto address = to_ir(plan.desc.address);
@@ -169,7 +169,7 @@ stmt_t create_stmt(const send_1d_plan_t &plan, const expr_t &mem_buf,
         int entry_idx = plan.reg_layout.to_linear_index(
                 plan.entry_tile, coord + sub_coord);
         auto &e = plan.entries[entry_idx];
-        ir_assert(e.coord == coord + sub_coord);
+        gpu_assert(e.coord == coord + sub_coord);
         auto header
                 = off_ctx.add_header(plan.desc, mem_buf, plan.addr, e.addr_inc);
         auto mask = off_ctx.add_mask(plan.mask, e.mask_incs);
@@ -198,7 +198,7 @@ stmt_t create_stmt(const send_2d_plan_t &plan, const expr_t &mem_buf,
         int entry_idx = plan.reg_layout.to_linear_index(
                 plan.entry_tile, coord + sub_coord);
         auto &e = plan.entries[entry_idx];
-        ir_assert(e.coord == coord + sub_coord);
+        gpu_assert(e.coord == coord + sub_coord);
         auto header = off_ctx.add_header(plan.desc, mem_buf, plan.base,
                 plan.x_base, plan.y_base, e.x_inc, e.y_inc);
         auto mask = off_ctx.add_mask(plan.mask);
@@ -220,7 +220,7 @@ stmt_t create_stmt(const send_plan_t &plan, const expr_t &mem_buf,
         return create_stmt(plan._1d, mem_buf, reg_buf, off_ctx, coord, tile);
     if (plan.is_2d())
         return create_stmt(plan._2d, mem_buf, reg_buf, off_ctx, coord, tile);
-    ir_error_not_expected();
+    gpu_error_not_expected();
     return stmt_t();
 }
 

--- a/src/gpu/intel/jit/v2/ir/builder.hpp
+++ b/src/gpu/intel/jit/v2/ir/builder.hpp
@@ -456,7 +456,7 @@ class var_ref_t {
 public:
     var_ref_t(ir_builder_t *parent, const type_t &type, const expr_t &buf)
         : parent_(parent), type_(type), buf_(buf) {
-        ir_assert(buf_.type().is_ptr());
+        gpu_assert(buf_.type().is_ptr());
     }
 
     operator expr_t() const { return load_t::make(type_, buf_, 0); }
@@ -561,7 +561,7 @@ public:
         params.op = send_op_t::store;
         params.init_max_entry_reg_size();
         auto plan = create_send_plan(params, mem_view);
-        ir_assert(plan.reg_layout() == reg_layout);
+        gpu_assert(plan.reg_layout() == reg_layout);
         store(plan, mem_buf, reg_buf);
     }
 
@@ -634,7 +634,7 @@ public:
     void emit(const stmt_t &stmt) { top_stmt() = top_stmt().append(stmt); }
     stmt_t get_stmt() const { return top_stmt(); }
     void set_stmt(const stmt_t &stmt) {
-        ir_assert(stmt_stack_.size() == 1);
+        gpu_assert(stmt_stack_.size() == 1);
         top_stmt() = stmt;
     }
     stmt_t get_init_stmt() const { return off_ctx().init_stmt(); }
@@ -642,16 +642,16 @@ public:
 private:
     static const std::string &get_buf_name(const expr_t &e) {
         auto *var = e.as_ptr<var_t>();
-        ir_assert(var) << e;
+        gpu_assert(var) << e;
         return var->name;
     }
 
     stmt_t &top_stmt() {
-        ir_assert(!stmt_stack_.empty());
+        gpu_assert(!stmt_stack_.empty());
         return stmt_stack_.back();
     }
     const stmt_t &top_stmt() const {
-        ir_assert(!stmt_stack_.empty());
+        gpu_assert(!stmt_stack_.empty());
         return stmt_stack_.back();
     }
     void enter_scope() { stmt_stack_.emplace_back(); }
@@ -668,7 +668,7 @@ private:
 };
 
 inline var_ref_t &var_ref_t::operator=(const expr_t &value) {
-    ir_assert(value.type() == type_);
+    gpu_assert(value.type() == type_);
     parent_->emit(store_t::make(buf_, 0, value));
     return *this;
 }
@@ -699,16 +699,16 @@ public:
         std::string name;
         if (auto *op = value.as_ptr<binary_op_t>()) {
             if (op->op_kind == op_kind_t::_div_up) {
-                ir_assert(is_const(op->b))
+                gpu_assert(is_const(op->b))
                         << "Expected constant denominator: " << value;
                 if (is_one(op->b)) return get_idiv_magic(op->a);
-                ir_assert(op->a.is<var_t>() || op->a.is<const_var_t>())
+                gpu_assert(op->a.is<var_t>() || op->a.is<const_var_t>())
                         << "Expected var/const var: " << op->a;
                 name = op->a.str();
                 name += "_divup_" + op->b.str();
             }
         } else {
-            ir_assert(value.is<var_t>() || value.is<const_var_t>())
+            gpu_assert(value.is<var_t>() || value.is<const_var_t>())
                     << "Expected var/const var: " << value;
             name = value.str();
         }
@@ -716,10 +716,10 @@ public:
     }
 
     expr_t get_arg(const type_t &type, const std::string &name) const {
-        ir_assert(kernel_iface_.has(name)) << "Cannot find argument " << name;
+        gpu_assert(kernel_iface_.has(name)) << "Cannot find argument " << name;
         auto var = kernel_iface_.find_arg(name);
-        ir_assert(var.type() == type) << "Type mismatch, found: " << var.type()
-                                      << " expected: " << type;
+        gpu_assert(var.type() == type) << "Type mismatch, found: " << var.type()
+                                       << " expected: " << type;
         return var;
     }
 

--- a/src/gpu/intel/jit/v2/ir/reqs.hpp
+++ b/src/gpu/intel/jit/v2/ir/reqs.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public:
     // TODO: Change to non-const.
     bool require(const expr_t &e) const;
     const prb_reqs_t &reqs() const {
-        ir_assert(reqs_);
+        gpu_assert(reqs_);
         return *reqs_;
     }
     explicit operator bool() const { return reqs_; }

--- a/src/gpu/intel/jit/v2/ir/send.cpp
+++ b/src/gpu/intel/jit/v2/ir/send.cpp
@@ -50,8 +50,8 @@ bool process_coef_y_stride(
             return true;
         }
     }
-    ir_error_not_expected() << "Cannot make " << u << " x " << v
-                            << " divisible by " << plane.y_stride;
+    gpu_error_not_expected() << "Cannot make " << u << " x " << v
+                             << " divisible by " << plane.y_stride;
     return false;
 }
 

--- a/src/gpu/intel/jit/v2/ir/send.hpp
+++ b/src/gpu/intel/jit/v2/ir/send.hpp
@@ -439,7 +439,7 @@ struct send_1d_plan_t : public base_plan_t {
         if (!desc.base_alignment_ok(addr_inc, prover)) return false;
         std::vector<expr_t> mask_incs(nmasks());
         auto coord = it.coord();
-        ir_assert(reg_layout.offset_in_bytes(coord) == reg_off);
+        gpu_assert(reg_layout.offset_in_bytes(coord) == reg_off);
         for (int i = 0; i < nmasks(); i++) {
             mask_incs[i] = mask_desc[i].to_expr(coord, /*with_const=*/false);
         }
@@ -555,7 +555,7 @@ struct send_2d_desc_t {
                     stride = utils::rnd_up(stride, grf_size / type.size());
                     break;
                 case pad_kind_t::none: break;
-                default: ir_error_not_expected();
+                default: gpu_error_not_expected();
             }
             cur_stride = stride;
         };
@@ -762,8 +762,8 @@ private:
             slot_size = std::min(max_slot_size, slot_size);
         if (type_size < slot_size && slot_size < 4) slot_size = type_size;
 
-        ir_assert(inner_bytes % slot_size == 0);
-        ir_assert(slot_size % type_size == 0);
+        gpu_assert(inner_bytes % slot_size == 0);
+        gpu_assert(slot_size % type_size == 0);
         bool is_scattered = (slot_size <= max_slot_size);
         if (is_scattered && params.kind == send_kind_t::block)
             return send_plan_t();
@@ -803,8 +803,8 @@ private:
 
         int elem_stride = 1;
         if (slot_stride > slot_size) {
-            ir_assert(slot_size < 4);
-            ir_assert(type_size == slot_size);
+            gpu_assert(slot_size < 4);
+            gpu_assert(type_size == slot_size);
             elem_stride = ir_utils::safe_div(slot_stride, slot_size);
         }
         auto reg_layout = middle_last.sub_layout(elem_stride);
@@ -849,7 +849,7 @@ private:
         int grf_size = params.hw.grf_size();
         auto reg_layout = desc.reg_layout(grf_size, view.layout().desc());
         int entry_reg_size = utils::rnd_up(reg_layout.size(), grf_size);
-        ir_assert(entry_reg_size <= params.max_entry_reg_size);
+        gpu_assert(entry_reg_size <= params.max_entry_reg_size);
         reg_layout.pad_bytes(grf_size);
 
         auto entry_tile = reg_layout.int_dim_sizes();
@@ -919,7 +919,7 @@ private:
         const int max_type_size = 512;
         if (desc.type_size <= max_type_size) return;
 
-        ir_assert(desc.type_size % max_type_size == 0);
+        gpu_assert(desc.type_size % max_type_size == 0);
         send_1d_plan_t new_plan;
         new_plan.desc = desc;
         new_plan.desc.type_size = max_type_size;
@@ -943,11 +943,11 @@ private:
 
 inline send_plan_t create_send_plan(const send_params_t &params,
         const view_t &view, bool allow_fail = false) {
-    ir_assert(params.max_entry_reg_size > 0);
+    gpu_assert(params.max_entry_reg_size > 0);
     send_plan_builder_t spb(params, view);
     auto plan = spb.build();
     if (!plan) {
-        if (!allow_fail) ir_error_not_expected() << "Cannot create send plan.";
+        if (!allow_fail) gpu_error_not_expected() << "Cannot create send plan.";
     }
     return plan;
 }

--- a/src/gpu/intel/jit/v2/ir/tensor.hpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.hpp
@@ -192,7 +192,7 @@ struct layout_raw_tag_entry_t {
         : letter(letter), block(block), is_blocked(is_blocked) {}
 
     dim_idx_t index() const {
-        ir_assert(letter >= 'a' && letter < 'x');
+        gpu_assert(letter >= 'a' && letter < 'x');
         return letter - 'a';
     }
     bool is_outer() const { return !is_blocked || (is_blocked && block == 0); }
@@ -330,7 +330,7 @@ public:
         desc_ = layout_desc_t();
         auto s = stream_parse<std::string>(in);
         auto parts = gpu_utils::split(s, ":");
-        ir_assert(parts.size() == 2);
+        gpu_assert(parts.size() == 2);
         jit::parse(parts[0], raw_tag_);
         jit::parse(parts[1], type_);
     }
@@ -477,7 +477,7 @@ public:
     }
 
     const block_t &operator*() const {
-        ir_assert(!is_end());
+        gpu_assert(!is_end());
         return block_;
     }
 

--- a/src/gpu/intel/logging.hpp
+++ b/src/gpu/intel/logging.hpp
@@ -1,0 +1,169 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_LOGGING_HPP
+#define GPU_INTEL_LOGGING_HPP
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "common/utils.hpp"
+#include "gpu/intel/utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+
+enum class log_level_t {
+    off = 0,
+    warning = 100,
+    suggestion = 120,
+    info = 150,
+    perf = 170,
+    trace = 200,
+};
+
+template <typename T, typename = void>
+struct print_helper_t {
+    static void call(std::ostream &out, const T &t) { out << t; }
+};
+
+template <typename T>
+struct print_helper_t<T, decltype(std::declval<T>().str(), void())> {
+    static void call(std::ostream &out, const T &t) { out << t.str(); }
+};
+
+template <log_level_t level, bool value = true>
+class logger_t {
+public:
+    logger_t(const char *file_name, int line, std::ostream &out = std::cout)
+        : file_path_(file_name + std::string(":") + std::to_string(line))
+        , out_(out) {}
+    ~logger_t() {
+        add_header(true);
+        if (lines_.size() == 1) {
+            out_ << " " << lines_[0] << std::endl;
+        } else {
+            out_ << std::endl;
+            for (auto &l : lines_) {
+                add_header(/*with_file=*/false);
+                out_ << "  " << l << std::endl;
+            }
+        }
+    }
+
+    static bool is_enabled() {
+        return get_verbose_dev_mode(verbose_t::debuginfo)
+                >= static_cast<int>(level);
+    }
+
+    log_level_t get_level() const { return level; }
+
+    operator bool() const { return value; }
+
+    template <typename T>
+    logger_t &operator<<(const T &obj) {
+        std::ostringstream oss;
+        print_helper_t<T>::call(oss, obj);
+        auto lines = gpu_utils::split(oss.str(), "\n");
+        if (lines_.empty() || lines.empty()) {
+            lines_ = lines;
+            return *this;
+        }
+        lines_.back() += lines[0];
+        lines_.insert(lines_.end(), lines.begin() + 1, lines.end());
+        return *this;
+    }
+
+private:
+    void add_header(bool with_file) {
+        switch (level) {
+            case log_level_t::warning: out_ << "[ WARN]"; break;
+            case log_level_t::suggestion: out_ << "[SUGGESTION]"; break;
+            case log_level_t::info: out_ << "[ INFO]"; break;
+            case log_level_t::perf: out_ << "[ PERF]"; break;
+            case log_level_t::trace: out_ << "[TRACE]"; break;
+            default: gpu_error_not_expected();
+        }
+        if (with_file) out_ << "[" << file_path_ << "]";
+    }
+
+    std::string file_path_;
+    std::ostream &out_;
+    std::vector<std::string> lines_;
+};
+
+#define gpu_perf() \
+    dnnl::impl::gpu::intel::logger_t< \
+            dnnl::impl::gpu::intel::log_level_t::perf>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::perf>( \
+                    __FILENAME__, __LINE__)
+
+// Trace can result in overhead making measurement meaningless
+#define gpu_perf_no_trace() \
+    dnnl::impl::gpu::intel::logger_t< \
+            dnnl::impl::gpu::intel::log_level_t::perf>::is_enabled() \
+            && !dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::trace>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::perf>( \
+                    __FILENAME__, __LINE__)
+
+#define gpu_info() \
+    dnnl::impl::gpu::intel::logger_t< \
+            dnnl::impl::gpu::intel::log_level_t::info>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::info>( \
+                    __FILENAME__, __LINE__)
+
+#define gpu_warning() \
+    dnnl::impl::gpu::intel::logger_t< \
+            dnnl::impl::gpu::intel::log_level_t::warning>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::warning>( \
+                    __FILENAME__, __LINE__)
+
+#define gpu_suggestion() \
+    dnnl::impl::gpu::intel::logger_t< \
+            dnnl::impl::gpu::intel::log_level_t::suggestion>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::suggestion>( \
+                    __FILENAME__, __LINE__)
+
+#define gpu_trace() \
+    dnnl::impl::gpu::intel::logger_t< \
+            dnnl::impl::gpu::intel::log_level_t::trace>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::trace>( \
+                    __FILENAME__, __LINE__)
+
+#define gpu_check(cond) \
+    if (!(cond)) \
+    return dnnl::impl::gpu::intel::logger_t< \
+                   dnnl::impl::gpu::intel::log_level_t::trace>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::trace, false>( \
+                    __FILENAME__, __LINE__)
+
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/intel/utils.hpp
+++ b/src/gpu/intel/utils.hpp
@@ -120,7 +120,7 @@ private:
 #define gpu_error_not_expected() gpu_assert(false) << "Not expected. "
 #define gpu_except_not_implemented(msg) \
     throw std::runtime_error(std::string(msg) + std::string(" at ") \
-            + std::string(__FILE_NAME__) + std::string(":") \
+            + std::string(__FILENAME__) + std::string(":") \
             + std::to_string(__LINE__))
 
 template <typename out_type, typename in_type,


### PR DESCRIPTION
Jira: https://jira.devtools.intel.com/browse/MFDNN-11400.

List of changes:


- Moved logging functionality to `src/gpu/intel/logging.hpp` with some slight refactoring (constant -> enum class)
    - Renamed `ir_{warning,perf,trace,...}` to `gpu`-prefixed versions
- Reworked logging format: see `src/gpu/intel/logging.hpp`
    - Example: `[TRACE][      codegen.cpp:95] codegen:bind h_34 -> r18 - r19`
    - Added level tag and file name/line number information
- Simplified logging implementation, mostly minor things:
    - Removed `ir_check` related not-relly-important features as `base_logger_t`, fatal and dynamic log levels, IR check guard
    - Added automatic new-line after every log message
- Dropped `ir_assert` (and similar macros), renamed usages to the existing `gpu_assert`, etc

Things left for the future:

- Documentation
- New log level: debug (or maybe refactored info/trace combination).  Now "trace" is used for both very detailed tracing and some useful/more high-level logging. There should be more granularity, e.g.:
    - Trace: max detail level, logging after every IR pass and even from inside of some passes
    - Debug/info: less details but enough to understand what kernel looks like, e.g. kernel parameters + final IR