### PR TITLE
xe: ocl: remove dead code

### DIFF
--- a/src/gpu/intel/ocl/gemm/ref_gemm.cl
+++ b/src/gpu/intel/ocl/gemm/ref_gemm.cl
@@ -82,10 +82,10 @@ __kernel void ref_gemm(__global A_DATA_T *a, __global B_DATA_T *b,
     long off_bias = mb * b_strides[0] + m * b_strides[1] + n * b_strides[2];
     temp += BIA_TO_REF(bias[off_bias]);
 #endif
+#if WITH_POST_OP
 #if WITH_SUM
     temp += (POST_OP_DATA_T)(beta * C_TO_REF(c[off_c]));
 #endif
-#if WITH_ELTWISE
     temp = fwd_eltwise(temp, eltwise_alpha, eltwise_beta, eltwise_scale);
 #endif
 #if WITH_DST_ZPOINTS

--- a/src/gpu/intel/ocl/gen9_eltwise.cpp
+++ b/src/gpu/intel/ocl/gen9_eltwise.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,7 +69,6 @@ compute::kernel_ctx_t gen9_eltwise_jit_params_t::get_kernel_ctx() const {
     kernel_ctx.set_data_type(data_type);
     def_eltwise_alg_kinds(kernel_ctx);
 
-    kernel_ctx.define_int("WITH_ELTWISE", 1);
     kernel_ctx.define_int("ELTWISE_ALG", alg_kind);
 
     kernel_ctx.define_int("VECT_DT_N", vector_size);

--- a/src/gpu/intel/ocl/ocl_eltwise.h
+++ b/src/gpu/intel/ocl/ocl_eltwise.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef GPU_INTEL_OCL_OCL_ELTWISE_H
 #define GPU_INTEL_OCL_OCL_ELTWISE_H
 
-#if WITH_ELTWISE
 #include "gpu/intel/ocl/ocl_types.h"
 
 #if DT_F16 == 1
@@ -345,7 +344,5 @@ float bwd_eltwise(
     return x;
 #endif
 }
-
-#endif // WITH_ELTWISE
 
 #endif // GPU_INTEL_OCL_OCL_ELTWISE_H

--- a/src/gpu/intel/ocl/ocl_post_ops.h
+++ b/src/gpu/intel/ocl/ocl_post_ops.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,9 +28,9 @@
 #include "gpu/intel/ocl/ocl_eltwise.h"
 #include "gpu/intel/ocl/ocl_io.h"
 
-float fwd_Xnary(unsigned kind, unsigned algorithm, float x, float y,
+float fwd_Xnary(bool is_binary, unsigned algorithm, float x, float y,
         float alpha, float beta, float scale) {
-    if (kind == PO_BINARY) {
+    if (is_binary) {
         switch (algorithm) {
             // binary
             case BINARY_ADD: return x + y; break;
@@ -55,8 +55,8 @@ float fwd_Xnary(unsigned kind, unsigned algorithm, float x, float y,
     }
 }
 
-#define FWD_XNARY_GENERIC_DT(po_kind, algorithm, res_ptr, arg0_ptr, arg0_len, \
-        arg1_ptr, arg1_len, alpha, beta, scale) \
+#define FWD_XNARY_GENERIC_DT(is_binary, algorithm, res_ptr, arg0_ptr, \
+        arg0_len, arg1_ptr, arg1_len, alpha, beta, scale) \
     { \
         auto ty = arg0_len + arg1_len; \
         const typeof(ty) out_len \
@@ -64,8 +64,8 @@ float fwd_Xnary(unsigned kind, unsigned algorithm, float x, float y,
         unroll_for(typeof(out_len + 0) idx = 0; idx < out_len; ++idx) { \
             const int arg0_idx = arg0_len == 1 ? 0 : idx; \
             const int arg1_idx = arg1_len == 1 ? 0 : idx; \
-            res_ptr[arg0_len == 1 && arg1_len == 1 ? 0 : idx] = fwd_Xnary( \
-                    po_kind, algorithm, into_float(arg0_ptr[arg0_idx]), \
+            res_ptr[idx] = fwd_Xnary(is_binary, algorithm, \
+                    into_float(arg0_ptr[arg0_idx]), \
                     into_float(arg1_ptr[arg1_idx]), alpha, beta, scale); \
         } \
     }
@@ -94,12 +94,12 @@ float fwd_Xnary(unsigned kind, unsigned algorithm, float x, float y,
 #define po_dt(idx) CONCAT3(PO_, idx, _BIN_ARG_ACTUAL_DATA_T)
 #define po_buf(idx) ((__global po_dt(idx) *)(CONCAT3(po_, idx, _binary_arg)))
 
-#define FILL_BIN_ARG_SERIAL(idx, dest_ptr, x0, x0_s, x1, x1_s, x1_incr, x2, \
-        x2_s, x3, x3_s, x4, x4_s, x5, x5_s) \
+#define FILL_BIN_ARG_SERIAL(idx, dest_ptr, x0, x0_s, x1, x1_s, x2, x2_s, x3, \
+        x3_s, x4, x4_s, x5, x5_s) \
     unroll_for(typeof(x0 + x0_s) x0_idx = x0, bin_arg_offset = 0; \
                x0_idx < x0 + x0_s; ++x0_idx) { \
-        unroll_for(typeof(x1 + x1_s + x1_incr) x1_idx = x1; \
-                   x1_idx < x1 + x1_s; x1_idx += x1_incr) { \
+        unroll_for(typeof(x1 + x1_s) x1_idx = x1; x1_idx < x1 + x1_s; \
+                   ++x1_idx) { \
             unroll_for(typeof(x2 + x2_s) x2_idx = x2; x2_idx < x2 + x2_s; \
                        ++x2_idx) { \
                 unroll_for(typeof(x3 + x3_s) x3_idx = x3; x3_idx < x3 + x3_s; \
@@ -126,164 +126,68 @@ float fwd_Xnary(unsigned kind, unsigned algorithm, float x, float y,
         } \
     }
 
-#define FILL_WITH_BLOCK_READ(src_ptr, dst_ptr, nelem) \
-    unroll_for(typeof(nelem + 0) load_idx = 0; load_idx < nelem; ++load_idx) { \
-        block_load(&dst_ptr[load_idx], \
-                src_ptr + load_idx * get_sub_group_size()); \
-    }
-
-#define X_NELEMS(x) (x / get_sub_group_size())
-
-#define CONDITIONAL_FILL(blocked_coord, nelem, src_ptr, dst_ptr) \
-    if (blocked_coord / get_sub_group_size() == nelem) \
-        FILL_WITH_BLOCK_READ(src_ptr, dst_ptr, nelem);
-
-#define FILL_BIN_ARG_TRY_BLOCK(idx, dest_ptr, dest_size, x0, x0_s, x1, x1_s, \
-        x1_incr, x2, x2_s, x3, x3_s, x4, x4_s, x5, x5_s) \
-    { \
-        unroll_for(typeof(x0 + x0_s) x0_idx = x0, arg_off = 0; \
-                   x0_idx < x0 + x0_s; ++x0_idx, arg_off += X_NELEMS(x1_s)) { \
-            const auto bin_arg_glob_off = OFF_MD(CONCAT3(PO_, idx, _BIN_ARG), \
-                    x0_idx % CONCAT3(PO_, idx, _BIN_ARG_D0), \
-                    x1 % CONCAT3(PO_, idx, _BIN_ARG_D1), \
-                    x2 % CONCAT3(PO_, idx, _BIN_ARG_D2), \
-                    x3 % CONCAT3(PO_, idx, _BIN_ARG_D3), \
-                    x4 % CONCAT3(PO_, idx, _BIN_ARG_D4), \
-                    x5 % CONCAT3(PO_, idx, _BIN_ARG_D5)); \
-\
-            CONDITIONAL_FILL(x1_s, 1, (po_buf(idx) + bin_arg_glob_off), \
-                    (dest_ptr + arg_off)); \
-            CONDITIONAL_FILL(x1_s, 2, (po_buf(idx) + bin_arg_glob_off), \
-                    (dest_ptr + arg_off)); \
-            CONDITIONAL_FILL(x1_s, 4, (po_buf(idx) + bin_arg_glob_off), \
-                    (dest_ptr + arg_off)); \
-        } \
-    }
-
-#define REPLICATE_DATA( \
-        dest_ptr, dest_size, x0_s, x1_s, x2_s, x3_s, x4_s, x5_s) \
-    { \
-        const auto copy_size = x0_s * x1_s * x2_s * x3_s * x4_s * x5_s; \
-        unroll_for(typeof(dest_size + 0) fid = copy_size; fid < dest_size; \
-                   ++fid) { \
-            *(dest_ptr + fid) = *(dest_ptr + (fid % copy_size)); \
-        } \
-    }
-
-#define IS_BURSTABLE(idx, x0, x0_s, x1, x1_s, x2, x2_s, x3, x3_s, x4, x4_s, \
-        x5, x5_s, is_burst) \
-    ({ \
-        bool is_burstable = is_burst; \
-        if (x0_s > CONCAT3(PO_, idx, _BIN_ARG_D0) && x0_s > 1) \
-            is_burstable = false; \
-        if (x1_s > CONCAT3(PO_, idx, _BIN_ARG_D1) && x1_s > 1) \
-            is_burstable = false; \
-        if (x2_s > CONCAT3(PO_, idx, _BIN_ARG_D2) && x2_s > 1) \
-            is_burstable = false; \
-        if (x3_s > CONCAT3(PO_, idx, _BIN_ARG_D3) && x3_s > 1) \
-            is_burstable = false; \
-        if (x4_s > CONCAT3(PO_, idx, _BIN_ARG_D4) && x4_s > 1) \
-            is_burstable = false; \
-        if (x5_s > CONCAT3(PO_, idx, _BIN_ARG_D5) && x5_s > 1) \
-            is_burstable = false; \
-        if ((CONCAT3(PO_, idx, _BIN_ARG_D0) == 1) \
-                && (CONCAT3(PO_, idx, _BIN_ARG_D1) == 1) \
-                && (CONCAT3(PO_, idx, _BIN_ARG_D2) == 1) \
-                && (CONCAT3(PO_, idx, _BIN_ARG_D2) == 1) \
-                && (CONCAT3(PO_, idx, _BIN_ARG_D3) == 1) \
-                && (CONCAT3(PO_, idx, _BIN_ARG_D4) == 1) \
-                && (CONCAT3(PO_, idx, _BIN_ARG_D5) == 1)) \
-            is_burstable = false; \
-\
-        is_burstable; \
-    })
-
-#define APPLY_PO_BINARY(idx, accumulator, x0, x0_s, x1, x1_s, x1_incr, x2, \
-        x2_s, x3, x3_s, x4, x4_s, x5, x5_s, is_burst, bin_arg_size) \
+// sum_args are unused and maintained for interface compatibility
+#define APPLY_PO_BINARY(idx, bin_arg_size, accumulator, _sum_arg1, _sum_arg2, \
+        _sum_arg3, x0, x0_s, x1, x1_s, x1_incr, x2, x2_s, x3, x3_s, x4, x4_s, \
+        x5, x5_s) \
     { \
         float bin_arg[bin_arg_size]; \
         __private float *bin_arg_ptr = &bin_arg[0]; \
-        const bool use_burst_read = IS_BURSTABLE(idx, x0, x0_s, x1, x1_s, x2, \
-                x2_s, x3, x3_s, x4, x4_s, x5, x5_s, is_burst); \
-        if (use_burst_read) { \
-            FILL_BIN_ARG_TRY_BLOCK(idx, bin_arg_ptr, bin_arg_size, x0, x0_s, \
-                    x1, x1_s, x1_incr, x2, x2_s, x3, x3_s, x4, x4_s, x5, \
-                    x5_s); \
-            REPLICATE_DATA(bin_arg_ptr, bin_arg_size, x0_s, X_NELEMS(x1_s), \
-                    x2_s, x3_s, x4_s, x5_s); \
-        } else { \
-            const auto x1_jump = is_burst ? (int)get_sub_group_size() : 1; \
-            const auto x1_size = x1_s / x1_jump; \
-            FILL_BIN_ARG_SERIAL(idx, bin_arg_ptr, x0, x0_s, (x1 + x1_incr), \
-                    x1_s, x1_jump, x2, x2_s, x3, x3_s, x4, x4_s, x5, x5_s); \
-            REPLICATE_DATA(bin_arg_ptr, bin_arg_size, x0_s, x1_size, x2_s, \
-                    x3_s, x4_s, x5_s); \
-        } \
-        FWD_XNARY_GENERIC_DT(PO_BINARY, CONCAT3(PO_, idx, _ALG), accumulator, \
+        FILL_BIN_ARG_SERIAL(idx, bin_arg_ptr, x0, x0_s, (x1 + x1_incr), x1_s, \
+                x2, x2_s, x3, x3_s, x4, x4_s, x5, x5_s); \
+        FWD_XNARY_GENERIC_DT(true, CONCAT3(PO_, idx, _ALG), accumulator, \
                 accumulator, bin_arg_size, bin_arg_ptr, bin_arg_size, 0.0f, \
                 0.0f, 1.0f); \
     }
 
+// VA_ARGS are unused and maintained for interface compatibility
 #define APPLY_PO_SUM( \
-        idx, accumulator, acc_size, acc_elem_dt, sum_src, sum_elem_dt) \
+        idx, acc_size, accumulator, acc_elem_dt, sum_src, sum_elem_dt, ...) \
     FMA_MIXED(acc_size, sum_src, sum_elem_dt, CONCAT3(PO_, idx, _SUM_SCALE), \
             accumulator, acc_elem_dt);
 
-#define APPLY_PO_ELTWISE(idx, accumulator, nelems) \
-    FWD_XNARY_GENERIC_DT(PO_ELTWISE, CONCAT3(PO_, idx, _ALG), accumulator, \
+// VA_ARGS are unused and maintained for interface compatibility
+#define APPLY_PO_ELTWISE(idx, nelems, accumulator, ...) \
+    FWD_XNARY_GENERIC_DT(false, CONCAT3(PO_, idx, _ALG), accumulator, \
             accumulator, nelems, accumulator, nelems, \
             CONCAT3(PO_, idx, _ELTWISE_ALPHA), \
             CONCAT3(PO_, idx, _ELTWISE_BETA), \
             CONCAT3(PO_, idx, _ELTWISE_SCALE));
 
-#define APPLY_PO_STAGE(idx, acc, acc_elem_dt, nelems, sum_src, sum_elem_dt, \
-        x0, x0_s, x1, x1_s, x1_incr, x2, x2_s, x3, x3_s, x4, x4_s, x5, x5_s, \
-        is_burst) \
-    switch (CONCAT3(PO_, idx, _KIND)) { \
-        case PO_BINARY: \
-            APPLY_PO_BINARY(idx, acc, x0, x0_s, x1, x1_s, x1_incr, x2, x2_s, \
-                    x3, x3_s, x4, x4_s, x5, x5_s, is_burst, nelems); \
-            break; \
-        case PO_ELTWISE: APPLY_PO_ELTWISE(idx, acc, nelems); break; \
-        case PO_SUM: \
-            APPLY_PO_SUM(idx, acc, nelems, acc_elem_dt, sum_src, sum_elem_dt); \
-            break; \
-    }
-
 // clang-format off
 #define APPLY_PO_STAGE_0(...)
-#define APPLY_PO_STAGE_1(...) APPLY_PO_STAGE(0, __VA_ARGS__)
-#define APPLY_PO_STAGE_2(...) APPLY_PO_STAGE_1(__VA_ARGS__) APPLY_PO_STAGE(1, __VA_ARGS__)
-#define APPLY_PO_STAGE_3(...) APPLY_PO_STAGE_2(__VA_ARGS__) APPLY_PO_STAGE(2, __VA_ARGS__)
-#define APPLY_PO_STAGE_4(...) APPLY_PO_STAGE_3(__VA_ARGS__) APPLY_PO_STAGE(3, __VA_ARGS__)
-#define APPLY_PO_STAGE_5(...) APPLY_PO_STAGE_4(__VA_ARGS__) APPLY_PO_STAGE(4, __VA_ARGS__)
-#define APPLY_PO_STAGE_6(...) APPLY_PO_STAGE_5(__VA_ARGS__) APPLY_PO_STAGE(5, __VA_ARGS__)
-#define APPLY_PO_STAGE_7(...) APPLY_PO_STAGE_6(__VA_ARGS__) APPLY_PO_STAGE(6, __VA_ARGS__)
-#define APPLY_PO_STAGE_8(...) APPLY_PO_STAGE_7(__VA_ARGS__) APPLY_PO_STAGE(7, __VA_ARGS__)
-#define APPLY_PO_STAGE_9(...) APPLY_PO_STAGE_8(__VA_ARGS__) APPLY_PO_STAGE(8, __VA_ARGS__)
-#define APPLY_PO_STAGE_10(...) APPLY_PO_STAGE_9(__VA_ARGS__) APPLY_PO_STAGE(9, __VA_ARGS__)
-#define APPLY_PO_STAGE_11(...) APPLY_PO_STAGE_10(__VA_ARGS__) APPLY_PO_STAGE(10, __VA_ARGS__)
-#define APPLY_PO_STAGE_12(...) APPLY_PO_STAGE_11(__VA_ARGS__) APPLY_PO_STAGE(11, __VA_ARGS__)
-#define APPLY_PO_STAGE_13(...) APPLY_PO_STAGE_12(__VA_ARGS__) APPLY_PO_STAGE(12, __VA_ARGS__)
-#define APPLY_PO_STAGE_14(...) APPLY_PO_STAGE_13(__VA_ARGS__) APPLY_PO_STAGE(13, __VA_ARGS__)
-#define APPLY_PO_STAGE_15(...) APPLY_PO_STAGE_14(__VA_ARGS__) APPLY_PO_STAGE(14, __VA_ARGS__)
-#define APPLY_PO_STAGE_16(...) APPLY_PO_STAGE_15(__VA_ARGS__) APPLY_PO_STAGE(15, __VA_ARGS__)
-#define APPLY_PO_STAGE_17(...) APPLY_PO_STAGE_16(__VA_ARGS__) APPLY_PO_STAGE(16, __VA_ARGS__)
-#define APPLY_PO_STAGE_18(...) APPLY_PO_STAGE_17(__VA_ARGS__) APPLY_PO_STAGE(17, __VA_ARGS__)
-#define APPLY_PO_STAGE_19(...) APPLY_PO_STAGE_18(__VA_ARGS__) APPLY_PO_STAGE(18, __VA_ARGS__)
-#define APPLY_PO_STAGE_20(...) APPLY_PO_STAGE_19(__VA_ARGS__) APPLY_PO_STAGE(19, __VA_ARGS__)
-#define APPLY_PO_STAGE_21(...) APPLY_PO_STAGE_20(__VA_ARGS__) APPLY_PO_STAGE(20, __VA_ARGS__)
-#define APPLY_PO_STAGE_22(...) APPLY_PO_STAGE_21(__VA_ARGS__) APPLY_PO_STAGE(21, __VA_ARGS__)
-#define APPLY_PO_STAGE_23(...) APPLY_PO_STAGE_22(__VA_ARGS__) APPLY_PO_STAGE(22, __VA_ARGS__)
-#define APPLY_PO_STAGE_24(...) APPLY_PO_STAGE_23(__VA_ARGS__) APPLY_PO_STAGE(23, __VA_ARGS__)
-#define APPLY_PO_STAGE_25(...) APPLY_PO_STAGE_24(__VA_ARGS__) APPLY_PO_STAGE(24, __VA_ARGS__)
-#define APPLY_PO_STAGE_26(...) APPLY_PO_STAGE_25(__VA_ARGS__) APPLY_PO_STAGE(25, __VA_ARGS__)
-#define APPLY_PO_STAGE_27(...) APPLY_PO_STAGE_26(__VA_ARGS__) APPLY_PO_STAGE(26, __VA_ARGS__)
-#define APPLY_PO_STAGE_28(...) APPLY_PO_STAGE_27(__VA_ARGS__) APPLY_PO_STAGE(27, __VA_ARGS__)
-#define APPLY_PO_STAGE_29(...) APPLY_PO_STAGE_28(__VA_ARGS__) APPLY_PO_STAGE(28, __VA_ARGS__)
-#define APPLY_PO_STAGE_30(...) APPLY_PO_STAGE_29(__VA_ARGS__) APPLY_PO_STAGE(29, __VA_ARGS__)
-#define APPLY_PO_STAGE_31(...) APPLY_PO_STAGE_30(__VA_ARGS__) APPLY_PO_STAGE(30, __VA_ARGS__)
-#define APPLY_PO_STAGE_32(...) APPLY_PO_STAGE_31(__VA_ARGS__) APPLY_PO_STAGE(31, __VA_ARGS__)
+#define APPLY_PO_STAGE_1(...) APPLY_PO_0(0, __VA_ARGS__)
+#define APPLY_PO_STAGE_2(...) APPLY_PO_STAGE_1(__VA_ARGS__) APPLY_PO_1(1, __VA_ARGS__)
+#define APPLY_PO_STAGE_3(...) APPLY_PO_STAGE_2(__VA_ARGS__) APPLY_PO_2(2, __VA_ARGS__)
+#define APPLY_PO_STAGE_4(...) APPLY_PO_STAGE_3(__VA_ARGS__) APPLY_PO_3(3, __VA_ARGS__)
+#define APPLY_PO_STAGE_5(...) APPLY_PO_STAGE_4(__VA_ARGS__) APPLY_PO_4(4, __VA_ARGS__)
+#define APPLY_PO_STAGE_6(...) APPLY_PO_STAGE_5(__VA_ARGS__) APPLY_PO_5(5, __VA_ARGS__)
+#define APPLY_PO_STAGE_7(...) APPLY_PO_STAGE_6(__VA_ARGS__) APPLY_PO_6(6, __VA_ARGS__)
+#define APPLY_PO_STAGE_8(...) APPLY_PO_STAGE_7(__VA_ARGS__) APPLY_PO_7(7, __VA_ARGS__)
+#define APPLY_PO_STAGE_9(...) APPLY_PO_STAGE_8(__VA_ARGS__) APPLY_PO_8(8, __VA_ARGS__)
+#define APPLY_PO_STAGE_10(...) APPLY_PO_STAGE_9(__VA_ARGS__) APPLY_PO_9(9, __VA_ARGS__)
+#define APPLY_PO_STAGE_11(...) APPLY_PO_STAGE_10(__VA_ARGS__) APPLY_PO_10(10, __VA_ARGS__)
+#define APPLY_PO_STAGE_12(...) APPLY_PO_STAGE_11(__VA_ARGS__) APPLY_PO_11(11, __VA_ARGS__)
+#define APPLY_PO_STAGE_13(...) APPLY_PO_STAGE_12(__VA_ARGS__) APPLY_PO_12(12, __VA_ARGS__)
+#define APPLY_PO_STAGE_14(...) APPLY_PO_STAGE_13(__VA_ARGS__) APPLY_PO_13(13, __VA_ARGS__)
+#define APPLY_PO_STAGE_15(...) APPLY_PO_STAGE_14(__VA_ARGS__) APPLY_PO_14(14, __VA_ARGS__)
+#define APPLY_PO_STAGE_16(...) APPLY_PO_STAGE_15(__VA_ARGS__) APPLY_PO_15(15, __VA_ARGS__)
+#define APPLY_PO_STAGE_17(...) APPLY_PO_STAGE_16(__VA_ARGS__) APPLY_PO_16(16, __VA_ARGS__)
+#define APPLY_PO_STAGE_18(...) APPLY_PO_STAGE_17(__VA_ARGS__) APPLY_PO_17(17, __VA_ARGS__)
+#define APPLY_PO_STAGE_19(...) APPLY_PO_STAGE_18(__VA_ARGS__) APPLY_PO_18(18, __VA_ARGS__)
+#define APPLY_PO_STAGE_20(...) APPLY_PO_STAGE_19(__VA_ARGS__) APPLY_PO_19(19, __VA_ARGS__)
+#define APPLY_PO_STAGE_21(...) APPLY_PO_STAGE_20(__VA_ARGS__) APPLY_PO_20(20, __VA_ARGS__)
+#define APPLY_PO_STAGE_22(...) APPLY_PO_STAGE_21(__VA_ARGS__) APPLY_PO_21(21, __VA_ARGS__)
+#define APPLY_PO_STAGE_23(...) APPLY_PO_STAGE_22(__VA_ARGS__) APPLY_PO_22(22, __VA_ARGS__)
+#define APPLY_PO_STAGE_24(...) APPLY_PO_STAGE_23(__VA_ARGS__) APPLY_PO_23(23, __VA_ARGS__)
+#define APPLY_PO_STAGE_25(...) APPLY_PO_STAGE_24(__VA_ARGS__) APPLY_PO_24(24, __VA_ARGS__)
+#define APPLY_PO_STAGE_26(...) APPLY_PO_STAGE_25(__VA_ARGS__) APPLY_PO_25(25, __VA_ARGS__)
+#define APPLY_PO_STAGE_27(...) APPLY_PO_STAGE_26(__VA_ARGS__) APPLY_PO_26(26, __VA_ARGS__)
+#define APPLY_PO_STAGE_28(...) APPLY_PO_STAGE_27(__VA_ARGS__) APPLY_PO_27(27, __VA_ARGS__)
+#define APPLY_PO_STAGE_29(...) APPLY_PO_STAGE_28(__VA_ARGS__) APPLY_PO_28(28, __VA_ARGS__)
+#define APPLY_PO_STAGE_30(...) APPLY_PO_STAGE_29(__VA_ARGS__) APPLY_PO_29(29, __VA_ARGS__)
+#define APPLY_PO_STAGE_31(...) APPLY_PO_STAGE_30(__VA_ARGS__) APPLY_PO_30(30, __VA_ARGS__)
+#define APPLY_PO_STAGE_32(...) APPLY_PO_STAGE_31(__VA_ARGS__) APPLY_PO_31(31, __VA_ARGS__)
 // clang-format on
 
 #define APPLY_ALL_PO_STAGES(accumulator, acc_elem_dt, ...) \
@@ -291,39 +195,24 @@ float fwd_Xnary(unsigned kind, unsigned algorithm, float x, float y,
         const int nelems = sizeof(accumulator) / sizeof(acc_elem_dt); \
         acc_elem_dt *acc = &accumulator; \
         CONCAT2(APPLY_PO_STAGE_, POST_OP_CHAIN_LENGTH) \
-        (acc, acc_elem_dt, nelems, __VA_ARGS__) \
+        (nelems, acc, acc_elem_dt, __VA_ARGS__) \
     }
-
-#define APPLY_POST_OPS_BL(accumulator, acc_elem_dt, sum_src, sum_elem_dt, x0, \
-        x0_s, x1, x1_s, x1_incr, x2, x2_s, x3, x3_s, x4, x4_s, x5, x5_s, \
-        is_burst) \
-    APPLY_ALL_PO_STAGES(accumulator, acc_elem_dt, sum_src, sum_elem_dt, x0, \
-            x0_s, x1, x1_s, x1_incr, x2, x2_s, x3, x3_s, x4, x4_s, x5, x5_s, \
-            is_burst);
-
-#define APPLY_POST_OPS_TRY_BURST(accumulator, acc_elem_dt, sum_src, \
-        sum_elem_dt, mb_start, mb_size, oc_start, oc_size, oc_serial_incr) \
-    APPLY_POST_OPS_BL(accumulator, acc_elem_dt, sum_src, sum_elem_dt, \
-            mb_start, mb_size, oc_start, oc_size, oc_serial_incr, 0, 1, 0, 1, \
-            0, 1, 0, 1, true)
 
 #define APPLY_POST_OPS_SERIAL(accumulator, acc_elem_dt, sum_src, sum_elem_dt, \
         mb_start, mb_size, oc_start, oc_size, d2_start, d2_size, d3_start, \
         d3_size, d4_start, d4_size, d5_start, d5_size) \
