### PR TITLE
graph, benchdnn: several minor fixes for SDPA with mask

### DIFF
--- a/src/graph/backend/dnnl/dnnl_op_def.hpp
+++ b/src/graph/backend/dnnl/dnnl_op_def.hpp
@@ -783,6 +783,7 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_gen_index, 1,
                 .set_output(0, "output")
                 // Attributes inherited from front GenIndex ops
                 .set_attr(op_attr::axis, true, attribute_kind::i)
+                .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 // Analysis rules
                 .set_shape_inference_function(infer_identity_output_shape)
                 .SET_LAYOUT_PROPAGATOR(layout_propagator_for_gen_index)
@@ -1126,6 +1127,7 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_mask, 1,
                 // Attributes inherited from front gen_index ops
                 .set_attr(op_attr::axis_row, true, attribute_kind::i)
                 .set_attr(op_attr::axis_col, true, attribute_kind::i)
+                .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 // Analysis rules
                 .set_shape_inference_function(infer_identity_output_shape)
                 .SET_LAYOUT_PROPAGATOR(layout_propagator_for_mask)

--- a/src/graph/backend/dnnl/passes/constant_propagation.cpp
+++ b/src/graph/backend/dnnl/passes/constant_propagation.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022-2023 Intel Corporation
+ * Copyright 2022-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,18 +34,12 @@ namespace {
 bool has_scratchpad(const op_t *op) {
     // the following ops do not have scratchpad output by definition
     const static std::set<op_kind_t> no_scratchpad_ops {
-            op_kind::dnnl_constant_scales,
-            op_kind::dnnl_constant_zps,
-            op_kind::dnnl_add_zps,
-            op_kind::dnnl_sub_zps,
-            op_kind::dnnl_to_group,
-            op_kind::dnnl_from_group,
-            op_kind::dnnl_permute,
-            op_kind::dnnl_squeeze,
-            op_kind::dnnl_unsqueeze,
-            op_kind::dnnl_transpose,
-            op_kind::dnnl_reshape,
-    };
+            op_kind::dnnl_constant_scales, op_kind::dnnl_constant_zps,
+            op_kind::dnnl_add_zps, op_kind::dnnl_sub_zps,
+            op_kind::dnnl_to_group, op_kind::dnnl_from_group,
+            op_kind::dnnl_permute, op_kind::dnnl_squeeze,
+            op_kind::dnnl_unsqueeze, op_kind::dnnl_transpose,
+            op_kind::dnnl_reshape, op_kind::dnnl_gen_index, op_kind::dnnl_mask};
 
     // the following ops may have scratchpad output if output size > 1
     const static std::set<op_kind_t> may_have_scratchpad_ops {

--- a/src/graph/backend/dnnl/passes/lower.cpp
+++ b/src/graph/backend/dnnl/passes/lower.cpp
@@ -703,6 +703,13 @@ static status_t gen_index_handler(
         const std::shared_ptr<op_t> &op, subgraph_rewriter_t &rewriter) {
     auto new_op = std::make_shared<op_t>(op_kind::dnnl_gen_index);
     new_op->merge_attributes(op->get_attributes());
+    int64_t axis = new_op->get_attr<int64_t>(op_attr::axis);
+    const int64_t ndims = static_cast<int64_t>(
+            ltw(op->get_input_value(0)->get_logical_tensor()).ndims());
+    VCHECK_INVALID_ARGUMENT(axis >= -1 * ndims && axis < ndims,
+            "GenIndex axis should be in range [-ndims, ndims) but got %d",
+            static_cast<int>(axis));
+    if (axis < 0) { new_op->set_attr<int64_t>(op_attr::axis, axis + ndims); }
     rewriter.replace_op(op, new_op);
     return status::success;
 }

--- a/tests/benchdnn/graph/custom_driver.cpp
+++ b/tests/benchdnn/graph/custom_driver.cpp
@@ -69,8 +69,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
 int execute(const prb_t *prb, const args_t &args, res_t *res) {
     dnn_mem_t &dst = const_cast<dnn_mem_t &>(args.find(DNNL_ARG_DST));
-    size_t axis = prb->axis;
     auto ndims = dst.ndims();
+    const size_t axis = prb->axis < 0 ? (prb->axis + ndims) : prb->axis;
     auto dims = dst.dims();
     auto strides = dst.strides();
 

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -49,6 +49,7 @@
 --reset --op-attrs=34107656704:group_shape:1x1x1x32+34107654464:transpose_b:1 --in-shapes=0:1x32x32x128+1:1x32x32x4+2:1x32x32x4 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 --reset --op-attrs=34107656704:qtype:per_channel*axis:3 --in-shapes=1:32+2:1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 --reset --op-attrs=34107656704:group_shape:1x1x128x1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
+--reset --dt=f32,bf16,f16 --op-attrs=2:axis:-2+3:axis:-1 --in-shapes=0:1x32x128x64+1:1x32x128x64+11:1x32x128x64 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
 
 # Re-written int8 graphs
 --reset --in-shapes=5:4x16x32x256+4:4x16x256x33+0:4x16x33x256+1:4x1x1x33+3:4x1x32x33 --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -46,6 +46,7 @@
 --reset --dt=f32,bf16,f16 --in-shapes=0:32x16x128x64+1:32x16x128x64+5:32x16x128x128+8:32x16x128x64  --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --in-shapes=0:acbd+1:acbd+8:acbd  --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --in-shapes=3:384,3:384x384,3:1x16x384x384 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
+--reset --dt=f32,bf16,f16 --in-shapes=5:384,5:1x384 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
 --reset --op-attrs=34107656704:group_shape:1x1x1x32+34107654464:transpose_b:1 --in-shapes=0:1x32x32x128+1:1x32x32x4+2:1x32x32x4 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 --reset --op-attrs=34107656704:qtype:per_channel*axis:3 --in-shapes=1:32+2:1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 --reset --op-attrs=34107656704:group_shape:1x1x128x1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json

--- a/tests/benchdnn/inputs/graph/op/harness_bf16_all
+++ b/tests/benchdnn/inputs/graph/op/harness_bf16_all
@@ -148,6 +148,7 @@
 --reset --dt=bf16 --case=op/f32/static_transpose.json
 --reset --dt=bf16 --case=op/f32/genindex.json
 --reset --dt=bf16 --op-attrs=0:axis:2 --case=op/f32/genindex.json
+--reset --dt=bf16 --op-attrs=0:axis:-1 --case=op/f32/genindex.json
 --reset --dt=bf16 --op-attrs=0:axis:2 --in-shapes=0:1x16x32x32*acbd+1:1x16x32x32*acbd --case=op/f32/genindex.json
 --reset --dt=bf16 --case=op/f32/greaterequal.json
 --reset --dt=bf16 --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json

--- a/tests/benchdnn/inputs/graph/op/harness_f16_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f16_all
@@ -148,6 +148,7 @@
 --reset --dt=f16 --case=op/f32/static_transpose.json
 --reset --dt=f16 --case=op/f32/genindex.json
 --reset --dt=f16 --op-attrs=0:axis:2 --case=op/f32/genindex.json
+--reset --dt=f16 --op-attrs=0:axis:-1 --case=op/f32/genindex.json
 --reset --dt=f16 --op-attrs=0:axis:2 --in-shapes=0:1x16x32x32*acbd+1:1x16x32x32*acbd --case=op/f32/genindex.json
 --reset --dt=f16 --case=op/f32/greaterequal.json
 --reset --dt=f16 --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json

--- a/tests/benchdnn/inputs/graph/op/harness_f32_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f32_all
@@ -955,6 +955,7 @@
 --reset --case=op/f32/static_transpose.json
 --reset --case=op/f32/genindex.json
 --reset --op-attrs=0:axis:2 --case=op/f32/genindex.json
+--reset --op-attrs=0:axis:-1 --case=op/f32/genindex.json
 --reset --op-attrs=0:axis:2 --in-shapes=0:1x16x32x32*acbd+1:1x16x32x32*acbd --case=op/f32/genindex.json
 --reset --case=op/f32/greaterequal.json
 --reset --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json


### PR DESCRIPTION
# Description

This PR includes 3 minor fixes for SDPA with explicit or implicit mask:
[x] enhance check of axis in implicit causal mask to include negative axis (-1 & -2).
[x] support 1D / 2D mask for explicit causal mask (MFDNN-13164).
[x] add a internal attribute for internal op dnnl_gen_index for constant propagation (SET_ATTR_IS_CONSTANT)