### PR TITLE
graph: address some *more* clang-tidy complaints

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -18,7 +18,7 @@ on:
       - "src/cpu/x64/**"
       - "src/gpu/*"
       - "src/gpu/intel/**"
-      - "src/gpu/graph/**"
+      - "src/graph/**"
       - "tests/**"
       - "CMakeLists.txt"
 

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -291,8 +291,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
     sub_mm1_wei = memory(sub_mm1_wei_md, p_engine, nullptr);
     sub_mm1_dst = memory(sub_mm1_dst_md, p_engine, nullptr);
     for (size_t i = 0; i < sub_mm1_post_md.size(); i++) {
-        sub_mm1_post_mem.emplace_back(
-                memory(sub_mm1_post_md[i], p_engine, nullptr));
+        sub_mm1_post_mem.emplace_back(sub_mm1_post_md[i], p_engine, nullptr);
     }
     // softmax
     sub_softmax_dst = memory(sub_softmax_dst_md, p_engine, nullptr);

--- a/src/graph/backend/dnnl/op_executable.cpp
+++ b/src/graph/backend/dnnl/op_executable.cpp
@@ -1102,9 +1102,8 @@ concat_executable_t::desc_t concat_executable_t::create_desc(
     for (const auto &in_val : op->get_input_values()) {
         const auto tmp_desc
                 = make_dnnl_memory_desc(in_val->get_logical_tensor());
-        src_mds.emplace_back(
-                memory::desc {tmp_desc.get_dims(), tmp_desc.get_data_type(),
-                        get_forced_format_tag(tmp_desc.get_dims())});
+        src_mds.emplace_back(tmp_desc.get_dims(), tmp_desc.get_data_type(),
+                get_forced_format_tag(tmp_desc.get_dims()));
     }
     const auto tmp_desc = make_dnnl_memory_desc(
             op->get_output_value(0)->get_logical_tensor());

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -439,8 +439,7 @@ status_t fold_mul_scales(std::shared_ptr<subgraph_t> &sg) {
             auto &consumer_op = consumers[0].get_op();
             if (consumer_op.get_kind() != op_kind::dnnl_mul_scales) continue;
 
-            folding_groups.emplace_back(
-                    std::pair<op_t *, op_t *> {cur_op.get(), &consumer_op});
+            folding_groups.emplace_back(cur_op.get(), &consumer_op);
             visited.insert(cur_op.get());
             visited.insert(&consumer_op);
         }
@@ -508,8 +507,7 @@ impl::status_t fold_sub_zps_add_zps(std::shared_ptr<subgraph_t> &sg) {
             auto &consumer_op = consumers[0].get_op();
             if (consumer_op.get_kind() != op_kind::dnnl_add_zps) continue;
 
-            folding_groups.emplace_back(
-                    std::pair<op_t *, op_t *> {cur_op.get(), &consumer_op});
+            folding_groups.emplace_back(cur_op.get(), &consumer_op);
             visited.insert(cur_op.get());
             visited.insert(&consumer_op);
         }
@@ -849,7 +847,7 @@ status_t fuse_post_ops(std::shared_ptr<subgraph_t> &sg) {
             if (not_fusible) { return status::success; }
 
             // push fusible pair to fuse group for later fusion
-            fuse_groups.emplace_back(std::pair<op_t *, op_t *> {op, &post_op});
+            fuse_groups.emplace_back(op, &post_op);
             visited.insert(op);
             visited.insert(&post_op);
             return status::success;
@@ -1208,8 +1206,7 @@ status_t fuse_dst_scales(std::shared_ptr<subgraph_t> &sg) {
         if (consumers.size() != 1) continue;
         auto &next_op = consumers[0].get_op();
         if (next_op.get_kind() != op_kind::dnnl_mul_scales) continue;
-        fuse_groups.emplace_back(
-                std::pair<op_t *, op_t *> {cur_op.get(), &next_op});
+        fuse_groups.emplace_back(cur_op.get(), &next_op);
         visited.insert(cur_op.get());
         visited.insert(&next_op);
     }
@@ -2070,8 +2067,7 @@ status_t fuse_reciprocal_mul_to_div(std::shared_ptr<subgraph_t> &sg) {
         size_t mul_other_offset = 1 - offset;
         mul_other_offsets.emplace_back(mul_other_offset);
 
-        div_patterns.emplace_back(
-                std::pair<op_t *, op_t *> {cur_op.get(), &csm_op});
+        div_patterns.emplace_back(cur_op.get(), &csm_op);
     }
 
     if (div_patterns.empty()) return status::success;
@@ -2582,7 +2578,7 @@ status_t fuse_adjacent_reorders(std::shared_ptr<subgraph_t> &sg) {
             }
 
             // push fusible pair to fuse group for later fusion
-            fuse_groups.emplace_back(std::pair<op_t *, op_t *> {op, &next_op});
+            fuse_groups.emplace_back(op, &next_op);
             visited.insert(op);
             visited.insert(&next_op);
             // destroy md before return
@@ -2885,8 +2881,7 @@ status_t fuse_dynamic_mul_scales_add_zps(std::shared_ptr<subgraph_t> &sg) {
                 || !consumer_op.get_attr<bool>(op_attr::with_runtime_zps))
             continue;
 
-        fuse_groups.emplace_back(std::pair<op_ptr, op_ptr> {
-                cur_op, (&consumer_op)->shared_from_this()});
+        fuse_groups.emplace_back(cur_op, (&consumer_op)->shared_from_this());
         visited.insert(cur_op.get());
         visited.insert(&consumer_op);
     }
@@ -2962,8 +2957,7 @@ status_t fuse_dynamic_sub_zps_mul_scales(std::shared_ptr<subgraph_t> &sg) {
                 || !consumer_op.get_attr<bool>(op_attr::with_runtime_scales))
             continue;
 
-        fuse_groups.emplace_back(std::pair<op_ptr, op_ptr> {
-                cur_op, (&consumer_op)->shared_from_this()});
+        fuse_groups.emplace_back(cur_op, (&consumer_op)->shared_from_this());
         visited.insert(cur_op.get());
         visited.insert(&consumer_op);
     }
