### PR TITLE
New code owners for gpu-generic component

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -216,6 +216,7 @@ Teams:
 | Anton Mitkov       | @ShanoToni            | Codeplay Software | Code Owner |
 | Atharva Dubey      | @AD2605               | Codeplay Software | Code Owner |
 | Mehdi Goli         | @mehdi-goli           | Codeplay Software | Code Owner |
+| Nicolò Scipione    | @s-Nick               | Codeplay Software | Code Owner |
 | Svetlozar Georgiev | @sgeor255             | Codeplay Software | Code Owner |
 | Romain Biessy      | @Rbiessy              | Codeplay Software | Code Owner |
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -217,6 +217,7 @@ Teams:
 | Atharva Dubey      | @AD2605               | Codeplay Software | Code Owner |
 | Mehdi Goli         | @mehdi-goli           | Codeplay Software | Code Owner |
 | Svetlozar Georgiev | @sgeor255             | Codeplay Software | Code Owner |
+| Romain Biessy      | @Rbiessy              | Codeplay Software | Code Owner |
 
 ## Support functions
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -214,6 +214,7 @@ Teams:
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Anton Mitkov       | @ShanoToni            | Codeplay Software | Code Owner |
+| Atharva Dubey      | @AD2605               | Codeplay Software | Code Owner |
 | Mehdi Goli         | @mehdi-goli           | Codeplay Software | Code Owner |
 | Svetlozar Georgiev | @sgeor255             | Codeplay Software | Code Owner |
 


### PR DESCRIPTION
Nominating @Rbiessy, @AD2605, and @s-Nick as code owners for `gpu-generic` component. @Rbiessy, @AD2605, and @s-Nick are Codeplay Software employees assigned to work on oneDNN and established contributors to UXL Foundation's [oneMath](https://github.com/uxlfoundation/oneMath) project with focus on cross-platform GPU support. Specific contributions:
* @Rbiessy: [oneDNN](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+involves%3Arbiessy), [oneMath](https://github.com/uxlfoundation/oneMath/pulls?q=is%3Apr+author%3Arbiessy)
* @AD2605: [oneDNN](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+author%3AAD2605), [oneMath](https://github.com/uxlfoundation/oneMath/pulls?q=is%3Apr+author%3AAD2605)
* @s-Nick: [oneDNN](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+involves%3As-Nick), [oneMath](https://github.com/uxlfoundation/oneMath/pulls?q=is%3Apr+author%3As-Nick)
