### PR TITLE
src: gpu: intel: jit: conv: fix reorder zp precomp page faults on xe3

### DIFF
--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -860,7 +860,7 @@ status_t init_tensor_layouts(
         // padding at the end is the easiest way to avoid that, as 1-2 KB of
         // additional VRAM per precalc buffer is virtually free
         // TODO: vectorize send params (in jit:ir:v2 maybe?) and add tmasks!
-        const dim_t max_read_blk_bytes = 512;
+        const dim_t max_read_blk_bytes = 2048;
         wei_md.extra.dst_size += max_read_blk_bytes * 2;
     }
     return status::success;


### PR DESCRIPTION
This resolves [MFDNN-13021](https://jira.devtools.intel.com/browse/MFDNN-13021) on Xe3-LPG.