### PR TITLE
Improve diagnostics for unimplemented RNN cases

### DIFF
--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -429,6 +429,37 @@ struct prb_t : public desc_t {
             return (direction == dnnl_bidirectional_concat ? 2 : 1) * dic;
         if (type == CELL) return dic;
         assert(!"unsupported dlc type");
+        return 0;
+    }
+
+    int ndims(rnn_data_kind_t kind) const {
+        switch (kind) {
+            case SRC_LAYER:
+            case DST_LAYER:
+            case AUGRU_ATTENTION:
+            case DIFF_SRC_LAYER:
+            case DIFF_DST_LAYER:
+            case DIFF_AUGRU_ATTENTION: return 3;
+            case SRC_ITER:
+            case SRC_ITER_C:
+            case WEIGHTS_PEEPHOLE:
+            case WEIGHTS_PROJECTION:
+            case BIAS:
+            case DST_ITER:
+            case DST_ITER_C:
+            case DIFF_SRC_ITER:
+            case DIFF_SRC_ITER_C:
+            case DIFF_WEIGHTS_PEEPHOLE:
+            case DIFF_WEIGHTS_PROJECTION:
+            case DIFF_BIAS:
+            case DIFF_DST_ITER:
+            case DIFF_DST_ITER_C: return 4;
+            case WEIGHTS_LAYER:
+            case WEIGHTS_ITER:
+            case DIFF_WEIGHTS_LAYER:
+            case DIFF_WEIGHTS_ITER: return 5;
+            default: assert(!"unknown data kind");
+        }
         return 0;
     }
 


### PR DESCRIPTION
Implements MFDNN-13023.

This PR improves diagnostics for unimplemented cases when domain specific tags are used. The idea is to normalize input tags prior to validating them to avoid skipping unimplemented cases that are supposed to implemented. This will help us to catch accidently disabled implementations or reduced coverage (e.g. MFDNN-12818).

For example:
```bash
# If unimplemented then the status is SKIPPED (not an error) - without this PR
 --rnn --cfg=u8u8u8u8 --tag=tnc:any:tnc --alg=VANILLA_GRU --activation=UNDEF l1t1mb3sic16slc16dhc16dic16n"uniform"

# If unimplemented then the status is UNIMPLEMENTED (error) - with this PR
 --rnn --cfg=u8u8u8u8 --tag=tnc:any:tnc --alg=VANILLA_GRU --activation=UNDEF l1t1mb3sic16slc16dhc16dic16n"uniform"
```