### PR TITLE
[backport] x64: updates for brgemm kernel and avx2 brgemm convolutions

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -236,6 +236,7 @@ struct brgemm_desc_t {
     bool with_scales = false;
     bool skip_zp_b_compensation = false;
     bool skip_scales = false;
+    bool n_bcast_1_load = false;
 
     brgemm_broadcast_t zp_type_a = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -186,7 +186,7 @@ int calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
 
 int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
 
-    constexpr int max_bcst_regs = 1;
+    const int max_bcst_regs = brg->n_bcast_1_load ? 0 : 1;
     const bool req_compensation = brg->req_s8s8_compensation
             || brg->zp_type_a != brgemm_broadcast_t::none;
     const bool req_zp_a_comp_pads
@@ -197,6 +197,11 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     const int b_vnni_regs = brg->is_f16_b_non_amx_vnni() ? 2 : 0;
 
     const int max_isa_regs = isa_num_vregs(brg->isa_impl);
+    const int postops_regs = brg->attr()
+            ? injector::aux_vec_count(
+                    brg->attr()->post_ops_, brg->isa_impl, true)
+            : 0;
+
     // note: the 'adj_ld_block2' already removes the necessary registers
     // for 'embd_bcst'
     auto max_reg_count = max_isa_regs - max_bcst_regs - beta_regs
@@ -205,12 +210,8 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
         max_reg_count
                 = nstl::min(max_reg_count, max_isa_regs - max_bcst_regs - 5);
 
-    const int postops_regs = brg->attr()
-            ? injector::aux_vec_count(
-                    brg->attr()->post_ops_, brg->isa_impl, true)
-            : 0;
-    int max_bcast_block
-            = max_reg_count - nstl::max(adj_ld_block2, postops_regs);
+    int max_bcast_block = max_reg_count
+            - nstl::max(brg->n_bcast_1_load ? 1 : adj_ld_block2, postops_regs);
 
     if (brg->is_bf16_emu) {
         // in theory, vmm bf16_emu register indices overlap with other vmm
@@ -223,7 +224,7 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     // non-VNNI INT8 dot product required 2 temp vectors
     if (brg->is_int8 && !brg->has_int8_vnni) max_bcast_block -= 2;
 
-    max_bcast_block /= adj_ld_block2;
+    max_bcast_block /= (adj_ld_block2 + brg->n_bcast_1_load);
 
     return max_bcast_block;
 }
@@ -244,12 +245,19 @@ status_t brgemm_blocking(brgemm_desc_t *brg) {
         brg->ldb = brg->load_dim / brg->ld_block;
         brg->ldb_tail = brg->load_dim % brg->ld_block;
 
+        int adj_ld_block2 = calculate_ldb_params(brg, 4);
+
+        brg->n_bcast_1_load
+                = (utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2)
+                          && adj_ld_block2 == 4)
+                || brg->brgattr.hint_loop_order == brgemm_lo_bl_1load;
+
+        int max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
+
+        // reduce 'ld_block2' to allow a larger 'bd_block'
         const int max_vpad = nstl::max(
                 brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
-        int adj_ld_block2 = calculate_ldb_params(brg, 4);
-        int max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
-        // reduce 'ld_block2' to allow a larger 'bd_block'
         if (is_superset(brg->isa_impl, avx2) && max_bcast_block < max_vpad) {
             for (int try_ld_block2 = 2; try_ld_block2 > 0; --try_ld_block2) {
                 adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -186,45 +186,75 @@ int calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
 
 int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
 
+    int max_isa_regs = isa_num_vregs(brg->isa_impl);
     const int max_bcst_regs = brg->n_bcast_1_load ? 0 : 1;
-    const bool req_compensation = brg->req_s8s8_compensation
-            || brg->zp_type_a != brgemm_broadcast_t::none;
+    const int load_regs = brg->n_bcast_1_load ? 1 : adj_ld_block2;
+
+    // ===========  all kernel ==================
+    // To support the f16 vnni B matrix on non-AMX we need to use two Vmm
+    // registers for permutation in brgemm kernel: f16_perm_even_vreg_ and
+    // f16_perm_odd_vreg_
+    const int b_vnni_regs = brg->is_f16_b_non_amx_vnni() ? 2 : 0;
+
+    // non-VNNI INT8 dot product required 2 temp vectors: see int8_ones_words()
+    // and int8_dot_product_temp() in brgemm kernel
+    const int non_int8_vnni_regs
+            = (brg->is_int8 && !brg->has_int8_vnni) ? 2 : 0;
+
+    // see vmm_inp_shift() in brgemm kernel
+    const int compensation_regs = brg->req_s8s8_compensation
+                    || brg->zp_type_a != brgemm_broadcast_t::none
+            ? 1
+            : 0;
+
     const bool req_zp_a_comp_pads
             = (brg->req_cal_comp_pads || brg->brgattr.max_top_vpad > 0
                       || brg->brgattr.max_bottom_vpad > 0)
             && brg->zp_type_a != brgemm_broadcast_t::none;
-    const int beta_regs = !one_of(brg->beta, 1.f, 0.f);
-    const int b_vnni_regs = brg->is_f16_b_non_amx_vnni() ? 2 : 0;
 
-    const int max_isa_regs = isa_num_vregs(brg->isa_impl);
+    // see compensation_padding(), vmm_zp_a_shift(), vmm_one_bytes()
+    // in brgemm kernel
+    const int zp_a_comp_pads_regs = req_zp_a_comp_pads ? 2 : 0;
+
+    max_isa_regs -= b_vnni_regs + non_int8_vnni_regs + compensation_regs
+            + zp_a_comp_pads_regs;
+
+    // ========== microkernel =============
+    const int microkernel_regs = 0; // no specific microkernels regs for now
+
+    const auto microkernel_max_reg_count
+            = max_isa_regs - microkernel_regs - load_regs - max_bcst_regs;
+
+    auto microkernel_max_bcast_block
+            = microkernel_max_reg_count / (adj_ld_block2 + brg->n_bcast_1_load);
+
+    // ========== post-ops and store accumulators =============
+
+    const int beta_regs = !one_of(brg->beta, 1.f, 0.f);
+
     const int postops_regs = brg->attr()
             ? injector::aux_vec_count(
                     brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;
 
-    // note: the 'adj_ld_block2' already removes the necessary registers
-    // for 'embd_bcst'
-    auto max_reg_count = max_isa_regs - max_bcst_regs - beta_regs
-            - req_compensation - req_zp_a_comp_pads - b_vnni_regs;
-    if (req_zp_a_comp_pads)
-        max_reg_count
-                = nstl::min(max_reg_count, max_isa_regs - max_bcst_regs - 5);
+    // Emulators: fp8 emulation are supported for amx only
+    // In theory, vmm bf16_emu register indices overlap with other vmm
+    // registers related to 'max_bcast_block'
+    assert(IMPLICATION(
+            brg->is_bf16_emu, is_superset(brg->isa_impl, avx512_core)));
+    const int bf16_emu_regs = brg->is_bf16_emu ? 4 : 0;
 
-    int max_bcast_block = max_reg_count
-            - nstl::max(brg->n_bcast_1_load ? 1 : adj_ld_block2, postops_regs);
+    const auto store_regs = nstl::max(beta_regs,
+            nstl::max(
+                    postops_regs, nstl::max(compensation_regs, bf16_emu_regs)));
 
-    if (brg->is_bf16_emu) {
-        // in theory, vmm bf16_emu register indices overlap with other vmm
-        // registers related to 'max_bcast_block'
-        assert(is_superset(brg->isa_impl, avx512_core));
-        constexpr int bf16_emu_reg_count = 28;
-        max_bcast_block = nstl::min(max_bcast_block, bf16_emu_reg_count);
-    }
+    const auto store_max_reg_count = max_isa_regs - store_regs;
 
-    // non-VNNI INT8 dot product required 2 temp vectors
-    if (brg->is_int8 && !brg->has_int8_vnni) max_bcast_block -= 2;
+    auto store_max_bcast_block = store_max_reg_count / adj_ld_block2;
 
-    max_bcast_block /= (adj_ld_block2 + brg->n_bcast_1_load);
+    // ========== final check =============
+    const auto max_bcast_block
+            = nstl::min(microkernel_max_bcast_block, store_max_bcast_block);
 
     return max_bcast_block;
 }

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -260,7 +260,7 @@ private:
     struct dim_iteration_t {
         size_t idx = 0;
         std ::vector<iteration_block_t> blocks;
-        virtual bool operator==(const dim_iteration_t &rhs) const {
+        bool operator==(const dim_iteration_t &rhs) const {
             return blocks == rhs.blocks;
         }
 
@@ -307,7 +307,7 @@ private:
         bd_iteration_t *similar {nullptr};
         Label lstart;
 
-        virtual bool operator==(const bd_iteration_t &rhs) const {
+        bool operator==(const bd_iteration_t &rhs) const {
             bool res = dim_iteration_t::operator==(rhs)
                     && A_shift == rhs.A_shift && C_shift == rhs.C_shift
                     && D_shift == rhs.D_shift && bd_mask == rhs.bd_mask

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2397,8 +2397,11 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
             L_aligned(BS_loop_label, 64);
             {
                 if (check_top_vpad || check_bottom_vpad) {
-                    const auto vpad_first = -brg.brgattr.max_bottom_vpad;
-                    const auto vpad_last = brg.brgattr.max_top_vpad;
+                    const auto vpad_first = check_bottom_vpad
+                            ? (-brg.brgattr.max_bottom_vpad)
+                            : 1;
+                    const auto vpad_last
+                            = check_top_vpad ? brg.brgattr.max_top_vpad : -1;
                     const auto n_vpads = vpad_last - vpad_first + 2;
                     constexpr auto MAX_N_VPADS = 2 * brgemm_desc_t::MAX_VPAD;
                     assert(n_vpads < MAX_N_VPADS);

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2150,32 +2150,103 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
     } else
         rd_loop = brg.rd_block;
 
-    auto broadcast = [this, rd_tail_size](Vmm v1, size_t offset, bool is_tail,
-                             data_type_t dt) {
+    auto broadcast_A = [this, rd_tail_size, is_rd_tail, rd_loop,
+                               rows_for_rd_tail,
+                               bd_e](Vmm vmm_bcast, int bd, int rd) {
+        const auto offset = A_offset(bd, rd);
+        const auto dt = brg.dt_a;
+        const bool maybe_load_bytes
+                = (rows_for_rd_tail > 0 || brg.brgattr.wary_tail_read)
+                && is_rd_tail && rd_tail_size != 0
+                && (brg.is_bf16 || brg.is_int8);
+        const bool have_to_load_bytes
+                = maybe_load_bytes && (rd == rd_loop - brg.rd_step);
+        const auto rows_by_load_bytes
+                = have_to_load_bytes ? rows_for_rd_tail : 0;
+        const auto bd_by_load_bytes = (bd >= bd_e - rows_by_load_bytes
+                || brg.brgattr.wary_tail_read);
+        const auto is_tail = have_to_load_bytes && bd_by_load_bytes;
         if (is_tail) {
-            Xmm xmm_tmp = Xmm(v1.getIdx());
+            Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
             load_bytes(
                     xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
-            uni_vpbroadcastd(v1, xmm_tmp);
+            uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
-                uni_vbroadcastss(v1, ptr[reg_aux_A + offset]);
+                uni_vbroadcastss(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (dt == data_type::bf16) {
                 if (brg.isa_impl == avx2_vnni_2)
-                    vbcstnebf162ps(v1, ptr[reg_aux_A + offset]);
+                    vbcstnebf162ps(vmm_bcast, ptr[reg_aux_A + offset]);
                 else
-                    uni_vpbroadcastd(v1, ptr[reg_aux_A + offset]);
+                    uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (one_of(dt, data_type::s8, data_type::u8)) {
-                uni_vpbroadcastd(v1, ptr[reg_aux_A + offset]);
+                uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (dt == data_type::f16) {
-                if (brg.isa_impl == avx2_vnni_2)
-                    vbcstnesh2ps(v1, ptr[reg_aux_A + offset]);
-                else
-                    vcvtph2psx(v1, ptr_b[reg_aux_A + offset]);
+                if (brg.isa_impl == avx2_vnni_2) {
+                    vbcstnesh2ps(vmm_bcast, ptr[reg_aux_A + offset]);
+                } else if (is_superset(brg.isa_impl, avx512_core_fp16)) {
+                    // Broadcast is not supported for legacy f16-conversions.
+                    vcvtph2psx(vmm_bcast, ptr_b[reg_aux_A + offset]);
+                }
             }
         }
 
-        if (brg.req_s8s8_compensation) uni_vpaddb(v1, v1, vmm_inp_shift());
+        if (brg.req_s8s8_compensation)
+            uni_vpaddb(vmm_bcast, vmm_bcast, vmm_inp_shift());
+    };
+
+    auto load_B = [this, is_ld_tail](int vmm_load_idx, int rd, int ld) {
+        const Vmm vmm_load
+                = vmm_mask(load(vmm_load_idx), is_ld_tail, false, ld_tail_mask);
+        const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
+        // Note: Assuming the tails are properly padded/blocked for
+        // avx2_vnni_2 with xf16 data type, as the B matrix is generally
+        // at least double-blocked.
+        if (brg.dt_b == data_type::f16) {
+            if (brg.isa_impl == avx2_vnni_2) {
+                if (rd % 2 == 0)
+                    vcvtneeph2ps(vmm_load, addr);
+                else
+                    vcvtneoph2ps(vmm_load, addr);
+            } else if (brg.is_f16_b_non_amx_vnni()) {
+                const auto actual_B_offset = B_offset(ld, utils::rnd_dn(rd, 2));
+                const auto vnni_addr = ptr[reg_aux_B + actual_B_offset];
+                vmovups(vmm_load, vnni_addr);
+                if (rd % 2 == 0)
+                    vpermw(vmm_load, f16_perm_even_vreg_, vmm_load);
+                else
+                    vpermw(vmm_load, f16_perm_odd_vreg_, vmm_load);
+                vcvtph2psx(vmm_load, Vmm_lower_t(vmm_load.getIdx()));
+            } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
+                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                vcvtph2ps(vmm_load, Xmm(vmm_load.getIdx()));
+            } else {
+                uni_vcvtph2psx(vmm_load, addr);
+            }
+        } else if (brg.dt_b == data_type::bf16) {
+            if (brg.isa_impl == avx2_vnni_2) {
+                if (rd % 2 == 0)
+                    vcvtneebf162ps(vmm_load, addr);
+                else
+                    vcvtneobf162ps(vmm_load, addr);
+            } else if (utils::one_of(brg.isa_impl, avx512_core, avx2)) {
+                // Upconvert: load 16 bits and move them 16 bits left.
+                uni_vpmovzxwd(vmm_load, addr);
+                uni_vpslld(vmm_load, vmm_load, 16);
+            } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
+                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+            } else {
+                uni_vmovups(vmm_load, addr);
+            }
+        } else if (is_ld_tail) {
+            if (is_superset(brg.isa_impl, avx512_core)) {
+                uni_vmovups(vmm_load, addr);
+            } else {
+                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+            }
+        } else {
+            uni_vmovups(vmm_load, addr);
+        }
     };
 
     const bool comp_vpad = vpad != 0
@@ -2185,63 +2256,13 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
         compute_int8_compensation(
                 rd_loop, bd_b, bd_e, bd_block, ld_block2, is_ld_tail, vpad);
 
-    bool maybe_load_bytes = (rows_for_rd_tail > 0 || brg.brgattr.wary_tail_read)
-            && is_rd_tail && rd_tail_size != 0 && (brg.is_bf16 || brg.is_int8);
-    if (brg.n_bcast_1_load) {
-        for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
-            bool have_to_load_bytes
-                    = maybe_load_bytes && (rd == rd_loop - brg.rd_step);
-
-            auto rows_by_load_bytes = have_to_load_bytes ? rows_for_rd_tail : 0;
-            for (int bd = bd_b; bd < bd_e && !is_emdbd; bd++) {
-                const auto bd_by_load_bytes = (bd >= bd_e - rows_by_load_bytes
-                        || brg.brgattr.wary_tail_read);
-                broadcast(bcst(bd), A_offset(bd, rd),
-                        have_to_load_bytes && bd_by_load_bytes, brg.dt_a);
-            }
+    for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
+        if (brg.n_bcast_1_load) {
+            for (int bd = bd_b; bd < bd_e && !is_emdbd; bd++)
+                broadcast_A(bcst(bd), bd, rd);
             for (int ld = 0; ld < ld_block2; ld++) {
-                const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
-                const Vmm vmm_load
-                        = vmm_mask(load(), is_ld_tail, false, ld_tail_mask);
-                // Note: Assuming the tails are properly padded/blocked for
-                // avx2_vnni_2 with xf16 data type, as the B matrix is generally
-                // at least double-blocked.
-                if (brg.dt_b == data_type::f16) {
-                    if (brg.isa_impl == avx2_vnni_2) {
-                        if (rd % 2 == 0)
-                            vcvtneeph2ps(vmm_load, addr);
-                        else
-                            vcvtneoph2ps(vmm_load, addr);
-                    } else {
-                        if (brg.is_f16_b_non_amx_vnni()) {
-                            const auto vnni_addr = ptr[reg_aux_B
-                                    + B_offset(ld, utils::rnd_dn(rd, 2))];
-                            vmovups(vmm_load, vnni_addr);
-                            if (rd % 2 == 0)
-                                vpermw(vmm_load, f16_perm_even_vreg_, vmm_load);
-                            else
-                                vpermw(vmm_load, f16_perm_odd_vreg_, vmm_load);
-                            vcvtph2psx(
-                                    vmm_load, Vmm_lower_t(vmm_load.getIdx()));
-                        } else
-                            vcvtph2psx(vmm_load, addr);
-                    }
-                } else if (brg.dt_b == data_type::bf16
-                        && brg.isa_impl == avx2_vnni_2) {
-                    if (rd % 2 == 0)
-                        vcvtneebf162ps(vmm_load, addr);
-                    else
-                        vcvtneobf162ps(vmm_load, addr);
-                } else if (is_ld_tail) {
-                    if (is_superset(brg.isa_impl, avx512_core)) {
-                        uni_vmovups(vmm_load, addr);
-                    } else {
-                        load_bytes(vmm_load, addr,
-                                brg.typesize_B * brg.ldb_tail * brg.ld_step);
-                    }
-                } else {
-                    uni_vmovups(vmm_load, addr);
-                }
+                load_B(0, rd, ld);
+
                 for (int bd = bd_b; bd < bd_e; bd++) {
                     auto vmm = accm(ld_block2, bd, ld);
                     if (is_emdbd)
@@ -2251,69 +2272,14 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                         dot_product(vmm, load(), bcst(bd));
                 }
             }
-        }
-    } else {
-        for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
+        } else {
             int prefetch_count_B = 0;
             for (int ld = 0; ld < ld_block2; ld++) {
-                const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
-                const Vmm vmm_load
-                        = vmm_mask(load(ld), is_ld_tail, false, ld_tail_mask);
-                // Note: Assuming the tails are properly padded/blocked for
-                // avx2_vnni_2, as the B matrix is generally
-                // at least double-blocked.
-                if (brg.dt_b == data_type::f16) {
-                    if (brg.isa_impl == avx2_vnni_2) {
-                        if (rd % 2 == 0)
-                            vcvtneeph2ps(vmm_load, addr);
-                        else
-                            vcvtneoph2ps(vmm_load, addr);
-                    } else {
-                        if (brg.is_f16_b_non_amx_vnni()) {
-                            const auto actual_B_offset
-                                    = B_offset(ld, utils::rnd_dn(rd, 2));
-                            const auto vnni_addr
-                                    = ptr[reg_aux_B + actual_B_offset];
-                            vmovups(vmm_load, vnni_addr);
-                            if (rd % 2 == 0)
-                                vpermw(vmm_load, f16_perm_even_vreg_, vmm_load);
-                            else
-                                vpermw(vmm_load, f16_perm_odd_vreg_, vmm_load);
-                            vcvtph2psx(
-                                    vmm_load, Vmm_lower_t(vmm_load.getIdx()));
-                        } else
-                            vcvtph2psx(vmm_load, addr);
-                    }
-                } else if (brg.dt_b == data_type::bf16
-                        && brg.isa_impl == avx2_vnni_2) {
-                    if (rd % 2 == 0)
-                        vcvtneebf162ps(vmm_load, addr);
-                    else
-                        vcvtneobf162ps(vmm_load, addr);
-                } else if (is_ld_tail) {
-                    if (is_superset(brg.isa_impl, avx512_core)) {
-                        uni_vmovups(vmm_load, addr);
-                    } else {
-                        load_bytes(vmm_load, addr,
-                                brg.typesize_B * brg.ldb_tail * brg.ld_step);
-                    }
-                } else {
-                    uni_vmovups(vmm_load, addr);
-                }
+                load_B(ld, rd, ld);
             }
 
-            bool have_to_load_bytes
-                    = maybe_load_bytes && (rd == rd_loop - brg.rd_step);
-
-            auto rows_by_load_bytes = have_to_load_bytes ? rows_for_rd_tail : 0;
             for (int bd = bd_b; bd < bd_e; bd++) {
-                if (!is_emdbd) {
-                    const auto bd_by_load_bytes
-                            = (bd >= bd_e - rows_by_load_bytes
-                                    || brg.brgattr.wary_tail_read);
-                    broadcast(bcst(), A_offset(bd, rd),
-                            have_to_load_bytes && bd_by_load_bytes, brg.dt_a);
-                }
+                if (!is_emdbd) broadcast_A(bcst(), bd, rd);
                 if (prefetch_count_B < ld_block2) {
                     prefetcht0(ptr[reg_aux_B + B_offset(prefetch_count_B++, rd)
                             + brg.LDB * brg.rd_block * brg.typesize_B]);

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1416,16 +1416,9 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
-        int n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
-        if (jcp.loop_order == loop_ndhwgc)
-            nd_iterator_init(start, n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh,
-                    owb, jcp.nb_ow, g, jcp.ngroups, ocb, jcp.nb_oc);
-        else if (jcp.loop_order == loop_ngcdhw)
-            nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc,
-                    odb, jcp.nb_od, ohb, jcp.nb_oh, owb, jcp.nb_ow);
-        else
-            assert(!"Unknown loop order");
 
+        int n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
+        BRGEMM_CONV_ITERATOR_INIT;
         for (auto work = start; work < end; work++) {
             btc.g = g;
             btc.n = n;
@@ -1479,14 +1472,7 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                 last_btc.ohb = ohb;
                 last_btc.owb = owb;
             }
-            if (jcp.loop_order == loop_ndhwgc)
-                nd_iterator_step(n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh, owb,
-                        jcp.nb_ow, g, jcp.ngroups, ocb, jcp.nb_oc);
-            else if (jcp.loop_order == loop_ngcdhw)
-                nd_iterator_step(n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc, odb,
-                        jcp.nb_od, ohb, jcp.nb_oh, owb, jcp.nb_ow);
-            else
-                assert(!"Unknown loop order");
+            BRGEMM_CONV_ITERATOR_STEP;
         }
         if (is_amx) { amx_tile_release(); }
     });

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1946,12 +1946,17 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     using namespace data_type;
     // ======================= blocking =================================
 
-    auto bcast_amount
-            = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw * jcp.src_dsz;
+    auto bcast_amount = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw
+            * jcp.src_dsz * jcp.ic;
     auto wei_amount = static_cast<size_t>(jcp.oc) * jcp.kd * jcp.kh * jcp.kw
-            * jcp.wei_dsz;
+            * jcp.wei_dsz * jcp.ic;
 
-    jcp.loop_order = (bcast_amount < wei_amount) ? loop_ngcdhw : loop_ndhwgc;
+    jcp.loop_order
+            = (one_of(isa, avx2, avx2_vnni, avx2_vnni_2) && jcp.mb > jcp.nthr
+                      && bcast_amount > brg_blocking_t::L2
+                      && wei_amount > brg_blocking_t::L2)
+            ? loop_gcndhw
+            : ((bcast_amount < wei_amount) ? loop_ngcdhw : loop_ndhwgc);
 
     const int min_oc_block = jcp.acc_simd_w;
 
@@ -1967,6 +1972,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         const bool small_amx_job = est_amx_job < 64 || jcp.oc < 256;
         auto start_ocb
                 = (is_amx(isa) && jcp.is_os_blocking && small_amx_job) ? 2 : 4;
+        if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)
+                && jcp.loop_order == loop_gcndhw)
+            start_ocb = 2;
+        if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)
+                && jcp.oh * jcp.ow >= 150 * 150)
+            start_ocb = 2;
+
         start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
 
         auto finish_ocb = 1;
@@ -2219,7 +2231,6 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 #endif
 
     // ============ end blocking ===========================================
-
     jcp.brg_type
             = (jcp.use_uker && one_of(jcp.exec_type, exec_base, exec_trans))
             ? brgemm_static_offs

--- a/src/cpu/x64/jit_brgemm_conv_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -64,6 +64,36 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
 status_t init_scratchpad_bwd_w(memory_tracking::registrar_t &scratchpad,
         const jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
         memory_desc_t &diff_weights_md, memory_desc_t &diff_dst_md);
+
+#define BRGEMM_CONV_NDHWGC_ORDER \
+    n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh, owb, jcp.nb_ow, g, jcp.ngroups, \
+            ocb, jcp.nb_oc
+#define BRGEMM_CONV_NGCDHW_ORDER \
+    n, jcp.mb, g, jcp.ngroups, ocb, jcp.nb_oc, odb, jcp.nb_od, ohb, jcp.nb_oh, \
+            owb, jcp.nb_ow
+#define BRGEMM_CONV_GCNDHW_ORDER \
+    g, jcp.ngroups, ocb, jcp.nb_oc, n, jcp.mb, odb, jcp.nb_od, ohb, jcp.nb_oh, \
+            owb, jcp.nb_ow
+
+#define BRGEMM_CONV_ITERATOR_INIT \
+    if (jcp.loop_order == loop_ndhwgc) \
+        nd_iterator_init(start, BRGEMM_CONV_NDHWGC_ORDER); \
+    else if (jcp.loop_order == loop_ngcdhw) \
+        nd_iterator_init(start, BRGEMM_CONV_NGCDHW_ORDER); \
+    else if (jcp.loop_order == loop_gcndhw) \
+        nd_iterator_init(start, BRGEMM_CONV_GCNDHW_ORDER); \
+    else \
+        assert(!"Unknown loop order");
+
+#define BRGEMM_CONV_ITERATOR_STEP \
+    if (jcp.loop_order == loop_ndhwgc) \
+        nd_iterator_step(BRGEMM_CONV_NDHWGC_ORDER); \
+    else if (jcp.loop_order == loop_ngcdhw) \
+        nd_iterator_step(BRGEMM_CONV_NGCDHW_ORDER); \
+    else if (jcp.loop_order == loop_gcndhw) \
+        nd_iterator_step(BRGEMM_CONV_GCNDHW_ORDER); \
+    else \
+        assert(!"Unknown loop order");
 
 } // namespace brgemm_convolution_utils
 

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -661,6 +661,7 @@ struct jit_brdgmm_conv_conf_t {
 enum conv_brgemm_loop_order_t {
     loop_ndhwgc,
     loop_ngcdhw,
+    loop_gcndhw,
 };
 
 enum conv_brgemm_exec_type_t {


### PR DESCRIPTION
This is backport of https://github.com/oneapi-src/oneDNN/pull/2420 to rls-v3.7 + update of calculate_max_bcast_block function in brgemm_utils to improve performance for some cases with post-ops (see #2540 ).