### PR TITLE
x64: utils: jit_io_helper: fix xf16 store from Xmm (fixes MFDNN-12635)

### DIFF
--- a/tests/benchdnn/inputs/reorder/harness_reorder_regression
+++ b/tests/benchdnn/inputs/reorder/harness_reorder_regression
@@ -11,3 +11,10 @@
 --stag=abdc --dtag=abcd
 --attr-zero-points=src0:common:1
 1x32x128x33
+
+# Test bf16 with aBcde4b format
+--reset
+--skip-impl=simple #skip non-jit version
+--sdt=bf16 --ddt=bf16
+--stag=aBcde4b --dtag=aBcde4b
+2x24x19x19x19


### PR DESCRIPTION
This is a short fix for [MFDNN-12635](https://jira.devtools.intel.com/browse/MFDNN-12635).

Function `jit_io_helper_t<Vmm>::store_bf16` doesn't support `Xmm`, that's why it crashed when using `bf16` with blocked format with channels blocked by 4.
I changed a way it works to use `jit_io_helper_t<Vmm>::store_byte_by_byte` function instead. 
Though, I have other idea that maybe using `store_bf16` could work if we introduced another `Opmask` to filter out the lower half of `Xmm`. It would require some changes to `jit_io_helper_t` class, so I prefer to not submit it now as a bugfix, but after some time (as it requires some analysis), that's why I left a `TODO` comment.

Also I'm adding reorder regression input to benchdnn, as it was likely not covered on CPU side.