### PR TITLE
xehpg: jit: gemm: fix walk order calculations for copy-based gemm

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -178,6 +178,9 @@ status_t gen_gemm_kernel_desc_t::finalize(const char *tags) {
     if (strategy_.barrierFreq > 0 && k_ >= 0 && k_ < 2 * strategy_.barrierFreq)
         strategy_.barrierFreq = 0;
 
+    // Correct GRF count in following calculations for fixed systolic kernels.
+    if (strategy_.fixedSystolic) strategy_.GRFs = 256;
+
     // Disable linear ordering and persistent threads if the GEMM doesn't fill the GPU.
     if (m_ >= 0 && n_ >= 0 && eu_count_ >= 0) {
         int wg_tile_m = strategy_.wg[LoopM] * strategy_.unroll[LoopM];


### PR DESCRIPTION
Addresses MFDNN-13083 -- regressions on XeHPG for certain sizes of copy-based systolic GEMMs due to d06bde39 improperly moving from boustrophedon to scanline walk order.

The copy-based systolic GEMMs use special hard-coded inner loops and implicitly use 256-GRF mode. When deciding whether we can get by with scanline walk order, we need to know the GRF mode in order to check how many thread groups can run concurrently on the GPU. The GRF mode will be adjusted by `GEMMStrategy::preflight` but this has not been called yet, so this PR manually adjusts GRF mode in the strategy.