### PR TITLE
xe: jit: gemm: remove unnecessary register duplication

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/common.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/common.cxx
@@ -589,9 +589,8 @@ void BLASKernelGenerator<hw>::calcIncrement(LDIncrements &increments, Subregiste
     else
         scaled = SubregisterPair(state.ra.alloc_sub(increments.type, getHint(HintType::LongTerm, strategy)));
 
-    int nr = strategy.avoidIncConflicts ? 2 : 1;
-    for (int i = 0; i < nr; i++)
-        emulConstant(1, scaled.getReg(i), base, scale, strategy, state);
+    emulConstant(1, scaled.getReg(0), base, scale, strategy, state);
+    if(scaled.isDuplicated()) emov(1, scaled.getReg(1), scaled.getReg(0), strategy, state);
 
     increments.push_back(std::make_pair(scale, scaled));
 }

--- a/src/gpu/intel/jit/gemm/generator/pieces/common.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/common.cxx
@@ -575,7 +575,8 @@ void BLASKernelGenerator<hw>::calcIncrement(LDIncrements &increments, Subregiste
 
     // Copy base for scale = 1.
     if (scale == 1) {
-        duplicateScalar(base, state);
+        if(strategy.avoidIncConflicts)
+            duplicateScalar(base, state);
         increments.push_back(std::make_pair(1, base));
         return;
     }


### PR DESCRIPTION
Fixes an out of registers failure on XeLP systems for the following workload:

```
benchdnn --matmul --engine=gpu --dt=bf16:s4:bf16 --wtag=acb --attr-scales=wei:per_ocic:bf16:32x1 --attr-zero-points=wei:per_ocic:s4:32x1 --attr-fpmath=bf16:true 3x96x96:3x96x64
```

On this workload, a duplicated scalar is the only subregister allocation present in r1. Removing this duplication thereby frees a register and avoids kernel generation failure.

Fixes [MFDNN-13167](https://jira.devtools.intel.com/browse/MFDNN-13167).