### PR TITLE
xe: ocl: add inline load

### DIFF
--- a/src/gpu/intel/ocl/bnorm/ref_batch_normalization.cpp
+++ b/src/gpu/intel/ocl/bnorm/ref_batch_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ static void init_conf_common(bnorm_conf_t &conf, compute::dispatch_t &dispatch,
 static void init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
         const bnorm_conf_t &conf, const compute::dispatch_t &dispatch,
         const offsets_t &off) {
-    kernel_ctx.set_data_type(conf.data_type);
+    kernel_ctx.set_data_type(conf.data_type, false);
 
     kernel_ctx.define_int("NDIMS", conf.ndims);
     kernel_ctx.define_int("MB", conf.mb);

--- a/src/gpu/intel/ocl/bnorm/reusable_bnorm.cpp
+++ b/src/gpu/intel/ocl/bnorm/reusable_bnorm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -185,7 +185,7 @@ static status_t init_conf_common(reusable_bnorm_params_t &conf,
 
 static void init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
         const reusable_bnorm_params_t &conf) {
-    kernel_ctx.set_data_type(conf.data_type);
+    kernel_ctx.set_data_type(conf.data_type, false);
 
     kernel_ctx.define_int("WITH_RELU", conf.with_relu);
     if (conf.with_leaky_relu) kernel_ctx.define_int("WITH_LEAKY_RELU", 1);

--- a/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
+++ b/src/gpu/intel/ocl/gemm/gemm_with_post_ops.cl
@@ -53,8 +53,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
         if (A_SCALES || B_SCALES) acc *= a_scale * b_scale;
 
         if (bias) {
-            ACC_DATA_T b;
-            load(&b, bias + BIAS_OFF(d0, d1, d2, d3, 0, 0));
+            ACC_DATA_T b = load(b, bias + BIAS_OFF(d0, d1, d2, d3, 0, 0));
             acc += b;
         }
 
@@ -71,8 +70,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
                 POST_OP_DATA_T, d0, 1, d1, 1, d2, 1, d3, 1, 0, 1, 0, 1);
 
         if (C_SCALES) {
-            POST_OP_DATA_T c_scale = 1;
-            load(&c_scale, c_scales);
+            POST_OP_DATA_T c_scale = load(c_scale, c_scales);
             accumulator /= c_scale;
         }
         if (DST_ZERO_POINT) accumulator += dst_zp[0];

--- a/src/gpu/intel/ocl/ocl_io.h
+++ b/src/gpu/intel/ocl/ocl_io.h
@@ -95,6 +95,10 @@ DECLARE_AS_BLOCK(double)
         *dst = CONCAT2(into_, dst_dt)(*val); \
     } \
     dst_dt __attribute__((overloadable, warn_unused_result)) \
+            load(dst_dt dst, __global src_dt *val) { \
+        return CONCAT2(into_, dst_dt)(*val); \
+    } \
+    dst_dt __attribute__((overloadable, warn_unused_result)) \
             load(dst_dt dst, __global const src_dt *val) { \
         return CONCAT2(into_, dst_dt)(*val); \
     } \
@@ -166,7 +170,7 @@ DECLARE_AS_BLOCK(double)
 
 #define DEF_write(dst_dt, src_dt) \
     void __attribute__((overloadable)) \
