### PR TITLE
[rls-v3.7] graph: backport coverity fixes

### DIFF
--- a/src/graph/backend/dnnl/fusion_info.cpp
+++ b/src/graph/backend/dnnl/fusion_info.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022-2024 Intel Corporation
+ * Copyright 2022-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                     // last two dimensions.
                     std::vector<int64_t> groups(
                             group_shape.end() - 2, group_shape.end());
-                    int64_t mask = (1 << group_shape.size()) - 1;
+                    int mask = (1 << group_shape.size()) - 1;
 
                     attr.set_scales(DNNL_ARG_WEIGHTS, mask, groups,
                             static_cast<dnnl::memory::data_type>(
@@ -168,7 +168,7 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                     // last two dimensions.
                     std::vector<int64_t> groups(
                             group_shape.end() - 2, group_shape.end());
-                    int64_t mask = (1 << group_shape.size()) - 1;
+                    int mask = (1 << group_shape.size()) - 1;
 
                     // Currently oneDNN only supports grouped zps on last two dimensions.
                     attr.set_zero_points(DNNL_ARG_WEIGHTS, mask, groups,

--- a/src/graph/backend/graph_compiler/core/src/runtime/microkernel/cpu/brgemm_onednn.cpp
+++ b/src/graph/backend/graph_compiler/core/src/runtime/microkernel/cpu/brgemm_onednn.cpp
@@ -125,7 +125,7 @@ static brgemm_attr_t get_dnnl_brgemm_attrs(const attrs_setting_t &attrs) {
                         = static_cast<brgemm_kernel_prefetching_t>(it.second);
                 break;
             case attr_key::wary_tail_read:
-                dnnl_attrs.wary_tail_read = static_cast<bool>(it.second);
+                dnnl_attrs.wary_A_k_tail_read = static_cast<bool>(it.second);
                 break;
             case attr_key::generate_skip_accumulation:
                 dnnl_attrs.generate_skip_accumulation

--- a/src/graph/utils/pm/nested_matcher.cpp
+++ b/src/graph/utils/pm/nested_matcher.cpp
@@ -981,8 +981,7 @@ bool match_alternation(const binding_t &bind_arg, match_context_t *ctx,
                 if (iter == local_ctx.in_port_map.end()) return false;
 
                 op_t *current_op = iter->second.first;
-                size_t current_port
-                        = local_ctx.in_port_map.find(0)->second.second;
+                size_t current_port = iter->second.second;
                 binding_t current_bind(BIND_OUT, current_op, current_port,
                         bind_arg.bind_node, bind_arg.bind_port);
                 return match_node_inputs(current_bind, ctx, matched_op_map);

--- a/src/graph/utils/pm/pass_manager.cpp
+++ b/src/graph/utils/pm/pass_manager.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ void pass_manager_t::print_passes(const std::string &pass_config_json) {
 }
 
 void pass_manager_t::print_passes(std::ostream *os) {
-    auto passes = get_passes();
+    const auto &passes = get_passes();
     json::json_writer_t write(os);
     write.begin_object();
     std::string hash = dnnl_version()->hash;

--- a/tests/benchdnn/graph/custom_driver.hpp
+++ b/tests/benchdnn/graph/custom_driver.hpp
@@ -43,8 +43,8 @@ struct settings_t {
 
     ::std::unordered_map<int, arg_md_t> arg_mds_;
     ::std::vector<int64_t> order;
-    int64_t axis;
-    alg_t alg;
+    int64_t axis = -1;
+    alg_t alg = ALG_UNKNOWN;
 
     // A stub to be compliant with `base_settings_t`.
     void finalize() {};
@@ -61,9 +61,9 @@ struct prb_t {
 
     ::std::unordered_map<int, arg_md_t> arg_mds_;
     ::std::vector<int64_t> order;
-    int64_t axis;
+    int64_t axis = -1;
     attr_t attr;
-    alg_t alg;
+    alg_t alg = ALG_UNKNOWN;
 };
 
 dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args);


### PR DESCRIPTION
1. Backports coverity fixes from #2449
2. Backports a minor fix for graph compiler build from #2424  