### PR TITLE
benchdnn: introduce --summary knob for better usability

### DIFF
--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -144,12 +144,16 @@ int main(int argc, char **argv) {
         zeropad::bench(--argc, ++argv);
     } else if (!strcmp("--brgemm", argv[0])) {
         brgemm::bench(--argc, ++argv);
-#ifdef BUILD_GRAPH
     } else if (!strcmp("--graph", argv[0])) {
+#ifdef BUILD_GRAPH
         graph::bench(--argc, ++argv);
+#else
+        printf("Error: the library was built without Graph API support.\n");
+        exit(1);
 #endif
     } else {
-        fprintf(stderr, "err: unknown driver\n");
+        printf("Error: can't parse the driver name \'%s\'.\n", argv[0]);
+        exit(1);
     }
 
     total_time.stamp();

--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -58,6 +58,7 @@ bool canonical {false};
 bool mem_check {true};
 std::string skip_impl;
 stat_t benchdnn_stat {0};
+summary_t summary {};
 std::string driver_name;
 
 double max_ms_per_prb {default_max_ms_per_prb};
@@ -157,6 +158,25 @@ int main(int argc, char **argv) {
     }
 
     total_time.stamp();
+
+    if (has_bench_mode_bit(mode_bit_t::corr) && summary.failed_cases
+            && !benchdnn_stat.failed_cases.empty()) {
+        printf("===========================================================\n");
+        printf("= Failed cases summary (--summary=no-failures to disable) =\n");
+        printf("===========================================================\n");
+        const size_t n_cases = benchdnn_stat.failed_cases.size();
+        size_t n_printed = 0;
+        for (const auto &e : benchdnn_stat.failed_cases) {
+            printf("%s\n", e.second.c_str());
+            n_printed++;
+            if (n_printed < 10) continue;
+            if (n_cases > n_printed) {
+                printf("(... %zu more cases ...)\n", n_cases - n_printed);
+            }
+            break;
+        }
+        printf("============================\n");
+    }
 
     printf("tests:%d passed:%d skipped:%d mistrusted:%d unimplemented:%d "
            "invalid_arguments:%d failed:%d listed:%d\n",

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -146,7 +146,10 @@ void parse_result(res_t &res, const char *pstr) {
     // case_num:status[ (reason)][ (error_stats)] __REPRO: prb_str
     std::string full_repro = std::to_string(bs.tests) + ":" + std::string(state)
             + reason + error_stat + " __REPRO: " + pstr;
-    if (is_failed) { bs.failed++; }
+    if (is_failed) {
+        bs.failed++;
+        bs.failed_cases.emplace(bs.tests, full_repro);
+    }
     if (print_me) { BENCHDNN_PRINT(0, "%s\n", full_repro.c_str()); }
 
     // Update this after collecting stats.

--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 
 #include <cinttypes>
 #include <functional>
+#include <map>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -136,6 +137,8 @@ struct stat_t {
     int invalid_arguments;
     int listed;
     std::unordered_map<std::string, double[timer::timer_t::mode_t::n_modes]> ms;
+    // Key is the number of the test, value is the repro string.
+    std::map<int, std::string> failed_cases;
 };
 extern stat_t benchdnn_stat;
 
@@ -202,5 +205,13 @@ void print_dhw(bool &print_d, bool &print_h, bool &print_w, int ndims,
 
 int benchdnn_getenv_int(const char *name, int default_value);
 std::string benchdnn_getenv_string(const char *name);
+
+// Responsible for printing service information.
+struct summary_t {
+    // Prints up to 10 failed cases reproducers at the end of the run.
+    bool failed_cases = true;
+};
+
+extern summary_t summary;
 
 #endif

--- a/tests/benchdnn/doc/knob_summary.md
+++ b/tests/benchdnn/doc/knob_summary.md
@@ -1,0 +1,36 @@
+# Summary information
+
+## Usage
+```
+    --summary=[no-]SETTING1[+[no-]SETTING2...]
+```
+
+The `--summary` knob is a global state of benchdnn and provides the summary
+statistics at the end of the run. Different options are separated with `+`
+delimiter. To negate the effect of the option, use the "no-" prefix in front of
+the option value.
+
+If the same setting is specified multiple times, only the latter value is
+considered.
+
+## Failed cases summary
+
+### Introduction
+A batch file can contain a large number of test cases. Running the batch file
+may result in the data in the beginning of the list getting lost due to the
+short session screen buffer. Even if the buffer fits all the test cases in it,
+to find the specific failed or unimplemented cases in the middle of the output
+usually requires additional steps such as copying the whole screen buffer to a
+memory buffer, collecting the data in a file, and using the search functionality
+to scan through the file.
+
+The `failures` knob can improve usability in such scenarios.
+
+### Usage
+```
+    --summary=[no-]failures
+```
+
+By default, you can see the summary with up to ten failed cases.
+
+To disable the summary output, use the "no-failures" input value.

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -140,6 +140,10 @@ Refer to [implementation filtering](knob_impl_filter.md) for details.
 `--start=N` specifies the test index `N` to start testing from. All tests
 before the index `N` will be skipped.
 
+### --summary
+`--summary=VALUE` provides additional specific statistics output. Refer to
+[summary documentation](knob_summary.md) for details.
+
 ### --verbose
 `--verbose=N`, or a short form `-vN`, specifies the driver verbosity level.
 Additional information is printed to the stdout depending on a level `N`. `N` is


### PR DESCRIPTION
This is the feature preview:
```
(100k rows of cases, the screen buffer has likely overflowed)
run: --brgemm --dt=f8_e5m2:f8_e4m3:f8_e5m2 --beta=1 --bs=16 --brgemm-attr=use_uker:0+use_interleave_stores:1 64x192:192x64_n"int8:no_tail:47"
56447:SKIPPED (Case not supported) __REPRO: --brgemm --dt=f8_e5m2:f8_e4m3:f8_e5m2 --beta=1 --bs=16 --brgemm-attr=use_uker:0+use_interleave_stores:1 64x192:192x64_n"int8:no_tail:47"
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:FAILED __REPRO: --brgemm 1x16:16x16_n"f32:no_tail:0"
1542:FAILED __REPRO: --brgemm --bs=16 13x16:16x16_n"f32:no_tail:16"
3084:FAILED __REPRO: --brgemm --beta=1 16x16:16x16_n"f32:no_tail:32"
4626:FAILED __REPRO: --brgemm --beta=1 --bs=16 64x16:16x16_n"f32:no_tail:48"
6432:FAILED __REPRO: --brgemm --dt=f32:f16:f32 1x16:16x48_n"f32:no_tail:2"
9894:FAILED __REPRO: --brgemm --dt=f32:f16:f32 --beta=1 16x16:16x48_n"f32:no_tail:34"
26516:FAILED __REPRO: --brgemm --dt=u8:s8:u8 --beta=1 1x64:64x16_n"int8:no_tail:0"
26774:FAILED __REPRO: --brgemm --dt=u8:s8:u8 --beta=1 --bs=16 1x192:192x16_n"int8:no_tail:8"
27040:FAILED __REPRO: --brgemm --dt=u8:s8:f32 13x128:128x32_n"int8:no_tail:17"
27298:FAILED __REPRO: --brgemm --dt=u8:s8:f32 --bs=16 16x64:64x32_n"int8:no_tail:25"
(... 26 more cases ...)
============================
tests:56448 passed:4572 skipped:51840 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:36 listed:0
total: 3.90s; fill: 0.80s (20%); compute_ref: 0.75s (19%); compare: 0.17s (4%);
```
It's enabled by default and can be disabled with `--summary=no-failures`.

The future extension of `--summary` is `failures-file` to dump these failed cases into a generated input file to run it instead of a big one and `impls` to provide implementation breakdown statistics. They are planned to be opt-in.