### PR TITLE
Fix GRU brgemm implementation

### DIFF
--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -630,7 +630,7 @@ struct rnn_conf_t {
     int dhc_block_peephole, dhc_tail_peephole, dhc_blocks_peephole;
     bool brgemm_fwd_iter_layer_fuse_possible = false;
 
-    dim_t nthr;
+    int nthr;
 #if DNNL_X64
     x64::cpu_isa_t brgemm_isa;
 #endif

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
               * rnn.diff_src_brgemm.N_layer_blocks)
     , LDA_(rnn.diff_src_brgemm.LDA)
     , LDC_(rnn.diff_src_brgemm.LDC)
-    , max_nthr_(rnn.nthr)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn.nthr))
     , n_blocking_(rnn.diff_src_brgemm.N_blocks)
     , m_blocking_(rnn.diff_src_brgemm.M_blocks)
     , work_amount_(n_blocking_ * m_blocking_)
@@ -446,7 +446,7 @@ brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
     , LDA_layer_(rnn.diff_wei_brgemm.LDA_layer)
     , LDC_iter_(rnn.diff_wei_brgemm.LDC_iter)
     , LDC_layer_(rnn.diff_wei_brgemm.LDC_layer)
-    , max_nthr_(rnn.nthr)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn.nthr))
     , n_blocking_(rnn.diff_wei_brgemm.N_blocks)
     , m_blocking_(rnn.diff_wei_brgemm.M_blocks)
     , k_blocks_(rnn.diff_wei_brgemm.K_blocks)

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
@@ -688,9 +688,8 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = 2
-            * nstl::max(rnn_.KB1_blocks + 1,
-                    nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
+    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+            nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * max_K_Block;
 

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
     , C_cell_(scratch_cell)
     , LDAl_(rnn_.src_layer_ld(cell_position))
     , LDAi_(rnn_.src_iter_ld(cell_position))
-    , max_nthr_(rnn_.nthr)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
     , n_blocking_((rnn_.unfused_post_gemm) ? rnn_.N_blocks * rnn_.n_gates
                                            : rnn_.N_blocks)
     , m_blocking_(rnn_.M_blocks)
@@ -452,7 +452,7 @@ brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::brgemm_dst_proj_t(
     , C_(output)
     , LDC_(rnn_.is_cell_dt_f32() ? rnn_.dst_layer_ld(cell_position, true)
                                  : rnn_.scratch_gates_ld)
-    , max_nthr_(rnn_.nthr)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
     , work_amount_proj_(rnn_.Nproj_blocks * rnn_.M_blocks)
     , B_n_offset_(rnn_.Kprojpadded * rnn_.n_block)
     , Bp_kb_offset_(rnn_.kproj_block * rnn_.n_block)
@@ -601,7 +601,7 @@ brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::brgemm_gru_t(
     , LDAl_(rnn_.src_layer_ld(cell_position))
     , LDAi_p1_(rnn_.src_iter_ld(cell_position))
     , LDAi_p2_(rnn_.dst_iter_part2_ld(cell_position))
-    , max_nthr_(rnn_.nthr)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
     , n_blocking_((rnn_.unfused_post_gemm) ? rnn_.N_blocks * rnn_.n_gates
                                            : rnn_.N_blocks)
     , m_blocking_(rnn_.M_blocks)
@@ -913,7 +913,7 @@ brgemm_merged_layer_t<src_t, weights_t, scratch_t,
     , Bl_(w_layer)
     , C_(scratch_gates)
     , LDAl_(rnn_.src_layer_ld(cell_position))
-    , max_nthr_(rnn_.nthr)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
     , n_blocking_((rnn_.unfused_post_gemm) ? rnn_.N_blocks * rnn_.n_gates
                                            : rnn_.N_blocks)
     , m_blocking_(rnn_.Mlayermerged_blocks)


### PR DESCRIPTION
This PR fixes a bug in GRU brgemm implementation causing a segfault due to out of bounds access. The bug was uncovered after enabling the implementation for AVX2. Apparently, running tests under SDE creates certain conditions that increase chances of running into the issue, supposedly because the chances of triggering a segfault under SDE is higher and the number of threads is limited because of threadpool. The bug is not specific to AVX2.
Additionally, this PR adds a check for the number of available threads at execution time.

7b7b478ee9e109ad2b1b5f27ec278fddbf9efc42: Fixes offset calculation for `addr_batch_global_`, which is scratchpad memory. 
b83a9b4f6782fee581c641a8406a90e349a2118e: Adds a check for the number of available threads at execution time to avoid using more threads than were available at creation time
9895dcbaab001e778a2924d5e0a3bb969b01aa37: (minor) use `int` for number of threads instead of `dim_t`

Failed cases:
```
test/intel-cpu/hsw/win/icx/intel-thrpool_eigen-release/test_benchdnn_modeC_gru_all_cpu 99.99% [ 19513 passed, 96 mistrusted, 27160 skipped, 0 unimplemented, 1 failed] CTest status:SEGFAULT 
test/intel-cpu/hsw/lnx/icx/intel-thrpool_eigen-release/test_benchdnn_modeC_gru_all_cpu 99.99% [ 19511 passed, 96 mistrusted, 27160 skipped, 0 unimplemented, 1 failed] CTest status:Child aborted
```