### PR TITLE
cpu: aarch64: ip: Allow bf16 for ACL inner product

### DIFF
--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,6 +79,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t<avx512_core_bf16>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_fwd_t<bf16>)
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t<avx2_vnni_2>)
+            CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
             CPU_INSTANCE(ref_inner_product_fwd_t)
             nullptr,
         }},


### PR DESCRIPTION
Enable ACL inner product for forward bf16. This change depends on updates in the next ACL release. With those, this has shown 170x and 160x performance improvements in torchbench for BERT_pytorch and alexnet respectively when run in bf16 compile mode.

Commands used for benchmarks:
`TORCHINDUCTOR_FREEZING=1 python3 run_benchmark.py cpu --model BERT_pytorch --torchdynamo inductor --test eval --nwarmup 5 --niter 15 --precision bf16`
`TORCHINDUCTOR_FREEZING=1 python3 run_benchmark.py cpu --model alexnet --torchdynamo inductor --test eval --nwarmup 5 --niter 15 --precision bf16`