### PR TITLE
[GPU] Remove unused function declaration

### DIFF
--- a/src/gpu/intel/jit/gemm/include/generator.hpp
+++ b/src/gpu/intel/jit/gemm/include/generator.hpp
@@ -488,7 +488,6 @@ protected:
     void gemmDowngradeAccess(const GEMMProblem &problem, GEMMStrategy &strategy, GEMMState &state);
     void gemmInitInterface(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState &state, bool inSK = false);
     void gemmInitState(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState &state, bool inSK = false);
-    static void gemmAutoTypeConversions(GEMMProblem &problem, const GEMMStrategy &strategy);
 
     // gemm.cpp
     void gemmSubkernel(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState state);


### PR DESCRIPTION
# Description

`gemmAutoTypeConversions` is no longer used only `autoTypeConversions`.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

