### PR TITLE
cpu: x64: brgemm: update conditions for zp with big ow

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2293,6 +2293,18 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = (jcp.s8s8_compensation_required || jcp.src_zero_point)
             && !everyone_is(0, jcp.t_pad, jcp.back_pad, jcp.f_pad, jcp.b_pad,
                     jcp.l_pad, jcp.r_pad);
+    // estimate the number of kernel range combination for compensation
+    const auto kd_cnt = 1 + utils::div_up(abs(jcp.f_pad), jcp.dilate_d + 1)
+            + utils::div_up(abs(jcp.back_pad), jcp.dilate_d + 1);
+    const auto kh_cnt = 1 + utils::div_up(abs(jcp.t_pad), jcp.dilate_h + 1)
+            + utils::div_up(abs(jcp.b_pad), jcp.dilate_h + 1);
+    jcp.ker_ranges_size = jcp.exec_type == exec_trans
+            ? kd_cnt * nstl::min(jcp.oh, jcp.oh_block + kh_cnt)
+            : kd_cnt * kh_cnt;
+    const auto comp_buffer_ow = jcp.exec_type != exec_vpad ? jcp.ow : 1;
+    jcp.comp_a_buffer_size = jcp.ngroups * jcp.nb_oc * jcp.ker_ranges_size
+            * comp_buffer_ow * jcp.oc_block;
+    jcp.s8s8_comp_buffer_size = jcp.comp_a_buffer_size;
 
     // For padding shapes, we calculate the comp along with the computation
     // inside brgemm kernel when output size is small to get optimal perf
@@ -2307,25 +2319,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = (output_sz <= 8192 && jcp.oc < 512) || jcp.ow > 128;
     const auto is_relo = jcp.is_relo() && jcp.relo_conv_weights;
     jcp.req_brg_comp_pad = compensation_w_padding && jcp.exec_type != exec_trans
-            && IMPLICATION(!is_relo, shape_for_brgemm_kernel);
+            && IMPLICATION(!is_relo, shape_for_brgemm_kernel)
+            && IMPLICATION(
+                    jcp.exec_type == exec_vpad, jcp.comp_a_buffer_size > 1024);
     jcp.req_cal_comp_pad = compensation_w_padding && !jcp.req_brg_comp_pad
             && IMPLICATION(jcp.exec_type == exec_vpad,
                     jcp.t_pad > 0 || jcp.b_pad > 0 || jcp.f_pad > 0
                             || jcp.back_pad > 0);
-
-    // estimate the number of kernel range combination for compensation
-    const auto kd_cnt = 1 + utils::div_up(abs(jcp.f_pad), jcp.dilate_d + 1)
-            + utils::div_up(abs(jcp.back_pad), jcp.dilate_d + 1);
-    const auto kh_cnt = 1 + utils::div_up(abs(jcp.t_pad), jcp.dilate_h + 1)
-            + utils::div_up(abs(jcp.b_pad), jcp.dilate_h + 1);
-    jcp.ker_ranges_size = jcp.exec_type == exec_trans
-            ? kd_cnt * nstl::min(jcp.oh, jcp.oh_block + kh_cnt)
-            : kd_cnt * kh_cnt;
-    const auto comp_buffer_ow = jcp.exec_type != exec_vpad ? jcp.ow : 1;
-    jcp.comp_a_buffer_size = jcp.ngroups * jcp.nb_oc * jcp.ker_ranges_size
-            * comp_buffer_ow * jcp.oc_block;
-
-    jcp.s8s8_comp_buffer_size = jcp.comp_a_buffer_size;
 
     // enable ununroll_bd_loop for big shapes to reduce kernel sizes
     jcp.ununroll_bd_loop


### PR DESCRIPTION
Partially fixed MFDNN-12557

When the shapes has big ow but small ic/oc, it may require small calculation work in pre-calculated compensation. So it's better to calculate the pre-calculate compensation instead of calculating the compensation in brgemm kernel. 

Summarized performance data on SRF and CLX:
![image](https://github.com/user-attachments/assets/c51bf25b-0ea0-4b89-b398-b5d0d81a5c08)
![image](https://github.com/user-attachments/assets/d881ec8e-4895-4bc9-a7cb-232ae0a01b70)

Raw data:
[brg_zp_avx2_vnni_2.xlsx](https://github.com/user-attachments/files/18596637/brg_zp_avx2_vnni_2.xlsx)
[brg_zp_avx512_core_vnni.xlsx](https://github.com/user-attachments/files/18596639/brg_zp_avx512_core_vnni.xlsx)
