### PR TITLE
src: cpu: aarch64: Enable fp16 data type in JIT Reorder kernel

### DIFF
--- a/src/cpu/reorder/cpu_reorder_regular_f16.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f16.cpp
@@ -33,6 +33,8 @@ const impl_list_map_t &regular_f16_impl_list_map() {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
 
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
+
             REG_SR(f16, any, f8_e5m2, any, fmt_order::any, spec::reference)
             REG_SR(f16, any, f8_e4m3, any, fmt_order::any, spec::reference)
             REG_SR(f16, any, f16, any, fmt_order::any, spec::reference)


### PR DESCRIPTION
# Description

This PR adds support for fp16 JIT reorder for data type `f16->f32`. Partially solves [issue](https://github.com/oneapi-src/oneDNN/issues/2185).

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
- [x] Have you submitted performance data that demonstrates performance improvements?

## Performance improvements

Bellow small test case logs are added to demonstrate performance numbers before and after.

`ONEDNN_VERBOSE=all ./benchdnn --reorder --sdt=f16 --ddt=f32 --mode=p 1x4096x4096`

**(new) jit:uni**: `total perf: min(ms):0.328857 avg(ms):0.348092`
**(old) simple:any**: `total perf: min(ms):65.8274 avg(ms):67.0692`

