### PR TITLE
gpu: amd: add support for rocm6.1

### DIFF
--- a/cmake/FindMIOpen.cmake
+++ b/cmake/FindMIOpen.cmake
@@ -34,6 +34,7 @@ list(APPEND EXTRA_SHARED_LIBS amd_comgr)
 
 # Prioritize MIOPENROOT
 list(APPEND miopen_root_hints
+            $ENV{ROCM_PATH}
             ${MIOPENROOT}
             $ENV{MIOPENROOT}
             "/opt/rocm"
@@ -67,6 +68,10 @@ if(EXISTS "${MIOpen_INCLUDE_DIR}/miopen/version.h")
     set(MIOpen_VERSION
         "${MIOpen_MAJOR_VERSION}.${MIOpen_MINOR_VERSION}.${MIOpen_PATCH_VERSION}"
     )
+
+    if(${MIOpen_MAJOR_VERSION} LESS 3)
+        add_definitions(-DMIOPEN_HAS_INT8X4=1)
+    endif()
 
     unset(MIOpen_VERSION_CONTENT)
 else()

--- a/cmake/FindrocBLAS.cmake
+++ b/cmake/FindrocBLAS.cmake
@@ -19,21 +19,23 @@ find_package(Threads REQUIRED)
 
 # Prioritize ROCBLASROOT
 list(APPEND rocblas_root_hints
+            $ENV{ROCM_PATH}
             ${ROCBLASROOT}
             $ENV{ROCBLASROOT}
             "/opt/rocm"
-            "/opt/rocm/rocblas")
+            "/opt/rocm/rocblas"
+            "/opt/rocm/lib")
 
 find_path(
     rocBLAS_INCLUDE_DIR "rocblas.h"
     HINTS ${rocblas_root_hints}
-    PATH_SUFFIXES include
+    PATH_SUFFIXES include include/rocblas
 )
 
 find_library(
     rocBLAS_LIBRARY rocblas
     HINTS ${rocblas_root_hints}
-    PATH_SUFFIXES lib
+    PATH_SUFFIXES lib lib/rocblas
 )
 
 if(EXISTS "${rocBLAS_INCLUDE_DIR}/internal/rocblas-version.h")

--- a/src/gpu/amd/README.md
+++ b/src/gpu/amd/README.md
@@ -3,14 +3,15 @@
 ## General information
 
 Support for AMD backend is implemented via SYCL HIP backend. The feature is
-disabled by default. Users must enable it at build time with a CMake option
-`DNNL_GPU_VENDOR=AMD`. The AMD GPUs can be used via oneDNN engine abstraction.
-The engine should be created using `dnnl::engine::kind::gpu` engine kind or the
-user can provide a `sycl::device` objects that corresponds to AMD GPUs.
+disabled by default and is currently experimental. You must enable it at the
+build time with a CMake option `DNNL_GPU_VENDOR=AMD`. The AMD GPUs can be used
+via oneDNN engine abstraction. The engine should be created using
+`dnnl::engine::kind::gpu` engine kind or you can provide `sycl::device` objects
+that correspond to AMD GPUs.
 
 ## Pre-requisites
 * [oneAPI DPC++ Compiler with support for HIP AMD](https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md#build-dpc-toolchain-with-support-for-hip-amd), version [2022-12](https://github.com/intel/llvm/releases/tag/2022-12)
-* [AMD ROCm](https://github.com/RadeonOpenCompute/ROCm), version 5.3 or newer
+* [AMD ROCm](https://github.com/RadeonOpenCompute/ROCm), version 5.3 or newer. The latest supported version currently is 6.1.
 * [MIOpen](https://github.com/ROCmSoftwarePlatform/MIOpen), version 2.18 or newer (optional if AMD ROCm includes the required version of MIOpen)
 * [rocBLAS](https://github.com/ROCmSoftwarePlatform/rocBLAS), version 2.45.0 or newer (optional if AMD ROCm includes the required version of rocBLAS)
 

--- a/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
+++ b/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
@@ -59,9 +59,11 @@ protected:
             case miopenInt8:
                 blas_dt = rocblas_datatype_i8_r;
                 return status::success;
+#if MIOPEN_HAS_INT8X4
             case miopenInt8x4:
                 blas_dt = rocblas_datatype_i8_r;
                 return status::success;
+#endif
             case miopenInt32:
                 blas_dt = rocblas_datatype_i32_r;
                 return status::success;


### PR DESCRIPTION
# Description

This PR enables compilation of oneDNN with rocm6.1 by updating the cmake configuration to find rocblas and miopen. Additionally, the `int8x4` datatype was removed in miopen version 3, so this PR adds a check for the miopen version and disables support for the `int8x4` datatype.