### PR TITLE
[rls-v3.6] xe: ocl: strengthen sycl header guard

### DIFF
--- a/src/gpu/intel/ocl/ocl_utils.cpp
+++ b/src/gpu/intel/ocl/ocl_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 #include "gpu/intel/ocl/ocl_utils.hpp"
 #include "xpu/ocl/utils.hpp"
 
-#if __has_include(<sycl/sycl.hpp>)
+#ifdef DNNL_WITH_SYCL
 #include "gpu/intel/sycl/engine.hpp"
 #endif
 


### PR DESCRIPTION
Backport of #2473.