### PR TITLE
cpu: x64: tile_config: fix lazy config to check full mask (fixes MFDNN-13157)

### DIFF
--- a/src/cpu/x64/amx_tile_configure.cpp
+++ b/src/cpu/x64/amx_tile_configure.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,8 +56,8 @@ private:
             vmovdqu64(Xbyak::Zmm(0), ptr[abi_param2]);
             // Sets `1` per word if values are equal.
             vpcmpeqw(Xbyak::Opmask(0), Xbyak::Zmm(0), ptr[abi_param1]);
-            // `kortestw` will set CF=1 if all `1` in the mask.
-            kortestw(Xbyak::Opmask(0), Xbyak::Opmask(0));
+            // `kortestq` (64 bits) will set CF=1 if all `1` in the mask.
+            kortestq(Xbyak::Opmask(0), Xbyak::Opmask(0));
             // Checks if CF=1. If it is, everything matched, skipping config...
             jc(skip_tilecfg, T_NEAR);
             // ... otherwise, configure tile with user palette.


### PR DESCRIPTION
MFDNN-13157

It used to check 16 bits instead of all 64 expected.