### PR TITLE
api: ukernel: make get_B_pack_type static for better usability

### DIFF
--- a/include/oneapi/dnnl/dnnl_ukernel.h
+++ b/include/oneapi/dnnl/dnnl_ukernel.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -185,13 +185,14 @@ dnnl_status_t DNNL_API dnnl_brgemm_finalize(dnnl_brgemm_t brgemm);
 
 /// Returns the packing type expected by a tensor B of a BRGeMM ukernel object.
 ///
-/// @param brgemm BRGeMM ukernel object.
-/// @param pack_type Output packing type. Can be `dnnl_brgemm_no_pack` if
-///     packing is not expected, and `dnnl_brgemm_pack_32`, otherwise.
+/// @param pack_type Output packing type. Can be `dnnl_brgemm_no_trans` if
+///     packing is not expected, and `dnnl_pack_type_pack32`, otherwise.
+/// @param a_dt Data type of tensor A.
+/// @param b_dt Data type of tensor B.
 /// @returns #dnnl_success on success and a status describing the error
 ///     otherwise.
-dnnl_status_t DNNL_API dnnl_brgemm_get_B_pack_type(
-        const_dnnl_brgemm_t brgemm, dnnl_pack_type_t *pack_type);
+dnnl_status_t DNNL_API dnnl_brgemm_get_B_pack_type(dnnl_pack_type_t *pack_type,
+        dnnl_data_type_t dt_a, dnnl_data_type_t dt_b);
 
 /// Returns the size of a scratchpad memory needed for the BRGeMM ukernel
 /// object.

--- a/include/oneapi/dnnl/dnnl_ukernel.hpp
+++ b/include/oneapi/dnnl/dnnl_ukernel.hpp
@@ -268,9 +268,14 @@ struct brgemm : public handle<dnnl_brgemm_t> {
 
     /// Returns the packing type expected by a tensor B of a BRGeMM ukernel
     /// object.
-    pack_type get_B_pack_type() const {
+    ///
+    /// @param a_dt Data type of tensor A.
+    /// @param b_dt Data type of tensor B.
+    static pack_type get_B_pack_type(
+            memory::data_type a_dt, memory::data_type b_dt) {
         dnnl_pack_type_t c_pack_type;
-        dnnl_status_t status = dnnl_brgemm_get_B_pack_type(get(), &c_pack_type);
+        dnnl_status_t status = dnnl_brgemm_get_B_pack_type(&c_pack_type,
+                memory::convert_to_c(a_dt), memory::convert_to_c(b_dt));
         if (status != dnnl_success)
             error::wrap_c_api(status, "could not query B pack type");
 

--- a/src/cpu/x64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.hpp
@@ -28,11 +28,16 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
+void init_kernel_datatype(
+        brgemm_desc_t *brg, data_type_t dt_a, data_type_t dt_b);
+
 namespace brgemm_utils {
 
 bool can_dispatch_uker(const brgemm_desc_t *brg);
 
 void maybe_try_bf32(brgemm_desc_t *brg);
+
+void set_isa_impl(brgemm_desc_t *brg);
 
 status_t brgemm_blocking(brgemm_desc_t *brg);
 

--- a/src/cpu/x64/brgemm/capi/brgemm_api.hpp
+++ b/src/cpu/x64/brgemm/capi/brgemm_api.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -96,7 +96,9 @@ struct dnnl_brgemm : public dnnl::impl::c_compatible {
 
     dnnl::impl::status_t finalize();
 
-    dnnl::impl::cpu::x64::pack_type_t get_B_pack_type() const;
+    static dnnl::impl::status_t get_B_pack_type(
+            dnnl::impl::cpu::x64::pack_type_t *pack_type,
+            dnnl::impl::data_type_t dt_a, dnnl::impl::data_type_t dt_b);
 
     size_t get_scratchpad_size() const;
 

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -435,7 +435,9 @@ int init_kernel(kernel_args_t &kernel_args) {
     if (res->state == SKIPPED) return OK;
 
     dnnl_pack_type_t pack_type = dnnl_pack_type_undef;
-    DNN_SAFE(dnnl_brgemm_get_B_pack_type(brgemm, &pack_type), WARN);
+    DNN_SAFE(dnnl_brgemm_get_B_pack_type(
+                     &pack_type, prb->src_dt(), prb->wei_dt()),
+            WARN);
     kernel_args.need_pack_ = pack_type == dnnl_pack_type_pack32;
 
     DNN_SAFE(dnnl_brgemm_generate(brgemm), WARN);


### PR DESCRIPTION
Certain user applications can't create brgemm objects at creation stage because of lacking certain information, like strides.
But current API mandates a brgemm object to query an information about packing the tensor B.
Thus, such users get into a trap when they are forced to move ukernel creation to their execution stage, but the decision about tensor B and its packing must have been done at creation stage which makes API unusable.

To address this kind of situation, this PR makes the function that is responsible for packing requirement `static`, or independent from the object, which would let query that information based on data types (which are available) and make specific choices ahead of time.