### PR TITLE
ngen: workaround for PVC SWSB HW bug

### DIFF
--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -1595,6 +1595,7 @@ enum class Directive {
     subdep_dst = 8,
     wrdep = 0x10,
     fencedep = 0x11,
+    pvcwarwa = 0x20,
 };
 
 static inline bool isSend(Opcode op)
@@ -2073,6 +2074,10 @@ public:
                          | (toVF(f3) << 24);
 
         return Immediate(payload, DataType::vf);
+    }
+
+    static Immediate zero(DataType dt) {
+        return Immediate(0, dt);
     }
 
     void fixup(HW hw, int execSize, int execWidth, DataType defaultType, int srcN, int arity) const {


### PR DESCRIPTION
Closes MFDNN-12992. Introduces a workaround for a PVC HW bug related to SWSB dependencies on send instruction src operands in the presence of heavy double precision usage. This is not an expected use case for oneDNN, but could theoretically occur if another f64-heavy kernel is running in parallel.

The workaround is carefully written to minimize performance impacts, but if performance impacts are still too high, we can enable the WA on an as-needs basis.

As requested in CMPLRLLVM-65139/MKLD-18120, the WA may be controlled by the environment variable `ONEAPI_PVCSendWARWA`.