### PR TITLE
Fix memory storage allocation for SYCL CPU

### DIFF
--- a/src/cpu/cpu_engine.cpp
+++ b/src/cpu/cpu_engine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ namespace cpu {
 
 status_t cpu_engine_t::create_memory_storage(
         memory_storage_t **storage, unsigned flags, size_t size, void *handle) {
+    assert(runtime_kind() != runtime_kind::sycl);
+    if (runtime_kind() == runtime_kind::sycl) return status::runtime_error;
+
     auto _storage = new cpu_memory_storage_t(this);
     if (_storage == nullptr) return status::out_of_memory;
     status_t status = _storage->init(flags, size, handle);

--- a/src/cpu/sycl/engine.hpp
+++ b/src/cpu/sycl/engine.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,6 +41,12 @@ public:
                 engine_kind::cpu, dev, ctx, index)) {}
 
     status_t init() { return init_impl(); }
+
+    status_t create_memory_storage(memory_storage_t **storage, unsigned flags,
+            size_t size, void *handle) override {
+        return impl()->create_memory_storage(
+                storage, this, flags, size, handle);
+    }
 
     status_t create_stream(impl::stream_t **stream,
             impl::stream_impl_t *stream_impl) override {

--- a/src/cpu/sycl/engine.hpp
+++ b/src/cpu/sycl/engine.hpp
@@ -44,6 +44,9 @@ public:
 
     status_t create_memory_storage(memory_storage_t **storage, unsigned flags,
             size_t size, void *handle) override {
+        assert(runtime_kind() == runtime_kind::sycl);
+        if (runtime_kind() != runtime_kind::sycl) return status::runtime_error;
+
         return impl()->create_memory_storage(
                 storage, this, flags, size, handle);
     }


### PR DESCRIPTION
SYCL CPU engine is inherited from classic CPU engine that overrides an interface for creating a memory storage therefore SYCL CPU engine must also override it.

This bug was introduced during the recent architecture refactoring (8187bb585b2e242fba778266cb8d2c396fe669d1) and caused SYCL CPU engine to allocate classic CPU memory storage. ~~It means that we haven't been testing usm/buffer for SYCL CPU since the bug was introduced. Also, it means that set_data_handle()/get_data_handle() and their counterparts for SYCL buffers might not work correctly (could manifest as weird issues in validation)~~.

**Update:** Only the `memory_t` objects created inside the library are affected.

I also, added additional checks to reduce the chance of introducing such a bug in the future.