### PR TITLE
fixup: src: introduce quant_entry_t and refactor arg_scales_t to rely on it

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -44,8 +44,6 @@ if [[ "$OS" == "Linux" ]]; then
     SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-mqa-cpp"
     SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
     SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
-    # TODO: Issue: https://github.com/oneapi-src/oneDNN/issues/2572
-    SKIPPED_GRAPH_TEST_FAILURES+="|test_graph_unit_dnnl_convolution"
     SKIPPED_GRAPH_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_cpu"
 fi
 

--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -291,8 +291,9 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
 
     const auto &src_scales = attr->scales_.get(DNNL_ARG_SRC);
     const auto &wei_scales = attr->scales_.get(DNNL_ARG_WEIGHTS);
-    brg->with_scales = !src_scales.has_default_values()
-            || !wei_scales.has_default_values()
+    const bool has_src_scales = !src_scales.has_default_values();
+    const bool has_wei_scales = !wei_scales.has_default_values();
+    brg->with_scales = has_src_scales || has_wei_scales
             || brg->with_weights_scale_adjust;
     if (brg->with_scales) {
         // Note. the current version supports only two different output scale
@@ -310,9 +311,11 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
     }
 
     const auto &dst_scales = attr->scales_.get(DNNL_ARG_DST);
-    brg->with_dst_scales = !dst_scales.has_default_values();
-    const bool scales_ok = src_scales.get_mask() == 0
-            && dst_scales.get_mask() == 0
+    const bool has_dst_scales = !dst_scales.has_default_values();
+    brg->with_dst_scales = has_dst_scales;
+    const bool scales_ok
+            = IMPLICATION(has_src_scales, src_scales.get_mask() == 0)
+            && IMPLICATION(has_dst_scales, dst_scales.get_mask() == 0)
             && attr->scales_.has_default_values(
                     {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST});
     if (!scales_ok) return status::unimplemented;


### PR DESCRIPTION
This fixes #2572.
Patches aarch64 brgemm dispatching without scales involved.

@Ryo-not-rio, you probably may use this commit for your performance regression tracking. It's a dispatching issue, performance should increase significantly (or should have caught a major regression).