### PR TITLE
{examples, src, gtests}: graph: fix clang-tidy warnings in headers

### DIFF
--- a/examples/graph/graph_example_utils.hpp
+++ b/examples/graph/graph_example_utils.hpp
@@ -293,7 +293,7 @@ static void *ocl_malloc_device(
 }
 
 static void ocl_free(
-        void *ptr, cl_device_id dev, const cl_context ctx, cl_event event) {
+        void *ptr, cl_device_id dev, cl_context ctx, cl_event event) {
     if (nullptr == ptr) return;
     using F = cl_int (*)(cl_context, void *);
     if (event) { OCL_CHECK(clWaitForEvents(1, &event)); }
@@ -587,7 +587,7 @@ public:
 #endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     void deallocate(
-            void *ptr, cl_device_id dev, const cl_context ctx, cl_event event) {
+            void *ptr, cl_device_id dev, cl_context ctx, cl_event event) {
         std::lock_guard<std::mutex> pool_guard(pool_lock);
         // This example currently supports `In-order`. So the kernel are
         // executed in the order in which they are submitted. Don't need to wait
@@ -657,8 +657,8 @@ inline dnnl::graph::allocator create_allocator(dnnl::engine::kind ekind) {
                                   cl_context ctx) -> void * {
             return get_mem_pool().allocate(size, alignment, dev, ctx);
         };
-        auto dealloc_func = [](void *ptr, cl_device_id dev,
-                                    const cl_context ctx, cl_event event) {
+        auto dealloc_func = [](void *ptr, cl_device_id dev, cl_context ctx,
+                                    cl_event event) {
             return get_mem_pool().deallocate(ptr, dev, ctx, event);
         };
         return dnnl::graph::ocl_interop::make_allocator(

--- a/examples/graph/graph_example_utils.hpp
+++ b/examples/graph/graph_example_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,7 +40,8 @@
 /// @param partitions a list of partitions
 /// @param id_to_set_any_layout a set of ids of logical tensors with any layout
 ///     type
-void set_any_layout(const std::vector<dnnl::graph::partition> &partitions,
+inline void set_any_layout(
+        const std::vector<dnnl::graph::partition> &partitions,
         std::unordered_set<size_t> &id_to_set_any_layout) {
     // mapping from output tensor id to the all supported flags of
     // supported partitions, we may only need outputs' supported flags
@@ -121,13 +122,13 @@ struct sycl_deletor {
     }
 };
 
-void *sycl_malloc_wrapper(
+inline void *sycl_malloc_wrapper(
         size_t size, size_t alignment, const void *dev, const void *ctx) {
     return malloc_shared(size, *static_cast<const ::sycl::device *>(dev),
             *static_cast<const ::sycl::context *>(ctx));
 }
 
-void sycl_free_wrapper(
+inline void sycl_free_wrapper(
         void *ptr, const void *device, const void *context, void *event) {
     // Device is not used in this example, but it may be useful for some users
     // application.
@@ -142,7 +143,7 @@ void sycl_free_wrapper(
 }
 #endif
 
-void allocate_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
+inline void allocate_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
         const std::vector<dnnl::graph::logical_tensor> &lts,
         std::vector<std::shared_ptr<void>> &data_buffer,
         const dnnl::engine &eng) {
@@ -159,7 +160,7 @@ void allocate_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
     }
 }
 
-void allocate_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
+inline void allocate_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
         const std::vector<dnnl::graph::logical_tensor> &lts,
         std::vector<std::shared_ptr<void>> &data_buffer,
         std::unordered_map<size_t, dnnl::graph::tensor> &global_outputs_ts_map,
@@ -191,7 +192,7 @@ void allocate_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
 }
 
 #ifdef DNNL_WITH_SYCL
-void allocate_sycl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
+inline void allocate_sycl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
         const std::vector<dnnl::graph::logical_tensor> &lts,
         std::vector<std::shared_ptr<void>> &data_buffer, sycl::queue &q,
         const dnnl::engine &eng) {
@@ -210,7 +211,7 @@ void allocate_sycl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
     }
 }
 
-void allocate_sycl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
+inline void allocate_sycl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
         const std::vector<dnnl::graph::logical_tensor> &lts,
         std::vector<std::shared_ptr<void>> &data_buffer,
         std::unordered_map<size_t, dnnl::graph::tensor> &global_outputs_ts_map,
@@ -305,7 +306,7 @@ static void ocl_free(
     OCL_CHECK(f(ctx, ptr));
 }
 
-void allocate_ocl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
+inline void allocate_ocl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
         const std::vector<dnnl::graph::logical_tensor> &lts,
         std::vector<std::shared_ptr<void>> &data_buffer,
         std::unordered_map<size_t, dnnl::graph::tensor> &global_outputs_ts_map,
@@ -341,7 +342,8 @@ void allocate_ocl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
     }
 }
 
