### PR TITLE
src: attr: quantization refactor (part 2)

### DIFF
--- a/src/common/convolution.cpp
+++ b/src/common/convolution.cpp
@@ -205,14 +205,18 @@ status_t conv_attr_check(const convolution_desc_t &desc, const engine_t *engine,
         // Check zero points
         if (!attr->zero_points_.has_default_values()) {
             const auto &zp = attr->zero_points_;
-            int mask_src = 0, mask_wei = 0, mask_dst = 0;
-            zp.get(DNNL_ARG_SRC, &mask_src);
-            zp.get(DNNL_ARG_WEIGHTS, &mask_wei);
-            zp.get(DNNL_ARG_DST, &mask_dst);
 
-            VCHECK_CONV_UNIMPL((mask_src == 0 || mask_src == 1 << 1)
-                            && (mask_wei == 0)
-                            && (mask_dst == 0 || mask_dst == 1 << 1),
+            VCHECK_CONV_UNIMPL(IMPLICATION(!zp.has_default_values(DNNL_ARG_SRC),
+                                       utils::one_of(zp.get_mask(DNNL_ARG_SRC),
+                                               0, 1 << 1)),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+            VCHECK_CONV_UNIMPL(
+                    IMPLICATION(!zp.has_default_values(DNNL_ARG_WEIGHTS),
+                            zp.get_mask(DNNL_ARG_WEIGHTS) == 0),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+            VCHECK_CONV_UNIMPL(IMPLICATION(!zp.has_default_values(DNNL_ARG_DST),
+                                       utils::one_of(zp.get_mask(DNNL_ARG_DST),
+                                               0, 1 << 1)),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         }
 

--- a/src/common/deconvolution.cpp
+++ b/src/common/deconvolution.cpp
@@ -192,13 +192,18 @@ status_t deconv_attr_check(const deconvolution_desc_t &desc,
         // Check zero points
         if (!attr->zero_points_.has_default_values()) {
             const auto &zp = attr->zero_points_;
-            int mask_src = 0, mask_dst = 0;
-            zp.get(DNNL_ARG_SRC, &mask_src);
-            zp.get(DNNL_ARG_DST, &mask_dst);
 
-            VCHECK_DECONV_UNIMPL(zp.has_default_values(DNNL_ARG_WEIGHTS)
-                            && (mask_src == 0 || mask_src == 1 << 1)
-                            && (mask_dst == 0 || mask_dst == 1 << 1),
+            VCHECK_DECONV_UNIMPL(
+                    IMPLICATION(!zp.has_default_values(DNNL_ARG_SRC),
+                            utils::one_of(
+                                    zp.get_mask(DNNL_ARG_SRC), 0, 1 << 1)),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+            VCHECK_DECONV_UNIMPL(zp.has_default_values(DNNL_ARG_WEIGHTS),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+            VCHECK_DECONV_UNIMPL(
+                    IMPLICATION(!zp.has_default_values(DNNL_ARG_DST),
+                            utils::one_of(
+                                    zp.get_mask(DNNL_ARG_DST), 0, 1 << 1)),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         }
 

--- a/src/common/primitive_attr_quant.cpp
+++ b/src/common/primitive_attr_quant.cpp
@@ -97,5 +97,40 @@ std::string scales_t::get_verbose() const {
     return s;
 }
 
+size_t zero_points_t::get_hash() const {
+    size_t seed = 0;
+    // Go through zero_points for all arguments.
+    for (const auto &e : zero_points_) {
+        seed = hash_combine(seed, e.first);
+        seed = hash_combine(seed, e.second.get_hash());
+    }
+    return seed;
+}
+
+void zero_points_t::serialize(serialization_stream_t &sstream) const {
+    for (const auto &e : zero_points_) {
+        sstream.write(&e.first);
+        e.second.serialize(sstream);
+    }
+}
+
+std::string zero_points_t::get_verbose() const {
+    std::string s;
+    std::string empty_delim, attr_delim = "+";
+    std::string delim = empty_delim;
+    for (const auto &zero_point : zero_points_) {
+        const auto &q = zero_point.second;
+        if (q.has_default_values()) continue;
+
+        int arg = zero_point.first;
+        s.append(delim)
+                .append(arg2str(arg))
+                .append(":")
+                .append(q.get_verbose());
+        delim = attr_delim;
+    }
+    return s;
+}
+
 } // namespace impl
 } // namespace dnnl

--- a/src/common/sdpa_pd.hpp
+++ b/src/common/sdpa_pd.hpp
@@ -224,17 +224,17 @@ private:
     static int zp_group_size(
             const zero_points_t &zp, const memory_desc_t &desc) {
         dim_t out = utils::array_product(desc.dims, desc.ndims);
-        if (zp.has_default_groups(DNNL_ARG_WEIGHTS)) {
-            for (int idx : mask_iterator(zp.get(DNNL_ARG_WEIGHTS))) {
+        if (zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
+            for (int idx : mask_iterator(zp.get_mask(DNNL_ARG_WEIGHTS))) {
                 out /= desc.dims[idx];
             }
         } else {
-            auto groups = zp.get_groups(DNNL_ARG_WEIGHTS);
-            for (int idx : mask_iterator(zp.get(DNNL_ARG_WEIGHTS))) {
+            for (int idx : mask_iterator(zp.get_mask(DNNL_ARG_WEIGHTS))) {
                 if (idx < 2) {
                     out /= desc.dims[idx];
                 } else {
-                    out /= (desc.dims[idx] / groups[idx - 2]);
+                    out /= (desc.dims[idx]
+                            / zp.get_group(DNNL_ARG_WEIGHTS, idx - 2));
                 }
             }
         }

--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -322,14 +322,21 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
 
     auto init_zp_type
             = [&](brgemm_broadcast_t &zp_type, int mem_arg) -> status_t {
-        auto zero_points = attr->zero_points_;
+        const auto &zp = attr->zero_points_;
+        // Always init a default value;
+        zp_type = brgemm_broadcast_t::none;
 
-        // common zero point type is supported for now
-        if (!zero_points.common(mem_arg)) return status::unimplemented;
+        if (!zp.has_default_values(mem_arg)) {
+            int mask = zp.get_mask(mem_arg);
+            if (mask == 0) {
+                zp_type = brgemm_broadcast_t::per_tensor;
+            } else if (mask == (1 << 1)) {
+                zp_type = brgemm_broadcast_t::per_n;
+            } else {
+                return status::unimplemented;
+            }
+        }
 
-        zp_type = zero_points.has_default_values(mem_arg)
-                ? brgemm_broadcast_t::none
-                : brgemm_broadcast_t::per_tensor;
         return status::success;
     };
 

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
@@ -66,12 +66,20 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
             return attr_scales_ok(supported_args);
         }
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
     };
 

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -1759,19 +1759,23 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     const int prelu_ind = p.find(primitive_kind::prelu);
     jcp.with_binary = !everyone_is(-1, binary_ind, prelu_ind);
 
+    const auto &zp = attr.zero_points_;
     jcp.src_zero_point
             = get_zp_type(attr, DNNL_ARG_SRC) != brgemm_broadcast_t::none;
     jcp.dst_zero_point
             = get_zp_type(attr, DNNL_ARG_DST) != brgemm_broadcast_t::none;
 
-    const bool has_zero_points = jcp.src_zero_point || jcp.dst_zero_point;
-    const bool params_ok
-            = IMPLICATION(has_zero_points, utils::one_of(jcp.src_dt, u8, s8))
-            && IMPLICATION(
-                    jcp.src_zero_point, attr.zero_points_.common(DNNL_ARG_SRC))
-            && IMPLICATION(
-                    jcp.dst_zero_point, attr.zero_points_.common(DNNL_ARG_DST));
-    if (!params_ok) return status::unimplemented;
+    VDISPATCH_CONV_IC(IMPLICATION(jcp.src_zero_point || jcp.dst_zero_point,
+                              utils::one_of(jcp.src_dt, s8, u8)),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
+
+    VDISPATCH_CONV_IC(
+            IMPLICATION(jcp.src_zero_point, zp.get_mask(DNNL_ARG_SRC) == 0),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
+
+    VDISPATCH_CONV_IC(
+            IMPLICATION(jcp.dst_zero_point, zp.get_mask(DNNL_ARG_DST) == 0),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
 
     jcp.nthr = nthreads;
     jcp.kh_sets = 1;

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
@@ -114,10 +114,11 @@ status_t _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel::init_conf(
     if (jcp.is_depthwise && (!jcp.signed_input || is_3d))
         return status::unimplemented;
 
-    if (!zero_points_valid(&attr)) return status::unimplemented;
+    VDISPATCH_DECONVOLUTION_IC(
+            zero_points_valid(&attr), VERBOSE_UNSUPPORTED_ZP_CFG);
     jcp.src_zero_point = !attr.zero_points_.has_default_values(DNNL_ARG_SRC);
     jcp.dst_zero_point = !attr.zero_points_.has_default_values(DNNL_ARG_DST);
-    jcp.zp_src_is_common = attr.zero_points_.common(DNNL_ARG_SRC);
+    jcp.zp_src_is_common = attr.zero_points_.get_mask(DNNL_ARG_SRC) == 0;
 
     format_tag_t dat_tag = utils::pick(
             ndims - 3, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -66,17 +66,19 @@ status_t acl_lowp_matmul_t::pd_t::init(engine_t *engine) {
                     | smask_t::zero_points_runtime | smask_t::post_ops),
             "only scale, zero point and post-ops attrs supported");
 
-    VDISPATCH_MATMUL(attr()->zero_points_.get(DNNL_ARG_SRC) == 0
-                    && attr()->zero_points_.get(DNNL_ARG_WEIGHTS) == 0
-                    && attr()->zero_points_.get(DNNL_ARG_DST) == 0,
-            "common zero points only");
-
     static const std::vector<int> supported_args {
             DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
     for (int arg : supported_args) {
         if (attr()->scales_.has_default_values(arg)) continue;
 
         VDISPATCH_MATMUL(attr()->scales_.get_mask(arg) == 0,
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
+    }
+
+    for (int arg : supported_args) {
+        if (attr()->zero_points_.has_default_values(arg)) continue;
+
+        VDISPATCH_MATMUL(attr()->zero_points_.get_mask(arg) == 0,
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
     }
 

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -62,10 +62,13 @@ status_t acl_lowp_matmul_sq_t::pd_t::init(engine_t *engine) {
                 VERBOSE_UNSUPPORTED_SCALES_CFG);
     }
 
-    VDISPATCH_MATMUL(attr()->zero_points_.get(DNNL_ARG_SRC) == 0
-                    && attr()->zero_points_.get(DNNL_ARG_WEIGHTS) == 0
-                    && attr()->zero_points_.get(DNNL_ARG_DST) == 0,
-            "common zero points only");
+    for (int arg : supported_args) {
+        if (attr()->zero_points_.has_default_values(arg)) continue;
+
+        VDISPATCH_MATMUL(attr()->zero_points_.get_mask(arg) == 0,
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
+    }
+
     VDISPATCH_MATMUL(
             !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
     const memory_desc_wrapper src_d(src_md_);

--- a/src/cpu/matmul/matmul_utils.hpp
+++ b/src/cpu/matmul/matmul_utils.hpp
@@ -156,7 +156,7 @@ struct matmul_helper_t {
     static status_t get_quant_md(memory_desc_t &md, const int ndims,
             const dims_t in_dims, const int quant_mask, const dim_t g0,
             const dim_t g1, const data_type_t dt) {
-        if (dt == data_type::undef) {
+        if (dt == data_type::undef || quant_mask < 0) {
             md = glob_zero_md;
             return status::success;
         }

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -88,16 +88,10 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
     const auto &attr_zps = pd()->attr()->zero_points_;
     const bool with_wei_zero_points
             = !attr_zps.has_default_values(DNNL_ARG_WEIGHTS);
-    int wei_zp_mask = 0;
-    attr_zps.get(DNNL_ARG_WEIGHTS, &wei_zp_mask);
+    int wei_zp_mask = attr_zps.get_mask(DNNL_ARG_WEIGHTS);
     const auto &wei_zp_dt = attr_zps.get_data_type(DNNL_ARG_WEIGHTS);
-    const auto wei_zp_group_ndims = attr_zps.get_groups_ndims(DNNL_ARG_WEIGHTS);
-    const auto wei_zp_group_k = wei_zp_group_ndims > 0
-            ? attr_zps.get_groups(DNNL_ARG_WEIGHTS)[0]
-            : 1;
-    const auto wei_zp_group_n = wei_zp_group_ndims > 0
-            ? attr_zps.get_groups(DNNL_ARG_WEIGHTS)[1]
-            : 1;
+    const auto wei_zp_group_k = attr_zps.get_group(DNNL_ARG_WEIGHTS, 0);
+    const auto wei_zp_group_n = attr_zps.get_group(DNNL_ARG_WEIGHTS, 1);
     // Initialize a memory desc for quant entries for easier offset calculation.
     memory_desc_t wei_zp_md {};
     CHECK(matmul_helper_t::get_quant_md(wei_zp_md, ndims, weights_d.dims(),

--- a/src/cpu/matmul/ref_matmul_int8.hpp
+++ b/src/cpu/matmul/ref_matmul_int8.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,46 +87,45 @@ struct ref_matmul_int8_t : public primitive_t {
 
     private:
         bool attr_zero_points_ok() const {
-            int mask_src = 0, mask_wei = 0, mask_dst = 0;
-            CHECK_BOOL(attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src));
-            CHECK_BOOL(attr()->zero_points_.get(DNNL_ARG_WEIGHTS, &mask_wei));
-            CHECK_BOOL(attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst));
+            const auto &zp = attr()->zero_points_;
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                bool ok = utils::one_of(mask_src, 0, src_qmask_K(),
+                        src_qmask_M() + src_qmask_K());
+                if (!ok) return false;
 
-            const auto src_group_ndims
-                    = attr()->zero_points_.get_groups_ndims(DNNL_ARG_SRC);
-            const auto src_group_dims
-                    = attr()->zero_points_.get_groups(DNNL_ARG_SRC);
-            const bool src_m_group_ok
-                    = IMPLICATION(src_group_ndims == 2, src_group_dims[0] == 1);
-            const bool src_k_group_ok
-                    = IMPLICATION(src_group_ndims == 2 && src_group_dims[1] > 1,
-                            K() % src_group_dims[1] == 0);
+                if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
+                    const auto gM = zp.get_group(DNNL_ARG_SRC, 0);
+                    ok = gM == 1;
+                    if (!ok) return false;
 
-            const auto wei_group_ndims
-                    = attr()->zero_points_.get_groups_ndims(DNNL_ARG_WEIGHTS);
-            const auto wei_group_dims
-                    = attr()->zero_points_.get_groups(DNNL_ARG_WEIGHTS);
-            const bool wei_k_group_ok
-                    = IMPLICATION(wei_group_ndims == 2 && wei_group_dims[0] > 1,
-                            K() % wei_group_dims[0] == 0);
-            const bool wei_n_group_ok
-                    = IMPLICATION(wei_group_ndims == 2 && wei_group_dims[1] > 1,
-                            N() % wei_group_dims[1] == 0);
+                    const auto gK = zp.get_group(DNNL_ARG_SRC, 1);
+                    ok = IMPLICATION(gK > 1, K() % gK == 0);
+                    if (!ok) return false;
+                }
+            }
+            /* weights decompression requires zero points support */
+            if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
+                if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups()) {
+                    const auto gK = zp.get_group(DNNL_ARG_WEIGHTS, 0);
+                    bool ok = IMPLICATION(gK > 1, K() % gK == 0);
+                    if (!ok) return false;
 
-            bool mask_src_ok = utils::one_of(
-                    mask_src, 0, src_qmask_K(), src_qmask_M() + src_qmask_K());
-            bool mask_dst_ok = utils::one_of(mask_dst, 0, wei_qmask_N());
+                    const auto gN = zp.get_group(DNNL_ARG_WEIGHTS, 1);
+                    ok = IMPLICATION(gN > 1, N() % gN == 0);
+                    if (!ok) return false;
 
-            return mask_src_ok && mask_dst_ok
-                    && utils::one_of(wei_group_ndims, 0, 2)
-                    && IMPLICATION(wei_group_ndims == 2,
-                            utils::one_of(
-                                    1, wei_group_dims[0], wei_group_dims[1])
-                                    && wei_k_group_ok && wei_n_group_ok)
-                    && IMPLICATION(src_group_ndims == 2,
-                            utils::one_of(
-                                    1, src_group_dims[0], src_group_dims[1])
-                                    && src_m_group_ok && src_k_group_ok);
+                    // Only one non-unit group is supported.
+                    ok = utils::one_of(1, gK, gN);
+                    if (!ok) return false;
+                }
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                bool ok = utils::one_of(mask_dst, 0, wei_qmask_N());
+                if (!ok) return false;
+            }
+            return true;
         }
     };
 

--- a/src/cpu/ref_convolution_int8.cpp
+++ b/src/cpu/ref_convolution_int8.cpp
@@ -106,9 +106,9 @@ status_t ref_convolution_int8_fwd_t::execute_forward(
 
     // zp_idx_mult = 1 for per_dim1 zero points and 0, otherwise
     const int src_zp_idx_mult
-            = !pd()->attr()->zero_points_.common(DNNL_ARG_SRC);
+            = pd()->attr()->zero_points_.get_mask(DNNL_ARG_SRC) > 0;
     const int dst_zp_idx_mult
-            = !pd()->attr()->zero_points_.common(DNNL_ARG_DST);
+            = pd()->attr()->zero_points_.get_mask(DNNL_ARG_DST) > 0;
 
     auto ker = [=](dim_t g, dim_t mb, dim_t oc, dim_t od, dim_t oh, dim_t ow) {
         int d = 0;

--- a/src/cpu/ref_deconvolution.hpp
+++ b/src/cpu/ref_deconvolution.hpp
@@ -264,16 +264,25 @@ struct ref_deconvolution_fwd_t : public primitive_t {
         }
 
         bool zero_points_ok() const {
-            using namespace data_type;
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
+            const auto &zp = attr()->zero_points_;
 
-            return IMPLICATION(!utils::one_of(src_md()->data_type, s8, u8),
-                           attr()->zero_points_.has_default_values())
-                    && attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && (mask_src == 0 || mask_src == 1 << 1)
-                    && (mask_dst == 0 || mask_dst == 1 << 1);
+            using namespace data_type;
+            bool ok = IMPLICATION(!utils::one_of(src_md()->data_type, s8, u8),
+                    zp.has_default_values());
+            if (!ok) return false;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                ok = utils::one_of(mask_src, 0, (1 << 1));
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                ok = utils::one_of(mask_dst, 0, (1 << 1));
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
     };
 

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -2341,16 +2341,11 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     src_scales_d.data_type());
         }
 
-        int src_zps_mask = -1;
-        CHECK(zps.get(DNNL_ARG_SRC, &src_zps_mask));
+        int src_zps_mask = zps.get_mask(DNNL_ARG_SRC);
         // Applied to the pre-last dimension.
-        const auto src_zps_group0 = zps.get_groups_ndims(DNNL_ARG_SRC) > 0
-                ? zps.get_groups(DNNL_ARG_SRC)[0]
-                : 1;
+        const auto src_zps_group0 = zps.get_group(DNNL_ARG_SRC, 0);
         // Applied to the last dimension.
-        const auto src_zps_group1 = zps.get_groups_ndims(DNNL_ARG_SRC) > 0
-                ? zps.get_groups(DNNL_ARG_SRC)[1]
-                : 1;
+        const auto src_zps_group1 = zps.get_group(DNNL_ARG_SRC, 1);
         memory_desc_t src_zps_md {};
         if (has_src_zps) {
             get_quant_md(src_zps_md, ndims, input_d.dims(), src_zps_mask,
@@ -2583,17 +2578,12 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         }
 
         const auto &zps = pd->attr()->zero_points_;
-        int src_zps_mask = -1;
-        CHECK(zps.get(DNNL_ARG_SRC, &src_zps_mask));
+        int src_zps_mask = zps.get_mask(DNNL_ARG_SRC);
         const bool has_src_zps = !zps.has_default_values(DNNL_ARG_SRC);
         // Applied to the pre-last dimension.
-        const auto src_zps_group0 = zps.get_groups_ndims(DNNL_ARG_SRC) > 0
-                ? zps.get_groups(DNNL_ARG_SRC)[0]
-                : 1;
+        const auto src_zps_group0 = zps.get_group(DNNL_ARG_SRC, 0);
         // Applied to the last dimension.
-        const auto src_zps_group1 = zps.get_groups_ndims(DNNL_ARG_SRC) > 0
-                ? zps.get_groups(DNNL_ARG_SRC)[1]
-                : 1;
+        const auto src_zps_group1 = zps.get_group(DNNL_ARG_SRC, 1);
         memory_desc_t src_zps_md {};
         if (has_src_zps) {
             get_quant_md(src_zps_md, ndims, input_d.dims(), src_zps_mask,

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -1029,8 +1029,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const auto zp = attr.zero_points_;
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
     jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
-    jcp.zp_src_is_common = zp.common(
-            DNNL_ARG_SRC); // otherwise, it's per-channel (not supported)
+    // If it's not per-tensor, then it's per-channel (not supported)
+    jcp.zp_src_is_common = zp.get_mask(DNNL_ARG_SRC) == 0;
     if (!IMPLICATION(jcp.src_zero_point, jcp.zp_src_is_common)
             || !IMPLICATION(jcp.dst_zero_point || jcp.src_zero_point,
                     is_int8_convolution))

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
@@ -95,12 +95,20 @@ struct jit_avx512_core_amx_1x1_convolution_fwd_t : public primitive_t {
 
     protected:
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
     };
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -2358,8 +2358,8 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const auto zp = attr.zero_points_;
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
     jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
-    jcp.zp_src_is_common = zp.common(
-            DNNL_ARG_SRC); // otherwise, it's per-channel (not supported)
+    // If it's not per-tensor, then it's per-channel (not supported)
+    jcp.zp_src_is_common = zp.get_mask(DNNL_ARG_SRC) == 0;
 
     VDISPATCH_CONV_IC(
             !(!IMPLICATION(jcp.src_zero_point, jcp.zp_src_is_common)

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -98,12 +98,20 @@ struct jit_avx512_core_amx_convolution_fwd_t : public primitive_t {
 
     protected:
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
     };
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -920,7 +920,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel::init_conf(
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
     jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
     jcp.zp_src_is_common
-            = zp.common(DNNL_ARG_SRC); // otherwise, it's per-channel
+            = zp.get_mask(DNNL_ARG_SRC) == 0; // otherwise, it's per-channel
     assert(IMPLICATION(jcp.src_zero_point, jcp.zp_src_is_common));
 
     if ((jcp.dst_zero_point || jcp.src_zero_point) && jcp.with_dw_conv)

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1478,7 +1478,7 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
     jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
     jcp.zp_src_is_common
-            = zp.common(DNNL_ARG_SRC); // otherwise, it's per-channel
+            = zp.get_mask(DNNL_ARG_SRC) == 0; // otherwise, it's per-channel
     assert(IMPLICATION(jcp.src_zero_point, jcp.zp_src_is_common));
 
     if ((jcp.dst_zero_point || jcp.src_zero_point) && jcp.is_fused_conv)

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -92,12 +92,20 @@ struct jit_avx512_core_x8s8s32x_convolution_fwd_t : public primitive_t {
 
     protected:
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
     };
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -126,7 +126,7 @@ status_t _jit_avx512_core_x8s8s32x_deconv_fwd_kernel::init_conf(
             zero_points_valid(&attr), VERBOSE_UNSUPPORTED_ZP_CFG);
     jcp.src_zero_point = !attr.zero_points_.has_default_values(DNNL_ARG_SRC);
     jcp.dst_zero_point = !attr.zero_points_.has_default_values(DNNL_ARG_DST);
-    jcp.zp_src_is_common = attr.zero_points_.common(DNNL_ARG_SRC);
+    jcp.zp_src_is_common = attr.zero_points_.get_mask(DNNL_ARG_SRC) == 0;
 
     format_tag_t dat_tag = utils::pick(
             ndims - 3, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -246,24 +246,28 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
             = attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST});
     VDISPATCH_CONV(scales_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-    const auto zp_attr = attr()->zero_points_;
-    jcp.src_zero_point = !zp_attr.has_default_values(DNNL_ARG_SRC);
-    jcp.dst_zero_point = !zp_attr.has_default_values(DNNL_ARG_DST);
+    const auto &zp = attr()->zero_points_;
+    jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
+    jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
 
-    // Only common zero points for the whole output tensor is supported now
-    const bool has_zero_points = jcp.src_zero_point || jcp.dst_zero_point;
-    const bool params_ok
-            = IMPLICATION(has_zero_points, utils::one_of(jcp.src_dt, u8, s8))
-            && IMPLICATION(jcp.src_zero_point,
-                    attr()->zero_points_.common(DNNL_ARG_SRC)
-                            || attr()->zero_points_.per_dim_1(DNNL_ARG_SRC))
-            && IMPLICATION(jcp.dst_zero_point,
-                    attr()->zero_points_.common(DNNL_ARG_DST));
-    VDISPATCH_CONV(params_ok, VERBOSE_UNSUPPORTED_ZP_CFG);
-
-    VDISPATCH_CONV(!(jcp.src_zero_point
-                           && cd.weights_desc.format_kind != format_kind::any),
+    VDISPATCH_CONV(IMPLICATION(jcp.src_zero_point || jcp.dst_zero_point,
+                           utils::one_of(jcp.src_dt, s8, u8)),
             VERBOSE_UNSUPPORTED_ZP_CFG);
+
+    VDISPATCH_CONV(
+            IMPLICATION(jcp.src_zero_point,
+                    utils::one_of(zp.get_mask(DNNL_ARG_SRC), 0, (1 << 1))),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
+
+    VDISPATCH_CONV(
+            IMPLICATION(jcp.dst_zero_point, zp.get_mask(DNNL_ARG_DST) == 0),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
+
+    // Source zero_point requires compensation, thus, must initialize weights
+    // descriptor and can't take predefined one.
+    const bool src_zp_format_ok = IMPLICATION(jcp.src_zero_point,
+            cd.weights_desc.format_kind == format_kind::any);
+    VDISPATCH_CONV(src_zp_format_ok, VERBOSE_UNSUPPORTED_ZP_CFG);
 
     // strd is only feasible for 1D (i.e., height dim is one)
     // and if there are no tails (for calculating matrix_B strides).
@@ -755,7 +759,8 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                 post_ops_data.oc_logical_off = ch;
                 post_ops_data.dst_scales = dst_scales;
                 const bool is_bcast_zp
-                        = pd()->attr()->zero_points_.common(DNNL_ARG_SRC);
+                        = pd()->attr()->zero_points_.get_mask(DNNL_ARG_SRC)
+                        == 0;
                 post_ops_data.a_zp_values = jcp.src_zero_point
                         ? src_zero_point + ch * !is_bcast_zp
                         : nullptr;

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -83,12 +83,20 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
             return attr_scales_ok(supported_args);
         }
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
 
     private:

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -136,12 +136,20 @@ struct brgemm_convolution_fwd_t : public primitive_t {
         }
 
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
 
         int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK,

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -699,7 +699,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel<isa>::init_conf(
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
     jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
     jcp.zp_src_is_common
-            = zp.common(DNNL_ARG_SRC); // otherwise, it's per-channel
+            = zp.get_mask(DNNL_ARG_SRC) == 0; // otherwise, it's per-channel
     assert(IMPLICATION(jcp.src_zero_point, jcp.zp_src_is_common));
 
     VDISPATCH_CONV_IC(

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -169,12 +169,20 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
 
     protected:
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
 
         status_t copy(const pd_t &other) {

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -1322,7 +1322,7 @@ status_t jit_uni_x8s8s32x_fwd_kernel<isa>::init_conf(jit_conv_conf_t &jcp,
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
     jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);
     jcp.zp_src_is_common
-            = zp.common(DNNL_ARG_SRC); // otherwise, it's per-channel
+            = zp.get_mask(DNNL_ARG_SRC) == 0; // otherwise, it's per-channel
     assert(IMPLICATION(jcp.src_zero_point, jcp.zp_src_is_common));
 
     VDISPATCH_CONV_IC(

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -90,12 +90,20 @@ struct jit_uni_x8s8s32x_convolution_fwd_t : public primitive_t {
 
     protected:
         bool zero_points_ok() const {
-            // Only common zero points are supported -> mask should only be 0
-            int mask_src = 0, mask_dst = 0;
-            attr()->zero_points_.get(DNNL_ARG_SRC, &mask_src);
-            attr()->zero_points_.get(DNNL_ARG_DST, &mask_dst);
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS)
-                    && mask_src == 0 && mask_dst == 0;
+            const auto &zp = attr()->zero_points_;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                const bool ok = mask_src == 0;
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                const bool ok = mask_dst == 0;
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
     };
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -101,7 +101,7 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel<isa>::init_conf(
             zero_points_valid(&attr), VERBOSE_UNSUPPORTED_ZP_CFG);
     jcp.src_zero_point = !attr.zero_points_.has_default_values(DNNL_ARG_SRC);
     jcp.dst_zero_point = !attr.zero_points_.has_default_values(DNNL_ARG_DST);
-    jcp.zp_src_is_common = attr.zero_points_.common(DNNL_ARG_SRC);
+    jcp.zp_src_is_common = attr.zero_points_.get_mask(DNNL_ARG_SRC) == 0;
 
     format_tag_t dat_tag = utils::pick(
             ndims - 3, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);

--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -49,7 +49,8 @@ status_t ref_convolution_fwd_t::pd_t::init_conf() {
     conf_.use_dst_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
-    conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
+    conf_.single_dst_zeropoint
+            = attr()->zero_points_.get_mask(DNNL_ARG_DST) == 0;
 
     conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
@@ -111,7 +112,8 @@ status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
     conf_.use_dst_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
-    conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
+    conf_.single_dst_zeropoint
+            = attr()->zero_points_.get_mask(DNNL_ARG_DST) == 0;
 
     conf_.post_ops = sycl_post_ops_t(attr(), diff_src_md());
 
@@ -174,7 +176,8 @@ status_t ref_convolution_bwd_weights_t::pd_t::init_conf() {
     conf_.use_dst_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
     conf_.single_data_zeropoint = attr()->zero_points_.common(DNNL_ARG_SRC_0);
-    conf_.single_dst_zeropoint = attr()->zero_points_.common(DNNL_ARG_DST);
+    conf_.single_dst_zeropoint
+            = attr()->zero_points_.get_mask(DNNL_ARG_DST) == 0;
 
     conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 

--- a/src/gpu/intel/jit/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/conv/gen_convolution.cpp
@@ -84,8 +84,7 @@ public:
                     || pd->data->pd_cfg.zp_cfg().needs_src_conv_precalc) {
                 primitive_attr_t attr;
                 if (pd->data->pd_cfg.zp_cfg().needs_src_conv_precalc) {
-                    int mask = 0;
-                    CHECK(pd->attr_.zero_points_.get(DNNL_ARG_SRC, &mask));
+                    int mask = pd->attr_.zero_points_.get_mask(DNNL_ARG_SRC);
                     attr.zero_points_.set(DNNL_ARG_SRC, mask);
                     attr.post_ops_.append_eltwise(
                             1.f, alg_kind::eltwise_linear, -1.f, 0.f);

--- a/src/gpu/intel/jit/gemm/gen_gemm.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.cpp
@@ -348,7 +348,7 @@ status_t gen_gemm_t::execute(const gemm_exec_ctx_t &ctx) const {
     if (pd()->with_c_zero_points()) {
         off_co0 = types::bytes_to_elements(c_type, co->offset())
                 + pd()->dyn_offset_co;
-        CHECK(pd()->attr()->zero_points_.get(DNNL_ARG_DST, &cmask));
+        cmask = pd()->attr()->zero_points_.get_mask(DNNL_ARG_DST);
     } else if (pd()->with_bias()) {
         off_co0 = types::bytes_to_elements(c_type, bias.offset());
         co = &bias;

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -71,11 +71,11 @@ public:
         , is_runtime_dst_zero_points(pd
                   && !pd->attr()->zero_points_.has_default_values(DNNL_ARG_DST))
         , is_common_src_zero_point(
-                  pd && pd->attr()->zero_points_.common(DNNL_ARG_SRC))
-        , is_common_wei_zero_point(
-                  pd && pd->attr()->zero_points_.common(DNNL_ARG_WEIGHTS))
+                  pd && pd->attr()->zero_points_.get_mask(DNNL_ARG_SRC) == 0)
+        , is_common_wei_zero_point(pd
+                  && pd->attr()->zero_points_.get_mask(DNNL_ARG_WEIGHTS) == 0)
         , is_common_dst_zero_point(
-                  pd && pd->attr()->zero_points_.common(DNNL_ARG_DST))
+                  pd && pd->attr()->zero_points_.get_mask(DNNL_ARG_DST) == 0)
         , needs_src_reorder_precalc(
                   pd && do_src_compensation && can_use_src_reorder_precalc(pd))
         , needs_src_conv_precalc(pd && do_src_compensation
@@ -111,7 +111,7 @@ private:
         // specify the weights mem desc so the convolution can choose it freely
         // and set a mem desc flag asking a reorder to precompute the values.
         return (pd->invariant_wei_md()->format_kind == format_kind::any)
-                && pd->attr()->zero_points_.common(DNNL_ARG_SRC)
+                && pd->attr()->zero_points_.get_mask(DNNL_ARG_SRC) == 0
                 && pd->attr()->zero_points_.has_default_values(
                         DNNL_ARG_WEIGHTS);
     }

--- a/src/gpu/intel/ocl/gemm/ref_gemm.cpp
+++ b/src/gpu/intel/ocl/gemm/ref_gemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,7 +48,9 @@ status_t ref_gemm_t::execute(const gemm_exec_ctx_t &ctx) const {
     const auto &c0 = GEMM_CTX_ARG_STORAGE(c_zero_point);
 
     int c0_mask = 0;
-    CHECK(pd()->attr()->zero_points_.get(DNNL_ARG_C, &c0_mask));
+    if (!pd()->attr()->zero_points_.has_default_values(DNNL_ARG_C)) {
+        c0_mask = pd()->attr()->zero_points_.get_mask(DNNL_ARG_C);
+    }
 
     const dim_t MB = exec_d->batch();
     const dim_t M = exec_d->m();

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -213,8 +213,8 @@ bool with_quantize_common(const quant_entry_t &scale_entry) {
 /// Returns true if a common zero points value is used for each slice of the
 /// tensor operation
 bool with_quantize_common(const zero_points_t &zp) {
-    int mask = zp.get(DNNL_ARG_WEIGHTS);
-    return !zp.has_default_values()
+    int mask = zp.get_mask(DNNL_ARG_WEIGHTS);
+    return !zp.has_default_values(DNNL_ARG_WEIGHTS)
             && (((mask & 3) != 0 && (mask & 12) == 0) || mask == 0);
 }
 

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -93,7 +93,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
                     qry_md()->dims[1], key_md()->dims[1], val_md()->dims[1]);
 
             int kq_scales_mask = desc()->kq_scales.get_mask();
-            int kq_zp_mask = desc()->kq_zero_points.get(DNNL_ARG_WEIGHTS);
+            int kq_zp_mask = desc()->kq_zero_points.get_mask(DNNL_ARG_WEIGHTS);
             if (!desc()->kq_scales.has_default_values()
                     && !desc()->kq_zero_points.has_default_values())
                 VDISPATCH_SDPA(kq_scales_mask == kq_zp_mask,
@@ -122,7 +122,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
             }
 
             int vs_scales_mask = desc()->vs_scales.get_mask();
-            int vs_zp_mask = desc()->vs_zero_points.get(DNNL_ARG_WEIGHTS);
+            int vs_zp_mask = desc()->vs_zero_points.get_mask(DNNL_ARG_WEIGHTS);
             if (!desc()->vs_scales.has_default_values()
                     && !desc()->vs_zero_points.has_default_values())
                 VDISPATCH_SDPA(vs_scales_mask == vs_zp_mask,

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -132,10 +132,12 @@ attr_info_t attr_info_t::create(const primitive_attr_t *attr) {
     attr_info.dst_zpoints_data_type = zp.get_data_type(DNNL_ARG_DST);
 
     attr_info.with_per_ic_src_zpoints = attr_info.with_src_zpoints
-            && !zp.has_default_values(DNNL_ARG_SRC) && !zp.common(DNNL_ARG_SRC);
+            && !zp.has_default_values(DNNL_ARG_SRC)
+            && zp.get_mask(DNNL_ARG_SRC) > 0;
 
     attr_info.with_per_oc_dst_zpoints = attr_info.with_dst_zpoints
-            && !zp.has_default_values(DNNL_ARG_DST) && !zp.common(DNNL_ARG_DST);
+            && !zp.has_default_values(DNNL_ARG_DST)
+            && zp.get_mask(DNNL_ARG_DST) > 0;
 
     // Rounding mode.
     attr_info.with_dst_sround = attr->rounding_mode_.get(DNNL_ARG_DST)


### PR DESCRIPTION
Move zero_points to quant_entry_t abstraction.
Same deal as in #2270.
With this change the interface will be completely aligned between those two.
The next part will clean up skip_mask_t flags and, probably, introduce a single base class for scales and zero-points to inherit from to avoid code duplication and new features enabling in the future.