### PR TITLE
graph: backend: dnnl: fix check for sdpa

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -457,6 +457,8 @@ impl::status_t sdp_decomp_config_t::record_input_offset(
                     graph::op_kind::SoftMax};
     for (const auto &cur_op : sg->get_ops()) {
         const auto &op_kind = cur_op->get_kind();
+        VCHECK_SDP_DECOMP(op_kind != graph::op_kind::GenIndex,
+                status::unimplemented, "Not support implicit causal mask");
         VCHECK_SDP_DECOMP(op_kind != graph::op_kind::DynamicDequantize,
                 status::unimplemented,
                 "Decomposed kernel does not support dynamic quantization");

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -207,9 +207,11 @@ status_t sdp_primitive_config_t::initial_check(
                 post_op = get_post_op(post_op);
             }
             // mask
-            if (post_op && post_op->get_kind() == graph::op_kind::Add) {
-                // Mask exists, update post_op and traverse to next op
-                post_op = get_post_op(post_op);
+            if (post_op) {
+                if (post_op->get_kind() == graph::op_kind::Add) {
+                    // Mask exists, update post_op and traverse to next op
+                    post_op = get_post_op(post_op);
+                }
                 // Not support select after scale(optional) and mask(optional)
                 // Distill-Bert:[mm1] --> [scale]* --> [mask]* --> [select] --> ...
                 VCHECK_SDP_PRIMITIVE(post_op


### PR DESCRIPTION
# Description

There are two fixes:

- [x] fix select check for sdpa primitive: sdpa prmitive doesn't support select after scale(optional) and mask(optional), filter them out.
- [x] add check for sdp decomp kernel: when cpu runtime = threadpool,  sdpa with implicit causal mask will first run into sdp decomp kernel, which is not supported, filter them out.
