### PR TITLE
[backport][rls-v3.7] Arch: coverity fixes (fixed MFDNN-12954)

### DIFF
--- a/src/common/ittnotify.cpp
+++ b/src/common/ittnotify.cpp
@@ -84,8 +84,10 @@ void primitive_task_start(primitive_kind_t kind) {
 #undef CASE
     int kind_idx = (int)kind;
     assert(kind_idx >= 0);
-    assert((size_t)kind_idx
-            < sizeof(prim_kind_itt_strings) / sizeof(prim_kind_itt_strings[0]));
+    if (kind_idx < primitive_kind::internal_only_start) {
+        assert((size_t)kind_idx < sizeof(prim_kind_itt_strings)
+                        / sizeof(prim_kind_itt_strings[0]));
+    }
     __itt_task_begin(itt_domain(), __itt_null, __itt_null,
             prim_kind_itt_strings[kind_idx]);
     thread_primitive_kind = kind;

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -86,10 +86,12 @@ static inline status_t sdpa_attr_check(const memory_desc_t *q_desc,
         VCHECK_SDPA_ATTR_TYPE(utils::one_of(zp_dt, s4, u4, u8, s8, s32),
                 vs_attr, "zero_points", "u4, s4, u8, s8, or s32");
     }
-    smask_t attr_mask = smask_t::none;
 
-    VCHECK_SDPA_UNIMPL(
-            attr->has_default_values(attr_mask), VERBOSE_UNSUPPORTED_ATTR);
+    if (attr) {
+        smask_t attr_mask = smask_t::none;
+        VCHECK_SDPA_UNIMPL(
+                attr->has_default_values(attr_mask), VERBOSE_UNSUPPORTED_ATTR);
+    }
 
     return status::success;
 }

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -437,7 +437,13 @@ static void fill_data(const memory::dim nelems, const memory &mem, data_t mean,
 
 inline void fill_data(memory::data_type dt, const memory &mem, float mean,
         float deviation, double sparsity = 1.) {
-    size_t nelems = mem.get_desc().get_size() / memory::data_type_size(dt);
+    const auto dt_size = memory::data_type_size(dt);
+    if (dt_size <= 0) {
+        assert(!"unexpected data type");
+        return;
+    }
+
+    size_t nelems = mem.get_desc().get_size() / dt_size;
     switch (dt) {
         case memory::data_type::f32:
             fill_data<float>(nelems, mem, mean, deviation, sparsity);

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -101,7 +101,7 @@ dnnl::engine::kind get_test_engine_kind();
 dnnl::engine get_test_engine();
 #endif
 
-inline int get_vendor_id(const std::string &vendor) {
+inline uint32_t get_vendor_id(const std::string &vendor) {
     if (vendor == "nvidia") {
         return 0x10DE;
     } else if (vendor == "amd") {
@@ -109,7 +109,7 @@ inline int get_vendor_id(const std::string &vendor) {
     } else if (vendor == "intel") {
         return 0x8086;
     } else {
-        return -1;
+        return 0x0;
     }
 }
 

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -443,7 +443,8 @@ inline void fill_data(memory::data_type dt, const memory &mem, float mean,
         return;
     }
 
-    size_t nelems = mem.get_desc().get_size() / dt_size;
+    memory::dim nelems
+            = static_cast<memory::dim>(mem.get_desc().get_size() / dt_size);
     switch (dt) {
         case memory::data_type::f32:
             fill_data<float>(nelems, mem, mean, deviation, sparsity);

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -249,10 +249,13 @@ protected:
                 int mant_digits
                         = dnnl::impl::nstl::numeric_limits<src_data_t>::digits;
                 int want_mant_digits = 3;
+                int digits_shift = mant_digits - want_mant_digits;
+                uint_type max_val = (uint_type)-1;
+                // Move left to keep mask value in uint_type range, move left
+                // to flush all digits but `want_mant_digits`.
+                uint_type mask = (max_val >> digits_shift) << digits_shift;
                 auto src_ptr = map_memory<src_data_t>(src_memory);
                 for (size_t i = 0; i < sz; i++) {
-                    uint_type mask = (uint_type)-1
-                            << (mant_digits - want_mant_digits);
                     *((uint_type *)&src_ptr[i]) &= mask;
                 }
             }


### PR DESCRIPTION
True backport of #2364, the previous one landed into main.
Also a backport of #2508.