### PR TITLE
gpu: quantization refactoring prerequisites

### DIFF
--- a/src/gpu/intel/ocl/convolution_inner_product.cpp
+++ b/src/gpu/intel/ocl/convolution_inner_product.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -197,6 +197,13 @@ status_t convolution_inner_product_fwd_t::execute_forward(
             = memory_arg_t {conf.reorder_dst ? wspace_dst.get() : dst, false};
 
     const auto &args = ctx.args();
+    for (const int arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
+        if (pd()->attr()->scales_.get(arg).has_default_values()) continue;
+
+        c_args[DNNL_ARG_ATTR_SCALES | arg]
+                = args.at(DNNL_ARG_ATTR_SCALES | arg);
+    }
+
     for (int idx = 0; idx < pd()->attr()->post_ops_.len(); ++idx) {
         if (pd()->attr()->post_ops_.entry_[idx].is_binary()) {
             c_args[DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1]

--- a/src/gpu/intel/ocl/convolution_inner_product.hpp
+++ b/src/gpu/intel/ocl/convolution_inner_product.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ struct convolution_inner_product_fwd_t : public gpu_primitive_t {
                     IMPLICATION(desc()->src_desc.data_type == f16,
                             compute_engine->mayiuse(
                                     compute::device_ext_t::khr_fp16)),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_INNER_PRODUCT(
                     (invariant_src_md()->format_desc.blocking.inner_nblks > 0
                             || invariant_wei_md()
@@ -82,7 +82,7 @@ struct convolution_inner_product_fwd_t : public gpu_primitive_t {
                             || (src_md_.format_kind == format_kind::any
                                     && weights_md_.format_kind
                                             == format_kind::any)),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+                    VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
             VDISPATCH_INNER_PRODUCT_SC(
                     init_conf(engine), VERBOSE_PRIMITIVE_CREATION_FAIL, "ip");

--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
@@ -62,7 +62,11 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
         APPLY_POST_OPS_SERIAL(accumulator, POST_OP_DATA_T, sum_src,
                 POST_OP_DATA_T, d0, 1, d1, 1, d2, 1, d3, 1, 0, 1, 0, 1);
 
-        if (C_SCALES) accumulator /= DST_SCALES_TO_REF(c_scales[0]);
+        if (C_SCALES) {
+            POST_OP_DATA_T c_scale = 1;
+            load(&c_scale, c_scales);
+            accumulator /= c_scale;
+        }
         if (DST_ZERO_POINT) accumulator += dst_zp[0];
     }
 

--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
@@ -183,10 +183,6 @@ status_t gemm_with_post_ops_t::pd_t::init_kernel_ctx(
     kernel_ctx.define_int("A_SCALES", with_src_scales);
     kernel_ctx.define_int("B_SCALES", with_wei_scales);
     kernel_ctx.define_int("C_SCALES", with_dst_scales);
-    def_data_type(kernel_ctx, attr_scales.get(DNNL_ARG_WEIGHTS).data_type_,
-            "WEI_SCALES");
-    def_data_type(
-            kernel_ctx, attr_scales.get(DNNL_ARG_DST).data_type_, "DST_SCALES");
     int dst_zp_mask;
     attr()->zero_points_.get(DNNL_ARG_DST, &dst_zp_mask);
     kernel_ctx.define_int("DST_ZERO_POINT",

--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cpp
@@ -178,8 +178,8 @@ status_t gemm_with_post_ops_t::pd_t::init_kernel_ctx(
     def_data_type(kernel_ctx, acc_type, "ACC");
 
     kernel_ctx.define_int("NDIMS", ndims);
-    CHECK(def_attr_info(
-            kernel_ctx, attr_info_, attr()->post_ops_, *gemm_pd_->dst_md()));
+    CHECK(def_attr_info(kernel_ctx, attr_info_, attr()->post_ops_,
+            *gemm_pd_->dst_md(), false));
     kernel_ctx.define_int("A_SCALES", with_src_scales);
     kernel_ctx.define_int("B_SCALES", with_wei_scales);
     kernel_ctx.define_int("C_SCALES", with_dst_scales);

--- a/src/gpu/intel/ocl/ocl_conversion.h
+++ b/src/gpu/intel/ocl/ocl_conversion.h
@@ -93,6 +93,16 @@ IF_DOUBLE_SUPPORTED(def_std_into(double, float));
 IF_DOUBLE_SUPPORTED(def_std_into(double, int));
 IF_DOUBLE_SUPPORTED(IF_HALF_SUPPORTED(def_std_into(double, half)));
 
+#define def_undef_into(out_type) \
+    out_type __attribute__((overloadable)) \
+            CONCAT2(into_, out_type)(undef_data val) { \
+        DEBUG_PRINT("Error: unexpected conversion from undefined data"); \
+        return 0xbadbad; \
+    }
+
+def_undef_into(float);
+def_undef_into(int);
+
 #undef def_std_into
 #undef def_std_into_sat
 
@@ -274,6 +284,15 @@ def_two_step_conversion(float, f8_e4m3, half);
 IF_DOUBLE_SUPPORTED(def_two_step_conversion(f8_e4m3, double, float));
 IF_DOUBLE_SUPPORTED(def_two_step_conversion(double, f8_e4m3, float));
 #endif // MATH_UTILS_DECLARE_HF8
+
+#ifdef MATH_UTILS_DECLARE_E8M0
+// Copy-paste from `cvt_e8m0_to_f32`.
+float __attribute__((overloadable)) into_float(e8m0 b) {
+    if (b.data == (char)0xff) return as_float(0xffc00000);
+    uint bits = b.data << 23;
+    return as_float(bits);
+}
+#endif
 
 IF_DOUBLE_SUPPORTED(def_two_step_conversion(bf16, double, float));
 IF_DOUBLE_SUPPORTED(def_two_step_conversion(double, bf16, float));

--- a/src/gpu/intel/ocl/ocl_custom_types.h
+++ b/src/gpu/intel/ocl/ocl_custom_types.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,6 +60,29 @@ f8_e4m3 as_f8_e4m3(char data) {
     f8_e4m3 res;
     res.data = data;
     return res;
+}
+
+/*****************************/
+
+typedef struct {
+    unsigned char data;
+} e8m0;
+
+e8m0 as_e8m0(unsigned char data) {
+    e8m0 res;
+    res.data = data;
+    return res;
+}
+
+/*****************************/
+
+typedef struct {
+    char invalid_data;
+} undef_data;
+
+undef_data as_undef_data(char data) {
+    undef_data ret = {0xba};
+    return ret;
 }
 
 #endif

--- a/src/gpu/intel/ocl/ocl_io.h
+++ b/src/gpu/intel/ocl/ocl_io.h
@@ -33,10 +33,12 @@
 #define BLOCK_DT_4 uint
 #define BLOCK_DT_8 ulong
 
+#define SIZE_undef_data 1
 #define SIZE_char 1
 #define SIZE_uchar 1
 #define SIZE_f8_e5m2 1
 #define SIZE_f8_e4m3 1
+#define SIZE_e8m0 1
 #define SIZE_bf16 2
 #define SIZE_half 2
 #define SIZE_int 4
@@ -79,6 +81,10 @@ DEF_load(int, char);
 DEF_load(int, uchar);
 DEF_load(int, int);
 DEF_load(float, bf16);
+
+// Included for compile time compatibility
+DEF_load(int, undef_data);
+DEF_load(float, undef_data);
 
 // Writes
 DEF_write(char, float);
@@ -131,6 +137,13 @@ DEF_write(f8_e4m3, float);
 DEF_write(f8_e4m3, int);
 
 #endif // MATH_UTILS_DECLARE_HF8
+
+#ifdef MATH_UTILS_DECLARE_E8M0
+// Loads
+DEF_load(float, e8m0);
+
+#endif
+
 #endif // cl_khr_fp16
 
 #ifdef cl_khr_fp64

--- a/src/gpu/intel/ocl/ocl_math_utils.h
+++ b/src/gpu/intel/ocl/ocl_math_utils.h
@@ -81,6 +81,10 @@ int rnd_down(int a, unsigned int b) {
 #define MATH_UTILS_DECLARE_BF16 1
 #endif
 
+#if DST_SCALES_DT_E8M0
+#define MATH_UTILS_DECLARE_E8M0 1
+#endif
+
 ulong8 __builtin_IB_simd_block_read_8_global_l(const __global ulong *);
 ushort16 __builtin_IB_simd_block_read_16_global_h(const __global ushort *);
 

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -396,8 +396,8 @@ void def_data_type(compute::kernel_ctx_t &kernel_ctx, data_type_t dt,
 
     switch (dt) {
         case data_type::undef:
-            kernel_ctx.add_option(
-                    utils::format("-D%s_DATA_T=void -D%s_DT_UNDEF", str, str));
+            kernel_ctx.add_option(utils::format(
+                    "-D%s_DATA_T=undef_data -D%s_DT_UNDEF", str, str));
             break;
         case data_type::bf16:
             kernel_ctx.add_option(utils::format(

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -807,7 +807,7 @@ bool post_ops_preserves_zeroes(
 
 status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md) {
+        const memory_desc_t &dst_md, bool with_punning) {
     gpu_assert(attr_info.initialized);
 
     kernel_ctx.define_int("WITH_POST_OP", post_ops.len() > 0);
@@ -830,9 +830,12 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("SRC_SCALES_MASK", attr_info.src_scales_mask);
     kernel_ctx.define_int("WEI_SCALES_MASK", attr_info.wei_scales_mask);
     kernel_ctx.define_int("DST_SCALES_MASK", attr_info.dst_scales_mask);
-    def_data_type(kernel_ctx, attr_info.src_scales_data_type, "SRC_SCALES");
-    def_data_type(kernel_ctx, attr_info.wei_scales_data_type, "WEI_SCALES");
-    def_data_type(kernel_ctx, attr_info.dst_scales_data_type, "DST_SCALES");
+    def_data_type(kernel_ctx, attr_info.src_scales_data_type, "SRC_SCALES",
+            with_punning);
+    def_data_type(kernel_ctx, attr_info.wei_scales_data_type, "WEI_SCALES",
+            with_punning);
+    def_data_type(kernel_ctx, attr_info.dst_scales_data_type, "DST_SCALES",
+            with_punning);
 
     kernel_ctx.define_int("WITH_SRC_ZPOINTS", attr_info.with_src_zpoints);
     kernel_ctx.define_int("WITH_WEI_ZPOINTS", attr_info.with_wei_zpoints);
@@ -854,8 +857,9 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
 
 status_t def_attr_info(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md) {
-    return def_attr_info_impl(kernel_ctx, attr_info, post_ops, dst_md);
+        const memory_desc_t &dst_md, bool with_punning) {
+    return def_attr_info_impl(
+            kernel_ctx, attr_info, post_ops, dst_md, with_punning);
 }
 
 void def_dispatch(compute::kernel_ctx_t &kernel_ctx,

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -714,11 +714,11 @@ bool post_ops_preserves_zeroes(
 
 status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md);
+        const memory_desc_t &dst_md, bool with_punning = true);
 
 status_t def_attr_info(compute::kernel_ctx_t &kernel_ctx,
         const attr_info_t &attr_info, const post_ops_t &post_ops,
-        const memory_desc_t &dst_md);
+        const memory_desc_t &dst_md, bool with_punning = true);
 
 void def_dispatch(
         compute::kernel_ctx_t &kernel_ctx, const compute::dispatch_t &dispatch);


### PR DESCRIPTION
This PR updates gemm_with_post_ops implementation with a new way of loading scales as they are going to be affected after refactor. The main issue is that `data_type::undef` becomes a valid data type for scales, meaning, they were not specified, which would trigger a bunch of issues in the existing implementation.

This PR guards from that situation.

Thanks to @rjoursler for a patch to deal with undefined data types.