### PR TITLE
[rls-v3.7]src: graph: backend: dnnl: enable block format in large partition kernel

### DIFF
--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -135,6 +135,11 @@ void larger_partition_kernel_t::setup_pipeline_stage1(
 void larger_partition_kernel_t::setup_pipeline_stage2(pass_pipeline_t &pipeline,
         memory_planner_t &mem_planner, bool enable_constant_cache) {
     pipeline.reset_visualize_arg(true, false);
+    // do constant propagation here so that we can
+    // prepare constant info for other optimizations.
+    if (enable_constant_cache) {
+        BACKEND_DNNL_ADD_PASS(pipeline, constant_propagation);
+    }
     BACKEND_DNNL_ADD_PASS(pipeline, infer_shape);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_src_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_matmul);


### PR DESCRIPTION
porting #2450 

fix bug that can't enable block format in large partition kernel.
root cause: setting wei for matmul before constant propagation, wei is not constant which makes block layout disabled.
fix: constant propagation before layout propagation.

original log:
onednn_verbose,v1,primitive,exec,cpu,matmul,brg_matmul:undef,src:bf16::blocked:ab::f0 wei:bf16::blocked:ba::f0 dst:bf16::blocked:ab::f0,attr-scratchpad:user,,4x4096:4096x11008,

after fix:
onednn_verbose,v1,primitive,exec,cpu,matmul,brg_matmul:undef,src:bf16::blocked:ab::f0 wei:bf16:a:blocked:BA16a64b2a::f0 dst:bf16::blocked:ab::f0,attr-scratchpad:user,,4x4096:4096x11008,