### PR TITLE
cpu: fixes coverity issues

### DIFF
--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -175,6 +175,7 @@ inline status_t get_quant_md(memory_desc_t &md, const int ndims,
     utils::copy_dims_with_mask(quant_dims, in_dims, ndims, quant_mask,
             /* fill_with_ones = */ true);
     if (ndims >= 2) {
+        if (utils::one_of(0, g0, g1)) return status::runtime_error;
         quant_dims[ndims - 1] /= g1;
         quant_dims[ndims - 2] /= g0;
     }

--- a/src/cpu/reorder/simple_sparse_reorder.hpp
+++ b/src/cpu/reorder/simple_sparse_reorder.hpp
@@ -100,7 +100,7 @@ struct simple_sparse_reorder_impl<SIMPLE_SPARSE_REORDER_TEMPL_CALL,
 
     static size_t get_scratchpad_size(const memory_desc_wrapper &input_d,
             const memory_desc_wrapper &output_d) {
-        const auto nelems = static_cast<size_t>(output_d.nelems(true));
+        const auto nelems = output_d.nelems(true);
         const auto tmp_output_sz = nelems * output_d.data_type_size();
         const auto nnz_per_blocks_sz
                 = nelems / output_d.blk_size() * sizeof(dim_t);

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -58,7 +58,7 @@ size_t binary_kernel_t::get_tail_size() const {
     const auto &dims = src0_d.dims();
     const auto &ndims = src0_d.ndims();
 
-    size_t nelems = 0;
+    dim_t nelems = 0;
 
     if (ndims == 1)
         nelems = dims[0];


### PR DESCRIPTION
Partially fixes MFDNN-12964

1. Check `g0`, `g1` before division
2. `nelems` can be negative, cast it into `size_t` may cause potential issue.