### PR TITLE
xe: jit: gemm: move catalog generation to its own compilation unit

### DIFF
--- a/src/gpu/intel/jit/gemm/CMakeLists.txt
+++ b/src/gpu/intel/jit/gemm/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2024 Intel Corporation
+# Copyright 2024-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,8 +68,12 @@ set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
 
 include_directories_with_host_compiler_before(${OBJ_LIB} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/../ngen)
 
-# Workaround for LTO bug in GCC 10, 11, 12 (possibly other versions)
 if(CMAKE_COMPILER_IS_GNUCC)
+    # Workaround for LTO bug in GCC 10, 11, 12 (possibly other versions)
     set_source_files_properties(generator/pieces/loop_sequencer.cpp PROPERTIES COMPILE_FLAGS -fno-lto)
     set_source_files_properties(generator/generator.cpp PROPERTIES COMPILE_FLAGS -fno-lto)
+
+
+    # Workaround for excessively long compile time in GCC 11, 12 (possibly other versions)
+    set_source_files_properties(gen_gemm_kernel_db.cpp PROPERTIES COMPILE_FLAGS -fno-var-tracking)
 endif()

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -17,6 +17,7 @@
 #include "gpu/intel/jit/gemm/gen_gemm_kernel.hpp"
 #include "common/impl_registration.hpp"
 #include "gpu/intel/compute/device_info.hpp"
+#include "gpu/intel/jit/gemm/gen_gemm_kernel_db.hpp"
 #include "gpu/intel/jit/gemm/include/generator.hpp"
 #include "gpu/intel/jit/gemm/include/strategy_parser.hpp"
 #include "gpu/intel/jit/utils/ngen_type_bridge.hpp"
@@ -27,11 +28,6 @@ namespace impl {
 namespace gpu {
 namespace intel {
 namespace jit {
-
-#define _CATALOG_ gemm_catalog
-#include "selector/db/kernel.db"
-;
-#undef _CATALOG_
 
 status_t gen_gemm_kernel_desc_t::create_generator(
         const compute::compute_engine_t &engine,
@@ -599,7 +595,7 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
     eval_params.batch = (batch_dims > 0);
     eval_params.deterministic = (mode & mode_deterministic);
 
-    entry_ = select(gemm_catalog, static_cast<int>(match_params.size()),
+    entry_ = select(catalog(), static_cast<int>(match_params.size()),
             match_params.data(), eval_params, aux_params_);
 
     if (!entry_) return status::unimplemented;
@@ -743,7 +739,7 @@ status_t gen_gemm_xe_systolic_kernel_desc_t::select_kernel(
     eval_params.cConvert = (acc_type != c_type);
     eval_params.batch = (batch_dims > 0);
 
-    entry_ = select(gemm_catalog, match_params, eval_params, aux_params_);
+    entry_ = select(catalog(), match_params, eval_params, aux_params_);
 
     if (!entry_) return status::unimplemented;
 

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel_db.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel_db.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/jit/gemm/gen_gemm_kernel_db.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+
+#define _CATALOG_ gemm_catalog
+#include "selector/db/kernel.db"
+#undef _CATALOG_
+
+const kcatalog::Catalog &catalog() {
+    static const kcatalog::Catalog c = gemm_catalog;
+    return c;
+};
+
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel_db.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel_db.hpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_JIT_GEMM_GEN_GEMM_KERNEL_DB_HPP
+#define GPU_INTEL_JIT_GEMM_GEN_GEMM_KERNEL_DB_HPP
+
+#include "gpu/intel/jit/gemm/include/kernel_catalog.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+
+const kcatalog::Catalog &catalog();
+
+}
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
GCC can take upwards of 10 minutes to compile the gemm catalog. This patch moves kcatalog generation to its own compilation unit to limit recompilations.

