### PR TITLE
ci: linters: clang-tidy job improvements

### DIFF
--- a/.github/automation/build_linters.sh
+++ b/.github/automation/build_linters.sh
@@ -33,7 +33,7 @@ if [[ "$ONEDNN_ACTION" == "configure" ]]; then
     fi
 elif [[ "$ONEDNN_ACTION" == "build" ]]; then
     set -x
-    cmake --build build
+    cmake --build build -j4
     set +x
 else
     echo "Unknown action: $ONEDNN_ACTION"

--- a/.github/automation/build_linters.sh
+++ b/.github/automation/build_linters.sh
@@ -33,7 +33,7 @@ if [[ "$ONEDNN_ACTION" == "configure" ]]; then
     fi
 elif [[ "$ONEDNN_ACTION" == "build" ]]; then
     set -x
-    cmake --build build -j4
+    cmake --build build -j`nproc`
     set +x
 else
     echo "Unknown action: $ONEDNN_ACTION"

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -101,6 +101,6 @@ jobs:
         run: |
           .github/automation/build_linters.sh | tee build.log
           grep -i "warning:" build.log | sort -u
-          grep -i "warning:" build.log && exit 1 || true
+          grep -q -i "warning:" build.log && exit 1 || true
         env:
           ONEDNN_ACTION: build

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -99,7 +99,8 @@ jobs:
 
       - name: Build oneDNN
         run: |
-          .github/automation/build_linters.sh 2>&1 | tee build.log
+          .github/automation/build_linters.sh | tee build.log
+          cat build.log
           grep -i "warning:" build.log | sort -u && exit 1 || true
         env:
           ONEDNN_ACTION: build

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -101,6 +101,6 @@ jobs:
         run: |
           .github/automation/build_linters.sh | tee build.log
           cat build.log
-          grep -i "warning:" build.log | sort -u && exit 1 || true
+          grep -i "warning:" build.log | sort -u | awk '{print}' && exit 1 || true
         env:
           ONEDNN_ACTION: build

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build oneDNN
         run: |
-          .github/automation/build_linters.sh | tee build.log
+          .github/automation/build_linters.sh 2>&1 | tee build.log
           grep -i "warning:" build.log | sort -u
           grep -q -i "warning:" build.log && exit 1 || true
         env:

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -98,6 +98,8 @@ jobs:
           ONEDNN_ACTION: configure
 
       - name: Build oneDNN
-        run: .github/automation/build_linters.sh
+        run: |
+          .github/automation/build_linters.sh 2>&1 | tee build.log
+          grep -i "warning:" build.log | sort -u && exit 1 || true
         env:
           ONEDNN_ACTION: build

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Build oneDNN
         run: |
           .github/automation/build_linters.sh | tee build.log
-          cat build.log
-          grep -i "warning:" build.log | sort -u | awk '{print}' && exit 1 || true
+          grep -i "warning:" build.log | sort -u
+          grep -i "warning:" build.log && exit 1 || true
         env:
           ONEDNN_ACTION: build


### PR DESCRIPTION
This PR is to provide fails in clang-tidy job in case of warnings occurrences, also speeded up a job.