### PR TITLE
xe: jit: refactor reorder interface

### DIFF
--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -241,9 +241,7 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
     ngen::DataType dst_type = dst.type();
     // Replace (float -> float) by (int -> int) as word/dword moves have less
     // restrictions.
-    if (src_type == dst_type
-            && utils::one_of(src_type, ngen::DataType::bf, ngen::DataType::hf,
-                    ngen::DataType::f, ngen::DataType::df)) {
+    if (src_type == dst_type && to_ir(src_type).is_fp()) {
         int factor = (src_type == ngen::DataType::df ? 2 : 1);
         if (factor == 1 || (src_stride == 1 && dst_stride == 1)) {
             src_type

--- a/src/gpu/intel/jit/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/conv/gen_convolution.cpp
@@ -399,8 +399,9 @@ private:
                     reorder_info.register_user_arg(user_buf, user_arg_key,
                             /*is_input=*/true);
                     add_compute_arg(reorder_info, compute_buf, false);
-                    reorder_info.set_nd_range(reorder_kernel_t<>::nd_range(
-                            cfg.exec_cfg(), t.user_layout, t.compute_layout));
+                    reorder_config_t reorder_cfg(
+                            cfg.exec_cfg(), t.user_layout, t.compute_layout);
+                    reorder_info.set_nd_range(reorder_cfg.nd_range());
                 }
                 if (!src_conv_precalc && t.is_output) {
                     auto &reorder_info
@@ -408,8 +409,9 @@ private:
                     add_compute_arg(reorder_info, compute_buf, true);
                     reorder_info.register_user_arg(user_buf, user_arg_key,
                             /*is_input=*/false);
-                    reorder_info.set_nd_range(reorder_kernel_t<>::nd_range(
-                            cfg.exec_cfg(), t.compute_layout, t.user_layout));
+                    reorder_config_t reorder_cfg(
+                            cfg.exec_cfg(), t.compute_layout, t.user_layout);
+                    reorder_info.set_nd_range(reorder_cfg.nd_range());
                 }
                 if (src_conv_precalc) {
                     scratchpad_book(++scratchpad_key);

--- a/src/gpu/intel/jit/ir/primitive_plan.cpp
+++ b/src/gpu/intel/jit/ir/primitive_plan.cpp
@@ -129,9 +129,8 @@ status_t primitive_init_plan_t::add_reorder_kernel(
         }
     }
     exec_config_t exec_cfg(hw_t(engine), regs_, simd_);
-    kernel_info.set_nd_range(
-            reorder_kernel_t<>::nd_range(exec_cfg, src.layout, dst.layout));
     reorder_config_t cfg(exec_cfg, src.layout, dst.layout);
+    kernel_info.set_nd_range(cfg.nd_range());
     auto kernel = make_kernel<reorder_kernel_t>(primitive,
             /*register_kernel=*/true, engine, cfg, "reorder", kernel_info,
             dpas_);

--- a/src/gpu/intel/jit/reorder/config.cpp
+++ b/src/gpu/intel/jit/reorder/config.cpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/jit/reorder/config.hpp"
+#include "gpu/intel/jit/reorder/normalization.hpp"
+#include "gpu/intel/jit/reorder/tiler.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+
+namespace reorder {
+
+pvar_t pvars[] = {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"},
+        {"j"}, {"k"}, {"l"}};
+
+static_assert(sizeof(pvars) == DNNL_MAX_NDIMS * sizeof(pvar_t),
+        "Incorrect number of pvars for reorder");
+
+} // namespace reorder
+
+reorder_config_t::reorder_config_t(
+        const exec_config_t &ec, layout_t src, layout_t dst) {
+    set_exec_cfg(ec);
+
+    reorder::normalize(src, dst);
+    src_layout().set_user(src);
+    dst_layout().set_user(dst);
+
+    auto rev_tiles = reorder::tiles(ec.hw(), src, dst);
+    tiles_.assign(rev_tiles.rbegin(), rev_tiles.rend());
+
+    dim_idx_t ndims = src.ndims();
+    auto thr_tile = tiles_.front();
+
+    pvar_tile_t iter_tile;
+    pvar_tile_t loop_tile;
+    pvar_tile_t tg_tile;
+
+    pvar_tile_t dims;
+    dim_idx_t grid_idx = 0;
+
+    for (dim_idx_t i = 0; i < ndims; ++i) {
+        pvar_t &d = reorder::pvars[i];
+
+        dim_t tg_dim = thr_tile(i);
+        dim_t outer = utils::div_up(dst.dim(i), tg_dim);
+        iter_tile[d] = tg_dim;
+        loop_tile[d] = 1;
+        dims[d] = std::max(src.dim(i), dst.dim(i));
+        grid_[grid_idx][d] = 1;
+
+        if (outer != 1) grid_idx = std::min<dim_idx_t>(grid_idx + 1, 2);
+    }
+
+    for (dim_idx_t i = 0; i < ndims; ++i) {
+        pvar_t &d = reorder::pvars[i];
+        dim_t tg_dim = thr_tile(i);
+        dim_t outer = utils::div_up(dims[d], tg_dim);
+
+        if (outer % 2 == 0) {
+            tg_tile[d] = 2;
+            break;
+        }
+    }
+
+    padded_dims().set(dims);
+    iter_dims().set(iter_tile);
+    loop_dims().set(loop_tile);
+    thread_group_dims().set(tg_tile);
+
+    init_kernel_grid(grid_);
+    init_thread_group_grid(grid_);
+}
+
+compute::nd_range_t reorder_config_t::nd_range() const {
+    compute::range_t gws = compute::range_t::empty();
+    compute::range_t lws = compute::range_t::empty();
+    for (dim_idx_t i = 0; i < compute::range_t::max_ndims; ++i) {
+        lws[i] = thread_group_grid().dim(i);
+        gws[i] = kernel_grid().dim(i) * lws[i];
+    }
+    lws[0] *= simd();
+    gws[0] *= simd();
+
+    return compute::nd_range_t(gws, lws);
+}
+
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/jit/reorder/config.hpp
+++ b/src/gpu/intel/jit/reorder/config.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,6 +28,12 @@ namespace gpu {
 namespace intel {
 namespace jit {
 
+namespace reorder {
+
+extern pvar_t pvars[];
+
+} // namespace reorder
+
 // Parameters for kernel generation.
 class reorder_config_t : public prim_config_t {
 public:
@@ -46,12 +52,16 @@ public:
 
     int pad_block(const pvar_t &d) const override { return 0; }
 
-    reorder_config_t(
-            const exec_config_t &ec, const layout_t &src, const layout_t &dst) {
-        src_layout().set_user(src);
-        dst_layout().set_user(dst);
-        set_exec_cfg(ec);
-    }
+    int simd() const { return exec_cfg().simd(); }
+    compute::nd_range_t nd_range() const;
+    const std::vector<tensor_t> &tiles() const { return tiles_; }
+    const std::array<pvar_tile_t, 3> &grid() const { return grid_; }
+
+    reorder_config_t(const exec_config_t &ec, layout_t src, layout_t dst);
+
+private:
+    std::vector<tensor_t> tiles_;
+    std::array<pvar_tile_t, 3> grid_;
 };
 
 } // namespace jit

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -181,8 +181,7 @@ status_t gen_reorder_t::pd_t::init_kernel_info() {
             /*oc=*/1, tensor_cfg);
 
     kernel_info = std::make_shared<kernel_info_t>();
-    auto nd_range = reorder_kernel_t<>::nd_range(cfg->exec_cfg(),
-            cfg->src_layout().user(), cfg->dst_layout().user());
+    auto nd_range = cfg->nd_range();
     auto global_range = nd_range.global_range();
     constexpr int max = std::numeric_limits<int>::max();
     // This case *probably* overflowed in int32 precision.

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -98,6 +98,12 @@ status_t gen_reorder_t::pd_t::init(impl::engine_t *engine,
     VDISPATCH_REORDER(IMPLICATION(src_dt == f64 || dst_dt == f64,
                               device_info->has_native(f64)),
             VERBOSE_UNSUPPORTED_DT_CFG);
+    VDISPATCH_REORDER(
+            IMPLICATION(src_dt == f64, utils::one_of(dst_dt, f32, f64)),
+            VERBOSE_UNSUPPORTED_DT_CFG);
+    VDISPATCH_REORDER(
+            IMPLICATION(dst_dt == f64, utils::one_of(src_dt, f32, f64)),
+            VERBOSE_UNSUPPORTED_DT_CFG);
     using sm = dnnl_primitive_attr::skip_mask_t;
     auto skip_mask = sm::post_ops | sm::zero_points_runtime | sm::scales_runtime
             | sm::rounding_mode;

--- a/src/gpu/intel/jit/reorder/ir_builder.cpp
+++ b/src/gpu/intel/jit/reorder/ir_builder.cpp
@@ -36,7 +36,7 @@
 #include "gpu/intel/jit/ir/reorder.hpp"
 #include "gpu/intel/jit/ir/tensor.hpp"
 #include "gpu/intel/jit/pass/pass.hpp"
-#include "gpu/intel/jit/utils/iterator.hpp"
+#include "gpu/intel/jit/reorder/tiler.hpp"
 #include "gpu/intel/jit/utils/range.hpp"
 #include "gpu/intel/jit/utils/trace.hpp"
 
@@ -46,684 +46,134 @@ namespace gpu {
 namespace intel {
 namespace jit {
 
-dim_t reorder_ir_builder_t::count_block_messages(
-        const exec_config_t &exec_cfg, dim_t inner_bytes, dim_t iterations) {
-    const auto max_block_owords = exec_cfg.grf_size() / 2;
-    const auto oword_size = 16;
-    const auto owords_per_grf = exec_cfg.grf_size() / oword_size;
-
-    dim_t block_owords = max_block_owords / 2;
-    auto inner_owords = inner_bytes / oword_size;
-    dim_t messages = inner_owords / max_block_owords;
-    inner_owords -= messages * max_block_owords;
-    // If iterations != 1, tail block messages must end on a grf boundary
-    const dim_t lower_bound = iterations == 1 ? 1 : owords_per_grf;
-    for (; block_owords >= lower_bound; block_owords >>= 1) {
-        if (inner_owords >= block_owords) {
-            inner_owords -= block_owords;
-            messages++;
-        }
+void split_tile(const tensor_t &wg_tile, const tensor_t &iter_tile,
+        pvar_tile_t &iter_dims, pvar_tile_t &loop_dims) {
+    const auto &wg_dims = wg_tile.dims();
+    const auto &it_dims = iter_tile.dims();
+    for (dim_idx_t i = 0; i < wg_tile.ndims(); ++i) {
+        pvar_t &d = reorder::pvars[i];
+        iter_dims[d] = it_dims[i];
+        loop_dims[d] = wg_dims[i] / it_dims[i];
     }
-    gpu_assert(inner_owords == 0);
-    return messages * iterations;
-}
-
-dim_t reorder_ir_builder_t::count_scattered_messages(
-        const exec_config_t &exec_cfg, dim_t inner_bytes, dim_t iterations) {
-    const auto max_block_items = exec_cfg.grf_size() / 2;
-    int item_size = 8;
-
-    // Find the largest uint size we can use
-    for (; item_size > 1; item_size >>= 1) {
-        if (inner_bytes % item_size == 0) break;
-    }
-
-    dim_t block_items = max_block_items / 2;
-    auto inner_items = (iterations * inner_bytes) / item_size;
-    dim_t messages = (inner_items + (block_items - 1)) / max_block_items;
-    inner_items -= std::min(inner_items, messages * max_block_items);
-    for (; block_items >= (dim_t)2; block_items >>= 1) {
-        if (inner_items > block_items / 2) {
-            inner_items -= std::min(inner_items, block_items);
-            messages++;
-        }
-    }
-    if (inner_items) messages++;
-    return messages;
-}
-
-dim_t reorder_ir_builder_t::message_latency(
-        const exec_config_t &exec_cfg, const layout_t &l, const tensor_t &t) {
-    const auto grf_size = exec_cfg.grf_size();
-    const int scattered_message_penalty = 4;
-    bool can_use_block_messages = true;
-    std::vector<dim_t> outer = t.dims();
-    dim_t inner_elems = 1;
-
-    for (auto &blk : l.blocks()) {
-        auto block = blk.block;
-        auto dim_idx = blk.dim_idx;
-        if (block == 1) continue;
-        if (outer[dim_idx] < block) {
-            if (block % outer[dim_idx] == 0) {
-                inner_elems *= outer[dim_idx];
-                outer[dim_idx] = 1;
-            }
-            break;
-        }
-
-        can_use_block_messages &= (outer[dim_idx] % block == 0);
-        inner_elems *= block;
-        outer[dim_idx] = utils::div_up(outer[dim_idx], block);
-    }
-
-    auto type_size = l.type().scalar().size();
-    auto inner_bytes = inner_elems * type_size;
-    auto iterations = tensor_t(outer).elems();
-    can_use_block_messages &= (inner_bytes % 16 == 0);
-    can_use_block_messages &= (iterations == 1 || inner_bytes % grf_size == 0);
-
-    if (inner_bytes == 0 || iterations == 0) return 0;
-
-    return can_use_block_messages
-            ? count_block_messages(exec_cfg, inner_bytes, iterations)
-            : count_scattered_messages(exec_cfg, inner_bytes, iterations)
-                    * scattered_message_penalty;
-}
-
-void reorder_ir_builder_t::compute_blocks(const exec_config_t &exec_cfg,
-        const layout_t &src, const layout_t &dst, std::vector<int> &iter_blocks,
-        std::vector<int> &loop_blocks, std::vector<int> &tg_blocks,
-        dim_t max_iter_tile_bytes, dim_t max_thr_tile_bytes) {
-    if (max_iter_tile_bytes <= 0)
-        max_iter_tile_bytes = max_tile_size(exec_cfg.hw(), dst, src);
-    if (max_thr_tile_bytes <= 0)
-        max_thr_tile_bytes = max_tile_size(exec_cfg.hw(), dst, src);
-
-    gpu_assert(src.ndims() == dst.ndims());
-    dim_idx_t ndims = src.ndims();
-    std::vector<dim_t> dims(ndims);
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        dims[i] = std::max(src.dim(i), dst.dim(i));
-    }
-
-    // Pad src/dst layouts to match each other.
-    auto pad_layout = [&](const layout_t &l) {
-        std::vector<block_t> padded_blocks;
-        for (auto &eb : l.enumerated_blocks()) {
-            auto b = eb.second;
-            if (l.is_outermost(eb)) {
-                dim_t inner = l.dim(b.dim_idx) / b.block;
-                b.block = ir_utils::safe_divide(dims[b.dim_idx], inner);
-            }
-            padded_blocks.push_back(b);
-        }
-        return layout_t(
-                l.type(), ndims, 0, padded_blocks, /*do_normalize=*/false);
-    };
-    layout_t padded_src = pad_layout(src);
-    layout_t padded_dst = pad_layout(dst);
-    gpu_assert(ir_utils::is_equal(padded_src.dims(), padded_dst.dims()));
-
-    dim_t elems = padded_src.elems();
-    int max_type_size = std::max(src.type().size(), dst.type().size());
-    dim_t max_iter_tile_elems
-            = std::min(max_iter_tile_bytes / max_type_size, elems);
-    dim_t max_thr_tile_elems
-            = std::min(max_thr_tile_bytes / max_type_size, elems);
-
-    using tile_pair_t = std::array<tensor_t, 2>;
-
-    auto can_be_mapped = [](const layout_t &l, const tensor_t &t) {
-        std::vector<dim_t> rem_dims = t.dims();
-        for (auto &b : l.blocks()) {
-            auto &rem_dim = rem_dims[b.dim_idx];
-            if (rem_dim >= b.block) {
-                if (rem_dim % b.block != 0) return false;
-                rem_dim /= b.block;
-                continue;
-            }
-            if (b.block % rem_dim != 0) return false;
-            rem_dim = 1;
-        }
-        for (auto d : rem_dims)
-            gpu_assert(d == 1);
-        return true;
-    };
-
-    auto add_pseudo_dimension = [](const layout_t &l) {
-        auto layout_size = l.size();
-        return [=](const tensor_t &t) {
-            auto dims = t.dims();
-            dims.push_back(layout_size);
-            return tensor_t(dims);
-        };
-    };
-
-    auto mappable_tiles = [&](const tensor_t &t) {
-        return can_be_mapped(padded_src, t) && can_be_mapped(padded_dst, t);
-    };
-
-    auto merge_tiles = [](const tile_pair_t &p) {
-        auto ndims = p[0].ndims() - 1;
-        std::vector<dim_t> dims(ndims);
-        for (dim_idx_t i = 0; i < ndims; ++i)
-            dims[i] = std::max(p[0](i), p[1](i));
-        return tensor_t(dims);
-    };
-
-    auto take_smaller = [](const tensor_t &a, const tensor_t &b) {
-        return a.elems() < b.elems();
-    };
-
-    // Incrementally increase subtiles in src and dst. The goal is to find the
-    // maximum src/dst tiles so that the final combined tile covers dense
-    // regions as big as possible in src/dst layouts.
-    std::vector<tensor_t> candidate_tiles;
-    auto a_tiles = inner_tiles(padded_src.blocks(), padded_src.ndims())
-            | filter(mappable_tiles)
-            | transform(add_pseudo_dimension(padded_src));
-    auto b_tiles = inner_tiles(padded_dst.blocks(), padded_dst.ndims())
-            | filter(mappable_tiles)
-            | transform(add_pseudo_dimension(padded_dst));
-    auto tiles = merge(a_tiles, b_tiles, take_smaller) | transform(merge_tiles);
-    for (auto tile : tiles) {
-        if (tile.elems() > max_thr_tile_elems) break;
-        candidate_tiles.push_back(tile);
-    }
-    gpu_assert(!candidate_tiles.empty());
-
-    const auto eu_count = exec_cfg.hw().eu_count();
-    std::sort(candidate_tiles.begin(), candidate_tiles.end(),
-            [&](const tensor_t &a, const tensor_t &b) {
-                auto a_threads_reqd = padded_src.elems() / a.elems();
-                auto b_threads_reqd = padded_src.elems() / b.elems();
-                auto a_eu_util = utils::div_up(a_threads_reqd, eu_count);
-                auto b_eu_util = utils::div_up(b_threads_reqd, eu_count);
-                auto a_msg_load = message_latency(exec_cfg, padded_src, a)
-                        + message_latency(exec_cfg, padded_dst, a);
-                auto b_msg_load = message_latency(exec_cfg, padded_src, b)
-                        + message_latency(exec_cfg, padded_dst, b);
-
-                // Choose tiles with less message overhead per thread
-                if (a_eu_util * a_msg_load != b_eu_util * b_msg_load)
-                    return (a_eu_util * a_msg_load < b_eu_util * b_msg_load);
-
-                // Choose tiles with more bytes per message
-                if (a.elems() * b_msg_load != b.elems() * a_msg_load)
-                    return (a.elems() * b_msg_load > b.elems() * a_msg_load);
-
-                // If all else fails, go with the bigger tile
-                return a.elems() > b.elems();
-            });
-
-    tensor_t thr_tile = candidate_tiles[0];
-    tensor_t iter_tile;
-    for (auto &tile : candidate_tiles) {
-        if (tile.elems() > max_iter_tile_elems || !thr_tile.is_divisible(tile))
-            continue;
-        if (iter_tile.is_empty() || tile.elems() > iter_tile.elems())
-            iter_tile = tile;
-    }
-
-    gpu_assert(!iter_tile.is_empty());
-    std::vector<int> thr_blocks(thr_tile.dims().begin(), thr_tile.dims().end());
-    iter_blocks.assign(iter_tile.dims().begin(), iter_tile.dims().end());
-
-    gpu_assert(utils::array_product(iter_blocks) <= max_iter_tile_elems);
-    gpu_assert(utils::array_product(thr_blocks) <= max_thr_tile_elems);
-
-    // Initialize loop blocks.
-    loop_blocks.resize(ndims, 1);
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        loop_blocks[i] = ir_utils::safe_divide(thr_blocks[i], iter_blocks[i]);
-    }
-
-    // Initialize thread group blocks.
-    // Heuristic: try to split outer dimension and assign its
-    // inner part to the thread group. This may give better
-    // bandwidth utilization on XeHP/XeHPG.
-    tg_blocks.resize(ndims, 1);
-    const int tg_factor = 2;
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        dim_t outer = utils::div_up(dims[i], thr_blocks[i]);
-        if (outer % tg_factor == 0) {
-            tg_blocks[i] = tg_factor;
-            break;
-        }
-    }
-}
-
-void reorder_ir_builder_t::compute_blocks(const exec_config_t &exec_cfg,
-        const layout_t &src, const layout_t &dst, std::vector<int> &tile_blocks,
-        std::vector<int> &tg_blocks) {
-    std::vector<int> iter_blocks;
-    std::vector<int> loop_blocks;
-    compute_blocks(exec_cfg, src, dst, iter_blocks, loop_blocks, tg_blocks);
-    size_t n = iter_blocks.size();
-    tile_blocks.resize(n);
-    for (size_t i = 0; i < n; i++) {
-        tile_blocks[i] = iter_blocks[i] * loop_blocks[i];
-    }
-}
-
-void reorder_ir_builder_t::compute_grid(const layout_t &src,
-        const layout_t &dst, const std::vector<int> &iter_blocks,
-        const std::vector<int> &loop_blocks, const std::vector<int> &tg_blocks,
-        grid_info_t &kernel_grid, grid_info_t &tg_grid,
-        std::vector<dim_idx_t> *dim2grid) {
-    dim_idx_t ndims = src.ndims();
-    std::vector<dim_t> dims(ndims);
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        dims[i] = std::max(src.dim(i), dst.dim(i));
-    }
-
-    if (dim2grid) dim2grid->resize(ndims, dim_idx::invalid);
-
-    const int grid_ndims = 3;
-    std::vector<dim_t> kernel_grid_dims(grid_ndims, 1);
-    std::vector<dim_t> tg_grid_dims(grid_ndims, 1);
-    dim_idx_t grid_idx = 0;
-    dim_idx_t max_grid_idx = grid_ndims - 1;
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        if (dim2grid) (*dim2grid)[i] = grid_idx;
-        dim_t outer = utils::div_up(
-                dims[i], iter_blocks[i] * loop_blocks[i] * tg_blocks[i]);
-        tg_grid_dims[grid_idx] *= tg_blocks[i];
-        kernel_grid_dims[grid_idx] *= outer;
-        if (outer != 1 && grid_idx != max_grid_idx) grid_idx++;
-    }
-    kernel_grid = grid_info_t(kernel_grid_dims, ir_builder_t::tg_idx);
-    tg_grid = grid_info_t(tg_grid_dims, ir_builder_t::thr_idx);
-}
-
-compute::nd_range_t reorder_ir_builder_t::nd_range(
-        const exec_config_t &exec_cfg, layout_t src, layout_t dst) {
-    const int simd = exec_cfg.simd();
-    std::vector<int> iter_blocks;
-    std::vector<int> loop_blocks;
-    std::vector<int> tg_blocks;
-    normalize_reorder_layouts(src, dst);
-    compute_blocks(exec_cfg, src, dst, iter_blocks, loop_blocks, tg_blocks);
-    grid_info_t kernel_grid;
-    grid_info_t tg_grid;
-    compute_grid(src, dst, iter_blocks, loop_blocks, tg_blocks, kernel_grid,
-            tg_grid);
-    compute::range_t global = compute::range_t::empty(kernel_grid.ndims());
-    compute::range_t local = compute::range_t::empty(kernel_grid.ndims());
-    for (dim_idx_t i = 0; i < kernel_grid.ndims(); i++) {
-        global[i] = kernel_grid[i] * tg_grid[i];
-        local[i] = tg_grid[i];
-        if (i == 0) {
-            global[i] *= simd;
-            local[i] *= simd;
-        }
-    }
-    return compute::nd_range_t(global, local);
-}
-
-struct normalization_stage_t {
-    int idx;
-    block_t curr, last;
-    std::array<dim_t, 2> tile;
-
-    bool is_dense() const { return curr.stride == last.stride * last.block; }
-
-    dim_t elems() const { return tile[0]; }
-
-    normalization_stage_t() = default;
-    normalization_stage_t(int idx, const block_t &curr, const block_t &last,
-            std::vector<dim_t> tile)
-        : idx(idx)
-        , curr(curr)
-        , last(last)
-        , tile({tile[curr.dim_idx], tile[last.dim_idx]}) {}
-};
-
-struct merge_info_t {
-    enum class merge_direction_t { none = 0, forward, backward };
-
-    int iter_idx;
-    merge_direction_t direction;
-
-    merge_info_t(int iter_idx, merge_direction_t direction)
-        : iter_idx(iter_idx), direction(direction) {}
-};
-
-merge_info_t::merge_direction_t merge_direction(
-        const normalization_stage_t &l, const normalization_stage_t &r) {
-    using direction_t = merge_info_t::merge_direction_t;
-    if (l.curr.dim_idx != r.curr.dim_idx) return direction_t::none;
-    if (l.last.dim_idx != r.last.dim_idx) return direction_t::none;
-    if (l.tile[0] != r.tile[0]) return direction_t::none;
-    if (l.curr.block == r.curr.block
-            && l.tile[1] * l.last.block == r.tile[1] * r.last.block)
-        return direction_t::backward;
-    if (l.tile[1] == r.tile[1] && l.last.block == r.last.block)
-        return direction_t::forward;
-    return direction_t::none;
-}
-
-struct layout_normalization_t {
-    using blocks_t = std::vector<block_t>;
-    using block_iterator_t = typename blocks_t::const_iterator;
-    using stage_t = normalization_stage_t;
-
-    struct iterator_t {
-        bool operator==(const iterator_t &o) const { return curr_ == o.curr_; }
-        bool operator!=(const iterator_t &o) const { return !operator==(o); }
-        stage_t operator*() const { return {idx_, *curr_, *last_, tile_}; }
-        iterator_t &operator++() {
-            if (curr_ == end_) return *this;
-            auto blk = *last_;
-            tile_[blk.dim_idx] *= blk.block;
-            last_ = curr_;
-            ++curr_;
-            ++idx_;
-            return *this;
-        }
-
-        iterator_t(dim_idx_t ndims, block_iterator_t it, block_iterator_t end)
-            : curr_(it == end ? end : it + 1)
-            , last_(it)
-            , end_(end)
-            , idx_(0)
-            , tile_(ndims, 1) {}
-
-    private:
-        block_iterator_t curr_, last_, end_;
-        int idx_;
-        std::vector<dim_t> tile_;
-    };
-
-    int ndims() const { return ndims_; }
-    const blocks_t &blocks() const { return blocks_; }
-
-    bool empty() const { return begin() == end(); }
-    bool contains_dim(dim_idx_t dim_idx) const {
-        for (auto &blk : blocks_)
-            if (blk.dim_idx == dim_idx) return true;
-        return false;
-    }
-
-    void merge(std::vector<merge_info_t> merges) {
-        using direction_t = merge_info_t::merge_direction_t;
-        if (empty()) {
-            if (blocks_.empty()) blocks_.emplace_back(0, 1, 1);
-            return;
-        }
-
-        std::sort(merges.begin(), merges.end(),
-                [](const merge_info_t &l, const merge_info_t &r) {
-                    return l.iter_idx < r.iter_idx;
-                });
-        auto merge_it = merges.begin();
-        auto merge_end = merges.end();
-        std::vector<block_t> blocks;
-        block_t last = (*begin()).last;
-        for (auto s : *this) {
-            if (merge_it != merge_end && merge_it->iter_idx == s.idx) {
-                if (merge_it->direction == direction_t::backward)
-                    s.curr.dim_idx = last.dim_idx;
-                s.curr.block *= last.block;
-                s.curr.stride = last.stride;
-                ++merge_it;
-            } else
-                blocks.push_back(last);
-            last = s.curr;
-        }
-        blocks.push_back(last);
-        blocks_ = std::move(blocks);
-    }
-
-    void reindex(int ndims, const std::vector<int> &map) {
-        ndims_ = ndims;
-        for (auto &blk : blocks_)
-            blk.dim_idx = map[blk.dim_idx];
-    }
-
-    layout_t layout() const {
-        return {type_, ndims_, offset_, blocks_, /*do_normalize=*/false};
-    }
-
-    iterator_t begin() const {
-        return {ndims_, blocks_.begin(), blocks_.end()};
-    }
-    iterator_t end() const { return {ndims_, blocks_.end(), blocks_.end()}; }
-
-    layout_normalization_t(
-            const layout_t &layout, const std::vector<bool> &dim_empty)
-        : type_(layout.type())
-        , ndims_(layout.ndims())
-        , offset_(layout.offset())
-        , blocks_(normalized_blocks(layout, dim_empty)) {}
-
-private:
-    static std::vector<block_t> normalized_blocks(
-            const layout_t &layout, std::vector<bool> dim_empty) {
-        std::vector<block_t> normalized_blocks;
-        for (auto &eb : layout.enumerated_blocks()) {
-            auto &blk = eb.second;
-            if (blk.block != 1
-                    || (layout.is_outermost(eb) && !dim_empty[blk.dim_idx])) {
-                if (normalized_blocks.empty()
-                        || normalized_blocks.back().dim_idx != blk.dim_idx) {
-                    normalized_blocks.push_back(blk);
-                    dim_empty[blk.dim_idx] = true;
-                } else {
-                    normalized_blocks.back().block *= blk.block;
-                }
-            }
-        }
-        return normalized_blocks;
-    }
-
-    type_t type_;
-    dim_idx_t ndims_;
-    expr_t offset_;
-    blocks_t blocks_;
-};
-
-// Given two layouts, finds an equivalent pair of simpler layouts by attempting
-// to combine consecutive blocks that appear in both layouts at the same level
-// of nesting for the dimensions to which the blocks belong. E.g.,
-//
-//             1.          2.
-// 16a16b16c ---> 256a16c ---> 256a16b
-// 16c16a16b ---> 16c256a ---> 16b256a
-//
-// 1. The consecutive blocks 16a16b are repeated. For the first layout it
-//    appears with an inner tile 1x1x16, and 1x1x1 for the second. Because the
-//    ab-subtile is 1x1 for both and  the inner block (16b) is the same for
-//    both, we can combine these blocks.
-// 2. The b dimension no longer appears, so we can remove it from the layout and
-//    re-index the dimensions so that the new layouts are 2D.
-void reorder_ir_builder_t::normalize_reorder_layouts(layout_t &a, layout_t &b) {
-    using direction_t = merge_info_t::merge_direction_t;
-    int ndims = a.ndims();
-    auto cmp = [](const normalization_stage_t &a,
-                       const normalization_stage_t &b) {
-        return a.elems() <= b.elems();
-    };
-    auto dim_blocks = [](dim_idx_t dim_idx) {
-        return [=](const normalization_stage_t &s) {
-            return s.curr.dim_idx == dim_idx;
-        };
-    };
-
-    std::vector<bool> empty_dimension(ndims, true);
-    for (auto &blk : a.blocks())
-        if (blk.block != 1) empty_dimension[blk.dim_idx] = false;
-    for (auto &blk : b.blocks())
-        if (blk.block != 1) empty_dimension[blk.dim_idx] = false;
-
-    layout_normalization_t a_normalization {a, empty_dimension};
-    layout_normalization_t b_normalization {b, empty_dimension};
-
-    std::vector<merge_info_t> a_merges;
-    std::vector<merge_info_t> b_merges;
-    // Find pairs of consecutive blocks which can be combined
-    for (int i = 0; i < ndims; ++i) {
-        auto dim_i_blocks = dim_blocks(i);
-        auto a_stages = a_normalization | filter(dim_i_blocks);
-        auto b_stages = b_normalization | filter(dim_i_blocks);
-        for (auto p : merge(a_stages, b_stages, cmp)) {
-            if (!p[0].is_dense() || !p[1].is_dense()) continue;
-            direction_t direction = merge_direction(p[0], p[1]);
-            if (direction == direction_t::none) continue;
-            a_merges.emplace_back(p[0].idx, direction);
-            b_merges.emplace_back(p[1].idx, direction);
-        }
-    }
-    a_normalization.merge(std::move(a_merges));
-    b_normalization.merge(std::move(b_merges));
-
-    // Find dimensions present in either normalized layout and construct map of
-    // new dimension indices
-    int curr_dim = 0;
-    std::vector<int> dim_map(ndims);
-    for (int i = 0; i < ndims; ++i)
-        if (a_normalization.contains_dim(i) || b_normalization.contains_dim(i))
-            dim_map[i] = curr_dim++;
-    a_normalization.reindex(curr_dim, dim_map);
-    b_normalization.reindex(curr_dim, dim_map);
-
-    a = a_normalization.layout();
-    b = b_normalization.layout();
 }
 
 void reorder_ir_builder_t::build() {
-    std::vector<int> iter_blocks;
-    std::vector<int> loop_blocks;
-    std::vector<int> tg_blocks;
-    compute_blocks(cfg_.exec_cfg(), src_layout_, dst_layout_, iter_blocks,
-            loop_blocks, tg_blocks);
+    const auto &wg_block = cfg_.tiles().front();
 
-    int max_iters = 10;
-    dim_t cur_iter_bytes
-            = max_tile_size(cfg_.exec_cfg().hw(), dst_layout_, src_layout_);
-    for (int i = 0; i < max_iters; i++) {
-        if (try_build(iter_blocks, loop_blocks, tg_blocks)) {
+    pvar_tile_t iter_tile, loop_tile;
+    for (auto &loop_block : cfg_.tiles()) {
+        if (!wg_block.is_divisible(loop_block)) continue;
+        split_tile(wg_block, loop_block, iter_tile, loop_tile);
+        if (try_build(iter_tile, loop_tile)) {
             gpu_info() << "Reorder configuration:";
-            gpu_info() << "  Source layout:              " << src_layout_;
-            gpu_info() << "  Destination layout:         " << dst_layout_;
-            gpu_info() << "  Iteration blocks:           "
-                       << ir_utils::make_seq_print_helper(iter_blocks, " x ");
-            gpu_info() << "  Loop blocks:                "
-                       << ir_utils::make_seq_print_helper(loop_blocks, " x ");
-            gpu_info() << "  Thread group blocks:        "
-                       << ir_utils::make_seq_print_helper(tg_blocks, " x ");
+            gpu_info() << "  Source layout:       " << cfg_.src_layout().user();
+            gpu_info() << "  Destination layout:  " << cfg_.dst_layout().user();
+            gpu_info() << "  Iteration blocks:    " << iter_tile;
+            gpu_info() << "  Loop blocks:         " << loop_tile;
+            gpu_info() << "  Thread group blocks: " << cfg_.thread_group_dims();
             return;
-        }
-
-        cur_iter_bytes /= 2;
-        while (cur_iter_bytes >= 1) {
-            std::vector<int> new_iter_blocks;
-            compute_blocks(cfg_.exec_cfg(), src_layout_, dst_layout_,
-                    new_iter_blocks, loop_blocks, tg_blocks, cur_iter_bytes);
-            if (!ir_utils::is_equal(new_iter_blocks, iter_blocks)) {
-                iter_blocks = std::move(new_iter_blocks);
-                break;
-            }
-            cur_iter_bytes /= 2;
         }
     }
     gpu_error_not_expected();
 }
 
-bool reorder_ir_builder_t::try_build(const std::vector<int> &iter_blocks,
-        const std::vector<int> &loop_blocks,
-        const std::vector<int> &tg_blocks) {
+bool reorder_ir_builder_t::try_build(
+        const pvar_tile_t &iter_tile, const pvar_tile_t &loop_tile) {
     constraint_set_t init_cset;
 
-    dim_idx_t ndims = src_layout_.ndims();
-    std::vector<expr_t> vars;
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        char letter = dim_idx::as_tag(i);
-        vars.push_back(var_t::make(type_t::s32(), std::string(1, letter)));
-    }
+    const auto &padded_dims = cfg_.padded_dims().get();
+    auto string_map = padded_dims.to_string_map();
+    const auto ndims = cfg_.src_layout().user().ndims();
 
-    std::vector<dim_idx_t> dim2grid;
-    compute_grid(src_layout_, dst_layout_, iter_blocks, loop_blocks, tg_blocks,
-            kernel_grid_, tg_grid_, &dim2grid);
+    std::vector<expr_t> vars;
+    vars.reserve(ndims);
+    for (auto &d : padded_dims) {
+        auto var = var_t::make(type_t::s32(), d.name());
+        vars.emplace_back(var);
+    }
 
     std::vector<stmt_t> init_stmts;
-    init_kernel_grid(kernel_grid_, tg_grid_, cfg_.exec_cfg().simd(), init_cset,
-            init_stmts);
-
-    std::vector<dim_t> vdims(ndims);
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        vdims[i] = std::max(src_layout_.dim(i), dst_layout_.dim(i));
-    }
-    std::unordered_map<std::string, dim_t> vdim_map;
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        vdim_map[vars[i].as<var_t>().name] = vdims[i];
-    }
+    init_kernel_grid(cfg_.kernel_grid(), cfg_.thread_group_grid(),
+            cfg_.exec_cfg().simd(), init_cset, init_stmts);
 
     view_t src_view(vars, ndims);
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        src_view.set_vdim(vars[i], vdims[i]);
-        src_view.set_tdim(i, vars[i]);
-    }
-    src_view.set_tlayout(src_layout_);
-    src_view.set_tmasks(vdim_map);
-
     view_t dst_view(vars, ndims);
-    for (dim_idx_t i = 0; i < ndims; i++) {
-        dst_view.set_vdim(vars[i], vdims[i]);
-        dst_view.set_tdim(i, vars[i]);
+    for (dim_idx_t i = 0; i < ndims; ++i) {
+        const auto &d = reorder::pvars[i];
+        expr_t &var = vars[i];
+        dim_t vdim = padded_dims[d];
+        src_view.set_vdim(var, vdim);
+        dst_view.set_vdim(var, vdim);
+        src_view.set_tdim(i, var);
+        dst_view.set_tdim(i, var);
     }
-    dst_view.set_tlayout(dst_layout_);
-    dst_view.set_tmasks(vdim_map);
+    src_view.set_tlayout(cfg_.src_layout().user());
+    dst_view.set_tlayout(cfg_.dst_layout().user());
+    src_view.set_tmasks(string_map);
+    dst_view.set_tmasks(string_map);
 
-    gemm_schedule_t schedule(init_cset, kernel_grid_, tg_grid_);
+    gemm_schedule_t schedule(
+            init_cset, cfg_.kernel_grid(), cfg_.thread_group_grid());
 
     schedule.set_view(src_view);
     schedule.set_view(dst_view);
 
     std::array<std::vector<expr_t>, 3> fused_idxs;
+    auto find_grid_idx = [&](const pvar_t &d) {
+        for (dim_idx_t grid_idx = 0; grid_idx < 3; ++grid_idx) {
+            const auto &grid = cfg_.grid()[grid_idx];
+            for (auto &grid_dim : grid)
+                if (grid_dim == d) return grid_idx;
+        }
+        gpu_error_not_expected();
+        return dim_idx::invalid;
+    };
     for (dim_idx_t i = 0; i < ndims; i++) {
         std::vector<expr_t> ordered;
         auto v = vars[i];
-        if (iter_blocks[i] != 1) {
+        const auto &d = reorder::pvars[i];
+        auto grid_idx = find_grid_idx(d);
+        const auto &iter_dim = iter_tile[d];
+        const auto &loop_dim = loop_tile[d];
+        const auto &tg_dim = cfg_.thread_group_dims().get(d);
+        if (iter_dim != 1) {
             expr_t outer, inner;
-            schedule.split(v, iter_blocks[i], outer, inner);
+            schedule.split(v, iter_dim, outer, inner);
             schedule.tensorize(inner);
             v = outer;
             ordered.insert(ordered.begin(), outer);
         }
-        if (loop_blocks[i] != 1) {
+        if (loop_dim != 1) {
             if (!ordered.empty()) ordered.erase(ordered.begin());
             expr_t outer, inner;
-            schedule.split(v, loop_blocks[i], outer, inner);
+            schedule.split(v, loop_dim, outer, inner);
             v = outer;
             ordered.insert(ordered.begin(), inner);
             ordered.insert(ordered.begin(), outer);
         }
-        if (tg_blocks[i] != 1) {
+        if (tg_dim != 1) {
             if (!ordered.empty()) ordered.erase(ordered.begin());
             expr_t outer, inner;
-            schedule.split(v, tg_blocks[i], outer, inner);
-            schedule.bind(inner, tg_grid_.idx(dim2grid[i]));
+            schedule.split(v, tg_dim, outer, inner);
+            schedule.bind(inner, cfg_.thread_group_grid().idx(grid_idx));
             v = outer;
             ordered.insert(ordered.begin(), inner);
             ordered.insert(ordered.begin(), outer);
         }
-        fused_idxs[dim2grid[i]].push_back(v);
         schedule.reorder(ordered);
+        fused_idxs[grid_idx].push_back(v);
     }
 
-    for (int i = 0; i < (int)fused_idxs.size(); i++) {
+    for (dim_idx_t i = 0; i < into<dim_idx_t>(fused_idxs.size()); i++) {
         auto &vec = fused_idxs[i];
         if (vec.empty()) continue;
         auto var = (vec.size() == 1 ? vec[0] : schedule.fuse(vec));
-        schedule.bind(var, kernel_grid_.idx(i));
+        schedule.bind(var, cfg_.kernel_grid().idx(i));
     }
 
     schedule.finalize();
 
     auto thr_tile = schedule.thr_view_tile(src_view, /*is_relative=*/false);
-
     auto src_thr_view = src_view.create_sub_view(thr_tile);
     auto dst_thr_view = dst_view.create_sub_view(thr_tile);
 

--- a/src/gpu/intel/jit/reorder/ir_builder.hpp
+++ b/src/gpu/intel/jit/reorder/ir_builder.hpp
@@ -38,62 +38,16 @@ public:
     reorder_ir_builder_t(const reorder_config_t &cfg,
             const kernel_info_t &kernel_info, const primitive_attr_t *attr,
             const memory_desc_t *dst_md)
-        : src_layout_(cfg.src_layout().user())
-        , dst_layout_(cfg.dst_layout().user())
-        , cfg_(cfg)
-        , kernel_info_(kernel_info)
-        , attr_(attr)
-        , dst_md_(dst_md) {
-        normalize_reorder_layouts(src_layout_, dst_layout_);
+        : cfg_(cfg), kernel_info_(kernel_info), attr_(attr), dst_md_(dst_md) {
         build();
     }
 
-    const grid_info_t &kernel_grid() const { return kernel_grid_; }
-
-    static void compute_blocks(const exec_config_t &exec_cfg,
-            const layout_t &src, const layout_t &dst,
-            std::vector<int> &iter_blocks, std::vector<int> &loop_blocks,
-            std::vector<int> &tg_blocks, dim_t max_iter_tile_bytes = 0,
-            dim_t max_thr_tile_bytes = 0);
-
-    static void compute_blocks(const exec_config_t &exec_cfg,
-            const layout_t &src, const layout_t &dst,
-            std::vector<int> &tile_blocks, std::vector<int> &tg_blocks);
-
-    static void compute_grid(const layout_t &src, const layout_t &dst,
-            const std::vector<int> &iter_blocks,
-            const std::vector<int> &loop_blocks,
-            const std::vector<int> &tg_blocks, grid_info_t &kernel_grid,
-            grid_info_t &tg_grid, std::vector<dim_idx_t> *dim2grid = nullptr);
-
-    static compute::nd_range_t nd_range(
-            const exec_config_t &exec_cfg, layout_t src, layout_t dst);
+    const grid_info_t &kernel_grid() const { return cfg_.kernel_grid(); }
 
 private:
     void build() override;
-    bool try_build(const std::vector<int> &iter_blocks,
-            const std::vector<int> &loop_blocks,
-            const std::vector<int> &tg_blocks);
+    bool try_build(const pvar_tile_t &iter_tile, const pvar_tile_t &loop_tile);
 
-    static void normalize_reorder_layouts(layout_t &a, layout_t &b);
-    static dim_t max_tile_size(
-            const hw_t &hw, const layout_t &dst, const layout_t &src) {
-        // XeHPC is fine with 2048 bytes, XeHPG and below can fit 2048 bytes if
-        // reorder is a simple copy.
-        return (hw <= ngen::HW::XeHPG && dst != src) ? 1024 : 2048;
-    }
-
-    static dim_t count_block_messages(
-            const exec_config_t &exec_cfg, dim_t bytes, dim_t iterations);
-    static dim_t count_scattered_messages(
-            const exec_config_t &exec_cfg, dim_t bytes, dim_t iterations);
-    static dim_t message_latency(const exec_config_t &exec_cfg,
-            const layout_t &l, const tensor_t &t);
-
-    grid_info_t kernel_grid_;
-    grid_info_t tg_grid_;
-    layout_t src_layout_;
-    layout_t dst_layout_;
     const reorder_config_t &cfg_;
     const kernel_info_t &kernel_info_;
     const primitive_attr_t *attr_;

--- a/src/gpu/intel/jit/reorder/normalization.cpp
+++ b/src/gpu/intel/jit/reorder/normalization.cpp
@@ -1,0 +1,263 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/jit/reorder/normalization.hpp"
+
+#include "gpu/intel/jit/utils/range.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+namespace reorder {
+
+struct normalization_stage_t {
+    int idx;
+    block_t curr, last;
+    std::array<dim_t, 2> tile;
+
+    bool is_dense() const { return curr.stride == last.stride * last.block; }
+
+    dim_t elems() const { return tile[0]; }
+
+    normalization_stage_t() = default;
+    normalization_stage_t(int idx, const block_t &curr, const block_t &last,
+            std::vector<dim_t> tile)
+        : idx(idx)
+        , curr(curr)
+        , last(last)
+        , tile({tile[curr.dim_idx], tile[last.dim_idx]}) {}
+};
+
+struct merge_info_t {
+    enum class merge_direction_t { none = 0, forward, backward };
+
+    int iter_idx;
+    merge_direction_t direction;
+
+    merge_info_t(int iter_idx, merge_direction_t direction)
+        : iter_idx(iter_idx), direction(direction) {}
+};
+
+merge_info_t::merge_direction_t merge_direction(
+        const normalization_stage_t &l, const normalization_stage_t &r) {
+    using direction_t = merge_info_t::merge_direction_t;
+    if (l.curr.dim_idx != r.curr.dim_idx) return direction_t::none;
+    if (l.last.dim_idx != r.last.dim_idx) return direction_t::none;
+    if (l.tile[0] != r.tile[0]) return direction_t::none;
+    if (l.curr.block == r.curr.block
+            && l.tile[1] * l.last.block == r.tile[1] * r.last.block)
+        return direction_t::backward;
+    if (l.tile[1] == r.tile[1] && l.last.block == r.last.block)
+        return direction_t::forward;
+    return direction_t::none;
+}
+
+struct layout_normalization_t {
+    using blocks_t = std::vector<block_t>;
+    using block_iterator_t = typename blocks_t::const_iterator;
+    using stage_t = normalization_stage_t;
+
+    struct iterator_t {
+        bool operator==(const iterator_t &o) const { return curr_ == o.curr_; }
+        bool operator!=(const iterator_t &o) const { return !operator==(o); }
+        stage_t operator*() const { return {idx_, *curr_, *last_, tile_}; }
+        iterator_t &operator++() {
+            if (curr_ == end_) return *this;
+            auto blk = *last_;
+            tile_[blk.dim_idx] *= blk.block;
+            last_ = curr_;
+            ++curr_;
+            ++idx_;
+            return *this;
+        }
+
+        iterator_t(dim_idx_t ndims, block_iterator_t it, block_iterator_t end)
+            : curr_(it == end ? end : it + 1)
+            , last_(it)
+            , end_(end)
+            , idx_(0)
+            , tile_(ndims, 1) {}
+
+    private:
+        block_iterator_t curr_, last_, end_;
+        int idx_;
+        std::vector<dim_t> tile_;
+    };
+
+    int ndims() const { return ndims_; }
+    const blocks_t &blocks() const { return blocks_; }
+
+    bool empty() const { return begin() == end(); }
+    bool contains_dim(dim_idx_t dim_idx) const {
+        for (auto &blk : blocks_)
+            if (blk.dim_idx == dim_idx) return true;
+        return false;
+    }
+
+    void merge(std::vector<merge_info_t> merges) {
+        using direction_t = merge_info_t::merge_direction_t;
+        if (empty()) {
+            if (blocks_.empty()) blocks_.emplace_back(0, 1, 1);
+            return;
+        }
+
+        std::sort(merges.begin(), merges.end(),
+                [](const merge_info_t &l, const merge_info_t &r) {
+                    return l.iter_idx < r.iter_idx;
+                });
+        auto merge_it = merges.begin();
+        auto merge_end = merges.end();
+        std::vector<block_t> blocks;
+        block_t last = (*begin()).last;
+        for (auto s : *this) {
+            if (merge_it != merge_end && merge_it->iter_idx == s.idx) {
+                if (merge_it->direction == direction_t::backward)
+                    s.curr.dim_idx = last.dim_idx;
+                s.curr.block *= last.block;
+                s.curr.stride = last.stride;
+                ++merge_it;
+            } else
+                blocks.push_back(last);
+            last = s.curr;
+        }
+        blocks.push_back(last);
+        blocks_ = std::move(blocks);
+    }
+
+    void reindex(int ndims, const std::vector<int> &map) {
+        ndims_ = ndims;
+        for (auto &blk : blocks_)
+            blk.dim_idx = map[blk.dim_idx];
+    }
+
+    layout_t layout() const {
+        return {type_, ndims_, offset_, blocks_, /*do_normalize=*/false};
+    }
+
+    iterator_t begin() const {
+        return {ndims_, blocks_.begin(), blocks_.end()};
+    }
+    iterator_t end() const { return {ndims_, blocks_.end(), blocks_.end()}; }
+
+    layout_normalization_t(
+            const layout_t &layout, const std::vector<bool> &dim_empty)
+        : type_(layout.type())
+        , ndims_(layout.ndims())
+        , offset_(layout.offset())
+        , blocks_(normalized_blocks(layout, dim_empty)) {}
+
+private:
+    static std::vector<block_t> normalized_blocks(
+            const layout_t &layout, std::vector<bool> dim_empty) {
+        std::vector<block_t> normalized_blocks;
+        for (auto &eb : layout.enumerated_blocks()) {
+            auto &blk = eb.second;
+            if (blk.block != 1
+                    || (layout.is_outermost(eb) && !dim_empty[blk.dim_idx])) {
+                if (normalized_blocks.empty()
+                        || normalized_blocks.back().dim_idx != blk.dim_idx) {
+                    normalized_blocks.push_back(blk);
+                    dim_empty[blk.dim_idx] = true;
+                } else {
+                    normalized_blocks.back().block *= blk.block;
+                }
+            }
+        }
+        return normalized_blocks;
+    }
+
+    type_t type_;
+    dim_idx_t ndims_;
+    expr_t offset_;
+    blocks_t blocks_;
+};
+
+// Given two layouts, finds an equivalent pair of simpler layouts by attempting
+// to combine consecutive blocks that appear in both layouts at the same level
+// of nesting for the dimensions to which the blocks belong. E.g.,
+//
+//             1.          2.
+// 16a16b16c ---> 256a16c ---> 256a16b
+// 16c16a16b ---> 16c256a ---> 16b256a
+//
+// 1. The consecutive blocks 16a16b are repeated. For the first layout it
+//    appears with an inner tile 1x1x16, and 1x1x1 for the second. Because the
+//    ab-subtile is 1x1 for both and  the inner block (16b) is the same for
+//    both, we can combine these blocks.
+// 2. The b dimension no longer appears, so we can remove it from the layout and
+//    re-index the dimensions so that the new layouts are 2D.
+void normalize(layout_t &a, layout_t &b) {
+    using direction_t = merge_info_t::merge_direction_t;
+    int ndims = a.ndims();
+    auto cmp = [](const normalization_stage_t &a,
+                       const normalization_stage_t &b) {
+        return a.elems() <= b.elems();
+    };
+    auto dim_blocks = [](dim_idx_t dim_idx) {
+        return [=](const normalization_stage_t &s) {
+            return s.curr.dim_idx == dim_idx;
+        };
+    };
+
+    std::vector<bool> empty_dimension(ndims, true);
+    for (auto &blk : a.blocks())
+        if (blk.block != 1) empty_dimension[blk.dim_idx] = false;
+    for (auto &blk : b.blocks())
+        if (blk.block != 1) empty_dimension[blk.dim_idx] = false;
+
+    layout_normalization_t a_normalization {a, empty_dimension};
+    layout_normalization_t b_normalization {b, empty_dimension};
+
+    std::vector<merge_info_t> a_merges;
+    std::vector<merge_info_t> b_merges;
+    // Find pairs of consecutive blocks which can be combined
+    for (int i = 0; i < ndims; ++i) {
+        auto dim_i_blocks = dim_blocks(i);
+        auto a_stages = a_normalization | filter(dim_i_blocks);
+        auto b_stages = b_normalization | filter(dim_i_blocks);
+        for (auto p : merge(a_stages, b_stages, cmp)) {
+            if (!p[0].is_dense() || !p[1].is_dense()) continue;
+            direction_t direction = merge_direction(p[0], p[1]);
+            if (direction == direction_t::none) continue;
+            a_merges.emplace_back(p[0].idx, direction);
+            b_merges.emplace_back(p[1].idx, direction);
+        }
+    }
+    a_normalization.merge(std::move(a_merges));
+    b_normalization.merge(std::move(b_merges));
+
+    // Find dimensions present in either normalized layout and construct map of
+    // new dimension indices
+    int curr_dim = 0;
+    std::vector<int> dim_map(ndims);
+    for (int i = 0; i < ndims; ++i)
+        if (a_normalization.contains_dim(i) || b_normalization.contains_dim(i))
+            dim_map[i] = curr_dim++;
+    a_normalization.reindex(curr_dim, dim_map);
+    b_normalization.reindex(curr_dim, dim_map);
+
+    a = a_normalization.layout();
+    b = b_normalization.layout();
+}
+
+} // namespace reorder
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/jit/reorder/normalization.hpp
+++ b/src/gpu/intel/jit/reorder/normalization.hpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_JIT_REORDER_NORMALIZATION_HPP
+#define GPU_INTEL_JIT_REORDER_NORMALIZATION_HPP
+
+#include <array>
+
+#include "gpu/intel/jit/ir/tensor.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+namespace reorder {
+
+void normalize(layout_t &a, layout_t &b);
+
+} // namespace reorder
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/intel/jit/reorder/reorder_kernel.hpp
+++ b/src/gpu/intel/jit/reorder/reorder_kernel.hpp
@@ -60,11 +60,6 @@ public:
 
         generate_epilogue();
     }
-
-    static compute::nd_range_t nd_range(const exec_config_t &exec_cfg,
-            const layout_t &src, const layout_t &dst) {
-        return reorder_ir_builder_t::nd_range(exec_cfg, src, dst);
-    }
 };
 
 } // namespace jit

--- a/src/gpu/intel/jit/reorder/tiler.cpp
+++ b/src/gpu/intel/jit/reorder/tiler.cpp
@@ -1,0 +1,241 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/jit/reorder/tiler.hpp"
+
+#include "gpu/intel/jit/utils/range.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+namespace reorder {
+
+dim_t max_elems(const hw_t &hw, const layout_t &a, const layout_t &b) {
+    // XeHPC is fine with 2048 bytes, XeHPG and below can fit 2048 bytes if
+    // reorder is a simple copy.
+    dim_t max_bytes = (hw <= ngen::HW::XeHPG && a != b) ? 1024 : 2048;
+    int max_type_size = std::max(a.type().size(), b.type().size());
+    return max_bytes / max_type_size;
+}
+
+dim_t count_block_messages(
+        const hw_t &hw, dim_t inner_bytes, dim_t iterations) {
+    const auto max_block_owords = hw.grf_size() / 2;
+    const auto oword_size = 16;
+    const auto owords_per_grf = hw.grf_size() / oword_size;
+
+    dim_t block_owords = max_block_owords / 2;
+    auto inner_owords = inner_bytes / oword_size;
+    dim_t messages = inner_owords / max_block_owords;
+    inner_owords -= messages * max_block_owords;
+    // If iterations != 1, tail block messages must end on a grf boundary
+    const dim_t lower_bound = iterations == 1 ? 1 : owords_per_grf;
+    for (; block_owords >= lower_bound; block_owords >>= 1) {
+        if (inner_owords >= block_owords) {
+            inner_owords -= block_owords;
+            messages++;
+        }
+    }
+    gpu_assert(inner_owords == 0);
+    return messages * iterations;
+}
+
+dim_t count_scattered_messages(
+        const hw_t &hw, dim_t inner_bytes, dim_t iterations) {
+    const auto max_block_items = hw.grf_size() / 2;
+    int item_size = 8;
+
+    // Find the largest uint size we can use
+    for (; item_size > 1; item_size >>= 1) {
+        if (inner_bytes % item_size == 0) break;
+    }
+
+    dim_t block_items = max_block_items / 2;
+    auto inner_items = (iterations * inner_bytes) / item_size;
+    dim_t messages = (inner_items + (block_items - 1)) / max_block_items;
+    inner_items -= std::min(inner_items, messages * max_block_items);
+    for (; block_items >= (dim_t)2; block_items >>= 1) {
+        if (inner_items > block_items / 2) {
+            inner_items -= std::min(inner_items, block_items);
+            messages++;
+        }
+    }
+    if (inner_items) messages++;
+    return messages;
+}
+
+dim_t message_latency(const hw_t &hw, const layout_t &l, const tensor_t &t) {
+    const auto grf_size = hw.grf_size();
+    const int scattered_message_penalty = 4;
+    bool can_use_block_messages = true;
+    std::vector<dim_t> outer = t.dims();
+    dim_t inner_elems = 1;
+
+    for (auto &blk : l.blocks()) {
+        auto block = blk.block;
+        auto dim_idx = blk.dim_idx;
+        if (block == 1) continue;
+        if (outer[dim_idx] < block) {
+            if (block % outer[dim_idx] == 0) {
+                inner_elems *= outer[dim_idx];
+                outer[dim_idx] = 1;
+            }
+            break;
+        }
+
+        can_use_block_messages &= (outer[dim_idx] % block == 0);
+        inner_elems *= block;
+        outer[dim_idx] = utils::div_up(outer[dim_idx], block);
+    }
+
+    auto type_size = l.type().scalar().size();
+    auto inner_bytes = inner_elems * type_size;
+    auto iterations = tensor_t(outer).elems();
+    can_use_block_messages &= (inner_bytes % 16 == 0);
+    can_use_block_messages &= (iterations == 1 || inner_bytes % grf_size == 0);
+
+    if (inner_bytes == 0 || iterations == 0) return 0;
+
+    return can_use_block_messages
+            ? count_block_messages(hw, inner_bytes, iterations)
+            : count_scattered_messages(hw, inner_bytes, iterations)
+                    * scattered_message_penalty;
+}
+
+std::vector<tensor_t> tiles(const hw_t &hw, layout_t a, layout_t b) {
+    using tile_pair_t = std::array<tensor_t, 2>;
+    auto max_elems = reorder::max_elems(hw, a, b);
+
+    std::vector<dim_t> dims(a.ndims());
+    for (dim_idx_t i = 0; i < a.ndims(); ++i)
+        dims[i] = std::max(a.dim(i), b.dim(i));
+
+    // Pad src/dst layouts to match each other.
+    auto pad_layout = [&](layout_t &l) {
+        std::vector<block_t> padded_blocks;
+        for (auto &eb : l.enumerated_blocks()) {
+            auto b = eb.second;
+            if (l.is_outermost(eb)) {
+                dim_t inner = l.dim(b.dim_idx) / b.block;
+                b.block = ir_utils::safe_divide(dims[b.dim_idx], inner);
+            }
+            padded_blocks.push_back(b);
+        }
+        l = {l.type(), l.ndims(), 0, padded_blocks, /*do_normalize=*/false};
+    };
+    pad_layout(a);
+    pad_layout(b);
+    gpu_assert(ir_utils::is_equal(a.dims(), b.dims()));
+
+    auto can_be_mapped = [](const layout_t &l, const tensor_t &t) {
+        std::vector<dim_t> rem_dims = t.dims();
+        for (auto &b : l.blocks()) {
+            auto &rem_dim = rem_dims[b.dim_idx];
+            if (rem_dim >= b.block) {
+                if (rem_dim % b.block != 0) return false;
+                rem_dim /= b.block;
+                continue;
+            }
+            if (b.block % rem_dim != 0) return false;
+            rem_dim = 1;
+        }
+        for (auto d : rem_dims)
+            gpu_assert(d == 1);
+        return true;
+    };
+
+    auto add_pseudo_dimension = [](const layout_t &l) {
+        auto layout_size = l.size();
+        return [=](const tensor_t &t) {
+            auto dims = t.dims();
+            dims.push_back(layout_size);
+            return tensor_t(dims);
+        };
+    };
+
+    auto mappable_tiles = [&](const tensor_t &t) {
+        return can_be_mapped(a, t) && can_be_mapped(b, t);
+    };
+
+    auto merge_tiles = [](const tile_pair_t &p) {
+        auto ndims = p[0].ndims() - 1;
+        std::vector<dim_t> dims(ndims);
+        for (dim_idx_t i = 0; i < ndims; ++i)
+            dims[i] = std::max(p[0](i), p[1](i));
+        return tensor_t(dims);
+    };
+
+    auto take_smaller = [](const tensor_t &a, const tensor_t &b) {
+        return a.elems() < b.elems();
+    };
+
+    // Incrementally increase subtiles in a and b. The goal is to find the
+    // maximum tiles so that the final combined tile covers dense regions as big
+    // as possible in a/b layouts.
+    std::vector<tensor_t> candidate_tiles;
+    auto a_tiles = inner_tiles(a.blocks(), a.ndims()) | filter(mappable_tiles)
+            | transform(add_pseudo_dimension(a));
+    auto b_tiles = inner_tiles(b.blocks(), b.ndims()) | filter(mappable_tiles)
+            | transform(add_pseudo_dimension(b));
+    auto tiles = merge(a_tiles, b_tiles, take_smaller) | transform(merge_tiles);
+    for (auto tile : tiles) {
+        if (tile.elems() > max_elems) break;
+        if (candidate_tiles.empty() || !tile.is_equal(candidate_tiles.back()))
+            candidate_tiles.push_back(tile);
+    }
+    gpu_assert(!candidate_tiles.empty());
+
+    const auto eu_count = hw.eu_count();
+    auto cmp = [&](const tensor_t &l, const tensor_t &r) {
+        auto l_threads_reqd = a.elems() / l.elems();
+        auto r_threads_reqd = a.elems() / r.elems();
+        auto l_eu_util = utils::div_up(l_threads_reqd, eu_count);
+        auto r_eu_util = utils::div_up(r_threads_reqd, eu_count);
+        auto l_msg_load = message_latency(hw, a, l) + message_latency(hw, b, l);
+        auto r_msg_load = message_latency(hw, a, r) + message_latency(hw, b, r);
+
+        // Choose tiles with less message overhead per thread
+        if (l_eu_util * l_msg_load != r_eu_util * r_msg_load)
+            return (l_eu_util * l_msg_load < r_eu_util * r_msg_load);
+
+        // Choose tiles with more bytes per message
+        if (l.elems() * r_msg_load != r.elems() * l_msg_load)
+            return (l.elems() * r_msg_load > r.elems() * l_msg_load);
+
+        // If all else fails, go with the bigger tile
+        return l.elems() > r.elems();
+    };
+    size_t best_idx = 0;
+    for (size_t i = 0; i < candidate_tiles.size(); ++i)
+        if (cmp(candidate_tiles[i], candidate_tiles[best_idx])) best_idx = i;
+    candidate_tiles.resize(best_idx + 1);
+    auto best = candidate_tiles.back();
+    candidate_tiles.erase(
+            std::remove_if(candidate_tiles.begin(), candidate_tiles.end(),
+                    [&](const tensor_t &t) { return !best.is_divisible(t); }),
+            candidate_tiles.end());
+    candidate_tiles.shrink_to_fit();
+    return candidate_tiles;
+}
+
+} // namespace reorder
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/jit/reorder/tiler.cpp
+++ b/src/gpu/intel/jit/reorder/tiler.cpp
@@ -60,20 +60,11 @@ dim_t count_block_messages(
 
 dim_t count_scattered_messages(
         const hw_t &hw, dim_t inner_bytes, dim_t iterations, int item_size) {
-    const auto max_block_items = hw.grf_size() / 2;
     constexpr int scattered_message_penalty = 4;
+    const int message_items = hw.grf_size() / 2;
 
-    dim_t block_items = max_block_items / 2;
     auto inner_items = (iterations * inner_bytes) / item_size;
-    dim_t messages = (inner_items + (block_items - 1)) / max_block_items;
-    inner_items -= std::min(inner_items, messages * max_block_items);
-    for (; block_items >= (dim_t)2; block_items >>= 1) {
-        if (inner_items > block_items / 2) {
-            inner_items -= std::min(inner_items, block_items);
-            messages++;
-        }
-    }
-    if (inner_items) messages++;
+    auto messages = utils::div_up(inner_items, message_items);
     return messages * scattered_message_penalty;
 }
 

--- a/src/gpu/intel/jit/reorder/tiler.cpp
+++ b/src/gpu/intel/jit/reorder/tiler.cpp
@@ -25,12 +25,15 @@ namespace intel {
 namespace jit {
 namespace reorder {
 
-dim_t max_elems(const hw_t &hw, const layout_t &a, const layout_t &b) {
+enum class message_kind_t {
+    block,
+    scattered,
+};
+
+dim_t max_bytes(const hw_t &hw, const layout_t &a, const layout_t &b) {
     // XeHPC is fine with 2048 bytes, XeHPG and below can fit 2048 bytes if
     // reorder is a simple copy.
-    dim_t max_bytes = (hw <= ngen::HW::XeHPG && a != b) ? 1024 : 2048;
-    int max_type_size = std::max(a.type().size(), b.type().size());
-    return max_bytes / max_type_size;
+    return (hw <= ngen::HW::XeHPG && a != b) ? 1024 : 2048;
 }
 
 dim_t count_block_messages(
@@ -56,14 +59,9 @@ dim_t count_block_messages(
 }
 
 dim_t count_scattered_messages(
-        const hw_t &hw, dim_t inner_bytes, dim_t iterations) {
+        const hw_t &hw, dim_t inner_bytes, dim_t iterations, int item_size) {
     const auto max_block_items = hw.grf_size() / 2;
-    int item_size = 8;
-
-    // Find the largest uint size we can use
-    for (; item_size > 1; item_size >>= 1) {
-        if (inner_bytes % item_size == 0) break;
-    }
+    constexpr int scattered_message_penalty = 4;
 
     dim_t block_items = max_block_items / 2;
     auto inner_items = (iterations * inner_bytes) / item_size;
@@ -76,17 +74,41 @@ dim_t count_scattered_messages(
         }
     }
     if (inner_items) messages++;
-    return messages;
+    return messages * scattered_message_penalty;
 }
 
-dim_t message_latency(const hw_t &hw, const layout_t &l, const tensor_t &t) {
-    const auto grf_size = hw.grf_size();
-    const int scattered_message_penalty = 4;
-    bool can_use_block_messages = true;
-    std::vector<dim_t> outer = t.dims();
-    dim_t inner_elems = 1;
+struct message_info_t {
+    message_info_t() = default;
+    message_info_t(message_kind_t kind, dim_t inner_bytes, dim_t iterations,
+            int item_size)
+        : kind(kind)
+        , inner_bytes(inner_bytes)
+        , iterations(iterations)
+        , item_size(item_size) {}
 
-    for (auto &blk : l.blocks()) {
+    message_kind_t kind = message_kind_t::block;
+    dim_t inner_bytes = 0;
+    dim_t iterations = 0;
+    int item_size = 16;
+
+    dim_t latency(const hw_t &hw) const {
+        if (inner_bytes == 0 || iterations == 0) return 0;
+        return kind == message_kind_t::block
+                ? count_block_messages(hw, inner_bytes, iterations)
+                : count_scattered_messages(
+                        hw, inner_bytes, iterations, item_size);
+    }
+};
+
+message_info_t estimate_message_info(
+        const hw_t &hw, const layout_t &layout, const tensor_t &tile) {
+    const auto grf_size = hw.grf_size();
+    bool can_use_block_messages = true;
+    std::vector<dim_t> outer = tile.dims();
+    dim_t inner_elems = 1;
+    int item_size = 16;
+
+    for (auto &blk : layout.blocks()) {
         auto block = blk.block;
         auto dim_idx = blk.dim_idx;
         if (block == 1) continue;
@@ -103,23 +125,27 @@ dim_t message_latency(const hw_t &hw, const layout_t &l, const tensor_t &t) {
         outer[dim_idx] = utils::div_up(outer[dim_idx], block);
     }
 
-    auto type_size = l.type().scalar().size();
-    auto inner_bytes = inner_elems * type_size;
+    auto inner_bytes = utils::div_up(
+            layout.type().with_elems(8).size() * inner_elems, 8);
     auto iterations = tensor_t(outer).elems();
     can_use_block_messages &= (inner_bytes % 16 == 0);
     can_use_block_messages &= (iterations == 1 || inner_bytes % grf_size == 0);
 
-    if (inner_bytes == 0 || iterations == 0) return 0;
+    if (inner_bytes == 0 || iterations == 0) return {};
 
-    return can_use_block_messages
-            ? count_block_messages(hw, inner_bytes, iterations)
-            : count_scattered_messages(hw, inner_bytes, iterations)
-                    * scattered_message_penalty;
+    auto message_kind = can_use_block_messages ? message_kind_t::block
+                                               : message_kind_t::scattered;
+    if (!can_use_block_messages)
+        // Find the largest unit size we can use
+        for (item_size = 8; item_size > 1; item_size >>= 1) {
+            if (inner_bytes % item_size == 0) break;
+        }
+    return {message_kind, inner_bytes, iterations, item_size};
 }
 
 std::vector<tensor_t> tiles(const hw_t &hw, layout_t a, layout_t b) {
     using tile_pair_t = std::array<tensor_t, 2>;
-    auto max_elems = reorder::max_elems(hw, a, b);
+    auto max_size = max_bytes(hw, a, b);
 
     std::vector<dim_t> dims(a.ndims());
     for (dim_idx_t i = 0; i < a.ndims(); ++i)
@@ -184,30 +210,18 @@ std::vector<tensor_t> tiles(const hw_t &hw, layout_t a, layout_t b) {
         return a.elems() < b.elems();
     };
 
-    // Incrementally increase subtiles in a and b. The goal is to find the
-    // maximum tiles so that the final combined tile covers dense regions as big
-    // as possible in a/b layouts.
-    std::vector<tensor_t> candidate_tiles;
-    auto a_tiles = inner_tiles(a.blocks(), a.ndims()) | filter(mappable_tiles)
-            | transform(add_pseudo_dimension(a));
-    auto b_tiles = inner_tiles(b.blocks(), b.ndims()) | filter(mappable_tiles)
-            | transform(add_pseudo_dimension(b));
-    auto tiles = merge(a_tiles, b_tiles, take_smaller) | transform(merge_tiles);
-    for (auto tile : tiles) {
-        if (tile.elems() > max_elems) break;
-        if (candidate_tiles.empty() || !tile.is_equal(candidate_tiles.back()))
-            candidate_tiles.push_back(tile);
-    }
-    gpu_assert(!candidate_tiles.empty());
-
     const auto eu_count = hw.eu_count();
     auto cmp = [&](const tensor_t &l, const tensor_t &r) {
         auto l_threads_reqd = a.elems() / l.elems();
         auto r_threads_reqd = a.elems() / r.elems();
         auto l_eu_util = utils::div_up(l_threads_reqd, eu_count);
         auto r_eu_util = utils::div_up(r_threads_reqd, eu_count);
-        auto l_msg_load = message_latency(hw, a, l) + message_latency(hw, b, l);
-        auto r_msg_load = message_latency(hw, a, r) + message_latency(hw, b, r);
+        auto l_a_msg = estimate_message_info(hw, a, l);
+        auto l_b_msg = estimate_message_info(hw, b, l);
+        auto r_a_msg = estimate_message_info(hw, a, r);
+        auto r_b_msg = estimate_message_info(hw, b, r);
+        auto l_msg_load = l_a_msg.latency(hw) + l_b_msg.latency(hw);
+        auto r_msg_load = r_a_msg.latency(hw) + r_b_msg.latency(hw);
 
         // Choose tiles with less message overhead per thread
         if (l_eu_util * l_msg_load != r_eu_util * r_msg_load)
@@ -220,6 +234,41 @@ std::vector<tensor_t> tiles(const hw_t &hw, layout_t a, layout_t b) {
         // If all else fails, go with the bigger tile
         return l.elems() > r.elems();
     };
+
+    // Incrementally increase subtiles in a and b. The goal is to find the
+    // maximum tiles so that the final combined tile covers dense regions as big
+    // as possible in a/b layouts.
+    std::vector<tensor_t> candidate_tiles;
+    auto a_tiles = inner_tiles(a.blocks(), a.ndims()) | filter(mappable_tiles)
+            | transform(add_pseudo_dimension(a));
+    auto b_tiles = inner_tiles(b.blocks(), b.ndims()) | filter(mappable_tiles)
+            | transform(add_pseudo_dimension(b));
+    auto tiles = merge(a_tiles, b_tiles, take_smaller) | transform(merge_tiles);
+
+    const int unit_size = std::max(a.type().size(), b.type().size());
+    const dim_t max_units = max_size / unit_size;
+
+    auto get_grf_layout_size = [&](const tensor_t &tile) {
+        auto elems = tile.elems();
+        dim_t grf_layout_size = 0;
+        for (const auto &l : {a, b}) {
+            auto info = estimate_message_info(hw, l, tile);
+            int elem_size = std::max(info.item_size, 4);
+            int elem_packing = info.item_size / l.type().size();
+            auto layout_size = elem_size * elems / elem_packing;
+            if (layout_size > grf_layout_size) grf_layout_size = layout_size;
+        }
+        return grf_layout_size;
+    };
+
+    for (auto tile : tiles) {
+        if (tile.elems() > max_units) break;
+        if (get_grf_layout_size(tile) > max_size) continue;
+        if (candidate_tiles.empty() || !tile.is_equal(candidate_tiles.back()))
+            candidate_tiles.push_back(tile);
+    }
+    gpu_assert(!candidate_tiles.empty());
+
     size_t best_idx = 0;
     for (size_t i = 0; i < candidate_tiles.size(); ++i)
         if (cmp(candidate_tiles[i], candidate_tiles[best_idx])) best_idx = i;

--- a/src/gpu/intel/jit/reorder/tiler.hpp
+++ b/src/gpu/intel/jit/reorder/tiler.hpp
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_JIT_REORDER_TILER_HPP
+#define GPU_INTEL_JIT_REORDER_TILER_HPP
+
+#include <array>
+
+#include "gpu/intel/jit/ir/tensor.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+namespace reorder {
+
+std::vector<tensor_t> tiles(const hw_t &hw, layout_t a, layout_t b);
+
+} // namespace reorder
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
Refactors the jit reorder interface so that the work tile (iter * loop) is known at config time. It is prework for [MFDNN-12529](https://jira.devtools.intel.com/browse/MFDNN-12529) to adhere to tile size restrictions at primitive creation time.

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
