### PR TITLE
gtests: fix linking for test_api_ocl with mem_debug (fixes MFDNN-13110)

### DIFF
--- a/tests/gtests/dnnl_test_common_ocl.hpp
+++ b/tests/gtests/dnnl_test_common_ocl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 #ifndef DNNL_TEST_COMMON_OCL_HPP
 #define DNNL_TEST_COMMON_OCL_HPP
 
-#include "gpu/intel/ocl/ocl_utils.hpp"
 #include "oneapi/dnnl/dnnl.hpp"
 #include "oneapi/dnnl/dnnl_debug.h"
 #include "oneapi/dnnl/dnnl_ocl.hpp"
@@ -27,9 +26,75 @@
 
 // Define a separate macro, that does not clash with OCL_CHECK from the library.
 #ifdef DNNL_ENABLE_MEM_DEBUG
+
+namespace mem_debug_utils {
+// Copy-pasted from src/xpu/ocl/utils.cpp::convert_to_dnnl() to avoid including
+// .cpp file or exposing the symbol.
+inline dnnl_status_t convert_to_dnnl(cl_int cl_status) {
+    switch (cl_status) {
+        case CL_SUCCESS: return dnnl_success;
+        case CL_MEM_OBJECT_ALLOCATION_FAILURE:
+        case CL_OUT_OF_RESOURCES:
+        case CL_OUT_OF_HOST_MEMORY: return dnnl_out_of_memory;
+        case CL_DEVICE_NOT_FOUND:
+        case CL_DEVICE_NOT_AVAILABLE:
+        case CL_COMPILER_NOT_AVAILABLE:
+        case CL_PROFILING_INFO_NOT_AVAILABLE:
+        case CL_MEM_COPY_OVERLAP:
+        case CL_IMAGE_FORMAT_MISMATCH:
+        case CL_IMAGE_FORMAT_NOT_SUPPORTED:
+        case CL_BUILD_PROGRAM_FAILURE:
+        case CL_MAP_FAILURE:
+        case CL_MISALIGNED_SUB_BUFFER_OFFSET:
+        case CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST:
+        case CL_COMPILE_PROGRAM_FAILURE:
+        case CL_LINKER_NOT_AVAILABLE:
+        case CL_LINK_PROGRAM_FAILURE:
+        case CL_DEVICE_PARTITION_FAILED:
+        case CL_KERNEL_ARG_INFO_NOT_AVAILABLE:
+        case CL_INVALID_PLATFORM:
+        case CL_INVALID_DEVICE: return dnnl_runtime_error;
+        case CL_INVALID_VALUE:
+        case CL_INVALID_DEVICE_TYPE:
+        case CL_INVALID_CONTEXT:
+        case CL_INVALID_QUEUE_PROPERTIES:
+        case CL_INVALID_COMMAND_QUEUE:
+        case CL_INVALID_HOST_PTR:
+        case CL_INVALID_MEM_OBJECT:
+        case CL_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+        case CL_INVALID_IMAGE_SIZE:
+        case CL_INVALID_SAMPLER:
+        case CL_INVALID_BINARY:
+        case CL_INVALID_BUILD_OPTIONS:
+        case CL_INVALID_PROGRAM:
+        case CL_INVALID_PROGRAM_EXECUTABLE:
+        case CL_INVALID_KERNEL_NAME:
+        case CL_INVALID_KERNEL_DEFINITION:
+        case CL_INVALID_KERNEL:
+        case CL_INVALID_ARG_INDEX:
+        case CL_INVALID_ARG_VALUE:
+        case CL_INVALID_ARG_SIZE:
+        case CL_INVALID_KERNEL_ARGS:
+        case CL_INVALID_WORK_DIMENSION:
+        case CL_INVALID_WORK_GROUP_SIZE:
+        case CL_INVALID_WORK_ITEM_SIZE:
+        case CL_INVALID_GLOBAL_OFFSET:
+        case CL_INVALID_EVENT_WAIT_LIST:
+        case CL_INVALID_EVENT:
+        case CL_INVALID_OPERATION:
+        case CL_INVALID_GL_OBJECT:
+        case CL_INVALID_BUFFER_SIZE:
+        case CL_INVALID_MIP_LEVEL:
+        case CL_INVALID_GLOBAL_WORK_SIZE: return dnnl_invalid_arguments;
+
+        default: return dnnl_runtime_error;
+    }
+}
+} // namespace mem_debug_utils
+
 #define TEST_OCL_CHECK(x) \
     do { \
-        dnnl_status_t s = dnnl::impl::xpu::ocl::convert_to_dnnl(x); \
+        dnnl_status_t s = mem_debug_utils::convert_to_dnnl(x); \
         dnnl::error::wrap_c_api(s, dnnl_status2str(s)); \
     } while (0)
 #else


### PR DESCRIPTION
MFDNN-13110

Symbol was moved from .hpp to .cpp and became hidden. Copy-paste the body to remove the dependency.