### PR TITLE
graph: enable build for nvidia gpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ if(POLICY CMP0148)
     cmake_policy(SET CMP0148 NEW)
 endif()
 
+# CMake 3.27: The FindCUDA module is removed.
+if(POLICY CMP0146)
+    cmake_policy(SET CMP0146 OLD)
+endif()
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
     message(STATUS "CMAKE_BUILD_TYPE is unset, defaulting to Release")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING

--- a/cmake/FindcublasLt.cmake
+++ b/cmake/FindcublasLt.cmake
@@ -1,5 +1,5 @@
 # ===============================================================================
-# Copyright 2020-2024 Intel Corporation 
+# Copyright 2020-2025 Intel Corporation 
 # Copyright 2020-2024 Codeplay Software Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -26,20 +26,20 @@ find_path(
 find_library(CUDA_DRIVER_LIBRARY cuda)
 
 find_library(
-  CUBLAS_LIBRARY cublasLt
+  CUBLASLT_LIBRARY cublasLt
   HINTS ${CUDA_TOOLKIT_ROOT_DIR}
   PATH_SUFFIXES lib lib64 bin)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  cublasLt REQUIRED_VARS CUBLASLT_INCLUDE_DIR CUDA_INCLUDE_DIRS CUBLAS_LIBRARY
+  cublasLt REQUIRED_VARS CUBLASLT_INCLUDE_DIR CUDA_INCLUDE_DIRS CUBLASLT_LIBRARY
                          CUDA_LIBRARIES CUDA_DRIVER_LIBRARY)
 
 if(NOT TARGET cublasLt::cublasLt)
   add_library(cublasLt::cublasLt SHARED IMPORTED)
   set_target_properties(
     cublasLt::cublasLt
-    PROPERTIES IMPORTED_LOCATION ${CUBLAS_LIBRARY}
+    PROPERTIES IMPORTED_LOCATION ${CUBLASLT_LIBRARY}
                INTERFACE_INCLUDE_DIRECTORIES
                "${CUBLASLT_INCLUDE_DIR};${CUDA_INCLUDE_DIRS}"
                INTERFACE_LINK_LIBRARIES

--- a/cmake/SYCL.cmake
+++ b/cmake/SYCL.cmake
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2019-2024 Intel Corporation
+# Copyright 2019-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ if(DNNL_SYCL_CUDA)
     adjust_headers_priority("cuBLAS::cuBLAS;cuDNN::cuDNN;cublasLt::cublasLt")
     add_definitions_with_host_compiler("-DCUDA_NO_HALF")
 
-    list(APPEND EXTRA_SHARED_LIBS cuBLAS::cuBLAS cuDNN::cuDNN)
+    list(APPEND EXTRA_SHARED_LIBS cuBLAS::cuBLAS cuDNN::cuDNN cublasLt::cublasLt)
     message(STATUS "DPC++ support is enabled (CUDA)")
 elseif(DNNL_SYCL_HIP)
     find_package(HIP REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,10 +153,10 @@ endif()
 if(ONEDNN_BUILD_GRAPH)
     message(STATUS "Graph component is enabled")
 
-    if (NOT DNNL_GPU_RUNTIME STREQUAL "NONE" AND NOT DNNL_GPU_VENDOR STREQUAL "INTEL")
+    if (NOT DNNL_GPU_RUNTIME STREQUAL "NONE" AND NOT DNNL_GPU_VENDOR STREQUAL "INTEL" AND NOT DNNL_GPU_VENDOR STREQUAL "NVIDIA")
         message(FATAL_ERROR "Graph API does not support ${DNNL_GPU_VENDOR} GPU. "
             "Either disable Graph API with ONEDNN_BUILD_GRAPH=OFF or change GPU "
-            "vendor to INTEL with ONEDNN_GPU_VENDOR=INTEL.")
+            "vendor to INTEL or NVIDIA.")
     endif()
 
     if (NOT DNNL_ENABLE_PRIMITIVE STREQUAL "ALL")

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -45,6 +45,10 @@ status_t sdp_primitive_kernel_t<quantized>::compile_impl(
         const dnnl_partition_impl_t *part, const engine_t *g_engine,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
+// sdp_primitive_kernel_t only supports Intel GPU.
+#if defined(DNNL_WITH_SYCL) && DNNL_GPU_VENDOR != DNNL_VENDOR_INTEL
+    return status::unimplemented;
+#endif
     p_engine_ = make_dnnl_engine(*g_engine);
     g_alloc_
             = reinterpret_cast<graph::allocator_t *>(g_engine->get_allocator());
@@ -235,7 +239,10 @@ status_t sdp_primitive_kernel_t<quantized>::sycl_execute_impl(
         const std::vector<tensor_t> &outputs,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
-
+// sdp_primitive_kernel_t only supports Intel GPU.
+#if DNNL_GPU_VENDOR != DNNL_VENDOR_INTEL
+    return status::unimplemented;
+#endif
     dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
 
     thread_local_cache_t<execution_args_set_t> res_cache;


### PR DESCRIPTION
1. Relax the gpu vendor limitation for nv gpu. amd gpu is still disabled as I don't have any machine to test it.
2. Fix a minor issue in finding and linking cublasLt.
3. Limit the ukernel based sdpa on intel gpu.

TODO:
- Still see failing cases due to some primitive fusions are not supported on nv gpu. We will need to define fusion patterns for different vendors in a follow-up PR.

With this PR, a matmul test on nv gpu as follows:

```
$ ONEDNN_VERBOSE=1 ./tests/benchdnn/benchdnn --graph --engine=gpu --case=op/f32/matmul_2d_4d.json
onednn_verbose,v1,info,oneDNN v3.8.0 (commit 6c99c4e24a4f915aa71b5a7325eb494d758a7e25)
onednn_verbose,v1,info,cpu,runtime:DPC++,nthr:48
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with Intel DL Boost
onednn_verbose,v1,info,gpu,runtime:DPC++
onednn_verbose,v1,info,cpu,engine,sycl cpu device count:1
onednn_verbose,v1,info,cpu,engine,0,backend:OpenCL,name:Intel(R) Xeon(R) Silver 4310 CPU @ 2.10GHz,driver_version:2024.18.10
onednn_verbose,v1,info,gpu,engine,sycl gpu device count:1
onednn_verbose,v1,info,gpu,engine,0,backend:Nvidia,name:NVIDIA A100 80GB PCIe,driver_version:0.0.0
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,1x1x384x1024,0.498047
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,4x8x32x384,0.115967
onednn_verbose,v1,primitive,exec,gpu,matmul,dpcpp:ref:any,undef,src:f32::blocked:abcd::f0 wei:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,4x8x32x384:1x1x384x1024,50.365
onednn_verbose,v1,primitive,exec,gpu,matmul,cuda:cudnn:any,undef,src:f32::blocked:ab::f0 wei:f32:a:blocked:ab::f0 dst:f32::blocked:ab::f0,attr-scratchpad:user,,1024x384:384x1024,4.64697
onednn_verbose,v1,graph,exec,gpu,100002,matmul_post_ops,MATMUL_0,,in0_f32:0:strided:undef:4x8x32x384:98304s12288s384s1 in1_f32:1:strided:constant:384x1024:1024s1 out0_f32:2:strided:undef:4x8x32x1024:262144s32768s1024s1,fpm:strict,matmul_t,dnnl_backend,5.08789
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,4x8x32x1024,0.726074
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,4x8x32x1024,0.293945
0:PASSED __REPRO: --graph --engine=gpu --case=op/f32/matmul_2d_4d.json
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.46s; fill: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```