### PR TITLE
x64: brgemm: update blocking for big virtual padding

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -307,29 +307,28 @@ status_t brgemm_blocking(brgemm_desc_t *brg) {
         brg->ldb = brg->load_dim / brg->ld_block;
         brg->ldb_tail = brg->load_dim % brg->ld_block;
 
-        int adj_ld_block2 = calculate_ldb_params(brg, 4);
-
-        brg->n_bcast_1_load
-                = (utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2)
-                          && adj_ld_block2 == 4)
-                || brg->brgattr.hint_loop_order == brgemm_lo_bl_1load;
-
-        int max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
-
-        // reduce 'ld_block2' to allow a larger 'bd_block'
         const int max_vpad = nstl::max(
                 brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
-        if (is_superset(brg->isa_impl, avx2) && max_bcast_block < max_vpad) {
-            for (int try_ld_block2 = 2; try_ld_block2 > 0; --try_ld_block2) {
-                adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);
-                max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
-                if (max_bcast_block >= max_vpad) break;
-            }
-            // bcast block in brgemm kernel should be greater than virtual
-            // padding to avoid possible functional issues
-            if (max_bcast_block < max_vpad) return status::unimplemented;
+        // iterate ld_block2 starting from 4 to allow bd_block larger than
+        // virtual padding
+        int max_bcast_block {0}, min_bcast_block {0}, adj_ld_block2 {0};
+        bool few_regs
+                = utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2);
+        bool hint_n_bcast_1_load
+                = brg->brgattr.hint_loop_order == brgemm_lo_bl_1load;
+        for (int try_ld_block2 = 4; try_ld_block2 > 0; --try_ld_block2) {
+            adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);
+            brg->n_bcast_1_load
+                    = (few_regs && adj_ld_block2 == 4) || hint_n_bcast_1_load;
+            max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
+            const auto bdb_tail = brg->bcast_dim % max_bcast_block;
+            min_bcast_block = bdb_tail > 0 ? bdb_tail : max_bcast_block;
+            if (min_bcast_block >= max_vpad) break;
         }
+        // bcast block in brgemm kernel should be greater than virtual
+        // padding to avoid possible functional issues
+        if (min_bcast_block < max_vpad) return status::unimplemented;
 
         const int min_block = nstl::max(1, max_vpad);
 


### PR DESCRIPTION
This is a backport of #2584  to fix [MFDNN-13143](https://jira.devtools.intel.com/browse/MFDNN-13143)