### PR TITLE
xe: reduction: fixup exceptions on zero dims

### DIFF
--- a/src/common/reduction_pd.hpp
+++ b/src/common/reduction_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -129,6 +129,10 @@ struct reduction_pd_t : public primitive_desc_t {
                 stride *= md.padded_dims[d] / blocks[d];
             }
         }
+    }
+
+    bool has_zero_dim_memory() const {
+        return memory_desc_wrapper(src_md()).has_zero_dim();
     }
 
 protected:

--- a/src/gpu/intel/ocl/reduction/atomic_reduction.cpp
+++ b/src/gpu/intel/ocl/reduction/atomic_reduction.cpp
@@ -101,6 +101,10 @@ atomic_reduction_conf_t::atomic_reduction_conf_t(
     conf.src_type = src_type;
     conf.dst_type = dst_type;
     conf.subgroup_size = device_info.max_subgroup_size();
+    // Short-circuit if zero-dim is present
+    gpu_assert(reduction_block.block != 0) << "Reducing over 0 elements";
+    if (outer_block.block == 0 || inner_block.block == 0) return;
+
     auto arch = device_info.gpu_arch();
     const int base_threads_per_eu
             = compute::device_info_t::threads_per_eu(arch);

--- a/src/gpu/intel/ocl/reduction/combined_reduction.cl
+++ b/src/gpu/intel/ocl/reduction/combined_reduction.cl
@@ -174,7 +174,11 @@ void write_padded_zeros(__global DST_DATA_T *dst) {
 }
 
 #if INNER_DIM_SIZE < SUBGROUP_SIZE
+#if INNER_DIM_SIZE == 0
+#define SLM_PER_SG 1
+#else
 #define SLM_PER_SG INNER_DIM_SIZE
+#endif // INNER_DIM_SIZE == 0
 #else
 #define SLM_PER_SG SUBGROUP_SIZE
 #endif


### PR DESCRIPTION
Fixes [MFDNN-13039](https://jira.devtools.intel.com/browse/MFDNN-13039). Reduction gtests were enabled on the GPU in #2243, which revealed floating point exceptions when dividing by zero:
```
$ ctest -R test_reduction_gpu
Test project oneDNN/build
    Start 209: test_reduction_gpu
1/1 Test #209: test_reduction_gpu ...............***Exception: Numerical  0.31 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.32 sec

The following tests FAILED:
        209 - test_reduction_gpu (NUMERICAL)
Errors while running CTest
```
These errors are fixed by adding appropriate short-circuit checks to skip most logic (and execution) when a zero-dim is present.