### PR TITLE
[GPU] Convolution: improve small IC/OC performance

### DIFF
--- a/src/gpu/intel/jit/conv/lookup_table_data.cpp
+++ b/src/gpu/intel/jit/conv/lookup_table_data.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,13 +31,9 @@ const char** get_conv_lookup_table_entries() {
         "xehpg dpas bwd_w x16:any:x16 mb1 ic3ih224oc128oh56kh4sh4ph0 simd=8 l=oh8 T=oc2 i=ic4kw4oc8ow16 bufs=0",
         "xehpg dpas fwd x8:x8:any mb128b ic64iw3136oc256ow3136kw1pw0 simd=8 l=ic2 T=ow8 i=ic32mb32oc32 bufs=2",
         "xehpg dpas fwd x16:x16:any mb2 ic320iw2304oc640ow2304kw1pw0 simd=8 l=ic20 T=oc4ow8 i=ic16oc32ow24",
-        "xehpg dpas fwd x16:x16:any mb32b ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=8 l=kw3 T=ow8 i=ic2kw8mb32oc8 bufs=1",
-        "xehpg dpas fwd x8:x8:any mb32b ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=8 l=kw3 T=ow8 i=ic4kw8mb32oc8 bufs=1",
         "xehpg dpas fwd x16:x16:any mb2 ic1280ih24oc1280oh24kh3ph1 simd=8 l=ic80kh3kw3 T=oc4 i=ic16oc32ow24",
         "xehpg dpas fwd x16:x16:any mb2 ic960iw9216oc320ow9216kw1pw0 simd=8 l=ic60 T=oc4ow8 i=ic16oc32ow32",
         "xehpg dpas fwd x8:x8:any mb128b ic128ih56oc128oh28kh3sh2ph1 simd=8 l=ic4kh3kw3 T=oc4ow8 i=ic32mb32oc32 bufs=3",
-        "xehpg mad fwd x16:x16:any mb1 ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=8 l=kw3 T=ow8 i=kw8oc8ow16 bufs=1",
-        "xehpg mad fwd x8:x8:any mb1 ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=8 l=x T=ow2 i=kw23oc8ow15 bufs=0",
         "xehpg dpas fwd x8:x8:any mb128b ic64ih56oc64oh56kh3ph1 simd=8 l=ic2kh3kw3 T=oc2ow8 i=ic32mb32oc32 bufs=3",
         "xehpg dpas fwd x8:x8:any mb128b ic1024iw196oc256ow196kw1pw0 simd=8 l=ic32 T=oc8ow4 i=ic32mb32oc32 bufs=3",
         "xehpc dpas fwd x16:x16:any mb1 ic256ih5oc12oh5kh3ph1 simd=16 l=ic2kh3kw3 T=ic8 i=ic16oc16ow8 bufs=0",
@@ -306,8 +302,6 @@ const char** get_conv_lookup_table_entries() {
         "xehpc dpas fwd x8:x8:any mb32b ic3id8ih224iw224oc16od8oh112ow112kd1kh3kw3sh2sw2pd0ph1pw1 simd=16 l=kh3 T=x i=ic4kw8mb32oc16 bufs=3",
         "xehpg dpas fwd x16:x16:any mb1 ic640ih32oc640oh16kh3sh2ph1 simd=8 l=ic10kh3kw3 T=ic4 i=ic16oc32ow16 bufs=0",
         "xehpg dpas fwd x16:x16:any mb1 ic1280ih8oc1280oh8kh3ph1 simd=8 l=ic20kh3kw3 T=ic2 i=ic32oc16ow8 bufs=0",
-        "xehpc dpas fwd x8:x8:any mb32b ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=16 l=kw3 T=ow4 i=ic4kw8mb32oc16 bufs=3",
-        "xehpc dpas fwd x16:x16:any mb32b ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=16 l=kw3 T=ow8 i=ic2kw8mb32oc16 bufs=3",
         "xehpc dpas bwd_w x16:any:x16 mb64 ic256iw90oc256ow59kw32pw0 simd=16 l=mb64ow4 T=ic8oc4 i=ic16oc64ow16",
         "xehpg dpas bwd_w x16:any:x16 mb3 ic256ih10iw16oc256oh10ow16kh5kw5ph2pw2 simd=8 l=oh10 T=ic8oc4 i=ic16oc64ow16 bufs=3",
         "xehpg dpas fwd x16:x16:any mb1 ic1920iw256oc1280ow256kw1pw0 simd=8 l=ic120 T=oc8ow4 i=ic16oc16ow32",
@@ -335,8 +329,6 @@ const char** get_conv_lookup_table_entries() {
         "xehpc mad fwd f64:f64:any mb2048 ic2ih10oc8oh8kh3ph0 simd=8 l=kh3 T=x i=ic2kw3oc8ow8 bufs=0",
         "xehpc dpas bwd_w x16:any:x16 mb64 ic128iw16oc64ow15kw2pw0 simd=16 l=x T=ic8 i=ic8kw2oc16ow16",
         "xehpg dpas fwd x8:x8:any mb32b ic10ih15oc20oh13kh3ph0 simd=8 l=kh3kw2 T=oc4ow4 i=ic16kw2mb32oc8 bufs=3",
-        "xehpc mad fwd x8:x8:any mb1 ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=16 l=x T=ow4 i=kw23oc16ow16 bufs=0",
-        "xehpc mad fwd x16:x16:any mb1 ic1ih80iw100650oc1oh80ow100650kh1kw23ph0pw11 simd=16 l=x T=x i=kw23oc16ow16 bufs=0",
         "xehpg dpas fwd x16:x16:any mb1 ic1280ih10oc1280oh8kh3ph0 simd=8 l=ic20kh3kw3 T=ic2 i=ic32oc16ow8 bufs=0",
         "xehpc dpas bwd_d any:x16:x16 mb64 ic256iw90oc256ow59kw32pw0 simd=16 l=kw32oc8 T=ic8iw4 i=ic32iw30oc32",
         "xehpg dpas fwd x16:x16:any mb2 ic640ih24oc1280oh24kh3ph1 simd=8 l=ic40kh3kw3 T=oc4 i=ic16oc32ow24",

--- a/src/gpu/intel/jit/conv/plan.cpp
+++ b/src/gpu/intel/jit/conv/plan.cpp
@@ -1379,6 +1379,10 @@ struct fma_context_t {
             auto fma_layout = bmnk_layout.make_with_block(
                     layout_t(ret.type(), 0, (int)bmnks.size(), blocks));
             auto abc_layout = mapper.map_from_bmnk(abc, bmnks, fma_layout, ret);
+            if (layout.type().is_x8()) {
+                gpu_assert(abc_layout.type().is_s16());
+                abc_layout = abc_layout.make_strided(2);
+            }
             return abc_layout;
         }
 

--- a/src/gpu/intel/jit/conv/plan.cpp
+++ b/src/gpu/intel/jit/conv/plan.cpp
@@ -1243,6 +1243,19 @@ std::string conv_plan_t::str() const {
     return jit::add_indent("conv_plan", oss.str());
 }
 
+type_t get_accumulation_type(
+        const conv_config_t &cfg, const type_t &a, const type_t &b) {
+    if (a.is_int()) return type_t::s32();
+    if (a.is_f64()) return type_t::f64();
+    if (cfg.fma_kind() == fma_kind_t::mad && a.is_f16() && b.is_f16()
+            && cfg.prb().is_fwd) {
+        // FIXME: f16 must use f32 accumulator according to documentation.
+        // Temporarily keeping f16 to avoid regressions.
+        return type_t::f16();
+    }
+    return type_t::f32();
+}
+
 struct fma_layout_hint_t {
     int vec_dim_idx = -1;
 
@@ -1257,7 +1270,7 @@ struct fma_context_t {
         fma = cfg.fma_kind();
         a_type = type_t(cfg.prb().a_data_type);
         b_type = type_t(cfg.prb().b_data_type);
-        c_type = type_t(cfg.prb().c_data_type);
+        acc_type = get_accumulation_type(cfg, a_type, b_type);
         is_src1_broadcast = !cfg.prb().is_dw;
         ab_swap_transpose_ = cfg.prb().ab_swap_transpose;
     }
@@ -1272,35 +1285,19 @@ struct fma_context_t {
 
     layout_t maybe_retype_layout_for_mad(
             bool is_a, const layout_t &layout) const {
-        bool is_b = !is_a;
         // mad with s8/u8 is not supported, promote to strided s16.
         if (layout.type().is_x8())
             return layout.retype(type_t::s16()).make_strided(2);
-
-        if (a_type.is_f16() && b_type.is_f16() && c_type.is_f32()) {
-            return layout.retype(type_t::f32()).make_dense();
-        }
-        if (layout.type().is_fp8()) {
-            auto alt_type = is_b ? a_type : b_type;
-            return layout.make_dense().retype(
-                    alt_type.is_fp8() ? type_t::f16() : alt_type);
-        }
-
         // mad with f16 requires aligned regioning for src1/src2.
-        if (a_type.is_f16()) return layout.make_dense();
-
-        if (layout.type().is_bf16() && !hw.systolic_support())
+        if (a_type.is_f16() && acc_type.is_f16()) {
+            return layout.make_dense();
+        }
+        bool is_a_xf8_or_xf16
+                = (a_type.is_fp8() || a_type.is_bf16() || a_type.is_f16());
+        bool is_b_xf8_or_xf16
+                = (b_type.is_fp8() || b_type.is_bf16() || b_type.is_f16());
+        if (is_a_xf8_or_xf16 || is_b_xf8_or_xf16) {
             return layout.retype(type_t::f32()).make_dense();
-
-        if (a_type.is_bf16()) {
-            // bf16 mixed mode requires src1 to be converted to f32 when it's
-            // broadcasted.
-            if (is_a && is_src1_broadcast)
-                return layout.retype(type_t::f32()).make_dense();
-            // bf16 mixed mode mad requires src1 to be packed
-            if (is_a) return layout.make_dense();
-            // bf16 mixed mode mad requires src2 to be f32.
-            if (is_b) return layout.retype(type_t::f32()).make_dense();
         }
         return layout;
     }
@@ -1310,7 +1307,6 @@ struct fma_context_t {
         bool is_mad = (fma == fma_kind_t::mad);
         bool is_dpas = is_dp_fma(fma);
         bool is_a = (abc == abc_kind_t::a);
-        bool is_b = (abc == abc_kind_t::b);
         auto type = (is_a ? a_type : b_type);
         int type_size = (layout.type().is_fp8() ? 2 : type.size());
         if (is_dpas) {
@@ -1342,30 +1338,6 @@ struct fma_context_t {
         }
 
         if (is_mad) {
-            // swap b blocks for axb layouts when a inner dim is required by transpose
-            if (is_b && ab_swap_transpose_) {
-                if (layout.blocks().size() > 1) {
-                    std::vector<block_t> blocks;
-                    dim_t new_inner_stride = 1;
-                    int nblocks = (int)layout.blocks().size();
-                    auto inner_most_block = layout.blocks()[0];
-                    for (int i = nblocks - 1; i >= 0; --i) {
-                        auto &b = layout.blocks()[i];
-                        if (b.dim_idx != inner_most_block.dim_idx) {
-                            new_inner_stride = b.block;
-                            blocks.insert(blocks.begin(),
-                                    block_t(b.dim_idx, b.block, stride_t(1)));
-                        } else {
-                            blocks.emplace_back(block_t(b.dim_idx, b.block,
-                                    stride_t(new_inner_stride)));
-                        }
-                    }
-                    return maybe_retype_layout_for_mad(is_a,
-                            layout_t(layout.type(), layout.ndims(),
-                                    layout.offset(), blocks)
-                                    .make_dense());
-                }
-            }
             // XXX: type and layout.type() may be different here when using mad
             // with fpmath attribute. For now type is ignored and hence fpmath
             // attribute has no effect with mad.
@@ -1462,7 +1434,7 @@ struct fma_context_t {
     fma_kind_t fma;
     type_t a_type;
     type_t b_type;
-    type_t c_type;
+    type_t acc_type;
     bool is_src1_broadcast;
     bool ab_swap_transpose_;
     fma_layout_hint_t a_layout_hint;
@@ -1577,13 +1549,6 @@ layout_t get_slm_layout(const fma_context_t &fma_ctx, abc_kind_t abc,
     return layout;
 }
 
-type_t get_default_accumulation_type(const type_t &a, const type_t &b) {
-    UNUSED(b);
-    if (a.is_int()) return type_t::s32();
-    if (a.is_f64()) return type_t::f64();
-    return type_t::f32();
-}
-
 struct reduce_mask_t {
     reduce_mask_t() = default;
     reduce_mask_t(uint32_t mask) : enable(true), mask(mask) {}
@@ -1632,7 +1597,8 @@ tensor_t to_reduce_tensor(const tensor_t &tile, uint32_t mask) {
     return tensor_t(reduce_dims, reduce_start);
 }
 
-layout_t to_reduce_layout(const layout_t &layout, uint32_t mask) {
+layout_t to_reduce_layout(
+        const conv_config_t &cfg, const layout_t &layout, uint32_t mask) {
     int reduce_ndims = layout.ndims();
     auto map = get_reduce_dim_map(mask, reduce_ndims);
     std::vector<block_t> reduce_blocks;
@@ -1642,7 +1608,7 @@ layout_t to_reduce_layout(const layout_t &layout, uint32_t mask) {
         bb.dim_idx = map[b.dim_idx];
         reduce_blocks.push_back(bb);
     }
-    auto type = get_default_accumulation_type(layout.type(), layout.type());
+    auto type = get_accumulation_type(cfg, layout.type(), layout.type());
     return layout_t(type, reduce_ndims, 0, reduce_blocks).make_dense();
 }
 
@@ -2111,7 +2077,7 @@ private:
         reorder = create_reorder_plan(cfg_.hw(), src, dst);
         if (reduce_mask && cfg_.allow_global_reduction()) {
             *reduce_tile = to_reduce_tensor(abs_thr_tile, reduce_mask.mask);
-            auto reduce_layout = to_reduce_layout(src, reduce_mask.mask);
+            auto reduce_layout = to_reduce_layout(cfg_, src, reduce_mask.mask);
             *reduce = create_reduce_plan(
                     cfg_.hw(), src, reduce_layout, reduce_mask.mask);
         }
@@ -2176,7 +2142,8 @@ private:
         layout = load.reg_layout();
         if (reduce_mask && !cfg_.allow_global_reduction()) {
             *reduce_tile = to_reduce_tensor(abs_thr_tile, reduce_mask.mask);
-            auto reduce_layout = to_reduce_layout(layout, reduce_mask.mask);
+            auto reduce_layout
+                    = to_reduce_layout(cfg_, layout, reduce_mask.mask);
             *reduce = create_reduce_plan(
                     cfg_.hw(), layout, reduce_layout, reduce_mask.mask);
         }
@@ -2218,7 +2185,8 @@ private:
         if (reduce_mask) {
             gpu_assert(!direct_view);
             *reduce_tile = to_reduce_tensor(abs_thr_tile, reduce_mask.mask);
-            auto reduce_layout = to_reduce_layout(reg_layout, reduce_mask.mask);
+            auto reduce_layout
+                    = to_reduce_layout(cfg_, reg_layout, reduce_mask.mask);
             *reduce = create_reduce_plan(
                     cfg_.hw(), reg_layout, reduce_layout, reduce_mask.mask);
         }
@@ -2381,11 +2349,7 @@ private:
         int k_blk = 1;
         auto &a_type = a_layout.type();
         auto &b_type = b_layout.type();
-        auto c_type = get_default_accumulation_type(a_type, b_type);
-        if (fma_kind == fma_kind_t::mad && a_type.is_f16() && b_type.is_f16()) {
-            // FIXME: f16 must use f32 accumulator according to documentation.
-            c_type = type_t::f16();
-        }
+        auto c_type = get_accumulation_type(cfg_, a_type, b_type);
         layout_t c_blk_layout(c_type, 0, std::vector<dim_t>(3, 1));
         switch (fma_kind) {
             case fma_kind_t::dp4a:

--- a/src/gpu/intel/jit/conv/plan.hpp
+++ b/src/gpu/intel/jit/conv/plan.hpp
@@ -89,7 +89,6 @@ struct slm_plan_t : public base_plan_t {
     send_plan_t a_g2s_load;
     send_plan_t b_g2s_load;
     tensor_t x_reduce_tile;
-    layout_t x_reduce_layout;
     reduce_plan_t x_reduce;
     reorder_plan_t a_reorder;
     reorder_plan_t b_reorder;
@@ -133,7 +132,6 @@ struct x2r_plan_t : public base_plan_t {
     send_plan_t a_load;
     send_plan_t b_load;
     tensor_t x_reduce_tile;
-    layout_t x_reduce_layout;
     reduce_plan_t x_reduce;
     reorder_plan_t a_reorder;
     reorder_plan_t b_reorder;


### PR DESCRIPTION
Jira: [MFDNN-13199](https://jira.devtools.intel.com/browse/MFDNN-13199)

List of changes:

- Adjusted heuristics to enable `mad` (instead of `dpas`) and M/N transposition
    - Both optimizations are to reduce padding (and related redundant work) in case of small channels
    - This is like 10th or so version of the heuristics - unfortunately still seeing a few regressions in P3 KPIs. There are much more improvements so it does not look too bad
- Removed suboptimal lookup table entries
- Refactored and simplified accumulator type and transposed blocking logic
    - We still incorrectly use f16 accumulator with f16 data type in some cases. I tried to fix it but it causes quite a few model-level slowdowns so let's keep it this way for now. In the future we need to add FP math mode based dispatching between f16 vs f32 (easier part) and ask our users to port their code to use the proper FP math mode to avoid regressions (harder part)

Jira cases:

| Case                                                                                                                    | base perf (GOps/sec) | test perf (GOps/sec) | Ratio |
|-------------------------------------------------------------------------------------------------------------------------|----------------------|----------------------|-------|
| --dir=FWD_I --dt=f16:f16:f16 --stag=acdb --dtag=acdb mb1ic3ih1080iw1920oc1oh1080ow1920kh1kw1ph0pw0                      | 10.935               | 86.114               | 7.88  |
| --dir=FWD_I --dt=f16:f16:f16 --stag=abcd --dtag=acdb --attr-post-ops=relu mb1ic3ih1080iw1920oc3oh1080ow1920kh1kw1ph0pw0 | 47.573               | 103.411              | 2.17  |
