### PR TITLE
x64: conv: addressing coverity issues

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -1258,6 +1258,10 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const auto call_brgemm = [&](int iw, int brg_idx, int oc_block_s,
                                      int n_oc_blocks, size_t comp_ker_offs,
                                      bool do_postops, bool do_only_comp) {
+        if (brg_idx < 0) {
+            assert(!"Requested brgemm kernel was not created.");
+            return;
+        }
         const auto kh_ee = kh_e;
         int k_sum = 0;
         int32_t *src_zp = jcp.src_zero_point
@@ -1513,6 +1517,10 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
          is_first_call_postops_state_changed = false;
     const auto call_brgemm = [&](int brg_idx, int oc_block_s, int n_oc_blocks,
                                      size_t comp_ker_offs, bool do_postops) {
+        if (brg_idx < 0) {
+            assert(!"Requested brgemm kernel was not created.");
+            return;
+        }
         const auto kh_ee = kh_e;
         const auto kw_e = kw_f;
         const auto pbuf_base = inp_buffer;


### PR DESCRIPTION
This PR fixes coverity issues with `Severity == Major` in Convolution primitive, in particular:
- [x]  `6980313` Improper use of negative value in file: `/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp:1365`. 
`brg_idx` could be equal `-1`, which causes issues in `call_brgemm(..., brg_idx, ...)`. 
Solution: add  an assertion in `call_brgemm()`.
- [x]  `6980310` Improper use of negative value in file: `/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp:1610`. 
The same as in `6980313`, but for tail computations.


PS. Other coverity hits in convolution will be marked as false positive.