-    APPLY_POST_OPS_BL(accumulator, acc_elem_dt, sum_src, sum_elem_dt, \
+    APPLY_ALL_PO_STAGES(accumulator, acc_elem_dt, sum_src, sum_elem_dt, \
             mb_start, mb_size, oc_start, oc_size, 0, d2_start, d2_size, \
-            d3_start, d3_size, d4_start, d4_size, d5_start, d5_size, false)
+            d3_start, d3_size, d4_start, d4_size, d5_start, d5_size)
 
 #define APPLY_POST_OPS_SERIAL_BINARY_2D(accumulator, acc_elem_dt, sum_src, \
         sum_elem_dt, mb_start, mb_size, oc_start, oc_size) \
-    APPLY_POST_OPS_BL(accumulator, acc_elem_dt, sum_src, sum_elem_dt, \
-            mb_start, mb_size, oc_start, oc_size, 0, 0, 1, 0, 1, 0, 1, 0, 1, \
-            false)
+    APPLY_ALL_PO_STAGES(accumulator, acc_elem_dt, sum_src, sum_elem_dt, \
+            mb_start, mb_size, oc_start, oc_size, 0, 0, 1, 0, 1, 0, 1, 0, 1)
 #else
 
 #define APPLY_POST_OPS_SERIAL(...)
 #define APPLY_POST_OPS_SERIAL_BINARY_2D(...)
