### PR TITLE
cpu: x64: conv: enable f32 with xf16 weights decompression support

### DIFF
--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -288,6 +288,22 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
+        {{backward_data, f32, bf16, f32}, REG_BWD_D_PK({
+            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core>)
+            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
+            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_t<avx2>)
+            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx2>)
+            CPU_INSTANCE(ref_convolution_bwd_data_t)
+            nullptr,
+        })},
+        {{backward_data, f32, f16, f32}, REG_BWD_D_PK({
+            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core>)
+            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
+            CPU_INSTANCE_AVX2(brgemm_convolution_bwd_t<avx2>)
+            CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx2>)
+            CPU_INSTANCE(ref_convolution_bwd_data_t)
+            nullptr,
+        })},
         {{backward_data, f32, bf16, bf16}, REG_BWD_D_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx>)

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -160,6 +160,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         }},
         {{forward, f32, f16, f32}, {
+            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2>)
@@ -168,6 +169,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         }},
         {{forward, f32, bf16, f32}, {
+            CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx512_core>)
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2>)

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -160,10 +160,18 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         }},
         {{forward, f32, f16, f32}, {
+            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx512_core>)
+            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx512_core>)
+            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2>)
+            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2>)
             CPU_INSTANCE(ref_convolution_fwd_t)
             nullptr,
         }},
         {{forward, f32, bf16, f32}, {
+            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx512_core>)
+            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx512_core>)
+            CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2>)
+            CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2>)
             CPU_INSTANCE(ref_convolution_fwd_t)
             nullptr,
         }},

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 * Copyright 2020-2025 Arm Ltd. and affiliates
 * Copyright 2020-2024 FUJITSU LIMITED
 *
@@ -157,6 +157,14 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(gemm_convolution_fwd_t)
             CPU_INSTANCE(ref_convolution_fwd_t)
             CPU_INSTANCE(ref_fused_convolution_fwd_t)
