### PR TITLE
[rls-v3.7]graph: backend: dnnl: not use decomp sdpa kernel for dynamic quantized cases

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -457,12 +457,9 @@ impl::status_t sdp_decomp_config_t::record_input_offset(
                     graph::op_kind::SoftMax};
     for (const auto &cur_op : sg->get_ops()) {
         const auto &op_kind = cur_op->get_kind();
-        VCHECK_SDP_DECOMP(
-                !(op_kind == graph::op_kind::DynamicDequantize
-                        && cur_op->get_attr<std::string>(op_attr::qtype)
-                                == "per_group"),
+        VCHECK_SDP_DECOMP(op_kind != graph::op_kind::DynamicDequantize,
                 status::unimplemented,
-                "Not support per_group DynamicDequantize");
+                "Decomposed kernel does not support dynamic quantization");
         // both mm1 and mm2 are found.
         if (mm1 && mm2) break;
         if (op_kind != graph::op_kind::MatMul) continue;


### PR DESCRIPTION
Backport the enhancement of restriction to not use decomposed sdpa for dynamic quantized cases.

Backports #2458 