### PR TITLE
benchdnn: inputs: matmul: fix descriptor name

### DIFF
--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
@@ -24,4 +24,4 @@
 --stag=ab
 --wtag=ab
 --dtag=ab
-8x2664:2664x256_n"k tails"
+8x2664:2664x256_n"k_tail"


### PR DESCRIPTION
Incorrect descriptor name causes the parsing step to fail.