### PR TITLE
x64: matmul: bugfix copy B padding calculation

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -1756,6 +1756,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     bool packed_sparse_weights() const { return bgmmc_.packed_sparse_weights; }
 
     int get_current_K_pad(int current_K_iters) const {
+        if (current_K_iters % bgmmc_.wei_k_blk == 0) return 0;
         return bgmmc_.extendable_k ? bgmmc_.wei_k_blk
                         - rnd_up(
                                 current_K_iters % bgmmc_.wei_k_blk, vnni_factor)

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
@@ -21,3 +21,11 @@
 # Test that cases when M == 1 are handled correctly.
 --reset
 --stag=ba,ab --wtag=ab --dtag=ab --dt=bf16 1x2:2x256
+
+# Shape to better test k tail.
+--reset
+--dt=bf16:bf16:bf16
+--stag=ab
+--wtag=ab
+--dtag=ab
+8x2664:2664x256_n"k_tails"


### PR DESCRIPTION
back port of bugfix for issue:
https://jira.devtools.intel.com/browse/MFDNN-13037
original pull request:
https://github.com/oneapi-src/oneDNN/pull/2491