### PR TITLE
.gitignore: ignore gnu global tags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ compile_commands.json
 **/.DS_Store
 __pycache__
 .cache
+GPATH
+GRTAGS
+GTAGS


### PR DESCRIPTION
Ignore GPATH, GRTAGS, GTAGS generate by GNU global tags generator via .gitignore