### PR TITLE
xpu: address some clang-tidy complaints

### DIFF
--- a/src/gpu/intel/ocl/ocl_gpu_kernel.cpp
+++ b/src/gpu/intel/ocl/ocl_gpu_kernel.cpp
@@ -29,6 +29,7 @@
 #include "xpu/ocl/memory_storage.hpp"
 #include "xpu/ocl/usm_utils.hpp"
 
+#include "gpu/intel/ocl/ocl_gpu_engine.hpp"
 #include "gpu/intel/ocl/ocl_stream.hpp"
 #include "gpu/intel/ocl/ocl_utils.hpp"
 

--- a/src/gpu/intel/ocl/ocl_stream.cpp
+++ b/src/gpu/intel/ocl/ocl_stream.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 #include "common/verbose.hpp"
 
+#include "xpu/ocl/engine_impl.hpp"
 #include "xpu/ocl/memory_storage.hpp"
 #include "xpu/ocl/stream_profiler.hpp"
 

--- a/src/xpu/ocl/context.hpp
+++ b/src/xpu/ocl/context.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ struct event_t final : xpu::event_t {
     static const event_t &from(const xpu::event_t &event) {
         return *utils::downcast<const event_t *>(&event);
     }
-    std::unique_ptr<xpu::event_t> clone() const {
+    std::unique_ptr<xpu::event_t> clone() const override {
         return std::unique_ptr<xpu::event_t>(new event_t(*this));
     }
 
@@ -62,10 +62,10 @@ struct event_t final : xpu::event_t {
 
 struct context_t final : public xpu::context_t {
     context_t() = default;
-    context_t(const std::vector<xpu::ocl::wrapper_t<cl_event>> &&events)
+    context_t(std::vector<xpu::ocl::wrapper_t<cl_event>> events)
         : events_(std::move(events)) {};
     context_t(const context_t &) = default;
-    ~context_t() = default;
+    ~context_t() override = default;
 
     context_t &operator=(const context_t &other) {
         events_ = other.events_;

--- a/src/xpu/ocl/engine_factory.hpp
+++ b/src/xpu/ocl/engine_factory.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public:
         VERROR_ENGINE(status == status::success, status,
                 VERBOSE_INVALID_ENGINE_KIND, "opencl", "gpu");
 
-        VERROR_ENGINE(ocl_devices.size() > 0, status::invalid_arguments,
+        VERROR_ENGINE(!ocl_devices.empty(), status::invalid_arguments,
                 "opencl gpu devices queried but not found");
 
         VERROR_ENGINE(index < ocl_devices.size(), status::invalid_arguments,

--- a/src/xpu/ocl/engine_impl.hpp
+++ b/src/xpu/ocl/engine_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -137,7 +137,6 @@ private:
     std::string name_;
     runtime_version_t runtime_version_;
 
-private:
     xpu::ocl::wrapper_t<cl_device_id> device_;
     xpu::ocl::wrapper_t<cl_context> context_;
     cl_platform_id platform_ = nullptr;

--- a/src/xpu/ocl/usm_memory_storage.hpp
+++ b/src/xpu/ocl/usm_memory_storage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,9 +27,6 @@
 
 #include "xpu/ocl/memory_storage_base.hpp"
 #include "xpu/ocl/usm_utils.hpp"
-
-#include "gpu/intel/ocl/ocl_gpu_engine.hpp"
-#include "gpu/intel/ocl/ocl_utils.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/xpu/ocl/verbose.hpp
+++ b/src/xpu/ocl/verbose.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ namespace impl {
 namespace xpu {
 namespace ocl {
 
-void print_verbose_header() {
+inline void print_verbose_header() {
     xpu::ocl::engine_factory_t factory(engine_kind::gpu);
 
     verbose_printf("info,gpu,engine,opencl device count:%zu %s\n",
@@ -50,7 +50,7 @@ void print_verbose_header() {
         const auto *engine_impl
                 = utils::downcast<const xpu::ocl::engine_impl_t *>(
                         eng_ptr->impl());
-        auto s_name = engine_impl->name();
+        const auto &s_name = engine_impl->name();
         auto s_ver = engine_impl->runtime_version().str();
 
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL

--- a/src/xpu/sycl/context.hpp
+++ b/src/xpu/sycl/context.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ struct event_t : public xpu::event_t {
     event_t(const std::vector<::sycl::event> &event) : events(event) {}
     event_t(std::vector<::sycl::event> &&event) : events(std::move(event)) {}
     event_t(const event_t &) = default;
-    event_t &operator=(event_t other) {
+    event_t &operator=(const event_t &other) {
         events = other.events;
         return *this;
     }
@@ -63,7 +63,7 @@ struct event_t : public xpu::event_t {
 
 struct context_t final : public xpu::context_t {
     context_t() = default;
-    context_t(const std::vector<::sycl::event> &&events)
+    context_t(std::vector<::sycl::event> events)
         : events_(std::move(events)) {};
     context_t(const context_t &) = default;
     ~context_t() override = default;


### PR DESCRIPTION
Partially addresses [MFDNN-13015](https://jira.devtools.intel.com/browse/MFDNN-13015). Also removes some Intel-specific `#include`s from `src/xpu/ocl/usm_memory_storage.hpp`.
