### PR TITLE
common: address some clang-tidy complaints

### DIFF
--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -835,10 +835,10 @@ struct memory : public handle<dnnl_memory_t> {
     using handle::handle;
 
     /// Integer type for representing dimension sizes and indices.
-    typedef dnnl_dim_t dim;
+    using dim = dnnl_dim_t;
     /// Vector of dimensions. Implementations are free to force a limit on the
     /// vector's length.
-    typedef std::vector<dim> dims;
+    using dims = std::vector<dim>;
 
     /// Helper function that validates that an `std::vector` of dimensions can
     /// be safely converted to the C API array ::dnnl_dims_t. Throws if

--- a/src/common/batch_normalization_pd.hpp
+++ b/src/common/batch_normalization_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -150,8 +150,8 @@ protected:
 };
 
 struct batch_normalization_fwd_pd_t : public batch_normalization_pd_t {
-    typedef batch_normalization_fwd_pd_t base_class;
-    typedef batch_normalization_fwd_pd_t hint_class;
+    using base_class = batch_normalization_fwd_pd_t;
+    using hint_class = batch_normalization_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -249,8 +249,8 @@ protected:
 };
 
 struct batch_normalization_bwd_pd_t : public batch_normalization_pd_t {
-    typedef batch_normalization_bwd_pd_t base_class;
-    typedef batch_normalization_fwd_pd_t hint_class;
+    using base_class = batch_normalization_bwd_pd_t;
+    using hint_class = batch_normalization_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_MEAN, DNNL_ARG_VARIANCE,

--- a/src/common/batch_normalization_pd.hpp
+++ b/src/common/batch_normalization_pd.hpp
@@ -97,7 +97,7 @@ struct batch_normalization_pd_t : public primitive_desc_t {
 
     float alpha() const {
         const auto &p = attr()->post_ops_;
-        const bool entry_size_ok = p.entry_.size() > 0;
+        const bool entry_size_ok = !p.entry_.empty();
         assert(entry_size_ok || fuse_norm_relu() || fuse_norm_add_relu());
         if (entry_size_ok) return p.entry_[0].eltwise.alpha;
         return 0.f;

--- a/src/common/batch_normalization_pd.hpp
+++ b/src/common/batch_normalization_pd.hpp
@@ -134,8 +134,7 @@ protected:
         , hint_fwd_pd_(hint_fwd_pd)
         , src_md_(desc_.src_desc)
         , stat_md_(desc_.stat_desc)
-        , scaleshift_md_(desc_.scaleshift_desc)
-        , ws_md_() {}
+        , scaleshift_md_(desc_.scaleshift_desc) {}
 
     virtual status_t init_default_ws(size_t bits_per_element) {
         const auto src_mdw = memory_desc_wrapper(src_md_);

--- a/src/common/binary_pd.hpp
+++ b/src/common/binary_pd.hpp
@@ -40,8 +40,8 @@ namespace impl {
 struct binary_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::binary;
 
-    typedef binary_pd_t base_class;
-    typedef binary_pd_t hint_class;
+    using base_class = binary_pd_t;
+    using hint_class = binary_pd_t;
 
     const binary_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {

--- a/src/common/concat_pd.hpp
+++ b/src/common/concat_pd.hpp
@@ -95,7 +95,6 @@ protected:
      * use this auxiliary array iff init() returned success */
     std::vector<memory_desc_t> src_image_mds_;
 
-protected:
     concat_desc_t desc_;
 
     concat_pd_t(const primitive_attr_t *attr, const memory_desc_t *dst_md,

--- a/src/common/concat_pd.hpp
+++ b/src/common/concat_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ struct concat_pd_t : public primitive_desc_t {
         return reinterpret_cast<const op_desc_t *>(this->desc());
     }
 
-    ~concat_pd_t() = default;
+    ~concat_pd_t() override = default;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg >= DNNL_ARG_MULTIPLE_SRC

--- a/src/common/convolution_pd.hpp
+++ b/src/common/convolution_pd.hpp
@@ -191,7 +191,7 @@ protected:
     bool set_default_formats_common_template(memory_desc_t &src_md,
             format_tag_t src_tag, memory_desc_t &wei_md, format_tag_t wei_tag,
             memory_desc_t &dst_md, format_tag_t dst_tag,
-            memory_desc_t &bia_md) {
+            memory_desc_t &bia_md) const {
         using namespace format_tag;
 
 #define IS_OK(f) \

--- a/src/common/convolution_pd.hpp
+++ b/src/common/convolution_pd.hpp
@@ -257,8 +257,8 @@ protected:
 };
 
 struct convolution_fwd_pd_t : public convolution_pd_t {
-    typedef convolution_fwd_pd_t base_class;
-    typedef convolution_fwd_pd_t hint_class;
+    using base_class = convolution_fwd_pd_t;
+    using hint_class = convolution_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_WEIGHTS))
@@ -337,8 +337,8 @@ protected:
 };
 
 struct convolution_bwd_data_pd_t : public convolution_pd_t {
-    typedef convolution_bwd_data_pd_t base_class;
-    typedef convolution_fwd_pd_t hint_class;
+    using base_class = convolution_bwd_data_pd_t;
+    using hint_class = convolution_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_WEIGHTS, DNNL_ARG_DIFF_DST))
@@ -408,8 +408,8 @@ protected:
 };
 
 struct convolution_bwd_weights_pd_t : public convolution_pd_t {
-    typedef convolution_bwd_weights_pd_t base_class;
-    typedef convolution_fwd_pd_t hint_class;
+    using base_class = convolution_bwd_weights_pd_t;
+    using hint_class = convolution_fwd_pd_t;
 
     convolution_bwd_weights_pd_t(const op_desc_t *adesc,
             const primitive_attr_t *attr,

--- a/src/common/deconvolution_pd.hpp
+++ b/src/common/deconvolution_pd.hpp
@@ -202,8 +202,8 @@ protected:
 };
 
 struct deconvolution_fwd_pd_t : public deconvolution_pd_t {
-    typedef deconvolution_fwd_pd_t base_class;
-    typedef deconvolution_fwd_pd_t hint_class;
+    using base_class = deconvolution_fwd_pd_t;
+    using hint_class = deconvolution_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_WEIGHTS))
@@ -266,8 +266,8 @@ protected:
 };
 
 struct deconvolution_bwd_data_pd_t : public deconvolution_pd_t {
-    typedef deconvolution_bwd_data_pd_t base_class;
-    typedef deconvolution_fwd_pd_t hint_class;
+    using base_class = deconvolution_bwd_data_pd_t;
+    using hint_class = deconvolution_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_WEIGHTS, DNNL_ARG_DIFF_DST))
@@ -326,8 +326,8 @@ protected:
 };
 
 struct deconvolution_bwd_weights_pd_t : public deconvolution_pd_t {
-    typedef deconvolution_bwd_weights_pd_t base_class;
-    typedef deconvolution_fwd_pd_t hint_class;
+    using base_class = deconvolution_bwd_weights_pd_t;
+    using hint_class = deconvolution_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_DIFF_DST))

