### PR TITLE
gpu: reduction: fix failing gtests

### DIFF
--- a/tests/gtests/test_reduction.cpp
+++ b/tests/gtests/test_reduction.cpp
@@ -49,6 +49,10 @@ protected:
 
         SKIP_IF(unsupported_data_type(src_dt),
                 "Engine does not support this data type.");
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+        SKIP_IF(get_test_engine().get_kind() != engine::kind::cpu,
+                "Engine does not support this primitive.");
+#endif
         SKIP_IF_CUDA(p.aalgorithm != algorithm::reduction_max
                         && p.aalgorithm != algorithm::reduction_min
                         && p.aalgorithm != algorithm::reduction_sum


### PR DESCRIPTION
# Description

#2243 caused some failures in the reduction gtests on intel GPU. This PR reverts a [skip which was incorrectly removed](https://github.com/oneapi-src/oneDNN/pull/2243/files#diff-38eb9abaf39baf897c0c419e65db5b41e8f52d2ecb9aee896d1a99c8ba1fa5b5L52-L53) which skips the tests on non-cpu engines. The `ifdef` for INTEL vendor is added as the tests should be enabled on generic backend.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?