### PR TITLE
gpu: generic: Fix dropout tests

### DIFF
--- a/src/gpu/generic/sycl/matmul_kernels.hpp
+++ b/src/gpu/generic/sycl/matmul_kernels.hpp
@@ -286,14 +286,14 @@ struct matmul_kernel_fwd_t {
             }
         }
 
-        void dropout(xpu::sycl::out_memory_arg_t dropout_mask, int threshold,
-                int seed, int inv_q, int offset, int row_stride) {
+        void dropout(xpu::sycl::out_memory_arg_t dropout_mask, uint threshold,
+                uint seed, float inv_q, int offset, int row_stride) {
             for (int row = 0; row < Rows; row++) {
                 for (int col = 0; col < Cols / vec_len; col++) {
                     for (int vec_el = 0; vec_el < vec_len; vec_el++) {
                         int dst_off = offset + row * row_stride + col * vec_len
                                 + vec_el;
-                        int random
+                        uint random
                                 = ::dnnl::impl::math::philox4x32(dst_off, seed);
                         char dropout = random > threshold;
                         data[row][col][vec_el]


### PR DESCRIPTION
# Description

The signature of dropout function doesn't respect arguments type it receives. Due to implicit casting, it doesn't appear as an issue but adding dropout to matmul would make it fails.
This patch fixes the issue.

To reproduce, run the following command on main:
`./tests/benchdnn/benchdnn --mode-modifier=P --matmul --engine=gpu  --dt=bf16:bf16:bf16 --stag=ab --dtag=ab --attr-dropout=0.5:12345678 100x1:1x1 `


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