--- a/src/common/dnnl_traits.hpp
+++ b/src/common/dnnl_traits.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,142 +30,142 @@ namespace dnnl {
 namespace impl {
 
 template <data_type_t>
-struct prec_traits {}; /* ::type -> float */
+struct prec_traits_t {}; /* ::type -> float */
 template <typename>
-struct data_traits {}; /* ::data_type -> f32 */
+struct data_traits_t {}; /* ::data_type -> f32 */
 template <int>
-struct typesize_traits {}; /* ::data_type_size -> f32 */
+struct typesize_traits_t {}; /* ::data_type_size -> f32 */
 template <primitive_kind_t>
-struct pkind_traits {}; /* ::desc_type, ::query_d */
+struct pkind_traits_t {}; /* ::desc_type, ::query_d */
 
 template <>
-struct prec_traits<data_type::f4_e3m0> {
+struct prec_traits_t<data_type::f4_e3m0> {
     typedef float4_e3m0_t type;
 };
 template <>
-struct prec_traits<data_type::f4_e2m1> {
+struct prec_traits_t<data_type::f4_e2m1> {
     typedef float4_e2m1_t type;
 };
 template <>
-struct prec_traits<data_type::e8m0> {
+struct prec_traits_t<data_type::e8m0> {
     typedef float8_e8m0_t type;
 };
 template <>
-struct prec_traits<data_type::f8_e5m2> {
+struct prec_traits_t<data_type::f8_e5m2> {
     typedef float8_e5m2_t type;
 };
 template <>
-struct prec_traits<data_type::f8_e4m3> {
+struct prec_traits_t<data_type::f8_e4m3> {
     typedef float8_e4m3_t type;
 };
 template <>
-struct prec_traits<data_type::f16> {
+struct prec_traits_t<data_type::f16> {
     typedef float16_t type;
 };
 template <>
-struct prec_traits<data_type::bf16> {
+struct prec_traits_t<data_type::bf16> {
     typedef bfloat16_t type;
 };
 template <>
-struct prec_traits<data_type::f32> {
+struct prec_traits_t<data_type::f32> {
     typedef float type;
 };
 template <>
-struct prec_traits<data_type::f64> {
+struct prec_traits_t<data_type::f64> {
     typedef double type;
 };
 template <>
-struct prec_traits<data_type::s32> {
+struct prec_traits_t<data_type::s32> {
     typedef int32_t type;
 };
 template <>
-struct prec_traits<data_type::s8> {
+struct prec_traits_t<data_type::s8> {
     typedef int8_t type;
 };
 template <>
-struct prec_traits<data_type::u8> {
+struct prec_traits_t<data_type::u8> {
     typedef uint8_t type;
 };
 template <>
-struct prec_traits<data_type::s4> {
+struct prec_traits_t<data_type::s4> {
     typedef int4_t type;
 };
 template <>
-struct prec_traits<data_type::u4> {
+struct prec_traits_t<data_type::u4> {
     typedef uint4_t type;
 };
 template <>
-struct prec_traits<data_type::boolean> {
+struct prec_traits_t<data_type::boolean> {
     typedef bool type;
 };
 
 template <>
-struct data_traits<float4_e3m0_t> {
+struct data_traits_t<float4_e3m0_t> {
     static constexpr data_type_t data_type = data_type::f4_e3m0;
 };
 template <>
-struct data_traits<float4_e2m1_t> {
+struct data_traits_t<float4_e2m1_t> {
     static constexpr data_type_t data_type = data_type::f4_e2m1;
 };
 template <>
-struct data_traits<float8_e8m0_t> {
+struct data_traits_t<float8_e8m0_t> {
     static constexpr data_type_t data_type = data_type::e8m0;
 };
 template <>
-struct data_traits<float8_e5m2_t> {
+struct data_traits_t<float8_e5m2_t> {
     static constexpr data_type_t data_type = data_type::f8_e5m2;
 };
 template <>
-struct data_traits<float8_e4m3_t> {
+struct data_traits_t<float8_e4m3_t> {
     static constexpr data_type_t data_type = data_type::f8_e4m3;
 };
 template <>
-struct data_traits<float16_t> {
+struct data_traits_t<float16_t> {
     static constexpr data_type_t data_type = data_type::f16;
 };
 template <>
-struct data_traits<bfloat16_t> {
+struct data_traits_t<bfloat16_t> {
     static constexpr data_type_t data_type = data_type::bf16;
 };
 template <>
-struct data_traits<float> {
+struct data_traits_t<float> {
     static constexpr data_type_t data_type = data_type::f32;
 };
 template <>
-struct data_traits<int32_t> {
+struct data_traits_t<int32_t> {
     static constexpr data_type_t data_type = data_type::s32;
 };
 template <>
-struct data_traits<int8_t> {
+struct data_traits_t<int8_t> {
     static constexpr data_type_t data_type = data_type::s8;
 };
 template <>
-struct data_traits<uint8_t> {
+struct data_traits_t<uint8_t> {
     static constexpr data_type_t data_type = data_type::u8;
 };
 template <>
-struct data_traits<int4_t> {
+struct data_traits_t<int4_t> {
     static constexpr data_type_t data_type = data_type::s4;
 };
 template <>
-struct data_traits<uint4_t> {
+struct data_traits_t<uint4_t> {
     static constexpr data_type_t data_type = data_type::u4;
 };
 template <>
-struct data_traits<bool> {
+struct data_traits_t<bool> {
     static constexpr data_type_t data_type = data_type::boolean;
 };
 
 template <>
-struct typesize_traits<4> {
+struct typesize_traits_t<4> {
     typedef float type;
 };
 template <>
-struct typesize_traits<2> {
+struct typesize_traits_t<2> {
     typedef int16_t type;
 };
 template <>
-struct typesize_traits<1> {
+struct typesize_traits_t<1> {
     typedef uint8_t type;
 };
 

--- a/src/common/dnnl_traits.hpp
+++ b/src/common/dnnl_traits.hpp
@@ -40,63 +40,63 @@ struct pkind_traits_t {}; /* ::desc_type, ::query_d */
 
 template <>
 struct prec_traits_t<data_type::f4_e3m0> {
-    typedef float4_e3m0_t type;
+    using type = float4_e3m0_t;
 };
 template <>
 struct prec_traits_t<data_type::f4_e2m1> {
-    typedef float4_e2m1_t type;
+    using type = float4_e2m1_t;
 };
 template <>
 struct prec_traits_t<data_type::e8m0> {
-    typedef float8_e8m0_t type;
+    using type = float8_e8m0_t;
 };
 template <>
 struct prec_traits_t<data_type::f8_e5m2> {
-    typedef float8_e5m2_t type;
+    using type = float8_e5m2_t;
 };
 template <>
 struct prec_traits_t<data_type::f8_e4m3> {
-    typedef float8_e4m3_t type;
+    using type = float8_e4m3_t;
 };
 template <>
 struct prec_traits_t<data_type::f16> {
-    typedef float16_t type;
+    using type = float16_t;
 };
 template <>
 struct prec_traits_t<data_type::bf16> {
-    typedef bfloat16_t type;
+    using type = bfloat16_t;
 };
 template <>
 struct prec_traits_t<data_type::f32> {
-    typedef float type;
+    using type = float;
 };
 template <>
 struct prec_traits_t<data_type::f64> {
-    typedef double type;
+    using type = double;
 };
 template <>
 struct prec_traits_t<data_type::s32> {
-    typedef int32_t type;
+    using type = int32_t;
 };
 template <>
 struct prec_traits_t<data_type::s8> {
-    typedef int8_t type;
+    using type = int8_t;
 };
 template <>
 struct prec_traits_t<data_type::u8> {
-    typedef uint8_t type;
+    using type = uint8_t;
 };
 template <>
 struct prec_traits_t<data_type::s4> {
-    typedef int4_t type;
+    using type = int4_t;
 };
 template <>
 struct prec_traits_t<data_type::u4> {
-    typedef uint4_t type;
+    using type = uint4_t;
 };
 template <>
 struct prec_traits_t<data_type::boolean> {
-    typedef bool type;
+    using type = bool;
 };
 
 template <>
@@ -158,15 +158,15 @@ struct data_traits_t<bool> {
 
 template <>
 struct typesize_traits_t<4> {
-    typedef float type;
+    using type = float;
 };
 template <>
 struct typesize_traits_t<2> {
-    typedef int16_t type;
+    using type = int16_t;
 };
 template <>
 struct typesize_traits_t<1> {
-    typedef uint8_t type;
+    using type = uint8_t;
 };
 
 } // namespace impl

--- a/src/common/eltwise_pd.hpp
+++ b/src/common/eltwise_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -117,8 +117,8 @@ private:
 };
 
 struct eltwise_fwd_pd_t : public eltwise_pd_t {
-    typedef eltwise_fwd_pd_t base_class;
-    typedef eltwise_fwd_pd_t hint_class;
+    using base_class = eltwise_fwd_pd_t;
+    using hint_class = eltwise_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -192,8 +192,8 @@ protected:
 };
 
 struct eltwise_bwd_pd_t : public eltwise_pd_t {
-    typedef eltwise_bwd_pd_t base_class;
-    typedef eltwise_fwd_pd_t hint_class;
+    using base_class = eltwise_bwd_pd_t;
+    using hint_class = eltwise_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (use_dst() ? arg == DNNL_ARG_DST : arg == DNNL_ARG_SRC)

--- a/src/common/gemm_pd.hpp
+++ b/src/common/gemm_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@ namespace impl {
 struct gemm_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::gemm;
 
-    typedef gemm_pd_t base_class;
-    typedef gemm_pd_t hint_class;
+    using base_class = gemm_pd_t;
+    using hint_class = gemm_pd_t;
 
     const gemm_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {

--- a/src/common/gemm_utils.hpp
+++ b/src/common/gemm_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ static inline status_t create_gemm_pd(
 
     gemm_pd_ = *(++it);
     if (!gemm_pd_) return status::unimplemented;
-    if (skip_ref && strstr(gemm_pd_.get()->name(), "ref") != NULL)
+    if (skip_ref && strstr(gemm_pd_->name(), "ref") != nullptr)
         return status::unimplemented;
 
     return status::success;

--- a/src/common/group_normalization_pd.hpp
+++ b/src/common/group_normalization_pd.hpp
@@ -112,8 +112,8 @@ protected:
 };
 
 struct group_normalization_fwd_pd_t : public group_normalization_pd_t {
-    typedef group_normalization_fwd_pd_t base_class;
-    typedef group_normalization_fwd_pd_t hint_class;
+    using base_class = group_normalization_fwd_pd_t;
+    using hint_class = group_normalization_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -208,8 +208,8 @@ protected:
 };
 
 struct group_normalization_bwd_pd_t : public group_normalization_pd_t {
-    typedef group_normalization_bwd_pd_t base_class;
-    typedef group_normalization_fwd_pd_t hint_class;
+    using base_class = group_normalization_bwd_pd_t;
+    using hint_class = group_normalization_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_MEAN, DNNL_ARG_VARIANCE,

--- a/src/common/inner_product_pd.hpp
+++ b/src/common/inner_product_pd.hpp
@@ -141,7 +141,7 @@ protected:
     bool set_default_formats_common_template(memory_desc_t &src_md,
             format_tag_t src_tag, memory_desc_t &wei_md, format_tag_t wei_tag,
             memory_desc_t &dst_md, format_tag_t dst_tag,
-            memory_desc_t &bia_md) {
+            memory_desc_t &bia_md) const {
         using namespace format_tag;
 
 #define IS_OK(f) \

--- a/src/common/inner_product_pd.hpp
+++ b/src/common/inner_product_pd.hpp
@@ -197,8 +197,8 @@ protected:
 };
 
 struct inner_product_fwd_pd_t : public inner_product_pd_t {
-    typedef inner_product_fwd_pd_t base_class;
-    typedef inner_product_fwd_pd_t hint_class;
+    using base_class = inner_product_fwd_pd_t;
+    using hint_class = inner_product_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_WEIGHTS))
@@ -267,8 +267,8 @@ protected:
 };
 
 struct inner_product_bwd_data_pd_t : public inner_product_pd_t {
-    typedef inner_product_bwd_data_pd_t base_class;
-    typedef inner_product_fwd_pd_t hint_class;
+    using base_class = inner_product_bwd_data_pd_t;
+    using hint_class = inner_product_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_WEIGHTS, DNNL_ARG_DIFF_DST))
@@ -333,8 +333,8 @@ protected:
 };
 
 struct inner_product_bwd_weights_pd_t : public inner_product_pd_t {
-    typedef inner_product_bwd_weights_pd_t base_class;
-    typedef inner_product_fwd_pd_t hint_class;
+    using base_class = inner_product_bwd_weights_pd_t;
+    using hint_class = inner_product_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_DIFF_DST))

--- a/src/common/layer_normalization_pd.hpp
+++ b/src/common/layer_normalization_pd.hpp
@@ -157,8 +157,8 @@ private:
 };
 
 struct layer_normalization_fwd_pd_t : public layer_normalization_pd_t {
-    typedef layer_normalization_fwd_pd_t base_class;
-    typedef layer_normalization_fwd_pd_t hint_class;
+    using base_class = layer_normalization_fwd_pd_t;
+    using hint_class = layer_normalization_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -267,8 +267,8 @@ protected:
 };
 
 struct layer_normalization_bwd_pd_t : public layer_normalization_pd_t {
-    typedef layer_normalization_bwd_pd_t base_class;
-    typedef layer_normalization_fwd_pd_t hint_class;
+    using base_class = layer_normalization_bwd_pd_t;
+    using hint_class = layer_normalization_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_MEAN, DNNL_ARG_VARIANCE,

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -23,15 +23,14 @@
 namespace dnnl {
 namespace impl {
 
-log_manager_t::log_manager_t() {
-
+log_manager_t::log_manager_t()
+    : logfile_path_(getenv_string_user("VERBOSE_LOGFILE"))
     // enables logging as well as printing to stdout
-    console_flag_ = getenv_int_user("VERBOSE_LOG_WITH_CONSOLE", 0);
+    , console_flag_(getenv_int_user("VERBOSE_LOG_WITH_CONSOLE", 0)) {
 
     // logging is automatically disabled when no filepath is provided by
     // DNNL_VERBOSE_LOGFILE
     // in this case, we fall back to printing to stdout
-    logfile_path_ = getenv_string_user("VERBOSE_LOGFILE");
     if (logfile_path_.empty()) {
         console_flag_ = true;
         return;

--- a/src/common/lrn_pd.hpp
+++ b/src/common/lrn_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -99,8 +99,8 @@ protected:
 };
 
 struct lrn_fwd_pd_t : public lrn_pd_t {
-    typedef lrn_fwd_pd_t base_class;
-    typedef lrn_fwd_pd_t hint_class;
+    using base_class = lrn_fwd_pd_t;
+    using hint_class = lrn_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -158,8 +158,8 @@ protected:
 };
 
 struct lrn_bwd_pd_t : public lrn_pd_t {
-    typedef lrn_bwd_pd_t base_class;
-    typedef lrn_fwd_pd_t hint_class;
+    using base_class = lrn_bwd_pd_t;
+    using hint_class = lrn_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_DIFF_DST))

--- a/src/common/lrn_pd.hpp
+++ b/src/common/lrn_pd.hpp
@@ -94,8 +94,7 @@ protected:
         : primitive_desc_t(attr, base_pkind)
         , desc_(*op_desc_t::to_desc<lrn_desc_t>(adesc))
         , hint_fwd_pd_(hint_fwd_pd)
-        , src_md_(desc_.src_desc)
-        , ws_md_() {}
+        , src_md_(desc_.src_desc) {}
 };
 
 struct lrn_fwd_pd_t : public lrn_pd_t {

--- a/src/common/math_utils.hpp
+++ b/src/common/math_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,9 +89,9 @@ inline int ilog2q(size_t v) {
     int p = 0;
 #define CP(pw) \
     do { \
-        if (v >= (1ull << pw)) { \
-            v >>= pw; \
-            p += pw; \
+        if (v >= (1ull << (pw))) { \
+            v >>= (pw); \
+            p += (pw); \
         } \
     } while (0)
     CP(32);

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -48,8 +48,8 @@ status_t matmul_desc_init(matmul_desc_t *matmul_desc,
 struct matmul_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::matmul;
 
-    typedef matmul_pd_t base_class;
-    typedef matmul_pd_t hint_class;
+    using base_class = matmul_pd_t;
+    using hint_class = matmul_pd_t;
 
     const matmul_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {

--- a/src/common/memory.cpp
+++ b/src/common/memory.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -100,9 +100,10 @@ dnnl_memory::dnnl_memory(dnnl::impl::engine_t *engine,
         const dnnl::impl::memory_desc_t *md,
         std::vector<std::unique_ptr<dnnl::impl::memory_storage_t>>
                 &&memory_storages)
-    : engine_(engine), md_(*md), counter_(1) {
-    memory_storages_ = std::move(memory_storages);
-}
+    : engine_(engine)
+    , md_(*md)
+    , memory_storages_(std::move(memory_storages))
+    , counter_(1) {}
 #endif
 
 status_t dnnl_memory::set_data_handle(void *handle, int index) const {

--- a/src/common/memory_desc.hpp
+++ b/src/common/memory_desc.hpp
@@ -291,8 +291,7 @@ struct dnnl_memory_desc : public dnnl::impl::c_compatible {
         , padded_offsets {}
         , offset0(0)
         , format_kind(dnnl::impl::format_kind::undef)
-        , format_desc {}
-        , extra {} {}
+        , format_desc {} {}
     // Number of dimensions
     int ndims;
     // Dimensions in the following order:

--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -451,8 +451,8 @@ struct registry_t {
                     (return_type)ptr_start, entry.size};
         }
     };
-    typedef common_iterator_t<void *> iterator;
-    typedef common_iterator_t<const void *> const_iterator;
+    using iterator = common_iterator_t<void *>;
+    using const_iterator = common_iterator_t<const void *>;
     iterator begin(void *base_ptr_) const {
         return iterator(base_ptr_, offset_map_);
     }

--- a/src/common/memory_zero_pad.cpp
+++ b/src/common/memory_zero_pad.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ void typed_zero_pad_blk(const memory_desc_wrapper &m_d, void *data_handle) {
      * This allows user will be to create bf16 memory
      * on non-avx512_core machines. */
     using data_t = typename utils::conditional<dt == bf16, uint16_t,
-            typename prec_traits<dt>::type>::type;
+            typename prec_traits_t<dt>::type>::type;
     auto data = reinterpret_cast<data_t *>(data_handle);
     const auto &dims = m_d.dims();
     const auto &pdims = m_d.padded_dims();
@@ -142,7 +142,7 @@ void typed_zero_pad_generic_blocked(
      * This allows user will be to create bf16 memory
      * on non-avx512_core machines. */
     using data_t = typename utils::conditional<dt == bf16, uint16_t,
-            typename prec_traits<dt>::type>::type;
+            typename prec_traits_t<dt>::type>::type;
     auto data = reinterpret_cast<data_t *>(data_handle);
     const int ndims = m_d.ndims();
     const auto &dims = m_d.dims();
@@ -204,7 +204,7 @@ status_t typed_zero_pad(const memory_t *memory, const exec_ctx_t &ctx) {
     void *mapped_ptr
             = ctx.map_memory_storage(memory_storage, ctx.stream(), map_size);
 
-    auto *data = static_cast<typename prec_traits<dt>::type *>(mapped_ptr);
+    auto *data = static_cast<typename prec_traits_t<dt>::type *>(mapped_ptr);
     auto blk = mdw.blocking_desc();
 
     auto get_blksize = [&](int ind) {

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -348,9 +348,9 @@ private:
     std::vector<T> _impl;
 
 public:
-    typedef typename std::vector<T>::iterator iterator;
-    typedef typename std::vector<T>::const_iterator const_iterator;
-    typedef typename std::vector<T>::size_type size_type;
+    using iterator = typename std::vector<T>::iterator;
+    using const_iterator = typename std::vector<T>::const_iterator;
+    using size_type = typename std::vector<T>::size_type;
     vector() {}
     vector(size_type n) : _impl(n) {}
     vector(size_type n, const T &value) : _impl(n, value) {}
@@ -382,9 +382,9 @@ private:
     std::map<Key, T> _impl;
 
 public:
-    typedef typename std::map<Key, T>::iterator iterator;
-    typedef typename std::map<Key, T>::const_iterator const_iterator;
-    typedef typename std::map<Key, T>::size_type size_type;
+    using iterator = typename std::map<Key, T>::iterator;
+    using const_iterator = typename std::map<Key, T>::const_iterator;
+    using size_type = typename std::map<Key, T>::size_type;
     map() {}
     ~map() {}
     size_type size() const { return _impl.size(); }

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -286,7 +286,7 @@ struct numeric_limits<int4_t> {
 };
 
 template <typename T>
-struct is_integral {
+struct is_integral { // NOLINT(readability-identifier-naming)
     static constexpr bool value = false;
 };
 template <>
@@ -315,7 +315,7 @@ struct is_integral<uint4_t> {
 };
 
 template <typename T, typename U>
-struct is_same {
+struct is_same { // NOLINT(readability-identifier-naming)
     static constexpr bool value = false;
 };
 template <typename T>
@@ -343,7 +343,7 @@ struct is_same<T, T> {
 enum nstl_status_t { success = 0, out_of_memory };
 
 template <typename T>
-class vector : public c_compatible {
+class vector : public c_compatible { // NOLINT(readability-identifier-naming)
 private:
     std::vector<T> _impl;
 
@@ -377,7 +377,7 @@ public:
 };
 
 template <typename Key, typename T>
-class map : public c_compatible {
+class map : public c_compatible { // NOLINT(readability-identifier-naming)
 private:
     std::map<Key, T> _impl;
 
@@ -402,10 +402,10 @@ public:
 
 // Compile-time sequence of indices (part of C++14)
 template <size_t... Ints>
-struct index_sequence {};
+struct index_sequence {}; // NOLINT(readability-identifier-naming)
 
 template <size_t N, size_t... Next>
-struct make_index_sequence_helper
+struct make_index_sequence_helper // NOLINT(readability-identifier-naming)
     : public make_index_sequence_helper<N - 1, N - 1, Next...> {};
 
 template <size_t... Next>

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -351,12 +351,12 @@ public:
     using iterator = typename std::vector<T>::iterator;
     using const_iterator = typename std::vector<T>::const_iterator;
     using size_type = typename std::vector<T>::size_type;
-    vector() {}
+    vector() = default;
     vector(size_type n) : _impl(n) {}
     vector(size_type n, const T &value) : _impl(n, value) {}
     template <typename input_iterator>
     vector(input_iterator first, input_iterator last) : _impl(first, last) {}
-    ~vector() {}
+    ~vector() = default;
     size_type size() const { return _impl.size(); }
     T &operator[](size_type i) { return _impl[i]; }
     const T &operator[](size_type i) const { return _impl[i]; }
@@ -385,8 +385,8 @@ public:
     using iterator = typename std::map<Key, T>::iterator;
     using const_iterator = typename std::map<Key, T>::const_iterator;
     using size_type = typename std::map<Key, T>::size_type;
-    map() {}
-    ~map() {}
+    map() = default;
+    ~map() = default;
     size_type size() const { return _impl.size(); }
     T &operator[](const Key &k) { return _impl[k]; }
     const T &operator[](const Key &k) const { return _impl[k]; }

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -84,14 +84,14 @@ protected:
 namespace nstl {
 
 template <typename T>
-constexpr const T abs(const T &a) {
+constexpr T abs(const T &a) {
     return a >= 0 ? a : -a;
 }
 
 // Computes the modulus and returns the result as the least positive residue
 // when the divisor > 0.
 template <typename T>
-inline const T modulo(const T &dividend, const T &divisor) {
+inline T modulo(const T &dividend, const T &divisor) {
     static_assert(std::is_integral<T>::value, "T must be an integer type.");
     assert(divisor > 0);
     T result = dividend % divisor;
@@ -101,7 +101,7 @@ inline const T modulo(const T &dividend, const T &divisor) {
 // Computes the additive inverse modulus and returns the result as the least
 // positive residue when the divisor > 0.
 template <typename T>
-inline const T additive_inverse_modulo(const T &dividend, const T &divisor) {
+inline T additive_inverse_modulo(const T &dividend, const T &divisor) {
     static_assert(std::is_integral<T>::value, "T must be an integer type.");
     assert(divisor > 0);
     T result = modulo(dividend, divisor);

--- a/src/common/pooling_pd.hpp
+++ b/src/common/pooling_pd.hpp
@@ -150,8 +150,7 @@ protected:
             const pooling_fwd_pd_t *hint_fwd_pd)
         : primitive_desc_t(attr, base_pkind)
         , desc_(*op_desc_t::to_desc<pooling_desc_t>(adesc))
-        , hint_fwd_pd_(hint_fwd_pd)
-        , ws_md_() {}
+        , hint_fwd_pd_(hint_fwd_pd) {}
 
     void init_default_ws(data_type_t dt = data_type::undef) {
         ws_md_ = is_fwd() ? *dst_md() : *diff_dst_md();

--- a/src/common/pooling_pd.hpp
+++ b/src/common/pooling_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ protected:
     data_type_t indices_data_type() const {
         /* the simplest way to express 256... */
         const int u8_max = nstl::numeric_limits<
-                typename prec_traits<data_type::u8>::type>::max();
+                typename prec_traits_t<data_type::u8>::type>::max();
         return utils::array_product(desc()->kernel, spatial_ndims()) <= u8_max
                 ? data_type::u8
                 : data_type::s32;

--- a/src/common/pooling_pd.hpp
+++ b/src/common/pooling_pd.hpp
@@ -177,8 +177,8 @@ private:
 };
 
 struct pooling_fwd_pd_t : public pooling_pd_t {
-    typedef pooling_fwd_pd_t base_class;
-    typedef pooling_fwd_pd_t hint_class;
+    using base_class = pooling_fwd_pd_t;
+    using hint_class = pooling_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -247,8 +247,8 @@ protected:
 };
 
 struct pooling_bwd_pd_t : public pooling_pd_t {
-    typedef pooling_bwd_pd_t base_class;
-    typedef pooling_fwd_pd_t hint_class;
+    using base_class = pooling_bwd_pd_t;
+    using hint_class = pooling_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_DIFF_DST) return arg_usage_t::input;

--- a/src/common/prelu_pd.hpp
+++ b/src/common/prelu_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -88,8 +88,8 @@ protected:
 };
 
 struct prelu_fwd_pd_t : public prelu_pd_t {
-    typedef prelu_fwd_pd_t base_class;
-    typedef prelu_fwd_pd_t hint_class;
+    using base_class = prelu_fwd_pd_t;
+    using hint_class = prelu_fwd_pd_t;
 
     primitive_desc_t::arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -150,8 +150,8 @@ protected:
 };
 
 struct prelu_bwd_pd_t : public prelu_pd_t {
-    typedef prelu_bwd_pd_t base_class;
-    typedef prelu_fwd_pd_t hint_class;
+    using base_class = prelu_bwd_pd_t;
+    using hint_class = prelu_fwd_pd_t;
 
     primitive_desc_t::arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;

--- a/src/common/primitive.hpp
+++ b/src/common/primitive.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -150,25 +150,25 @@ private:
 } // namespace impl
 } // namespace dnnl
 
-#define ARG_TYPE(t) \
-    typename std::remove_cv<typename std::remove_pointer<t>::type>::type
+#define ARG_PTR_TYPE(t) \
+    typename std::remove_cv<typename std::remove_pointer<t>::type>::type *
 
 // Returns destination memory which has been zero pad initialized. This macro
 // may result in a failure returned via the `status` input since zero pad
 // may fail.
 #define CTX_OUT_CLEAN_MEM(type, arg, status) \
-    static_cast<ARG_TYPE(type) *>(ctx.host_ptr(arg, true, &status))
+    static_cast<ARG_PTR_TYPE(type)>(ctx.host_ptr(arg, true, &(status)))
 
 // Returns destination memory which may not have been zero pad initialized.
 #define CTX_OUT_MEM_COMMON(type, arg, index) \
-    static_cast<ARG_TYPE(type) *>(ctx.host_ptr(arg, false, nullptr, index))
+    static_cast<ARG_PTR_TYPE(type)>(ctx.host_ptr(arg, false, nullptr, index))
 #define CTX_OUT_MEm(type, arg) CTX_OUT_MEM_COMMON(type, arg, 0)
 #define CTX_OUT_MEm0(type, arg) CTX_OUT_MEM_COMMON(type, arg, 0)
 #define CTX_OUT_MEm1(type, arg) CTX_OUT_MEM_COMMON(type, arg, 1)
 #define CTX_OUT_MEm2(type, arg) CTX_OUT_MEM_COMMON(type, arg, 2)
 
 #define CTX_IN_MEM_COMMON(type, arg, index) \
-    static_cast<const ARG_TYPE(type) *>( \
+    static_cast<const ARG_PTR_TYPE(type)>( \
             ctx.host_ptr(arg, false, nullptr, index))
 #define CTX_IN_MEm(type, arg) CTX_IN_MEM_COMMON(type, arg, 0)
 #define CTX_IN_MEm0(type, arg) CTX_IN_MEM_COMMON(type, arg, 0)

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -417,7 +417,7 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
         }
     };
 
-    dnnl_post_ops() : entry_() {}
+    dnnl_post_ops() = default;
     ~dnnl_post_ops() = default;
 
     dnnl::impl::status_t append_sum(float scale, int32_t zero_point = 0,

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -529,7 +529,8 @@ struct dnnl_primitive_attr : public dnnl::impl::c_compatible {
         return new dnnl_primitive_attr(*this);
     }
 
-    dnnl_primitive_attr(const dnnl_primitive_attr &other) {
+    dnnl_primitive_attr(const dnnl_primitive_attr &other)
+        : c_compatible(other) {
         if (copy_from(other) != dnnl::impl::status::success)
             is_initialized_ = false;
     }

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -457,11 +457,11 @@ protected:
         /** the only reason why this class is here is the inability of
          * utils::make_unique() to operate on protected parent classes
          * of the derivative pd_t's; compilers should optimize it out */
-        class pd_t_compat : public pd_t {
+        class pd_compat_t : public pd_t {
         public:
-            pd_t_compat(Args &&...args) : pd_t(std::forward<Args>(args)...) {}
+            pd_compat_t(Args &&...args) : pd_t(std::forward<Args>(args)...) {}
         };
-        return utils::make_unique<pd_t_compat>(std::forward<Args>(args)...);
+        return utils::make_unique<pd_compat_t>(std::forward<Args>(args)...);
     }
 
     template <typename pd_t>

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -80,7 +80,7 @@ struct primitive_desc_t : public c_compatible {
     //     doesn't require any special handling since `get_verbose` is `false`.
     std::string info_with_runtime_dims(engine_t *engine,
             const memory_desc_t *src_md, const memory_desc_t *wei_md,
-            const memory_desc_t *bia_md, const memory_desc_t *dst_md) {
+            const memory_desc_t *bia_md, const memory_desc_t *dst_md) const {
         std::string info_str = info(engine);
 
         // Matmul and reorder are the only primitives supporting runtime dims.

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -435,7 +435,6 @@ protected:
 
     memory_tracking::registry_t scratchpad_registry_;
 
-protected:
     void init_pd_iterator_offset(int offset) { pd_iterator_offset_ = offset; }
     void init_skip_idx(int skip_idx) { skip_idx_ = skip_idx; }
 

--- a/src/common/profiler.hpp
+++ b/src/common/profiler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -90,8 +90,7 @@ static double get_msec() {
 // names are copied into long term storage.
 
 struct profiler_t {
-    profiler_t(const std::string &profile_name)
-        : _profile_name(profile_name), _run_data(), _data() {
+    profiler_t(const std::string &profile_name) : _profile_name(profile_name) {
         // Reserve data on construction to reduce chance of recording
         // reallocation
         _run_data.reserve(128);

--- a/src/common/reduction_pd.hpp
+++ b/src/common/reduction_pd.hpp
@@ -40,7 +40,7 @@ status_t reduction_desc_init(reduction_desc_t *reduction_desc,
 struct reduction_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::reduction;
 
-    typedef reduction_pd_t hint_class;
+    using hint_class = reduction_pd_t;
 
     const reduction_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {

--- a/src/common/reorder_pd.hpp
+++ b/src/common/reorder_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -177,7 +177,6 @@ protected:
         return *this;
     }
 
-protected:
     void init_desc(engine_kind_t src_engine_kind, engine_kind_t dst_engine_kind,
             bool is_cross_engine) {
         desc_ = reorder_desc_t();

--- a/src/common/resampling_pd.hpp
+++ b/src/common/resampling_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -112,8 +112,8 @@ private:
 };
 
 struct resampling_fwd_pd_t : public resampling_pd_t {
-    typedef resampling_fwd_pd_t base_class;
-    typedef resampling_fwd_pd_t hint_class;
+    using base_class = resampling_fwd_pd_t;
+    using hint_class = resampling_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -170,8 +170,8 @@ protected:
 };
 
 struct resampling_bwd_pd_t : public resampling_pd_t {
-    typedef resampling_bwd_pd_t base_class;
-    typedef resampling_fwd_pd_t hint_class;
+    using base_class = resampling_bwd_pd_t;
+    using hint_class = resampling_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_DIFF_DST) return arg_usage_t::input;

--- a/src/common/rnn_pd.hpp
+++ b/src/common/rnn_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -250,8 +250,8 @@ protected:
 };
 
 struct rnn_fwd_pd_t : public rnn_pd_t {
-    typedef rnn_fwd_pd_t base_class;
-    typedef rnn_fwd_pd_t hint_class;
+    using base_class = rnn_fwd_pd_t;
+    using hint_class = rnn_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC_LAYER) return arg_usage_t::input;
@@ -329,8 +329,8 @@ protected:
 };
 
 struct rnn_bwd_pd_t : public rnn_pd_t {
-    typedef rnn_bwd_pd_t base_class;
-    typedef rnn_fwd_pd_t hint_class;
+    using base_class = rnn_bwd_pd_t;
+    using hint_class = rnn_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_SRC_LAYER, DNNL_ARG_DST_LAYER,

--- a/src/common/rnn_pd.hpp
+++ b/src/common/rnn_pd.hpp
@@ -245,8 +245,7 @@ protected:
         , bias_md_(desc_.bias_desc)
         , dst_layer_md_(desc_.dst_layer_desc)
         , dst_iter_md_(desc_.dst_iter_desc)
-        , dst_iter_c_md_(desc_.dst_iter_c_desc)
-        , ws_md_() {}
+        , dst_iter_c_md_(desc_.dst_iter_c_desc) {}
 };
 
 struct rnn_fwd_pd_t : public rnn_pd_t {

--- a/src/common/scratchpad.hpp
+++ b/src/common/scratchpad.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2020 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ namespace dnnl {
 namespace impl {
 
 struct scratchpad_t {
-    virtual ~scratchpad_t() {}
+    virtual ~scratchpad_t() = default;
     virtual const memory_storage_t *get_memory_storage() const = 0;
     virtual size_t size() const = 0;
 };

--- a/src/common/sdpa_pd.hpp
+++ b/src/common/sdpa_pd.hpp
@@ -39,8 +39,8 @@ namespace impl {
 struct sdpa_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::sdpa;
 
-    typedef sdpa_pd_t base_class;
-    typedef sdpa_pd_t hint_class;
+    using base_class = sdpa_pd_t;
+    using hint_class = sdpa_pd_t;
 
     const sdpa_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {

--- a/src/common/shuffle_pd.hpp
+++ b/src/common/shuffle_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ namespace impl {
 struct shuffle_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::shuffle;
 
-    typedef shuffle_pd_t base_class;
-    typedef shuffle_pd_t hint_class;
+    using base_class = shuffle_pd_t;
+    using hint_class = shuffle_pd_t;
 
     const shuffle_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {

--- a/src/common/softmax_pd.hpp
+++ b/src/common/softmax_pd.hpp
@@ -120,8 +120,8 @@ private:
 };
 
 struct softmax_fwd_pd_t : public softmax_pd_t {
-    typedef softmax_fwd_pd_t base_class;
-    typedef softmax_fwd_pd_t hint_class;
+    using base_class = softmax_fwd_pd_t;
+    using hint_class = softmax_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
@@ -194,8 +194,8 @@ protected:
 };
 
 struct softmax_bwd_pd_t : public softmax_pd_t {
-    typedef softmax_bwd_pd_t base_class;
-    typedef softmax_fwd_pd_t hint_class;
+    using base_class = softmax_bwd_pd_t;
+    using hint_class = softmax_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
         if (utils::one_of(arg, DNNL_ARG_DST, DNNL_ARG_DIFF_DST))

--- a/src/common/stream.hpp
+++ b/src/common/stream.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 struct dnnl_stream : public dnnl::impl::c_compatible {
     dnnl_stream(dnnl::impl::engine_t *engine, dnnl::impl::stream_impl_t *impl)
         : engine_(engine), impl_(impl) {}
-    virtual ~dnnl_stream() {}
+    virtual ~dnnl_stream() = default;
 
     /** returns stream's engine */
     dnnl::impl::engine_t *engine() const { return engine_; }

--- a/src/common/tag_traits.hpp
+++ b/src/common/tag_traits.hpp
@@ -325,12 +325,12 @@ constexpr int AB_or_BC_blk_off(int x0, int x1) {
 }
 
 template <inner_blk_t b>
-struct inner_blk_traits {
+struct inner_blk_traits_t {
     using ib = inner_blk_t;
 };
 
 template <format_tag_t>
-struct tag_traits {
+struct tag_traits_t {
     // block_dim_t block_dims;
     // inner_blk_t inner_blks;
     // int ndims;
@@ -338,7 +338,7 @@ struct tag_traits {
 
 #define DECL_TRAITS(_tag, _blk_fmt, _inner_blk, _ndims) \
     template <> \
-    struct tag_traits<format_tag::_tag> { \
+    struct tag_traits_t<format_tag::_tag> { \
         static constexpr block_dim_t block_dims = block_dim_t::_blk_fmt; \
         static constexpr inner_blk_t inner_blks = inner_blk_t::_inner_blk; \
         static constexpr int ndims = _ndims; \

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -630,7 +630,7 @@ inline bool operator!=(const memory_desc_t &lhs, const memory_desc_t &rhs) {
 #define DEREF_AND_COMPARE_DESC_MEMBERS(m) *lhs.m == *rhs.m
 #define COMPARE_FLOAT_DESC_MEMBERS(m) utils::equal_with_nan(lhs.m, rhs.m)
 #define COMPARE_FLOAT_DESC_ARRAY_MEMBERS(m, s) \
-    !std::memcmp(lhs.m, rhs.m, sizeof(float) * s)
+    !std::memcmp(lhs.m, rhs.m, sizeof(float) * (s))
 
 // clang-format off
 inline bool operator==(const batch_normalization_desc_t &lhs,

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -996,7 +996,8 @@ inline bool operator==(const sdpa_desc_t &lhs, const sdpa_desc_t &rhs) {
 #undef COMPARE_FLOAT_DESC_MEMBERS
 #undef COMPARE_FLOAT_DESC_ARRAY_MEMBERS
 
-inline bool is_dense_format_kind(const std::vector<const memory_desc_t *> mds) {
+inline bool is_dense_format_kind(
+        const std::vector<const memory_desc_t *> &mds) {
 #ifdef DNNL_EXPERIMENTAL_SPARSE
     for (const auto *md : mds)
         if (md->format_kind == format_kind::sparse) return false;

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -93,22 +93,22 @@ namespace types {
 inline size_t data_type_size(data_type_t data_type) {
     using namespace data_type;
     switch ((int)data_type) {
-        case f4_e3m0: return sizeof(prec_traits<f4_e3m0>::type);
-        case f4_e2m1: return sizeof(prec_traits<f4_e2m1>::type);
-        case e8m0: return sizeof(prec_traits<e8m0>::type);
-        case f8_e5m2: return sizeof(prec_traits<f8_e5m2>::type);
-        case f8_e4m3: return sizeof(prec_traits<f8_e4m3>::type);
-        case f16: return sizeof(prec_traits<f16>::type);
-        case bf16: return sizeof(prec_traits<bf16>::type);
+        case f4_e3m0: return sizeof(prec_traits_t<f4_e3m0>::type);
+        case f4_e2m1: return sizeof(prec_traits_t<f4_e2m1>::type);
+        case e8m0: return sizeof(prec_traits_t<e8m0>::type);
+        case f8_e5m2: return sizeof(prec_traits_t<f8_e5m2>::type);
+        case f8_e4m3: return sizeof(prec_traits_t<f8_e4m3>::type);
+        case f16: return sizeof(prec_traits_t<f16>::type);
+        case bf16: return sizeof(prec_traits_t<bf16>::type);
         case tf32: // the tf32 type is an f32
-        case f32: return sizeof(prec_traits<f32>::type);
-        case f64: return sizeof(prec_traits<f64>::type);
-        case s32: return sizeof(prec_traits<s32>::type);
-        case s8: return sizeof(prec_traits<s8>::type);
-        case u8: return sizeof(prec_traits<u8>::type);
-        case s4: return sizeof(prec_traits<s4>::type);
-        case u4: return sizeof(prec_traits<u4>::type);
-        case boolean: return sizeof(prec_traits<boolean>::type);
+        case f32: return sizeof(prec_traits_t<f32>::type);
+        case f64: return sizeof(prec_traits_t<f64>::type);
+        case s32: return sizeof(prec_traits_t<s32>::type);
+        case s8: return sizeof(prec_traits_t<s8>::type);
+        case u8: return sizeof(prec_traits_t<u8>::type);
+        case s4: return sizeof(prec_traits_t<s4>::type);
+        case u4: return sizeof(prec_traits_t<u4>::type);
+        case boolean: return sizeof(prec_traits_t<boolean>::type);
         case data_type::undef:
         default: assert(!"unknown data_type");
     }
@@ -142,7 +142,8 @@ inline T min_value(data_type_t data_type) {
     using namespace data_type;
 #define CASE(x) \
     case x: \
-        return static_cast<T>(nstl::numeric_limits<prec_traits<x>::type>::min())
+        return static_cast<T>( \
+                nstl::numeric_limits<prec_traits_t<x>::type>::min())
     switch (data_type) {
         CASE(f4_e3m0);
         CASE(f4_e2m1);
@@ -170,7 +171,8 @@ inline T max_value(data_type_t data_type) {
     using namespace data_type;
 #define CASE(x) \
     case x: \
-        return static_cast<T>(nstl::numeric_limits<prec_traits<x>::type>::max())
+        return static_cast<T>( \
+                nstl::numeric_limits<prec_traits_t<x>::type>::max())
     switch (data_type) {
         CASE(f4_e3m0);
         CASE(f4_e2m1);
@@ -200,7 +202,7 @@ inline float max_value(data_type_t data_type) {
 #define CASE(x) \
     case x: \
         return static_cast<float>( \
-                nstl::numeric_limits<prec_traits<x>::type>::max())
+                nstl::numeric_limits<prec_traits_t<x>::type>::max())
     switch (data_type) {
         CASE(f4_e3m0);
         CASE(f4_e2m1);
@@ -239,7 +241,7 @@ inline T lowest_value(data_type_t data_type) {
 #define CASE(x) \
     case x: \
         return static_cast<T>( \
-                nstl::numeric_limits<prec_traits<x>::type>::lowest())
+                nstl::numeric_limits<prec_traits_t<x>::type>::lowest())
     switch (data_type) {
         CASE(f4_e3m0);
         CASE(f4_e2m1);
@@ -268,7 +270,7 @@ inline T digits(data_type_t data_type) {
 #define CASE(x) \
     case x: \
         return static_cast<T>( \
-                nstl::numeric_limits<prec_traits<x>::type>::digits)
+                nstl::numeric_limits<prec_traits_t<x>::type>::digits)
     switch (data_type) {
         CASE(f4_e3m0);
         CASE(f4_e2m1);

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -104,7 +104,8 @@ namespace utils {
 
 /* SFINAE helper -- analogue to std::enable_if */
 template <bool expr, class T = void>
-struct enable_if {};
+struct enable_if {}; // NOLINT(readability-identifier-naming)
+
 template <class T>
 struct enable_if<true, T> {
     using type = T;
@@ -112,7 +113,7 @@ struct enable_if<true, T> {
 
 /* analogue std::conditional */
 template <bool, typename, typename>
-struct conditional {};
+struct conditional {}; // NOLINT(readability-identifier-naming)
 template <typename T, typename F>
 struct conditional<true, T, F> {
     using type = T;
@@ -149,7 +150,7 @@ struct conditional_v<false, U, t, f> {
 };
 
 template <typename T>
-struct remove_reference {
+struct remove_reference { // NOLINT(readability-identifier-naming)
     using type = T;
 };
 template <typename T>

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ template <bool expr, class T = void>
 struct enable_if {};
 template <class T>
 struct enable_if<true, T> {
-    typedef T type;
+    using type = T;
 };
 
 /* analogue std::conditional */
@@ -115,26 +115,26 @@ template <bool, typename, typename>
 struct conditional {};
 template <typename T, typename F>
 struct conditional<true, T, F> {
-    typedef T type;
+    using type = T;
 };
 template <typename T, typename F>
 struct conditional<false, T, F> {
-    typedef F type;
+    using type = F;
 };
 
 template <bool, typename, bool, typename, typename>
 struct conditional3 {};
 template <typename T, typename FT, typename FF>
 struct conditional3<true, T, false, FT, FF> {
-    typedef T type;
+    using type = T;
 };
 template <typename T, typename FT, typename FF>
 struct conditional3<false, T, true, FT, FF> {
-    typedef FT type;
+    using type = FT;
 };
 template <typename T, typename FT, typename FF>
 struct conditional3<false, T, false, FT, FF> {
-    typedef FF type;
+    using type = FF;
 };
 
 template <bool, typename U, U, U>
@@ -150,15 +150,15 @@ struct conditional_v<false, U, t, f> {
 
 template <typename T>
 struct remove_reference {
-    typedef T type;
+    using type = T;
 };
 template <typename T>
 struct remove_reference<T &> {
-    typedef T type;
+    using type = T;
 };
 template <typename T>
 struct remove_reference<T &&> {
-    typedef T type;
+    using type = T;
 };
 
 template <typename T>

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -52,17 +52,17 @@ namespace impl {
 
 #define DNNL_SHORT_CIRCUIT_SELF_ASSIGN(other) \
     do { \
-        if (this == &other) return *this; \
+        if (this == &(other)) return *this; \
     } while (0)
 
 #define DNNL_SHORT_CIRCUIT_SELF_COMPARISON(other) \
     do { \
-        if (this == &other) return true; \
+        if (this == &(other)) return true; \
     } while (0)
 
 #define DNNL_DISALLOW_COPY_AND_ASSIGN(T) \
     T(const T &) = delete; \
-    T &operator=(const T &) = delete;
+    void operator=(const T &) = delete;
 
 // Sanity check for 64 bits
 static_assert(sizeof(void *) == 8, "oneDNN supports 64-bit architectures only");

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -244,7 +244,7 @@ uint32_t get_verbose(verbose_t::flag_kind verbosity_kind,
             }
 
             // filter enabled and at least one component is hit
-            if (filter_status.components.length() != 0) {
+            if (!filter_status.components.empty()) {
                 // pop out the last comma
                 filter_status.components.pop_back();
                 filter_status.status = filter_status_t::flags::valid;

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -57,14 +57,14 @@ inline constexpr size_t get_file_name_offset(T (&str)[1]) {
     return 0;
 }
 template <typename T, T v>
-struct const_expr_value {
+struct const_expr_value_t {
     static constexpr const T value = v;
 };
 
 } // namespace utility
 
 #define UTILITY_CONST_EXPR_VALUE(exp) \
-    utility::const_expr_value<decltype(exp), exp>::value
+    utility::const_expr_value_t<decltype(exp), exp>::value
 
 #define __FILENAME__ (&__FILE__[utility::get_file_name_offset(__FILE__)])
 

--- a/src/common/z_magic.hpp
+++ b/src/common/z_magic.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
 #define PRAGMA_MACRO(x) PRAGMA_MACRo(x)
 #endif
 
-#define UNUSED(x) ((void)x)
+#define UNUSED(x) ((void)(x))
 #define MAYBE_UNUSED(x) UNUSED(x)
 
 #if defined(_WIN32) && !defined(__GNUC__)

--- a/src/cpu/aarch64/acl_depthwise_convolution.cpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.cpp
@@ -22,7 +22,7 @@ namespace cpu {
 namespace aarch64 {
 
 namespace {
-using data_t = prec_traits<data_type::f32>::type;
+using data_t = prec_traits_t<data_type::f32>::type;
 
 // Keys are anonymous. So deduce the type automagically.
 using conv_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);

--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
@@ -52,10 +52,10 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override;
 
-    using src_data_t = typename prec_traits<src_type>::type;
-    using wei_data_t = typename prec_traits<wei_type>::type;
-    using dst_data_t = typename prec_traits<dst_type>::type;
-    using bia_data_t = typename prec_traits<bia_type>::type;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
+    using bia_data_t = typename prec_traits_t<bia_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -25,7 +25,7 @@ namespace cpu {
 namespace aarch64 {
 
 namespace {
-using data_t = typename prec_traits<data_type::f32>::type;
+using data_t = typename prec_traits_t<data_type::f32>::type;
 
 // Keys are anonymous. So deduce the type automagically.
 using conv_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -20,7 +20,7 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
-using data_t = prec_traits<data_type::f32>::type;
+using data_t = prec_traits_t<data_type::f32>::type;
 
 status_t acl_wino_convolution_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -131,7 +131,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
 
     ~acl_wino_convolution_fwd_t() override = default;
 
-    using data_t = typename prec_traits<data_type::f32>::type;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);

--- a/src/cpu/aarch64/cpu_reducer.cpp
+++ b/src/cpu/aarch64/cpu_reducer.cpp
@@ -99,7 +99,7 @@ using namespace Xbyak_aarch64;
 
 template <impl::data_type_t data_type, cpu_isa_t isa>
 struct reducer_2d_driver_t : public jit_generator {
-    using data_t = typename prec_traits<data_type>::type;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     reducer_2d_driver_t(int n_src, size_t src_ld, size_t src_step,
             size_t dst_step, bool nullify_dst)
@@ -122,7 +122,7 @@ template <impl::data_type_t data_type, cpu_isa_t isa>
 struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type, isa> {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(reducer_2d_driver_f_s_32_t)
 
-    using data_t = typename prec_traits<data_type>::type;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     void operator()(
             data_t *dst, const data_t *srcs, size_t ny, size_t nx) override {
@@ -134,7 +134,7 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type, isa> {
 
     const int vlen = cpu_isa_traits<isa>::vlen;
     const int typesize
-            = sizeof(typename dnnl::impl::prec_traits<data_type>::type);
+            = sizeof(typename dnnl::impl::prec_traits_t<data_type>::type);
     XReg reg_dst = abi_param1;
     XReg reg_src = abi_param2;
     XReg reg_ny = abi_param3;

--- a/src/cpu/aarch64/cpu_reducer.hpp
+++ b/src/cpu/aarch64/cpu_reducer.hpp
@@ -169,7 +169,7 @@ struct reducer_2d_driver_t;
  */
 template <impl::data_type_t data_type, cpu_isa_t isa = sve_512>
 struct cpu_reducer_t {
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     struct conf_t {
         conf_t() = default;
@@ -249,7 +249,7 @@ private:
 
 template <impl::data_type_t data_type, cpu_isa_t isa = sve_512>
 struct cpu_reducer_2d_t {
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     struct conf_t {
         conf_t() = default;
@@ -334,7 +334,7 @@ private:
 /** simple 1d accumulator: y[:] += x[:] */
 template <impl::data_type_t data_type, cpu_isa_t isa = sve_512>
 struct cpu_accumulator_1d_t {
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     cpu_accumulator_1d_t();
     ~cpu_accumulator_1d_t();

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
@@ -812,8 +812,8 @@ status_t jit_sve_1x1_conv_kernel<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
         if (jcp.wei_tag != wei_tag) return status::unimplemented;
 
         //        jcp.fma_step = 1;
-        jcp.typesize_in = sizeof(prec_traits<data_type::f32>::type);
-        jcp.typesize_out = sizeof(prec_traits<data_type::f32>::type);
+        jcp.typesize_in = sizeof(prec_traits_t<data_type::f32>::type);
+        jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
     } else {
         // TODO: currently, only support fp32;
         return status::unimplemented;

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
@@ -315,9 +315,9 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
 
     jit_sve_1x1_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -470,9 +470,9 @@ struct jit_sve_1x1_convolution_bwd_data_t : public primitive_t {
 
     jit_sve_1x1_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -628,7 +628,7 @@ struct jit_sve_1x1_convolution_bwd_weights_t : public primitive_t {
 
     jit_sve_1x1_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
@@ -73,9 +73,9 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
     jit_sve_512_x8s8s32x_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<data_type::s8>::type wei_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<data_type::s8>::type wei_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/aarch64/jit_sve_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_convolution.hpp
@@ -70,9 +70,9 @@ struct jit_sve_convolution_fwd_t : public primitive_t {
 
     jit_sve_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -142,9 +142,9 @@ struct jit_sve_convolution_bwd_data_t : public primitive_t {
 
     jit_sve_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -229,9 +229,9 @@ struct jit_sve_convolution_bwd_weights_t : public primitive_t {
 
     jit_sve_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<diff_weights_type>::type diff_weights_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_convolution.hpp
@@ -76,10 +76,10 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
 
     jit_uni_dw_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits<src_type>::type data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
+    typedef typename prec_traits_t<src_type>::type data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -158,9 +158,9 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
 
     jit_uni_dw_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<diff_dst_type>::type wei_data_t;
+    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type wei_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -252,11 +252,11 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
 
     jit_uni_dw_convolution_bwd_weights_t(const pd_t *apd);
 
-    typedef typename prec_traits<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<src_type>::type diff_dst_data_t;
-    typedef typename prec_traits<diff_weights_type>::type diff_weights_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<src_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/aarch64/jit_uni_eltwise.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.hpp
@@ -50,7 +50,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
     jit_uni_eltwise_fwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_fwd_t();
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t init(engine_t *engine) override;
 
@@ -75,7 +75,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
     jit_uni_eltwise_bwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_bwd_t();
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.hpp
@@ -50,7 +50,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
     jit_uni_eltwise_int_fwd_t(const pd_t *apd);
     ~jit_uni_eltwise_int_fwd_t();
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
@@ -128,8 +128,8 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator {
     // thus we need to take into account ratio of sizes s32/i8 = 4
     static constexpr data_type_t avg_proc_dt = data_type::s32;
     enum : int {
-        s32_to_i8_ratio = sizeof(typename prec_traits<avg_proc_dt>::type)
-                / sizeof(typename prec_traits<data_type::u8>::type),
+        s32_to_i8_ratio = sizeof(typename prec_traits_t<avg_proc_dt>::type)
+                / sizeof(typename prec_traits_t<data_type::u8>::type),
         max_num_ll = s32_to_i8_ratio,
         mmx_msk_base_reg = 3
     };

--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -560,7 +560,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(const data_t *src,
     const auto post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(jpp.post_ops, ctx);
 
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
     using namespace jit_uni_pooling_utils;
 
     const auto transpose_facade
@@ -688,7 +688,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(const data_t *src,
     const auto post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(jpp.post_ops, ctx);
 
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
     using namespace jit_uni_pooling_utils;
     static constexpr int first_ithr = 0;
 
@@ -893,7 +893,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
         const exec_ctx_t &ctx) const {
 
     using namespace jit_uni_pooling_utils;
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
 
     const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
@@ -1018,7 +1018,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
 
     const auto &jpp = pd()->jpp_;
 
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
     using namespace jit_uni_pooling_utils;
     static constexpr int first_ithr = 0;
 

--- a/src/cpu/aarch64/jit_uni_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_pooling.hpp
@@ -82,7 +82,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
     jit_uni_pooling_fwd_t &operator=(jit_uni_pooling_fwd_t &&) = default;
     ~jit_uni_pooling_fwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 
@@ -151,7 +151,7 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
     jit_uni_pooling_bwd_t &operator=(jit_uni_pooling_bwd_t &&) = default;
     ~jit_uni_pooling_bwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -27,7 +27,7 @@ namespace matmul {
 using namespace data_type;
 
 namespace {
-using data_t = prec_traits<data_type::f32>::type;
+using data_t = prec_traits_t<data_type::f32>::type;
 } // namespace
 
 status_t acl_matmul_t::init(engine_t *engine) {

--- a/src/cpu/gemm_convolution.hpp
+++ b/src/cpu/gemm_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ struct gemm_convolution_fwd_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         bool is_nspc = pd()->jcp_.is_nspc;
@@ -170,7 +170,7 @@ struct gemm_convolution_bwd_data_t : public primitive_t {
 
     gemm_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         bool is_nspc = pd()->jcp_.is_nspc;
@@ -223,7 +223,7 @@ struct gemm_convolution_bwd_weights_t : public primitive_t {
 
     gemm_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         const bool is_nspc = pd()->jcp_.is_nspc;

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -57,7 +57,7 @@ template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
         data_type_t *col, dim_t od, int spatial_step, int spatial_block) {
     using data_t =
-            typename conditional<data_traits<data_type_t>::data_type == bf16,
+            typename conditional<data_traits_t<data_type_t>::data_type == bf16,
                     uint16_t, data_type_t>::type;
     const data_t *__restrict _im
             = reinterpret_cast<const data_t *__restrict>(im);
@@ -279,11 +279,12 @@ template <typename orig_im_dt, typename orig_col_dt>
 void im2col_dt_3d(const conv_gemm_conf_t &jcp, const void *__restrict _imtr,
         orig_col_dt *__restrict _col, dim_t od) {
     // For performance reasons, use uint16_t as a proxy for bfloat16_t
-    using im_dt = typename utils::conditional<data_traits<orig_im_dt>::data_type
-                    == bf16,
-            uint16_t, orig_im_dt>::type;
+    using im_dt =
+            typename utils::conditional<data_traits_t<orig_im_dt>::data_type
+                            == bf16,
+                    uint16_t, orig_im_dt>::type;
     using col_dt =
-            typename utils::conditional<data_traits<orig_col_dt>::data_type
+            typename utils::conditional<data_traits_t<orig_col_dt>::data_type
                             == bf16,
                     uint16_t, orig_col_dt>::type;
     const im_dt *__restrict imtr
@@ -416,7 +417,7 @@ void im2col(const conv_gemm_conf_t &jcp, const data_type_t *__restrict im,
         data_type_t *__restrict col, dim_t ss, dim_t sb, dim_t cs, dim_t cb) {
 
     using data_t =
-            typename utils::conditional<data_traits<data_type_t>::data_type
+            typename utils::conditional<data_traits_t<data_type_t>::data_type
                             == bf16,
                     uint16_t, data_type_t>::type;
     const data_t *__restrict _im
@@ -577,11 +578,12 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
         void *__restrict _imtr, orig_col_dt *__restrict _col, dim_t hs,
         dim_t hb, dim_t ws, dim_t wb) {
     // For performance reasons, use uint16_t as a proxy for bfloat16_t
-    using im_dt = typename utils::conditional<data_traits<orig_im_dt>::data_type
-                    == bf16,
-            uint16_t, orig_im_dt>::type;
+    using im_dt =
+            typename utils::conditional<data_traits_t<orig_im_dt>::data_type
+                            == bf16,
+                    uint16_t, orig_im_dt>::type;
     using col_dt =
-            typename utils::conditional<data_traits<orig_col_dt>::data_type
+            typename utils::conditional<data_traits_t<orig_col_dt>::data_type
                             == bf16,
                     uint16_t, orig_col_dt>::type;
     const im_dt *__restrict im = reinterpret_cast<const im_dt *__restrict>(_im);
@@ -720,9 +722,8 @@ template <typename orig_T>
 void col2im_dt(const conv_gemm_conf_t &jcp, const orig_T *__restrict _col,
         orig_T *__restrict _im) {
     // For performance reasons, use uint16_t as a proxy for bfloat16_t
-    using T =
-            typename utils::conditional<data_traits<orig_T>::data_type == bf16,
-                    uint16_t, orig_T>::type;
+    using T = typename utils::conditional<
+            data_traits_t<orig_T>::data_type == bf16, uint16_t, orig_T>::type;
     const T *__restrict col = reinterpret_cast<const T *__restrict>(_col);
     T *__restrict im = reinterpret_cast<T *__restrict>(_im);
 

--- a/src/cpu/gemm_inner_product.hpp
+++ b/src/cpu/gemm_inner_product.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ struct gemm_inner_product_fwd_t : public primitive_t {
         return pp_kernel_->create_kernel();
     }
 
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -163,7 +163,7 @@ struct gemm_inner_product_bwd_data_t : public primitive_t {
     };
 
     gemm_inner_product_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_data(ctx);
@@ -208,7 +208,7 @@ struct gemm_inner_product_bwd_weights_t : public primitive_t {
     };
 
     gemm_inner_product_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_weights(ctx);

--- a/src/cpu/gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution_utils.cpp
@@ -78,7 +78,7 @@ void ref_pp_ker_t<dst_data_t>::operator()(void *void_dst, const acc_data_t *acc,
 
     if (end <= start) return;
 
-    assert(data_traits<dst_data_t>::data_type == jcp_.dst_data_type);
+    assert(data_traits_t<dst_data_t>::data_type == jcp_.dst_data_type);
 
     const lldiv_t dv_start = std::div((long long)start, (long long)jcp_.oc);
     const lldiv_t dv_end = std::div((long long)(end - 1), (long long)jcp_.oc);

--- a/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ struct pp_ker_t {
             const convolution_pd_t *pd, const conv_gemm_conf_t &jcp);
     virtual ~pp_ker_t() = default;
 
-    typedef typename prec_traits<data_type::s32>::type acc_data_t;
+    typedef typename prec_traits_t<data_type::s32>::type acc_data_t;
 
     virtual void operator()(void *dst, const acc_data_t *acc, const char *bias,
             const float *scales, float dst_scale, float sum_scale,

--- a/src/cpu/matmul/gemm_bf16_matmul.hpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -90,10 +90,10 @@ struct gemm_bf16_matmul_t : public primitive_t {
     static constexpr data_type_t weights_type = data_type::bf16;
     static constexpr data_type_t acc_type = data_type::f32;
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<weights_type>::type weights_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
-    typedef typename prec_traits<acc_type>::type acc_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<weights_type>::type weights_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<acc_type>::type acc_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_ref(ctx);

--- a/src/cpu/matmul/gemm_f32_matmul.hpp
+++ b/src/cpu/matmul/gemm_f32_matmul.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -88,10 +88,10 @@ struct gemm_f32_matmul_t : public primitive_t {
     static constexpr data_type_t dst_type = data_type::f32;
     static constexpr data_type_t acc_type = data_type::f32;
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<weights_type>::type weights_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
-    typedef typename prec_traits<acc_type>::type acc_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<weights_type>::type weights_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<acc_type>::type acc_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_ref(ctx);

--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ status_t nchw_pooling_fwd_t<data_type::f32>::execute_forward(
                     + (size_t)OW * oh + (size_t)ow;
             if (ws_dt == data_type::u8) {
                 assert(0 <= value
-                        && value <= numeric_limits<typename prec_traits<
+                        && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
                 ws[ws_offset] = value;
             } else
@@ -272,7 +272,7 @@ status_t nchw_pooling_fwd_t<d_type>::execute_forward(
                     + (size_t)OW * oh + (size_t)ow;
             if (ws_dt == data_type::u8) {
                 assert(0 <= value
-                        && value <= numeric_limits<typename prec_traits<
+                        && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
                 ws[ws_offset] = value;
             } else

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ struct nchw_pooling_fwd_t : public primitive_t {
 
     nchw_pooling_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override {
         ref_post_ops_
@@ -209,7 +209,7 @@ struct nchw_pooling_bwd_t : public primitive_t {
     };
 
     nchw_pooling_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/ncsp_batch_normalization.hpp
+++ b/src/cpu/ncsp_batch_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ struct ncsp_batch_normalization_fwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
     typedef float acc_data_t;
 
     ncsp_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
@@ -209,7 +209,7 @@ struct ncsp_batch_normalization_bwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
     typedef float acc_data_t;
 
     ncsp_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -113,8 +113,8 @@ struct nhwc_pooling_fwd_t : public primitive_t {
 
     nhwc_pooling_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    using data_t = typename prec_traits<d_type>::type;
-    using ker_data_t = typename prec_traits<data_type::f32>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
+    using ker_data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
         ref_post_ops_
@@ -210,7 +210,7 @@ struct nhwc_pooling_bwd_t : public primitive_t {
     };
 
     nhwc_pooling_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/nspc_batch_normalization.hpp
+++ b/src/cpu/nspc_batch_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ struct nspc_batch_normalization_fwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
     typedef float acc_data_t;
 
     nspc_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
@@ -200,7 +200,7 @@ struct nspc_batch_normalization_bwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
     typedef float acc_data_t;
 
     nspc_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/cpu/ref_batch_normalization.hpp
+++ b/src/cpu/ref_batch_normalization.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ struct ref_batch_normalization_fwd_t : public primitive_t {
 
     ref_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -134,7 +134,7 @@ struct ref_batch_normalization_bwd_t : public primitive_t {
     };
 
     ref_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -293,7 +293,7 @@ dim_t get_weights_off(const memory_desc_wrapper &wei_d, bool with_groups,
 template <data_type_t wei_type>
 static void compute_src_zp_compensation(const exec_ctx_t &ctx,
         const int32_t *src_zero_point, const bool is_src_zp_common,
-        typename prec_traits<wei_type>::type *wei,
+        typename prec_traits_t<wei_type>::type *wei,
         const cpu_deconvolution_fwd_pd_t *pd) {
     using namespace memory_tracking::names;
 
@@ -340,7 +340,8 @@ template <data_type_t wei_type>
 static std::function<int32_t(
         const dim_t, const dim_t, const dim_t, const dim_t, const dim_t)>
 prepare_zp_pad_comp_ker(const dim_t ndims, const int32_t *src_zero_point,
-        const bool is_src_zp_common, typename prec_traits<wei_type>::type *wei,
+        const bool is_src_zp_common,
+        typename prec_traits_t<wei_type>::type *wei,
         const cpu_deconvolution_fwd_pd_t *deconv_pd) {
 
     const auto KH = deconv_pd->KH();
@@ -416,7 +417,7 @@ prepare_zp_pad_comp_ker(const dim_t ndims, const int32_t *src_zero_point,
 template <data_type_t wei_type>
 static status_t apply_src_zero_point(const exec_ctx_t &ctx,
         const cpu_deconvolution_fwd_pd_t *deconv_pd, float *conv_output) {
-    using wei_data_t = typename prec_traits<wei_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
     using namespace memory_tracking::names;
     using namespace data_type;
 
@@ -593,8 +594,8 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias(
 
 template <data_type_t dbia_type, data_type_t ddst_type>
 void ref_deconvolution_bwd_weights_t::compute_bwd_bias_ncdhw(
-        typename prec_traits<dbia_type>::type *diff_bias,
-        const typename prec_traits<ddst_type>::type *diff_dst) const {
+        typename prec_traits_t<dbia_type>::type *diff_bias,
+        const typename prec_traits_t<ddst_type>::type *diff_dst) const {
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
 
     const auto OC = pd()->OC();
@@ -616,8 +617,8 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_ncdhw(
 
 template <data_type_t dbia_type, data_type_t ddst_type>
 void ref_deconvolution_bwd_weights_t::compute_bwd_bias_ndhwc(
-        typename prec_traits<dbia_type>::type *diff_bias,
-        const typename prec_traits<ddst_type>::type *diff_dst) const {
+        typename prec_traits_t<dbia_type>::type *diff_bias,
+        const typename prec_traits_t<ddst_type>::type *diff_dst) const {
     const auto MB = pd()->MB();
     const auto SP = pd()->OW() * pd()->OH() * pd()->OD();
     const auto OC = pd()->OC();
@@ -631,14 +632,15 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_ndhwc(
                 db += diff_dst[offset];
             }
         }
-        diff_bias[oc] = static_cast<typename prec_traits<dbia_type>::type>(db);
+        diff_bias[oc]
+                = static_cast<typename prec_traits_t<dbia_type>::type>(db);
     });
 }
 
 template <data_type_t dbia_type, data_type_t ddst_type, dim_t blksize>
 void ref_deconvolution_bwd_weights_t::compute_bwd_bias_nCdhwXc(
-        typename prec_traits<dbia_type>::type *diff_bias,
-        const typename prec_traits<ddst_type>::type *diff_dst) const {
+        typename prec_traits_t<dbia_type>::type *diff_bias,
+        const typename prec_traits_t<ddst_type>::type *diff_dst) const {
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
 
     const auto OC = pd()->OC();
@@ -671,8 +673,8 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_nCdhwXc(
 template <data_type_t dbia_type, data_type_t ddst_type>
 void ref_deconvolution_bwd_weights_t::compute_bias(
         const exec_ctx_t &ctx) const {
-    using dbia_data_t = typename prec_traits<dbia_type>::type;
-    using ddst_data_t = typename prec_traits<ddst_type>::type;
+    using dbia_data_t = typename prec_traits_t<dbia_type>::type;
+    using ddst_data_t = typename prec_traits_t<ddst_type>::type;
 
     auto diff_bias = CTX_OUT_MEM(dbia_data_t *, DNNL_ARG_DIFF_BIAS);
     auto diff_dst = CTX_IN_MEM(const ddst_data_t *, DNNL_ARG_DIFF_DST);

--- a/src/cpu/ref_deconvolution.hpp
+++ b/src/cpu/ref_deconvolution.hpp
@@ -411,7 +411,7 @@ struct ref_deconvolution_bwd_data_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     ref_deconvolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
@@ -566,18 +566,18 @@ private:
 
     template <data_type_t dbia_type, data_type_t ddst_type>
     void compute_bwd_bias_ncdhw(
-            typename prec_traits<dbia_type>::type *diff_bias,
-            const typename prec_traits<ddst_type>::type *diff_dst) const;
+            typename prec_traits_t<dbia_type>::type *diff_bias,
+            const typename prec_traits_t<ddst_type>::type *diff_dst) const;
 
     template <data_type_t dbia_type, data_type_t ddst_type>
     void compute_bwd_bias_ndhwc(
-            typename prec_traits<dbia_type>::type *diff_bias,
-            const typename prec_traits<ddst_type>::type *diff_dst) const;
+            typename prec_traits_t<dbia_type>::type *diff_bias,
+            const typename prec_traits_t<ddst_type>::type *diff_dst) const;
 
     template <data_type_t dbia_type, data_type_t ddst_type, dim_t blksize>
     void compute_bwd_bias_nCdhwXc(
-            typename prec_traits<dbia_type>::type *diff_bias,
-            const typename prec_traits<ddst_type>::type *diff_dst) const;
+            typename prec_traits_t<dbia_type>::type *diff_bias,
+            const typename prec_traits_t<ddst_type>::type *diff_dst) const;
 
     template <data_type_t dbia_type, data_type_t ddst_type>
     void compute_bias(const exec_ctx_t &ctx) const;

--- a/src/cpu/ref_eltwise.hpp
+++ b/src/cpu/ref_eltwise.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ struct ref_eltwise_fwd_t : public primitive_t {
         return status::success;
     }
 
-    using data_t = typename prec_traits<data_type>::type;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         if (pd()->use_dense_)
@@ -172,7 +172,7 @@ struct ref_eltwise_bwd_t : public primitive_t {
     };
 
     ref_eltwise_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         if (pd()->use_dense_)

--- a/src/cpu/ref_io_helper.hpp
+++ b/src/cpu/ref_io_helper.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ inline int load_int_value(data_type_t dt, const void *ptr, dim_t idx) {
 #define CASE(dt) \
     case dt: \
         return static_cast<int>( \
-                reinterpret_cast<const typename prec_traits<dt>::type *>( \
+                reinterpret_cast<const typename prec_traits_t<dt>::type *>( \
                         ptr)[idx]);
 
     using namespace data_type;
@@ -67,7 +67,7 @@ inline float load_float_value(data_type_t dt, const void *ptr, dim_t idx) {
 #define CASE(dt) \
     case dt: \
         return static_cast<float>( \
-                reinterpret_cast<const typename prec_traits<dt>::type *>( \
+                reinterpret_cast<const typename prec_traits_t<dt>::type *>( \
                         ptr)[idx]);
 
     using namespace data_type;
@@ -116,7 +116,7 @@ inline void store_float_value(data_type_t dt, float val, void *ptr, dim_t idx) {
     assert(ptr);
 #define CASE(dt) \
     case dt: { \
-        using type_ = typename prec_traits<dt>::type; \
+        using type_ = typename prec_traits_t<dt>::type; \
         *(reinterpret_cast<type_ *>(ptr) + idx) \
                 = cpu::q10n::saturate_and_round<type_>(val); \
     } break;

--- a/src/cpu/ref_lrn.hpp
+++ b/src/cpu/ref_lrn.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ struct ref_lrn_fwd_t : public primitive_t {
     };
 
     ref_lrn_fwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         using namespace format_tag;
@@ -127,7 +127,7 @@ struct ref_lrn_bwd_t : public primitive_t {
     };
 
     ref_lrn_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         using namespace format_tag;

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ status_t ref_pooling_fwd_t<data_type, acc_type>::execute_forward(
             const auto off = get_offset(ws_d, mb, oc, od, oh, ow);
             if (ws_dt == data_type::u8) {
                 assert(0 <= value
-                        && value <= numeric_limits<typename prec_traits<
+                        && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
                 ws[off] = value;
             } else

--- a/src/cpu/ref_pooling.hpp
+++ b/src/cpu/ref_pooling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,8 +80,8 @@ struct ref_pooling_fwd_t : public primitive_t {
         return status::success;
     }
 
-    using data_t = typename prec_traits<data_type>::type;
-    using acc_data_t = typename prec_traits<acc_type>::type;
+    using data_t = typename prec_traits_t<data_type>::type;
+    using acc_data_t = typename prec_traits_t<acc_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);

--- a/src/cpu/ref_reduction.hpp
+++ b/src/cpu/ref_reduction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -75,9 +75,9 @@ struct ref_reduction_t : public primitive_t {
         return status::success;
     }
 
-    using src_t = typename prec_traits<src_type>::type;
-    using acc_t = typename prec_traits<acc_type>::type;
-    using dst_t = typename prec_traits<dst_type>::type;
+    using src_t = typename prec_traits_t<src_type>::type;
+    using acc_t = typename prec_traits_t<acc_type>::type;
+    using dst_t = typename prec_traits_t<dst_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_ref(ctx);

--- a/src/cpu/ref_resampling.cpp
+++ b/src/cpu/ref_resampling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ template <data_type_t type>
 load_fn_t create_load() {
     return [](const byte *base, dim_t offset) -> float {
         return static_cast<float>(
-                reinterpret_cast<const typename prec_traits<type>::type *>(
+                reinterpret_cast<const typename prec_traits_t<type>::type *>(
                         base)[offset]);
     };
 }
@@ -55,7 +55,7 @@ load_fn_t create_load<data_type::f32>() {
 }
 template <data_type_t type>
 store_fn_t create_store() {
-    using dst_t = typename prec_traits<type>::type;
+    using dst_t = typename prec_traits_t<type>::type;
     return [](const float val, byte *base, const dim_t offset) {
         *reinterpret_cast<dst_t *>(base + sizeof(dst_t) * offset)
                 = cpu::q10n::saturate_and_round<dst_t>(val);

--- a/src/cpu/ref_shuffle.cpp
+++ b/src/cpu/ref_shuffle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2023 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ template <int data_type_size>
 status_t ref_shuffle_t::execute_(const exec_ctx_t &ctx) const {
     using namespace prop_kind;
     using namespace utils;
-    using data_t = typename typesize_traits<data_type_size>::type;
+    using data_t = typename typesize_traits_t<data_type_size>::type;
 
     const memory_desc_wrapper src_d(
             pd()->is_fwd() ? pd()->src_md() : pd()->diff_src_md());

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -43,7 +43,7 @@ using bd = block_dim_t;
 using ib = inner_blk_t;
 
 template <impl::data_type_t type>
-using data_t = typename prec_traits<type>::type;
+using data_t = typename prec_traits_t<type>::type;
 
 template <impl::data_type_t type_i, impl::data_type_t type_o>
 using _qz_a1b0 = q10n::qz_a1b0<data_t<type_i>, data_t<type_o>>;
@@ -472,17 +472,18 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         constexpr int is_3d = utils::one_of(tag_o, gOIdhw4i16o4i, OIdhw4i16o4i,
                 gOIdhw2i8o4i, OIdhw2i8o4i, gOIdhw4o4i, OIdhw4o4i, OIdhw4i32o4i,
                 OIdhw4i64o4i);
-        constexpr dim_t icblksize = utils::one_of(tag_traits<tag_o>::inner_blks,
-                                            ib::_4a4b, ib::_4b4c)
+        constexpr dim_t icblksize
+                = utils::one_of(
+                          tag_traits_t<tag_o>::inner_blks, ib::_4a4b, ib::_4b4c)
                 ? 4
-                : utils::one_of(tag_traits<tag_o>::inner_blks, ib::_2c8b4c,
+                : utils::one_of(tag_traits_t<tag_o>::inner_blks, ib::_2c8b4c,
                           ib::_2b8a4b)
                 ? 8
                 : 16;
         constexpr dim_t ocblksize
-                = tag_traits<tag_o>::inner_blks == ib::_4b32a4b ? 32
-                : tag_traits<tag_o>::inner_blks == ib::_4b64a4b ? 64
-                                                                : icblksize;
+                = tag_traits_t<tag_o>::inner_blks == ib::_4b32a4b ? 32
+                : tag_traits_t<tag_o>::inner_blks == ib::_4b64a4b ? 64
+                                                                  : icblksize;
 
         const auto &plain_d = order_keep ? input_d : output_d;
         const auto &dims = input_d.dims();
@@ -536,7 +537,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                            int32_t *c, int32_t *zp, const float *s,
                            const float *d, const dim_t oc_block,
                            const dim_t ic_block) {
-#define index AB_or_BC_blk_off<tag_traits<tag_o>::inner_blks>
+#define index AB_or_BC_blk_off<tag_traits_t<tag_o>::inner_blks>
             for_(dim_t ic = 0; ic < ic_block; ++ic)
             for (dim_t oc = 0; oc < oc_block; ++oc) {
                 const auto plain_off
@@ -856,11 +857,11 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         constexpr dim_t oc_blksize = 16;
         constexpr dim_t ic_blksize
-                = utils::one_of(tag_traits<tag_o>::inner_blks, ib::_16b16a4b,
+                = utils::one_of(tag_traits_t<tag_o>::inner_blks, ib::_16b16a4b,
                           ib::_16c16b4c)
                 ? 64
-                : utils::one_of(
-                          tag_traits<tag_o>::inner_blks, ib::_16a4b, ib::_16b4c)
+                : utils::one_of(tag_traits_t<tag_o>::inner_blks, ib::_16a4b,
+                          ib::_16b4c)
                 ? 4
                 : 1;
         assert(ic_blksize != 1);
@@ -901,7 +902,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 const auto plain_off
                         = oc * plain_d.blocking_desc().strides[w_groups + 0]
                         + ic * plain_d.blocking_desc().strides[w_groups + 1];
-                auto index = AB_or_BC_blk_off<tag_traits<tag_o>::inner_blks>(
+                auto index = AB_or_BC_blk_off<tag_traits_t<tag_o>::inner_blks>(
                         oc, ic);
                 out[index] = q10n::qz_b0<data_t<type_i>, data_t<type_o>>()(
                         inp[plain_off], s[oc] * adj_scale * d[oc]);
@@ -1026,16 +1027,16 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         // 3D: batch_dim <-> a, d0 <-> b, d1 <-> c
         constexpr dim_t D0_blksize = 64;
         constexpr dim_t D1_blksize
-                = (utils::one_of(tag_traits<tag_o>::inner_blks, ib::_16a64b4a,
+                = (utils::one_of(tag_traits_t<tag_o>::inner_blks, ib::_16a64b4a,
                           ib::_16b64c4b))
                 ? 64
-                : (utils::one_of(tag_traits<tag_o>::inner_blks, ib::_16a48b4a,
+                : (utils::one_of(tag_traits_t<tag_o>::inner_blks, ib::_16a48b4a,
                           ib::_16b48c4b))
                 ? 48
-                : (utils::one_of(tag_traits<tag_o>::inner_blks, ib::_16a32b4a,
+                : (utils::one_of(tag_traits_t<tag_o>::inner_blks, ib::_16a32b4a,
                           ib::_16b32c4b))
                 ? 32
-                : (utils::one_of(tag_traits<tag_o>::inner_blks, ib::_16a16b4a,
+                : (utils::one_of(tag_traits_t<tag_o>::inner_blks, ib::_16a16b4a,
                           ib::_16b16c4b))
                 ? 16
                 : 1;
@@ -1074,7 +1075,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                             = d0 * plain_d.blocking_desc().strides[ndims - 2]
                             + d1 * plain_d.blocking_desc().strides[ndims - 1];
                     auto index
-                            = AB_or_BC_blk_off<tag_traits<tag_o>::inner_blks>(
+                            = AB_or_BC_blk_off<tag_traits_t<tag_o>::inner_blks>(
                                     d0, d1);
                     out[index] = q10n::qz_b0<data_t<type_i>, data_t<type_o>>()(
                             inp[plain_off], s[0] * adj_scale * d[0]);
@@ -1085,7 +1086,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 }
                 for (int d1 = d1_block; d1 < D1_blksize; ++d1) {
                     auto index
-                            = AB_or_BC_blk_off<tag_traits<tag_o>::inner_blks>(
+                            = AB_or_BC_blk_off<tag_traits_t<tag_o>::inner_blks>(
                                     d0, d1);
                     out[index] = q10n::qz_b0<data_t<type_i>, data_t<type_o>>()(
                             0, s[0] * adj_scale * d[0]);
@@ -1094,7 +1095,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
             for_(int d0 = d0_block; d0 < D0_blksize; ++d0)
             for (int d1 = 0; d1 < D1_blksize; ++d1) {
-                auto index = AB_or_BC_blk_off<tag_traits<tag_o>::inner_blks>(
+                auto index = AB_or_BC_blk_off<tag_traits_t<tag_o>::inner_blks>(
                         d0, d1);
                 out[index] = q10n::qz_b0<data_t<type_i>, data_t<type_o>>()(
                         0, s[0] * adj_scale * d[0]);
@@ -1591,7 +1592,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         constexpr int is_3d = utils::one_of(tag_i, nCdhw4c, nCdhw8c);
 
         constexpr dim_t blksize_i
-                = tag_traits<tag_i>::inner_blks == ib::_4b ? 4 : 8;
+                = tag_traits_t<tag_i>::inner_blks == ib::_4b ? 4 : 8;
         constexpr dim_t blksize_16 = 16;
 
         constexpr dim_t ic_mult = order_keep ? blksize_16 / blksize_i : 1;
@@ -1705,10 +1706,10 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 template <SIMPLE_REORDER_TEMPL_DECL>
 struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
-                && (tag_traits<tag_o>::block_dims == bd::_A
-                        || tag_traits<tag_o>::block_dims == bd::_B)
-                && tag_traits<tag_o>::ndims >= 3
-                && tag_traits<tag_o>::ndims <= 6>::type> {
+                && (tag_traits_t<tag_o>::block_dims == bd::_A
+                        || tag_traits_t<tag_o>::block_dims == bd::_B)
+                && tag_traits_t<tag_o>::ndims >= 3
+                && tag_traits_t<tag_o>::ndims <= 6>::type> {
     PLAIN_TO_BLOCKED_IS_APPLICABLE();
 
     GET_SCRATCHPAD_SIZE_ZERO();
@@ -1721,8 +1722,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         const dims_t &dims = input_d.dims();
         const dims_t &pdims = block_d.padded_dims();
 
-        const int ndims = tag_traits<tag_o>::ndims;
-        const int blk_idx = tag_traits<tag_o>::block_dims == bd::_A ? 0 : 1;
+        const int ndims = tag_traits_t<tag_o>::ndims;
+        const int blk_idx = tag_traits_t<tag_o>::block_dims == bd::_A ? 0 : 1;
 
         const dim_t H0 = dims[0];
         const dim_t H1 = dims[1];
@@ -1737,7 +1738,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         using namespace utils;
 
         dim_t blksize = -1;
-        switch (tag_traits<tag_o>::inner_blks) {
+        switch (tag_traits_t<tag_o>::inner_blks) {
             case ib::_4a:
             case ib::_4b: blksize = 4; break;
             case ib::_8a:
@@ -1856,14 +1857,14 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 template <SIMPLE_REORDER_TEMPL_DECL>
 struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
-                && (tag_traits<tag_o>::block_dims == bd::_AB
-                        || tag_traits<tag_o>::block_dims == bd::_BC)
-                && IMPLICATION(tag_traits<tag_o>::block_dims == bd::_AB,
-                        tag_traits<tag_o>::ndims >= 3
-                                && tag_traits<tag_o>::ndims <= 5)
-                && IMPLICATION(tag_traits<tag_o>::block_dims == bd::_BC,
-                        tag_traits<tag_o>::ndims >= 4
-                                && tag_traits<tag_o>::ndims <= 6)>::type> {
+                && (tag_traits_t<tag_o>::block_dims == bd::_AB
+                        || tag_traits_t<tag_o>::block_dims == bd::_BC)
+                && IMPLICATION(tag_traits_t<tag_o>::block_dims == bd::_AB,
+                        tag_traits_t<tag_o>::ndims >= 3
+                                && tag_traits_t<tag_o>::ndims <= 5)
+                && IMPLICATION(tag_traits_t<tag_o>::block_dims == bd::_BC,
+                        tag_traits_t<tag_o>::ndims >= 4
+                                && tag_traits_t<tag_o>::ndims <= 6)>::type> {
     PLAIN_TO_BLOCKED_IS_APPLICABLE();
 
     GET_SCRATCHPAD_SIZE_ZERO();
@@ -1876,9 +1877,10 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         const auto &pdims
                 = order_keep ? output_d.padded_dims() : input_d.padded_dims();
 
-        constexpr int ndims = tag_traits<tag_o>::ndims;
+        constexpr int ndims = tag_traits_t<tag_o>::ndims;
 
-        static constexpr bool with_g = tag_traits<tag_o>::block_dims == bd::_BC;
+        static constexpr bool with_g
+                = tag_traits_t<tag_o>::block_dims == bd::_BC;
         const dim_t G = with_g ? dims[0] : 1;
 
         const dim_t H0 = dims[0 + with_g];
@@ -1895,7 +1897,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         dim_t blksize_0 = -1;
         dim_t blksize_1 = -1;
-        switch (tag_traits<tag_o>::inner_blks) {
+        switch (tag_traits_t<tag_o>::inner_blks) {
             case ib::_4b4a:
             case ib::_4b4c:
             case ib::_4c4b:
@@ -1949,7 +1951,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                            const int block_h0, const int block_h1) {
-#define blk_off AB_or_BC_blk_off<tag_traits<tag_o>::inner_blks>
+#define blk_off AB_or_BC_blk_off<tag_traits_t<tag_o>::inner_blks>
             if (alpha == 1.0 && beta == 0.0) {
                 for (int h0 = 0; h0 < block_h0; ++h0) {
                     for (int h1 = 0; h1 < block_h1; ++h1) {

--- a/src/cpu/rnn/postgemm_dispatcher.hpp
+++ b/src/cpu/rnn/postgemm_dispatcher.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -52,14 +52,14 @@ template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t scratch_type, impl::data_type_t acc_type>
 struct rnn_postgemm_dispatcher {
 
-    typedef typename prec_traits<src_type>::type src_layer_t;
-    typedef typename prec_traits<src_type>::type src_iter_t;
-    typedef typename prec_traits<src_type>::type dst_layer_t;
-    typedef typename prec_traits<src_type>::type dst_iter_t;
-    typedef typename prec_traits<acc_type>::type gemm_acc_t;
-    typedef typename prec_traits<scratch_type>::type scratch_t;
-    typedef typename prec_traits<src_type>::type ht_t;
-    typedef typename prec_traits<src_type>::type gates_t;
+    typedef typename prec_traits_t<src_type>::type src_layer_t;
+    typedef typename prec_traits_t<src_type>::type src_iter_t;
+    typedef typename prec_traits_t<src_type>::type dst_layer_t;
+    typedef typename prec_traits_t<src_type>::type dst_iter_t;
+    typedef typename prec_traits_t<acc_type>::type gemm_acc_t;
+    typedef typename prec_traits_t<scratch_type>::type scratch_t;
+    typedef typename prec_traits_t<src_type>::type ht_t;
+    typedef typename prec_traits_t<src_type>::type gates_t;
 
     using class_name
             = rnn_postgemm_dispatcher<aprop, src_type, scratch_type, acc_type>;

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 * Copyright 2018-2024 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,16 +97,16 @@ struct _ref_rnn_common_t : public primitive_t {
             rnn_postgemm_bwd_t<src_type, scratch_type, acc_type>>::type;
 
     /* These types are defined for each element in the cell execution */
-    typedef typename prec_traits<src_type>::type src_layer_t;
-    typedef typename prec_traits<src_type>::type src_iter_t;
-    typedef typename prec_traits<src_type>::type dst_layer_t;
-    typedef typename prec_traits<src_type>::type dst_iter_t;
-    typedef typename prec_traits<weights_type>::type weights_t;
-    typedef typename prec_traits<src_type>::type gemm_data_t;
-    typedef typename prec_traits<acc_type>::type gemm_acc_t;
-    typedef typename prec_traits<scratch_type>::type scratch_t;
-    typedef typename prec_traits<src_type>::type ht_t;
-    typedef typename prec_traits<src_type>::type gates_t;
+    typedef typename prec_traits_t<src_type>::type src_layer_t;
+    typedef typename prec_traits_t<src_type>::type src_iter_t;
+    typedef typename prec_traits_t<src_type>::type dst_layer_t;
+    typedef typename prec_traits_t<src_type>::type dst_iter_t;
+    typedef typename prec_traits_t<weights_type>::type weights_t;
+    typedef typename prec_traits_t<src_type>::type gemm_data_t;
+    typedef typename prec_traits_t<acc_type>::type gemm_acc_t;
+    typedef typename prec_traits_t<scratch_type>::type scratch_t;
+    typedef typename prec_traits_t<src_type>::type ht_t;
+    typedef typename prec_traits_t<src_type>::type gates_t;
 
     using class_name
             = _ref_rnn_common_t<aprop, src_type, weights_type, acc_type>;

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -61,7 +61,7 @@ template <data_type_t type_i>
 static inline void quantize_igo(int8_t *scratch_quantized,
         const memory_desc_wrapper &src_d, const float *src, int mask,
         float *scales) {
-    typedef typename prec_traits<type_i>::type in_data_t;
+    typedef typename prec_traits_t<type_i>::type in_data_t;
 
     // TODO: trivial strides assumes here.
     //       Use proper strides where appropriate
@@ -87,7 +87,7 @@ template <data_type_t type_i>
 static inline void quantize_goi(int8_t *scratch_quantized,
         const memory_desc_wrapper &src_d, const float *src, int mask,
         float *scales) {
-    typedef typename prec_traits<type_i>::type in_data_t;
+    typedef typename prec_traits_t<type_i>::type in_data_t;
 
     // TODO: trivial strides assumes here.
     //       Use proper strides where appropriate
@@ -232,8 +232,8 @@ struct rnn_data_reorder_t : public primitive_t {
     rnn_data_reorder_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits<type_i>::type in_data_t;
-    typedef typename prec_traits<type_o>::type out_data_t;
+    typedef typename prec_traits_t<type_i>::type in_data_t;
+    typedef typename prec_traits_t<type_o>::type out_data_t;
 
     bool is_dense() const {
         const memory_desc_wrapper &input_d = pd()->src_md();
@@ -428,7 +428,7 @@ struct rnn_weights_reorder_s8_t : public primitive_t {
     rnn_weights_reorder_s8_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits<type_i>::type in_data_t;
+    typedef typename prec_traits_t<type_i>::type in_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         // TODO: trivial strides assumed here.
@@ -615,8 +615,8 @@ struct rnn_weights_reorder_t : public primitive_t {
     rnn_weights_reorder_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits<type_i>::type in_data_t;
-    typedef typename prec_traits<type_o>::type out_data_t;
+    typedef typename prec_traits_t<type_i>::type in_data_t;
+    typedef typename prec_traits_t<type_o>::type out_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         // TODO: trivial strides assumed here.
@@ -838,8 +838,8 @@ struct rnn_brgemm_weights_reorder_s8_t : public primitive_t {
     rnn_brgemm_weights_reorder_s8_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits<type_i>::type in_data_t;
-    typedef typename prec_traits<type_o>::type out_data_t;
+    typedef typename prec_traits_t<type_i>::type in_data_t;
+    typedef typename prec_traits_t<type_o>::type out_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         using namespace format_tag;

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -683,7 +683,7 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
     rnn.dst_iter_c_dt = dst_iter_c_d.is_zero() ? data_type::f32
                                                : dst_iter_c_d.data_type();
 
-    rnn.cell_dt = data_traits<typename T::src_layer_t>::data_type;
+    rnn.cell_dt = data_traits_t<typename T::src_layer_t>::data_type;
     switch (rd.direction) {
         case dnnl_unidirectional_left2right: rnn.exec_dir = l2r; break;
         case dnnl_unidirectional_right2left: rnn.exec_dir = r2l; break;

--- a/src/cpu/rv64/rvv_nchw_pooling.hpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.hpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 * Copyright 2023 KNS Group LLC (YADRO)
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +66,7 @@ struct riscv_nchw_pooling_fwd_t : public primitive_t {
 
     riscv_nchw_pooling_fwd_t(const pd_t *apd);
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);

--- a/src/cpu/simple_concat.hpp
+++ b/src/cpu/simple_concat.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ struct simple_concat_t : public primitive_t {
 
     status_t execute(const exec_ctx_t &ctx) const override;
 
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/simple_q10n.hpp
+++ b/src/cpu/simple_q10n.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ saturate(const acc_t &x) {
     acc_t v = x;
     acc_t lbound = (acc_t)nstl::numeric_limits<data_t>::lowest();
     // Pick up a modified version of max value when do f32 -> s32.
-    acc_t ubound = types::max_value<acc_t>(data_traits<data_t>::data_type);
+    acc_t ubound = types::max_value<acc_t>(data_traits_t<data_t>::data_type);
     if (v < lbound) v = lbound;
     if (v > ubound) v = ubound;
     return v;

--- a/src/cpu/simple_resampling.cpp
+++ b/src/cpu/simple_resampling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ template <data_type_t src_type, data_type_t dst_type>
 struct simple_resampling_kernel_t : public simple_resampling_base_t {
     simple_resampling_kernel_t(const resampling_pd_t *pd);
 
-    using src_data_t = typename prec_traits<src_type>::type;
-    using dst_data_t = typename prec_traits<dst_type>::type;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init() override;
     status_t execute(const exec_ctx_t &ctx) const override;

--- a/src/cpu/simple_sum.hpp
+++ b/src/cpu/simple_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -124,9 +124,9 @@ struct simple_sum_t : public primitive_t {
     status_t execute(const exec_ctx_t &ctx) const override;
 
     enum { max_num_arrs = 16 };
-    typedef typename prec_traits<src_data_type>::type src_data_t;
-    typedef typename prec_traits<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<src_data_type>::type src_data_t;
+    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2023 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ using namespace Xbyak;
 
 template <impl::data_type_t data_type>
 struct reducer_2d_driver_t : public jit_generator {
-    using data_t = typename prec_traits<data_type>::type;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     reducer_2d_driver_t(int n_src, size_t src_ld, size_t src_step,
             size_t dst_step, bool nullify_dst, const char *name)
@@ -122,7 +122,7 @@ template <impl::data_type_t data_type, cpu_isa_t isa>
 struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(reducer_2d_driver_f_s_32_t)
 
-    using data_t = typename prec_traits<data_type>::type;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     void operator()(
             data_t *dst, const data_t *srcs, size_t ny, size_t nx) override {
@@ -147,7 +147,7 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
 
     const int vlen = cpu_isa_traits<isa>::vlen;
     const int typesize
-            = sizeof(typename dnnl::impl::prec_traits<data_type>::type);
+            = sizeof(typename dnnl::impl::prec_traits_t<data_type>::type);
     Xbyak::Reg64 reg_dst = abi_param1;
     Xbyak::Reg64 reg_src = abi_param2;
     Xbyak::Reg64 reg_ny = abi_param3;

--- a/src/cpu/x64/cpu_reducer.hpp
+++ b/src/cpu/x64/cpu_reducer.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2020 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ struct reducer_2d_driver_t;
  */
 template <impl::data_type_t data_type>
 struct cpu_reducer_t {
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     struct conf_t {
         conf_t() = default;
@@ -248,7 +248,7 @@ private:
 
 template <impl::data_type_t data_type>
 struct cpu_reducer_2d_t {
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     struct conf_t {
         conf_t() = default;
@@ -333,7 +333,7 @@ private:
 /** simple 1d accumulator: y[:] += x[:] */
 template <impl::data_type_t data_type>
 struct cpu_accumulator_1d_t {
-    typedef typename prec_traits<data_type>::type data_t;
+    typedef typename prec_traits_t<data_type>::type data_t;
 
     cpu_accumulator_1d_t();
     ~cpu_accumulator_1d_t();

--- a/src/cpu/x64/gemm/gemm_driver.cpp
+++ b/src/cpu/x64/gemm/gemm_driver.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
         c_type *c_data, const dim_t ldc, const c_type *co,
         offset_type offsetc) {
 
-    constexpr bool is_int8 = data_traits<c_type>::data_type == data_type::s32;
+    constexpr bool is_int8 = data_traits_t<c_type>::data_type == data_type::s32;
 
     for (dim_t j = 0; j < n; ++j) {
         for (dim_t i = 0; i < m; ++i) {
@@ -254,7 +254,7 @@ static inline void *align(void *ptr, size_t alignment) {
 template <typename scale_t, typename mat_t>
 void scale_matrix(
         dim_t m, dim_t n, scale_t alpha, mat_t *__restrict p_mat, dim_t ld) {
-    if (data_traits<mat_t>::data_type == data_type::f32) {
+    if (data_traits_t<mat_t>::data_type == data_type::f32) {
         for (dim_t j = 0; j < n; j++) {
             for (dim_t i = 0; i < m; i++) {
                 p_mat[i + j * ld] = (mat_t)((scale_t)p_mat[i + j * ld] * alpha);
@@ -400,8 +400,8 @@ void gemm_kernel(dim_t m, dim_t n, const dim_t k, const float alpha,
     bool row_req = false;
 
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    constexpr bool is_f32 = data_traits<a_type>::data_type == data_type::f32;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    constexpr bool is_f32 = data_traits_t<a_type>::data_type == data_type::f32;
     bool is_int8_amx = is_int8 && mayiuse(avx512_core_amx) && __BUILD_GEMM_AMX;
 
     dim_t m_stk = col_offset_ws ? 1 : m;
@@ -547,8 +547,9 @@ static dnnl_status_t gemm_kernel_driver(int ithr, dim_t m, dim_t n, dim_t k,
     float alpha = arg->alpha;
 
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    constexpr bool is_bf16 = data_traits<a_type>::data_type == data_type::bf16;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    constexpr bool is_bf16
+            = data_traits_t<a_type>::data_type == data_type::bf16;
 
     bool is_int8_amx = is_int8 && mayiuse(avx512_core_amx) && __BUILD_GEMM_AMX;
     bool is_bf16_amx = is_bf16 && mayiuse(avx512_core_amx) && __BUILD_GEMM_AMX;
@@ -826,8 +827,9 @@ static dnnl_status_t kernel_driver_parallel_acopiedbcopy(int ithr, dim_t m,
     size_t b_buf_nelems = k * n_padd;
     size_t b_col_sum_nelems = n_padd;
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    constexpr bool is_bf16 = data_traits<a_type>::data_type == data_type::bf16;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    constexpr bool is_bf16
+            = data_traits_t<a_type>::data_type == data_type::bf16;
 
     bool is_int8_amx = is_int8 && mayiuse(avx512_core_amx) && __BUILD_GEMM_AMX;
     bool is_bf16_amx = is_bf16 && mayiuse(avx512_core_amx) && __BUILD_GEMM_AMX;
@@ -1050,7 +1052,7 @@ template <typename a_type, typename b_type, typename c_type>
 static inline bool nocopy_checker(
         int nthr, const gemm_info_t<a_type, b_type, c_type> *arg) {
 
-    if (data_traits<a_type>::data_type != data_type::f32) return false;
+    if (data_traits_t<a_type>::data_type != data_type::f32) return false;
 
     if (!(mayiuse(avx) && __BUILD_GEMM_AVX2)) return false;
 
@@ -1089,8 +1091,8 @@ static inline void set_thread_opts_nopack(int nthrs, int nthrs_spawn,
     static constexpr dim_t M2D_MIN = 384;
 
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    bool isSgemm = data_traits<a_type>::data_type == data_type::f32;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    bool isSgemm = data_traits_t<a_type>::data_type == data_type::f32;
 
     dim_t m = arg->m;
     dim_t n = arg->n;
@@ -1247,8 +1249,9 @@ static inline void set_thread_opts_pack(int nthrs,
         bool do_n_blocking = true) {
 
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    constexpr bool is_bf16 = data_traits<a_type>::data_type == data_type::bf16;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    constexpr bool is_bf16
+            = data_traits_t<a_type>::data_type == data_type::bf16;
 
     bool do_m_blocking_only = do_m_blocking && !do_n_blocking;
 
@@ -1362,8 +1365,9 @@ static inline int set_thread_opts(int nthrs, int nthrs_spawn,
     thread_info.thread_m = thread_info.thread_n = thread_info.thread_k = -1;
 
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    constexpr bool is_bf16 = data_traits<a_type>::data_type == data_type::bf16;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    constexpr bool is_bf16
+            = data_traits_t<a_type>::data_type == data_type::bf16;
 
     if (nocopy_checker(nthrs, arg)) {
         thread_info.copy = copy_type::no_copy;
@@ -1452,8 +1456,9 @@ static dnnl_status_t parallel_a_copy(const int ithr, const int nthrs,
     float alpha = arg->alpha;
 
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    constexpr bool is_bf16 = data_traits<a_type>::data_type == data_type::bf16;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    constexpr bool is_bf16
+            = data_traits_t<a_type>::data_type == data_type::bf16;
     bool is_int8_amx = is_int8 && mayiuse(avx512_core_amx) && __BUILD_GEMM_AMX;
     bool is_bf16_amx = is_bf16 && mayiuse(avx512_core_amx) && __BUILD_GEMM_AMX;
     bool is_amx = is_int8_amx || is_bf16_amx;
@@ -1608,7 +1613,7 @@ static inline void adjust_thread_count(dim_t m, dim_t n, dim_t k, int *nthrs) {
     auto veclen = get_vector_length<T>();
     const double fp_per_cycle = 2.0 * 2.0 * veclen;
 
-    const bool is_f32 = data_traits<T>::data_type == data_type::f32;
+    const bool is_f32 = data_traits_t<T>::data_type == data_type::f32;
 
     const bool is_avx512 = mayiuse(avx512_core) && __BUILD_GEMM_AVX512;
     const bool is_avx = mayiuse(avx) && __BUILD_GEMM_AVX2;
@@ -1729,8 +1734,9 @@ static dnnl_status_t gemm_threading_driver(
     auto is_a_packed = (arg->transa == packed);
     auto is_b_packed = (arg->transb == packed);
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
-    constexpr bool is_bf16 = data_traits<a_type>::data_type == data_type::bf16;
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
+    constexpr bool is_bf16
+            = data_traits_t<a_type>::data_type == data_type::bf16;
 
     if ((arg->m <= 0) || (arg->n <= 0)) return dnnl_success;
 
@@ -1971,7 +1977,7 @@ static dnnl_status_t gemm_threading_driver(
                         // This route is taken only if we realize we need no-copy
                         //  after launching the parallel section, due to less
                         //  threads being spawned than expected.
-                        assert(data_traits<a_type>::data_type
+                        assert(data_traits_t<a_type>::data_type
                                 == data_type::f32);
                         assert(arg->packing == pack_type::none);
 
@@ -2048,13 +2054,13 @@ dnnl_status_t gemm_driver(const char *transA, const char *transB,
         pack_type packing, gemm_pack_storage_t *pack_dst, bool measure_only) {
 
     constexpr bool is_int8 = utils::one_of(
-            data_traits<a_type>::data_type, data_type::s8, data_type::u8);
+            data_traits_t<a_type>::data_type, data_type::s8, data_type::u8);
     MAYBE_UNUSED(is_int8);
 
 #if __BUILD_GEMM_AVX512
     // gemm_driver supports bfloat16 gemm for Intel AVX512 and
     // Intel AVX512 BF16.
-    assert(IMPLICATION(data_traits<a_type>::data_type == data_type::bf16,
+    assert(IMPLICATION(data_traits_t<a_type>::data_type == data_type::bf16,
             mayiuse(avx512_core) && !force_nocopy));
 #endif
 
@@ -2067,8 +2073,8 @@ dnnl_status_t gemm_driver(const char *transA, const char *transB,
 #if __BUILD_GEMM_SSE41
     // gemm_driver supports sgemm for Intel AVX512, Intel AVX2, Intel AVX,
     // and Intel SSE4.1
-    assert(IMPLICATION(
-            data_traits<a_type>::data_type == data_type::f32, mayiuse(sse41)));
+    assert(IMPLICATION(data_traits_t<a_type>::data_type == data_type::f32,
+            mayiuse(sse41)));
 #endif
 
     // 8-bit integer gemm doesn't support nocopy kernels.

--- a/src/cpu/x64/gemm/gemm_pack.cpp
+++ b/src/cpu/x64/gemm/gemm_pack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -79,8 +79,8 @@ static inline CBLAS_OFFSET cblas_offset(const char *offset) {
 template <typename a_dt, typename b_dt>
 static inline bool use_reference_igemm(void) {
     constexpr bool is_s8u8 = true
-            && data_traits<a_dt>::data_type == data_type::s8
-            && data_traits<b_dt>::data_type == data_type::u8;
+            && data_traits_t<a_dt>::data_type == data_type::s8
+            && data_traits_t<b_dt>::data_type == data_type::u8;
     if (is_s8u8)
         return !mayiuse(sse41);
     else
@@ -241,8 +241,8 @@ dnnl_status_t gemm_x8x8s32_pack_get_size(const char *identifier,
 
 #if USE_MKL_PACKED_GEMM
     constexpr bool is_s8u8 = true
-            && data_traits<a_dt>::data_type == data_type::s8
-            && data_traits<b_dt>::data_type == data_type::u8;
+            && data_traits_t<a_dt>::data_type == data_type::s8
+            && data_traits_t<b_dt>::data_type == data_type::u8;
 
     if (is_s8u8) {
         *size = cblas_gemm_s8u8s32_pack_get_size(
@@ -356,8 +356,8 @@ dnnl_status_t gemm_x8x8s32_pack(const char *identifier, const char *transa,
 
 #if USE_MKL_PACKED_GEMM
     constexpr bool is_s8u8 = true
-            && data_traits<a_dt>::data_type == data_type::s8
-            && data_traits<b_dt>::data_type == data_type::u8;
+            && data_traits_t<a_dt>::data_type == data_type::s8
+            && data_traits_t<b_dt>::data_type == data_type::u8;
 
     if (is_s8u8) {
         auto cblas_id = cblas_identifier(identifier);
@@ -459,8 +459,8 @@ dnnl_status_t gemm_x8x8s32_compute(const char *transa, const char *transb,
 
 #if USE_MKL_PACKED_GEMM
     constexpr bool is_s8u8 = true
-            && data_traits<a_dt>::data_type == data_type::s8
-            && data_traits<b_dt>::data_type == data_type::u8;
+            && data_traits_t<a_dt>::data_type == data_type::s8
+            && data_traits_t<b_dt>::data_type == data_type::u8;
 
     if (is_s8u8) {
         if (utils::any_null(transa, transb, offsetc, M, N, K, alpha, A, lda, ao,

--- a/src/cpu/x64/gemm/gemm_utils.hpp
+++ b/src/cpu/x64/gemm/gemm_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ dnnl_status_t pack_no_copy(const T *src, dim_t ld_src, dim_t nrows, dim_t ncols,
     dim_t nrows_dst, ncols_dst;
     dim_t ld_dst, td_dst;
 
-    constexpr bool is_f32 = data_traits<T>::data_type == data_type::f32;
+    constexpr bool is_f32 = data_traits_t<T>::data_type == data_type::f32;
 
     if (!dst_pack->get_nocopy(0, trans_dst, ld_dst, td_dst))
         return dnnl_invalid_arguments;

--- a/src/cpu/x64/gemm/gemv_driver.cpp
+++ b/src/cpu/x64/gemm/gemv_driver.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ template <typename a_t>
 static inline int thread_checker(
         int nthr, const dim_t m, const dim_t n, int trans) {
     constexpr bool is_f32
-            = utils::one_of(data_traits<a_t>::data_type, data_type::f32);
+            = utils::one_of(data_traits_t<a_t>::data_type, data_type::f32);
 
     if (is_f32) {
         // Threshold based on performance measurement with warm and cold cache
@@ -317,7 +317,7 @@ template <typename T>
 static inline void part_1d(const dim_t m, const int ithr, const int nthr,
         T *addr, dim_t &off, dim_t &size) {
     constexpr bool is_f32
-            = utils::one_of(data_traits<T>::data_type, data_type::f32);
+            = utils::one_of(data_traits_t<T>::data_type, data_type::f32);
 
     if (ithr >= nthr) {
         size = 0;
@@ -397,9 +397,9 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
         const b_t *x, const dim_t incx, const float beta, c_t *y,
         const dim_t incy, const gemm_info_t<a_t, b_t, c_t> *arg) {
     constexpr bool is_f32
-            = utils::one_of(data_traits<a_t>::data_type, data_type::f32);
+            = utils::one_of(data_traits_t<a_t>::data_type, data_type::f32);
     constexpr bool is_bf16
-            = utils::one_of(data_traits<a_t>::data_type, data_type::bf16);
+            = utils::one_of(data_traits_t<a_t>::data_type, data_type::bf16);
 
     // Quick return if possible.
     if (m <= 0 || n <= 0) return;

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -95,10 +95,10 @@ struct gemm_bf16_convolution_fwd_t : public primitive_t {
     gemm_bf16_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd), pp_ker_(nullptr) {}
 
-    typedef typename prec_traits<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
 
     status_t init(engine_t *engine) override {
         const auto &post_ops = pd()->attr()->post_ops_;
@@ -274,10 +274,10 @@ struct gemm_bf16_convolution_bwd_data_t : public primitive_t {
 
     gemm_bf16_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits<diff_src_data_type>::type diff_src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<diff_src_data_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         const bool is_nspc = pd()->jcp_.is_nspc;
@@ -340,10 +340,10 @@ struct gemm_bf16_convolution_bwd_weights_t : public primitive_t {
     gemm_bf16_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd), acc_ker_(nullptr) {}
 
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<diff_wei_data_type>::type diff_wei_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<diff_wei_data_type>::type diff_wei_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(

--- a/src/cpu/x64/gemm_bf16_inner_product.hpp
+++ b/src/cpu/x64/gemm_bf16_inner_product.hpp
@@ -108,10 +108,10 @@ struct gemm_bf16_inner_product_fwd_t : public primitive_t {
 
     gemm_bf16_inner_product_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
 
     status_t init(engine_t *engine) override {
         const bool has_bias = pd()->with_bias();
@@ -204,10 +204,10 @@ struct gemm_bf16_inner_product_bwd_data_t : public primitive_t {
 
     gemm_bf16_inner_product_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits<diff_src_data_type>::type diff_src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<diff_src_data_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_data(ctx);
@@ -316,10 +316,10 @@ struct gemm_bf16_inner_product_bwd_weights_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<diff_wei_data_type>::type diff_wei_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<diff_wei_data_type>::type diff_wei_data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_weights(ctx);

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 * Copyright 2018 YANDEX LLC
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -733,8 +733,8 @@ status_t jit_avx2_1x1_conv_kernel_f32::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
     jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
 
-    jcp.typesize_in = sizeof(prec_traits<data_type::f32>::type);
-    jcp.typesize_out = sizeof(prec_traits<data_type::f32>::type);
+    jcp.typesize_in = sizeof(prec_traits_t<data_type::f32>::type);
+    jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
 
     const auto &post_ops = attr.post_ops_;
     const int dw_conv_ind = post_ops.find(primitive_kind::convolution);

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -337,7 +337,7 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         execute_forward(ctx);
@@ -441,7 +441,7 @@ struct jit_avx2_1x1_convolution_bwd_data_t : public primitive_t {
 
     jit_avx2_1x1_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -588,7 +588,7 @@ struct jit_avx2_1x1_convolution_bwd_weights_t : public primitive_t {
     jit_avx2_1x1_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ struct jit_avx2_convolution_fwd_t : public primitive_t {
 
     jit_avx2_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -197,7 +197,7 @@ struct jit_avx2_convolution_bwd_data_t : public primitive_t {
 
     jit_avx2_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(
@@ -320,7 +320,7 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
 
     jit_avx2_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -683,8 +683,8 @@ status_t jit_avx512_common_1x1_conv_kernel::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
     if (jcp.wei_tag != wei_tag) return status::unimplemented;
 
-    jcp.typesize_in = sizeof(prec_traits<data_type::f32>::type);
-    jcp.typesize_out = sizeof(prec_traits<data_type::f32>::type);
+    jcp.typesize_in = sizeof(prec_traits_t<data_type::f32>::type);
+    jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
 
     /* once all the formats are set, check the padding consistency */
     if (!is_data_layout_nxc) {

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -311,9 +311,9 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
     jit_avx512_common_1x1_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -440,9 +440,9 @@ struct jit_avx512_common_1x1_convolution_bwd_data_t : public primitive_t {
     jit_avx512_common_1x1_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -567,7 +567,7 @@ struct jit_avx512_common_1x1_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_common_1x1_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_common_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,9 +74,9 @@ struct jit_avx512_common_convolution_fwd_t : public primitive_t {
 
     jit_avx512_common_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -151,9 +151,9 @@ struct jit_avx512_common_convolution_bwd_data_t : public primitive_t {
     jit_avx512_common_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<wei_type>::type wei_data_t;
-    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<wei_type>::type wei_data_t;
+    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -241,9 +241,9 @@ struct jit_avx512_common_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_common_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<diff_weights_type>::type diff_weights_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -283,8 +283,8 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_core_amx_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1330,7 +1330,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel::init_conf(
         jcp.dst_dt = src_d.data_type();
     } else if (jcp.prop_kind == backward_weights) {
         jcp.typesize_in = types::data_type_size(src_d.data_type());
-        jcp.typesize_out = sizeof(prec_traits<data_type::f32>::type);
+        jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
         jcp.dst_dt = weights_d.data_type();
     }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -322,12 +322,12 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
     jit_avx512_core_bf16_1x1_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
     // Note: In case of fused depthwise convolution, the final output datatype
     // may not be dst_data_t.
-    typedef typename prec_traits<dst_type>::type dw_wei_data_t;
+    typedef typename prec_traits_t<dst_type>::type dw_wei_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -448,9 +448,9 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_data_t : public primitive_t {
     jit_avx512_core_bf16_1x1_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
-    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -576,10 +576,10 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_weights_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
 
-    typedef typename prec_traits<diff_weights_type>::type diff_wei_data_t;
+    typedef typename prec_traits_t<diff_weights_type>::type diff_wei_data_t;
 
 private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -83,8 +83,8 @@ struct jit_avx512_core_bf16_convolution_fwd_t : public primitive_t {
     jit_avx512_core_bf16_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -157,8 +157,8 @@ struct jit_avx512_core_bf16_convolution_bwd_data_t : public primitive_t {
     jit_avx512_core_bf16_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits<data_type::bf16>::type wei_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(
@@ -232,8 +232,8 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_core_bf16_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits<data_type::bf16>::type diff_dst_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -314,7 +314,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
 
     // Note: In case of fused depthwise convolution, the final output data type
     // after fusion may not be same as for dst.
-    typedef typename prec_traits<data_type::s32>::type acc_data_t;
+    typedef typename prec_traits_t<data_type::s32>::type acc_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -588,8 +588,8 @@ status_t jit_sse41_1x1_conv_kernel_f32::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.os = jcp.oh * jcp.ow;
     jcp.is = jcp.ih * jcp.iw;
 
-    jcp.typesize_in = sizeof(prec_traits<data_type::f32>::type);
-    jcp.typesize_out = sizeof(prec_traits<data_type::f32>::type);
+    jcp.typesize_in = sizeof(prec_traits_t<data_type::f32>::type);
+    jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
 
     const auto &post_ops = attr.post_ops_;
 

--- a/src/cpu/x64/jit_sse41_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -288,7 +288,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
 
     jit_sse41_1x1_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_sse41_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
 
     jit_sse41_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type data_t;
+    typedef typename prec_traits_t<data_type::f32>::type data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -81,10 +81,10 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
 
     jit_uni_dw_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits<src_type>::type data_t;
-    typedef typename prec_traits<dst_type>::type dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
+    typedef typename prec_traits_t<src_type>::type data_t;
+    typedef typename prec_traits_t<dst_type>::type dst_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -152,9 +152,9 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
 
     jit_uni_dw_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits<diff_src_type>::type diff_src_data_t;
-    typedef typename prec_traits<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits<diff_dst_type>::type wei_data_t;
+    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<diff_dst_type>::type wei_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -236,11 +236,11 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
     };
     jit_uni_dw_convolution_bwd_weights_t(const pd_t *apd);
 
-    typedef typename prec_traits<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits<src_type>::type src_data_t;
-    typedef typename prec_traits<src_type>::type diff_dst_data_t;
-    typedef typename prec_traits<diff_weights_type>::type diff_weights_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
+    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
+    typedef typename prec_traits_t<src_type>::type src_data_t;
+    typedef typename prec_traits_t<src_type>::type diff_dst_data_t;
+    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_uni_eltwise.hpp
+++ b/src/cpu/x64/jit_uni_eltwise.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2020 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
     jit_uni_eltwise_fwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_fwd_t();
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t init(engine_t *engine) override;
 
@@ -84,7 +84,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
     jit_uni_eltwise_bwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_bwd_t();
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
     jit_uni_eltwise_int_fwd_t(const pd_t *apd);
     ~jit_uni_eltwise_int_fwd_t();
 
-    typedef typename prec_traits<d_type>::type data_t;
+    typedef typename prec_traits_t<d_type>::type data_t;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -160,8 +160,8 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator {
     // thus we need to take into account ratio of sizes s32/i8 = 4
     static constexpr data_type_t avg_proc_dt = data_type::s32;
     enum : int {
-        s32_to_i8_ratio = sizeof(typename prec_traits<avg_proc_dt>::type)
-                / sizeof(typename prec_traits<data_type::u8>::type),
+        s32_to_i8_ratio = sizeof(typename prec_traits_t<avg_proc_dt>::type)
+                / sizeof(typename prec_traits_t<data_type::u8>::type),
         max_num_ll = s32_to_i8_ratio,
         mmx_msk_base_reg = 3
     };

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017 - 2024 Intel Corporation
+* Copyright 2017 - 2025 Intel Corporation
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
@@ -558,7 +558,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(const data_t *src,
     const auto post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(jpp.post_ops, ctx);
 
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
     using namespace jit_uni_pooling_utils;
 
     const auto transpose_facade
@@ -687,7 +687,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(const data_t *src,
     const auto post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(jpp.post_ops, ctx);
 
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
     using namespace jit_uni_pooling_utils;
     static constexpr int first_ithr = 0;
 
@@ -892,7 +892,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
         const exec_ctx_t &ctx) const {
 
     using namespace jit_uni_pooling_utils;
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
 
     const memory_desc_wrapper diff_src_d(pd()->diff_src_md());
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
@@ -1017,7 +1017,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
 
     const auto &jpp = pd()->jpp_;
 
-    using wsp_data_t = typename prec_traits<wsp_dt_>::type;
+    using wsp_data_t = typename prec_traits_t<wsp_dt_>::type;
     using namespace jit_uni_pooling_utils;
     static constexpr int first_ithr = 0;
 

--- a/src/cpu/x64/jit_uni_pooling.hpp
+++ b/src/cpu/x64/jit_uni_pooling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
     jit_uni_pooling_fwd_t &operator=(jit_uni_pooling_fwd_t &&) = default;
     ~jit_uni_pooling_fwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 
@@ -162,7 +162,7 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
     jit_uni_pooling_bwd_t &operator=(jit_uni_pooling_bwd_t &&) = default;
     ~jit_uni_pooling_bwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -369,7 +369,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
 
     // Note: In case of fused depthwise convolution, the final output data type
     // after fusion may not be same as for dst.
-    typedef typename prec_traits<data_type::s32>::type acc_data_t;
+    typedef typename prec_traits_t<data_type::s32>::type acc_data_t;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_uni_xf16_sum.hpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -322,9 +322,9 @@ struct jit_xf16_sum_t : public primitive_t {
 
     status_t execute(const exec_ctx_t &ctx) const override;
 
-    typedef typename prec_traits<src_data_type>::type src_data_t;
-    typedef typename prec_traits<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits<data_type::f32>::type acc_data_t;
+    typedef typename prec_traits_t<src_data_type>::type src_data_t;
+    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
+    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2022 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ struct jit_avx512_common_lrn_fwd_t : public primitive_t {
     jit_avx512_common_lrn_fwd_t(const pd_t *apd);
     ~jit_avx512_common_lrn_fwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override {
         return lrn_executor_->create_kernel();
@@ -93,7 +93,7 @@ struct jit_avx512_common_lrn_bwd_t : public primitive_t {
     jit_avx512_common_lrn_bwd_t(const pd_t *apd);
     ~jit_avx512_common_lrn_bwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override {
         return lrn_executor_->create_kernel();

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public:
     jit_avx512_common_lrn_kernel_bwd_t(float alpha, float beta, int local_size,
             const char *name = jit_name());
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     struct jit_args_bwd_t {
         jit_args_bwd_t();

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_blocked.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_blocked.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ template <data_type_t d_type>
 class jit_avx512_common_lrn_kernel_bwd_blocked_t
     : public jit_avx512_common_lrn_kernel_bwd_t<d_type> {
 public:
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     struct jit_args_bwd_t {
         const data_t *src, *diff_dst, *ws0, *ws1;

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public:
     jit_avx512_common_lrn_kernel_fwd_t(prop_kind_t prop_kind, float alpha,
             float beta, float k, int local_size, const char *name = jit_name());
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     struct jit_args_fwd_t {
         jit_args_fwd_t();

--- a/src/cpu/x64/lrn/jit_uni_lrn.hpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2021 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ struct jit_uni_lrn_fwd_t : public primitive_t {
     jit_uni_lrn_fwd_t(const pd_t *apd);
     ~jit_uni_lrn_fwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 
@@ -82,7 +82,7 @@ struct jit_uni_lrn_bwd_t : public primitive_t {
     jit_uni_lrn_bwd_t(const pd_t *apd);
     ~jit_uni_lrn_bwd_t();
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ jit_uni_lrn_kernel_t<Derived<isa, d_type>>::jit_uni_lrn_kernel_t(
     : jit_uni_lrn_kernel_t(name) {
     if (config.dat_tag == nhwc)
         single_pixel_offset_
-                = config.C * sizeof(typename prec_traits<d_type>::type);
+                = config.C * sizeof(typename prec_traits_t<d_type>::type);
 }
 
 template <template <cpu_isa_t isa, data_type_t d_type> class Derived,

--- a/src/cpu/x64/lrn/jit_uni_lrn_kernel.hpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ protected:
     const Xbyak::Reg64 reg_tmp_ = this->rsi;
     static constexpr size_t simd_w_ = cpu_isa_traits<isa>::vlen / sizeof(float);
     int single_pixel_offset_
-            = VECTOR_LENGTH * sizeof(typename prec_traits<d_type>::type);
+            = VECTOR_LENGTH * sizeof(typename prec_traits_t<d_type>::type);
 
     io::jit_io_multi_dt_helper_t<Vmm> io_;
 };

--- a/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public:
         }
     }
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t create_kernel() override {
         CHECK(ker_->create_kernel());
@@ -205,7 +205,7 @@ public:
         }
     }
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t create_kernel() override {
         CHECK(ker_->create_kernel());

--- a/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public:
         , H_(pd->H())
         , W_(pd->W()) {}
 
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t create_kernel() override { return ker_->create_kernel(); }
 
@@ -94,7 +94,7 @@ public:
         , C_(pd->C())
         , H_(pd->H())
         , W_(pd->W()) {}
-    using data_t = typename prec_traits<d_type>::type;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t create_kernel() override { return ker_->create_kernel(); }
 

--- a/src/gpu/intel/ocl/simple_sum.hpp
+++ b/src/gpu/intel/ocl/simple_sum.hpp
@@ -68,7 +68,7 @@ struct simple_sum_t : public gpu_primitive_t {
     status_t execute(const exec_ctx_t &ctx) const override;
 
     enum { max_num_arrs = 16 };
-    using data_t = typename prec_traits<data_type>::type;
+    using data_t = typename prec_traits_t<data_type>::type;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }


### PR DESCRIPTION
Partially addresses [13015](https://jira.devtools.intel.com/browse/MFDNN-13015) with some pre-work for #2648, the most common clang-tidy hits, and some other low-hanging fruit.