### PR TITLE
cpu: x64: matmul: correct batch layout support for int4 wei

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1683,6 +1683,15 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.use_buffer_reduce
             = (bgmmc.reduce_dt != data_type::f32) || (bgmmc.nthr_k > 1);
 
+    // When is_wei_batch_layout_trivial is true, we only support that
+    // batch offset can be divided by 2
+    if (bgmmc.is_int4_weights) {
+        VCONDCHECK_BG(IMPLICATION(bgmmc.is_wei_batch_layout_trivial
+                                      && bgmmc.batch > 1,
+                              bgmmc.B_strides[2] % 2 == 0),
+                VERBOSE_BAD_DIM);
+    }
+
     // Dispatch small shapes to VNNI for better performance
     const bool runtime_dims
             = bgmmc.is_runtime_M || bgmmc.is_runtime_N || bgmmc.is_runtime_K;


### PR DESCRIPTION
Fixes MFDNN-13095

When `is_wei_batch_layout_trivial == true`, [B_batch_offset ](https://github.com/intel-innersource/libraries.performance.math.onednn/blob/main/src/cpu/x64/matmul/brgemm_matmul.cpp#L1495) may not be divided by 2 and then cause correctness issue.