### PR TITLE
cpu: address some clang-tidy complaints

### DIFF
--- a/src/cpu/gemm_convolution.hpp
+++ b/src/cpu/gemm_convolution.hpp
@@ -115,7 +115,7 @@ struct gemm_convolution_fwd_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         bool is_nspc = pd()->jcp_.is_nspc;
@@ -170,7 +170,7 @@ struct gemm_convolution_bwd_data_t : public primitive_t {
 
     gemm_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         bool is_nspc = pd()->jcp_.is_nspc;
@@ -223,7 +223,7 @@ struct gemm_convolution_bwd_weights_t : public primitive_t {
 
     gemm_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         const bool is_nspc = pd()->jcp_.is_nspc;

--- a/src/cpu/gemm_inner_product.hpp
+++ b/src/cpu/gemm_inner_product.hpp
@@ -120,7 +120,7 @@ struct gemm_inner_product_fwd_t : public primitive_t {
         return pp_kernel_->create_kernel();
     }
 
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -163,7 +163,7 @@ struct gemm_inner_product_bwd_data_t : public primitive_t {
     };
 
     gemm_inner_product_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_data(ctx);
@@ -208,7 +208,7 @@ struct gemm_inner_product_bwd_weights_t : public primitive_t {
     };
 
     gemm_inner_product_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_weights(ctx);

--- a/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
@@ -32,7 +32,7 @@ struct pp_ker_t {
             const convolution_pd_t *pd, const conv_gemm_conf_t &jcp);
     virtual ~pp_ker_t() = default;
 
-    typedef typename prec_traits_t<data_type::s32>::type acc_data_t;
+    using acc_data_t = typename prec_traits_t<data_type::s32>::type;
 
     virtual void operator()(void *dst, const acc_data_t *acc, const char *bias,
             const float *scales, float dst_scale, float sum_scale,

--- a/src/cpu/matmul/gemm_bf16_matmul.hpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.hpp
@@ -90,10 +90,10 @@ struct gemm_bf16_matmul_t : public primitive_t {
     static constexpr data_type_t weights_type = data_type::bf16;
     static constexpr data_type_t acc_type = data_type::f32;
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<weights_type>::type weights_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
-    typedef typename prec_traits_t<acc_type>::type acc_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using weights_data_t = typename prec_traits_t<weights_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
+    using acc_data_t = typename prec_traits_t<acc_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_ref(ctx);

--- a/src/cpu/matmul/gemm_f32_matmul.hpp
+++ b/src/cpu/matmul/gemm_f32_matmul.hpp
@@ -88,10 +88,10 @@ struct gemm_f32_matmul_t : public primitive_t {
     static constexpr data_type_t dst_type = data_type::f32;
     static constexpr data_type_t acc_type = data_type::f32;
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<weights_type>::type weights_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
-    typedef typename prec_traits_t<acc_type>::type acc_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using weights_data_t = typename prec_traits_t<weights_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
+    using acc_data_t = typename prec_traits_t<acc_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_ref(ctx);

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -209,7 +209,7 @@ struct nchw_pooling_bwd_t : public primitive_t {
     };
 
     nchw_pooling_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/ncsp_batch_normalization.hpp
+++ b/src/cpu/ncsp_batch_normalization.hpp
@@ -112,8 +112,8 @@ struct ncsp_batch_normalization_fwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits_t<d_type>::type data_t;
-    typedef float acc_data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
+    using acc_data_t = float;
 
     ncsp_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
     ~ncsp_batch_normalization_fwd_t() {}
@@ -209,8 +209,8 @@ struct ncsp_batch_normalization_bwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits_t<d_type>::type data_t;
-    typedef float acc_data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
+    using acc_data_t = float;
 
     ncsp_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
     ~ncsp_batch_normalization_bwd_t() {}

--- a/src/cpu/ncsp_batch_normalization.hpp
+++ b/src/cpu/ncsp_batch_normalization.hpp
@@ -116,7 +116,7 @@ struct ncsp_batch_normalization_fwd_t : public primitive_t {
     using acc_data_t = float;
 
     ncsp_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
-    ~ncsp_batch_normalization_fwd_t() {}
+    ~ncsp_batch_normalization_fwd_t() override = default;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -213,7 +213,7 @@ struct ncsp_batch_normalization_bwd_t : public primitive_t {
     using acc_data_t = float;
 
     ncsp_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    ~ncsp_batch_normalization_bwd_t() {}
+    ~ncsp_batch_normalization_bwd_t() override = default;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -210,7 +210,7 @@ struct nhwc_pooling_bwd_t : public primitive_t {
     };
 
     nhwc_pooling_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/nspc_batch_normalization.hpp
+++ b/src/cpu/nspc_batch_normalization.hpp
@@ -109,8 +109,8 @@ struct nspc_batch_normalization_fwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits_t<d_type>::type data_t;
-    typedef float acc_data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
+    using acc_data_t = float;
 
     nspc_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
     ~nspc_batch_normalization_fwd_t() {}
@@ -200,8 +200,8 @@ struct nspc_batch_normalization_bwd_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits_t<d_type>::type data_t;
-    typedef float acc_data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
+    using acc_data_t = float;
 
     nspc_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
     ~nspc_batch_normalization_bwd_t() {}

--- a/src/cpu/nspc_batch_normalization.hpp
+++ b/src/cpu/nspc_batch_normalization.hpp
@@ -113,7 +113,7 @@ struct nspc_batch_normalization_fwd_t : public primitive_t {
     using acc_data_t = float;
 
     nspc_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
-    ~nspc_batch_normalization_fwd_t() {}
+    ~nspc_batch_normalization_fwd_t() override = default;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -204,7 +204,7 @@ struct nspc_batch_normalization_bwd_t : public primitive_t {
     using acc_data_t = float;
 
     nspc_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    ~nspc_batch_normalization_bwd_t() {}
+    ~nspc_batch_normalization_bwd_t() override = default;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/ref_batch_normalization.hpp
+++ b/src/cpu/ref_batch_normalization.hpp
@@ -78,7 +78,7 @@ struct ref_batch_normalization_fwd_t : public primitive_t {
 
     ref_batch_normalization_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_forward(ctx);
@@ -134,7 +134,7 @@ struct ref_batch_normalization_bwd_t : public primitive_t {
     };
 
     ref_batch_normalization_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward(ctx);

--- a/src/cpu/ref_deconvolution.hpp
+++ b/src/cpu/ref_deconvolution.hpp
@@ -411,7 +411,7 @@ struct ref_deconvolution_bwd_data_t : public primitive_t {
         }
     };
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     ref_deconvolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 

--- a/src/cpu/ref_eltwise.hpp
+++ b/src/cpu/ref_eltwise.hpp
@@ -172,7 +172,7 @@ struct ref_eltwise_bwd_t : public primitive_t {
     };
 
     ref_eltwise_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         if (pd()->use_dense_)

--- a/src/cpu/ref_lrn.hpp
+++ b/src/cpu/ref_lrn.hpp
@@ -69,7 +69,7 @@ struct ref_lrn_fwd_t : public primitive_t {
     };
 
     ref_lrn_fwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         using namespace format_tag;
@@ -127,7 +127,7 @@ struct ref_lrn_bwd_t : public primitive_t {
     };
 
     ref_lrn_bwd_t(const pd_t *apd) : primitive_t(apd) {}
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         using namespace format_tag;

--- a/src/cpu/simple_concat.hpp
+++ b/src/cpu/simple_concat.hpp
@@ -168,7 +168,7 @@ struct simple_concat_t : public primitive_t {
 
     status_t execute(const exec_ctx_t &ctx) const override;
 
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/simple_resampling.cpp
+++ b/src/cpu/simple_resampling.cpp
@@ -179,25 +179,19 @@ void simple_resampling_kernel_t<src_type, dst_type>::fill_coeffs() {
     if (pd_->is_fwd()) {
         linear_coeffs_.reserve(pd_->OD() + pd_->OH() + pd_->OW());
         for (dim_t od = 0; od < pd_->OD(); od++)
-            linear_coeffs_.emplace_back(
-                    linear_coeffs_t(od, pd_->OD(), pd_->ID()));
+            linear_coeffs_.emplace_back(od, pd_->OD(), pd_->ID());
         for (dim_t oh = 0; oh < pd_->OH(); oh++)
-            linear_coeffs_.emplace_back(
-                    linear_coeffs_t(oh, pd_->OH(), pd_->IH()));
+            linear_coeffs_.emplace_back(oh, pd_->OH(), pd_->IH());
         for (dim_t ow = 0; ow < pd_->OW(); ow++)
-            linear_coeffs_.emplace_back(
-                    linear_coeffs_t(ow, pd_->OW(), pd_->IW()));
+            linear_coeffs_.emplace_back(ow, pd_->OW(), pd_->IW());
     } else {
         bwd_linear_coeffs_.reserve(pd_->ID() + pd_->IH() + pd_->IW());
         for (dim_t id = 0; id < pd_->ID(); id++)
-            bwd_linear_coeffs_.emplace_back(
-                    bwd_linear_coeffs_t(id, pd_->OD(), pd_->ID()));
+            bwd_linear_coeffs_.emplace_back(id, pd_->OD(), pd_->ID());
         for (dim_t ih = 0; ih < pd_->IH(); ih++)
-            bwd_linear_coeffs_.emplace_back(
-                    bwd_linear_coeffs_t(ih, pd_->OH(), pd_->IH()));
+            bwd_linear_coeffs_.emplace_back(ih, pd_->OH(), pd_->IH());
         for (dim_t iw = 0; iw < pd_->IW(); iw++)
-            bwd_linear_coeffs_.emplace_back(
-                    bwd_linear_coeffs_t(iw, pd_->OW(), pd_->IW()));
+            bwd_linear_coeffs_.emplace_back(iw, pd_->OW(), pd_->IW());
     }
 }
 

--- a/src/cpu/simple_sum.hpp
+++ b/src/cpu/simple_sum.hpp
@@ -124,9 +124,9 @@ struct simple_sum_t : public primitive_t {
     status_t execute(const exec_ctx_t &ctx) const override;
 
     enum { max_num_arrs = 16 };
-    typedef typename prec_traits_t<src_data_type>::type src_data_t;
-    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    using src_data_t = typename prec_traits_t<src_data_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_data_type>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }


### PR DESCRIPTION
Partially addresses [MFDNN-13014](https://jira.devtools.intel.com/browse/MFDNN-13014) and failures observed in the clang-tidy CI step.
