### PR TITLE
benchdnn, ngen, xe: fix memory use miss-estimation triggering out-of-memory issues

### DIFF
--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1138,7 +1138,10 @@ static int check_total_size(
     }
 
     size_t total_size_cpu = check_mem_size_args.total_size_cpu;
-    if (is_cpu()) total_size_cpu += check_mem_size_args.total_size_device;
+
+    // Add device size as a simple method to account for integrated devices and
+    // mapping/unmapping memory
+    total_size_cpu += check_mem_size_args.total_size_device;
     bool fits_cpu_ram = total_size_cpu <= benchdnn_cpu_limit;
 
     if (!fits_cpu_ram) {


### PR DESCRIPTION
Partial fix for MFDNN-13045
In addition, memory estimation of iGPU memory within benchnn is currently incorrect, as the device memory needs to be added to the system memory. As identifying when this extra memory is a tricky problem, this PR just requires the device memory requirements fit within the available CPU memory.

In addition, there is a memory miss estimation coming from blocked memory formats used in the reference primitive. In the worst case, the padding in the blocked formats could increase memory utilization of a buffer by 16x. This issue is expected to be addressed in a future PR by @dzarukin. 