-void ocl_memcpy(dnnl::engine &eng, void *dst, const void *src, size_t size) {
+inline void ocl_memcpy(
+        dnnl::engine &eng, void *dst, const void *src, size_t size) {
     using F = cl_int (*)(cl_command_queue, cl_bool, void *, const void *,
             size_t, cl_uint, const cl_event *, cl_event *);
     if (!src || !dst) return;
@@ -610,12 +612,12 @@ private:
     std::unordered_map<void *, bool> is_free_ptr_;
 };
 
-simple_memory_pool_t &get_mem_pool() {
+inline simple_memory_pool_t &get_mem_pool() {
     static simple_memory_pool_t mem_pool;
     return mem_pool;
 }
 
-dnnl::graph::allocator create_allocator(dnnl::engine::kind ekind) {
+inline dnnl::graph::allocator create_allocator(dnnl::engine::kind ekind) {
     if (ekind == dnnl::engine::kind::cpu) {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
         auto alloc_func = [](size_t size, size_t alignment, const void *dev,

--- a/examples/graph/graph_example_utils.hpp
+++ b/examples/graph/graph_example_utils.hpp
@@ -372,8 +372,6 @@ inline void ocl_memcpy(
     err = f(queue, CL_FALSE, dst, src, size, 0, nullptr, nullptr);
     if (err != CL_SUCCESS)
         throw std::runtime_error("clEnqueueMemcpyINTEL failed");
-
-    return;
 }
 #endif
 
@@ -593,13 +591,11 @@ public:
         // executed in the order in which they are submitted. Don't need to wait
         // event.
         is_free_ptr_[ptr] = true;
-        return;
     }
 #endif
     void deallocate_host(void *ptr) {
         std::lock_guard<std::mutex> pool_guard(pool_lock);
         is_free_ptr_[ptr] = true;
-        return;
     }
     void clear() {
         dnnl::graph::set_compiled_partition_cache_capacity(0);

--- a/src/graph/backend/dnnl/kernels/dummy.hpp
+++ b/src/graph/backend/dnnl/kernels/dummy.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ private:
     std::shared_ptr<subgraph_t> subgraph_;
 
 public:
-    dummy_kernel_t() {}
+    dummy_kernel_t() = default;
 
-    ~dummy_kernel_t() override {}
+    ~dummy_kernel_t() override = default;
 
     status_t compile_impl(const dnnl_partition_impl_t *part,
             const engine_t *g_engine,

--- a/src/graph/backend/dnnl/kernels/kernel_base.hpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.hpp
@@ -119,10 +119,6 @@ using FCreateKernel = std::function<kernel_ptr(void)>;
 #define DEF_KERNEL_METHOD_STR(name) \
     std::string str() const override { return #name; }
 
-#define DNNL_DISALLOW_COPY_AND_ASSIGN(T) \
-    T(const T &) = delete; \
-    T &operator=(const T &) = delete;
-
 } // namespace dnnl_impl
 } // namespace graph
 } // namespace impl

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public:
                                      std::vector<std::unordered_map<int,
                                              memory>> &args) {
                 args.resize(nthr);
-                for (auto iter : ori_args) {
+                for (const auto &iter : ori_args) {
                     memory ori_mem = iter.second;
                     if (mem_map.count(ori_mem.get()) == 0) {
                         //construct new memory

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ public:
                                      std::vector<std::unordered_map<int,
                                              memory>> &args) {
                 args.resize(nthr);
-                for (auto iter : ori_args) {
+                for (const auto &iter : ori_args) {
                     memory ori_mem = iter.second;
                     if (mem_map.count(ori_mem.get()) == 0) {
                         //construct new memory

--- a/src/graph/backend/dnnl/layout_propagator.cpp
+++ b/src/graph/backend/dnnl/layout_propagator.cpp
@@ -171,7 +171,7 @@ status_t layout_propagator_for_conv(op_ptr &op, const dnnl::engine &p_engine,
         const auto &post_ops = fusion_info.get_post_ops();
         for (size_t i = 0; i < post_ops.size(); ++i) {
             if (!post_ops[i]->is_post_binary()) continue;
-            auto binary = post_ops[i];
+            const auto &binary = post_ops[i];
             std::vector<size_t> binary_idx
                     = binary->get_unfused_input_indices();
             if (binary_idx.empty()) continue;

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -276,7 +276,7 @@ struct memory_reparser_t : public dummy_impl_t {
             const memory &dst_mem = to->second;
             assert(deps.size() <= 1);
             // Passing the empty event to memcpy below causes failure.
-            const bool empty = deps.size() == 0 || deps[0] == 0;
+            const bool empty = deps.empty() || deps[0] == 0;
             const cl_uint num = empty ? 0 : static_cast<cl_uint>(deps.size());
             cl_event e;
             UNUSED_STATUS(xpu::ocl::usm::memcpy(stream.get(),
@@ -360,7 +360,7 @@ struct const_memory_filler_t : public op_executable_t {
         const memory &dst_mem = args.find(DNNL_ARG_TO)->second;
         assert(deps.size() <= 1);
         // Passing the empty event to memcpy below causes failure.
-        const bool empty = deps.size() == 0 || deps[0] == 0;
+        const bool empty = deps.empty() || deps[0] == 0;
         const cl_uint num = empty ? 0 : static_cast<cl_uint>(deps.size());
         cl_event e;
         UNUSED_STATUS(

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -307,6 +307,7 @@ struct const_memory_filler_t : public op_executable_t {
         UNUSED(p_engine);
         UNUSED(mgr);
         UNUSED(pd_cache);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         attr_data_
                 = get_attr_data(op->get_attr<std::vector<attr_dt>>(attr_name),
                         std::is_same<attr_dt, target_dt>());
@@ -1816,8 +1817,8 @@ struct batchnorm_executable_t : public op_executable_t {
 
     batchnorm_executable_t(std::shared_ptr<op_t> &op,
             const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        is_training_ = op->get_attr<bool>(op_attr::is_training);
+            pd_cache_t &pd_cache)
+        : is_training_(op->get_attr<bool>(op_attr::is_training)) {
         float momentum = 0.5;
         if (op->has_attr(op_attr::momentum))
             momentum = op->get_attr<float>(op_attr::momentum);

--- a/src/graph/backend/dnnl/passes/memory_planning.hpp
+++ b/src/graph/backend/dnnl/passes/memory_planning.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2023 Intel Corporation
+ * Copyright 2021-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ class buffer_assigner_t {
 public:
     // constructor
     explicit buffer_assigner_t(const size_t match_range)
-        : match_range_(match_range), free_(), data_() {}
+        : match_range_(match_range) {}
 
     // request a free buffer
     size_t request(size_t size) {

--- a/src/graph/backend/dnnl/patterns/data_type_check_pass.hpp
+++ b/src/graph/backend/dnnl/patterns/data_type_check_pass.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ namespace pattern {
 
 namespace {
 
-platform::dir_t get_op_dir(const std::shared_ptr<op_t> &aop) {
+inline platform::dir_t get_op_dir(const std::shared_ptr<op_t> &aop) {
     using namespace dnnl::impl::graph::op_kind;
     using namespace dnnl::impl::graph::dnnl_impl::platform;
 
@@ -121,7 +121,7 @@ platform::dir_t get_op_dir(const std::shared_ptr<op_t> &aop) {
     return dir;
 }
 
-bool is_reorder_type(op_kind_t op_kind) {
+inline bool is_reorder_type(op_kind_t op_kind) {
     using namespace dnnl::impl::graph::op_kind;
     static const std::unordered_set<int> reorder_ops {Reorder, Quantize,
             Dequantize, DynamicDequantize, DynamicQuantize, TypeCast};

--- a/src/graph/backend/dnnl/subgraph.hpp
+++ b/src/graph/backend/dnnl/subgraph.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022-2024 Intel Corporation
+ * Copyright 2022-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,6 +109,7 @@ public:
     {
         MAYBE_UNUSED(partition_id);
         // Set _DNNL_BACKEND_SUBGRAPH_DUMP=1 to enable dump subgraph
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         enabled_ = graph::utils::getenv_int_internal("BACKEND_SUBGRAPH_DUMP", 0)
                 > 0;
     }

--- a/src/graph/interface/allocator.hpp
+++ b/src/graph/interface/allocator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -65,15 +65,10 @@ public:
         size_t alignment_;
 
         /// Default constructor for an uninitialized attribute
-        mem_attr_t() {
-            type_ = mem_type_t::persistent;
-            alignment_ = 0;
-        }
+        mem_attr_t() : type_(mem_type_t::persistent), alignment_(0) {}
 
-        mem_attr_t(mem_type_t type, size_t alignment) {
-            type_ = type;
-            alignment_ = alignment;
-        }
+        mem_attr_t(mem_type_t type, size_t alignment)
+            : type_(type), alignment_(alignment) {}
     };
 
     void *allocate(size_t size, mem_attr_t attr = {}) const {

--- a/src/graph/interface/graph.hpp
+++ b/src/graph/interface/graph.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -295,7 +295,7 @@ public:
     // This function is used to infer shape for all the ops in a graph.
     // Before calling this function, the inputs value of the graph should
     // have valid shape
-    graph::status_t infer_shape() {
+    graph::status_t infer_shape() const {
         using value_ptr = std::shared_ptr<value_t>;
 
         // Check inputs shape
@@ -346,6 +346,7 @@ public:
 
     // This function is used to set user given logical tensors for inputs and
     // outputs of a graph.
+    // NOLINTNEXTLINE(readability-make-member-function-const)
     graph::status_t set_user_inputs_outputs(
             const std::vector<graph::logical_tensor_t> &inputs,
             const std::vector<graph::logical_tensor_t> &outputs) {

--- a/src/graph/interface/op.hpp
+++ b/src/graph/interface/op.hpp
@@ -106,7 +106,7 @@ public:
     }
 
     bool attributes_equal(const dnnl_graph_op &other) const {
-        for (auto attr : this->attributes_) {
+        for (const auto &attr : this->attributes_) {
             // There is no need to check internal attributes.
             if (attr.first >= dnnl_graph_op_attr_t::dnnl_graph_op_attr_end)
                 continue;

--- a/src/graph/utils/any.hpp
+++ b/src/graph/utils/any.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2023 Intel Corporation
+ * Copyright 2020-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,10 +59,11 @@ public:
     any_t() = default;
     any_t(any_t &&v) {
         clear();
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         avtable_ = v.avtable_;
         v.avtable_ = nullptr;
     }
-    any_t(const any_t &v) { avtable_ = v.avtable_; }
+    any_t(const any_t &v) = default;
 
     template <typename T,
             typename = enable_if_t<!std::is_same<T, any_t &>::value>>
@@ -70,6 +71,7 @@ public:
         clear();
         using value_type = typename std::decay<
                 typename std::remove_reference<T>::type>::type;
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         avtable_ = std::make_shared<vtable_t<value_type>>(std::forward<T>(v));
     }
 

--- a/src/graph/utils/json.hpp
+++ b/src/graph/utils/json.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2024 Intel Corporation
+ * Copyright 2020-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,7 +194,7 @@ private:
     template <typename T>
     inline static void reader_function(json_reader_t *reader, void *addr);
     /*! \brief callback type to reader function */
-    typedef void (*readfunc)(json_reader_t *reader, void *addr);
+    using readfunc = void (*)(json_reader_t *reader, void *addr);
     /*! \brief data entry */
     struct entry_t {
         readfunc func;

--- a/src/graph/utils/pm/pbuilder.cpp
+++ b/src/graph/utils/pm/pbuilder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -380,9 +380,9 @@ repetition_t::repetition_t(std::shared_ptr<pb_graph_t> p_node, port_map p_map,
     : body_ {std::move(p_node)}
     , port_map_ {std::move(p_map)}
     , min_rep_ {min_rep}
-    , max_rep_ {max_rep} {
+    , max_rep_ {max_rep}
+    , min_op_num_ {body_->get_min_op_num() * min_rep} {
     node_kind_ = pb_node_kind::PB_NODE_KIND_REPETITION;
-    min_op_num_ = body_->get_min_op_num() * min_rep_;
     auto contained_ops = body_->get_contained_ops();
     p_ops_.insert(contained_ops.begin(), contained_ops.end());
 }

--- a/tests/gtests/graph/api/test_api_common.hpp
+++ b/tests/gtests/graph/api/test_api_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -150,7 +150,6 @@ struct sycl_deletor {
 
 struct engine_handle_t {
     dnnl_engine_t engine = nullptr;
-    ~engine_handle_t() {};
     explicit operator bool() const noexcept {
         return static_cast<bool>(engine);
     }

--- a/tests/gtests/graph/unit/backend/dnnl/dnnl_test_common.hpp
+++ b/tests/gtests/graph/unit/backend/dnnl/dnnl_test_common.hpp
@@ -72,23 +72,24 @@ static inline void run_all_single_passes(dnnl::impl::graph::graph_t &agraph) {
 // given graph will be deep copied first so that all the changes inside the
 // function are not visible outside.
 static inline dnnl::impl::graph::status_t run_graph(
-        dnnl::impl::graph::graph_t &agraph,
+        const dnnl::impl::graph::graph_t &agraph,
         const std::vector<test_tensor_t> &g_in_ts,
         const std::vector<test_tensor_t> &g_out_ts,
         dnnl::impl::graph::engine_t &eng, dnnl::impl::graph::stream_t &strm) {
     namespace graph = dnnl::impl::graph;
     namespace dnnl_impl = graph::dnnl_impl;
     graph::status_t ret;
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     graph::graph_t copied(agraph);
     auto ops = copied.get_ops();
 
     // force each tensor to be strided
     for (auto &op : ops) {
-        for (auto val : op->get_input_values()) {
+        for (const auto &val : op->get_input_values()) {
             val->set_layout_type(graph::layout_type::strided);
         }
 
-        for (auto val : op->get_output_values()) {
+        for (const auto &val : op->get_output_values()) {
             val->set_layout_type(graph::layout_type::strided);
         }
     }

--- a/tests/gtests/graph/unit/backend/dnnl/dnnl_test_common.hpp
+++ b/tests/gtests/graph/unit/backend/dnnl/dnnl_test_common.hpp
@@ -268,56 +268,69 @@ static inline size_t product(std::vector<int64_t> &in) {
 
 #define for_ for
 #define SET_Q_DQ_DATA_ATTR(q_dq_data) \
-    q_dq_data.set_attr<std::string>( \
+    (q_dq_data).set_attr<std::string>( \
             dnnl::impl::graph::op_attr::qtype, "per_tensor"); \
-    q_dq_data.set_attr<std::vector<int64_t>>( \
+    (q_dq_data).set_attr<std::vector<int64_t>>( \
             dnnl::impl::graph::op_attr::zps, {zp_src}); \
-    q_dq_data.set_attr<std::vector<float>>( \
+    (q_dq_data).set_attr<std::vector<float>>( \
             dnnl::impl::graph::op_attr::scales, {scale_src}); \
-    q_dq_data.set_attr<int64_t>(dnnl::impl::graph::op_attr::axis, 0);
+    (q_dq_data).set_attr<int64_t>(dnnl::impl::graph::op_attr::axis, 0);
 
 #define SET_Q_DQ_WEIGHT_ATTR(q_dq_weight, pc_axis) \
-    q_dq_weight.set_attr<std::string>( \
-            dnnl::impl::graph::op_attr::qtype, wei_qtype); \
-    q_dq_weight.set_attr<std::vector<int64_t>>( \
-            dnnl::impl::graph::op_attr::zps, zp_wei); \
-    q_dq_weight.set_attr<std::vector<float>>( \
-            dnnl::impl::graph::op_attr::scales, scale_wei); \
-    q_dq_weight.set_attr<int64_t>(dnnl::impl::graph::op_attr::axis, pc_axis);
+    (q_dq_weight) \
+            .set_attr<std::string>( \
+                    dnnl::impl::graph::op_attr::qtype, wei_qtype); \
+    (q_dq_weight) \
+            .set_attr<std::vector<int64_t>>( \
+                    dnnl::impl::graph::op_attr::zps, zp_wei); \
+    (q_dq_weight) \
+            .set_attr<std::vector<float>>( \
+                    dnnl::impl::graph::op_attr::scales, scale_wei); \
+    (q_dq_weight) \
+            .set_attr<int64_t>(dnnl::impl::graph::op_attr::axis, (pc_axis));
 
 #define SET_CONV_ATTR(conv, nd) \
-    conv.set_attr<dims>(dnnl::impl::graph::op_attr::strides, dims(nd, 1)); \
-    conv.set_attr<dims>(dnnl::impl::graph::op_attr::dilations, dims(nd, 1)); \
-    conv.set_attr<dims>(dnnl::impl::graph::op_attr::pads_begin, dims(nd, 0)); \
-    conv.set_attr<dims>(dnnl::impl::graph::op_attr::pads_end, dims(nd, 0)); \
-    conv.set_attr<int64_t>(dnnl::impl::graph::op_attr::groups, g); \
-    conv.set_attr<std::string>( \
+    (conv).set_attr<dims>(dnnl::impl::graph::op_attr::strides, dims((nd), 1)); \
+    (conv).set_attr<dims>( \
+            dnnl::impl::graph::op_attr::dilations, dims((nd), 1)); \
+    (conv).set_attr<dims>( \
+            dnnl::impl::graph::op_attr::pads_begin, dims((nd), 0)); \
+    (conv).set_attr<dims>( \
+            dnnl::impl::graph::op_attr::pads_end, dims((nd), 0)); \
+    (conv).set_attr<int64_t>(dnnl::impl::graph::op_attr::groups, g); \
+    (conv).set_attr<std::string>( \
             dnnl::impl::graph::op_attr::data_format, "NCX"); \
-    conv.set_attr<std::string>( \
+    (conv).set_attr<std::string>( \
             dnnl::impl::graph::op_attr::weights_format, "OIX");
 
 #define SET_CONVTRANSPOSE_ATTR(convtranspose, nd) \
-    convtranspose.set_attr<dims>( \
-            dnnl::impl::graph::op_attr::strides, dims(nd, 1)); \
-    convtranspose.set_attr<dims>( \
-            dnnl::impl::graph::op_attr::dilations, dims(nd, 1)); \
-    convtranspose.set_attr<dims>( \
-            dnnl::impl::graph::op_attr::pads_begin, dims(nd, 0)); \
-    convtranspose.set_attr<dims>( \
-            dnnl::impl::graph::op_attr::pads_end, dims(nd, 0)); \
-    convtranspose.set_attr<int64_t>(dnnl::impl::graph::op_attr::groups, g); \
-    convtranspose.set_attr<std::string>( \
-            dnnl::impl::graph::op_attr::data_format, "NCX"); \
-    convtranspose.set_attr<std::string>( \
-            dnnl::impl::graph::op_attr::weights_format, "IOX");
+    (convtranspose) \
+            .set_attr<dims>( \
+                    dnnl::impl::graph::op_attr::strides, dims((nd), 1)); \
+    (convtranspose) \
+            .set_attr<dims>( \
+                    dnnl::impl::graph::op_attr::dilations, dims((nd), 1)); \
+    (convtranspose) \
+            .set_attr<dims>( \
+                    dnnl::impl::graph::op_attr::pads_begin, dims((nd), 0)); \
+    (convtranspose) \
+            .set_attr<dims>( \
+                    dnnl::impl::graph::op_attr::pads_end, dims((nd), 0)); \
+    (convtranspose).set_attr<int64_t>(dnnl::impl::graph::op_attr::groups, g); \
+    (convtranspose) \
+            .set_attr<std::string>( \
+                    dnnl::impl::graph::op_attr::data_format, "NCX"); \
+    (convtranspose) \
+            .set_attr<std::string>( \
+                    dnnl::impl::graph::op_attr::weights_format, "IOX");
 
 #define SET_Q_DQ_OUT_ATTR(q_dq_out) \
-    q_dq_out.set_attr<std::string>( \
+    (q_dq_out).set_attr<std::string>( \
             dnnl::impl::graph::op_attr::qtype, "per_tensor"); \
-    q_dq_out.set_attr<std::vector<int64_t>>( \
+    (q_dq_out).set_attr<std::vector<int64_t>>( \
             dnnl::impl::graph::op_attr::zps, {zp_out}); \
-    q_dq_out.set_attr<std::vector<float>>( \
+    (q_dq_out).set_attr<std::vector<float>>( \
             dnnl::impl::graph::op_attr::scales, {scale_out}); \
-    q_dq_out.set_attr<int64_t>(dnnl::impl::graph::op_attr::axis, 0);
+    (q_dq_out).set_attr<int64_t>(dnnl::impl::graph::op_attr::axis, 0);
 
 #endif

--- a/tests/gtests/graph/unit/backend/dnnl/ref_func.hpp
+++ b/tests/gtests/graph/unit/backend/dnnl/ref_func.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,34 +64,35 @@ static inline std::vector<float> hardsigmoidbackward_func(
 
 static inline std::vector<float> sigmoid_func(
         const std::vector<float> &ref_dst) {
-    std::vector<float> out;
-    for (auto &rdst : ref_dst) {
-        out.emplace_back(static_cast<float>(1 / (exp(-rdst) + 1)));
+    std::vector<float> out(ref_dst.size());
+    for (size_t i = 0; i < ref_dst.size(); ++i) {
+        out[i] = static_cast<float>(1 / (exp(-1 * ref_dst[i]) + 1));
     }
     return out;
 }
 
 static inline std::vector<float> tanh_func(const std::vector<float> &ref_dst) {
-    std::vector<float> out;
-    for (auto &rdst : ref_dst) {
-        out.emplace_back(static_cast<float>(
-                (exp(rdst) - exp(-rdst)) / (exp(rdst) + exp(-rdst))));
+    std::vector<float> out(ref_dst.size());
+    for (size_t i = 0; i < ref_dst.size(); ++i) {
+        const auto rdst = ref_dst[i];
+        out[i] = static_cast<float>(
+                (exp(rdst) - exp(-rdst)) / (exp(rdst) + exp(-rdst)));
     }
     return out;
 }
 
 static inline std::vector<float> sqrt_func(const std::vector<float> &ref_dst) {
-    std::vector<float> out;
-    for (auto &rdst : ref_dst) {
-        out.emplace_back(static_cast<float>(sqrt(rdst)));
+    std::vector<float> out(ref_dst.size());
+    for (size_t i = 0; i < ref_dst.size(); ++i) {
+        out[i] = static_cast<float>(sqrt(ref_dst[i]));
     }
     return out;
 }
 
 static inline std::vector<float> round_func(const std::vector<float> &ref_dst) {
-    std::vector<float> out;
-    for (auto &rdst : ref_dst) {
-        out.emplace_back(static_cast<float>(round(rdst)));
+    std::vector<float> out(ref_dst.size());
+    for (size_t i = 0; i < ref_dst.size(); ++i) {
+        out[i] = static_cast<float>(round(ref_dst[i]));
     }
     return out;
 }

--- a/tests/gtests/graph/unit/backend/dnnl/test_batch_norm.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_batch_norm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,12 +26,13 @@ namespace graph = dnnl::impl::graph;
 namespace utils = dnnl::graph::tests::unit::utils;
 
 static inline void ref_batchnorm_fwd(graph::dim_t mb, graph::dim_t ic,
-        graph::dim_t ih, graph::dim_t iw, test_tensor *src, test_tensor *dst,
-        test_tensor *scale, test_tensor *shift, test_tensor *mean = nullptr,
-        test_tensor *variance = nullptr, test_tensor *running_mean = nullptr,
-        test_tensor *running_variance = nullptr,
-        test_tensor *batch_mean = nullptr,
-        test_tensor *batch_variance = nullptr, float epsilon = 0.001f,
+        graph::dim_t ih, graph::dim_t iw, test_tensor_t *src,
+        test_tensor_t *dst, test_tensor_t *scale, test_tensor_t *shift,
+        test_tensor_t *mean = nullptr, test_tensor_t *variance = nullptr,
+        test_tensor_t *running_mean = nullptr,
+        test_tensor_t *running_variance = nullptr,
+        test_tensor_t *batch_mean = nullptr,
+        test_tensor_t *batch_variance = nullptr, float epsilon = 0.001f,
         float momentum = 0.1f,
         std::function<float(const float)> activation = nullptr,
         bool channel_last = false, bool is_training = false) {
@@ -355,26 +356,28 @@ public:
                     });
         }
 
-        test_tensor src_ts(src, engine, src_data);
-        test_tensor scale_ts(scale, engine, scale_data);
-        test_tensor shift_ts(shift, engine, shift_data);
-        test_tensor mean_ts(mean, engine, mean_data);
-        test_tensor variance_ts(variance, engine, variance_data);
-        test_tensor running_mean_ts(running_mean, engine, running_mean_data);
-        test_tensor running_variance_ts(
+        test_tensor_t src_ts(src, engine, src_data);
+        test_tensor_t scale_ts(scale, engine, scale_data);
+        test_tensor_t shift_ts(shift, engine, shift_data);
+        test_tensor_t mean_ts(mean, engine, mean_data);
+        test_tensor_t variance_ts(variance, engine, variance_data);
+        test_tensor_t running_mean_ts(running_mean, engine, running_mean_data);
+        test_tensor_t running_variance_ts(
                 running_variance, engine, running_variance_data);
-        test_tensor batch_mean_ts(batch_mean, engine, batch_mean_data);
-        test_tensor batch_variance_ts(
+        test_tensor_t batch_mean_ts(batch_mean, engine, batch_mean_data);
+        test_tensor_t batch_variance_ts(
                 batch_variance, engine, batch_variance_data);
-        test_tensor dst_ts(params.with_relu ? relu_dst : dst, engine, dst_data);
-        test_tensor ref_dst_ts(
+        test_tensor_t dst_ts(
+                params.with_relu ? relu_dst : dst, engine, dst_data);
+        test_tensor_t ref_dst_ts(
                 params.with_relu ? relu_dst : dst, engine, ref_dst_data);
-        test_tensor ref_running_mean_ts(
+        test_tensor_t ref_running_mean_ts(
                 running_mean, engine, ref_running_mean_data);
-        test_tensor ref_running_variance_ts(
+        test_tensor_t ref_running_variance_ts(
                 running_variance, engine, ref_running_variance_data);
-        test_tensor ref_batch_mean_ts(batch_mean, engine, ref_batch_mean_data);
-        test_tensor ref_batch_variance_ts(
+        test_tensor_t ref_batch_mean_ts(
+                batch_mean, engine, ref_batch_mean_data);
+        test_tensor_t ref_batch_variance_ts(
                 batch_variance, engine, ref_batch_variance_data);
 
         graph::stream_t *strm = get_stream();
@@ -555,14 +558,14 @@ TEST(test_batch_norm_compile, BatchNormBackwardFp32) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor scale_ts(scale, engine, scale_data);
-    test_tensor mean_ts(mean, engine, mean_data);
-    test_tensor variance_ts(variance, engine, varience_data);
-    test_tensor diff_dst_ts(diff_dst, engine, diff_dst_data);
-    test_tensor diff_src_ts(diff_src, engine, diff_src_data);
-    test_tensor diff_scale_ts(diff_scale, engine, diff_scale_data);
-    test_tensor diff_shift_ts(diff_shift, engine, diff_shift_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t scale_ts(scale, engine, scale_data);
+    test_tensor_t mean_ts(mean, engine, mean_data);
+    test_tensor_t variance_ts(variance, engine, varience_data);
+    test_tensor_t diff_dst_ts(diff_dst, engine, diff_dst_data);
+    test_tensor_t diff_src_ts(diff_src, engine, diff_src_data);
+    test_tensor_t diff_scale_ts(diff_scale, engine, diff_scale_data);
+    test_tensor_t diff_shift_ts(diff_shift, engine, diff_shift_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -651,11 +654,11 @@ TEST(test_batch_norm_compile, BatchNormBackwardFp32WithSingleOutput) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor mean_ts(mean, engine, mean_data);
-    test_tensor variance_ts(variance, engine, variance_data);
-    test_tensor diff_dst_ts(diff_dst, engine, diff_dst_data);
-    test_tensor diff_src_ts(diff_src, engine, diff_src_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t mean_ts(mean, engine, mean_data);
+    test_tensor_t variance_ts(variance, engine, variance_data);
+    test_tensor_t diff_dst_ts(diff_dst, engine, diff_dst_data);
+    test_tensor_t diff_src_ts(diff_src, engine, diff_src_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -771,11 +774,11 @@ TEST(test_batch_norm_compile, BatchNormForwardTrainingWith1DSpatialInput) {
     ASSERT_TRUE(std::equal(output_strides.begin(), output_strides.end(),
             output_strides_ref.begin()));
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor scale_ts(scale, engine, scale_data);
-    test_tensor shift_ts(shift, engine, shift_data);
-    test_tensor mean_ts(mean, engine, mean_data);
-    test_tensor variance_ts(variance, engine, variance_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t scale_ts(scale, engine, scale_data);
+    test_tensor_t shift_ts(shift, engine, shift_data);
+    test_tensor_t mean_ts(mean, engine, mean_data);
+    test_tensor_t variance_ts(variance, engine, variance_data);
     graph::logical_tensor_t dst_, running_mean_, running_variance_, batch_mean_,
             batch_variance_;
     cp.query_logical_tensor(dst.id, &dst_);
@@ -783,11 +786,11 @@ TEST(test_batch_norm_compile, BatchNormForwardTrainingWith1DSpatialInput) {
     cp.query_logical_tensor(running_variance.id, &running_variance_);
     cp.query_logical_tensor(batch_mean.id, &batch_mean_);
     cp.query_logical_tensor(batch_variance.id, &batch_variance_);
-    test_tensor dst_ts(dst_, engine);
-    test_tensor running_mean_ts(running_mean_, engine);
-    test_tensor running_variance_ts(running_variance_, engine);
-    test_tensor batch_mean_ts(batch_mean_, engine);
-    test_tensor batch_variance_ts(batch_variance_, engine);
+    test_tensor_t dst_ts(dst_, engine);
+    test_tensor_t running_mean_ts(running_mean_, engine);
+    test_tensor_t running_variance_ts(running_variance_, engine);
+    test_tensor_t batch_mean_ts(batch_mean_, engine);
+    test_tensor_t batch_variance_ts(batch_variance_, engine);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -904,11 +907,11 @@ TEST(test_batch_norm_compile, BatchNormForwardTrainingWith0DSpatialInput) {
     ASSERT_TRUE(std::equal(output_strides.begin(), output_strides.end(),
             output_strides_ref.begin()));
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor scale_ts(scale, engine, scale_data);
-    test_tensor shift_ts(shift, engine, shift_data);
-    test_tensor mean_ts(mean, engine, mean_data);
-    test_tensor variance_ts(variance, engine, variance_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t scale_ts(scale, engine, scale_data);
+    test_tensor_t shift_ts(shift, engine, shift_data);
+    test_tensor_t mean_ts(mean, engine, mean_data);
+    test_tensor_t variance_ts(variance, engine, variance_data);
     graph::logical_tensor_t dst_, running_mean_, running_variance_, batch_mean_,
             batch_variance_;
     cp.query_logical_tensor(dst.id, &dst_);
@@ -916,11 +919,11 @@ TEST(test_batch_norm_compile, BatchNormForwardTrainingWith0DSpatialInput) {
     cp.query_logical_tensor(running_variance.id, &running_variance_);
     cp.query_logical_tensor(batch_mean.id, &batch_mean_);
     cp.query_logical_tensor(batch_variance.id, &batch_variance_);
-    test_tensor dst_ts(dst_, engine);
-    test_tensor running_mean_ts(running_mean_, engine);
-    test_tensor running_variance_ts(running_variance_, engine);
-    test_tensor batch_mean_ts(batch_mean_, engine);
-    test_tensor batch_variance_ts(batch_variance_, engine);
+    test_tensor_t dst_ts(dst_, engine);
+    test_tensor_t running_mean_ts(running_mean_, engine);
+    test_tensor_t running_variance_ts(running_variance_, engine);
+    test_tensor_t batch_mean_ts(batch_mean_, engine);
+    test_tensor_t batch_variance_ts(batch_variance_, engine);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -1008,18 +1011,18 @@ TEST(test_batch_norm_execute, BatchNormInt8) {
     ASSERT_EQ(g.add_op(&quant), graph::status::success);
     g.finalize();
 
-    test_tensor src_ts(src_int8, &engine);
+    test_tensor_t src_ts(src_int8, &engine);
     src_ts.fill<int8_t>(0, 5);
-    test_tensor scale_ts(scale, &engine);
+    test_tensor_t scale_ts(scale, &engine);
     scale_ts.fill<float>();
-    test_tensor shift_ts(shift, &engine);
+    test_tensor_t shift_ts(shift, &engine);
     shift_ts.fill<float>();
-    test_tensor mean_ts(mean, &engine);
+    test_tensor_t mean_ts(mean, &engine);
     mean_ts.fill<float>();
-    test_tensor variance_ts(variance, &engine);
+    test_tensor_t variance_ts(variance, &engine);
     variance_ts.fill<float>();
-    test_tensor dst_ts(dst_int8_out, &engine);
-    test_tensor ref_dst_ts(dst_int8_out, &engine);
+    test_tensor_t dst_ts(dst_int8_out, &engine);
+    test_tensor_t ref_dst_ts(dst_int8_out, &engine);
 
     ASSERT_EQ(run_graph(g, {src_ts, scale_ts, shift_ts, mean_ts, variance_ts},
                       {ref_dst_ts}, engine, strm),
@@ -1167,18 +1170,18 @@ TEST(test_batch_norm_execute, BatchNormReluInt8) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, &engine), graph::status::success);
 
-    test_tensor src_ts(src_int8, &engine);
+    test_tensor_t src_ts(src_int8, &engine);
     src_ts.fill<int8_t>(0, 5);
-    test_tensor scale_ts(scale, &engine);
+    test_tensor_t scale_ts(scale, &engine);
     scale_ts.fill<float>();
-    test_tensor shift_ts(shift, &engine);
+    test_tensor_t shift_ts(shift, &engine);
     shift_ts.fill<float>();
-    test_tensor mean_ts(mean, &engine);
+    test_tensor_t mean_ts(mean, &engine);
     mean_ts.fill<float>();
-    test_tensor variance_ts(variance, &engine);
+    test_tensor_t variance_ts(variance, &engine);
     variance_ts.fill<float>();
-    test_tensor dst_ts(dst_int8_out, &engine);
-    test_tensor ref_dst_ts(dst_int8_out, &engine);
+    test_tensor_t dst_ts(dst_int8_out, &engine);
+    test_tensor_t ref_dst_ts(dst_int8_out, &engine);
 
     graph::stream_t &strm = *get_stream();
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_binary_op.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_binary_op.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,9 +74,9 @@ TEST(test_binary_op_execute, BinaryOp) {
 
         ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-        test_tensor src0_ts(src0_lt, eng, src0);
-        test_tensor src1_ts(src1_lt, eng, src1);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src0_ts(src0_lt, eng, src0);
+        test_tensor_t src1_ts(src1_lt, eng, src1);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -133,9 +133,9 @@ TEST(test_binary_op_execute, MulEltwise) {
         std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
         ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-        test_tensor src0_ts(src0_lt, eng, src0);
-        test_tensor src1_ts(src1_lt, eng, src1);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src0_ts(src0_lt, eng, src0);
+        test_tensor_t src1_ts(src1_lt, eng, src1);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -195,10 +195,10 @@ TEST(test_binary_op_execute, BinaryOpAddFusion) {
         std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
         p.compile(&cp, inputs, outputs, eng);
 
-        test_tensor src0_ts(src0_lt, eng, src0);
-        test_tensor src1_ts(src1_lt, eng, src1);
-        test_tensor post_src_ts(post_src_lt, eng, post_src);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src0_ts(src0_lt, eng, src0);
+        test_tensor_t src1_ts(src1_lt, eng, src1);
+        test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src0_ts.get(), src1_ts.get(), post_src_ts.get()},
@@ -245,9 +245,9 @@ TEST(test_binary_op_execute, BinarySub) {
     std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -307,9 +307,9 @@ TEST(test_binary_op_execute, MinEltwise) {
         std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
         p.compile(&cp, inputs, outputs, eng);
 
-        test_tensor src0_ts(src0_lt, eng, src0);
-        test_tensor src1_ts(src1_lt, eng, src1);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src0_ts(src0_lt, eng, src0);
+        test_tensor_t src1_ts(src1_lt, eng, src1);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -367,9 +367,9 @@ TEST(test_binary_op_execute, MaxEltwise) {
         std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
         p.compile(&cp, inputs, outputs, eng);
 
-        test_tensor src0_ts(src0_lt, eng, src0);
-        test_tensor src1_ts(src1_lt, eng, src1);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src0_ts(src0_lt, eng, src0);
+        test_tensor_t src1_ts(src1_lt, eng, src1);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -433,12 +433,12 @@ TEST(test_binary_op_execute_subgraph_fp32, BinarySwish) {
         g.add_op(&multiply);
         g.finalize();
 
-        test_tensor binary_src0_ts(binary_src0, engine, src0_data);
-        test_tensor binary_src1_ts(binary_src1, engine, src1_data);
+        test_tensor_t binary_src0_ts(binary_src0, engine, src0_data);
+        test_tensor_t binary_src1_ts(binary_src1, engine, src1_data);
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(binary_dst_shape));
-        test_tensor mul_dst_ts(mul_dst, engine, case1_out_data);
+        test_tensor_t mul_dst_ts(mul_dst, engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, {binary_src0_ts, binary_src1_ts}, {mul_dst_ts},
                           *engine, *strm),
@@ -462,7 +462,7 @@ TEST(test_binary_op_execute_subgraph_fp32, BinarySwish) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(binary_dst_shape));
-        test_tensor mul_dst_ts2(mul_dst, engine, case2_out_data);
+        test_tensor_t mul_dst_ts2(mul_dst, engine, case2_out_data);
 
         cp.execute(strm, {binary_src0_ts.get(), binary_src1_ts.get()},
                 {mul_dst_ts2.get()});
@@ -541,11 +541,11 @@ TEST(test_binary_op_execute, Eltwise3BinaryPostops) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    test_tensor relu_src_ts(relu_src_lt, eng, src);
-    test_tensor div_src_ts(div_src_lt, eng, binary_src1);
-    test_tensor max_src_ts(max_src_lt, eng, binary_src2);
-    test_tensor sub_src_ts(sub_src_lt, eng, binary_src3);
-    test_tensor sub_dst_ts(sub_dst_lt, eng, dst);
+    test_tensor_t relu_src_ts(relu_src_lt, eng, src);
+    test_tensor_t div_src_ts(div_src_lt, eng, binary_src1);
+    test_tensor_t max_src_ts(max_src_lt, eng, binary_src2);
+    test_tensor_t sub_src_ts(sub_src_lt, eng, binary_src3);
+    test_tensor_t sub_dst_ts(sub_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
 
@@ -636,16 +636,16 @@ TEST(test_binary_op_execute_subgraph_fp32, Binary3Postops) {
             g.add_op(&pop);
         g.finalize();
 
-        test_tensor binary_src0_ts(lt_vec[0], engine, src_datas[0]);
-        test_tensor binary_src1_ts(lt_vec[1], engine, src_datas[1]);
-        std::vector<test_tensor> src_tss {};
+        test_tensor_t binary_src0_ts(lt_vec[0], engine, src_datas[0]);
+        test_tensor_t binary_src1_ts(lt_vec[1], engine, src_datas[1]);
+        std::vector<test_tensor_t> src_tss {};
         for (size_t i = 0; i < input_lts.size(); ++i)
             src_tss.emplace_back(
-                    test_tensor(lt_vec[input_lts[i]], engine, src_datas[i]));
+                    test_tensor_t(lt_vec[input_lts[i]], engine, src_datas[i]));
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(binary_src_shape));
-        test_tensor case1_dst_ts(lt_vec[lt_idx], engine, case1_out_data);
+        test_tensor_t case1_dst_ts(lt_vec[lt_idx], engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, src_tss, {case1_dst_ts}, *engine, *strm),
                 graph::status::success);
@@ -671,9 +671,9 @@ TEST(test_binary_op_execute_subgraph_fp32, Binary3Postops) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(binary_dst_shape));
-        test_tensor case2_dst_ts(lt_vec[lt_idx], engine, case2_out_data);
+        test_tensor_t case2_dst_ts(lt_vec[lt_idx], engine, case2_out_data);
 
-        cp.execute(strm, test_tensor::to_graph_tensor(src_tss),
+        cp.execute(strm, test_tensor_t::to_graph_tensor(src_tss),
                 {case2_dst_ts.get()});
         strm->wait();
         ASSERT_TRUE(allclose<float>(
@@ -727,9 +727,9 @@ TEST(test_binary_op_execute, Add) {
     ASSERT_EQ(dst_lt.layout_type, graph::layout_type::any);
     ASSERT_EQ(compiled_dst_lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -747,9 +747,9 @@ TEST(test_binary_op_execute, Add) {
             2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0};
     std::vector<float> dst_2nd(src0_2nd.size(), 0.0);
 
-    test_tensor src0_2nd_ts(src0_lt, eng, src0_2nd);
-    test_tensor src1_2nd_ts(src1_lt, eng, src1_2nd);
-    test_tensor dst_2nd_ts(compiled_dst_lt, eng, dst_2nd);
+    test_tensor_t src0_2nd_ts(src0_lt, eng, src0_2nd);
+    test_tensor_t src1_2nd_ts(src1_lt, eng, src1_2nd);
+    test_tensor_t dst_2nd_ts(compiled_dst_lt, eng, dst_2nd);
     cp.execute(
             strm, {src0_2nd_ts.get(), src1_2nd_ts.get()}, {dst_2nd_ts.get()});
     strm->wait();
@@ -802,9 +802,9 @@ TEST(test_binary_op_execute, AddWithDifferentFormat) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -863,9 +863,9 @@ TEST(test_binary_op_execute, BroadcastAdd) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -883,9 +883,9 @@ TEST(test_binary_op_execute, BroadcastAdd) {
             2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0};
     std::vector<float> dst_2nd(src0_2nd.size(), 0.0);
 
-    test_tensor src0_2nd_ts(src0_lt, eng, src0_2nd);
-    test_tensor src1_2nd_ts(src1_lt, eng, src1_2nd);
-    test_tensor dst_2nd_ts(compiled_dst_lt, eng, dst_2nd);
+    test_tensor_t src0_2nd_ts(src0_lt, eng, src0_2nd);
+    test_tensor_t src1_2nd_ts(src1_lt, eng, src1_2nd);
+    test_tensor_t dst_2nd_ts(compiled_dst_lt, eng, dst_2nd);
     cp.execute(
             strm, {src0_2nd_ts.get(), src1_2nd_ts.get()}, {dst_2nd_ts.get()});
     strm->wait();
@@ -939,9 +939,9 @@ TEST(test_binary_op_execute, SwapBroadcastAdd) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -957,7 +957,7 @@ TEST(test_binary_op_execute, SwapBroadcastAdd) {
     ASSERT_EQ(inplace_pair[0].input_id, src1_lt.id);
     ASSERT_EQ(inplace_pair[0].output_id, dst_lt.id);
 
-    test_tensor dst_ts2(compiled_dst_lt, eng, src1);
+    test_tensor_t dst_ts2(compiled_dst_lt, eng, src1);
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts2.get()});
     strm->wait();
 
@@ -1010,9 +1010,9 @@ TEST(test_binary_op_execute, MultidirectionalBroadcastAddBA) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -1029,9 +1029,9 @@ TEST(test_binary_op_execute, MultidirectionalBroadcastAddBA) {
             2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0};
     std::vector<float> dst_2nd(ref_dst_2nd.size(), 0.0);
 
-    test_tensor src0_2nd_ts(src0_lt, eng, src0_2nd);
-    test_tensor src1_2nd_ts(src1_lt, eng, src1_2nd);
-    test_tensor dst_2nd_ts(compiled_dst_lt, eng, dst_2nd);
+    test_tensor_t src0_2nd_ts(src0_lt, eng, src0_2nd);
+    test_tensor_t src1_2nd_ts(src1_lt, eng, src1_2nd);
+    test_tensor_t dst_2nd_ts(compiled_dst_lt, eng, dst_2nd);
     cp.execute(
             strm, {src0_2nd_ts.get(), src1_2nd_ts.get()}, {dst_2nd_ts.get()});
     strm->wait();
@@ -1085,9 +1085,9 @@ TEST(test_binary_op_execute, multidirectionalbBroadcastAddAB) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -1142,9 +1142,9 @@ TEST(test_binary_op_execute, MultidirectionalBroadcastAdd) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -1199,9 +1199,9 @@ TEST(test_binary_op_execute, MultidirectionalBroadcastAddExpandDim) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -1368,9 +1368,9 @@ TEST(test_binary_op_execute, ReversedDifferentFormatBroadcastAdd) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -1434,9 +1434,9 @@ TEST(test_binary_op_execute, BiasAdd) {
         std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
         p.compile(&cp, inputs, outputs, eng);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor bias_ts(bias_lt, eng, bias);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t bias_ts(bias_lt, eng, bias);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src_ts.get(), bias_ts.get()}, {dst_ts.get()});
@@ -1508,10 +1508,10 @@ TEST(test_binary_op_execute, AddMul) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get(), post_src_ts.get()},
@@ -1577,10 +1577,10 @@ TEST(test_binary_op_execute, AddMulPostSrcAsNxc) {
     graph::logical_tensor_t compiled_dst_lt;
     cp.query_logical_tensor(dst_lt.id, &compiled_dst_lt);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get(), post_src_ts.get()},
@@ -1643,9 +1643,9 @@ TEST(test_binary_op_execute, AddRelu) {
     ASSERT_EQ(dst_lt.layout_type, graph::layout_type::any);
     ASSERT_EQ(compiled_dst_lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -1706,9 +1706,9 @@ TEST(test_binary_op_execute, AddSigmoid) {
     ASSERT_EQ(dst_lt.layout_type, graph::layout_type::any);
     ASSERT_EQ(compiled_dst_lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor dst_ts(compiled_dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t dst_ts(compiled_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -1785,11 +1785,11 @@ TEST(test_binary_op_execute, AddAdd) {
     ASSERT_EQ(inplace_pair[0].input_id, post_src_lt.id);
     ASSERT_EQ(inplace_pair[0].output_id, dst_lt.id);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_inplace_ts(dst_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_inplace_ts(dst_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get(), post_src_ts.get()},
@@ -1851,9 +1851,9 @@ TEST(test_binary_op_execute, ScalarScalarAdd) {
     ASSERT_EQ(scalar_lt.layout_type, graph::layout_type::strided);
     ASSERT_EQ(scalar_lt.ndims, 0);
 
-    test_tensor src0_ts(src0, eng, src0_data);
-    test_tensor src1_ts(src1, eng, src1_data);
-    test_tensor dst_ts(scalar_lt, eng, dst_data);
+    test_tensor_t src0_ts(src0, eng, src0_data);
+    test_tensor_t src1_ts(src1, eng, src1_data);
+    test_tensor_t dst_ts(scalar_lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()}),
@@ -1912,9 +1912,9 @@ TEST(test_binary_op_execute, ScalarVectorAdd) {
     ASSERT_EQ(scalar_lt.layout_type, graph::layout_type::strided);
     ASSERT_EQ(scalar_lt.ndims, 1);
 
-    test_tensor src0_ts(src0, eng, src0_data);
-    test_tensor src1_ts(src1, eng, src1_data);
-    test_tensor dst_ts(scalar_lt, eng, dst_data);
+    test_tensor_t src0_ts(src0, eng, src0_data);
+    test_tensor_t src1_ts(src1, eng, src1_data);
+    test_tensor_t dst_ts(scalar_lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()}),
@@ -1976,10 +1976,10 @@ TEST(test_binary_op_execute, MulAddPerTensorBroadcast) {
     std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get(), post_src_ts.get()},
@@ -2042,10 +2042,10 @@ TEST(test_binary_op_execute, MulAddPerHwBroadcast) {
     std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get(), post_src_ts.get()},
@@ -2108,10 +2108,10 @@ TEST(test_binary_op_execute, MulAddPerChannelBroadcast) {
     std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get(), post_src_ts.get()},
@@ -2186,11 +2186,11 @@ TEST(test_binary_op_execute, MulAddAdd) {
     std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor mul_src1_ts(mul_src1_lt, eng, mul_src1);
-    test_tensor mul_src2_ts(mul_src2_lt, eng, mul_src2);
-    test_tensor add1_src_ts(add1_src_lt, eng, add1_src);
-    test_tensor add2_src_ts(add2_src_lt, eng, add2_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t mul_src1_ts(mul_src1_lt, eng, mul_src1);
+    test_tensor_t mul_src2_ts(mul_src2_lt, eng, mul_src2);
+    test_tensor_t add1_src_ts(add1_src_lt, eng, add1_src);
+    test_tensor_t add2_src_ts(add2_src_lt, eng, add2_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -2248,9 +2248,9 @@ TEST(test_binary_op_execute, AddEmptyInput) {
     ASSERT_EQ(empty_lt.dims[1], 3);
     ASSERT_EQ(empty_lt.dims[2], 0);
 
-    test_tensor src0_ts(src0, eng);
-    test_tensor src1_ts(src1, eng);
-    test_tensor dst_ts(empty_lt, eng);
+    test_tensor_t src0_ts(src0, eng);
+    test_tensor_t src1_ts(src1, eng);
+    test_tensor_t dst_ts(empty_lt, eng);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()}),

--- a/tests/gtests/graph/unit/backend/dnnl/test_bmm.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_bmm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -91,12 +91,12 @@ TEST(test_bmm_execute_subgraph_int8, BmmU8u8f32) {
     g.add_op(&matmul_op);
     g.finalize();
 
-    test_tensor src_u8_ts(src_u8, engine);
+    test_tensor_t src_u8_ts(src_u8, engine);
     src_u8_ts.fill<uint8_t>(20, 10);
-    test_tensor weight_u8_ts(weight_u8, engine);
+    test_tensor_t weight_u8_ts(weight_u8, engine);
     weight_u8_ts.fill<uint8_t>(20, 10);
     // -------------------------case 1----------------------------------
-    test_tensor dst_f32_ts(dst_f32, engine);
+    test_tensor_t dst_f32_ts(dst_f32, engine);
     ASSERT_EQ(run_graph(g, {src_u8_ts, weight_u8_ts}, {dst_f32_ts}, *engine,
                       *strm),
             graph::status::success);
@@ -117,7 +117,7 @@ TEST(test_bmm_execute_subgraph_int8, BmmU8u8f32) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor dst_f32_case2_ts(dst_f32, engine);
+    test_tensor_t dst_f32_case2_ts(dst_f32, engine);
     cp.execute(strm, {src_u8_ts.get(), weight_u8_ts.get()},
             {dst_f32_case2_ts.get()});
     strm->wait();
@@ -220,11 +220,11 @@ TEST(test_bmm_execute_subgraph_int8, BmmU8u8f32NonContiguous) {
     g.add_op(&matmul_op);
     g.finalize();
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
     // -------------------------case 1----------------------------------
     std::vector<float> case1_out_data(product(dst_shape));
-    test_tensor dst_f32_ts(dst_f32, engine, case1_out_data);
+    test_tensor_t dst_f32_ts(dst_f32, engine, case1_out_data);
     ASSERT_EQ(run_graph(g, {src_u8_ts, weight_f32_ts}, {dst_f32_ts}, *engine,
                       *strm),
             graph::status::success);
@@ -246,7 +246,7 @@ TEST(test_bmm_execute_subgraph_int8, BmmU8u8f32NonContiguous) {
     p.compile(&cp, lt_ins, lt_outs, engine);
 
     std::vector<float> case2_out_data(product(dst_shape));
-    test_tensor dst_f32_case2_ts(dst_f32, engine, case2_out_data);
+    test_tensor_t dst_f32_case2_ts(dst_f32, engine, case2_out_data);
     cp.execute(strm, {weight_f32_ts.get(), src_u8_ts.get()},
             {dst_f32_case2_ts.get()});
     strm->wait();
@@ -362,11 +362,11 @@ TEST(test_bmm_execute_subgraph_int8, BmmDivU8u8f32) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_u8_ts(weight_u8, engine, weight_data);
-    test_tensor div_src1_ts(div_src1, engine, div_src1_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_u8_ts(weight_u8, engine, weight_data);
+    test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
     std::vector<float> case2_out_data(product(dst_shape));
-    test_tensor dst_f32_case2_ts(div_f32, engine, case2_out_data);
+    test_tensor_t dst_f32_case2_ts(div_f32, engine, case2_out_data);
     cp.execute(strm, {src_u8_ts.get(), weight_u8_ts.get(), div_src1_ts.get()},
             {dst_f32_case2_ts.get()});
     strm->wait();
@@ -491,11 +491,11 @@ TEST(test_bmm_execute_subgraph_int8, BmmDivAddU8u8f32) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_u8_ts(weight_u8, engine, weight_data);
-    test_tensor div_src1_ts(div_src1, engine, div_src1_data);
-    test_tensor add_src1_ts(add_src1, engine, add_src1_data);
-    test_tensor dst_f32_case2_ts(add_f32, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_u8_ts(weight_u8, engine, weight_data);
+    test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
+    test_tensor_t add_src1_ts(add_src1, engine, add_src1_data);
+    test_tensor_t dst_f32_case2_ts(add_f32, engine);
     cp.execute(strm,
             {src_u8_ts.get(), weight_u8_ts.get(), div_src1_ts.get(),
                     add_src1_ts.get()},
@@ -631,9 +631,9 @@ TEST(test_bmm_execute_subgraph_int8, BmmX8x8bf16_CPU) {
 
             p.compile(&cp, lt_ins, lt_outs, engine);
 
-            test_tensor src_ts(src, engine, src_data);
-            test_tensor weight_ts(weight, engine, weight_data);
-            test_tensor dst_ts(dst_bf16, engine);
+            test_tensor_t src_ts(src, engine, src_data);
+            test_tensor_t weight_ts(weight, engine, weight_data);
+            test_tensor_t dst_ts(dst_bf16, engine);
             cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
             strm->wait();
         }
@@ -782,10 +782,10 @@ TEST(test_bmm_execute_subgraph_int8, BmmDivX8x8bf16_CPU) {
             p.compile(&cp, lt_ins, lt_outs, engine);
 
             std::vector<bfloat16_t> div_src1_data(1);
-            test_tensor src_ts(src, engine, src_data);
-            test_tensor weight_ts(weight, engine, weight_data);
-            test_tensor div_src1_ts(div_src1, engine, div_src1_data);
-            test_tensor dst_ts(div_bf16, engine);
+            test_tensor_t src_ts(src, engine, src_data);
+            test_tensor_t weight_ts(weight, engine, weight_data);
+            test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
+            test_tensor_t dst_ts(div_bf16, engine);
             cp.execute(strm, {src_ts.get(), weight_ts.get(), div_src1_ts.get()},
                     {dst_ts.get()});
             strm->wait();
@@ -934,10 +934,10 @@ TEST(test_bmm_execute_subgraph_int8, BmmDivBlockedX8x8bf16_CPU) {
             p.compile(&cp, lt_ins, lt_outs, engine);
 
             std::vector<bfloat16_t> div_src1_data(1);
-            test_tensor src_ts(src, engine, src_data);
-            test_tensor weight_ts(weight, engine, weight_data);
-            test_tensor div_src1_ts(div_src1, engine, div_src1_data);
-            test_tensor dst_ts(div_bf16, engine);
+            test_tensor_t src_ts(src, engine, src_data);
+            test_tensor_t weight_ts(weight, engine, weight_data);
+            test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
+            test_tensor_t dst_ts(div_bf16, engine);
             cp.execute(strm, {src_ts.get(), weight_ts.get(), div_src1_ts.get()},
                     {dst_ts.get()});
             strm->wait();
@@ -1106,11 +1106,11 @@ TEST(test_bmm_execute_subgraph_int8, BmmDivAddX8x8bf16_CPU) {
 
             p.compile(&cp, lt_ins, lt_outs, engine);
 
-            test_tensor src_ts(src, engine, src_data);
-            test_tensor weight_ts(weight, engine, weight_data);
-            test_tensor div_src1_ts(div_src1, engine);
-            test_tensor add_src1_ts(add_src1, engine);
-            test_tensor dst_ts(add_bf16, engine);
+            test_tensor_t src_ts(src, engine, src_data);
+            test_tensor_t weight_ts(weight, engine, weight_data);
+            test_tensor_t div_src1_ts(div_src1, engine);
+            test_tensor_t add_src1_ts(add_src1, engine);
+            test_tensor_t dst_ts(add_bf16, engine);
             cp.execute(strm,
                     {src_ts.get(), weight_ts.get(), div_src1_ts.get(),
                             add_src1_ts.get()},
@@ -1240,12 +1240,12 @@ TEST(test_bmm_execute_subgraph_int8, BmmMulAddTransposeBU8s8f32) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-    test_tensor mul_src1_ts(mul_src1, engine, mul_src1_data);
-    test_tensor add_src1_ts(add_src1, engine, add_src1_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t mul_src1_ts(mul_src1, engine, mul_src1_data);
+    test_tensor_t add_src1_ts(add_src1, engine, add_src1_data);
     std::vector<float> case2_out_data(product(dst_shape));
-    test_tensor dst_f32_case2_ts(add_f32, engine, case2_out_data);
+    test_tensor_t dst_f32_case2_ts(add_f32, engine, case2_out_data);
     cp.execute(strm,
             {src_u8_ts.get(), weight_s8_ts.get(), mul_src1_ts.get(),
                     add_src1_ts.get()},

--- a/tests/gtests/graph/unit/backend/dnnl/test_common.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_common.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ TEST(test_common, MakeDnnlMemory) {
 
     graph::logical_tensor_t lt
             = utils::logical_tensor_init(0, {1, 2}, graph::data_type::f32);
-    test_tensor t1 {lt, &eng};
+    test_tensor_t t1 {lt, &eng};
     if (eng.kind() == graph::engine_kind::cpu) {
         ASSERT_NO_THROW(graph::dnnl_impl::make_dnnl_memory(
                 t1.get(), dnnl::engine(dnnl::engine::kind::cpu, 0)));

--- a/tests/gtests/graph/unit/backend/dnnl/test_compiled_partition.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_compiled_partition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ TEST(test_compiled_partition, Relu) {
         data_in[i] = static_cast<float>(i) - static_cast<float>(ele_num_in / 2);
     }
 
-    test_tensor t_in(lt_in, eng, data_in), t_out(query_out_lt, eng, data_out);
+    test_tensor_t t_in(lt_in, eng, data_in), t_out(query_out_lt, eng, data_out);
 
     std::vector<graph::tensor_t> t_inputs, t_outputs;
     t_inputs.emplace_back(t_in.get());
@@ -185,24 +185,24 @@ TEST(test_compiled_partition, SearchRequiredInputsOutputs) {
         data_in[i] = static_cast<float>(i) - static_cast<float>(ele_num_in / 2);
     }
 
-    test_tensor t_in(lt_in, eng, data_in), t_out(query_lt_out, eng, data_out);
-    test_tensor t_in_additional1(lt_in_additional1, eng),
+    test_tensor_t t_in(lt_in, eng, data_in), t_out(query_lt_out, eng, data_out);
+    test_tensor_t t_in_additional1(lt_in_additional1, eng),
             t_in_additional2(lt_in_additional2, eng);
 
-    test_tensor t_out_additional1(lt_out_additional1, eng),
+    test_tensor_t t_out_additional1(lt_out_additional1, eng),
             t_out_additional2(lt_out_additional2, eng);
 
     // when submit, in/outputs tensor's order must be same as compile
     // funcstion's in/outputs logical tensor
-    std::vector<test_tensor> t_inputs_correct {
+    std::vector<test_tensor_t> t_inputs_correct {
             t_in_additional1, t_in, t_in_additional2};
-    std::vector<test_tensor> t_outputs_correct {
+    std::vector<test_tensor_t> t_outputs_correct {
             t_out_additional1, t_out_additional2, t_out};
 
     graph::stream_t *strm = get_stream();
     EXPECT_SUCCESS(
-            cp.execute(strm, test_tensor::to_graph_tensor(t_inputs_correct),
-                    test_tensor::to_graph_tensor(t_outputs_correct)));
+            cp.execute(strm, test_tensor_t::to_graph_tensor(t_inputs_correct),
+                    test_tensor_t::to_graph_tensor(t_outputs_correct)));
     strm->wait();
 
     std::vector<float> ref_out(ele_num_in);
@@ -271,16 +271,16 @@ TEST(test_compiled_partition, AllowRepeatedInputs) {
     std::vector<float> ref_out {
             1.0f, 4.0f, 9.0f, 16.0f, 25.0f, 36.0f, 49.0f, 64.0f, 81.0f};
 
-    test_tensor t_in1(lt_in1, eng, data_in);
-    test_tensor t_out(query_lt_out, eng, data_out);
+    test_tensor_t t_in1(lt_in1, eng, data_in);
+    test_tensor_t t_out(query_lt_out, eng, data_out);
 
     // only one input
-    std::vector<test_tensor> t_ins {t_in1};
-    std::vector<test_tensor> t_outs {t_out};
+    std::vector<test_tensor_t> t_ins {t_in1};
+    std::vector<test_tensor_t> t_outs {t_out};
 
     graph::stream_t *strm = get_stream();
-    EXPECT_SUCCESS(cp.execute(strm, test_tensor::to_graph_tensor(t_ins),
-            test_tensor::to_graph_tensor(t_outs)));
+    EXPECT_SUCCESS(cp.execute(strm, test_tensor_t::to_graph_tensor(t_ins),
+            test_tensor_t::to_graph_tensor(t_outs)));
     strm->wait();
     data_out = t_out.as_vec_type<float>();
     for (size_t i = 0; i < ref_out.size(); i++) {

--- a/tests/gtests/graph/unit/backend/dnnl/test_concat.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_concat.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,9 +89,9 @@ public:
         g.add_op(&concat_op);
         g.finalize();
 
-        test_tensor src0_ts(src0_lt, eng, src0_data);
-        test_tensor src1_ts(src1_lt, eng, src1_data);
-        test_tensor case1_dst_ts(dst_lt, eng, case1_out_data);
+        test_tensor_t src0_ts(src0_lt, eng, src0_data);
+        test_tensor_t src1_ts(src1_lt, eng, src1_data);
+        test_tensor_t case1_dst_ts(dst_lt, eng, case1_out_data);
 
         ASSERT_EQ(run_graph(g, {src0_ts, src1_ts}, {case1_dst_ts}, *eng, *strm),
                 graph::status::success);
@@ -112,7 +112,7 @@ public:
 
         p.compile(&cp, inputs, outputs, eng);
 
-        test_tensor case2_dst_ts(dst_lt, eng, case2_out_data);
+        test_tensor_t case2_dst_ts(dst_lt, eng, case2_out_data);
         cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {case2_dst_ts.get()});
         strm->wait();
 
@@ -321,11 +321,11 @@ TEST(test_concat_execute_subgraph_int8, Concat) {
     g.add_op(&q_op);
     g.finalize();
 
-    test_tensor src0_s8_ts(src0_s8, engine, src0_s8_data);
-    test_tensor src1_s8_ts(src1_s8, engine, src1_s8_data);
-    test_tensor src2_s8_ts(src2_s8, engine, src2_s8_data);
-    test_tensor case1_dst_s8_ts(dst_s8_q, engine, case1_dst_s8_data);
-    test_tensor case2_dst_s8_ts(dst_s8_q, engine, case2_dst_s8_data);
+    test_tensor_t src0_s8_ts(src0_s8, engine, src0_s8_data);
+    test_tensor_t src1_s8_ts(src1_s8, engine, src1_s8_data);
+    test_tensor_t src2_s8_ts(src2_s8, engine, src2_s8_data);
+    test_tensor_t case1_dst_s8_ts(dst_s8_q, engine, case1_dst_s8_data);
+    test_tensor_t case2_dst_s8_ts(dst_s8_q, engine, case2_dst_s8_data);
 
     // -------------------------case 1----------------------------------
     ASSERT_EQ(run_graph(g, {src0_s8_ts, src1_s8_ts, src2_s8_ts},
@@ -413,10 +413,10 @@ TEST(test_concat_execute, ConcatEmptyInput) {
     std::vector<float> src2_data(24);
     std::vector<float> dst_data(48);
 
-    test_tensor src0_ts(src0, eng, src0_data);
-    test_tensor src1_ts(src1_lt, eng);
-    test_tensor src2_ts(src2, eng, src2_data);
-    test_tensor dst_ts(lt, eng, dst_data);
+    test_tensor_t src0_ts(src0, eng, src0_data);
+    test_tensor_t src1_ts(src1_lt, eng);
+    test_tensor_t src2_ts(src2, eng, src2_data);
+    test_tensor_t dst_ts(lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src0_ts.get(), src1_ts.get(), src2_ts.get()},

--- a/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -392,9 +392,9 @@ TEST(test_convolution_execute, ConvolutionNcxOix) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -458,9 +458,9 @@ TEST(test_convolution_execute, ConvtransposeWithGroups) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
     ASSERT_EQ(dst_lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()}),
@@ -527,9 +527,9 @@ TEST(test_convolution_execute, Convolution3DNcxOix) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -595,9 +595,9 @@ TEST(test_convolution_execute, ConvolutionNcxXio) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -663,9 +663,9 @@ TEST(test_convolution_execute, Convolution3DNcxXio) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -732,9 +732,9 @@ TEST(test_convolution_execute, ConvolutionNxcXio) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -801,9 +801,9 @@ TEST(test_convolution_execute, Convolution3DNxcXio) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -869,9 +869,9 @@ TEST(test_convolution_execute, ConvolutionNxcOix) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -937,9 +937,9 @@ TEST(test_convolution_execute, Convolution3DNxcOix) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -1006,9 +1006,9 @@ TEST(test_convolution_execute, ConvolutionF16F16F16_GPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -1076,9 +1076,9 @@ TEST(test_convolution_execute, ConvolutionBf16Bf16Bf16) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -1273,9 +1273,9 @@ TEST(test_convolution_execute, GroupConvolution) {
     std::vector<float> weight(32 * 8 * 1 * 1, 1);
     std::vector<float> dst(8 * 32 * 16 * 16, 1);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -1344,9 +1344,9 @@ TEST(test_convolution_execute, ConvolutionBackwardData) {
     cp.query_logical_tensor(diff_src_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-    test_tensor diff_src_ts(diff_src_lt, eng, diff_src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(diff_src_lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {diff_dst_ts.get(), weight_ts.get()}, {diff_src_ts.get()});
@@ -1420,13 +1420,13 @@ TEST(test_convolution_execute, ConvolutionBnFp32) {
     std::generate(bn_shift.begin(), bn_shift.end(),
             [&]() { return distribution(generator); });
 
-    test_tensor conv_src_ts(conv_src_lt, eng, conv_src);
-    test_tensor conv_weight_ts(conv_weight_lt, eng, conv_weight);
-    test_tensor bn_gamma_ts(gamma_lt, eng, bn_gamma);
-    test_tensor bn_beta_ts(beta_lt, eng, bn_beta);
-    test_tensor bn_scale_ts(scale_lt, eng, bn_scale);
-    test_tensor bn_shift_ts(shift_lt, eng, bn_shift);
-    test_tensor bn_dst_ts(bn_dst_lt, eng, bn_dst);
+    test_tensor_t conv_src_ts(conv_src_lt, eng, conv_src);
+    test_tensor_t conv_weight_ts(conv_weight_lt, eng, conv_weight);
+    test_tensor_t bn_gamma_ts(gamma_lt, eng, bn_gamma);
+    test_tensor_t bn_beta_ts(beta_lt, eng, bn_beta);
+    test_tensor_t bn_scale_ts(scale_lt, eng, bn_scale);
+    test_tensor_t bn_shift_ts(shift_lt, eng, bn_shift);
+    test_tensor_t bn_dst_ts(bn_dst_lt, eng, bn_dst);
 
     conv_op.add_input(conv_src_lt);
     conv_op.add_input(conv_weight_lt);
@@ -1469,7 +1469,7 @@ TEST(test_convolution_execute, ConvolutionBnFp32) {
     p.compile(&cp, inputs, outputs, eng);
 
     std::vector<float> convbn_dst(8 * 32 * 16 * 16, 0.0);
-    test_tensor convbn_dst_ts(bn_dst_lt, eng, convbn_dst);
+    test_tensor_t convbn_dst_ts(bn_dst_lt, eng, convbn_dst);
 
     cp.execute(strm,
             {conv_src_ts.get(), conv_weight_ts.get(), bn_gamma_ts.get(),
@@ -1533,10 +1533,10 @@ TEST(test_convolution_compile, ConvBnSharedInputs) {
     std::generate(bn_shared_input.begin(), bn_shared_input.end(),
             [&]() { return distribution(generator); });
 
-    test_tensor conv_src_ts(conv_src_lt, eng, conv_src);
-    test_tensor conv_weight_ts(conv_weight_lt, eng, conv_weight);
-    test_tensor bn_shared_input_ts(shared_lt, eng, bn_shared_input);
-    test_tensor bn_dst_ts(bn_dst_lt, eng, bn_dst);
+    test_tensor_t conv_src_ts(conv_src_lt, eng, conv_src);
+    test_tensor_t conv_weight_ts(conv_weight_lt, eng, conv_weight);
+    test_tensor_t bn_shared_input_ts(shared_lt, eng, bn_shared_input);
+    test_tensor_t bn_dst_ts(bn_dst_lt, eng, bn_dst);
 
     conv_op.add_input(conv_src_lt);
     conv_op.add_input(conv_weight_lt);
@@ -1580,7 +1580,7 @@ TEST(test_convolution_compile, ConvBnSharedInputs) {
     p.compile(&cp, inputs, outputs, eng);
 
     std::vector<float> convbn_dst(8 * 32 * 16 * 16, 0.0);
-    test_tensor convbn_dst_ts(bn_dst_lt, eng, convbn_dst);
+    test_tensor_t convbn_dst_ts(bn_dst_lt, eng, convbn_dst);
 
     cp.execute(strm,
             {conv_src_ts.get(), conv_weight_ts.get(), bn_shared_input_ts.get(),
@@ -1671,10 +1671,10 @@ TEST(test_convolution_execute, ConvAdd) {
         cp.query_logical_tensor(add_dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor weight_ts(weight_lt, eng, weight);
-        test_tensor post_src_ts(post_src_lt, eng, post_src);
-        test_tensor add_dst_ts(add_dst_lt, eng, dst);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t weight_ts(weight_lt, eng, weight);
+        test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+        test_tensor_t add_dst_ts(add_dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -1758,10 +1758,10 @@ TEST(test_convolution_execute, ConvAddPerTensorBroadcast) {
     cp.query_logical_tensor(add_dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -1842,10 +1842,10 @@ TEST(test_convolution_execute, ConvAddExpandedPerTensorBroadcast) {
     cp.query_logical_tensor(add_dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -1927,10 +1927,10 @@ TEST(test_convolution_execute, ConvAddPerChannelBroadcast) {
     cp.query_logical_tensor(add_dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -2012,10 +2012,10 @@ TEST(test_convolution_execute, ConvAddPerChannelBroadcastNxc) {
     cp.query_logical_tensor(add_dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -2169,10 +2169,10 @@ TEST(test_convolution_execute, ConvAddRelu) {
     cp.query_logical_tensor(relu_dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor post_src_ts(post_lt, eng, post_src);
-    test_tensor relu_dst_ts(relu_dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t post_src_ts(post_lt, eng, post_src);
+    test_tensor_t relu_dst_ts(relu_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -2293,13 +2293,13 @@ TEST(test_convolution_execute, ConvMultiplePostOps) {
     cp.query_logical_tensor(add_dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor bias_ts(bias_lt, eng, bias);
-    test_tensor mul_other_ts(mul_other_lt, eng, mul_other);
-    test_tensor sum_other_ts(sum_other_lt, eng, sum_other);
-    test_tensor add_other_ts(add_other_lt, eng, add_other);
-    test_tensor add_dst_ts(add_dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t bias_ts(bias_lt, eng, bias);
+    test_tensor_t mul_other_ts(mul_other_lt, eng, mul_other);
+    test_tensor_t sum_other_ts(sum_other_lt, eng, sum_other);
+    test_tensor_t add_other_ts(add_other_lt, eng, add_other);
+    test_tensor_t add_dst_ts(add_dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -2416,10 +2416,10 @@ TEST(test_convolution_execute, ConvBiasEltwise) {
         cp.query_logical_tensor(eltwise_dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor weight_ts(weight_lt, eng, weight);
-        test_tensor bias_ts(bias_lt, eng, param.bias);
-        test_tensor eltwise_dst_ts(eltwise_dst_lt, eng, dst);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t weight_ts(weight_lt, eng, weight);
+        test_tensor_t bias_ts(bias_lt, eng, param.bias);
+        test_tensor_t eltwise_dst_ts(eltwise_dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -2532,11 +2532,11 @@ TEST(test_convolution_execute, ConvBiasAddEltwise) {
         cp.query_logical_tensor(eltwise_dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor weight_ts(weight_lt, eng, weight);
-        test_tensor bias_ts(bias_lt, eng, param.bias);
-        test_tensor post_src_ts(post_lt, eng, post_src);
-        test_tensor eltwise_dst_ts(eltwise_dst_lt, eng, dst);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t weight_ts(weight_lt, eng, weight);
+        test_tensor_t bias_ts(bias_lt, eng, param.bias);
+        test_tensor_t post_src_ts(post_lt, eng, post_src);
+        test_tensor_t eltwise_dst_ts(eltwise_dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm,
@@ -2655,10 +2655,10 @@ TEST(test_convolution_execute, ConvAddEltwise) {
         cp.query_logical_tensor(eltwise_dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor weight_ts(weight_lt, eng, weight);
-        test_tensor post_src_ts(post_lt, eng, post_src);
-        test_tensor eltwise_dst_ts(eltwise_dst_lt, eng, dst);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t weight_ts(weight_lt, eng, weight);
+        test_tensor_t post_src_ts(post_lt, eng, post_src);
+        test_tensor_t eltwise_dst_ts(eltwise_dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -2735,13 +2735,13 @@ TEST(test_convolution_execute_subgraph_fp32, ConvDepthwise_CPU) {
     g.add_op(&depthwise);
     g.finalize();
 
-    test_tensor conv_src_ts(conv_src, engine, src_data);
-    test_tensor conv_wei_ts(conv_wei, engine, wei_data);
-    test_tensor dw_wei_ts(dw_wei, engine, dw_wei_data);
+    test_tensor_t conv_src_ts(conv_src, engine, src_data);
+    test_tensor_t conv_wei_ts(conv_wei, engine, wei_data);
+    test_tensor_t dw_wei_ts(dw_wei, engine, dw_wei_data);
 
     // -------------------------case 1----------------------------------
     std::vector<float> case1_out_data(product(dw_dst_shape));
-    test_tensor dw_dst_ts(dw_dst, engine, case1_out_data);
+    test_tensor_t dw_dst_ts(dw_dst, engine, case1_out_data);
 
     ASSERT_EQ(run_graph(g, {conv_src_ts, conv_wei_ts, dw_wei_ts}, {dw_dst_ts},
                       *engine, *strm),
@@ -2766,7 +2766,7 @@ TEST(test_convolution_execute_subgraph_fp32, ConvDepthwise_CPU) {
     ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine), graph::status::success);
 
     std::vector<float> case2_out_data(product(dw_dst_shape));
-    test_tensor dw_dst_ts2(dw_dst, engine, case2_out_data);
+    test_tensor_t dw_dst_ts2(dw_dst, engine, case2_out_data);
 
     cp.execute(strm, {conv_src_ts.get(), conv_wei_ts.get(), dw_wei_ts.get()},
             {dw_dst_ts2.get()});
@@ -2904,14 +2904,14 @@ TEST(test_convolution_execute_subgraph_int8, Conv1dConv2dConv3d) {
         g.add_op(&qout_node);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
@@ -3081,14 +3081,14 @@ static inline void quantized_conv2d_eltwise(
         g.add_op(&qout_node);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
@@ -3324,15 +3324,15 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dSumRelu) {
         }
         dst_s8 = utils::logical_tensor_init(9, dst_shape, graph::data_type::s8);
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor other_s8_ts(other_s8, engine, other_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g,
@@ -3533,12 +3533,12 @@ TEST(test_convolution_execute_subgraph_int8,
     bias_f32 = utils::logical_tensor_init(6, bias_shape, graph::data_type::f32);
     dst_u8 = utils::logical_tensor_init(9, dst_shape, graph::data_type::u8);
 
-    test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-    test_tensor other_s8_ts(other_s8, engine, other_s8_data);
-    test_tensor bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
-    test_tensor dst_u8_ts(dst_u8, engine, case1_out_data);
-    test_tensor dst_u8_case2_ts(dst_u8, engine, case2_out_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+    test_tensor_t other_s8_ts(other_s8, engine, other_s8_data);
+    test_tensor_t bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
+    test_tensor_t dst_u8_ts(dst_u8, engine, case1_out_data);
+    test_tensor_t dst_u8_case2_ts(dst_u8, engine, case2_out_data);
 
     // -------------------------case 1----------------------------------
     ASSERT_EQ(run_graph(agraph,
@@ -3738,15 +3738,15 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dSumReluNxc) {
         }
         dst_s8 = utils::logical_tensor_init(9, dst_shape, graph::data_type::s8);
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor other_s8_ts(other_s8, engine, other_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g,
@@ -3919,16 +3919,16 @@ TEST(test_convolution_execute_subgraph_int8, Conv1d2d3dX8s8f32) {
         g.add_op(&conv_node);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(dst_shape));
-        test_tensor dst_f32_ts(dst_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_ts(dst_f32, engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
                           {dst_f32_ts}, *engine, *strm),
@@ -3956,7 +3956,7 @@ TEST(test_convolution_execute_subgraph_int8, Conv1d2d3dX8s8f32) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(dst_shape));
-        test_tensor dst_f32_case2_ts(dst_f32, engine, case2_out_data);
+        test_tensor_t dst_f32_case2_ts(dst_f32, engine, case2_out_data);
         if (with_bias)
             cp.execute(strm,
                     {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get()},
@@ -4088,14 +4088,14 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dReluX8s8f32) {
         g.add_op(&relu_node);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_relu_f32_ts(dst_relu_f32, engine, case1_out_data);
-        test_tensor dst_f32_case2_ts(dst_relu_f32, engine, case2_out_data);
+        test_tensor_t dst_relu_f32_ts(dst_relu_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_case2_ts(dst_relu_f32, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
@@ -4502,10 +4502,10 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasU8s8u8MixBf16) {
         ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine),
                 graph::status::success);
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_bf16_ts(bias_bf16, engine, bias_data);
-        test_tensor dst_ts(dst_u8, engine);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_bf16_ts(bias_bf16, engine, bias_data);
+        test_tensor_t dst_ts(dst_u8, engine);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_bf16_ts.get()},
                 {dst_ts.get()});
@@ -4694,10 +4694,10 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasaddU8s8u8MixBf16) {
         ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine),
                 graph::status::success);
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-        test_tensor dst_ts(dst_u8, engine);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t dst_ts(dst_u8, engine);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
                 {dst_ts.get()});
@@ -4869,10 +4869,10 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasGeluU8s8u8MixBf16) {
         ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine),
                 graph::status::success);
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_bf16_ts(bias_bf16, engine, bias_data);
-        test_tensor dst_ts(dst_u8, engine);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_bf16_ts(bias_bf16, engine, bias_data);
+        test_tensor_t dst_ts(dst_u8, engine);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_bf16_ts.get()},
                 {dst_ts.get()});
@@ -5008,10 +5008,10 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionReluMulS8Bf16Accuracy) {
 
     ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine), graph::status::success);
 
-    test_tensor src_s8_ts(src_s8, engine, src_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-    test_tensor mul_bf16_ts(mul_bf16, engine, mul_data);
-    test_tensor dst_bf16_ts(mul_out_bf16, engine, act_dst_data);
+    test_tensor_t src_s8_ts(src_s8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t mul_bf16_ts(mul_bf16, engine, mul_data);
+    test_tensor_t dst_bf16_ts(mul_out_bf16, engine, act_dst_data);
     cp.execute(strm, {src_s8_ts.get(), weight_s8_ts.get(), mul_bf16_ts.get()},
             {dst_bf16_ts.get()});
     strm->wait();
@@ -5211,10 +5211,10 @@ TEST(test_convolution_execute_subgraph_int8,
         ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine),
                 graph::status::success);
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-        test_tensor dst_ts(dst_u8, engine);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t dst_ts(dst_u8, engine);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
                 {dst_ts.get()});
@@ -5838,11 +5838,11 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionAddU8s8u8MixBf16) {
 
     ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine), graph::status::success);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-    test_tensor post_add_src1_bf16_ts(bias_bf16, engine, post_add_src1_data);
-    test_tensor dst_ts(bias_out_bf16, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t post_add_src1_bf16_ts(bias_bf16, engine, post_add_src1_data);
+    test_tensor_t dst_ts(bias_out_bf16, engine);
     cp.execute(strm,
             {src_u8_ts.get(), weight_f32_ts.get(), post_add_src1_bf16_ts.get()},
             {dst_ts.get()});
@@ -5938,11 +5938,11 @@ TEST(test_convolution_execute, ConvSumSum) {
     cp.query_logical_tensor(add2_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor src2_ts(src2_lt, eng, src2);
-    test_tensor src3_ts(src3_lt, eng, src3);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor add2_ts(add2_lt, eng, dst);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t src2_ts(src2_lt, eng, src2);
+    test_tensor_t src3_ts(src3_lt, eng, src3);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t add2_ts(add2_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -5996,10 +5996,10 @@ TEST(test_convolution_execute, ConvolutionBf16InFp32Out) {
     std::vector<uint16_t> post_src(8 * 32 * 16 * 16, 1);
     std::vector<float> tc_dst(8 * 32 * 16 * 16, 0.0);
 
-    test_tensor conv_src_ts(conv_src_lt, eng, conv_src);
-    test_tensor conv_weight_ts(conv_weight_lt, eng, conv_weight);
-    test_tensor post_src_ts(post_src_lt, eng, post_src);
-    test_tensor tc_dst_ts(tc_dst_lt, eng, tc_dst);
+    test_tensor_t conv_src_ts(conv_src_lt, eng, conv_src);
+    test_tensor_t conv_weight_ts(conv_weight_lt, eng, conv_weight);
+    test_tensor_t post_src_ts(post_src_lt, eng, post_src);
+    test_tensor_t tc_dst_ts(tc_dst_lt, eng, tc_dst);
 
     conv_op.add_input(conv_src_lt);
     conv_op.add_input(conv_weight_lt);
@@ -6041,7 +6041,7 @@ TEST(test_convolution_execute, ConvolutionBf16InFp32Out) {
     p.compile(&cp, inputs, outputs, eng);
 
     std::vector<float> convtc_dst(8 * 32 * 16 * 16, 0.0);
-    test_tensor convtc_dst_ts(tc_dst_lt, eng, convtc_dst);
+    test_tensor_t convtc_dst_ts(tc_dst_lt, eng, convtc_dst);
 
     cp.execute(strm,
             {conv_src_ts.get(), conv_weight_ts.get(), post_src_ts.get()},
@@ -6224,15 +6224,15 @@ TEST(test_convolution_execute_subgraph_int8, QuantWeiConv2dSumRelu) {
             bias_f32.property = graph::property_type::constant;
         }
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_f32_ts(weight_f32, engine, weight_f32_data);
-        test_tensor other_s8_ts(other_s8, engine, other_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_f32_ts(weight_f32, engine, weight_f32_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g,
@@ -6467,15 +6467,15 @@ TEST(test_convolution_execute_subgraph_int8, QuantWeiConv2dSumS8Relu) {
             bias_f32.property = graph::property_type::constant;
         }
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_f32_ts(weight_f32, engine, weight_f32_data);
-        test_tensor other_s8_ts(other_s8, engine, other_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_f32_ts(weight_f32, engine, weight_f32_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_u8_ts(dst_u8, engine, case1_out_data);
-        test_tensor dst_u8_case2_ts(dst_u8, engine, case2_out_data);
+        test_tensor_t dst_u8_ts(dst_u8, engine, case1_out_data);
+        test_tensor_t dst_u8_case2_ts(dst_u8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g,
@@ -6578,9 +6578,9 @@ TEST(test_convolution_execute, ConvReluUnfused) {
     std::vector<float> conv_weight(32 * 32 * 1 * 1, 1);
     std::vector<float> relu_dst(8 * 32 * 16 * 16, 1);
 
-    test_tensor conv_src_ts(conv_src_lt, eng, conv_src);
-    test_tensor conv_weight_ts(conv_weight_lt, eng, conv_weight);
-    test_tensor relu_dst_ts(relu_dst_lt, eng, relu_dst);
+    test_tensor_t conv_src_ts(conv_src_lt, eng, conv_src);
+    test_tensor_t conv_weight_ts(conv_weight_lt, eng, conv_weight);
+    test_tensor_t relu_dst_ts(relu_dst_lt, eng, relu_dst);
 
     // run unfused graph to compute the reference
     ASSERT_EQ(run_graph(g, {conv_src_ts, conv_weight_ts}, {relu_dst_ts}, *eng,
@@ -6742,10 +6742,10 @@ TEST(test_convolution_execute_subgraph_int8, ConvDepthwise) {
         g.add_op(&qout_node);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, eng, src_u8_data);
-        test_tensor weight_f32_ts(weight_f32, eng, weight_f32_data);
-        test_tensor dst_s8_ts(dst_s8, eng, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, eng, case2_out_data);
+        test_tensor_t src_u8_ts(src_u8, eng, src_u8_data);
+        test_tensor_t weight_f32_ts(weight_f32, eng, weight_f32_data);
+        test_tensor_t dst_s8_ts(dst_s8, eng, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, eng, case2_out_data);
 
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
@@ -6840,7 +6840,7 @@ TEST(test_convolution_execute_subgraph_int8, ShareCachedWeights) {
     std::vector<int8_t> weight_s8_data(product(weight_shape));
     std::generate(weight_s8_data.begin(), weight_s8_data.end(),
             [&]() { return static_cast<int8_t>(s8_distribution(generator)); });
-    test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
 
     std::vector<std::vector<int64_t>> src_shapes {
             {1, 8, 12, 12}, {3, 8, 12, 12}};
@@ -6869,13 +6869,13 @@ TEST(test_convolution_execute_subgraph_int8, ShareCachedWeights) {
         std::generate(src_u8_data.begin(), src_u8_data.end(), [&]() {
             return static_cast<uint8_t>(u8_distribution(generator));
         });
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor dst_ts(dst_f32, engine);
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t dst_ts(dst_f32, engine);
 
         cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get()}, {dst_ts.get()});
         strm->wait();
 
-        test_tensor ref_dst_ts(dst_f32, engine);
+        test_tensor_t ref_dst_ts(dst_f32, engine);
 
         ASSERT_EQ(run_graph(agraph, {src_u8_ts, weight_s8_ts}, {ref_dst_ts},
                           *engine, *strm),

--- a/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -128,13 +128,13 @@ public:
         p.compile(&cp, inputs, outputs, eng);
         ASSERT_EQ(dst_lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src_data);
-        test_tensor weight_ts(weight_lt, eng, weight_data);
-        test_tensor dst1_ts(dst_lt, eng, case1_out_data);
-        test_tensor dst2_ts(dst_lt, eng, case2_out_data);
-        test_tensor bias_ts;
+        test_tensor_t src_ts(src_lt, eng, src_data);
+        test_tensor_t weight_ts(weight_lt, eng, weight_data);
+        test_tensor_t dst1_ts(dst_lt, eng, case1_out_data);
+        test_tensor_t dst2_ts(dst_lt, eng, case2_out_data);
+        test_tensor_t bias_ts;
         if (params.with_bias) {
-            bias_ts = test_tensor(bias_lt, eng, bias_data);
+            bias_ts = test_tensor_t(bias_lt, eng, bias_data);
         }
         graph::stream_t *strm = get_stream();
         if (params.with_bias) {
@@ -243,10 +243,10 @@ public:
         cp.query_logical_tensor(diff_src_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-        test_tensor weight_ts(weight_lt, eng, weight);
-        test_tensor diff_src1_ts(diff_src_lt, eng, case1_out_data);
-        test_tensor diff_src2_ts(diff_src_lt, eng, case2_out_data);
+        test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+        test_tensor_t weight_ts(weight_lt, eng, weight);
+        test_tensor_t diff_src1_ts(diff_src_lt, eng, case1_out_data);
+        test_tensor_t diff_src2_ts(diff_src_lt, eng, case2_out_data);
 
         graph::stream_t *strm = get_stream();
         ASSERT_EQ(run_graph(g, {diff_dst_ts, weight_ts}, {diff_src1_ts}, *eng,
@@ -336,10 +336,10 @@ public:
         cp.query_logical_tensor(diff_wei_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-        test_tensor diff_wei_ts1(diff_wei_lt, eng, case1_out_data);
-        test_tensor diff_wei_ts2(diff_wei_lt, eng, case2_out_data);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+        test_tensor_t diff_wei_ts1(diff_wei_lt, eng, case1_out_data);
+        test_tensor_t diff_wei_ts2(diff_wei_lt, eng, case2_out_data);
 
         graph::stream_t *strm = get_stream();
         ASSERT_EQ(run_graph(g, {src_ts, diff_dst_ts}, {diff_wei_ts1}, *eng,
@@ -452,13 +452,13 @@ public:
         cp.query_logical_tensor(add_dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src_data);
-        test_tensor weight_ts(weight_lt, eng, weight_data);
-        test_tensor bias_ts;
-        if (params.with_bias) bias_ts = test_tensor(bias_lt, eng, bias_data);
-        test_tensor add_src_ts(add_src_lt, eng, add_src_data);
-        test_tensor add_dst_ts1(add_dst_lt, eng, case1_out_data);
-        test_tensor add_dst_ts2(add_dst_lt, eng, case2_out_data);
+        test_tensor_t src_ts(src_lt, eng, src_data);
+        test_tensor_t weight_ts(weight_lt, eng, weight_data);
+        test_tensor_t bias_ts;
+        if (params.with_bias) bias_ts = test_tensor_t(bias_lt, eng, bias_data);
+        test_tensor_t add_src_ts(add_src_lt, eng, add_src_data);
+        test_tensor_t add_dst_ts1(add_dst_lt, eng, case1_out_data);
+        test_tensor_t add_dst_ts2(add_dst_lt, eng, case2_out_data);
 
         graph::stream_t *strm = get_stream();
         if (params.with_bias) {
@@ -824,11 +824,11 @@ TEST(test_convtranspose_operator_kernel, convtranspose_relu) {
         cp.query_logical_tensor(relu_dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src_data);
-        test_tensor weight_ts(weight_lt, eng, weight_data);
-        test_tensor bias_ts;
-        if (with_bias) bias_ts = test_tensor(bias_lt, eng, bias_data);
-        test_tensor relu_dst_ts(relu_dst_lt, eng, dst_data);
+        test_tensor_t src_ts(src_lt, eng, src_data);
+        test_tensor_t weight_ts(weight_lt, eng, weight_data);
+        test_tensor_t bias_ts;
+        if (with_bias) bias_ts = test_tensor_t(bias_lt, eng, bias_data);
+        test_tensor_t relu_dst_ts(relu_dst_lt, eng, dst_data);
 
         graph::stream_t *strm = get_stream();
         if (with_bias)
@@ -926,11 +926,11 @@ TEST(test_convtranspose_operator_kernel, convtranspose_swish) {
         cp.query_logical_tensor(multiply_dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src_data);
-        test_tensor weight_ts(weight_lt, eng, weight_data);
-        test_tensor bias_ts;
-        if (with_bias) bias_ts = test_tensor(bias_lt, eng, bias_data);
-        test_tensor multiply_dst_ts(multiply_dst_lt, eng, dst_data);
+        test_tensor_t src_ts(src_lt, eng, src_data);
+        test_tensor_t weight_ts(weight_lt, eng, weight_data);
+        test_tensor_t bias_ts;
+        if (with_bias) bias_ts = test_tensor_t(bias_lt, eng, bias_data);
+        test_tensor_t multiply_dst_ts(multiply_dst_lt, eng, dst_data);
 
         graph::stream_t *strm = get_stream();
         if (with_bias)
@@ -1034,10 +1034,10 @@ TEST(test_convtranspose_execute_subgraph_int8,
     agraph.add_op(&qout_node);
     agraph.finalize();
 
-    test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-    test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-    test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+    test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+    test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
     // -------------------------case 1----------------------------------
     ASSERT_EQ(run_graph(agraph, {src_u8_ts, weight_s8_ts}, {dst_s8_ts}, *engine,
@@ -1173,10 +1173,10 @@ TEST(test_convtranspose_execute_subgraph_int8,
     agraph.add_op(&qout_node);
     agraph.finalize();
 
-    test_tensor src_s8_ts(src_s8, engine, src_s8_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-    test_tensor dst_s8_case1_ts(dst_s8, engine, case1_out_data);
-    test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+    test_tensor_t src_s8_ts(src_s8, engine, src_s8_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+    test_tensor_t dst_s8_case1_ts(dst_s8, engine, case1_out_data);
+    test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
     // -------------------------case 1----------------------------------
     ASSERT_EQ(run_graph(agraph, {src_s8_ts, weight_s8_ts}, {dst_s8_case1_ts},
@@ -1351,14 +1351,14 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3d) {
         g.add_op(&qout_node);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
@@ -1594,14 +1594,14 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose2dEltwise_CPU) {
         graph.add_op(&qout_node);
         graph.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(graph, {src_u8_ts, weight_s8_ts, bias_f32_ts},
@@ -1808,14 +1808,14 @@ TEST(test_convtranspose_execute_subgraph_int8,
         // graph.add_op(&qout_node);
         graph.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_f32_ts(dst_eltwise_f32, engine, case1_out_data);
-        test_tensor dst_f32_case2_ts(dst_eltwise_f32, engine, case2_out_data);
+        test_tensor_t dst_f32_ts(dst_eltwise_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_case2_ts(dst_eltwise_f32, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(graph, {src_u8_ts, weight_s8_ts, bias_f32_ts},
@@ -1976,10 +1976,11 @@ TEST(test_convtranspose_execute_subgraph_int8, X8X8F32ConvTransposeSwish) {
         graph.add_op(&multiply_node);
         graph.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor dst_f32_ts(dst_multiply_f32, engine, case1_out_data);
-        test_tensor dst_f32_case2_ts(dst_multiply_f32, engine, case2_out_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t dst_f32_ts(dst_multiply_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_case2_ts(
+                dst_multiply_f32, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(graph, {src_u8_ts, weight_s8_ts}, {dst_f32_ts},
@@ -2219,15 +2220,15 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3dAdd) {
         graph.add_op(&qout_node);
         graph.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor other_s8_ts(other_s8, engine, other_s8_data);
-        test_tensor bias_f32_ts;
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_s8_data);
+        test_tensor_t bias_f32_ts;
         if (with_bias) {
-            bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            bias_f32_ts = test_tensor_t(bias_f32, engine, bias_data);
         }
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(graph,
@@ -2431,11 +2432,11 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3dBinary) {
         graph.add_op(&qout_node);
         graph.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_s8_data);
-        test_tensor other_f32_ts(other_f32, engine, other_f32_data);
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_s8_data);
+        test_tensor_t other_f32_ts(other_f32, engine, other_f32_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(graph, {src_u8_ts, weight_s8_ts, other_f32_ts},
@@ -2870,9 +2871,9 @@ TEST(test_convtranspose_execute_subgraph_fp32, Convtranspose3Postops) {
 
         agraph.finalize();
 
-        test_tensor dst_case1_ts(lt_vec[output_lts[0]], engine);
-        test_tensor dst_case2_ts(lt_vec[output_lts[0]], engine);
-        std::vector<test_tensor> src_tss {};
+        test_tensor_t dst_case1_ts(lt_vec[output_lts[0]], engine);
+        test_tensor_t dst_case2_ts(lt_vec[output_lts[0]], engine);
+        std::vector<test_tensor_t> src_tss {};
         for (size_t i = 0; i < input_lts.size(); ++i) {
             src_tss.emplace_back(lt_vec[input_lts[i]], engine);
             src_tss.back().fill<float>();
@@ -2906,7 +2907,7 @@ TEST(test_convtranspose_execute_subgraph_fp32, Convtranspose3Postops) {
 
         p.compile(&cp, lt_ins, lt_outs, engine);
 
-        cp.execute(strm, test_tensor::to_graph_tensor(src_tss),
+        cp.execute(strm, test_tensor_t::to_graph_tensor(src_tss),
                 {dst_case2_ts.get()});
         strm->wait();
 
@@ -2968,9 +2969,9 @@ TEST(test_convtranspose_execute, ConvtransposeWithCache) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
     ASSERT_EQ(dst_lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor weight_ts(weight_lt, eng, weight);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t weight_ts(weight_lt, eng, weight);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()}),
@@ -2989,9 +2990,9 @@ TEST(test_convtranspose_execute, ConvtransposeWithCache) {
     std::vector<float> ref_dst2 {3.0, 0.0, 3.0, 0.0, 7.0, 0.0, 7.0, 0.0};
     std::vector<float> dst2(ref_dst.size(), 0);
 
-    test_tensor src_ts2(src_lt, eng, src2);
-    test_tensor weight_ts2(weight_lt, eng, weight2);
-    test_tensor dst_ts2(dst_lt, eng, dst2);
+    test_tensor_t src_ts2(src_lt, eng, src2);
+    test_tensor_t weight_ts2(weight_lt, eng, weight2);
+    test_tensor_t dst_ts2(dst_lt, eng, dst2);
 
     ASSERT_EQ(cp.execute(
                       strm, {src_ts2.get(), weight_ts2.get()}, {dst_ts2.get()}),

--- a/tests/gtests/graph/unit/backend/dnnl/test_dequantize.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_dequantize.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,8 +78,8 @@ TEST(test_dequantize_execute, DequantizePerTensor) {
         cp.query_logical_tensor(dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, engine, src);
-        test_tensor dst_ts(dst_lt, engine, dst);
+        test_tensor_t src_ts(src_lt, engine, src);
+        test_tensor_t dst_ts(dst_lt, engine, dst);
 
         graph::stream_t *strm = get_stream();
         ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -140,8 +140,8 @@ TEST(test_dequantize_execute, DequantizePerTensorAnyLayout) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(lt, engine, dst);
 
     graph::stream_t *strm = get_stream();
 
@@ -200,8 +200,8 @@ TEST(test_dequantize_execute, DequantizePerChannelSymmetric) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(dst_lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(dst_lt, engine, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -270,10 +270,10 @@ TEST(test_dequantize_execute, DynamicDequantizeS32ZpsPerTensor_CPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scales_ts(scales_lt, eng, scales);
-    test_tensor zps_ts(zps_lt, eng, zps);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scales_ts(scales_lt, eng, scales);
+    test_tensor_t zps_ts(zps_lt, eng, zps);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), scales_ts.get(), zps_ts.get()},
@@ -343,10 +343,10 @@ TEST(test_dequantize_execute, DynamicDequantizeS8ZpsPerTensor_CPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scales_ts(scales_lt, eng, scales);
-    test_tensor zps_ts(zps_lt, eng, zps);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scales_ts(scales_lt, eng, scales);
+    test_tensor_t zps_ts(zps_lt, eng, zps);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), scales_ts.get(), zps_ts.get()},
@@ -411,9 +411,9 @@ TEST(test_dequantize_execute, DynamicDequantizeNoZpsPerTensor_CPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scales_ts(scales_lt, eng, scales);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scales_ts(scales_lt, eng, scales);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), scales_ts.get()}, {dst_ts.get()}),

--- a/tests/gtests/graph/unit/backend/dnnl/test_eltwise.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_eltwise.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,8 +78,8 @@ static inline void test_eltwise_common(std::vector<float> &src,
 
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
 
@@ -102,8 +102,8 @@ static inline void test_eltwise_common(std::vector<float> &src,
     //if the memory cache runs correctly
     std::vector<float> dst2(dst.size(), 0.0);
 
-    test_tensor src_ts2(src_lt, eng, src);
-    test_tensor dst_ts2(lt, eng, dst2);
+    test_tensor_t src_ts2(src_lt, eng, src);
+    test_tensor_t dst_ts2(lt, eng, dst2);
 
     cp.execute(strm, {src_ts2.get()}, {dst_ts2.get()});
     strm->wait();
@@ -225,15 +225,15 @@ static inline void test_eltwise_bwd_common(
     std::vector<const graph::logical_tensor_t *> outputs {&diff_src_lt};
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor fwd_data_ts(fwd_data_lt, eng, fwd_data);
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst_data);
-    test_tensor diff_src_ts(diff_src_lt, eng, diff_src_data);
+    test_tensor_t fwd_data_ts(fwd_data_lt, eng, fwd_data);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst_data);
+    test_tensor_t diff_src_ts(diff_src_lt, eng, diff_src_data);
 
-    std::vector<test_tensor> input_ts {fwd_data_ts, diff_dst_ts};
-    std::vector<test_tensor> output_ts {diff_src_ts};
+    std::vector<test_tensor_t> input_ts {fwd_data_ts, diff_dst_ts};
+    std::vector<test_tensor_t> output_ts {diff_src_ts};
     graph::stream_t *strm = get_stream();
-    cp.execute(strm, test_tensor::to_graph_tensor(input_ts),
-            test_tensor::to_graph_tensor(output_ts));
+    cp.execute(strm, test_tensor_t::to_graph_tensor(input_ts),
+            test_tensor_t::to_graph_tensor(output_ts));
     strm->wait();
     diff_src_data = diff_src_ts.as_vec_type<float>();
     for (size_t i = 0; i < diff_src_data.size(); ++i) {
@@ -723,8 +723,8 @@ TEST(test_eltwise_execute_subgraph_fp32, Shuffle) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> dst_data(product(reshape1_dst_shape));
-        test_tensor reshape0_src_ts(reshape0_src, engine, src_data);
-        test_tensor reshape1_dst_ts(reshape1_dst, engine, dst_data);
+        test_tensor_t reshape0_src_ts(reshape0_src, engine, src_data);
+        test_tensor_t reshape1_dst_ts(reshape1_dst, engine, dst_data);
 
         cp.execute(strm, {reshape0_src_ts.get()}, {reshape1_dst_ts.get()});
         strm->wait();
@@ -786,9 +786,9 @@ TEST(test_eltwise_execute_subgraph_fp32, ReciprocalMul) {
     cp.query_logical_tensor(mul_dst.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src0_ts(src0, eng, src0_data);
-    test_tensor src1_ts(src1, eng, src1_data);
-    test_tensor dst_ts(lt, eng, dst_data);
+    test_tensor_t src0_ts(src0, eng, src0_data);
+    test_tensor_t src1_ts(src1, eng, src1_data);
+    test_tensor_t dst_ts(lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()}),
@@ -893,12 +893,12 @@ TEST(test_eltwise_execute, Sum) {
     std::vector<float> input4_data(product(input_dims), 1);
     std::vector<float> output_data(product(input_dims), 0);
 
-    test_tensor input0_ts(input0, engine, input0_data);
-    test_tensor input1_ts(input1, engine, input1_data);
-    test_tensor input2_ts(input2, engine, input2_data);
-    test_tensor input3_ts(input3, engine, input3_data);
-    test_tensor input4_ts(input4, engine, input4_data);
-    test_tensor output_ts(output3, engine, output_data);
+    test_tensor_t input0_ts(input0, engine, input0_data);
+    test_tensor_t input1_ts(input1, engine, input1_data);
+    test_tensor_t input2_ts(input2, engine, input2_data);
+    test_tensor_t input3_ts(input3, engine, input3_data);
+    test_tensor_t input4_ts(input4, engine, input4_data);
+    test_tensor_t output_ts(output3, engine, output_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -1038,9 +1038,9 @@ public:
         cp.query_logical_tensor(eltwise_src_lt.id, &esrc_lt);
         cp.query_logical_tensor(binary_src_lt.id, &bsrc_lt);
         cp.query_logical_tensor(binary_dst_lt.id, &bdst_lt);
-        test_tensor src_ts(esrc_lt, eng, src);
-        test_tensor binary_src_ts(bsrc_lt, eng, binary_src);
-        test_tensor binary_dst_ts(bdst_lt, eng);
+        test_tensor_t src_ts(esrc_lt, eng, src);
+        test_tensor_t binary_src_ts(bsrc_lt, eng, binary_src);
+        test_tensor_t binary_dst_ts(bdst_lt, eng);
 
         graph::stream_t *strm = get_stream();
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_group_norm.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_group_norm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -96,12 +96,12 @@ TEST(test_group_norm_execute, GroupnormTraining) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scale_ts(scale_lt, eng, scale);
-    test_tensor shift_ts(shift_lt, eng, shift);
-    test_tensor dst_ts(dst_lt, eng, dst);
-    test_tensor mean_ts(mean_lt, eng, mean);
-    test_tensor var_ts(variance_lt, eng, var);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scale_ts(scale_lt, eng, scale);
+    test_tensor_t shift_ts(shift_lt, eng, shift);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
+    test_tensor_t mean_ts(mean_lt, eng, mean);
+    test_tensor_t var_ts(variance_lt, eng, var);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), scale_ts.get(), shift_ts.get()},
@@ -182,10 +182,10 @@ TEST(test_group_norm_execute, GroupnormInference) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scale_ts(scale_lt, eng, scale);
-    test_tensor shift_ts(shift_lt, eng, shift);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scale_ts(scale_lt, eng, scale);
+    test_tensor_t shift_ts(shift_lt, eng, shift);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), scale_ts.get(), shift_ts.get()},
@@ -289,11 +289,11 @@ TEST(test_group_norm_execute, GroupnormSwishTypecastQuant) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scale_ts(scale_lt, eng, scale);
-    test_tensor shift_ts(shift_lt, eng, shift);
-    test_tensor dst_ts(quant_dst_lt, eng);
-    test_tensor ref_dst_ts(quant_dst_lt, eng);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scale_ts(scale_lt, eng, scale);
+    test_tensor_t shift_ts(shift_lt, eng, shift);
+    test_tensor_t dst_ts(quant_dst_lt, eng);
+    test_tensor_t ref_dst_ts(quant_dst_lt, eng);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), scale_ts.get(), shift_ts.get()},

--- a/tests/gtests/graph/unit/backend/dnnl/test_interpolate.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_interpolate.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,8 +69,8 @@ TEST(test_interpolate_execute, InterpolateForwardNearest) {
     graph::logical_tensor_t lt;
     cp.query_logical_tensor(dst_lt.id, &lt);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(lt, engine, dst);
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
     strm->wait();
     dst = dst_ts.as_vec_type<float>();
@@ -137,9 +137,9 @@ TEST(test_interpolate_execute, InterpolateAddForwardNearest) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor src1_ts(src1_lt, engine, src1);
-    test_tensor dst_add_ts(*lt_outs[0], engine, dst_add);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t src1_ts(src1_lt, engine, src1);
+    test_tensor_t dst_add_ts(*lt_outs[0], engine, dst_add);
     cp.execute(strm, {src_ts.get(), src1_ts.get()}, {dst_add_ts.get()});
     strm->wait();
     dst_add = dst_add_ts.as_vec_type<float>();
@@ -207,8 +207,8 @@ TEST(test_interpolate_execute, InterpolateSwish) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_mul_ts(*lt_outs[0], engine, dst_mul);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_mul_ts(*lt_outs[0], engine, dst_mul);
     cp.execute(strm, {src_ts.get()}, {dst_mul_ts.get()});
     strm->wait();
 }
@@ -280,9 +280,9 @@ TEST(test_interpolate_execute, Interpolate3PostOps) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor src_div_ts(src_div_lt, engine, src_div);
-    test_tensor dst_div_ts(dst_div_lt, engine, dst_div);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t src_div_ts(src_div_lt, engine, src_div);
+    test_tensor_t dst_div_ts(dst_div_lt, engine, dst_div);
     cp.execute(strm, {src_ts.get(), src_div_ts.get()}, {dst_div_ts.get()});
     strm->wait();
 }
@@ -397,9 +397,9 @@ TEST(test_interpolate_execute, InterpolatePostOps) {
 
         p.compile(&cp, lt_ins, lt_outs, engine);
 
-        test_tensor src_ts(src_lt, engine, src);
-        test_tensor src1_ts(src1_lt, engine, src1);
-        test_tensor dst_add_ts(*lt_outs[0], engine, dst_add);
+        test_tensor_t src_ts(src_lt, engine, src);
+        test_tensor_t src1_ts(src1_lt, engine, src1);
+        test_tensor_t dst_add_ts(*lt_outs[0], engine, dst_add);
         if (std::find(
                     two_inputs_ops.begin(), two_inputs_ops.end(), post_op_kind)
                 != two_inputs_ops.end()) {
@@ -458,8 +458,8 @@ TEST(test_interpolate_execute, InterpolateForwardLinear) {
     graph::logical_tensor_t dst_lt_tmp;
     cp.query_logical_tensor(dst_lt.id, &dst_lt_tmp);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(dst_lt_tmp, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(dst_lt_tmp, engine, dst);
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
     strm->wait();
     dst = dst_ts.as_vec_type<float>();
@@ -510,9 +510,9 @@ TEST(test_interpolate_execute, InterpolateBackwardNearest) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-    test_tensor diff_src_ts(diff_src_lt, eng, diff_src);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(diff_src_lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), diff_dst_ts.get()}, {diff_src_ts.get()});
@@ -566,9 +566,9 @@ TEST(test_interpolate_execute, InterpolateBackwardLinear) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-    test_tensor diff_src_ts(diff_src_lt, eng, diff_src);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(diff_src_lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), diff_dst_ts.get()}, {diff_src_ts.get()});

--- a/tests/gtests/graph/unit/backend/dnnl/test_large_partition.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_large_partition.cpp
@@ -57,7 +57,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2Block) {
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     graph::graph_t g(eng->kind());
     utils::construct_int8_resnet50_stage2_block(
             &g, id_gen, 3, false, false, 1.2f, 1, 0);
@@ -93,7 +93,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2Block) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts, ref_outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts, ref_outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -110,8 +110,8 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2Block) {
     ASSERT_EQ(run_graph(g, inputs_ts, ref_outputs_ts, *eng, *strm),
             graph::status::success);
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 
@@ -124,7 +124,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithZeroZps) {
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     graph::graph_t g(eng->kind());
     int64_t zps_postbinary = eng->kind() == graph::engine_kind::gpu ? 0 : 78;
     utils::construct_int8_resnet50_stage2_block(
@@ -161,7 +161,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithZeroZps) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts, ref_outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts, ref_outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -178,8 +178,8 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithZeroZps) {
     ASSERT_EQ(run_graph(g, inputs_ts, ref_outputs_ts, *eng, *strm),
             graph::status::success);
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 
@@ -192,7 +192,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithQuantWei) {
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     graph::graph_t g(eng->kind());
     utils::construct_int8_resnet50_stage2_block(&g, id_gen, 3, true, true);
     g.finalize();
@@ -227,7 +227,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithQuantWei) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -240,8 +240,8 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithQuantWei) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -250,7 +250,7 @@ TEST(test_large_partition_execute, F32Resnet50Stage2Block) {
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     graph::graph_t g(eng->kind());
     utils::construct_f32_resnet50_stage2_block(
             &g, id_gen, 3, /* use biasadd */ true);
@@ -290,7 +290,7 @@ TEST(test_large_partition_execute, F32Resnet50Stage2Block) {
 
     std::vector<std::vector<float>> inputs_data;
     std::vector<std::vector<float>> outputs_data, ref_outputs_data;
-    std::vector<test_tensor> inputs_ts, outputs_ts, ref_outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts, ref_outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_data.emplace_back(
@@ -318,18 +318,18 @@ TEST(test_large_partition_execute, F32Resnet50Stage2Block) {
     ASSERT_EQ(run_graph(g, inputs_ts, ref_outputs_ts, *eng, *strm),
             graph::status::success);
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     // execute another iteration to test constant cache hit
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     // disable constant tensor cache and then to test constant cache miss
     dnnl::graph::set_constant_tensor_cache_capacity(
             static_cast<engine::kind>(eng->kind()), 0);
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 
@@ -342,7 +342,7 @@ TEST(test_large_partition_execute, ItexInt8Resnet50Stage2Block) {
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     graph::graph_t g(eng->kind());
     utils::construct_itex_int8_resnet50_stage2_block(&g, id_gen, 3);
     g.finalize();
@@ -378,7 +378,7 @@ TEST(test_large_partition_execute, ItexInt8Resnet50Stage2Block) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -392,12 +392,12 @@ TEST(test_large_partition_execute, ItexInt8Resnet50Stage2Block) {
     }
 
     std::cout << "----------------iter 1----------------\n";
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     std::cout << "----------------iter 2----------------\n";
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -517,7 +517,7 @@ TEST(test_large_partition_execute, Int8Mha_CPU) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -530,8 +530,8 @@ TEST(test_large_partition_execute, Int8Mha_CPU) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -574,7 +574,7 @@ TEST(test_large_partition_execute, Int8DistilBertMha) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -587,8 +587,8 @@ TEST(test_large_partition_execute, Int8DistilBertMha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -631,7 +631,7 @@ TEST(test_large_partition_execute, Int8GptMha) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -644,8 +644,8 @@ TEST(test_large_partition_execute, Int8GptMha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -690,7 +690,7 @@ TEST(test_large_partition_execute, F32Mha) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -703,8 +703,8 @@ TEST(test_large_partition_execute, F32Mha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -751,7 +751,7 @@ TEST(test_large_partition_execute, F32DistilBertMha) {
 
     using ltw = graph::logical_tensor_wrapper_t;
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -768,8 +768,8 @@ TEST(test_large_partition_execute, F32DistilBertMha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -815,7 +815,7 @@ TEST(test_large_partition_execute, F32GptMha) {
 
     using ltw = graph::logical_tensor_wrapper_t;
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -832,8 +832,8 @@ TEST(test_large_partition_execute, F32GptMha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -876,7 +876,7 @@ TEST(test_large_partition_execute, F32JaxMha) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -889,8 +889,8 @@ TEST(test_large_partition_execute, F32JaxMha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -938,7 +938,7 @@ TEST(test_large_partition_execute, F32JaxMqa) {
     // Set back to avoid affecting other tests
     custom_setenv("_ONEDNN_GRAPH_SDPA_FORCE_PRIMITIVE", "0", 1);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -951,8 +951,8 @@ TEST(test_large_partition_execute, F32JaxMqa) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -1026,7 +1026,7 @@ TEST(test_large_partition_execute, Bf16Mha_CPU) {
     using ltw = graph::logical_tensor_wrapper_t;
 
     std::vector<std::vector<uint16_t>> inputs_data;
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         // set all the input value to 1.f, then the value after softmax should
@@ -1042,8 +1042,8 @@ TEST(test_large_partition_execute, Bf16Mha_CPU) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 
@@ -1101,7 +1101,7 @@ TEST(test_large_partition_execute, Bf16GptMha) {
 
     using ltw = graph::logical_tensor_wrapper_t;
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -1118,8 +1118,8 @@ TEST(test_large_partition_execute, Bf16GptMha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -1172,7 +1172,7 @@ TEST(test_large_partition_execute, Bf16DistilBertMha) {
 
     using ltw = graph::logical_tensor_wrapper_t;
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
@@ -1189,8 +1189,8 @@ TEST(test_large_partition_execute, Bf16DistilBertMha) {
         outputs_ts.emplace_back(compiled_output, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -1237,7 +1237,7 @@ TEST(test_large_partition_execute, Int8Bf16Mha_CPU) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : partition_inputs) {
         inputs_ts.emplace_back(lt, eng);
@@ -1247,8 +1247,8 @@ TEST(test_large_partition_execute, Int8Bf16Mha_CPU) {
         outputs_ts.emplace_back(lt, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -1296,7 +1296,7 @@ TEST(test_large_partition_execute, Int8Bf16DistilBertMha_CPU) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : partition_inputs) {
         inputs_ts.emplace_back(lt, eng);
@@ -1306,8 +1306,8 @@ TEST(test_large_partition_execute, Int8Bf16DistilBertMha_CPU) {
         outputs_ts.emplace_back(lt, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -1355,7 +1355,7 @@ TEST(test_large_partition_execute, Int8Bf16GptMha_CPU) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
 
     for (auto &lt : partition_inputs) {
         inputs_ts.emplace_back(lt, eng);
@@ -1365,8 +1365,8 @@ TEST(test_large_partition_execute, Int8Bf16GptMha_CPU) {
         outputs_ts.emplace_back(lt, eng);
     }
 
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }

--- a/tests/gtests/graph/unit/backend/dnnl/test_layer_norm.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_layer_norm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -131,12 +131,12 @@ TEST(test_layer_norm_execute, LayernormTraining) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scale_ts(scale_lt, eng, scale);
-    test_tensor shift_ts(shift_lt, eng, shift);
-    test_tensor dst_ts(dst_lt, eng, dst);
-    test_tensor mean_ts(mean_lt, eng, mean);
-    test_tensor var_ts(variance_lt, eng, var);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scale_ts(scale_lt, eng, scale);
+    test_tensor_t shift_ts(shift_lt, eng, shift);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
+    test_tensor_t mean_ts(mean_lt, eng, mean);
+    test_tensor_t var_ts(variance_lt, eng, var);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), scale_ts.get(), shift_ts.get()},
@@ -207,10 +207,10 @@ TEST(test_layer_norm_execute, LayernormInference) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scale_ts(scale_lt, eng, scale);
-    test_tensor shift_ts(shift_lt, eng, shift);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scale_ts(scale_lt, eng, scale);
+    test_tensor_t shift_ts(shift_lt, eng, shift);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), scale_ts.get(), shift_ts.get()},
@@ -265,8 +265,8 @@ TEST(test_layer_norm_execute, LayernormInferenceWithoutScaleShift) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -383,26 +383,26 @@ TEST(test_layer_norm_execute, LayerNormBackwardFp32) {
         ASSERT_EQ(inplace_pairs[0].input_id, diff_dst.id);
         ASSERT_EQ(inplace_pairs[0].output_id, diff_src.id);
 
-        test_tensor src_ts(src, engine, src_data);
-        test_tensor diff_dst_ts(diff_dst, engine,
+        test_tensor_t src_ts(src, engine, src_data);
+        test_tensor_t diff_dst_ts(diff_dst, engine,
                 use_affine ? diff_dst_data : diff_dst_data_no_affine);
-        test_tensor mean_ts(mean, engine, mean_data);
-        test_tensor var_ts(var, engine, var_data);
-        test_tensor scale_ts(scale, engine, scale_data);
-        test_tensor diff_src_ts(diff_src, engine, diff_src_data);
-        test_tensor diff_scale_ts(diff_scale, engine, diff_scale_data);
-        test_tensor diff_shift_ts(diff_shift, engine, diff_shift_data);
+        test_tensor_t mean_ts(mean, engine, mean_data);
+        test_tensor_t var_ts(var, engine, var_data);
+        test_tensor_t scale_ts(scale, engine, scale_data);
+        test_tensor_t diff_src_ts(diff_src, engine, diff_src_data);
+        test_tensor_t diff_scale_ts(diff_scale, engine, diff_scale_data);
+        test_tensor_t diff_shift_ts(diff_shift, engine, diff_shift_data);
 
-        std::vector<test_tensor> inputs_ts {
+        std::vector<test_tensor_t> inputs_ts {
                 src_ts, diff_dst_ts, mean_ts, var_ts, scale_ts};
-        std::vector<test_tensor> outputs_ts {diff_src_ts};
+        std::vector<test_tensor_t> outputs_ts {diff_src_ts};
         if (use_affine) {
             outputs_ts.push_back(diff_scale_ts);
             outputs_ts.push_back(diff_shift_ts);
         }
 
-        cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                test_tensor::to_graph_tensor(outputs_ts));
+        cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                test_tensor_t::to_graph_tensor(outputs_ts));
         strm->wait();
 
         const float abs_err {0.001f};
@@ -508,11 +508,11 @@ TEST(test_layer_norm_execute_subgraph_int8, LayernormTypecastQuant_CPU) {
     std::vector<float> scale(product(scale_lt_shape));
     std::vector<float> shift(product(shift_lt_shape));
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor scale_ts(scale_lt, engine, scale);
-    test_tensor shift_ts(shift_lt, engine, shift);
-    test_tensor dst_ts(quant_dst, engine);
-    test_tensor ref_ts(quant_dst, engine);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t scale_ts(scale_lt, engine, scale);
+    test_tensor_t shift_ts(shift_lt, engine, shift);
+    test_tensor_t dst_ts(quant_dst, engine);
+    test_tensor_t ref_ts(quant_dst, engine);
 
     ASSERT_EQ(run_graph(g, {src_ts, scale_ts, shift_ts}, {ref_ts}, *engine,
                       *strm),

--- a/tests/gtests/graph/unit/backend/dnnl/test_matmul.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_matmul.cpp
@@ -77,10 +77,10 @@ TEST(test_matmul_execute, MatmulFp32) {
 
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor bias_ts(bias, eng, bias_data);
-    test_tensor dst_ts(dst, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t bias_ts(bias, eng, bias_data);
+    test_tensor_t dst_ts(dst, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -99,10 +99,10 @@ TEST(test_matmul_execute, MatmulFp32) {
     std::vector<float> ref_dst_data2 {5};
     std::vector<float> dst_data2(ref_dst_data2.size(), 0.0);
 
-    test_tensor src_ts2(src, eng, src_data2);
-    test_tensor weight_ts2(weight, eng, weight_data2);
-    test_tensor bias_ts2(bias, eng, bias_data2);
-    test_tensor dst_ts2(dst, eng, dst_data2);
+    test_tensor_t src_ts2(src, eng, src_data2);
+    test_tensor_t weight_ts2(weight, eng, weight_data2);
+    test_tensor_t bias_ts2(bias, eng, bias_data2);
+    test_tensor_t dst_ts2(dst, eng, dst_data2);
 
     cp.execute(strm, {src_ts2.get(), weight_ts2.get(), bias_ts2.get()},
             {dst_ts2.get()});
@@ -162,9 +162,9 @@ TEST(test_matmul_execute, MatmulF16F16F16_GPU) {
 
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor dst_ts(dst, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t dst_ts(dst, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -217,9 +217,9 @@ TEST(test_matmul_execute, MatmulBf16Bf16Bf16) {
 
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor dst_ts(dst, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t dst_ts(dst, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -399,9 +399,9 @@ TEST(test_matmul_execute, MatmulNdx1d) {
             ASSERT_EQ(p.compile(&cp, inputs, outputs, engine),
                     graph::status::success);
 
-            test_tensor src_ts(src, engine, src_data);
-            test_tensor weight_ts(weight, engine, weight_data);
-            test_tensor dst_ts(dst, engine, dst_data);
+            test_tensor_t src_ts(src, engine, src_data);
+            test_tensor_t weight_ts(weight, engine, weight_data);
+            test_tensor_t dst_ts(dst, engine, dst_data);
 
             ASSERT_EQ(cp.execute(strm, {src_ts.get(), weight_ts.get()},
                               {dst_ts.get()}),
@@ -494,9 +494,9 @@ TEST(test_matmul_execute, Matmul1dxNd) {
 
             p.compile(&cp, inputs, outputs, engine);
 
-            test_tensor src_ts(src, engine, src_data);
-            test_tensor weight_ts(weight, engine, weight_data);
-            test_tensor dst_ts(dst, engine, dst_data);
+            test_tensor_t src_ts(src, engine, src_data);
+            test_tensor_t weight_ts(weight, engine, weight_data);
+            test_tensor_t dst_ts(dst, engine, dst_data);
 
             cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
             strm->wait();
@@ -564,9 +564,9 @@ TEST(test_matmul_execute, Matmul3dx3d) {
 
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor dst_ts(dst, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t dst_ts(dst, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -631,10 +631,10 @@ TEST(test_matmul_execute, MatmulBiasAdd) {
     p.compile(&cp, inputs, outputs, engine);
     cp.query_logical_tensor(add_dst.id, &add_dst);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor post_src_ts(post_src, engine, post_src_data);
-    test_tensor dst_ts(add_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t post_src_ts(post_src, engine, post_src_data);
+    test_tensor_t dst_ts(add_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), post_src_ts.get()},
@@ -707,11 +707,11 @@ TEST(test_matmul_execute, MatmulBiasAddPerTensorBroadcast) {
 
         p.compile(&cp, inputs, outputs, engine);
 
-        test_tensor src_ts(src, engine, src_data);
-        test_tensor weight_ts(weight, engine, weight_data);
-        test_tensor bias_ts(bias, engine, bias_data);
-        test_tensor post_src_ts(post_src, engine, post_src_data);
-        test_tensor dst_ts(add_dst, engine, dst_data);
+        test_tensor_t src_ts(src, engine, src_data);
+        test_tensor_t weight_ts(weight, engine, weight_data);
+        test_tensor_t bias_ts(bias, engine, bias_data);
+        test_tensor_t post_src_ts(post_src, engine, post_src_data);
+        test_tensor_t dst_ts(add_dst, engine, dst_data);
 
         cp.execute(strm,
                 {src_ts.get(), weight_ts.get(), bias_ts.get(),
@@ -785,11 +785,11 @@ TEST(test_matmul_execute, MatmulBiasAddPerChannelBroadcast) {
 
         p.compile(&cp, inputs, outputs, engine);
 
-        test_tensor src_ts(src, engine, src_data);
-        test_tensor weight_ts(weight, engine, weight_data);
-        test_tensor bias_ts(bias, engine, bias_data);
-        test_tensor post_src_ts(post_src, engine, post_src_data);
-        test_tensor dst_ts(add_dst, engine, dst_data);
+        test_tensor_t src_ts(src, engine, src_data);
+        test_tensor_t weight_ts(weight, engine, weight_data);
+        test_tensor_t bias_ts(bias, engine, bias_data);
+        test_tensor_t post_src_ts(post_src, engine, post_src_data);
+        test_tensor_t dst_ts(add_dst, engine, dst_data);
 
         cp.execute(strm,
                 {src_ts.get(), weight_ts.get(), bias_ts.get(),
@@ -1066,13 +1066,13 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2d) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
 
         // -------------------------case 1----------------------------------
         std::vector<int8_t> case1_out_data(product(dst_shape));
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
                           {dst_s8_ts}, *engine, *strm),
                 graph::status::success);
@@ -1097,7 +1097,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2d) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<int8_t> case2_out_data(product(dst_shape));
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get()},
                 {dst_s8_case2_ts.get()});
@@ -1210,13 +1210,13 @@ TEST(test_matmul_execute_subgraph_int8, MatmulU8U8) {
         g.add_op(&matmul_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_u8_ts(weight_u8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_u8_ts(weight_u8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(dst_shape));
-        test_tensor dst_f32_ts(dst_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_ts(dst_f32, engine, case1_out_data);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_u8_ts, bias_f32_ts},
                           {dst_f32_ts}, *engine, *strm),
                 graph::status::success);
@@ -1240,7 +1240,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulU8U8) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(dst_shape));
-        test_tensor dst_f32_case2_ts(dst_f32, engine, case2_out_data);
+        test_tensor_t dst_f32_case2_ts(dst_f32, engine, case2_out_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_u8_ts.get(), bias_f32_ts.get()},
                 {dst_f32_case2_ts.get()});
@@ -1363,11 +1363,11 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx1d) {
             g.add_op(&qout_op);
             g.finalize();
 
-            test_tensor src_u8_ts(src_u8, engine, src_data);
-            test_tensor weight_s8_ts(weight_s8, engine, weight_data);
+            test_tensor_t src_u8_ts(src_u8, engine, src_data);
+            test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
             // -------------------------case 1----------------------------------
             std::vector<int8_t> case1_out_data(product(dst_shape));
-            test_tensor dst_s8_case1_ts(dst_s8, engine, case1_out_data);
+            test_tensor_t dst_s8_case1_ts(dst_s8, engine, case1_out_data);
             ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts}, {dst_s8_case1_ts},
                               *engine, *strm),
                     graph::status::success);
@@ -1392,7 +1392,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx1d) {
             p.compile(&cp, lt_ins, lt_outs, engine);
 
             std::vector<int8_t> case2_out_data(product(dst_shape));
-            test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+            test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
             cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get()},
                     {dst_s8_case2_ts.get()});
             strm->wait();
@@ -1526,12 +1526,13 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2dWithTranspose) {
             g.add_op(&qout_op);
             g.finalize();
 
-            test_tensor src_u8_ts(src_u8, engine, src_data);
-            test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-            test_tensor bias_f32_ts = test_tensor(bias_f32, engine, bias_data);
+            test_tensor_t src_u8_ts(src_u8, engine, src_data);
+            test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+            test_tensor_t bias_f32_ts
+                    = test_tensor_t(bias_f32, engine, bias_data);
             // -------------------------case 1----------------------------------
             std::vector<int8_t> case1_out_data(product(dst_shape));
-            test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+            test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
             ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
                               {dst_s8_ts}, *engine, *strm),
                     graph::status::success);
@@ -1556,7 +1557,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2dWithTranspose) {
             p.compile(&cp, lt_ins, lt_outs, engine);
 
             std::vector<int8_t> case2_out_data(product(dst_shape));
-            test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+            test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
             cp.execute(strm,
                     {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get()},
                     {dst_s8_case2_ts.get()});
@@ -1729,13 +1730,13 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasSumNdx2d) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-        test_tensor other_s8_ts(other_s8, engine, other_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_data);
         // -------------------------case 1----------------------------------
         std::vector<int8_t> case1_out_data(product(dst_shape));
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
         ASSERT_EQ(run_graph(g,
                           {src_u8_ts, weight_s8_ts, bias_f32_ts, other_s8_ts},
                           {dst_s8_ts}, *engine, *strm),
@@ -1763,7 +1764,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasSumNdx2d) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<int8_t> case2_out_data(product(dst_shape));
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get(),
                         other_s8_ts.get()},
@@ -1915,13 +1916,13 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasBinary) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-        test_tensor other_f32_ts(other_f32, engine, other_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t other_f32_ts(other_f32, engine, other_data);
         // -------------------------case 1----------------------------------
         std::vector<int8_t> case1_out_data(product(dst_shape));
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
         ASSERT_EQ(run_graph(g,
                           {src_u8_ts, weight_s8_ts, bias_f32_ts, other_f32_ts},
                           {dst_s8_ts}, *engine, *strm),
@@ -1946,7 +1947,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasBinary) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<int8_t> case2_out_data(product(dst_shape));
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get(),
                         other_f32_ts.get()},
@@ -2137,14 +2138,14 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasAddMul) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-        test_tensor add_other_s8_ts(other_s8, engine, add_other_data);
-        test_tensor mul_other_f32_ts(mul_src_f32, engine, mul_other_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t add_other_s8_ts(other_s8, engine, add_other_data);
+        test_tensor_t mul_other_f32_ts(mul_src_f32, engine, mul_other_data);
         // -------------------------case 1----------------------------------
         std::vector<int8_t> case1_out_data(product(dst_shape));
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
         ASSERT_EQ(run_graph(g,
                           {src_u8_ts, weight_s8_ts, bias_f32_ts,
                                   add_other_s8_ts, mul_other_f32_ts},
@@ -2173,7 +2174,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasAddMul) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<int8_t> case2_out_data(product(dst_shape));
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get(),
                         add_other_s8_ts.get(), mul_other_f32_ts.get()},
@@ -2286,12 +2287,12 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasNdx2dX8s8f32) {
         g.add_op(&matmul_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(dst_shape));
-        test_tensor dst_f32_ts(dst_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_ts(dst_f32, engine, case1_out_data);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
                           {dst_f32_ts}, *engine, *strm),
                 graph::status::success);
@@ -2314,7 +2315,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasNdx2dX8s8f32) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(dst_shape));
-        test_tensor dst_f32_case2_ts(dst_f32, engine, case2_out_data);
+        test_tensor_t dst_f32_case2_ts(dst_f32, engine, case2_out_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get()},
                 {dst_f32_case2_ts.get()});
@@ -2418,11 +2419,11 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2dX8s8f32) {
         g.add_op(&matmul_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(dst_shape));
-        test_tensor dst_f32_ts(dst_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_ts(dst_f32, engine, case1_out_data);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts}, {dst_f32_ts}, *engine,
                           *strm),
                 graph::status::success);
@@ -2445,7 +2446,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2dX8s8f32) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(dst_shape));
-        test_tensor dst_f32_case2_ts(dst_f32, engine, case2_out_data);
+        test_tensor_t dst_f32_case2_ts(dst_f32, engine, case2_out_data);
         cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get()},
                 {dst_f32_case2_ts.get()});
         strm->wait();
@@ -2564,12 +2565,12 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasGeluNdx2dX8s8f32) {
         g.add_op(&gelu_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(dst_shape));
-        test_tensor dst_f32_ts(gelu_f32, engine, case1_out_data);
+        test_tensor_t dst_f32_ts(gelu_f32, engine, case1_out_data);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts, bias_f32_ts},
                           {dst_f32_ts}, *engine, *strm),
                 graph::status::success);
@@ -2592,7 +2593,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasGeluNdx2dX8s8f32) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(dst_shape));
-        test_tensor dst_f32_case2_ts(gelu_f32, engine, case2_out_data);
+        test_tensor_t dst_f32_case2_ts(gelu_f32, engine, case2_out_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get()},
                 {dst_f32_case2_ts.get()});
@@ -2819,11 +2820,11 @@ TEST(test_matmul_execute_subgraph_int8, Matmul2dx3dWithTranspose) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         // execute
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
         std::vector<int8_t> dst_data(product(dst_shape));
-        test_tensor dst_s8_ts(dst_s8, engine, dst_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, dst_data);
         cp.execute(strm,
                 {src_u8_ts.get(), weight_s8_ts.get(), bias_f32_ts.get()},
                 {dst_s8_ts.get()});
@@ -3163,10 +3164,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasU8s8bf16_CPU) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-    test_tensor bias_bf16_ts(bias_bf16, engine, bias_data);
-    test_tensor dst_ts(dst_bf16, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t bias_bf16_ts(bias_bf16, engine, bias_data);
+    test_tensor_t dst_ts(dst_bf16, engine);
     cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get(), bias_bf16_ts.get()},
             {dst_ts.get()});
     strm->wait();
@@ -3275,9 +3276,9 @@ TEST(test_matmul_execute_subgraph_int8, MatmulU8U8bf16) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_s8_ts(weight_u8, engine, weight_data);
-    test_tensor dst_ts(dst_bf16, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_u8, engine, weight_data);
+    test_tensor_t dst_ts(dst_bf16, engine);
     cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get()}, {dst_ts.get()});
     strm->wait();
 }
@@ -3411,11 +3412,11 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasAddBF16U8s8bf16_CPU) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-    test_tensor bias_bf16_ts(bias_bf16, engine, bias_data);
-    test_tensor other_bf16_ts(other_bf16, engine, other_data);
-    test_tensor dst_ts(dst_bf16, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t bias_bf16_ts(bias_bf16, engine, bias_data);
+    test_tensor_t other_bf16_ts(other_bf16, engine, other_data);
+    test_tensor_t dst_ts(dst_bf16, engine);
     cp.execute(strm,
             {src_u8_ts.get(), weight_s8_ts.get(), bias_bf16_ts.get(),
                     other_bf16_ts.get()},
@@ -3582,11 +3583,11 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasaddAddBF16U8s8bf16_CPU) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-    test_tensor other_bf16_ts(other_bf16, engine, other_data);
-    test_tensor dst_ts(dst_bf16, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t other_bf16_ts(other_bf16, engine, other_data);
+    test_tensor_t dst_ts(dst_bf16, engine);
     cp.execute(strm,
             {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get(),
                     other_bf16_ts.get()},
@@ -3727,10 +3728,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasU8s8u8MixBf16) {
     p.compile(&cp, lt_ins, lt_outs, engine);
 
     std::vector<uint8_t> dst_data(product(dst_shape));
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-    test_tensor bias_bf16_ts(bias_bf16, engine, bias_data);
-    test_tensor dst_ts(dst_u8, engine, dst_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t bias_bf16_ts(bias_bf16, engine, bias_data);
+    test_tensor_t dst_ts(dst_u8, engine, dst_data);
     cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get(), bias_bf16_ts.get()},
             {dst_ts.get()});
     strm->wait();
@@ -3899,10 +3900,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasaddU8s8u8MixBf16) {
     p.compile(&cp, lt_ins, lt_outs, engine);
 
     std::vector<uint8_t> dst_data(product(dst_shape));
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-    test_tensor dst_ts(dst_u8, engine, dst_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t dst_ts(dst_u8, engine, dst_data);
     cp.execute(strm, {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
             {dst_ts.get()});
     strm->wait();
@@ -4060,10 +4061,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasGeluU8s8u8MixBf16) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
-    test_tensor bias_bf16_ts(bias_bf16, engine, bias_data);
-    test_tensor dst_ts(dst_u8, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t bias_bf16_ts(bias_bf16, engine, bias_data);
+    test_tensor_t dst_ts(dst_u8, engine);
     cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get(), bias_bf16_ts.get()},
             {dst_ts.get()});
     strm->wait();
@@ -4238,10 +4239,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasaddGeluU8s8u8MixBf16) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_bf32_ts(bias_f32, engine, bias_data);
-    test_tensor dst_ts(dst_u8, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_bf32_ts(bias_f32, engine, bias_data);
+    test_tensor_t dst_ts(dst_u8, engine);
     cp.execute(strm, {src_u8_ts.get(), weight_f32_ts.get(), bias_bf32_ts.get()},
             {dst_ts.get()});
     strm->wait();
@@ -4327,9 +4328,9 @@ TEST(test_matmul_execute, MatmulTransposeReorder) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_f32_ts(src_f32, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor dst_ts(reorder_f32, engine);
+    test_tensor_t src_f32_ts(src_f32, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t dst_ts(reorder_f32, engine);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(
                 strm, {src_f32_ts.get(), weight_f32_ts.get()}, {dst_ts.get()});
@@ -4483,11 +4484,11 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasTransposeReorder) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
     std::vector<int8_t> dst_out_data(product(dst_shape));
-    test_tensor dst_ts(dst_s8, engine, dst_out_data);
+    test_tensor_t dst_ts(dst_s8, engine, dst_out_data);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(strm,
                 {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -4657,10 +4658,10 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMixBf16MatmulTransposeReorder) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
     std::vector<int8_t> dst_out_data(product(dst_shape));
-    test_tensor dst_ts(dst_s8, engine, dst_out_data);
+    test_tensor_t dst_ts(dst_s8, engine, dst_out_data);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(
                 strm, {src_u8_ts.get(), weight_f32_ts.get()}, {dst_ts.get()});
@@ -4716,9 +4717,9 @@ TEST(test_matmul_execute, MatmulScalarOutput) {
     ASSERT_EQ(scalar_lt.layout_type, graph::layout_type::strided);
     ASSERT_EQ(scalar_lt.ndims, 0);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor dst_ts(scalar_lt, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t dst_ts(scalar_lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()}),
@@ -4909,13 +4910,13 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasSumNdx2d) {
         // set bias to be constant
         bias_f32.property = graph::property_type::constant;
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-        test_tensor other_s8_ts(other_s8, engine, other_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
         // -------------------------case 1----------------------------------
         std::vector<int8_t> case1_out_data(product(dst_shape));
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
         ASSERT_EQ(run_graph(g,
                           {src_u8_ts, weight_f32_ts, bias_f32_ts, other_s8_ts},
                           {dst_s8_ts}, *engine, *strm),
@@ -4943,7 +4944,7 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasSumNdx2d) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<int8_t> case2_out_data(product(dst_shape));
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
         for (size_t iter = 0; iter < 5; iter++) {
             cp.execute(strm,
                     {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get(),
@@ -5089,12 +5090,12 @@ TEST(test_matmul_execute_subgraph_int8, U8S8U8MatmulAddF32) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-        test_tensor other_f32_ts(other_f32, engine, other_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+        test_tensor_t other_f32_ts(other_f32, engine, other_data);
         // -------------------------case 1----------------------------------
         std::vector<int8_t> case1_out_data(product(dst_shape));
-        test_tensor dst_u8_ts(dst_u8, engine, case1_out_data);
+        test_tensor_t dst_u8_ts(dst_u8, engine, case1_out_data);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_f32_ts, other_f32_ts},
                           {dst_u8_ts}, *engine, *strm),
                 graph::status::success);
@@ -5118,7 +5119,7 @@ TEST(test_matmul_execute_subgraph_int8, U8S8U8MatmulAddF32) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<int8_t> case2_out_data(product(dst_shape));
-        test_tensor dst_u8_case2_ts(dst_u8, engine, case2_out_data);
+        test_tensor_t dst_u8_case2_ts(dst_u8, engine, case2_out_data);
         for (size_t iter = 0; iter < 5; iter++) {
             cp.execute(strm,
                     {src_u8_ts.get(), weight_f32_ts.get(), other_f32_ts.get()},
@@ -5272,12 +5273,12 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasNdx2dWithTranspose) {
         // set bias to be constant
         bias_f32.property = graph::property_type::constant;
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-        test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+        test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
         // -------------------------case 1----------------------------------
         std::vector<int8_t> case1_out_data(product(dst_shape));
-        test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+        test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_f32_ts, bias_f32_ts},
                           {dst_s8_ts}, *engine, *strm),
                 graph::status::success);
@@ -5300,7 +5301,7 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasNdx2dWithTranspose) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<int8_t> case2_out_data(product(dst_shape));
-        test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
         for (size_t iter = 0; iter < 1; iter++) {
             cp.execute(strm,
                     {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -5435,14 +5436,14 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasReluNdx2d) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine);
+        test_tensor_t src_u8_ts(src_u8, engine);
         src_u8_ts.fill<uint8_t>(20, 5);
-        test_tensor weight_f32_ts(weight_f32, engine);
+        test_tensor_t weight_f32_ts(weight_f32, engine);
         weight_f32_ts.fill<float>();
-        test_tensor bias_f32_ts(bias_f32, engine);
+        test_tensor_t bias_f32_ts(bias_f32, engine);
         bias_f32_ts.fill<float>();
         // -------------------------case 1----------------------------------
-        test_tensor dst_s8_ts(dst_s8, engine);
+        test_tensor_t dst_s8_ts(dst_s8, engine);
         ASSERT_EQ(run_graph(g, {src_u8_ts, weight_f32_ts, bias_f32_ts},
                           {dst_s8_ts}, *engine, *strm),
                 graph::status::success);
@@ -5466,7 +5467,7 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasReluNdx2d) {
 
         p.compile(&cp, lt_ins, lt_outs, engine);
 
-        test_tensor dst_s8_case2_ts(dst_s8, engine);
+        test_tensor_t dst_s8_case2_ts(dst_s8, engine);
         for (size_t iter = 0; iter < 5; iter++) {
             if (with_bias) {
                 cp.execute(strm,
@@ -5541,9 +5542,9 @@ TEST(test_matmul_execute, MatmulReluFusion) {
 
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor dst_ts(relu_dst, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t dst_ts(relu_dst, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()});
@@ -5600,10 +5601,10 @@ TEST(test_matmul_execute, MatmulBiasFusion) {
 
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor bias_ts(bias, eng, bias_data);
-    test_tensor dst_ts(dst, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t bias_ts(bias, eng, bias_data);
+    test_tensor_t dst_ts(dst, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -5668,10 +5669,10 @@ TEST(test_matmul_execute, MatmulSumBroadcast1d) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor add_src1_ts(add_src1, engine, add_src1_data);
-    test_tensor dst_ts(add_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t add_src1_ts(add_src1, engine, add_src1_data);
+    test_tensor_t dst_ts(add_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), add_src1_ts.get()},
@@ -5736,10 +5737,10 @@ TEST(test_matmul_execute, MatmulSumFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor add_src1_ts(add_src1, engine, add_src1_data);
-    test_tensor dst_ts(add_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t add_src1_ts(add_src1, engine, add_src1_data);
+    test_tensor_t dst_ts(add_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), add_src1_ts.get()},
@@ -5809,10 +5810,10 @@ TEST(test_matmul_execute, MatmulSumGeluFusion) {
 
     p.compile(&cp, inputs, outputs, eng);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor other_ts(other, eng, other_data);
-    test_tensor dst_ts(gelu_dst, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t other_ts(other, eng, other_data);
+    test_tensor_t dst_ts(gelu_dst, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), other_ts.get()},
@@ -5882,10 +5883,10 @@ TEST(test_matmul_execute, MatmulSumReluFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor other_ts(other, engine, other_data);
-    test_tensor dst_ts(relu_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t other_ts(other, engine, other_data);
+    test_tensor_t dst_ts(relu_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), other_ts.get()},
@@ -5948,10 +5949,10 @@ TEST(test_matmul_execute, MatmulBiasReluFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor dst_ts(relu_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t dst_ts(relu_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -6014,10 +6015,10 @@ TEST(test_matmul_execute, MatmulBiasGeluFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor dst_ts(gelu_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t dst_ts(gelu_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -6083,10 +6084,10 @@ TEST(test_matmul_execute, MatmulBiasRelu6Fusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor dst_ts(clamp_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t dst_ts(clamp_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -6152,10 +6153,10 @@ TEST(test_matmul_execute, MatmulBiasClampFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor dst_ts(clamp_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t dst_ts(clamp_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -6220,10 +6221,10 @@ TEST(test_matmul_execute, MatmulBiasEluFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor dst_ts(elu_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t dst_ts(elu_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -6286,10 +6287,10 @@ TEST(test_matmul_execute, MatmulBiasSigmoidFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor dst_ts(sigmoid_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t dst_ts(sigmoid_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), bias_ts.get()},
@@ -6357,11 +6358,11 @@ TEST(test_matmul_execute, MatmulBiasAddFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor post_src_ts(post_src, engine, post_src_data);
-    test_tensor dst_ts(add_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t post_src_ts(post_src, engine, post_src_data);
+    test_tensor_t dst_ts(add_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -6428,10 +6429,10 @@ TEST(test_matmul_execute, MatmulDivFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor div_src1_ts(div_src1, engine, div_src1_data);
-    test_tensor dst_ts(div_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
+    test_tensor_t dst_ts(div_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), weight_ts.get(), div_src1_ts.get()},
@@ -6507,11 +6508,11 @@ TEST(test_matmul_execute, MatmulDivAddFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor div_src1_ts(div_src1, engine, div_src1_data);
-    test_tensor add_src1_ts(add_src1, engine, add_src1_data);
-    test_tensor dst_ts(add_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
+    test_tensor_t add_src1_ts(add_src1, engine, add_src1_data);
+    test_tensor_t dst_ts(add_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -6604,11 +6605,11 @@ TEST(test_matmul_execute, MatmulSwapBinaryMulAddFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor div_src1_ts(div_src1, engine, div_src1_data);
-    test_tensor add_src1_ts(add_src1, engine, add_src1_data);
-    test_tensor dst_ts(add_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
+    test_tensor_t add_src1_ts(add_src1, engine, add_src1_data);
+    test_tensor_t dst_ts(add_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -6715,11 +6716,11 @@ TEST(test_matmul_execute_subgraph_int8, MatmulReluFusion) {
     g.add_op(&qout_op);
     g.finalize();
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
     // -------------------------case 1----------------------------------
     std::vector<int8_t> case1_out_data(product(dst_shape));
-    test_tensor dst_s8_ts(dst_s8, engine, case1_out_data);
+    test_tensor_t dst_s8_ts(dst_s8, engine, case1_out_data);
     ASSERT_EQ(run_graph(g, {src_u8_ts, weight_s8_ts}, {dst_s8_ts}, *engine,
                       *strm),
             graph::status::success);
@@ -6742,7 +6743,7 @@ TEST(test_matmul_execute_subgraph_int8, MatmulReluFusion) {
     p.compile(&cp, lt_ins, lt_outs, engine);
 
     std::vector<int8_t> case2_out_data(product(dst_shape));
-    test_tensor dst_s8_case2_ts(dst_s8, engine, case2_out_data);
+    test_tensor_t dst_s8_case2_ts(dst_s8, engine, case2_out_data);
     cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get()},
             {dst_s8_case2_ts.get()});
     strm->wait();
@@ -6904,10 +6905,10 @@ TEST(test_matmul_execute_subgraph_int8,
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-    test_tensor dst_s8_ts(dst_s8, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t dst_s8_ts(dst_s8, engine);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(strm,
                 {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -7065,11 +7066,11 @@ TEST(test_matmul_execute_subgraph_int8,
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
     std::vector<int8_t> dst_out_data(product(dst_shape));
-    test_tensor dst_s8_ts(dst_s8, engine, dst_out_data);
+    test_tensor_t dst_s8_ts(dst_s8, engine, dst_out_data);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(strm,
                 {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -7267,10 +7268,10 @@ TEST(test_matmul_execute_subgraph_int8,
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-    test_tensor dst_s8_ts(dst_s8, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t dst_s8_ts(dst_s8, engine);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(strm,
                 {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -7469,10 +7470,10 @@ TEST(test_matmul_execute_subgraph_int8,
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_u8_ts(src_u8, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-    test_tensor dst_s8_ts(dst_s8, engine);
+    test_tensor_t src_u8_ts(src_u8, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t dst_s8_ts(dst_s8, engine);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(strm,
                 {src_u8_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -7572,12 +7573,12 @@ TEST(test_matmul_execute, MatmulBiasReshapeTranspose) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_f32_ts(src_f32, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t src_f32_ts(src_f32, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
     graph::logical_tensor_t lt;
     cp.query_logical_tensor(transpose_f32.id, &lt);
-    test_tensor dst_f32_ts(lt, engine);
+    test_tensor_t dst_f32_ts(lt, engine);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(strm,
                 {src_f32_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -7678,10 +7679,10 @@ TEST(test_matmul_execute, MatmulBiasTransposeReshape) {
 
     p.compile(&cp, lt_ins, lt_outs, engine);
 
-    test_tensor src_f32_ts(src_f32, engine, src_data);
-    test_tensor weight_f32_ts(weight_f32, engine, weight_data);
-    test_tensor bias_f32_ts(bias_f32, engine, bias_data);
-    test_tensor dst_f32_ts(reshape_f32, engine);
+    test_tensor_t src_f32_ts(src_f32, engine, src_data);
+    test_tensor_t weight_f32_ts(weight_f32, engine, weight_data);
+    test_tensor_t bias_f32_ts(bias_f32, engine, bias_data);
+    test_tensor_t dst_f32_ts(reshape_f32, engine);
     for (size_t iter = 0; iter < 5; iter++) {
         cp.execute(strm,
                 {src_f32_ts.get(), weight_f32_ts.get(), bias_f32_ts.get()},
@@ -7738,9 +7739,9 @@ TEST(test_matmul_execute, MatmulStridedScalarOutput) {
     ASSERT_EQ(scalar_lt.layout_type, graph::layout_type::strided);
     ASSERT_EQ(scalar_lt.ndims, 0);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor weight_ts(weight, eng, weight_data);
-    test_tensor dst_ts(scalar_lt, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t weight_ts(weight, eng, weight_data);
+    test_tensor_t dst_ts(scalar_lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()}),
@@ -7814,11 +7815,11 @@ TEST(test_matmul_execute, MatmulBiasAddReluFusion) {
 
     p.compile(&cp, inputs, outputs, engine);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor bias_ts(bias, engine, bias_data);
-    test_tensor post_src_ts(post_src, engine, post_src_data);
-    test_tensor dst_ts(relu_dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t bias_ts(bias, engine, bias_data);
+    test_tensor_t post_src_ts(post_src, engine, post_src_data);
+    test_tensor_t dst_ts(relu_dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm,
@@ -7877,9 +7878,9 @@ TEST(test_matmul_execute, MatmulEmptyInput) {
     cp.query_logical_tensor(weight.id, &weight);
     cp.query_logical_tensor(dst.id, &dst);
 
-    test_tensor src_ts(src, eng);
-    test_tensor weight_ts(weight, eng);
-    test_tensor dst_ts(dst, eng);
+    test_tensor_t src_ts(src, eng);
+    test_tensor_t weight_ts(weight, eng);
+    test_tensor_t dst_ts(dst, eng);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), weight_ts.get()}, {dst_ts.get()}),
@@ -7977,7 +7978,7 @@ TEST(test_matmul_execute_subgraph_int8, ShareCachedWeight) {
     std::vector<int8_t> weight_data(product(weight_shape));
     std::generate(weight_data.begin(), weight_data.end(),
             [&]() { return static_cast<int8_t>(s8_distribution(generator)); });
-    test_tensor weight_s8_ts(weight_s8, engine, weight_data);
+    test_tensor_t weight_s8_ts(weight_s8, engine, weight_data);
 
     // set constant tensor cache capacity as 1GB
     dnnl::graph::set_constant_tensor_cache_capacity(
@@ -8008,8 +8009,8 @@ TEST(test_matmul_execute_subgraph_int8, ShareCachedWeight) {
             return static_cast<uint8_t>(u8_distribution(generator));
         });
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor dst_s8_ts(compiled_output, engine);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t dst_s8_ts(compiled_output, engine);
         ASSERT_EQ(cp.execute(strm, {src_u8_ts.get(), weight_s8_ts.get()},
                           {dst_s8_ts.get()}),
                 graph::status::success);
@@ -8121,13 +8122,13 @@ TEST(test_matmul_execute_subgraph_int8, NoShareCachedWeight) {
     std::uniform_real_distribution<float> s8_distribution(-127.0f, 128.0f);
     std::vector<int8_t> weight_data(product(weight_shape));
     // Construct different weight tensor obejct with different memory address.
-    std::vector<test_tensor> weight_s8_ts_vec;
+    std::vector<test_tensor_t> weight_s8_ts_vec;
     for (size_t i = 0; i < src_shapes.size(); i++) {
         std::generate(weight_data.begin(), weight_data.end(), [&]() {
             return static_cast<int8_t>(s8_distribution(generator));
         });
         weight_s8_ts_vec.emplace_back(
-                test_tensor(weight_s8, engine, weight_data));
+                test_tensor_t(weight_s8, engine, weight_data));
     }
 
     for (size_t i = 0; i < src_shapes.size(); ++i) {
@@ -8155,8 +8156,8 @@ TEST(test_matmul_execute_subgraph_int8, NoShareCachedWeight) {
             return static_cast<uint8_t>(u8_distribution(generator));
         });
 
-        test_tensor src_u8_ts(src_u8, engine, src_data);
-        test_tensor dst_s8_ts(compiled_output, engine);
+        test_tensor_t src_u8_ts(src_u8, engine, src_data);
+        test_tensor_t dst_s8_ts(compiled_output, engine);
         ASSERT_EQ(cp.execute(strm, {src_u8_ts.get(), weight_s8_ts_vec[i].get()},
                           {dst_s8_ts.get()}),
                 graph::status::success);

--- a/tests/gtests/graph/unit/backend/dnnl/test_mqa_decomp.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_mqa_decomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ TEST(test_mqa_decomp_execute, F32MqaDecomp_CPU) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
         inputs_ts.back().fill<float>();
@@ -96,8 +96,8 @@ TEST(test_mqa_decomp_execute, F32MqaDecomp_CPU) {
         cp.query_logical_tensor(lt->id, &compiled_output);
         outputs_ts.emplace_back(compiled_output, eng);
     }
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -150,7 +150,7 @@ TEST(test_mqa_decomp_execute, Bf16MqaDecomp_CPU) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts, outputs_ts;
+    std::vector<test_tensor_t> inputs_ts, outputs_ts;
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
         inputs_ts.back().fill<float>();
@@ -161,8 +161,8 @@ TEST(test_mqa_decomp_execute, Bf16MqaDecomp_CPU) {
         cp.query_logical_tensor(lt->id, &compiled_output);
         outputs_ts.emplace_back(compiled_output, eng);
     }
-    ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs_ts)),
+    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();
 }
@@ -210,7 +210,7 @@ TEST(test_mqa_decomp_execute, MultithreaMqaDecomp_CPU) {
     graph::compiled_partition_t cp(p);
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> inputs_ts;
+    std::vector<test_tensor_t> inputs_ts;
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
         inputs_ts.back().fill<float>();
@@ -219,15 +219,16 @@ TEST(test_mqa_decomp_execute, MultithreaMqaDecomp_CPU) {
     auto func = [&]() {
         graph::stream_t *strm;
         dnnl_stream_create(&strm, eng, dnnl_stream_in_order);
-        std::vector<test_tensor> outputs_ts;
+        std::vector<test_tensor_t> outputs_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp.query_logical_tensor(lt->id, &compiled_output);
             outputs_ts.emplace_back(compiled_output, eng);
         }
         for (int i = 0; i < 5; i++) {
-            ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs_ts)),
+            ASSERT_EQ(
+                    cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs_ts)),
                     graph::status::success);
         }
         strm->wait();
@@ -284,7 +285,7 @@ TEST(test_mqa_decomp_execute, F32MqaCorr_CPU) {
         outputs.emplace_back(&lt);
     }
 
-    std::vector<test_tensor> inputs_ts;
+    std::vector<test_tensor_t> inputs_ts;
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
         inputs_ts.back().fill<float>();
@@ -295,14 +296,14 @@ TEST(test_mqa_decomp_execute, F32MqaCorr_CPU) {
     graph::compiled_partition_t cp1(p);
     ASSERT_EQ(p.compile(&cp1, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> outputs1_ts;
+    std::vector<test_tensor_t> outputs1_ts;
     for (auto &lt : outputs) {
         graph::logical_tensor_t compiled_output;
         cp1.query_logical_tensor(lt->id, &compiled_output);
         outputs1_ts.emplace_back(compiled_output, eng);
     }
-    ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs1_ts)),
+    ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs1_ts)),
             graph::status::success);
     strm->wait();
 
@@ -311,14 +312,14 @@ TEST(test_mqa_decomp_execute, F32MqaCorr_CPU) {
     graph::compiled_partition_t cp2(p);
     ASSERT_EQ(p.compile(&cp2, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> outputs2_ts;
+    std::vector<test_tensor_t> outputs2_ts;
     for (auto &lt : outputs) {
         graph::logical_tensor_t compiled_output;
         cp2.query_logical_tensor(lt->id, &compiled_output);
         outputs2_ts.emplace_back(compiled_output, eng);
     }
-    ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs2_ts)),
+    ASSERT_EQ(cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs2_ts)),
             graph::status::success);
     strm->wait();
 
@@ -372,7 +373,7 @@ TEST(test_mqa_decomp_execute, Bf16MqaCorr_CPU) {
         outputs.emplace_back(&lt);
     }
 
-    std::vector<test_tensor> inputs_ts;
+    std::vector<test_tensor_t> inputs_ts;
     for (auto &lt : inputs) {
         inputs_ts.emplace_back(*lt, eng);
         inputs_ts.back().fill<float>();
@@ -383,14 +384,14 @@ TEST(test_mqa_decomp_execute, Bf16MqaCorr_CPU) {
     graph::compiled_partition_t cp1(p);
     ASSERT_EQ(p.compile(&cp1, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> outputs1_ts;
+    std::vector<test_tensor_t> outputs1_ts;
     for (auto &lt : outputs) {
         graph::logical_tensor_t compiled_output;
         cp1.query_logical_tensor(lt->id, &compiled_output);
         outputs1_ts.emplace_back(compiled_output, eng);
     }
-    ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs1_ts)),
+    ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs1_ts)),
             graph::status::success);
     strm->wait();
 
@@ -399,14 +400,14 @@ TEST(test_mqa_decomp_execute, Bf16MqaCorr_CPU) {
     graph::compiled_partition_t cp2(p);
     ASSERT_EQ(p.compile(&cp2, inputs, outputs, eng), graph::status::success);
 
-    std::vector<test_tensor> outputs2_ts;
+    std::vector<test_tensor_t> outputs2_ts;
     for (auto &lt : outputs) {
         graph::logical_tensor_t compiled_output;
         cp2.query_logical_tensor(lt->id, &compiled_output);
         outputs2_ts.emplace_back(compiled_output, eng);
     }
-    ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                      test_tensor::to_graph_tensor(outputs2_ts)),
+    ASSERT_EQ(cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                      test_tensor_t::to_graph_tensor(outputs2_ts)),
             graph::status::success);
     strm->wait();
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_pool.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_pool.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -171,10 +171,10 @@ TEST(test_pool_execute_subgraph_int8, PoolAdd) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_s8_ts(src_s8, engine, src_s8_data);
-        test_tensor other_s8_ts(other_s8, engine, other_s8_data);
-        test_tensor case1_dst_s8_ts(dst_s8, engine, case1_dst_s8_data);
-        test_tensor case2_dst_s8_ts(dst_s8, engine, case2_dst_s8_data);
+        test_tensor_t src_s8_ts(src_s8, engine, src_s8_data);
+        test_tensor_t other_s8_ts(other_s8, engine, other_s8_data);
+        test_tensor_t case1_dst_s8_ts(dst_s8, engine, case1_dst_s8_data);
+        test_tensor_t case2_dst_s8_ts(dst_s8, engine, case2_dst_s8_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g, {src_s8_ts, other_s8_ts}, {case1_dst_s8_ts},
@@ -303,13 +303,13 @@ TEST(test_pool_execute_subgraph_fp32, Pool3Postops) {
             g.add_op(&pop);
         g.finalize();
 
-        std::vector<test_tensor> src_tss {};
+        std::vector<test_tensor_t> src_tss {};
         for (size_t i = 0; i < input_lts.size(); ++i)
             src_tss.emplace_back(lt_vec[input_lts[i]], engine, src_datas[i]);
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(pool_dst_shape));
-        test_tensor case1_dst_ts(lt_vec[lt_idx], engine, case1_out_data);
+        test_tensor_t case1_dst_ts(lt_vec[lt_idx], engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, src_tss, {case1_dst_ts}, *engine, *strm),
                 graph::status::success);
@@ -335,9 +335,9 @@ TEST(test_pool_execute_subgraph_fp32, Pool3Postops) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(pool_dst_shape));
-        test_tensor case2_dst_ts(lt_vec[lt_idx], engine, case2_out_data);
+        test_tensor_t case2_dst_ts(lt_vec[lt_idx], engine, case2_out_data);
 
-        cp.execute(strm, test_tensor::to_graph_tensor(src_tss),
+        cp.execute(strm, test_tensor_t::to_graph_tensor(src_tss),
                 {case2_dst_ts.get()});
         strm->wait();
 
@@ -400,8 +400,8 @@ TEST(test_pool_execute, AvgPoolExcludePad) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -463,8 +463,8 @@ TEST(test_pool_execute, AvgPoolIncludePad) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -522,8 +522,8 @@ TEST(test_pool_execute, AvgPoolBackwardExcludePad) {
     cp.query_logical_tensor(diff_src_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-    test_tensor diff_src_ts(lt, eng, diff_src);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {diff_dst_ts.get()}, {diff_src_ts.get()});
@@ -581,8 +581,8 @@ TEST(test_pool_execute, AvgPoolBackwardIncludePad) {
     cp.query_logical_tensor(diff_src_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-    test_tensor diff_src_ts(lt, eng, diff_src);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {diff_dst_ts.get()}, {diff_src_ts.get()});
@@ -689,9 +689,9 @@ TEST(test_pool_execute_subgraph_int8, Avgpool) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor dst_u8_ts(dst_u8, engine, case1_out_data);
-        test_tensor dst_u8_case2_ts(dst_u8, engine, case2_out_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t dst_u8_ts(dst_u8, engine, case1_out_data);
+        test_tensor_t dst_u8_case2_ts(dst_u8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g, {src_u8_ts}, {dst_u8_ts}, *engine, *strm),
@@ -780,8 +780,8 @@ TEST(test_pool_execute, MaxPool) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -842,8 +842,8 @@ TEST(test_pool_execute, MaxPoolwithCache) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -860,8 +860,8 @@ TEST(test_pool_execute, MaxPoolwithCache) {
     std::vector<float> ref_dst2 {-1.0, 2.0, 4.0, 2.0};
     std::vector<float> dst2(ref_dst2.size(), 0.0);
 
-    test_tensor src_ts2(src_lt, eng, src2);
-    test_tensor dst_ts2(lt, eng, dst2);
+    test_tensor_t src_ts2(src_lt, eng, src2);
+    test_tensor_t dst_ts2(lt, eng, dst2);
 
     cp.execute(strm, {src_ts2.get()}, {dst_ts2.get()});
     strm->wait();
@@ -996,9 +996,9 @@ TEST(test_pool_execute, MaxPoolBackward) {
     cp.query_logical_tensor(diff_src_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-    test_tensor diff_src_ts(lt, eng, diff_src);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), diff_dst_ts.get()}, {diff_src_ts.get()});
@@ -1059,9 +1059,9 @@ TEST(test_pool_execute, MaxPoolBackwardPlainGrad) {
     std::vector<float> diff_dst(product(output_dims), 1);
     std::vector<float> diff_src(product(input_dims), 1);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-    test_tensor diff_src_ts(lt, eng, diff_src);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get(), diff_dst_ts.get()}, {diff_src_ts.get()});
@@ -1165,9 +1165,9 @@ TEST(test_pool_execute_subgraph_int8, Maxpool) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-        test_tensor dst_u8_ts(dst_u8, engine, case1_out_data);
-        test_tensor dst_u8_case2_ts(dst_u8, engine, case2_out_data);
+        test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+        test_tensor_t dst_u8_ts(dst_u8, engine, case1_out_data);
+        test_tensor_t dst_u8_case2_ts(dst_u8, engine, case2_out_data);
 
         // -------------------------case 1----------------------------------
         ASSERT_EQ(run_graph(g, {src_u8_ts}, {dst_u8_ts}, *engine, *strm),
@@ -1281,9 +1281,9 @@ TEST(test_pool_execute_subgraph_int8, MaxpoolAsymmetric) {
     g.add_op(&qout_op);
     g.finalize();
 
-    test_tensor src_u8_ts(src_u8, engine, src_u8_data);
-    test_tensor dst_u8_ts(dst_u8, engine, case1_out_data);
-    test_tensor dst_u8_case2_ts(dst_u8, engine, case2_out_data);
+    test_tensor_t src_u8_ts(src_u8, engine, src_u8_data);
+    test_tensor_t dst_u8_ts(dst_u8, engine, case1_out_data);
+    test_tensor_t dst_u8_case2_ts(dst_u8, engine, case2_out_data);
 
     // -------------------------case 1----------------------------------
     ASSERT_EQ(run_graph(g, {src_u8_ts}, {dst_u8_ts}, *engine, *strm),
@@ -1457,11 +1457,11 @@ public:
             cp.query_logical_tensor(add_dst_lt.id, &lt);
             ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-            test_tensor src_ts(src_lt, eng);
+            test_tensor_t src_ts(src_lt, eng);
             src_ts.fill<bfloat16_t>(4.0);
-            test_tensor post_src_ts(post_src_lt, eng);
+            test_tensor_t post_src_ts(post_src_lt, eng);
             post_src_ts.fill<bfloat16_t>(2.0);
-            test_tensor add_dst_ts(add_dst_lt, eng);
+            test_tensor_t add_dst_ts(add_dst_lt, eng);
 
             graph::stream_t *strm = get_stream();
             ASSERT_EQ(cp.execute(strm, {src_ts.get(), post_src_ts.get()},
@@ -1627,8 +1627,8 @@ TEST(test_pool_execute_subgraph_int8, DequantizePoolReshapeQunatize) {
         g.add_op(&qout_op);
         g.finalize();
 
-        test_tensor src_s8_ts(dq_in_s8, engine, src_s8_data);
-        test_tensor case1_dst_s8_ts(q_out_s8, engine, case1_dst_s8_data);
+        test_tensor_t src_s8_ts(dq_in_s8, engine, src_s8_data);
+        test_tensor_t case1_dst_s8_ts(q_out_s8, engine, case1_dst_s8_data);
         graph::pass::pass_base_ptr apass
                 = get_pass("x8_pool_reshape_transpose");
         apass->run(g);

--- a/tests/gtests/graph/unit/backend/dnnl/test_prelu.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_prelu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,9 +87,9 @@ public:
 
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor wei_ts(wei_lt, eng, wei);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t wei_ts(wei_lt, eng, wei);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
         graph::stream_t *strm = get_stream();
 
         cp.execute(strm, {src_ts.get(), wei_ts.get()}, {dst_ts.get()});
@@ -175,11 +175,11 @@ public:
 
         ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor wei_ts(wei_lt, eng, wei);
-        test_tensor diff_dst_ts(diff_dst_lt, eng, diff_dst);
-        test_tensor diff_src_ts(diff_src_lt, eng, diff_src);
-        test_tensor diff_wei_ts(diff_wei_lt, eng, diff_wei);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t wei_ts(wei_lt, eng, wei);
+        test_tensor_t diff_dst_ts(diff_dst_lt, eng, diff_dst);
+        test_tensor_t diff_src_ts(diff_src_lt, eng, diff_src);
+        test_tensor_t diff_wei_ts(diff_wei_lt, eng, diff_wei);
 
         ASSERT_EQ(cp.execute(strm,
                           {src_ts.get(), wei_ts.get(), diff_dst_ts.get()},

--- a/tests/gtests/graph/unit/backend/dnnl/test_quantize.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_quantize.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,8 +82,8 @@ TEST(test_quantize_execute, QuantizePerTensor) {
         cp.query_logical_tensor(dst_lt.id, &lt);
         ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-        test_tensor src_ts(src_lt, engine, src);
-        test_tensor dst_ts(dst_lt, engine, dst);
+        test_tensor_t src_ts(src_lt, engine, src);
+        test_tensor_t dst_ts(dst_lt, engine, dst);
 
         graph::stream_t *strm = get_stream();
         ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -144,8 +144,8 @@ TEST(test_quantize_execute, QuantizePerTensorAnyLayout) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(lt, engine, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -202,8 +202,8 @@ TEST(test_quantize_execute, QuantizePerChannelSymmetric) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(lt, engine, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -268,8 +268,8 @@ TEST(test_quantize_execute, TypecastQuantize) {
     ASSERT_EQ(p.compile(&cp, lt_ins, lt_outs, engine), graph::status::success);
 
     std::vector<uint8_t> dst_data(product(src_shape));
-    test_tensor src_ts(src_bf16, engine, src_data);
-    test_tensor dst_ts(dst_int8, engine, dst_data);
+    test_tensor_t src_ts(src_bf16, engine, src_data);
+    test_tensor_t dst_ts(dst_int8, engine, dst_data);
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
             graph::status::success);
     strm->wait();
@@ -332,10 +332,10 @@ TEST(test_quantize_execute, DynamicQuantizeS32ZpsPerTensor_CPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scales_ts(scales_lt, eng, scales);
-    test_tensor zps_ts(zps_lt, eng, zps);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scales_ts(scales_lt, eng, scales);
+    test_tensor_t zps_ts(zps_lt, eng, zps);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), scales_ts.get(), zps_ts.get()},
@@ -411,10 +411,10 @@ TEST(test_quantize_execute, DynamicQuantizeS32ZpsPerChannel_CPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scales_ts(scales_lt, eng, scales);
-    test_tensor zps_ts(zps_lt, eng, zps);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scales_ts(scales_lt, eng, scales);
+    test_tensor_t zps_ts(zps_lt, eng, zps);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), scales_ts.get(), zps_ts.get()},
@@ -484,10 +484,10 @@ TEST(test_quantize_execute, DynamicQuantizeS8ZpsPerTensor_CPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scales_ts(scales_lt, eng, scales);
-    test_tensor zps_ts(zps_lt, eng, zps);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scales_ts(scales_lt, eng, scales);
+    test_tensor_t zps_ts(zps_lt, eng, zps);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), scales_ts.get(), zps_ts.get()},
@@ -552,9 +552,9 @@ TEST(test_quantize_execute, DynamicQuantizeNoZpsPerTensor_CPU) {
     cp.query_logical_tensor(dst_lt.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor scales_ts(scales_lt, eng, scales);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t scales_ts(scales_lt, eng, scales);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get(), scales_ts.get()}, {dst_ts.get()}),
@@ -619,8 +619,8 @@ TEST(test_quantize_execute, QuantizeZeroVolume) {
     ASSERT_EQ(lt.layout.strides[2], 1U);
     ASSERT_EQ(graph::logical_tensor_wrapper_t(lt).size(), 0U);
 
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(lt, engine, dst);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),

--- a/tests/gtests/graph/unit/backend/dnnl/test_reduce.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_reduce.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -106,9 +106,9 @@ TEST(test_reduce_compile, TestReduce) {
 
         std::vector<float> case1_out_data(product(new_reduce_dst_shape));
         std::vector<float> case2_out_data(product(new_reduce_dst_shape));
-        test_tensor reduce_src_ts(reduce_src, engine, src_data);
-        test_tensor reduce_dst_ts1(reduce_dst, engine, case1_out_data);
-        test_tensor reduce_dst_ts2(reduce_dst, engine, case2_out_data);
+        test_tensor_t reduce_src_ts(reduce_src, engine, src_data);
+        test_tensor_t reduce_dst_ts1(reduce_dst, engine, case1_out_data);
+        test_tensor_t reduce_dst_ts2(reduce_dst, engine, case2_out_data);
 
         ASSERT_EQ(
                 run_graph(g, {reduce_src_ts}, {reduce_dst_ts1}, *engine, *strm),
@@ -193,12 +193,12 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceAdd) {
         g.add_op(&add);
         g.finalize();
 
-        test_tensor reduce_src_ts(reduce_src, engine, src_data);
-        test_tensor add_src1_ts(add_src1, engine, src1_data);
+        test_tensor_t reduce_src_ts(reduce_src, engine, src_data);
+        test_tensor_t add_src1_ts(add_src1, engine, src1_data);
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(reduce_dst_shape));
-        test_tensor add_dst_ts(add_dst, engine, case1_out_data);
+        test_tensor_t add_dst_ts(add_dst, engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, {reduce_src_ts, add_src1_ts}, {add_dst_ts},
                           *engine, *strm),
@@ -223,7 +223,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceAdd) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(reduce_dst_shape));
-        test_tensor add_dst_ts2(add_dst, engine, case2_out_data);
+        test_tensor_t add_dst_ts2(add_dst, engine, case2_out_data);
 
         cp.execute(strm, {reduce_src_ts.get(), add_src1_ts.get()},
                 {add_dst_ts2.get()});
@@ -290,11 +290,11 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceRelu) {
         g.add_op(&relu);
         g.finalize();
 
-        test_tensor reduce_src_ts(reduce_src, engine, src_data);
+        test_tensor_t reduce_src_ts(reduce_src, engine, src_data);
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(reduce_dst_shape));
-        test_tensor relu_dst_ts(relu_dst, engine, case1_out_data);
+        test_tensor_t relu_dst_ts(relu_dst, engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, {reduce_src_ts}, {relu_dst_ts}, *engine, *strm),
                 graph::status::success);
@@ -317,7 +317,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceRelu) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(reduce_dst_shape));
-        test_tensor relu_dst_ts2(relu_dst, engine, case2_out_data);
+        test_tensor_t relu_dst_ts2(relu_dst, engine, case2_out_data);
 
         cp.execute(strm, {reduce_src_ts.get()}, {relu_dst_ts2.get()});
         strm->wait();
@@ -388,11 +388,11 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceSwish) {
         g.add_op(&multiply);
         g.finalize();
 
-        test_tensor reduce_src_ts(reduce_src, engine, src_data);
+        test_tensor_t reduce_src_ts(reduce_src, engine, src_data);
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(reduce_dst_shape));
-        test_tensor mul_dst_ts(mul_dst, engine, case1_out_data);
+        test_tensor_t mul_dst_ts(mul_dst, engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, {reduce_src_ts}, {mul_dst_ts}, *engine, *strm),
                 graph::status::success);
@@ -415,7 +415,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceSwish) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(reduce_dst_shape));
-        test_tensor mul_dst_ts2(mul_dst, engine, case2_out_data);
+        test_tensor_t mul_dst_ts2(mul_dst, engine, case2_out_data);
 
         cp.execute(strm, {reduce_src_ts.get()}, {mul_dst_ts2.get()});
         strm->wait();
@@ -501,13 +501,13 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceWith3PostOps_CPU) {
         g.add_op(&multiply);
         g.finalize();
 
-        test_tensor reduce_src_ts(reduce_src, engine, src_data);
-        test_tensor max_src_ts(max_src, engine, max_src_data);
-        test_tensor mul_src_ts(mul_src, engine, mul_src_data);
+        test_tensor_t reduce_src_ts(reduce_src, engine, src_data);
+        test_tensor_t max_src_ts(max_src, engine, max_src_data);
+        test_tensor_t mul_src_ts(mul_src, engine, mul_src_data);
 
         // -------------------------case 1----------------------------------
         std::vector<float> case1_out_data(product(reduce_dst_shape));
-        test_tensor mul_dst_ts(mul_dst, engine, case1_out_data);
+        test_tensor_t mul_dst_ts(mul_dst, engine, case1_out_data);
 
         ASSERT_EQ(run_graph(g, {reduce_src_ts, max_src_ts, mul_src_ts},
                           {mul_dst_ts}, *engine, *strm),
@@ -532,7 +532,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceWith3PostOps_CPU) {
         p.compile(&cp, lt_ins, lt_outs, engine);
 
         std::vector<float> case2_out_data(product(reduce_dst_shape));
-        test_tensor mul_dst_ts2(mul_dst, engine, case2_out_data);
+        test_tensor_t mul_dst_ts2(mul_dst, engine, case2_out_data);
 
         cp.execute(strm,
                 {reduce_src_ts.get(), max_src_ts.get(), mul_src_ts.get()},
@@ -599,8 +599,8 @@ TEST(test_reduce_execute, ReduceMeanOutputDims) {
         cp.query_logical_tensor(dst.id, &dst_lt);
         ASSERT_EQ(dst_lt.layout_type, graph::layout_type::strided);
         ASSERT_EQ(dst_lt.ndims, static_cast<int>(new_dst_shape.size()));
-        test_tensor src0_ts(src0, engine, src0_data);
-        test_tensor dst_ts(dst_lt, engine, dst_data);
+        test_tensor_t src0_ts(src0, engine, src0_data);
+        test_tensor_t dst_ts(dst_lt, engine, dst_data);
 
         ASSERT_EQ(cp.execute(strm, {src0_ts.get()}, {dst_ts.get()}),
                 graph::status::success);

--- a/tests/gtests/graph/unit/backend/dnnl/test_reorder.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,8 +64,8 @@ TEST(test_reorder_execute, ReorderData) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
     graph::stream_t *stream = get_stream();
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(dst_lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(dst_lt, engine, dst);
 
     cp.execute(stream, {src_ts.get()}, {dst_ts.get()});
     stream->wait();
@@ -140,8 +140,8 @@ TEST(test_reorder_execute, Int8Reorder) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
     graph::stream_t *stream = get_stream();
-    test_tensor src_ts(int8_src_lt, engine, int8_src);
-    test_tensor dst_ts(int8_dst_lt, engine, int8_dst);
+    test_tensor_t src_ts(int8_src_lt, engine, int8_src);
+    test_tensor_t dst_ts(int8_dst_lt, engine, int8_dst);
 
     cp.execute(stream, {src_ts.get()}, {dst_ts.get()});
     stream->wait();
@@ -226,8 +226,8 @@ TEST(test_reorder_execute, ReorderDataBf16) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
     graph::stream_t *stream = get_stream();
-    test_tensor src_ts(src_lt, engine, src);
-    test_tensor dst_ts(dst_lt, engine, dst);
+    test_tensor_t src_ts(src_lt, engine, src);
+    test_tensor_t dst_ts(dst_lt, engine, dst);
 
     cp.execute(stream, {src_ts.get()}, {dst_ts.get()});
     stream->wait();
@@ -286,9 +286,9 @@ TEST(test_reorder_execute, ReorderAddBf16) {
     std::vector<const graph::logical_tensor_t *> outputs {&add_dst_lt};
     ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor post_src_ts(add_src_lt, eng, post_src);
-    test_tensor dst_ts(add_dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t post_src_ts(add_src_lt, eng, post_src);
+    test_tensor_t dst_ts(add_dst_lt, eng, dst);
     cp.execute(strm, {src_ts.get(), post_src_ts.get()}, {dst_ts.get()});
     strm->wait();
 }
@@ -435,9 +435,9 @@ TEST(test_reorder_execute, Int8ReorderAdd) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
     graph::stream_t *stream = get_stream();
-    test_tensor src_ts(int8_src_lt, engine, int8_src);
-    test_tensor src_other_ts(int8_src_other_lt, engine, int8_src_other);
-    test_tensor dst_ts(int8_dst_add_lt, engine, int8_dst);
+    test_tensor_t src_ts(int8_src_lt, engine, int8_src);
+    test_tensor_t src_other_ts(int8_src_other_lt, engine, int8_src_other);
+    test_tensor_t dst_ts(int8_dst_add_lt, engine, int8_dst);
 
     cp.execute(stream, {src_ts.get(), src_other_ts.get()}, {dst_ts.get()});
     stream->wait();

--- a/tests/gtests/graph/unit/backend/dnnl/test_sdp_decomp.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_sdp_decomp.cpp
@@ -121,7 +121,7 @@ TEST(test_sdp_decomp_execute, F32SdpDecomp_CPU) {
             ASSERT_EQ(p.compile(&cp, inputs, outputs, eng),
                     graph::status::success);
 
-            std::vector<test_tensor> inputs_ts, outputs_ts;
+            std::vector<test_tensor_t> inputs_ts, outputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<float>();
@@ -132,8 +132,9 @@ TEST(test_sdp_decomp_execute, F32SdpDecomp_CPU) {
                 cp.query_logical_tensor(lt->id, &compiled_output);
                 outputs_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs_ts)),
+            ASSERT_EQ(
+                    cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs_ts)),
                     graph::status::success);
             strm->wait();
         }
@@ -224,7 +225,7 @@ TEST(test_sdp_decomp_execute, Bf16SdpDecomp_CPU) {
             ASSERT_EQ(p.compile(&cp, inputs, outputs, eng),
                     graph::status::success);
 
-            std::vector<test_tensor> inputs_ts, outputs_ts;
+            std::vector<test_tensor_t> inputs_ts, outputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<bfloat16_t>();
@@ -235,8 +236,9 @@ TEST(test_sdp_decomp_execute, Bf16SdpDecomp_CPU) {
                 cp.query_logical_tensor(lt->id, &compiled_output);
                 outputs_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs_ts)),
+            ASSERT_EQ(
+                    cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs_ts)),
                     graph::status::success);
             strm->wait();
         }
@@ -321,7 +323,7 @@ TEST(test_sdp_decomp_execute, Int8SdpDecomp_CPU) {
             ASSERT_EQ(p.compile(&cp, inputs, outputs, eng),
                     graph::status::success);
 
-            std::vector<test_tensor> inputs_ts, outputs_ts;
+            std::vector<test_tensor_t> inputs_ts, outputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<uint8_t>();
@@ -332,8 +334,9 @@ TEST(test_sdp_decomp_execute, Int8SdpDecomp_CPU) {
                 cp.query_logical_tensor(lt->id, &compiled_output);
                 outputs_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs_ts)),
+            ASSERT_EQ(
+                    cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs_ts)),
                     graph::status::success);
             strm->wait();
         }
@@ -419,7 +422,7 @@ TEST(test_sdp_decomp_execute, Int8Bf16SdpDecomp_CPU) {
             ASSERT_EQ(p.compile(&cp, inputs, outputs, eng),
                     graph::status::success);
 
-            std::vector<test_tensor> inputs_ts, outputs_ts;
+            std::vector<test_tensor_t> inputs_ts, outputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<bfloat16_t>();
@@ -429,8 +432,9 @@ TEST(test_sdp_decomp_execute, Int8Bf16SdpDecomp_CPU) {
                 outputs_ts.emplace_back(lt, eng);
             }
 
-            ASSERT_EQ(cp.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs_ts)),
+            ASSERT_EQ(
+                    cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs_ts)),
                     graph::status::success);
 
             strm->wait();
@@ -506,7 +510,7 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecomp_CPU) {
 
         graph::compiled_partition_t cp(p);
         ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> inputs_ts;
+        std::vector<test_tensor_t> inputs_ts;
         for (auto &lt : inputs) {
             inputs_ts.emplace_back(*lt, eng);
             inputs_ts.back().fill<uint8_t>();
@@ -515,15 +519,15 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecomp_CPU) {
         auto func = [&]() {
             graph::stream_t *strm;
             dnnl_stream_create(&strm, eng, dnnl_stream_in_order);
-            std::vector<test_tensor> outputs_ts;
+            std::vector<test_tensor_t> outputs_ts;
             outputs_ts.reserve(partition_outputs.size());
             for (auto &lt : partition_outputs) {
                 outputs_ts.emplace_back(lt, eng);
             }
             for (int i = 0; i < 10; i++)
                 ASSERT_EQ(cp.execute(strm,
-                                  test_tensor::to_graph_tensor(inputs_ts),
-                                  test_tensor::to_graph_tensor(outputs_ts)),
+                                  test_tensor_t::to_graph_tensor(inputs_ts),
+                                  test_tensor_t::to_graph_tensor(outputs_ts)),
                         graph::status::success);
             strm->wait();
             dnnl_stream_destroy(strm);
@@ -610,7 +614,7 @@ TEST(test_sdp_decomp_execute, F32SdpCorr_CPU) {
             ASSERT_EQ(p.compile(&cp, inputs, outputs, eng),
                     graph::status::success);
 
-            std::vector<test_tensor> inputs_ts, outputs_ts;
+            std::vector<test_tensor_t> inputs_ts, outputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<float>();
@@ -627,14 +631,15 @@ TEST(test_sdp_decomp_execute, F32SdpCorr_CPU) {
             graph::compiled_partition_t cp1(p);
             ASSERT_EQ(p.compile(&cp1, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs1_ts;
+            std::vector<test_tensor_t> outputs1_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp1.query_logical_tensor(lt->id, &compiled_output);
                 outputs1_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs1_ts)),
+            ASSERT_EQ(
+                    cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs1_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -643,14 +648,15 @@ TEST(test_sdp_decomp_execute, F32SdpCorr_CPU) {
             graph::compiled_partition_t cp2(p);
             ASSERT_EQ(p.compile(&cp2, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs2_ts;
+            std::vector<test_tensor_t> outputs2_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp2.query_logical_tensor(lt->id, &compiled_output);
                 outputs2_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs2_ts)),
+            ASSERT_EQ(
+                    cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs2_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -726,7 +732,7 @@ TEST(test_sdp_decomp_execute, F32DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp(p);
         ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-        std::vector<test_tensor> inputs_ts, outputs_ts;
+        std::vector<test_tensor_t> inputs_ts, outputs_ts;
         for (auto &lt : inputs) {
             inputs_ts.emplace_back(*lt, eng);
             inputs_ts.back().fill<float>();
@@ -743,14 +749,14 @@ TEST(test_sdp_decomp_execute, F32DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp1(p);
         ASSERT_EQ(
                 p.compile(&cp1, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs1_ts;
+        std::vector<test_tensor_t> outputs1_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp1.query_logical_tensor(lt->id, &compiled_output);
             outputs1_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs1_ts)),
+        ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs1_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -759,14 +765,14 @@ TEST(test_sdp_decomp_execute, F32DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp2(p);
         ASSERT_EQ(
                 p.compile(&cp2, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs2_ts;
+        std::vector<test_tensor_t> outputs2_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp2.query_logical_tensor(lt->id, &compiled_output);
             outputs2_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs2_ts)),
+        ASSERT_EQ(cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs2_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -851,7 +857,7 @@ TEST(test_sdp_decomp_execute, Bf16SdpCorr_CPU) {
             ASSERT_EQ(p.compile(&cp, inputs, outputs, eng),
                     graph::status::success);
 
-            std::vector<test_tensor> inputs_ts, outputs_ts;
+            std::vector<test_tensor_t> inputs_ts, outputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<bfloat16_t>();
@@ -868,14 +874,15 @@ TEST(test_sdp_decomp_execute, Bf16SdpCorr_CPU) {
             graph::compiled_partition_t cp1(p);
             ASSERT_EQ(p.compile(&cp1, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs1_ts;
+            std::vector<test_tensor_t> outputs1_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp1.query_logical_tensor(lt->id, &compiled_output);
                 outputs1_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs1_ts)),
+            ASSERT_EQ(
+                    cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs1_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -884,14 +891,15 @@ TEST(test_sdp_decomp_execute, Bf16SdpCorr_CPU) {
             graph::compiled_partition_t cp2(p);
             ASSERT_EQ(p.compile(&cp2, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs2_ts;
+            std::vector<test_tensor_t> outputs2_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp2.query_logical_tensor(lt->id, &compiled_output);
                 outputs2_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs2_ts)),
+            ASSERT_EQ(
+                    cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs2_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -972,7 +980,7 @@ TEST(test_sdp_decomp_execute, Bf16DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp(p);
         ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
 
-        std::vector<test_tensor> inputs_ts, outputs_ts;
+        std::vector<test_tensor_t> inputs_ts, outputs_ts;
         for (auto &lt : inputs) {
             inputs_ts.emplace_back(*lt, eng);
             inputs_ts.back().fill<bfloat16_t>();
@@ -989,14 +997,14 @@ TEST(test_sdp_decomp_execute, Bf16DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp1(p);
         ASSERT_EQ(
                 p.compile(&cp1, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs1_ts;
+        std::vector<test_tensor_t> outputs1_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp1.query_logical_tensor(lt->id, &compiled_output);
             outputs1_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs1_ts)),
+        ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs1_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -1005,14 +1013,14 @@ TEST(test_sdp_decomp_execute, Bf16DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp2(p);
         ASSERT_EQ(
                 p.compile(&cp2, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs2_ts;
+        std::vector<test_tensor_t> outputs2_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp2.query_logical_tensor(lt->id, &compiled_output);
             outputs2_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs2_ts)),
+        ASSERT_EQ(cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs2_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -1088,7 +1096,7 @@ TEST(test_sdp_decomp_execute, Int8SdpCorr_CPU) {
                         lt.id, lt.data_type, graph::layout_type::strided);
                 outputs.emplace_back(&lt);
             }
-            std::vector<test_tensor> inputs_ts;
+            std::vector<test_tensor_t> inputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<uint8_t>();
@@ -1098,14 +1106,15 @@ TEST(test_sdp_decomp_execute, Int8SdpCorr_CPU) {
             graph::compiled_partition_t cp1(p);
             ASSERT_EQ(p.compile(&cp1, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs1_ts;
+            std::vector<test_tensor_t> outputs1_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp1.query_logical_tensor(lt->id, &compiled_output);
                 outputs1_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs1_ts)),
+            ASSERT_EQ(
+                    cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs1_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -1114,14 +1123,15 @@ TEST(test_sdp_decomp_execute, Int8SdpCorr_CPU) {
             graph::compiled_partition_t cp2(p);
             ASSERT_EQ(p.compile(&cp2, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs2_ts;
+            std::vector<test_tensor_t> outputs2_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp2.query_logical_tensor(lt->id, &compiled_output);
                 outputs2_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs2_ts)),
+            ASSERT_EQ(
+                    cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs2_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -1203,7 +1213,7 @@ TEST(test_sdp_decomp_execute, Int8Bf16SdpCorr_CPU) {
                         lt.id, lt.data_type, graph::layout_type::strided);
                 outputs.emplace_back(&lt);
             }
-            std::vector<test_tensor> inputs_ts;
+            std::vector<test_tensor_t> inputs_ts;
             for (auto &lt : inputs) {
                 inputs_ts.emplace_back(*lt, eng);
                 inputs_ts.back().fill<uint8_t>();
@@ -1213,14 +1223,15 @@ TEST(test_sdp_decomp_execute, Int8Bf16SdpCorr_CPU) {
             graph::compiled_partition_t cp1(p);
             ASSERT_EQ(p.compile(&cp1, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs1_ts;
+            std::vector<test_tensor_t> outputs1_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp1.query_logical_tensor(lt->id, &compiled_output);
                 outputs1_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs1_ts)),
+            ASSERT_EQ(
+                    cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs1_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -1229,14 +1240,15 @@ TEST(test_sdp_decomp_execute, Int8Bf16SdpCorr_CPU) {
             graph::compiled_partition_t cp2(p);
             ASSERT_EQ(p.compile(&cp2, inputs, outputs, eng),
                     graph::status::success);
-            std::vector<test_tensor> outputs2_ts;
+            std::vector<test_tensor_t> outputs2_ts;
             for (auto &lt : outputs) {
                 graph::logical_tensor_t compiled_output;
                 cp2.query_logical_tensor(lt->id, &compiled_output);
                 outputs2_ts.emplace_back(compiled_output, eng);
             }
-            ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                              test_tensor::to_graph_tensor(outputs2_ts)),
+            ASSERT_EQ(
+                    cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                            test_tensor_t::to_graph_tensor(outputs2_ts)),
                     graph::status::success);
             strm->wait();
 
@@ -1310,7 +1322,7 @@ TEST(test_sdp_decomp_execute, Int8DistilBertSdpCorr_CPU) {
                     lt.id, lt.data_type, graph::layout_type::strided);
             outputs.emplace_back(&lt);
         }
-        std::vector<test_tensor> inputs_ts;
+        std::vector<test_tensor_t> inputs_ts;
         for (auto &lt : inputs) {
             inputs_ts.emplace_back(*lt, eng);
             inputs_ts.back().fill<uint8_t>();
@@ -1320,14 +1332,14 @@ TEST(test_sdp_decomp_execute, Int8DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp1(p);
         ASSERT_EQ(
                 p.compile(&cp1, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs1_ts;
+        std::vector<test_tensor_t> outputs1_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp1.query_logical_tensor(lt->id, &compiled_output);
             outputs1_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs1_ts)),
+        ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs1_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -1336,14 +1348,14 @@ TEST(test_sdp_decomp_execute, Int8DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp2(p);
         ASSERT_EQ(
                 p.compile(&cp2, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs2_ts;
+        std::vector<test_tensor_t> outputs2_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp2.query_logical_tensor(lt->id, &compiled_output);
             outputs2_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs2_ts)),
+        ASSERT_EQ(cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs2_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -1422,7 +1434,7 @@ TEST(test_sdp_decomp_execute, Int8Bf16DistilBertSdpCorr_CPU) {
                     lt.id, lt.data_type, graph::layout_type::strided);
             outputs.emplace_back(&lt);
         }
-        std::vector<test_tensor> inputs_ts;
+        std::vector<test_tensor_t> inputs_ts;
         for (auto &lt : inputs) {
             inputs_ts.emplace_back(*lt, eng);
             inputs_ts.back().fill<uint8_t>();
@@ -1432,14 +1444,14 @@ TEST(test_sdp_decomp_execute, Int8Bf16DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp1(p);
         ASSERT_EQ(
                 p.compile(&cp1, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs1_ts;
+        std::vector<test_tensor_t> outputs1_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp1.query_logical_tensor(lt->id, &compiled_output);
             outputs1_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs1_ts)),
+        ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs1_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -1448,14 +1460,14 @@ TEST(test_sdp_decomp_execute, Int8Bf16DistilBertSdpCorr_CPU) {
         graph::compiled_partition_t cp2(p);
         ASSERT_EQ(
                 p.compile(&cp2, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs2_ts;
+        std::vector<test_tensor_t> outputs2_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp2.query_logical_tensor(lt->id, &compiled_output);
             outputs2_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp2.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs2_ts)),
+        ASSERT_EQ(cp2.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs2_ts)),
                 graph::status::success);
         strm->wait();
 
@@ -1534,7 +1546,7 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecompCorr_CPU) {
 
         graph::compiled_partition_t cp(p);
         ASSERT_EQ(p.compile(&cp, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> inputs_ts;
+        std::vector<test_tensor_t> inputs_ts;
         for (auto &lt : inputs) {
             inputs_ts.emplace_back(*lt, eng);
             inputs_ts.back().fill<uint8_t>();
@@ -1545,29 +1557,29 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecompCorr_CPU) {
         graph::compiled_partition_t cp1(p);
         ASSERT_EQ(
                 p.compile(&cp1, inputs, outputs, eng), graph::status::success);
-        std::vector<test_tensor> outputs1_ts;
+        std::vector<test_tensor_t> outputs1_ts;
         for (auto &lt : outputs) {
             graph::logical_tensor_t compiled_output;
             cp1.query_logical_tensor(lt->id, &compiled_output);
             outputs1_ts.emplace_back(compiled_output, eng);
         }
-        ASSERT_EQ(cp1.execute(strm, test_tensor::to_graph_tensor(inputs_ts),
-                          test_tensor::to_graph_tensor(outputs1_ts)),
+        ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+                          test_tensor_t::to_graph_tensor(outputs1_ts)),
                 graph::status::success);
         strm->wait();
 
         auto func = [&]() {
             graph::stream_t *strm_eng;
             dnnl_stream_create(&strm_eng, eng, dnnl_stream_in_order);
-            std::vector<test_tensor> outputs_ts;
+            std::vector<test_tensor_t> outputs_ts;
             outputs_ts.reserve(partition_outputs.size());
             for (auto &lt : partition_outputs) {
                 outputs_ts.emplace_back(lt, eng);
             }
             for (int i = 0; i < 10; i++) {
                 ASSERT_EQ(cp.execute(strm_eng,
-                                  test_tensor::to_graph_tensor(inputs_ts),
-                                  test_tensor::to_graph_tensor(outputs_ts)),
+                                  test_tensor_t::to_graph_tensor(inputs_ts),
+                                  test_tensor_t::to_graph_tensor(outputs_ts)),
                         graph::status::success);
                 strm_eng->wait();
             }

--- a/tests/gtests/graph/unit/backend/dnnl/test_select.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_select.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,10 +74,10 @@ TEST(test_select_execute, TestSelect) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
     graph::stream_t *stream = get_stream();
-    test_tensor cond_ts(cond_lt, engine, cond);
-    test_tensor src0_ts(src0_lt, engine, src0);
-    test_tensor src1_ts(src1_lt, engine, src1);
-    test_tensor dst_ts(dst_lt, engine, dst);
+    test_tensor_t cond_ts(cond_lt, engine, cond);
+    test_tensor_t src0_ts(src0_lt, engine, src0);
+    test_tensor_t src1_ts(src1_lt, engine, src1);
+    test_tensor_t dst_ts(dst_lt, engine, dst);
 
     ASSERT_EQ(cp.execute(stream, {cond_ts.get(), src0_ts.get(), src1_ts.get()},
                       {dst_ts.get()}),
@@ -170,12 +170,12 @@ TEST(test_select_execute, MatmulSelect) {
 
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor weight_ts(weight, engine, weight_data);
-    test_tensor div_src1_ts(div_src1, engine, div_src1_data);
-    test_tensor cond_ts(cond, engine, cond_data);
-    test_tensor select_src0_ts(select_src0, engine, select_src1_data);
-    test_tensor dst_ts(dst, engine, dst_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t weight_ts(weight, engine, weight_data);
+    test_tensor_t div_src1_ts(div_src1, engine, div_src1_data);
+    test_tensor_t cond_ts(cond, engine, cond_data);
+    test_tensor_t select_src0_ts(select_src0, engine, select_src1_data);
+    test_tensor_t dst_ts(dst, engine, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm,

--- a/tests/gtests/graph/unit/backend/dnnl/test_softmax.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -67,8 +67,8 @@ TEST(test_softmax_execute, Softmax) {
     cp.query_logical_tensor(dst.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor dst_ts(lt, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t dst_ts(lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -121,8 +121,8 @@ TEST(test_softmax_execute, SoftmaxWithLastDim) {
     cp.query_logical_tensor(dst.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor dst_ts(lt, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t dst_ts(lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -185,9 +185,9 @@ static inline void test_softmax_bwd_common(const graph::op_kind_t op_kind,
     for (auto i = 0; i < dst_lt.ndims; i++)
         ASSERT_EQ(q_lt.dims[i], dst_lt.dims[i]);
 
-    test_tensor dst_ts(dst_lt, eng, dst);
-    test_tensor diff_dst_ts(d_lt, eng, diff_dst);
-    test_tensor diff_src_ts(q_lt, eng, diff_src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
+    test_tensor_t diff_dst_ts(d_lt, eng, diff_dst);
+    test_tensor_t diff_src_ts(q_lt, eng, diff_src);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {diff_dst_ts.get(), dst_ts.get()},
@@ -265,8 +265,8 @@ TEST(test_softmax_execute, LogSoftmax) {
     cp.query_logical_tensor(dst.id, &lt);
     ASSERT_EQ(lt.layout_type, graph::layout_type::strided);
 
-    test_tensor src_ts(src, eng, src_data);
-    test_tensor dst_ts(lt, eng, dst_data);
+    test_tensor_t src_ts(src, eng, src_data);
+    test_tensor_t dst_ts(lt, eng, dst_data);
 
     graph::stream_t *strm = get_stream();
     ASSERT_EQ(cp.execute(strm, {src_ts.get()}, {dst_ts.get()}),
@@ -419,9 +419,9 @@ TEST(test_softmax_execute_subgraph_int8, SoftmaxTypecastQuant) {
 
     std::vector<uint8_t> dst_data(product(softmax_shape));
     std::vector<uint8_t> ref_data(product(softmax_shape));
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor dst_ts(quant_dst, engine, dst_data);
-    test_tensor ref_ts(quant_dst, engine, ref_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t dst_ts(quant_dst, engine, dst_data);
+    test_tensor_t ref_ts(quant_dst, engine, ref_data);
 
     ASSERT_EQ(run_graph(g, {src_ts}, {ref_ts}, *engine, *strm),
             graph::status::success);
@@ -492,10 +492,10 @@ TEST(test_softmax_compile, SoftmaxAdd) {
 
     std::vector<float> dst_data(product(softmax_shape));
     std::vector<float> ref_data(product(softmax_shape));
-    test_tensor src_ts(src, engine, src_data);
-    test_tensor src1_ts(add_src1, engine, src1_data);
-    test_tensor dst_ts(add_dst, engine, dst_data);
-    test_tensor ref_ts(add_dst, engine, ref_data);
+    test_tensor_t src_ts(src, engine, src_data);
+    test_tensor_t src1_ts(add_src1, engine, src1_data);
+    test_tensor_t dst_ts(add_dst, engine, dst_data);
+    test_tensor_t ref_ts(add_dst, engine, ref_data);
 
     ASSERT_EQ(run_graph(g, {src_ts, src1_ts}, {ref_ts}, *engine, *strm),
             graph::status::success);

--- a/tests/gtests/graph/unit/backend/dnnl/test_typecast.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_typecast.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -62,8 +62,8 @@ TEST(test_typecast_execute, Typecast) {
     ASSERT_EQ(p.compile(&cp, inputs, outputs, engine), graph::status::success);
 
     graph::stream_t *stream = get_stream();
-    test_tensor f32_ts(f32_lt, engine, f32_val);
-    test_tensor bf16_ts(bf16_lt, engine, bf16_val);
+    test_tensor_t f32_ts(f32_lt, engine, f32_val);
+    test_tensor_t bf16_ts(bf16_lt, engine, bf16_val);
 
     // f32 --> bf16
     ASSERT_EQ(cp.execute(stream, {f32_ts.get()}, {bf16_ts.get()}),

--- a/tests/gtests/graph/unit/backend/graph_compiler/test_backend_api.cpp
+++ b/tests/gtests/graph/unit/backend/graph_compiler/test_backend_api.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ static void build_conv_add_partition(graph::graph_t &agraph,
         const graph::dims &strides, const graph::dims &output_shape) {
     using dims = graph::dims;
     // construct conv-add graph
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     auto dtype = graph::data_type::f32;
     graph::logical_tensor_t input0
             = utils::logical_tensor_init(id_gen.get_id(), input_shape, dtype);

--- a/tests/gtests/graph/unit/backend/graph_compiler/test_compile_execute.cpp
+++ b/tests/gtests/graph/unit/backend/graph_compiler/test_compile_execute.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -97,8 +97,8 @@ static void compile_execution_pipeline(impl::graph_t &agraph,
         impl::engine_t &eng = *get_engine();
         ASSERT_EQ(p.compile(&cp, inputs, outputs, &eng), impl::status::success);
 
-        std::vector<test_tensor> execution_inputs;
-        std::vector<test_tensor> execution_outputs;
+        std::vector<test_tensor_t> execution_inputs;
+        std::vector<test_tensor_t> execution_outputs;
         partition_outputs.clear();
         for (auto &lt : outputs) {
             impl::logical_tensor_t compiled_output;
@@ -119,18 +119,18 @@ static void compile_execution_pipeline(impl::graph_t &agraph,
         }
 
         for (auto &lt : partition_inputs) {
-            test_tensor placeholder(lt, &eng);
+            test_tensor_t placeholder(lt, &eng);
             execution_inputs.push_back(placeholder);
         }
         for (auto &lt : partition_outputs) {
-            test_tensor placeholder(lt, &eng);
+            test_tensor_t placeholder(lt, &eng);
             execution_outputs.push_back(placeholder);
         }
 
         impl::stream_t &strm = *get_stream();
         ASSERT_EQ(cp.execute(&strm,
-                          test_tensor::to_graph_tensor(execution_inputs),
-                          test_tensor::to_graph_tensor(execution_outputs)),
+                          test_tensor_t::to_graph_tensor(execution_inputs),
+                          test_tensor_t::to_graph_tensor(execution_outputs)),
                 impl::status::success);
         strm.wait();
     }
@@ -349,23 +349,23 @@ TEST(GCGraphTest, FP32MHACompileExecutionMultiThreading_CPU) {
     int thread_num = 2;
 
     auto thread_func = [&](size_t tid) {
-        std::vector<test_tensor> execution_inputs;
-        std::vector<test_tensor> execution_outputs;
+        std::vector<test_tensor_t> execution_inputs;
+        std::vector<test_tensor_t> execution_outputs;
 
         for (auto &lt : partition_inputs) {
-            test_tensor placeholder(lt, engine);
+            test_tensor_t placeholder(lt, engine);
             execution_inputs.push_back(placeholder);
         }
         for (auto &lt : partition_outputs) {
             graph::logical_tensor_t compiled_output;
             cp.query_logical_tensor(lt.id, &compiled_output);
-            test_tensor placeholder(compiled_output, engine);
+            test_tensor_t placeholder(compiled_output, engine);
             execution_outputs.push_back(placeholder);
         }
         impl::stream_t &strm = *get_stream();
         ASSERT_EQ(cp.execute(&strm,
-                          test_tensor::to_graph_tensor(execution_inputs),
-                          test_tensor::to_graph_tensor(execution_outputs)),
+                          test_tensor_t::to_graph_tensor(execution_inputs),
+                          test_tensor_t::to_graph_tensor(execution_outputs)),
                 impl::status::success);
     };
 
@@ -702,7 +702,7 @@ TEST(GCGraphTest, BF16MHATrainingGraphCompileExecution2_CPU) {
 TEST(GCGraphTest, FP32IdenticalBottleneckCompileExecution_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_resblock(&agraph, id_gen,
@@ -716,7 +716,7 @@ TEST(GCGraphTest, FP32IdenticalBottleneckCompileExecution_CPU) {
 TEST(GCGraphTest, FP32ConvolutionalBottleneckCompileExecution_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_convolutional_bottleneck_resblock(&agraph, id_gen,
@@ -730,7 +730,7 @@ TEST(GCGraphTest, FP32ConvolutionalBottleneckCompileExecution_CPU) {
 TEST(GCGraphTest, INT8IdenticalBottleneckCompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_int8_identical_bottleneck_resblock(&agraph,
@@ -744,7 +744,7 @@ TEST(GCGraphTest, INT8IdenticalBottleneckCompileExecution_CPU) {
 TEST(GCGraphTest, INT8IdenticalBottleneckCompileExecutionNXC_CPU) {
     REQUIRE_VNNI_AMXINT8();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_int8_identical_bottleneck_resblock(&agraph,
@@ -759,7 +759,7 @@ TEST(GCGraphTest, INT8IdenticalBottleneckCompileExecutionNXC_CPU) {
 TEST(GCGraphTest, INT8ConvolutionalBottleneckCompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_int8_convolutional_bottleneck_resblock(&agraph,
@@ -773,7 +773,7 @@ TEST(GCGraphTest, INT8ConvolutionalBottleneckCompileExecution_CPU) {
 TEST(GCGraphTest, FP32IdenticalBottleneckTrainingCompileExecution_CPU) {
     REQUIRE_AVX512();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_training_subgraph(&agraph,
@@ -787,7 +787,7 @@ TEST(GCGraphTest, FP32IdenticalBottleneckTrainingCompileExecution_CPU) {
 TEST(GCGraphTest, FP32IdenticalBottleneckTrainingCompileExecutionNCX_CPU) {
     REQUIRE_AVX512();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_training_subgraph(&agraph,
@@ -802,7 +802,7 @@ TEST(GCGraphTest, FP32IdenticalBottleneckTrainingCompileExecutionNCX_CPU) {
 TEST(GCGraphTest, FP32ConvolutionalBottleneckTrainingCompileExecution_CPU) {
     REQUIRE_AVX512();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_convolutional_bottleneck_training_subgraph(
@@ -816,7 +816,7 @@ TEST(GCGraphTest, FP32ConvolutionalBottleneckTrainingCompileExecution_CPU) {
 TEST(GCGraphTest, BF16IdenticalBottleneckTrainingCompileExecution_CPU) {
     REQUIRE_AMXBF16();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_training_subgraph(&agraph,
@@ -837,7 +837,7 @@ TEST(GCGraphTest, BF16ConvolutionalBottleneckTrainingCompileExecution_CPU) {
         return;
     }
 #endif
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_convolutional_bottleneck_training_subgraph(
@@ -852,7 +852,7 @@ TEST(GCGraphTest, BF16ConvolutionalBottleneckTrainingCompileExecution_CPU) {
 TEST(GCGraphTest, INT8IdenticalBottleneckCompileExecutionDynamicQuantize_CPU) {
     REQUIRE_VNNI_AMXINT8();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_int8_identical_bottleneck_resblock(&agraph,
@@ -870,7 +870,7 @@ TEST(GCGraphTest,
     REQUIRE_VNNI_AMXINT8();
     REQUIRE_AMX();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_int8_identical_bottleneck_resblock(&agraph,
@@ -887,7 +887,7 @@ TEST(GCGraphTest,
         INT8ConvolutionalBottleneckCompileExecutionDynamicQuantize_CPU) {
     REQUIRE_VNNI_AMXINT8();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_int8_convolutional_bottleneck_resblock(&agraph,
@@ -904,7 +904,7 @@ TEST(GCGraphTest,
 TEST(GCGraphTest, INT8MulQuantizeCompileExecution_CPU) {
     REQUIRE_AVX512();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_mul_quantize_subgraph(
@@ -916,7 +916,7 @@ TEST(GCGraphTest, INT8MulQuantizeCompileExecution_CPU) {
 
 TEST(GCGraphTest, FP32GPTMHACompileExecution_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, false, false);
@@ -927,7 +927,7 @@ TEST(GCGraphTest, FP32GPTMHACompileExecution_CPU) {
 
 TEST(GCGraphTest, BF16GPTMHACompileExecution_CPU) {
     REQUIRE_BF16_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, true, false);
@@ -938,7 +938,7 @@ TEST(GCGraphTest, BF16GPTMHACompileExecution_CPU) {
 
 TEST(GCGraphTest, INT8FP32GPTMHACompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, false, true);
@@ -949,7 +949,7 @@ TEST(GCGraphTest, INT8FP32GPTMHACompileExecution_CPU) {
 
 TEST(GCGraphTest, INT8BF16GPTMHACompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, true, true);
@@ -960,7 +960,7 @@ TEST(GCGraphTest, INT8BF16GPTMHACompileExecution_CPU) {
 
 TEST(GCGraphTest, FP32LLAMAMHACompileExecution_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, false, false);
@@ -971,7 +971,7 @@ TEST(GCGraphTest, FP32LLAMAMHACompileExecution_CPU) {
 
 TEST(GCGraphTest, BF16LLAMAMHACompileExecution_CPU) {
     REQUIRE_BF16_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, true, false);
@@ -983,7 +983,7 @@ TEST(GCGraphTest, BF16LLAMAMHACompileExecution_CPU) {
 TEST(GCGraphTest, INT8FP32LLAMAMHACompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, false, true);
@@ -995,7 +995,7 @@ TEST(GCGraphTest, INT8FP32LLAMAMHACompileExecution_CPU) {
 TEST(GCGraphTest, INT8BF16LLAMAMHACompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, true, true);
@@ -1007,7 +1007,7 @@ TEST(GCGraphTest, INT8BF16LLAMAMHACompileExecution_CPU) {
 TEST(GCGraphTest, FP32GPTMLPCompileExecution_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, false, false);
@@ -1019,7 +1019,7 @@ TEST(GCGraphTest, FP32GPTMLPCompileExecution_CPU) {
 TEST(GCGraphTest, BF16GPTMLPCompileExecution_CPU) {
     REQUIRE_BF16_AMXBF16();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, true, false);
@@ -1031,7 +1031,7 @@ TEST(GCGraphTest, BF16GPTMLPCompileExecution_CPU) {
 TEST(GCGraphTest, INT8FP32GPTMLPCompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, false, true);
@@ -1043,7 +1043,7 @@ TEST(GCGraphTest, INT8FP32GPTMLPCompileExecution_CPU) {
 TEST(GCGraphTest, INT8BF16GPTMLPCompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, true, true);
@@ -1055,7 +1055,7 @@ TEST(GCGraphTest, INT8BF16GPTMLPCompileExecution_CPU) {
 TEST(GCGraphTest, FP32LLAMAMLPCompileExecution_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, false, false);
@@ -1067,7 +1067,7 @@ TEST(GCGraphTest, FP32LLAMAMLPCompileExecution_CPU) {
 TEST(GCGraphTest, BF16LLAMAMLPCompileExecution_CPU) {
     REQUIRE_BF16_AMXBF16();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, true, false);
@@ -1079,7 +1079,7 @@ TEST(GCGraphTest, BF16LLAMAMLPCompileExecution_CPU) {
 TEST(GCGraphTest, INT8FP32LLAMAMLPCompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, false, true);
@@ -1091,7 +1091,7 @@ TEST(GCGraphTest, INT8FP32LLAMAMLPCompileExecution_CPU) {
 TEST(GCGraphTest, INT8BF16LLAMAMLPCompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, true, true);
@@ -1140,7 +1140,7 @@ TEST(GCGraphTest, LlamaInt8Bf16Concat_CPU) {
 
 TEST(GCGraphTest, FP32STARCODERMHACompileExecution_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(
@@ -1152,7 +1152,7 @@ TEST(GCGraphTest, FP32STARCODERMHACompileExecution_CPU) {
 
 TEST(GCGraphTest, BF16STARCODERMHACompileExecution_CPU) {
     REQUIRE_BF16_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(
@@ -1165,7 +1165,7 @@ TEST(GCGraphTest, BF16STARCODERMHACompileExecution_CPU) {
 TEST(GCGraphTest, INT8FP32STARCODERMHACompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(
@@ -1178,7 +1178,7 @@ TEST(GCGraphTest, INT8FP32STARCODERMHACompileExecution_CPU) {
 TEST(GCGraphTest, INT8BF16STARCODERMHACompileExecution_CPU) {
     REQUIRE_VNNI_AMXINT8();
     SKIP_WHEN_SINGLE_OP_PATTERN_ON();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     impl::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(

--- a/tests/gtests/graph/unit/backend/graph_compiler/test_pattern.cpp
+++ b/tests/gtests/graph/unit/backend/graph_compiler/test_pattern.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -520,7 +520,7 @@ TEST(GCPatternTests, BF16MHATrainingPattern2_CPU) {
 TEST(GCPatternTests, FP32IdenticalBottleneckPattern1_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_resblock(&agraph, id_gen,
@@ -535,7 +535,7 @@ TEST(GCPatternTests, FP32IdenticalBottleneckPattern1_CPU) {
 TEST(GCPatternTests, FP32IdenticalBottleneckPattern2_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_resblock(&agraph, id_gen,
@@ -552,7 +552,7 @@ TEST(GCPatternTests, FP32IdenticalBottleneckPattern2_CPU) {
 TEST(GCPatternTests, FP32ConvolutionalBottleneckPattern1_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_convolutional_bottleneck_resblock(&agraph, id_gen,
@@ -567,7 +567,7 @@ TEST(GCPatternTests, FP32ConvolutionalBottleneckPattern1_CPU) {
 TEST(GCPatternTests, FP32ConvolutionalBottleneckPattern2_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_convolutional_bottleneck_resblock(&agraph, id_gen,
@@ -584,7 +584,7 @@ TEST(GCPatternTests, FP32ConvolutionalBottleneckPattern2_CPU) {
 
 TEST(GCPatternTests, BF16IdenticalBottleneckPattern_CPU) {
     REQUIRE_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_resblock(&agraph, id_gen,
@@ -599,7 +599,7 @@ TEST(GCPatternTests, BF16IdenticalBottleneckPattern_CPU) {
 TEST(GCPatternTests, INT8ConvolutionalBottleneckPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_int8_convolutional_bottleneck_resblock(&agraph,
@@ -616,7 +616,7 @@ TEST(GCPatternTests, INT8ConvolutionalBottleneckPattern_CPU) {
 
 TEST(GCPatternTests, BF16ConvolutionalBottleneckPattern_CPU) {
     REQUIRE_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_convolutional_bottleneck_resblock(&agraph, id_gen,
@@ -631,7 +631,7 @@ TEST(GCPatternTests, BF16ConvolutionalBottleneckPattern_CPU) {
 
 TEST(GCPatternTests, FP32ConvolutionalBottleneckTrainingPattern_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_convolutional_bottleneck_training_subgraph(
@@ -647,7 +647,7 @@ TEST(GCPatternTests, FP32ConvolutionalBottleneckTrainingPattern_CPU) {
 
 TEST(GCPatternTests, FP32IdenticalBottleneckTrainingPattern_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_identical_bottleneck_training_subgraph(&agraph,
@@ -708,7 +708,7 @@ TEST(GCPatternTests, INT8BF16MatMulSoftmaxPattern_CPU) {
 TEST(GCPatternTests, INT8MulQuantizePattern_CPU) {
     {
         REQUIRE_AVX512();
-        utils::id_generator id_gen;
+        utils::id_generator_t id_gen;
         REQUIRE_CPU_ENGINE();
         graph::graph_t agraph(engine->kind());
         compiler_utils::construct_mul_quantize_subgraph(
@@ -746,7 +746,7 @@ TEST(GCPatternTests, INT8MulQuantizePattern_CPU) {
     }
     {
         REQUIRE_AVX512();
-        utils::id_generator id_gen;
+        utils::id_generator_t id_gen;
         REQUIRE_CPU_ENGINE();
         graph::graph_t agraph(engine->kind());
         compiler_utils::construct_mul_quantize_subgraph(
@@ -788,7 +788,7 @@ TEST(GCPatternTests, INT8MulQuantizePattern_CPU) {
 
 TEST(GCPatternTests, FP32GPTMHAPattern_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, false, false);
@@ -800,7 +800,7 @@ TEST(GCPatternTests, FP32GPTMHAPattern_CPU) {
 
 TEST(GCPatternTests, BF16GPTMHAPattern_CPU) {
     REQUIRE_BF16_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, true, false);
@@ -812,7 +812,7 @@ TEST(GCPatternTests, BF16GPTMHAPattern_CPU) {
 
 TEST(GCPatternTests, INT8FP32GPTMHAPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, false, true);
@@ -824,7 +824,7 @@ TEST(GCPatternTests, INT8FP32GPTMHAPattern_CPU) {
 
 TEST(GCPatternTests, INT8BF16GPTMHAPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mha_subgraph(&agraph, id_gen, true, true);
@@ -836,7 +836,7 @@ TEST(GCPatternTests, INT8BF16GPTMHAPattern_CPU) {
 
 TEST(GCPatternTests, FP32LLAMAMHAPattern_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, false, false);
@@ -848,7 +848,7 @@ TEST(GCPatternTests, FP32LLAMAMHAPattern_CPU) {
 
 TEST(GCPatternTests, BF16LLAMAMHAPattern_CPU) {
     REQUIRE_BF16_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, true, false);
@@ -860,7 +860,7 @@ TEST(GCPatternTests, BF16LLAMAMHAPattern_CPU) {
 
 TEST(GCPatternTests, INT8FP32LLAMAMHAPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, false, true);
@@ -872,7 +872,7 @@ TEST(GCPatternTests, INT8FP32LLAMAMHAPattern_CPU) {
 
 TEST(GCPatternTests, INT8BF16LLAMAMHAPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mha_subgraph(&agraph, id_gen, true, true);
@@ -885,7 +885,7 @@ TEST(GCPatternTests, INT8BF16LLAMAMHAPattern_CPU) {
 TEST(GCPatternTests, FP32GPTMLPPattern_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, false, false);
@@ -897,7 +897,7 @@ TEST(GCPatternTests, FP32GPTMLPPattern_CPU) {
 
 TEST(GCPatternTests, INT8GPTMLPPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, false, true);
@@ -910,7 +910,7 @@ TEST(GCPatternTests, INT8GPTMLPPattern_CPU) {
 TEST(GCPatternTests, BF16GPTMLPPattern_CPU) {
     REQUIRE_BF16_AMXBF16();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, true, false);
@@ -922,7 +922,7 @@ TEST(GCPatternTests, BF16GPTMLPPattern_CPU) {
 
 TEST(GCPatternTests, INT8BF16GPTMLPPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_gpt_mlp_subgraph(&agraph, id_gen, true, true);
@@ -935,7 +935,7 @@ TEST(GCPatternTests, INT8BF16GPTMLPPattern_CPU) {
 TEST(GCPatternTests, FP32LLAMAMLPPattern_CPU) {
     REQUIRE_AVX512();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, false, false);
@@ -947,7 +947,7 @@ TEST(GCPatternTests, FP32LLAMAMLPPattern_CPU) {
 
 TEST(GCPatternTests, INT8LLAMAMLPPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, false, true);
@@ -960,7 +960,7 @@ TEST(GCPatternTests, INT8LLAMAMLPPattern_CPU) {
 TEST(GCPatternTests, BF16LLAMAMLPPattern_CPU) {
     REQUIRE_BF16_AMXBF16();
     REQUIRE_AMX();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, true, false);
@@ -972,7 +972,7 @@ TEST(GCPatternTests, BF16LLAMAMLPPattern_CPU) {
 
 TEST(GCPatternTests, INT8BF16LLAMAMLPPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_llama_mlp_subgraph(&agraph, id_gen, true, true);
@@ -1130,7 +1130,7 @@ TEST(GCPatternTests, add_typecast_concat_typecasts_quant_CPU) {
 
 TEST(GCPatternTests, FP32STARCODERMHAPattern_CPU) {
     REQUIRE_AVX512();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(
@@ -1143,7 +1143,7 @@ TEST(GCPatternTests, FP32STARCODERMHAPattern_CPU) {
 
 TEST(GCPatternTests, BF16STARCODERMHAPattern_CPU) {
     REQUIRE_BF16_AMXBF16();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(
@@ -1156,7 +1156,7 @@ TEST(GCPatternTests, BF16STARCODERMHAPattern_CPU) {
 
 TEST(GCPatternTests, INT8FP32STARCODERMHAPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(
@@ -1169,7 +1169,7 @@ TEST(GCPatternTests, INT8FP32STARCODERMHAPattern_CPU) {
 
 TEST(GCPatternTests, INT8BF16STARCODERMHAPattern_CPU) {
     REQUIRE_VNNI_AMXINT8();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::graph_t agraph(engine->kind());
     compiler_utils::construct_starcoder_mha_subgraph(

--- a/tests/gtests/graph/unit/backend/graph_compiler/test_single_op_partition.cpp
+++ b/tests/gtests/graph/unit/backend/graph_compiler/test_single_op_partition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ namespace compiler_utils = dnnl::impl::graph::tests::unit::compiler::utils;
 
 TEST(GCSingleOpTest, BinaryOpCompileExecution_CPU) {
     REQUIRE_SINGLE_OP_PATTERN();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::engine_t *eng = get_engine();
 
@@ -74,9 +74,9 @@ TEST(GCSingleOpTest, BinaryOpCompileExecution_CPU) {
 
         std::vector<float> src0(16 * 16), src1(16), dst(16 * 16);
 
-        test_tensor src0_ts(src0_lt, eng, src0);
-        test_tensor src1_ts(src1_lt, eng, src1);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src0_ts(src0_lt, eng, src0);
+        test_tensor_t src1_ts(src1_lt, eng, src1);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src0_ts.get(), src1_ts.get()}, {dst_ts.get()});
@@ -86,7 +86,7 @@ TEST(GCSingleOpTest, BinaryOpCompileExecution_CPU) {
 
 TEST(GCSingleOpTest, UnaryActivationOpCompileExecution_CPU) {
     REQUIRE_SINGLE_OP_PATTERN();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::engine_t *eng = get_engine();
 
@@ -126,8 +126,8 @@ TEST(GCSingleOpTest, UnaryActivationOpCompileExecution_CPU) {
 
         std::vector<float> src(16 * 16), dst(16 * 16);
 
-        test_tensor src_ts(src_lt, eng, src);
-        test_tensor dst_ts(dst_lt, eng, dst);
+        test_tensor_t src_ts(src_lt, eng, src);
+        test_tensor_t dst_ts(dst_lt, eng, dst);
 
         graph::stream_t *strm = get_stream();
         cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -137,7 +137,7 @@ TEST(GCSingleOpTest, UnaryActivationOpCompileExecution_CPU) {
 
 TEST(GCSingleOpTest, StaticReshapeOpCompileExecution_CPU) {
     REQUIRE_SINGLE_OP_PATTERN();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::engine_t *eng = get_engine();
 
@@ -175,8 +175,8 @@ TEST(GCSingleOpTest, StaticReshapeOpCompileExecution_CPU) {
 
     std::vector<float> src(16 * 16), dst(16 * 16);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -185,7 +185,7 @@ TEST(GCSingleOpTest, StaticReshapeOpCompileExecution_CPU) {
 
 TEST(GCSingleOpTest, StaticTransposeOpCompileExecution_CPU) {
     REQUIRE_SINGLE_OP_PATTERN();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::engine_t *eng = get_engine();
 
@@ -222,8 +222,8 @@ TEST(GCSingleOpTest, StaticTransposeOpCompileExecution_CPU) {
 
     std::vector<float> src(16 * 16), dst(16 * 16);
 
-    test_tensor src_ts(src_lt, eng, src);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src_ts(src_lt, eng, src);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src_ts.get()}, {dst_ts.get()});
@@ -232,7 +232,7 @@ TEST(GCSingleOpTest, StaticTransposeOpCompileExecution_CPU) {
 
 TEST(GCSingleOpTest, SelectOpCompileExecution_CPU) {
     REQUIRE_SINGLE_OP_PATTERN();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::engine_t *eng = get_engine();
 
@@ -274,10 +274,10 @@ TEST(GCSingleOpTest, SelectOpCompileExecution_CPU) {
     std::vector<float> then(2 * 3 * 4 * 5), els(1), dst(2 * 3 * 4 * 5);
     std::vector<char> cond(2 * 5);
 
-    test_tensor cond_ts(cond_lt, eng, cond);
-    test_tensor then_ts(then_lt, eng, then);
-    test_tensor else_ts(else_lt, eng, els);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t cond_ts(cond_lt, eng, cond);
+    test_tensor_t then_ts(then_lt, eng, then);
+    test_tensor_t else_ts(else_lt, eng, els);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {cond_ts.get(), then_ts.get(), else_ts.get()},
@@ -287,7 +287,7 @@ TEST(GCSingleOpTest, SelectOpCompileExecution_CPU) {
 
 TEST(GCSingleOpTest, ConcatOpCompileExecution_CPU) {
     REQUIRE_SINGLE_OP_PATTERN();
-    utils::id_generator id_gen;
+    utils::id_generator_t id_gen;
     REQUIRE_CPU_ENGINE();
     graph::engine_t *eng = get_engine();
 
@@ -330,10 +330,10 @@ TEST(GCSingleOpTest, ConcatOpCompileExecution_CPU) {
     std::vector<float> src0(16 * 8 * 1 * 8), src1(16 * 8 * 2 * 8),
             src2(16 * 8 * 3 * 8), dst(16 * 8 * 6 * 8);
 
-    test_tensor src0_ts(src0_lt, eng, src0);
-    test_tensor src1_ts(src1_lt, eng, src1);
-    test_tensor src2_ts(src2_lt, eng, src2);
-    test_tensor dst_ts(dst_lt, eng, dst);
+    test_tensor_t src0_ts(src0_lt, eng, src0);
+    test_tensor_t src1_ts(src1_lt, eng, src1);
+    test_tensor_t src2_ts(src2_lt, eng, src2);
+    test_tensor_t dst_ts(dst_lt, eng, dst);
 
     graph::stream_t *strm = get_stream();
     cp.execute(strm, {src0_ts.get(), src1_ts.get(), src2_ts.get()},

--- a/tests/gtests/graph/unit/backend/graph_compiler/test_utils.hpp
+++ b/tests/gtests/graph/unit/backend/graph_compiler/test_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2920,7 +2920,7 @@ static std::vector<graph::dim_t> extract_filter_info(
 }
 
 inline graph::logical_tensor_t create_dyn_dequantize(
-        utils::id_generator &id_gen, graph_t &agraph,
+        utils::id_generator_t &id_gen, graph_t &agraph,
         const graph::logical_tensor_t &src, const std::string &qtype,
         int64_t axis, graph::dim_t channel_size = 1) {
     graph::op_t dq_op(
@@ -2941,9 +2941,10 @@ inline graph::logical_tensor_t create_dyn_dequantize(
     return dst;
 }
 
-inline graph::logical_tensor_t create_dyn_quantize(utils::id_generator &id_gen,
-        graph_t &agraph, const graph::logical_tensor_t &src,
-        data_type_t dst_dtype, const std::string &qtype, int64_t axis) {
+inline graph::logical_tensor_t create_dyn_quantize(
+        utils::id_generator_t &id_gen, graph_t &agraph,
+        const graph::logical_tensor_t &src, data_type_t dst_dtype,
+        const std::string &qtype, int64_t axis) {
     graph::op_t q_op(
             id_gen.get_id(), graph::op_kind::DynamicQuantize, "quantize");
     q_op.set_attr<std::string>(op_attr::qtype, qtype);
@@ -2960,7 +2961,7 @@ inline graph::logical_tensor_t create_dyn_quantize(utils::id_generator &id_gen,
 }
 
 inline graph::logical_tensor_t create_int8_convolution_dyn_quant(
-        utils::id_generator &id_gen, graph_t &agraph,
+        utils::id_generator_t &id_gen, graph_t &agraph,
         const graph::logical_tensor_t &src, int64_t ic, int64_t ks, int64_t oc,
         int64_t groups, const dims &strides, const dims &dilations,
         const dims &pads_begin, const dims &pads_end,
@@ -3053,7 +3054,7 @@ inline graph::logical_tensor_t create_int8_convolution_dyn_quant(
 // filter_shape in the order of 1x1; 1x1 + 3x3 + 1x1
 // strides and paddings also start with the single conv branch
 inline void construct_convolutional_bottleneck_resblock(graph::graph_t *agraph,
-        utils::id_generator &id_gen, const dims &input_shape,
+        utils::id_generator_t &id_gen, const dims &input_shape,
         const std::vector<dims> &filter_shapes, bool is_bf16 = false,
         const std::vector<std::vector<int64_t>> &strides
         = {{2, 2}, {1, 1}, {2, 2}, {1, 1}},
@@ -3088,7 +3089,7 @@ inline void construct_convolutional_bottleneck_resblock(graph::graph_t *agraph,
 }
 
 inline void construct_identical_bottleneck_resblock(graph::graph_t *agraph,
-        utils::id_generator &id_gen, const dims &input_shape,
+        utils::id_generator_t &id_gen, const dims &input_shape,
         const std::vector<dims> &filter_shapes, bool is_bf16 = false,
         const std::vector<std::vector<int64_t>> &strides
         = {{1, 1}, {1, 1}, {1, 1}},
@@ -3117,7 +3118,7 @@ inline void construct_identical_bottleneck_resblock(graph::graph_t *agraph,
 }
 
 inline void construct_int8_identical_bottleneck_resblock(graph::graph_t *agraph,
-        utils::id_generator &id_gen, const dims &input_shape,
+        utils::id_generator_t &id_gen, const dims &input_shape,
         const std::vector<dims> &filter_shapes,
         const std::vector<std::vector<int64_t>> &strides
         = {{1, 1}, {1, 1}, {1, 1}},
@@ -3174,7 +3175,7 @@ inline void construct_int8_identical_bottleneck_resblock(graph::graph_t *agraph,
 // filter_shape in the order of 1x1; 1x1+3x3+1x1
 // strides and paddings also first consider the single conv branch
 inline void construct_int8_convolutional_bottleneck_resblock(
-        graph::graph_t *agraph, utils::id_generator &id_gen,
+        graph::graph_t *agraph, utils::id_generator_t &id_gen,
         const dims &input_shape, const std::vector<dims> &filter_shapes,
         const std::vector<std::vector<int64_t>> &strides
         = {{2, 2}, {1, 1}, {2, 2}, {1, 1}},
@@ -3244,7 +3245,7 @@ inline void construct_int8_convolutional_bottleneck_resblock(
     (void)(q2);
 }
 
-inline graph::logical_tensor_t create_relu_bwd(utils::id_generator &id_gen,
+inline graph::logical_tensor_t create_relu_bwd(utils::id_generator_t &id_gen,
         graph::graph_t &agraph, const graph::logical_tensor_t &dst,
         const graph::logical_tensor_t &delta_in, const dims &dims) {
     graph::op_t relu_bwd(
@@ -3258,7 +3259,7 @@ inline graph::logical_tensor_t create_relu_bwd(utils::id_generator &id_gen,
     return delta;
 }
 
-inline graph::logical_tensor_t create_relu_bwd2(utils::id_generator &id_gen,
+inline graph::logical_tensor_t create_relu_bwd2(utils::id_generator_t &id_gen,
         graph::graph_t &agraph, const graph::logical_tensor_t &dst,
         const graph::logical_tensor_t &delta) {
     graph::op_t relu_bwd(
@@ -3287,7 +3288,7 @@ inline graph::logical_tensor_t create_relu_bwd2(utils::id_generator &id_gen,
         (dst)         (delta_in_next)
 */
 inline std::vector<graph::logical_tensor_t> create_convolution_training(
-        utils::id_generator &id_gen, graph::graph_t &agraph,
+        utils::id_generator_t &id_gen, graph::graph_t &agraph,
         const graph::logical_tensor_t &src, graph::logical_tensor_t &delta_in,
         const dims &filter_shape, const dims &strides, const dims &pads_begin,
         const dims &pads_end, const std::string &data_format,
@@ -3497,7 +3498,7 @@ inline std::vector<graph::logical_tensor_t> create_convolution_training(
 }
 
 inline void construct_identical_bottleneck_training_subgraph(
-        graph::graph_t *agraph, utils::id_generator &id_gen,
+        graph::graph_t *agraph, utils::id_generator_t &id_gen,
         const dims &input_shape, const std::vector<dims> &filter_shapes,
         bool is_bf16 = false, bool is_bn_bf16 = false,
         const std::vector<std::vector<int64_t>> &strides
@@ -3542,7 +3543,7 @@ inline void construct_identical_bottleneck_training_subgraph(
 
 // filter is in order {rhs, lhs0, lhs1, lhs2}
 inline void construct_convolutional_bottleneck_training_subgraph(
-        graph::graph_t *agraph, utils::id_generator &id_gen,
+        graph::graph_t *agraph, utils::id_generator_t &id_gen,
         const dims &input_shape, const std::vector<dims> &filter_shapes,
         bool is_bf16 = false, bool is_bn_bf16 = false,
         const std::vector<std::vector<int64_t>> &strides
@@ -4109,7 +4110,7 @@ inline void add_bart_mlp_residual_subgraph(graph::graph_t *agraph,
 }
 
 inline void construct_mul_quantize_subgraph(graph::graph_t *agraph,
-        utils::id_generator &id_gen, const graph::dims &input_shape,
+        utils::id_generator_t &id_gen, const graph::dims &input_shape,
         bool is_mixed_precision = false) {
     graph::dims smooth_quant_scales_shape {input_shape[input_shape.size() - 1]};
     auto dtype = is_mixed_precision ? graph::data_type::bf16
@@ -4140,7 +4141,7 @@ inline void construct_mul_quantize_subgraph(graph::graph_t *agraph,
 }
 
 inline void construct_gpt_mha_subgraph(graph::graph_t *agraph,
-        utils::id_generator &id_gen, bool use_bf16 = false,
+        utils::id_generator_t &id_gen, bool use_bf16 = false,
         bool use_int8 = false, int batch_size = 4, int seq_len = 34,
         int num_head = 16, int head_dim = 4096) {
     int size_per_head = head_dim / num_head;
@@ -4409,7 +4410,7 @@ inline void construct_gpt_mha_subgraph(graph::graph_t *agraph,
 }
 
 static void construct_llama_mha_base(graph::graph_t *agraph,
-        utils::id_generator &id_gen, graph::data_type_t dtype,
+        utils::id_generator_t &id_gen, graph::data_type_t dtype,
         int batch_size = 4, int seq_len = 34, int num_head = 32,
         int head_dim = 4096) {
     int size_per_head = head_dim / num_head;
@@ -4518,7 +4519,7 @@ static void construct_llama_mha_base(graph::graph_t *agraph,
 }
 
 static void insert_quantization_before_op(graph::graph_t *agraph,
-        utils::id_generator &id_gen, graph::op_t *op, int idx, bool is_bf16) {
+        utils::id_generator_t &id_gen, graph::op_t *op, int idx, bool is_bf16) {
     // init quant dequant
     graph::op_t quantize {
             id_gen.get_id(), graph::op_kind::Quantize, "quantize"};
@@ -4578,7 +4579,7 @@ static void insert_quantization_before_op(graph::graph_t *agraph,
 }
 
 static void insert_quantization_after_output(graph::graph_t *agraph,
-        utils::id_generator &id_gen, const graph::logical_tensor_t &output_lt,
+        utils::id_generator_t &id_gen, const graph::logical_tensor_t &output_lt,
         bool is_bf16) {
     // init quant dequant
     graph::op_t quantize {
@@ -4630,7 +4631,7 @@ static void insert_quantization_after_output(graph::graph_t *agraph,
 }
 
 inline void construct_llama_mha_subgraph(graph::graph_t *agraph,
-        utils::id_generator &id_gen, bool use_bf16 = false,
+        utils::id_generator_t &id_gen, bool use_bf16 = false,
         bool use_int8 = false, int batch_size = 4, int seq_len = 34,
         int num_head = 32, int head_dim = 4096) {
     construct_llama_mha_base(agraph, id_gen,
@@ -4698,8 +4699,9 @@ inline void construct_llama_mha_subgraph(graph::graph_t *agraph,
     }
 }
 
-static inline graph::logical_tensor_t create_matmul(utils::id_generator &id_gen,
-        graph::graph_t *agraph, const graph::logical_tensor_t *input,
+static inline graph::logical_tensor_t create_matmul(
+        utils::id_generator_t &id_gen, graph::graph_t *agraph,
+        const graph::logical_tensor_t *input,
         const graph::logical_tensor_t *weight,
         const graph::logical_tensor_t *bias = nullptr,
         bool transpose_b = false) {
@@ -4715,7 +4717,7 @@ static inline graph::logical_tensor_t create_matmul(utils::id_generator &id_gen,
 }
 
 static graph::logical_tensor_t construct_gpt_mlp_base(graph::graph_t *agraph,
-        utils::id_generator &id_gen, graph::data_type_t dtype,
+        utils::id_generator_t &id_gen, graph::data_type_t dtype,
         graph::dim_t batch_size = 4,
         std::vector<graph::dim_t> hidden_sizes = {4096, 16384, 4096}) {
     std::vector<graph::dim_t> input_shape {batch_size, 1, hidden_sizes[0]};
@@ -4777,7 +4779,7 @@ static graph::logical_tensor_t construct_gpt_mlp_base(graph::graph_t *agraph,
 }
 
 inline void construct_gpt_mlp_subgraph(graph::graph_t *agraph,
-        utils::id_generator &id_gen, bool use_bf16 = false,
+        utils::id_generator_t &id_gen, bool use_bf16 = false,
         bool use_int8 = false, graph::dim_t batch_size = 4,
         std::vector<graph::dim_t> hidden_sizes = {4096, 16384, 4096}) {
     auto output_lt = construct_gpt_mlp_base(agraph, id_gen,
@@ -4799,7 +4801,7 @@ inline void construct_gpt_mlp_subgraph(graph::graph_t *agraph,
 }
 
 static graph::logical_tensor_t construct_rms_norm_subgraph(
-        graph::graph_t *agraph, utils::id_generator &id_gen,
+        graph::graph_t *agraph, utils::id_generator_t &id_gen,
         const graph::logical_tensor_t &input_desc,
         graph::dim_t mul_in_size = 4096) {
     bool is_bf16 = input_desc.data_type == graph::data_type::bf16;
@@ -4877,7 +4879,7 @@ static graph::logical_tensor_t construct_rms_norm_subgraph(
 }
 
 static graph::logical_tensor_t construct_llama_mlp_base(graph::graph_t *agraph,
-        utils::id_generator &id_gen, graph::data_type_t dtype,
+        utils::id_generator_t &id_gen, graph::data_type_t dtype,
         graph::dim_t batch_size = 4,
         std::vector<graph::dim_t> hidden_sizes = {4096, 4096, 11008, 4096}) {
     std::vector<graph::dim_t> input_shape {batch_size, 1, hidden_sizes[0]};
@@ -4939,7 +4941,7 @@ static graph::logical_tensor_t construct_llama_mlp_base(graph::graph_t *agraph,
 }
 
 inline void construct_llama_mlp_subgraph(graph::graph_t *agraph,
-        utils::id_generator &id_gen, bool use_bf16 = false,
+        utils::id_generator_t &id_gen, bool use_bf16 = false,
         bool use_int8 = false, graph::dim_t batch_size = 4,
         std::vector<graph::dim_t> hidden_sizes = {4096, 4096, 11008, 4096}) {
     auto output_lt = construct_llama_mlp_base(agraph, id_gen,
@@ -5295,7 +5297,7 @@ inline void add_llama_concat_subgraph(
 }
 
 static void construct_starcoder_mha_base(graph::graph_t *agraph,
-        utils::id_generator &id_gen, graph::data_type_t dtype,
+        utils::id_generator_t &id_gen, graph::data_type_t dtype,
         int batch_size = 1, int query_seq_len = 16, int key_seq_len = 16,
         int num_head = 32, int head_dim = 4096) {
     int size_per_head = head_dim / num_head;
@@ -5382,7 +5384,7 @@ static void construct_starcoder_mha_base(graph::graph_t *agraph,
 }
 
 inline void construct_starcoder_mha_subgraph(graph::graph_t *agraph,
-        utils::id_generator &id_gen, bool use_bf16 = false,
+        utils::id_generator_t &id_gen, bool use_bf16 = false,
         bool use_int8 = false, int batch_size = 1, int query_seq_len = 16,
         int key_seq_len = 16, int num_head = 32, int head_dim = 4096) {
     construct_starcoder_mha_base(agraph, id_gen,

--- a/tests/gtests/graph/unit/interface/test_tensor.cpp
+++ b/tests/gtests/graph/unit/interface/test_tensor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ TEST(test_interface_tensor, GetEngine) {
     graph::engine_t &engine = *get_engine();
     graph::logical_tensor_t lt = utils::logical_tensor_init(
             0, {1, 2}, graph::data_type::f32, graph::layout_type::strided);
-    test_tensor tmp(lt, &engine);
+    test_tensor_t tmp(lt, &engine);
     ASSERT_EQ(tmp.get().get_engine(), &engine);
 }
 

--- a/tests/gtests/graph/unit/unit_test_common.hpp
+++ b/tests/gtests/graph/unit/unit_test_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,12 +80,12 @@ inline int set_compiled_partition_cache_capacity(int capacity) {
     return 0;
 }
 
-class test_tensor {
+class test_tensor_t {
 private:
     using ltw = dnnl::impl::graph::logical_tensor_wrapper_t;
 
-    struct deletor_wrapper {
-        deletor_wrapper(const dnnl::impl::graph::engine_t *eng) : eng_(eng) {}
+    struct deletor_wrapper_t {
+        deletor_wrapper_t(const dnnl::impl::graph::engine_t *eng) : eng_(eng) {}
         void operator()(void *p) {
             if (p) {
                 const auto k = eng_->kind();
@@ -129,16 +129,16 @@ private:
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
             data.reset(static_cast<char *>(alc->allocate(
                                size, get_device(), get_context())),
-                    deletor_wrapper {e});
+                    deletor_wrapper_t {e});
 #else
             data.reset(static_cast<char *>(alc->allocate(size)),
-                    deletor_wrapper {e});
+                    deletor_wrapper_t {e});
 #endif
         } else { // gpu kind
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
             data.reset(static_cast<char *>(alc->allocate(
                                size, get_device(), get_context())),
-                    deletor_wrapper {e});
+                    deletor_wrapper_t {e});
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
             const auto *ocl_engine = dnnl::impl::utils::downcast<
                     const dnnl::impl::gpu::intel::ocl::ocl_gpu_engine_t *>(e);
@@ -146,7 +146,7 @@ private:
             auto ctx = ocl_engine->context();
 
             data.reset(static_cast<char *>(alc->allocate(size, dev, ctx)),
-                    deletor_wrapper {e});
+                    deletor_wrapper_t {e});
 #else
             assert(!"only sycl and ocl runtime is supported on gpu");
 #endif
@@ -155,9 +155,9 @@ private:
     }
 
 public:
-    test_tensor() = default;
+    test_tensor_t() = default;
 
-    test_tensor(const dnnl::impl::graph::logical_tensor_t &lt,
+    test_tensor_t(const dnnl::impl::graph::logical_tensor_t &lt,
             const dnnl::impl::graph::engine_t *e)
         : num_bytes_(ltw(lt).size()) {
         data_ = allocate(e, num_bytes_);
@@ -165,9 +165,9 @@ public:
     }
 
     template <typename T>
-    test_tensor(const dnnl::impl::graph::logical_tensor_t &lt,
+    test_tensor_t(const dnnl::impl::graph::logical_tensor_t &lt,
             const dnnl::impl::graph::engine_t *e, const std::vector<T> &data)
-        : test_tensor(lt, e) {
+        : test_tensor_t(lt, e) {
         this->fill(data);
     }
 
@@ -237,7 +237,7 @@ public:
     }
 
     static std::vector<dnnl::impl::graph::tensor_t> to_graph_tensor(
-            const std::vector<test_tensor> &vecs) {
+            const std::vector<test_tensor_t> &vecs) {
         std::vector<dnnl::impl::graph::tensor_t> res;
         for (const auto &e : vecs) {
             res.emplace_back(e.get());

--- a/tests/gtests/graph/unit/unit_test_common.hpp
+++ b/tests/gtests/graph/unit/unit_test_common.hpp
@@ -86,7 +86,7 @@ private:
 
     struct deletor_wrapper_t {
         deletor_wrapper_t(const dnnl::impl::graph::engine_t *eng) : eng_(eng) {}
-        void operator()(void *p) {
+        void operator()(void *p) const {
             if (p) {
                 const auto k = eng_->kind();
                 auto alc = static_cast<dnnl::impl::graph::allocator_t *>(

--- a/tests/gtests/graph/unit/unit_test_common.hpp
+++ b/tests/gtests/graph/unit/unit_test_common.hpp
@@ -238,9 +238,9 @@ public:
 
     static std::vector<dnnl::impl::graph::tensor_t> to_graph_tensor(
             const std::vector<test_tensor_t> &vecs) {
-        std::vector<dnnl::impl::graph::tensor_t> res;
-        for (const auto &e : vecs) {
-            res.emplace_back(e.get());
+        std::vector<dnnl::impl::graph::tensor_t> res(vecs.size());
+        for (size_t i = 0; i < vecs.size(); ++i) {
+            res[i] = vecs[i].get();
         }
         return res;
     }

--- a/tests/gtests/graph/unit/utils.hpp
+++ b/tests/gtests/graph/unit/utils.hpp
@@ -421,9 +421,9 @@ static inline void infer_conv_shape(dnnl::impl::graph::op_kind_t kind) {
 }
 
 static inline void verify_shape_infer_for_conv(
-        const dnnl::impl::graph::op_kind_t op_kind_, std::string data_format,
-        std::string filter_format, int64_t groups,
-        const std::vector<int64_t> &in_data,
+        const dnnl::impl::graph::op_kind_t op_kind_,
+        const std::string &data_format, const std::string &filter_format,
+        int64_t groups, const std::vector<int64_t> &in_data,
         const std::vector<int64_t> &in_weight,
         const std::vector<int64_t> &expected_out_shape) {
     using namespace dnnl::impl::graph;
@@ -505,9 +505,9 @@ static inline void verify_shape_infer_for_convtranspose_bprop_data(
 }
 
 static inline void verify_shape_infer_for_convtranspose(
-        const dnnl::impl::graph::op_kind_t op_kind_, std::string data_format,
-        std::string filter_format, int64_t groups,
-        const std::vector<int64_t> &in_data,
+        const dnnl::impl::graph::op_kind_t op_kind_,
+        const std::string &data_format, const std::string &filter_format,
+        int64_t groups, const std::vector<int64_t> &in_data,
         const std::vector<int64_t> &in_weight,
         const std::vector<int64_t> &expected_out_shape) {
     using namespace dnnl::impl::graph;
@@ -553,9 +553,9 @@ static inline void verify_shape_infer_for_convtranspose(
 }
 
 static inline void verify_shape_infer_for_conv(
-        const dnnl::impl::graph::op_kind_t op_kind_, std::string data_format,
-        std::string filter_format, int64_t groups,
-        const std::vector<int64_t> &in_data,
+        const dnnl::impl::graph::op_kind_t op_kind_,
+        const std::string &data_format, const std::string &filter_format,
+        int64_t groups, const std::vector<int64_t> &in_data,
         const std::vector<int64_t> &in_weight,
         const std::vector<int64_t> &in_bias,
         const std::vector<int64_t> &expected_out_shape) {
@@ -603,9 +603,9 @@ static inline void verify_shape_infer_for_conv(
 }
 
 static inline void verify_shape_infer_for_conv_bprop_data(
-        const dnnl::impl::graph::op_kind_t op_kind_, std::string data_format,
-        std::string filter_format, int64_t groups,
-        const std::vector<int64_t> &in_data,
+        const dnnl::impl::graph::op_kind_t op_kind_,
+        const std::string &data_format, const std::string &filter_format,
+        int64_t groups, const std::vector<int64_t> &in_data,
         const std::vector<int64_t> &in_weight,
         const std::vector<int64_t> &in_output_shape,
         const std::vector<int64_t> &expected_out_shape) {

--- a/tests/gtests/graph/unit/utils.hpp
+++ b/tests/gtests/graph/unit/utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1898,16 +1898,16 @@ inline void construct_chained_relu(dnnl::impl::graph::graph_t *agraph) {
     agraph->add_op(&relu2);
 }
 
-class id_generator {
+class id_generator_t {
 public:
-    id_generator() : id_(0) {};
+    id_generator_t() : id_(0) {};
     size_t get_id() { return id_++; }
 
 private:
     size_t id_;
 };
 
-inline impl::graph::logical_tensor_t create_convolution(id_generator &id_gen,
+inline impl::graph::logical_tensor_t create_convolution(id_generator_t &id_gen,
         impl::graph::graph_t &agraph, const impl::graph::logical_tensor_t &src,
         int64_t ic, int64_t ks, int64_t oc, int64_t groups,
         const impl::graph::dims &strides, const impl::graph::dims &dilations,
@@ -2017,7 +2017,7 @@ inline impl::graph::logical_tensor_t create_convolution(id_generator &id_gen,
     return dst;
 }
 
-inline impl::graph::logical_tensor_t create_add(id_generator &id_gen,
+inline impl::graph::logical_tensor_t create_add(id_generator_t &id_gen,
         impl::graph::graph_t &agraph, const impl::graph::logical_tensor_t &src0,
         const impl::graph::logical_tensor_t &src1) {
     impl::graph::op_t add(id_gen.get_id(), impl::graph::op_kind::Add, "add");
@@ -2029,7 +2029,7 @@ inline impl::graph::logical_tensor_t create_add(id_generator &id_gen,
     return dst;
 }
 
-inline impl::graph::logical_tensor_t create_relu(id_generator &id_gen,
+inline impl::graph::logical_tensor_t create_relu(id_generator_t &id_gen,
         impl::graph::graph_t &agraph,
         const impl::graph::logical_tensor_t &src) {
     impl::graph::op_t relu_op(
@@ -2041,7 +2041,7 @@ inline impl::graph::logical_tensor_t create_relu(id_generator &id_gen,
     return dst;
 }
 
-inline impl::graph::logical_tensor_t create_dequantize(id_generator &id_gen,
+inline impl::graph::logical_tensor_t create_dequantize(id_generator_t &id_gen,
         impl::graph::graph_t &agraph, const impl::graph::logical_tensor_t &src,
         const std::string &qtype, const std::vector<int64_t> &zps,
         const std::vector<float> &scales, int64_t axis) {
@@ -2060,7 +2060,7 @@ inline impl::graph::logical_tensor_t create_dequantize(id_generator &id_gen,
     return dst;
 }
 
-inline impl::graph::logical_tensor_t create_quantize(id_generator &id_gen,
+inline impl::graph::logical_tensor_t create_quantize(id_generator_t &id_gen,
         impl::graph::graph_t &agraph, const impl::graph::logical_tensor_t &src,
         impl::graph::data_type_t dst_dtype, const std::string &qtype,
         const std::vector<int64_t> &zps, const std::vector<float> &scales,
@@ -2080,7 +2080,7 @@ inline impl::graph::logical_tensor_t create_quantize(id_generator &id_gen,
 }
 
 inline impl::graph::logical_tensor_t create_int8_convolution(
-        id_generator &id_gen, impl::graph::graph_t &agraph,
+        id_generator_t &id_gen, impl::graph::graph_t &agraph,
         const impl::graph::logical_tensor_t &src, int64_t ic, int64_t ks,
         int64_t oc, int64_t groups, const impl::graph::dims &strides,
         const impl::graph::dims &dilations, const impl::graph::dims &pads_begin,
@@ -2186,7 +2186,7 @@ inline impl::graph::logical_tensor_t create_int8_convolution(
 }
 
 inline void construct_convolutional_bottleneck_resblock(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen) {
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen) {
     auto input = utils::logical_tensor_init(
             id_gen.get_id(), {8, 64, 56, 56}, impl::graph::data_type::f32);
     auto conv0 = create_convolution(id_gen, *agraph, input, 64, 1, 64, 1,
@@ -2207,7 +2207,7 @@ inline void construct_convolutional_bottleneck_resblock(
 }
 
 inline void construct_int8_conv_bias_relu_conv_bias_relu_block(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen) {
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen) {
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};
 
@@ -2231,7 +2231,7 @@ inline void construct_int8_conv_bias_relu_conv_bias_relu_block(
 }
 
 inline void construct_int8_identical_bottleneck_resblock(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen) {
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen) {
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};
 
@@ -2267,7 +2267,7 @@ inline void construct_int8_identical_bottleneck_resblock(
 }
 
 inline void construct_int8_convolutional_bottleneck_resblock(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen) {
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen) {
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};
 
@@ -2318,7 +2318,7 @@ While CPU supports.
 we can set Post-sum/binary zero points by zp_postbinary.
 */
 inline void construct_int8_resnet50_stage2_block(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen,
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen,
         size_t three_conv_block_num = 2, bool use_biasadd = false,
         bool is_quantize_wei = false, float scales = 1 / 255.f,
         int64_t zps = 78, int64_t zp_postbinary = 0) {
@@ -2386,7 +2386,7 @@ inline void construct_int8_resnet50_stage2_block(
 }
 
 inline void construct_f32_resnet50_stage2_block(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen,
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen,
         size_t three_conv_block_num = 2, bool use_biasadd = false) {
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};
@@ -2432,7 +2432,7 @@ inline void construct_f32_resnet50_stage2_block(
 }
 
 inline void construct_itex_int8_resnet50_stage2_block(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen,
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen,
         size_t three_conv_block_num = 2) {
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};
@@ -2502,7 +2502,7 @@ inline void construct_itex_int8_resnet50_stage2_block(
 }
 
 inline void construct_int8_resnext101_stage3_block(
-        dnnl::impl::graph::graph_t *agraph, id_generator &id_gen,
+        dnnl::impl::graph::graph_t *agraph, id_generator_t &id_gen,
         size_t three_conv_block_num = 22) {
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};

--- a/tests/gtests/graph/unit/utils/test_pattern_matcher_cpu.cpp
+++ b/tests/gtests/graph/unit/utils/test_pattern_matcher_cpu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2519,7 +2519,7 @@ TEST(test_utils_pattern_matcher, ShouldNotMatchIdenticalResblock) {
 
     graph_t agraph;
 
-    id_generator id_gen;
+    id_generator_t id_gen;
 
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};
@@ -2826,7 +2826,7 @@ TEST(test_utils_pattern_matcher, RepConvReluWithMultiConsumers) {
     //     |                |
     graph::graph_t agraph;
 
-    id_generator id_gen;
+    id_generator_t id_gen;
 
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};
@@ -2886,7 +2886,7 @@ TEST(test_utils_pattern_matcher, RepConvReluWithMultiConsumersCase2) {
     //     |                |
     graph::graph_t agraph;
 
-    id_generator id_gen;
+    id_generator_t id_gen;
 
     int64_t ic = 8, oc = 8, ks = 1;
     std::vector<int64_t> src_shape {1, ic, 12, 12};


### PR DESCRIPTION
This is a follow-up work after https://github.com/oneapi-src/oneDNN/pull/2338.

Fixed the graph related clang-tidy warnings in src, examples, and gtests.
Benchdnn graph driver fixes will be in another PR.