-#define APPLY_POST_OPS_TRY_BURST(...)
 
 #endif // WITH_POST_OP
 

--- a/src/gpu/intel/ocl/ocl_post_ops.h
+++ b/src/gpu/intel/ocl/ocl_post_ops.h
@@ -19,11 +19,6 @@
 
 #if WITH_POST_OP
 
-#if !WITH_ELTWISE
-#undef WITH_ELTWISE
-#define WITH_ELTWISE 1
-#endif
-
 #include "gpu/intel/ocl/ocl_conversion.h"
 #include "gpu/intel/ocl/ocl_eltwise.h"
 #include "gpu/intel/ocl/ocl_io.h"

--- a/src/gpu/intel/ocl/ref_eltwise.cpp
+++ b/src/gpu/intel/ocl/ref_eltwise.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,7 +69,6 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
 
     def_eltwise_alg_kinds(kernel_ctx);
 
-    kernel_ctx.define_int("WITH_ELTWISE", 1);
     kernel_ctx.define_int("ELTWISE_ALG", conf.alg);
     kernel_ctx.define_int("NDIMS", conf.ndims);
     kernel_ctx.define_int("GWS0", conf.dispatch.nd_range().global_range()[0]);

--- a/src/gpu/intel/ocl/ref_prelu.cpp
+++ b/src/gpu/intel/ocl/ref_prelu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -83,7 +83,6 @@ static status_t init_kernel_ctx_common(
 
     kernel_ctx.set_data_type(conf.dst_md_info.data_type);
     def_eltwise_alg_kinds(kernel_ctx);
-    kernel_ctx.define_int("WITH_ELTWISE", 1);
 
     kernel_ctx.define_int("IS_FWD", conf.is_forward);
 

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -778,8 +778,6 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
 
     kernel_ctx.define_int("WITH_POST_OP", post_ops.len() > 0);
 
-    if (!kernel_ctx.has_macro("WITH_ELTWISE"))
-        kernel_ctx.define_int("WITH_ELTWISE", attr_info.with_eltwise);
     if (!kernel_ctx.has_macro("ELTWISE_ALG"))
         kernel_ctx.define_int("ELTWISE_ALG", attr_info.eltwise_alg);
 


### PR DESCRIPTION
Remove dead code emitted by OpenCL Post Ops, this just triggers needless complexity.

Removes many post-op macros which are unused anywhere.

Removes the WITH_ELTWISE define. All primitives support post-ops, thereby always enabling this define, except eltwise kernels which just need the support anyway.