### PR TITLE
xe: ocl: add missing type enablement

### DIFF
--- a/src/gpu/intel/ocl/ocl_math_utils.h
+++ b/src/gpu/intel/ocl/ocl_math_utils.h
@@ -45,13 +45,15 @@ int rnd_down(int a, unsigned int b) {
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
 #if DT_BF8 || SRC_DT_BF8 || WEI_DT_BF8 || DST_DT_BF8 || BIA_DT_BF8 || A_DT_BF8 \
-        || B_DT_BF8 || C_DT_BF8 || DATA_DT_BF8 || POST_OP_USING_BF8
+        || B_DT_BF8 || C_DT_BF8 || DATA_DT_BF8 || POST_OP_USING_BF8 \
+        || SRC_SCALES_DT_BF8 || WEI_SCALES_DT_BF8 || DST_SCALES_DT_BF8
 #define MATH_UTILS_DECLARE_BF8 1
 #endif
 
 #if DT_HF8 || SRC_DT_HF8 || WEI_DT_HF8 || DST_DT_HF8 || BIA_DT_HF8 || A_DT_HF8 \
         || A_DT_HF8 || B_DT_HF8 || C_DT_HF8 || DATA_DT_HF8 \
-        || POST_OP_USING_HF8
+        || POST_OP_USING_HF8 || SRC_SCALES_DT_HF8 || WEI_SCALES_DT_HF8 \
+        || DST_SCALES_DT_HF8
 #define MATH_UTILS_DECLARE_HF8 1
 #endif
 


### PR DESCRIPTION
Fixes the following error observed on XeLP systems.
```
./benchdnn --matmul --engine=gpu --dt=f8_e5m2:s4:f8_e5m2 --stag=abc --attr-scales=src:common:2+wei:per_ocic:f8_e4m3:32x1 --attr-zero-points=wei:per_ocic
:s4:32x1 --attr-fpmath=bf16:true 7x6x32:7x32x64
onednn_verbose,v1,info,oneDNN v3.8.0 (commit 0eb6cd6d9e934905c6caa2db8cbe131da7af2231)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:24
onednn_verbose,v1,info,cpu,isa:Intel AVX2 with Intel DL Boost
onednn_verbose,v1,info,gpu,runtime:OpenCL
onednn_verbose,v1,info,gpu,engine,opencl device count:2
onednn_verbose,v1,info,gpu,engine,0,name:Intel(R) UHD Graphics 770 [0x4680],driver_version:22.49.25018,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,1,name:Intel(R) UHD Graphics 770 [0x4680],driver_version:22.49.25018,binary_kernels:enabled
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,common,error,ocl,Error during the build of OpenCL program. Build log:
3:12187:25: error: implicit declaration of function 'cvt_f8_e4m3_to_hf' is invalid in OpenCL
            wei_scale = WEI_SCALES_TO_REF(wei_scales[wei_scale_off]);
                        ^
3:2435:44: note: expanded from macro 'WEI_SCALES_TO_REF'
#define WEI_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
                                           ^
3:12187:25: note: did you mean 'cvt_f8_e5m2_to_hf'?
3:2435:44: note: expanded from macro 'WEI_SCALES_TO_REF'
#define WEI_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
                                           ^
3:596:38: note: 'cvt_f8_e5m2_to_hf' declared here
half16 __attribute__((overloadable)) cvt_f8_e5m2_to_hf(uchar16 b) {
                                     ^
,src/gpu/intel/ocl/ocl_gpu_engine.cpp:174
onednn_verbose,v1,primitive,error,ocl,errcode -11,CL_BUILD_PROGRAM_FAILURE,src/gpu/intel/ocl/ocl_gpu_engine.cpp:279,src/gpu/intel/ocl/ocl_gpu_engine.cpp:279
0:UNTESTED_FAILED __REPRO: --matmul --engine=gpu --dt=f8_e5m2:s4:f8_e5m2 --stag=abc --attr-scales=src:common:2+wei:per_ocic:f8_e4m3:32x1 --attr-zero-points=wei:per_ocic:s4:32x1 --attr-fpmath=bf16:true 7x6x32:7x32x64
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 0.32s; fill: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```
