### PR TITLE
graph: backend: dnnl: not use decomp sdpa kernel for dynamic quantized cases

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -457,12 +457,9 @@ impl::status_t sdp_decomp_config_t::record_input_offset(
                     graph::op_kind::SoftMax};
     for (const auto &cur_op : sg->get_ops()) {
         const auto &op_kind = cur_op->get_kind();
-        VCHECK_SDP_DECOMP(
-                !(op_kind == graph::op_kind::DynamicDequantize
-                        && cur_op->get_attr<std::string>(op_attr::qtype)
-                                == "per_group"),
+        VCHECK_SDP_DECOMP(op_kind != graph::op_kind::DynamicDequantize,
                 status::unimplemented,
-                "Not support per_group DynamicDequantize");
+                "Decomposed kernel does not support dynamic quantization");
         // both mm1 and mm2 are found.
         if (mm1 && mm2) break;
         if (op_kind != graph::op_kind::MatMul) continue;


### PR DESCRIPTION
## Description

Recently we supported a SDPA with compressed K using per_channel quantization [case](https://github.com/oneapi-src/oneDNN/blob/22037c494cd3b0b8d118a48b10e84aa8cb99d5f3/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all#L50), which will run into the decomposed sdpa primitive kernel unexpectedly with `THREADPOOL` cpu runtime( as it passes the [check](https://github.com/oneapi-src/oneDNN/blob/22037c494cd3b0b8d118a48b10e84aa8cb99d5f3/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp#L87)). 
As we do not aim to support dynamic quantized cases in decomposed sdpa kernel, the PR enhanced the restriction to avoid such case.