@@ -3582,8 +3576,7 @@ impl::status_t lift_up_typecast(std::shared_ptr<subgraph_t> &sg) {
                     || is_layout_reorder(producer);
             if (!ok) continue;
 
-            to_be_swapped.emplace_back(
-                    std::pair<op_t *, op_t *> {producer, op.get()});
+            to_be_swapped.emplace_back(producer, op.get());
         }
 
         if (to_be_swapped.empty()) break;
@@ -3620,8 +3613,7 @@ impl::status_t lift_up_quantize(std::shared_ptr<subgraph_t> &sg) {
                     || is_layout_reorder(producer);
             if (!ok) continue;
 
-            to_be_swapped.emplace_back(
-                    std::pair<op_t *, op_t *> {producer, op.get()});
+            to_be_swapped.emplace_back(producer, op.get());
         }
 
         if (to_be_swapped.empty()) break;
@@ -3962,9 +3954,7 @@ impl::status_t swap_relu_mul_scales(std::shared_ptr<subgraph_t> &sg) {
                     = producer->get_input_value(0)->get_producer();
             if (prv_op.get_kind() == op_kind::dnnl_batchnorm
                     && !prv_op.get_attr<bool>(op_attr::is_training)) {
-                to_be_swapped.emplace_back(
-                        std::pair<graph::op_t *, graph::op_t *> {
-                                producer, op.get()});
+                to_be_swapped.emplace_back(producer, op.get());
             } else {
                 continue;
             }

--- a/src/graph/interface/graph.cpp
+++ b/src/graph/interface/graph.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ bool logical_tensor_sanity_check(
 // partition into `topo_fused_ops`, the definition of “proxy op” is: the last
 // one in the topological order of the partition
 status_t dnnl_graph_graph::get_ordered_partitions(
-        std::vector<partition_t *> &partitions) {
+        std::vector<partition_t *> &partitions) const {
 
     std::vector<op_t *> topo_unfused_ops;
     std::vector<op_t *> topo_fused_ops;

--- a/src/graph/interface/graph.hpp
+++ b/src/graph/interface/graph.hpp
@@ -280,7 +280,7 @@ public:
      * \param list of partitions
      */
     graph::status_t get_ordered_partitions(
-            std::vector<graph::partition_t *> &partitions);
+            std::vector<graph::partition_t *> &partitions) const;
 
     // Finalize the graph after finishing adding ops.
     graph::status_t finalize();

--- a/src/graph/interface/op_schema.cpp
+++ b/src/graph/interface/op_schema.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -86,8 +86,7 @@ std::set<size_t> op_schema_t::get_num_outputs() const {
 op_schema_t &op_schema_t::set_input(
         size_t in_offset, std::string &&in_name, std::string &&dtype_string) {
     verify_input_(in_offset);
-    inputs_.emplace_back(
-            op_parameter_t(std::move(in_name), std::move(dtype_string)));
+    inputs_.emplace_back(std::move(in_name), std::move(dtype_string));
     return *this;
 }
 
@@ -99,8 +98,7 @@ op_schema_t::get_inputs() const {
 op_schema_t &op_schema_t::set_output(
         size_t out_offset, std::string &&out_name, std::string &&dtype_string) {
     verify_output_(out_offset);
-    outputs_.emplace_back(
-            op_parameter_t(std::move(out_name), std::move(dtype_string)));
+    outputs_.emplace_back(std::move(out_name), std::move(dtype_string));
     return *this;
 }
 

--- a/src/graph/utils/pm/pbuilder.cpp
+++ b/src/graph/utils/pm/pbuilder.cpp
@@ -220,6 +220,7 @@ bool pb_graph_t::set_edge(const std::shared_ptr<consumer_t> &p_consumer,
 
 std::vector<pb_node_t *> pb_graph_t::get_nodes() {
     std::vector<pb_node_t *> retval;
+    retval.reserve(nodes_.size());
     for (auto const &i : nodes_) {
         retval.push_back(i.get());
     }
@@ -369,6 +370,7 @@ alternation_t::alternation_t(std::vector<std::shared_ptr<pb_graph_t>> p_nodes)
 
 std::vector<pb_graph_t *> alternation_t::get_alternatives() {
     std::vector<pb_graph_t *> retval;
+    retval.reserve(alternatives_.size());
     for (auto const &i : alternatives_) {
         retval.push_back(i.get());
     }

--- a/src/graph/utils/utils.hpp
+++ b/src/graph/utils/utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ using namespace dnnl::impl::utils;
 #ifndef NDEBUG
 #define DEBUG_PRINT_ERROR(message) \
     do { \
-        std::cout << message << std::endl; \
+        std::cout << (message) << std::endl; \
     } while (0)
 #else
 #define DEBUG_PRINT_ERROR(message)


### PR DESCRIPTION
Addresses two missed hits from #2517/[MFDNN-13013](https://jira.devtools.intel.com/browse/MFDNN-13013) and some others from the clang-tidy CI step.