-            write(__global dst_dt *dst, __private src_dt *val) { \
+            write(__global dst_dt *dst, __private const src_dt *val) { \
         *dst = CONCAT2(into_, dst_dt)(*val); \
     } \
     void __attribute__((overloadable)) \

--- a/src/gpu/intel/ocl/ref_eltwise.cpp
+++ b/src/gpu/intel/ocl/ref_eltwise.cpp
@@ -81,10 +81,11 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int(
             "USE_GWS_GET", conf.with_zero_padding || with_binary_post_ops);
 
-    def_memory_desc_info(kernel_ctx, conf.data_md_info, "DATA");
+    def_data_type(kernel_ctx, conf.data_md_info.data_type, "SRC", false);
+    def_memory_desc_info(kernel_ctx, conf.data_md_info, "DST", false);
 
     if (!conf.is_forward) {
-        def_memory_desc_info(kernel_ctx, conf.data_diff_md_info, "DIFF_DATA");
+        def_memory_desc_info(kernel_ctx, conf.data_diff_md_info, "DIFF", false);
     } else {
         kernel_ctx.define_int("IS_FWD", 1);
     }

--- a/src/gpu/intel/ocl/ref_lrn.hpp
+++ b/src/gpu/intel/ocl/ref_lrn.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ struct ref_lrn_fwd_t : public gpu_primitive_t {
         status_t status = status::success;
         const auto *desc = pd()->desc();
 
-        kernel_ctx.set_data_type(desc->src_desc.data_type);
+        kernel_ctx.set_data_type(desc->src_desc.data_type, false);
 
         kernel_ctx.define_int("IS_FWD", 1);
 
@@ -214,7 +214,7 @@ struct ref_lrn_bwd_t : public gpu_primitive_t {
         status_t status = status::success;
         const auto *desc = pd()->desc();
 
-        kernel_ctx.set_data_type(desc->src_desc.data_type);
+        kernel_ctx.set_data_type(desc->src_desc.data_type, false);
 
         kernel_ctx.define_int("IS_BWD", 1);
 

--- a/src/gpu/intel/ocl/reusable_lnorm.cl
+++ b/src/gpu/intel/ocl/reusable_lnorm.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,8 +27,7 @@ __kernel void lnorm_reusable_calc_mean(__global SRC_STAT_DT *src,
 
     ACC_DT sum = SPECIAL(ACC_DT, zero);
     for (off_t i = 0; i < reduce_size; i++) {
-        ACC_DT src_val;
-        load(&src_val, src + i * (off_t)reduce_stride);
+        ACC_DT src_val = load(src_val, src + i * (off_t)reduce_stride);
         sum += src_val;
     }
 
@@ -44,12 +43,10 @@ __kernel void lnorm_reusable_calc_var(__global SRC_STAT_DT *src,
     mean = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, mean);
     variance = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, variance);
 
-    float mean_val;
-    load(&mean_val, mean);
+    float mean_val = load(mean_val, mean);
     float sum = 0.0f;
     for (off_t i = 0; i < reduce_size; i++) {
-        ACC_DT src_val;
-        load(&src_val, src + i * (off_t)reduce_stride);
+        ACC_DT src_val = load(src_val, src + i * (off_t)reduce_stride);
         float v0 = src_val - mean_val;
         sum += v0 * v0;
     }
@@ -76,21 +73,18 @@ __kernel void lnorm_reusable_fwd(__global SRC_DT *src, __global float *mean,
     float sv = 0.0f;
     if (USE_SCALE) load(&sm, scale);
     if (USE_SHIFT) load(&sv, shift);
-    float src_val, var_val, mean_val;
-    load(&src_val, src);
-    load(&var_val, variance);
-    load(&mean_val, mean);
+    float src_val = load(src_val, src);
+    float var_val = load(var_val, variance);
+    float mean_val = load(mean_val, mean);
     float sqrt_variance = 1.0f / sqrt(var_val + eps);
     float res = sm * (src_val - mean_val) * sqrt_variance + sv;
 
     if (WITH_SRC_SCALES) {
-        float src_scale_val;
-        load(&src_scale_val, src_scale);
+        float src_scale_val = load(src_scale_val, src_scale);
         res *= src_scale_val;
     }
     if (WITH_DST_SCALES) {
-        float dst_scale_val;
-        load(&dst_scale_val, dst_scale);
+        float dst_scale_val = load(dst_scale_val, dst_scale);
         res /= dst_scale_val;
     }
 
@@ -116,14 +110,10 @@ __kernel void lnorm_reusable_bwd_scaleshift(__global SRC_SS_DT *src,
     float beta = 0.0f;
     for (int i = 0; i < stat_size; i++) {
         off_t off = i * stat_stride;
-        ACC_BWD_DT dst_val;
-        load(&dst_val, diff_dst + off);
-        ACC_DT src_val;
-        load(&src_val, src + off);
-
-        float mean_val, var_val;
-        load(&mean_val, mean + i);
-        load(&var_val, variance + i);
+        ACC_BWD_DT dst_val = load(dst_val, diff_dst + off);
+        ACC_DT src_val = load(src_val, src + off);
+        float mean_val = load(mean_val, mean + i);
+        float var_val = load(var_val, variance + i);
 
         beta += dst_val;
         gamma += dst_val * (src_val - mean_val) / sqrt(var_val + eps);
@@ -150,9 +140,8 @@ __kernel void lnorm_reusable_bwd(__global SRC_STAT_DT *src,
     mean = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, mean);
     variance = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, variance);
 
-    float mean_val, var_val;
-    load(&mean_val, mean);
-    load(&var_val, variance);
+    float mean_val = load(mean_val, mean);
+    float var_val = load(var_val, variance);
 
     float inv_var = rsqrt(var_val + eps);
 
@@ -162,10 +151,8 @@ __kernel void lnorm_reusable_bwd(__global SRC_STAT_DT *src,
     if (include_stats) {
         for (int i = 0; i < norm_size; i++) {
             off_t off = i * norm_stride;
-            ACC_BWD_DT dst_val;
-            load(&dst_val, diff_dst + off);
-            ACC_DT src_val;
-            load(&src_val, src + off);
+            ACC_BWD_DT dst_val = load(dst_val, diff_dst + off);
+            ACC_DT src_val = load(src_val, src + off);
             float scale_val = 1.0f;
             if (scale) load(&scale_val, scale + i);
 
@@ -179,10 +166,8 @@ __kernel void lnorm_reusable_bwd(__global SRC_STAT_DT *src,
     // Apply these stats to the entirety of the norm dim
     for (int i = 0; i < norm_size; i++) {
         off_t off = i * norm_stride;
-        ACC_BWD_DT dst_val;
-        load(&dst_val, diff_dst + off);
-        ACC_DT src_val;
-        load(&src_val, src + off);
+        ACC_BWD_DT dst_val = load(dst_val, diff_dst + off);
+        ACC_DT src_val = load(src_val, src + off);
         float scale_val = 1.0f;
         if (scale) load(&scale_val, scale + i);
 


### PR DESCRIPTION
Adds a new load function overload to remove the need for variable pre-declaration before loading. In addition, refactors a few reference kernels (ref_bnorm, ref_eltwise, ref_lrn) to use ocl_io.h to demonstrate the utility.
