### PR TITLE
[GPU] Gemm: remove invalid src post-ops condition

### DIFF
--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
@@ -115,7 +115,6 @@ status_t jit_gemm_pd_t::init_post_ops() {
         bool convert = (mask == 0);
         if (src_scales->ndims_ > 1) {
             convert |= (src_scales->group_dims_[1] >= d->k());
-            convert |= (src_scales->group_dims_[0] >= d->n());
         }
         if (convert) {
             if (mask == 0) {


### PR DESCRIPTION
# Description

Revert invalid condition allowing conversion of src scales to post ops. 

Fixes # https://jira.devtools.intel.com/browse/MFDNN-13045
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
