### PR TITLE
github: workflows: Add GitHub hosted Cobalt-100 runners

### DIFF
--- a/.github/automation/common_aarch64.sh
+++ b/.github/automation/common_aarch64.sh
@@ -24,6 +24,13 @@ set -o errexit -o pipefail -o noclobber
 
 export OS=$(uname)
 
+# Num threads on system.
+if [[ "$OS" == "Darwin" ]]; then
+    export MP="-j$(sysctl -n hw.ncpu)"
+elif [[ "$OS" == "Linux" ]]; then
+    export MP="-j$(nproc)"
+fi
+
 if [[ "$BUILD_TOOLSET" == "gcc" ]]; then
     export CC=gcc-${GCC_VERSION}
     export CXX=g++-${GCC_VERSION}

--- a/.github/workflows/aarch64-acl.yml
+++ b/.github/workflows/aarch64-acl.yml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         config: [
           { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release },
+          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: Release },
           { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug },
           { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: gcc, build: Release }
         ]
@@ -85,19 +86,19 @@ jobs:
           sudo apt update -y
           sudo apt install -y scons
 
-      - if: ${{ startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.threading == 'OMP') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+      - if: ${{ contains(matrix.config.label,'ubuntu') && (matrix.config.threading == 'OMP') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
         name: Install openmp
         run: |
           sudo apt install -y libomp-dev
 
-      - if: ${{ startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'gcc') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+      - if: ${{ contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'gcc') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
         name: Install gcc
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt update -y
           sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
 
-      - if: ${{ startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'clang') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+      - if: ${{ contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'clang') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
         name: Install clang
         uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
         with:

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -64,6 +64,7 @@ jobs:
       matrix:
         config: [
           { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release, testset: SMOKE },
+          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: Release, testset: SMOKE },
           { name: c6g, label: ah-ubuntu_22_04-c6g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI },
           { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug, testset: SMOKE },
           { name: c7g, label: ah-ubuntu_22_04-c7g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }
@@ -90,19 +91,19 @@ jobs:
           cmakeVersion: 3.31.0
           ninjaVersion: 1.12.0
 
-      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.threading == 'OMP')) }}
+      - if: ${{ (contains(matrix.config.label,'ubuntu') && (matrix.config.threading == 'OMP')) }}
         name: Install openmp
         run: |
           sudo apt install -y libomp-dev
 
-      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'gcc')) }}
+      - if: ${{ (contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'gcc')) }}
         name: Install gcc
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt update -y
           sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
 
-      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'clang')) }}
+      - if: ${{ (contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'clang')) }}
         name: Install clang
         uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
         with:


### PR DESCRIPTION
GitHub-hosted Cobalt-100 runners are now [available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

It comes with the caveat of the restrictions of the free GitHub-hosted runners (size, limited runners), however, let's put this in and observe the impact it has on CI. But the advantage is that this architecture is different from the Arm-Hosted Graviton-based runners.