### PR TITLE
Fix crash in sparse reorder

### DIFF
--- a/src/cpu/reorder/simple_sparse_reorder.hpp
+++ b/src/cpu/reorder/simple_sparse_reorder.hpp
@@ -88,7 +88,6 @@ struct simple_sparse_reorder_impl<SIMPLE_SPARSE_REORDER_TEMPL_CALL,
 
     static size_t get_scratchpad_size(const memory_desc_wrapper &input_d,
             const memory_desc_wrapper &output_d) {
-        if (output_d.nelems(true)) return 0;
         const auto nelems = static_cast<size_t>(output_d.nelems(true));
         const auto tmp_output_sz = nelems * output_d.data_type_size();
         const auto nnz_per_blocks_sz


### PR DESCRIPTION
Fixes MFDNN-13062.

Incorrect condition `if (output_d.nelems(true)) return 0;` was introduced in b20dcfcd409 resulting in returning an incorrect scratchpad size an consequently the crash.
This PR removes the condition and improves verbose diagnostics. 

The piece of code below is removed because `nelems()` can return a value that is < 0 only if md contains runtime dimensions, and that check was moved to `is_applicable()`.
```cpp
const memory_desc_wrapper dst_d(dst_md());
if (dst_d.nelems(true) < 0) return status::unimplemented
```