### PR TITLE
Fixups for recent changes.

### DIFF
--- a/examples/ukernels/cpu_brgemm.cpp
+++ b/examples/ukernels/cpu_brgemm.cpp
@@ -66,8 +66,17 @@ void brgemm_example() {
     // packing requirements once for multiple objects.
     // Based on this information, specific `ldb` value can be used, since
     // transform has a limited set of values supported.
-    const bool need_pack
-            = brgemm::get_B_pack_type(a_dt, b_dt) == pack_type::pack32;
+    bool need_pack = false;
+    try {
+        need_pack = brgemm::get_B_pack_type(a_dt, b_dt) == pack_type::pack32;
+    } catch (error &e) {
+        if (e.status == dnnl_unimplemented)
+            throw example_allows_unimplemented {
+                    "Kernel is not supported on this platform.\n"};
+
+        // on any other error just re-throw
+        throw;
+    }
 
     const memory::dim lda = K;
     // `ldb` for `need_pack = true` must be one of 16, 32, 48, or 64. This

--- a/src/cpu/x64/brgemm/capi/brgemm_api.cpp
+++ b/src/cpu/x64/brgemm/capi/brgemm_api.cpp
@@ -168,7 +168,7 @@ status_t brgemm_t::get_B_pack_type(
     brgemm_utils::set_isa_impl(&brg);
     if (brg.isa_impl == cpu_isa_t::isa_undef) {
         VCHECK_BRGEMM_STATUS(
-                status::invalid_arguments, false, "get_B_pack_type failed");
+                status::unimplemented, false, "get_B_pack_type failed");
     }
     const bool has_vnni_layout = brgemm_desc_t::is_b_data_layout_vnni(
             dt_a, dt_b, /* brgattr.b_is_vnni = */ false, brg.isa_impl);

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -442,7 +442,7 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
             if (args.dt == dnnl_f16) binary_comp_po_diff_trh = 5e-3f;
             if (args.dt == dnnl_f32) {
                 binary_comp_po_diff_trh = 4e-6f;
-                binary_comp_po_rdiff_trh = 7e-6f;
+                binary_comp_po_rdiff_trh = 8e-6f;
             }
             ok = has_binary_compute_po(attr)
                     && (args.diff <= binary_comp_po_diff_trh


### PR DESCRIPTION
get_B_pack_type is not working for int8 on AVX and older.
Windows has slightly higher precision issue with logsoftmax than Linux.
All failures popped-up in Nightly.