### PR TITLE
gpu: generic: skip unimplemented cases

### DIFF
--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -311,7 +311,7 @@ int check_dnnl_status(dnnl_status_t status, const prb_t *prb, res_t *res) {
         case dnnl_unimplemented: {
             // Unconditionally set all Nvidia backend unimplemented cases as
             // not supported.
-            if (is_nvidia_gpu() || is_amd_gpu()) {
+            if (is_nvidia_gpu() || is_amd_gpu() || is_generic_gpu()) {
                 res->state = SKIPPED;
                 res->reason = skip_reason::case_not_supported;
                 return OK;


### PR DESCRIPTION
# Description

Currently, when running benchdnn tests on the generic SYCL backend, unimplemented cases are reported as failures. This makes it challenging to identify actual failures. It also clutters the CI logs with false-positive failure reports. Furthermore, the generic implementations are still under development, and there are several known limitations (e.g., lack of blocked format support) that should not be flagged as errors. For instance, the reorder issue reported in MFDNN-13088 currently appears as a failing test, but it is actually due to unsupported features like blocked formats and zero-points. This PR changes the status of such tests to SKIPPED, as is done with the NVIDIA and AMD backends, to prevent them from being reported as failures.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
