### PR TITLE
additional fp64 checks for generic reorder

### DIFF
--- a/src/gpu/intel/ocl/generic_reorder.hpp
+++ b/src/gpu/intel/ocl/generic_reorder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,6 +73,12 @@ struct generic_reorder_t : public gpu_primitive_t {
                                     && compute_engine->mayiuse(
                                             compute::device_ext_t::
                                                     intel_subgroups_short)),
+                    VERBOSE_UNSUPPORTED_DT_CFG);
+            VDISPATCH_REORDER(IMPLICATION(utils::one_of(data_type::f64,
+                                                  src_md()->data_type,
+                                                  dst_md()->data_type),
+                                      compute_engine->mayiuse(
+                                              compute::device_ext_t::khr_fp64)),
                     VERBOSE_UNSUPPORTED_DT_CFG);
 
             VDISPATCH_REORDER_SC(init_conf(engine),

--- a/tests/benchdnn/inputs/concat/test_concat_large_gpu
+++ b/tests/benchdnn/inputs/concat/test_concat_large_gpu
@@ -37,4 +37,4 @@
 --reset --sdt=bf16 --ddt=f64 --stag=acb:acb --dtag=bca 1469x124250x3:1469x28x3
 --reset --sdt=s8 --ddt=u8 --stag=cab:abc --dtag=cba 6x1489864x171:6x1069566x171
 --reset --sdt=f32 --ddt=f32 --stag=bca:cab --dtag=bac 10301x2103x1:10301x62502x1
---reset --sdt=f8_e5m2 --ddt=bf16 --stag=bac:cba --dtag=cba 26x4x7:267x743407x7
+--reset --sdt=f8_e5m2 --ddt=bf16 --stag=bac:cba --dtag=cba 267x4x7:267x743407x7


### PR DESCRIPTION
# Description

The new large buffer concat tests trigger an attempt to use an unsupported fp64 extension on DG2. This PR adds the missing checks for the extension required by the kernel. 

An invalid configuration in the new concat tests is also addressed.

Fixes [MFDNN-13206](https://jira.devtools.intel.com/browse/MFDNN-13206).

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
