### PR TITLE
src:cpu:aarch64: Enable JIT fp32 -> fp16 reorder

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018-2023 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2022-2024 Arm Ltd. and affiliates
+* Copyright 2022-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -170,7 +170,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
                 || (p.itype == bf16 && p.otype == f32 && mayiuse_bf16()
                         && p.beta == 0.f);
 
-        bool f16_ok = (p.itype != f16 && p.otype != f16)
+        bool is_f16 = (p.itype == f16 || p.otype == f16);
+        bool f16_ok = (p.itype == f32 && p.otype == f16 && p.beta == 0.f)
                 || (p.itype == f16 && p.otype == f32 && p.beta == 0.f);
 
         bool ok = true && p.ndims > 0
@@ -181,7 +182,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
                 && utils::everyone_is(0, p.ioff, p.ooff) /* do we need this? */
                 && utils::one_of(p.beta, 0.f, 1.f) /* anything else? */
                 && simple_impl_desc_init(p, nullptr) && prb_has_small_strides(p)
-                && bf16_ok && f16_ok;
+                && bf16_ok && IMPLICATION(is_f16, f16_ok);
 
         return ok;
     }

--- a/src/cpu/reorder/cpu_reorder_regular_f32_f16.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f32_f16.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2024 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,6 +30,8 @@ const impl_list_map_t &regular_f32_f16_impl_list_map() {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
+
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
 
             REG_SR(f32, any, f16, any, fmt_order::any, spec::reference)
 


### PR DESCRIPTION
# Description

This PR adds support for fp16 JIT reorder for data type f32->f16. Partially solves [issue](https://github.com/oneapi-src/oneDNN/issues/2185)

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
- [x] Have you submitted performance data that demonstrates performance improvements?

## Performance improvements

Below are small test case logs that demonstrate performance numbers before and after.

`./tests/benchdnn/benchdnn --reorder --sdt=f32 --ddt=f16 --mode=p 1x4096x4096`

**(new) jit:uni**: `total perf: min(ms):0.125977 avg(ms):0.136528`
**(old) simple:any**: `total perf: min(ms):10.1409 avg(ms):10.168`
