### PR TITLE
gpu: nvidia: fix relu type cast for dimension

### DIFF
--- a/src/gpu/nvidia/cudnn_eltwise_impl.hpp
+++ b/src/gpu/nvidia/cudnn_eltwise_impl.hpp
@@ -92,6 +92,13 @@ public:
         if (pd->ndims() > CUDNN_DIM_MAX) { return status::invalid_arguments; }
         ndims = pd->ndims() < 4 ? 4 : pd->ndims();
 
+        for (int i = 0; i < ndims; ++i) {
+            if (pd->src_md()->padded_dims[i]
+                    > std::numeric_limits<int>::max()) {
+                return status::unimplemented;
+            }
+        }
+
         // Obtain source and destination dimensions, strides and datatype
         convert_dims(pd->src_md()->padded_dims, dims_, pd->ndims());
         convert_dims(pd->src_md()->format_desc.blocking.strides, strides_,
@@ -139,6 +146,12 @@ public:
         if (pd->ndims() > CUDNN_DIM_MAX) { return status::invalid_arguments; }
         ndims = pd->ndims() < 4 ? 4 : pd->ndims();
 
+        for (int i = 0; i < ndims; ++i) {
+            if (pd->src_md()->padded_dims[i]
+                    > std::numeric_limits<int>::max()) {
+                return status::unimplemented;
+            }
+        }
         // Obtain dimension and strides for the backward eltwise operation
         convert_dims(pd->src_md()->padded_dims, dims_, pd->ndims());
 


### PR DESCRIPTION
# Description

This patch fix dimension conversion from `int64_t` to `int`. Currently the conversion is performed without checking if the provided value respect `int` value limit, with this patch every dimension is checked to respect it and return `unimplemented` in case of error.

To check the error run test with a very big dimension as input e.g.:
`./tests/benchdnn/benchdnn --mode-modifier=P --eltwise --engine=gpu --allow-enum-tags-only=false --dir=BWD_D --dt=bf16 --alg=relu --alpha=0 --beta=0 4294967297_n"large_dim1"`

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
