### PR TITLE
ci: aarch64: don't run performance tests on cobalt

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -174,15 +174,14 @@ jobs:
 
       ## Performance test steps ##
       - name: Checkout oneDNN base
-        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.base_ref }}
           path: oneDNN_base
 
-      # TODO :: Create separate pipeline to cache oneDNN base
       - name: Configure oneDNN base
-        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
         run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
         working-directory: ${{ github.workspace }}/oneDNN_base
         env:
@@ -196,7 +195,7 @@ jobs:
           ONEDNN_THREADING: ${{ matrix.config.threading }}
 
       - name: Build oneDNN base
-        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
         run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
         working-directory: ${{ github.workspace }}/oneDNN_base
         env:
@@ -204,7 +203,7 @@ jobs:
 
       - name: Run performance tests
         shell: bash
-        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
         run: |
           OMP_NUM_THREADS=4 bash ${{ github.workspace }}/oneDNN/.github/automation/performance/bench_performance.sh ${{ github.workspace }}/oneDNN_base/build/tests/benchdnn/benchdnn ${{ github.workspace }}/oneDNN/build/tests/benchdnn/benchdnn base.txt new.txt
           OMP_NUM_THREADS=16 bash ${{ github.workspace }}/oneDNN/.github/automation/performance/bench_performance.sh ${{ github.workspace }}/oneDNN_base/build/tests/benchdnn/benchdnn ${{ github.workspace }}/oneDNN/build/tests/benchdnn/benchdnn base.txt new.txt
@@ -212,13 +211,13 @@ jobs:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
 
       - name: Compare performance test results
-        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' }}
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
         id: performance-test
         continue-on-error: true
         run: python ${{ github.workspace }}/oneDNN/.github/automation/performance/benchdnn_comparison.py base.txt new.txt
 
       - name: Check performance test failure
-        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && steps.performance-test.outputs.pass != 'True' }}
+        if: ${{ steps.performance-test.outputs.pass != 'True' && github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
         run: echo "::warning file=.github/workflows/ci-aarch64.yml,line=1,col=1::${{ steps.performance-test.outputs.message }}"
 
   # This job adds a check named "CI AArch64" that represents overall


### PR DESCRIPTION
preventing performance tests being run on cobalt in order to not block the ci runners