### PR TITLE
xe: ocl: strengthen sycl header guard

### DIFF
--- a/src/gpu/intel/ocl/ocl_utils.cpp
+++ b/src/gpu/intel/ocl/ocl_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 #include "gpu/intel/ocl/ocl_utils.hpp"
 #include "xpu/ocl/utils.hpp"
 
-#if __has_include(<sycl/sycl.hpp>)
+#ifdef DNNL_WITH_SYCL
 #include "gpu/intel/sycl/engine.hpp"
 #endif
 


### PR DESCRIPTION
Handles the header layout for DPC++ 2025.1.0, where OpenCL headers and the `sycl` subdirectory are located in the same place, so `__has_include(<sycl/sycl.hpp>)` is true even for OpenCL builds.

Fixes [MFDNN-13073](https://jira.devtools.intel.com/browse/MFDNN-13073).


- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