+            nullptr,
+        }},
+        {{forward, f32, f16, f32}, {
+            CPU_INSTANCE(ref_convolution_fwd_t)
+            nullptr,
+        }},
+        {{forward, f32, bf16, f32}, {
+            CPU_INSTANCE(ref_convolution_fwd_t)
             nullptr,
         }},
         {{forward, bf16, bf16, f32}, {

--- a/src/cpu/ref_convolution.hpp
+++ b/src/cpu/ref_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -57,7 +57,10 @@ struct ref_convolution_fwd_t : public primitive_t {
             VDISPATCH_CONV(
                     utils::one_of(src_type, f32, bf16, f16, f8_e5m2, f8_e4m3),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_CONV(src_type == wei_type, VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_CONV(IMPLICATION(src_type != wei_type,
+                                   utils::one_of(wei_type, f16, bf16)
+                                           && src_type == f32),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_CONV(utils::one_of(dst_type, src_type, f32),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_CONV(

--- a/src/cpu/ref_convolution.hpp
+++ b/src/cpu/ref_convolution.hpp
@@ -140,7 +140,10 @@ struct ref_convolution_bwd_data_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_CONV(utils::one_of(diff_dst_type, f32, bf16, f16),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_CONV(wei_type == diff_dst_type, VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_CONV(IMPLICATION(wei_type != diff_dst_type,
+                                   utils::one_of(wei_type, f16, bf16)
+                                           && diff_dst_type == f32),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_CONV(utils::one_of(diff_src_type, f32, diff_dst_type),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_CONV(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);

--- a/src/cpu/ref_deconvolution.hpp
+++ b/src/cpu/ref_deconvolution.hpp
@@ -372,7 +372,9 @@ struct ref_deconvolution_bwd_data_t : public primitive_t {
                     VERBOSE_BAD_PROPKIND);
             VDISPATCH_DECONVOLUTION(utils::one_of(wei_type, f32, bf16, f16),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_DECONVOLUTION(ddst_type == wei_type,
+            VDISPATCH_DECONVOLUTION(IMPLICATION(ddst_type != wei_type,
+                                            utils::one_of(wei_type, bf16, f16)
+                                                    && ddst_type == f32),
                     VERBOSE_INCONSISTENT_DT, "diff_dst", "weights");
             VDISPATCH_DECONVOLUTION(utils::one_of(dsrc_type, wei_type, f32),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -56,8 +56,9 @@ void init_kernel_datatype(
     // Note: f32:bf16 is treated as f32 case while f32:f16 has already been
     // treated as f16. Probably, need a common ground here.
     brg->is_f32 = (dt_a == data_type::f32)
-            && utils::one_of(dt_b, data_type::f32, data_type::bf16);
-    brg->is_f16 = utils::one_of(data_type::f16, dt_a, dt_b);
+            && utils::one_of(
+                    dt_b, data_type::f32, data_type::bf16, data_type::f16);
+    brg->is_f16 = utils::one_of(data_type::f16, dt_a, dt_b) && !brg->is_f32;
     brg->is_fp8 = one_of(dt_a, data_type::f8_e5m2, data_type::f8_e4m3)
             && one_of(dt_b, data_type::f8_e5m2, data_type::f8_e4m3);
     assert(brg->is_int8 || brg->is_bf16 || brg->is_f32 || brg->is_f16

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -726,9 +726,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_a(
             + is_tail_block * v_i * simd_w_ * brg.typesize_A];
     if (IMPLICATION(mask_flag, isa_has_masks(brg.isa_impl))) {
         vmma = maybe_mask(vmma, mask_flag, false);
-        if (brg.is_f32) {
+        if (brg.dt_a == data_type::f32) {
             vmovups(vmma, addr);
-        } else if (brg.is_bf16) {
+        } else if (brg.dt_a == data_type::bf16) {
             if (brg.isa_impl == avx2_vnni_2) {
                 if (is_tail_block) {
                     vpmovzxwd(vmma, addr);
@@ -741,7 +741,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_a(
                 vpmovzxwd(vmma, addr);
                 if (is_slow_bf16_vnni()) vpslld(vmma, vmma, 16);
             }
-        } else if (brg.is_f16) {
+        } else if (brg.dt_b == data_type::f16) {
             if (brg.isa_impl == avx2_vnni_2) {
                 if (is_tail_block)
                     vcvtph2ps(vmma, addr);
@@ -751,7 +751,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_a(
                     vcvtneoph2ps(vmma, addr);
             } else
                 vcvtph2ps(vmma, addr);
-        } else if (brg.is_int8) {
+        } else if (utils::one_of(brg.dt_a, data_type::s8, data_type::u8)) {
             if (is_fast_vnni_int8()) {
                 assert(!mask_flag);
                 vbroadcasti32x4(vmma, addr);
@@ -777,9 +777,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_b(
     const bool is_tail_block = has_n_tail && (n_i + 1 == n_blocks);
     const auto addr = ptr[reg_aux_B + B_offset(n_i)
             + is_tail_block * v_i * simd_w_ * brg.typesize_B];
-    if (brg.is_f32) {
+    if (brg.dt_b == data_type::f32) {
         vmovups(vmmb, addr);
-    } else if (brg.is_int8) {
+    } else if (brg.dt_b == data_type::s8) {
         if (wei_zp) { // load weights for zero-point computation
             vpmovsxbd(vmmb, addr);
             if (is_fast_vnni_int8()) vpermd(vmmb, vmm_permute(), vmmb);
@@ -792,7 +792,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_b(
                 vpmovsxbd(vmmb, addr);
             }
         }
-    } else if (brg.is_f16) {
+    } else if (brg.dt_b == data_type::f16) {
         if (brg.isa_impl == avx2_vnni_2) {
             if (is_tail_block)
                 vcvtph2ps(vmmb, addr);
@@ -802,7 +802,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_b(
                 vcvtneoph2ps(vmmb, addr);
         } else
             vcvtph2ps(vmmb, addr);
-    } else if (brg.is_bf16) {
+    } else if (brg.dt_b == data_type::bf16) {
         if (brg.isa_impl == avx2_vnni_2) {
             if (is_tail_block) {
                 vpmovzxwd(vmmb, addr);
@@ -813,7 +813,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_b(
                 vcvtneobf162ps(vmmb, addr);
         } else {
             vpmovzxwd(vmmb, addr);
-            if (is_slow_bf16_vnni()) vpslld(vmmb, vmmb, 16);
+            if (is_slow_bf16_vnni() || brg.is_f32) vpslld(vmmb, vmmb, 16);
         }
     }
 }

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -89,10 +89,10 @@ bool post_ops_ok(jit_brdgmm_conv_conf_t &jcp, const primitive_attr_t &attr,
                     broadcasting_strategy_t::no_broadcast}));
 }
 
-cpu_isa_t get_supported_isa(
-        bool is_f32, bool is_int8, bool is_bf16, bool is_f16) {
+cpu_isa_t get_supported_isa(bool is_f32, bool is_int8, bool is_bf16,
+        bool is_f16, bool is_f32_bf16, bool is_f32_f16) {
     std::vector<cpu_isa_t> isa_list;
-    if (is_f32) {
+    if (one_of(true, is_f32, is_f32_bf16, is_f32_f16)) {
         isa_list = {avx512_core, avx2};
     } else if (is_int8) {
         isa_list = {avx512_core_vnni, avx2_vnni_2, avx2_vnni};
@@ -125,7 +125,12 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
             && one_of(dst_type, bf16, f32);
     const bool is_f16 = everyone_is(f16, src_type, wei_type)
             && one_of(dst_type, f16, f32);
-    const cpu_isa_t isa = get_supported_isa(is_f32, is_int8, is_bf16, is_f16);
+    const bool is_f32_bf16
+            = everyone_is(f32, src_type, dst_type) && wei_type == bf16;
+    const bool is_f32_f16
+            = everyone_is(f32, src_type, dst_type) && wei_type == f16;
+    const cpu_isa_t isa = get_supported_isa(
+            is_f32, is_int8, is_bf16, is_f16, is_f32_bf16, is_f32_f16);
 
     auto skip_mask = skip_mask_t::post_ops;
     if (is_int8)
@@ -133,7 +138,8 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
                 | skip_mask_t::zero_points_runtime);
 
     VDISPATCH_CONV(is_fwd(), VERBOSE_BAD_PROPKIND);
-    VDISPATCH_CONV(one_of(true, is_f32, is_int8, is_bf16, is_f16),
+    VDISPATCH_CONV(one_of(true, is_f32, is_int8, is_bf16, is_f16, is_f32_f16,
+                           is_f32_bf16),
             VERBOSE_UNSUPPORTED_DT);
     VDISPATCH_CONV(
             IMPLICATION(is_int8,

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -796,6 +796,8 @@ struct jit_brgemm_conv_conf_t {
     bool is_bf32;
     bool is_fp8 {false};
     bool is_fp8_convert {false};
+    bool is_f32_f16 {false};
+    bool is_f32_bf16 {false};
     bool comp_with_vpads;
 
     int nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b, nthr_oh;

--- a/tests/benchdnn/inputs/conv/test_conv_bfloat16_nxc
+++ b/tests/benchdnn/inputs/conv/test_conv_bfloat16_nxc
@@ -5,14 +5,14 @@
 --skip-impl=ref
 --dir=FWD_B
 --dt=bf16:bf16:f32  --batch=shapes_resnet_50
---dt=bf16 --batch=set_conv_all
+--dt=bf16,f32:bf16:f32 --batch=set_conv_all
 
 --dir=FWD_D
 --dt=bf16 --batch=shapes_resnet_50
 
 --dir=BWD_D
 --dt=f32:bf16:bf16  --batch=shapes_resnet_50
---dt=bf16 --batch=set_conv_all
+--dt=bf16,f32:bf16:f32 --batch=set_conv_all
 
 --dir=BWD_WB
 --dt=bf16:f32:bf16 --batch=set_conv_all --batch=set_dilated-conv

--- a/tests/benchdnn/inputs/conv/test_conv_ci
+++ b/tests/benchdnn/inputs/conv/test_conv_ci
@@ -7,7 +7,7 @@
 --dir=FWD_B,FWD_D
 ### Direct
 --alg=direct
---dt=f32,bf16,f8_e5m2,f8_e4m3,f16
+--dt=f32,bf16,f8_e5m2,f8_e4m3,f16,f32:f16:f32,f32:bf16:f32
 --stag=any,axb
 --dtag=any,axb
 --attr-post-ops=, \

--- a/tests/benchdnn/inputs/conv/test_conv_float16_nxc
+++ b/tests/benchdnn/inputs/conv/test_conv_float16_nxc
@@ -5,14 +5,14 @@
 --skip-impl=ref
 --dir=FWD_B
 --dt=f16:f16:f32 --batch=shapes_resnet_50
---dt=f16 --batch=set_conv_all
+--dt=f16,f32:f16:f32 --batch=set_conv_all
 
 --dir=FWD_D
 --dt=f16 --batch=shapes_resnet_50
 
 --dir=BWD_D
 --dt=f32:f16:f16 --batch=shapes_resnet_50
---dt=f16 --batch=set_conv_all
+--dt=f16,f32:f16:f32 --batch=set_conv_all
 
 --dir=BWD_WB
 --dt=f16:f32:f16 --batch=set_conv_all --batch=set_dilated-conv

--- a/tests/benchdnn/inputs/deconv/test_deconv_bfloat16_nxc
+++ b/tests/benchdnn/inputs/deconv/test_deconv_bfloat16_nxc
@@ -13,8 +13,8 @@
 --attr-post-ops=
 --batch=set_all
 
---dt=bf16:bf16:f32 --dir=FWD_B --batch=set_all
---dt=f32:bf16:bf16 --dir=BWD_D --batch=set_all
+--dt=bf16:bf16:f32,f32:bf16:f32 --dir=FWD_B --batch=set_all
+--dt=f32:bf16:bf16,f32:bf16:f32 --dir=BWD_D --batch=set_all
 --dt=bf16:f32:bf16 --dir=BWD_WB --batch=set_all
 
 # Test Deconv w/bias through GeMM

--- a/tests/benchdnn/inputs/deconv/test_deconv_ci
+++ b/tests/benchdnn/inputs/deconv/test_deconv_ci
@@ -13,7 +13,7 @@
 --dt=f64
 --batch=shapes_ci
 
---dt=f32,bf16,f16
+--dt=f32,bf16,f16,f32:f16:f32,f32:bf16:f32
 --attr-post-ops=, \
                 sum:0.5, \
                 linear:2:1, \

--- a/tests/benchdnn/inputs/deconv/test_deconv_float16_nxc
+++ b/tests/benchdnn/inputs/deconv/test_deconv_float16_nxc
@@ -13,8 +13,8 @@
 --attr-post-ops=
 --batch=set_all
 
---dt=f16:f16:f32 --dir=FWD_B --batch=set_all
---dt=f32:f16:f16 --dir=BWD_D --batch=set_all
+--dt=f16:f16:f32,f32:f16:f32 --dir=FWD_B --batch=set_all
+--dt=f32:f16:f16,f32:f16:f32 --dir=BWD_D --batch=set_all
 --dt=f16:f32:f16 --dir=BWD_WB --batch=set_all
 
 # Test Deconv w/bias through GeMM


### PR DESCRIPTION
Fixes MFDNN-12960
This patch enables fp32 conv with bf16/f16 weights support(including fwd/bwd conv and deconv) on avx2 and avx512. 

Note: We do not expect that f32 with xf16 weights has better performance than fp32.
![image](https://github.com/user-attachments/assets/6bbbf614-f54b-48ce-a4a9-1e8384c7e971)
![image](https://github.com/user-attachments/assets/f2fb2aea-fd41-44c8-b7b1-12ee567fb490)
![image](https://github.com/user-attachments/assets/6724d1c4-bf48-4f7a-af84-dbf5e244a308)

[brgconv_f32_xf16_perf_v2.xlsx](https://github.com/user-attachments/files/18855501/brgconv_f32_xf16_perf_v2.xlsx)

