### PR TITLE
x64: address some clang-tidy complaints

### DIFF
--- a/src/cpu/rnn/postgemm_dispatcher.hpp
+++ b/src/cpu/rnn/postgemm_dispatcher.hpp
@@ -52,14 +52,14 @@ template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t scratch_type, impl::data_type_t acc_type>
 struct rnn_postgemm_dispatcher {
 
-    typedef typename prec_traits_t<src_type>::type src_layer_t;
-    typedef typename prec_traits_t<src_type>::type src_iter_t;
-    typedef typename prec_traits_t<src_type>::type dst_layer_t;
-    typedef typename prec_traits_t<src_type>::type dst_iter_t;
-    typedef typename prec_traits_t<acc_type>::type gemm_acc_t;
-    typedef typename prec_traits_t<scratch_type>::type scratch_t;
-    typedef typename prec_traits_t<src_type>::type ht_t;
-    typedef typename prec_traits_t<src_type>::type gates_t;
+    using src_layer_t = typename prec_traits_t<src_type>::type;
+    using src_iter_t = typename prec_traits_t<src_type>::type;
+    using dst_layer_t = typename prec_traits_t<src_type>::type;
+    using dst_iter_t = typename prec_traits_t<src_type>::type;
+    using gemm_acc_t = typename prec_traits_t<acc_type>::type;
+    using scratch_t = typename prec_traits_t<scratch_type>::type;
+    using ht_t = typename prec_traits_t<src_type>::type;
+    using gates_t = typename prec_traits_t<src_type>::type;
 
     using class_name
             = rnn_postgemm_dispatcher<aprop, src_type, scratch_type, acc_type>;

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -97,16 +97,16 @@ struct _ref_rnn_common_t : public primitive_t {
             rnn_postgemm_bwd_t<src_type, scratch_type, acc_type>>::type;
 
     /* These types are defined for each element in the cell execution */
-    typedef typename prec_traits_t<src_type>::type src_layer_t;
-    typedef typename prec_traits_t<src_type>::type src_iter_t;
-    typedef typename prec_traits_t<src_type>::type dst_layer_t;
-    typedef typename prec_traits_t<src_type>::type dst_iter_t;
-    typedef typename prec_traits_t<weights_type>::type weights_t;
-    typedef typename prec_traits_t<src_type>::type gemm_data_t;
-    typedef typename prec_traits_t<acc_type>::type gemm_acc_t;
-    typedef typename prec_traits_t<scratch_type>::type scratch_t;
-    typedef typename prec_traits_t<src_type>::type ht_t;
-    typedef typename prec_traits_t<src_type>::type gates_t;
+    using src_layer_t = typename prec_traits_t<src_type>::type;
+    using src_iter_t = typename prec_traits_t<src_type>::type;
+    using dst_layer_t = typename prec_traits_t<src_type>::type;
+    using dst_iter_t = typename prec_traits_t<src_type>::type;
+    using weights_t = typename prec_traits_t<weights_type>::type;
+    using gemm_data_t = typename prec_traits_t<src_type>::type;
+    using gemm_acc_t = typename prec_traits_t<acc_type>::type;
+    using scratch_t = typename prec_traits_t<scratch_type>::type;
+    using ht_t = typename prec_traits_t<src_type>::type;
+    using gates_t = typename prec_traits_t<src_type>::type;
 
     using class_name
             = _ref_rnn_common_t<aprop, src_type, weights_type, acc_type>;

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -61,7 +61,7 @@ template <data_type_t type_i>
 static inline void quantize_igo(int8_t *scratch_quantized,
         const memory_desc_wrapper &src_d, const float *src, int mask,
         float *scales) {
-    typedef typename prec_traits_t<type_i>::type in_data_t;
+    using in_data_t = typename prec_traits_t<type_i>::type;
 
     // TODO: trivial strides assumes here.
     //       Use proper strides where appropriate
@@ -87,7 +87,7 @@ template <data_type_t type_i>
 static inline void quantize_goi(int8_t *scratch_quantized,
         const memory_desc_wrapper &src_d, const float *src, int mask,
         float *scales) {
-    typedef typename prec_traits_t<type_i>::type in_data_t;
+    using in_data_t = typename prec_traits_t<type_i>::type;
 
     // TODO: trivial strides assumes here.
     //       Use proper strides where appropriate
@@ -232,8 +232,8 @@ struct rnn_data_reorder_t : public primitive_t {
     rnn_data_reorder_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits_t<type_i>::type in_data_t;
-    typedef typename prec_traits_t<type_o>::type out_data_t;
+    using in_data_t = typename prec_traits_t<type_i>::type;
+    using out_data_t = typename prec_traits_t<type_o>::type;
 
     bool is_dense() const {
         const memory_desc_wrapper &input_d = pd()->src_md();
@@ -428,7 +428,7 @@ struct rnn_weights_reorder_s8_t : public primitive_t {
     rnn_weights_reorder_s8_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits_t<type_i>::type in_data_t;
+    using in_data_t = typename prec_traits_t<type_i>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         // TODO: trivial strides assumed here.
@@ -615,8 +615,8 @@ struct rnn_weights_reorder_t : public primitive_t {
     rnn_weights_reorder_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits_t<type_i>::type in_data_t;
-    typedef typename prec_traits_t<type_o>::type out_data_t;
+    using in_data_t = typename prec_traits_t<type_i>::type;
+    using out_data_t = typename prec_traits_t<type_o>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         // TODO: trivial strides assumed here.
@@ -838,8 +838,8 @@ struct rnn_brgemm_weights_reorder_s8_t : public primitive_t {
     rnn_brgemm_weights_reorder_s8_t(const pd_t *apd) : primitive_t(apd) {}
 
 private:
-    typedef typename prec_traits_t<type_i>::type in_data_t;
-    typedef typename prec_traits_t<type_o>::type out_data_t;
+    using in_data_t = typename prec_traits_t<type_i>::type;
+    using out_data_t = typename prec_traits_t<type_o>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         using namespace format_tag;

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ private:
 };
 
 struct brgemm_palette_container_t {
-    typedef std::array<char, AMX_PALETTE_SIZE> S_t;
+    using S_t = std::array<char, AMX_PALETTE_SIZE>;
 
     brgemm_palette_container_t() {}
     brgemm_palette_container_t(size_t ns) { resize(ns); }

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -2413,11 +2413,9 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                 auto abdb = bdb + ibdb;
                 if (abdb >= brg.bdb) break;
                 if (brg.bdb_tail && abdb == brg.bdb - 1)
-                    bdi.blocks.emplace_back(
-                            iteration_block_t(bdi_pos, brg.bdb_tail, true));
+                    bdi.blocks.emplace_back(bdi_pos, brg.bdb_tail, true);
                 else
-                    bdi.blocks.emplace_back(
-                            iteration_block_t(bdi_pos, brg.bd_block, false));
+                    bdi.blocks.emplace_back(bdi_pos, brg.bd_block, false);
                 bdi_pos += brg.bd_block;
                 if (bdi_pos >= brg.bcast_dim) break;
                 bdi_pos = skipped_bd_mask(bdi_pos);
@@ -2458,11 +2456,9 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                 auto aldb = ldb + ildb;
                 if (aldb >= brg.ldb) break;
                 if (brg.ldb_tail && aldb == brg.ldb - 1)
-                    ldi.blocks.emplace_back(
-                            iteration_block_t(ldi_pos, brg.ldb_tail, true));
+                    ldi.blocks.emplace_back(ldi_pos, brg.ldb_tail, true);
                 else
-                    ldi.blocks.emplace_back(
-                            iteration_block_t(ldi_pos, brg.ld_block, false));
+                    ldi.blocks.emplace_back(ldi_pos, brg.ld_block, false);
                 ldi_pos++;
             }
             ldi.idx = tloop.ldis.size();
@@ -2474,15 +2470,14 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         rdi.blocks.reserve(1);
         for (int rdb = 0; rdb < brg.rdb; rdb++) {
             rdi.blocks.clear();
-            rdi.blocks.emplace_back(iteration_block_t(rdi_pos, brg.rd_block));
+            rdi.blocks.emplace_back(rdi_pos, brg.rd_block);
             rdi.idx = tloop.rdis.size();
             tloop.rdis.push_back(rdi);
             rdi_pos++;
         }
         if (brg.rdb_tail > 0) {
             rdi.blocks.clear();
-            rdi.blocks.emplace_back(
-                    iteration_block_t(rdi_pos, brg.rdb_tail, true));
+            rdi.blocks.emplace_back(rdi_pos, brg.rdb_tail, true);
             rdi.idx = tloop.rdis.size();
             tloop.rdis.push_back(rdi);
         }

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -213,19 +213,19 @@ struct vreg_traits {};
 
 template <>
 struct vreg_traits<Xbyak::Zmm> {
-    typedef Xbyak::Ymm Vmm_lower_t;
+    using Vmm_lower_t = Xbyak::Ymm;
     static constexpr size_t vlen = 64;
 };
 
 template <>
 struct vreg_traits<Xbyak::Ymm> {
-    typedef Xbyak::Xmm Vmm_lower_t;
+    using Vmm_lower_t = Xbyak::Xmm;
     static constexpr size_t vlen = 32;
 };
 
 template <>
 struct vreg_traits<Xbyak::Xmm> {
-    typedef Xbyak::Xmm Vmm_lower_t;
+    using Vmm_lower_t = Xbyak::Xmm;
     static constexpr size_t vlen = 16;
 };
 
@@ -251,7 +251,7 @@ struct cpu_isa_traits<isa_all> {
 
 template <>
 struct cpu_isa_traits<sse41> {
-    typedef Xbyak::Xmm Vmm;
+    using Vmm = Xbyak::Xmm;
     static constexpr int vlen_shift = 4;
     static constexpr int vlen = vreg_traits<Vmm>::vlen;
     static constexpr int n_vregs = 16;
@@ -261,7 +261,7 @@ struct cpu_isa_traits<sse41> {
 
 template <>
 struct cpu_isa_traits<avx> {
-    typedef Xbyak::Ymm Vmm;
+    using Vmm = Xbyak::Ymm;
     static constexpr int vlen_shift = 5;
     static constexpr int vlen = vreg_traits<Vmm>::vlen;
     static constexpr int n_vregs = 16;
@@ -289,7 +289,7 @@ struct cpu_isa_traits<avx2_vnni_2> : public cpu_isa_traits<avx2> {
 
 template <>
 struct cpu_isa_traits<avx512_core> {
-    typedef Xbyak::Zmm Vmm;
+    using Vmm = Xbyak::Zmm;
     static constexpr int vlen_shift = 6;
     static constexpr int vlen = vreg_traits<Vmm>::vlen;
     static constexpr int n_vregs = 32;
@@ -313,7 +313,7 @@ struct cpu_isa_traits<avx512_core_bf16> : public cpu_isa_traits<avx512_core> {
 
 template <>
 struct cpu_isa_traits<avx10_1_512_amx> {
-    typedef Xbyak::Zmm Vmm;
+    using Vmm = Xbyak::Zmm;
     static constexpr int vlen = vreg_traits<Vmm>::vlen;
     static constexpr dnnl_cpu_isa_t user_option_val
             = dnnl_cpu_isa_avx10_1_512_amx;
@@ -328,7 +328,7 @@ struct cpu_isa_traits<avx10_1_512> : public cpu_isa_traits<avx512_core> {
 
 template <>
 struct cpu_isa_traits<avx10_1_512_amx_fp16> {
-    typedef Xbyak::Zmm Vmm;
+    using Vmm = Xbyak::Zmm;
     static constexpr dnnl_cpu_isa_t user_option_val
             = dnnl_cpu_isa_avx10_1_512_amx_fp16;
     static constexpr const char *user_option_env = "avx10_1_512_amx_fp16";

--- a/src/cpu/x64/cpu_reducer.hpp
+++ b/src/cpu/x64/cpu_reducer.hpp
@@ -168,7 +168,7 @@ struct reducer_2d_driver_t;
  */
 template <impl::data_type_t data_type>
 struct cpu_reducer_t {
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     struct conf_t {
         conf_t() = default;
@@ -248,7 +248,7 @@ private:
 
 template <impl::data_type_t data_type>
 struct cpu_reducer_2d_t {
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     struct conf_t {
         conf_t() = default;
@@ -333,7 +333,7 @@ private:
 /** simple 1d accumulator: y[:] += x[:] */
 template <impl::data_type_t data_type>
 struct cpu_accumulator_1d_t {
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     cpu_accumulator_1d_t();
     ~cpu_accumulator_1d_t();

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -95,10 +95,10 @@ struct gemm_bf16_convolution_fwd_t : public primitive_t {
     gemm_bf16_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd), pp_ker_(nullptr) {}
 
-    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    using dst_data_t = typename prec_traits_t<dst_data_type>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t init(engine_t *engine) override {
         const auto &post_ops = pd()->attr()->post_ops_;
@@ -274,10 +274,10 @@ struct gemm_bf16_convolution_bwd_data_t : public primitive_t {
 
     gemm_bf16_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits_t<diff_src_data_type>::type diff_src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
+    using diff_src_data_t = typename prec_traits_t<diff_src_data_type>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         const bool is_nspc = pd()->jcp_.is_nspc;
@@ -340,10 +340,10 @@ struct gemm_bf16_convolution_bwd_weights_t : public primitive_t {
     gemm_bf16_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd), acc_ker_(nullptr) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<diff_wei_data_type>::type diff_wei_data_t;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using diff_wei_data_t = typename prec_traits_t<diff_wei_data_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(

--- a/src/cpu/x64/gemm_bf16_inner_product.hpp
+++ b/src/cpu/x64/gemm_bf16_inner_product.hpp
@@ -108,10 +108,10 @@ struct gemm_bf16_inner_product_fwd_t : public primitive_t {
 
     gemm_bf16_inner_product_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    using dst_data_t = typename prec_traits_t<dst_data_type>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t init(engine_t *engine) override {
         const bool has_bias = pd()->with_bias();
@@ -204,10 +204,10 @@ struct gemm_bf16_inner_product_bwd_data_t : public primitive_t {
 
     gemm_bf16_inner_product_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits_t<diff_src_data_type>::type diff_src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
+    using diff_src_data_t = typename prec_traits_t<diff_src_data_type>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_data(ctx);
@@ -316,10 +316,10 @@ struct gemm_bf16_inner_product_bwd_weights_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<diff_wei_data_type>::type diff_wei_data_t;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using diff_wei_data_t = typename prec_traits_t<diff_wei_data_type>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         return execute_backward_weights(ctx);

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -337,7 +337,7 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         execute_forward(ctx);
@@ -441,7 +441,7 @@ struct jit_avx2_1x1_convolution_bwd_data_t : public primitive_t {
 
     jit_avx2_1x1_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -588,7 +588,7 @@ struct jit_avx2_1x1_convolution_bwd_weights_t : public primitive_t {
     jit_avx2_1x1_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -109,7 +109,7 @@ struct jit_avx2_convolution_fwd_t : public primitive_t {
 
     jit_avx2_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -197,7 +197,7 @@ struct jit_avx2_convolution_bwd_data_t : public primitive_t {
 
     jit_avx2_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(
@@ -320,7 +320,7 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
 
     jit_avx2_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -311,9 +311,9 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
     jit_avx512_common_1x1_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -440,9 +440,9 @@ struct jit_avx512_common_1x1_convolution_bwd_data_t : public primitive_t {
     jit_avx512_common_1x1_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using diff_src_data_t = typename prec_traits_t<diff_src_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -567,7 +567,7 @@ struct jit_avx512_common_1x1_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_common_1x1_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_common_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.hpp
@@ -74,9 +74,9 @@ struct jit_avx512_common_convolution_fwd_t : public primitive_t {
 
     jit_avx512_common_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -151,9 +151,9 @@ struct jit_avx512_common_convolution_bwd_data_t : public primitive_t {
     jit_avx512_common_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using diff_src_data_t = typename prec_traits_t<diff_src_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -241,9 +241,9 @@ struct jit_avx512_common_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_common_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using diff_weights_data_t = typename prec_traits_t<diff_weights_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -283,8 +283,8 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_core_amx_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -322,12 +322,12 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
     jit_avx512_core_bf16_1x1_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
     // Note: In case of fused depthwise convolution, the final output datatype
     // may not be dst_data_t.
-    typedef typename prec_traits_t<dst_type>::type dw_wei_data_t;
+    using dw_wei_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -448,9 +448,9 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_data_t : public primitive_t {
     jit_avx512_core_bf16_1x1_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
-    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using diff_src_data_t = typename prec_traits_t<diff_src_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -576,10 +576,10 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_weights_t : public primitive_t {
         return status::success;
     }
 
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
 
-    typedef typename prec_traits_t<diff_weights_type>::type diff_wei_data_t;
+    using diff_wei_data_t = typename prec_traits_t<diff_weights_type>::type;
 
 private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -2655,8 +2655,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32::compute_ic_block_step(
                 src_offset, kernel_offset, ddst_offset, is_tail);
 }
 
-void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32 ::get_ur_w(
-        int &ur_w, int &ur_w_tail, int &ur_w_trips) {
+void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32::get_ur_w(
+        int &ur_w, int &ur_w_tail, int &ur_w_trips) const {
     if (jcp.tr_ow <= max_ur_w) {
         ur_w = jcp.tr_ow;
         ur_w_tail = 0;

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
@@ -83,8 +83,8 @@ struct jit_avx512_core_bf16_convolution_fwd_t : public primitive_t {
     jit_avx512_core_bf16_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -157,8 +157,8 @@ struct jit_avx512_core_bf16_convolution_bwd_data_t : public primitive_t {
     jit_avx512_core_bf16_convolution_bwd_data_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type wei_data_t;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(
@@ -232,8 +232,8 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t : public primitive_t {
     jit_avx512_core_bf16_convolution_bwd_weights_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::bf16>::type src_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type diff_dst_data_t;
+    using src_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using diff_dst_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -314,7 +314,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
 
     // Note: In case of fused depthwise convolution, the final output data type
     // after fusion may not be same as for dst.
-    typedef typename prec_traits_t<data_type::s32>::type acc_data_t;
+    using acc_data_t = typename prec_traits_t<data_type::s32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::zp_src_comp_pad_operation(
     if (op) {
         Xbyak::Label end;
         host_->cmp(should_apply_zp_src_pad_, 0);
-        host_->je(end, host_->T_NEAR);
+        host_->je(end, jit_generator::T_NEAR);
         op(reg_zp_pad_comp_);
         host_->L(end);
     }
@@ -195,7 +195,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::load_zp_src_comp_pad_addr_if_needed(
         const Xbyak::Address &g_oc_offset) {
     Xbyak::Label calc_zp_src_comp_pad_addr, end;
     host_->cmp(should_apply_zp_src_pad_, 0);
-    host_->je(end, host_->T_NEAR);
+    host_->je(end, jit_generator::T_NEAR);
 
     host_->L(calc_zp_src_comp_pad_addr);
     {
@@ -251,20 +251,20 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::get_zp_pad_com_dim(
     host_->L(lower_bound);
     {
         host_->cmp(dim_under_lower_bound, 0);
-        host_->je(upper_bound, host_->T_NEAR);
+        host_->je(upper_bound, jit_generator::T_NEAR);
         host_->mov(reg_zp_pad_comp_tmp_, out_point_dim);
         host_->mov(result, reg_zp_pad_comp_tmp_);
-        host_->jmp(end, host_->T_NEAR);
+        host_->jmp(end, jit_generator::T_NEAR);
     }
     host_->L(upper_bound);
     {
         host_->cmp(dim_over_eq_upper_bound, 0);
-        host_->je(mid_point, host_->T_NEAR);
+        host_->je(mid_point, jit_generator::T_NEAR);
         host_->mov(reg_zp_pad_comp_tmp_,
                 begin_pad + mid_pad + end_pad - out_dim_size);
         host_->add(reg_zp_pad_comp_tmp_, out_point_dim);
         host_->mov(result, reg_zp_pad_comp_tmp_);
-        host_->jmp(end, host_->T_NEAR);
+        host_->jmp(end, jit_generator::T_NEAR);
     }
 
     host_->L(mid_point);
@@ -299,7 +299,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::next_point() {
     }
 
     host_->cmp(reg_w, w_size_addr_);
-    host_->jl(store_w, host_->T_NEAR);
+    host_->jl(store_w, jit_generator::T_NEAR);
 
     if (with_zp_pad_com_h_) {
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -69,12 +69,11 @@ typedef enum {
 
 // TODO: move this somewhere else? Although this is only used by jit kernels
 // (Roma)
-static inline int float2int(float x) {
+inline int float2int(float x) {
     return utils::bit_cast<int>(x);
 }
 
-static inline void tc_configure_tile(
-        palette_config_t *tc, int t, int rows, int cols) {
+inline void tc_configure_tile(palette_config_t *tc, int t, int rows, int cols) {
     const bool rows_ok = (size_t)t < sizeof(tc->rows) / sizeof(tc->rows[0]);
     const bool cols_ok = (size_t)t < sizeof(tc->cols) / sizeof(tc->cols[0]);
     if (rows_ok && cols_ok) {
@@ -239,8 +238,7 @@ public:
     // By default it assumes to be called after the prologue
     // Note: that we cannot use RBP inside as we override it in preamble
     // for address computation in EVEX instructions
-    inline const Xbyak::RegExp get_stack_params_address(
-            bool after_prolog = true) {
+    inline Xbyak::RegExp get_stack_params_address(bool after_prolog = true) {
         int saved_regs_size = after_prolog ? get_size_of_abi_save_regs() : 0;
 #ifdef _WIN32
         // Using stack layout described in MS ABI
@@ -2711,7 +2709,7 @@ public:
                   /*allocator=*/this)
         , max_cpu_isa_(max_cpu_isa) {}
 
-    virtual ~jit_generator() {}
+    ~jit_generator() override = default;
 
     virtual const char *name() const = 0;
     virtual const char *source_file() const = 0;

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -2700,7 +2700,6 @@ public:
             Xbyak::Ymm &ymm_mask, Xbyak::Xmm &xmm_upper_mask);
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_generator);
 
-public:
     /* All uni_ instructions -- apart from uni_vzeroupper() -- will comply with
      * the max_cpu_isa argument */
     jit_generator(const char *name, cpu_isa_t max_cpu_isa = get_max_cpu_isa())

--- a/src/cpu/x64/jit_sse41_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.hpp
@@ -288,7 +288,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
 
     jit_sse41_1x1_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_sse41_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_convolution.hpp
@@ -104,7 +104,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
 
     jit_sse41_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -600,7 +600,7 @@ inline int best_divider(int value, int min_divider, int max_divider,
     return x_divider;
 }
 
-typedef jit_1x1_conv_conf_t jcp_t;
+using jcp_t = jit_1x1_conv_conf_t;
 
 inline bool is_bcast_layout_nxc(const jcp_t &jcp) {
     switch (jcp.prop_kind) {

--- a/src/cpu/x64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.cpp
@@ -135,7 +135,8 @@ struct jit_bnorm_conf_t {
     // given nthr and shape of problem, choose the thread partition
     // to use (ie set N_nthr, C_nthr, and S_nthr)
     bool thread_partition(bool spatial_thr_allowed, int nthr, dim_t N,
-            dim_t C_blks, dim_t SP, int &C_nthr, int &N_nthr, int &S_nthr) {
+            dim_t C_blks, dim_t SP, int &C_nthr, int &N_nthr,
+            int &S_nthr) const {
         if (((nthr <= C_blks) && IMPLICATION(is_nspc_, N == 1))
                 || !dnnl_thr_syncable()) {
             C_nthr = nthr;

--- a/src/cpu/x64/jit_uni_batch_normalization_s8.hpp
+++ b/src/cpu/x64/jit_uni_batch_normalization_s8.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ struct jit_uni_batch_normalization_s8_fwd_t : public primitive_t {
         status_t init(engine_t *engine);
     };
 
-    typedef int8_t data_t;
+    using data_t = int8_t;
 
     jit_uni_batch_normalization_s8_fwd_t(const pd_t *apd);
     ~jit_uni_batch_normalization_s8_fwd_t();

--- a/src/cpu/x64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.hpp
@@ -81,10 +81,10 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
 
     jit_uni_dw_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits_t<src_type>::type data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using f32_data_t = typename prec_traits_t<data_type::f32>::type;
+    using bf16_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using data_t = typename prec_traits_t<src_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -152,9 +152,9 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
 
     jit_uni_dw_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<diff_dst_type>::type wei_data_t;
+    using diff_src_data_t = typename prec_traits_t<diff_src_type>::type;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using wei_data_t = typename prec_traits_t<diff_dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -236,11 +236,11 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
     };
     jit_uni_dw_convolution_bwd_weights_t(const pd_t *apd);
 
-    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<src_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
+    using f32_data_t = typename prec_traits_t<data_type::f32>::type;
+    using bf16_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using diff_dst_data_t = typename prec_traits_t<src_type>::type;
+    using diff_weights_data_t = typename prec_traits_t<diff_weights_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_uni_eltwise.hpp
+++ b/src/cpu/x64/jit_uni_eltwise.hpp
@@ -54,7 +54,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
     jit_uni_eltwise_fwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_fwd_t();
 
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 
@@ -84,7 +84,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
     jit_uni_eltwise_bwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_bwd_t();
 
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.hpp
@@ -49,7 +49,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
     jit_uni_eltwise_int_fwd_t(const pd_t *apd);
     ~jit_uni_eltwise_int_fwd_t();
 
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -331,7 +331,7 @@ struct jit_bnorm_process_relu_t {
         const Xmm xmm_aux = Xmm(valpha.getIdx());
         h_->vmovq(xmm_aux, reg_alpha);
         h_->vbroadcastss(valpha, xmm_aux);
-        h_->vcmpps(kstore_mask_, vzero_, vmm_dst, h_->_cmp_lt_os);
+        h_->vcmpps(kstore_mask_, vzero_, vmm_dst, jit_generator::_cmp_lt_os);
         h_->vmulps(valpha, vmm_dst, valpha);
         h_->vblendmps(vmm_dst | kstore_mask_, valpha, vmm_dst);
     }
@@ -341,7 +341,7 @@ struct jit_bnorm_process_relu_t {
         h_->uni_vpxor(vmask, vmask, vmask);
         h_->uni_vmovq(xmm_aux, reg_alpha);
         h_->uni_vbroadcastss(valpha, xmm_aux);
-        h_->uni_vcmpps(vmask, vmm_dst, vzero_, h_->_cmp_lt_os);
+        h_->uni_vcmpps(vmask, vmm_dst, vzero_, jit_generator::_cmp_lt_os);
         h_->uni_vmulps(valpha, valpha, vmm_dst);
         h_->uni_vblendvps(
                 vmm_dst, vmm_dst, valpha, vmask); // swaped aux and dst
@@ -436,7 +436,8 @@ struct helper_vmovups_data_t {
                 h_->uni_vmovups(dst.getAddress(), dst_reg);
             } else if (is_f16_) {
                 auto src_reg = Vmm(src.getIdx());
-                h_->vcvtps2ph(dst.getAddress(), src_reg, h_->_op_mxcsr);
+                h_->vcvtps2ph(
+                        dst.getAddress(), src_reg, jit_generator::_op_mxcsr);
             } else {
                 h_->uni_vmovups(dst.getAddress(), Vmm(src.getIdx()));
             }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -369,7 +369,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
 
     // Note: In case of fused depthwise convolution, the final output data type
     // after fusion may not be same as for dst.
-    typedef typename prec_traits_t<data_type::s32>::type acc_data_t;
+    using acc_data_t = typename prec_traits_t<data_type::s32>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/x64/jit_uni_xf16_sum.hpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.hpp
@@ -322,9 +322,9 @@ struct jit_xf16_sum_t : public primitive_t {
 
     status_t execute(const exec_ctx_t &ctx) const override;
 
-    typedef typename prec_traits_t<src_data_type>::type src_data_t;
-    typedef typename prec_traits_t<dst_data_type>::type dst_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type acc_data_t;
+    using src_data_t = typename prec_traits_t<src_data_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_data_type>::type;
+    using acc_data_t = typename prec_traits_t<data_type::f32>::type;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_base.cpp
@@ -70,7 +70,7 @@ void jit_avx512_common_lrn_kernel_bwd_t<f16>::load_data(
 template <>
 void jit_avx512_common_lrn_kernel_bwd_t<f16>::store_data(
         bool nt, const Address addr, Zmm zr) {
-    this->vcvtps2ph(addr, zr, this->_op_mxcsr);
+    this->vcvtps2ph(addr, zr, jit_generator::_op_mxcsr);
 }
 
 template <>

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
@@ -111,7 +111,7 @@ void jit_avx512_common_lrn_kernel_fwd_t<d_type>::load_tail(int tail_value,
 template <>
 void jit_avx512_common_lrn_kernel_fwd_t<f16>::store_data(
         const Address addr, Zmm zr, Ymm yr) {
-    this->vcvtps2ph(addr, zr, this->_op_mxcsr);
+    this->vcvtps2ph(addr, zr, jit_generator::_op_mxcsr);
 }
 
 template <>

--- a/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
@@ -625,7 +625,7 @@ void jit_uni_lrn_fwd_kernel_t<sse41, data_type::f32>::generate(
     if (pk_ != prop_kind::forward_inference) add(scratch_, 32);
     this->dec(hw);
     this->cmp(hw, 0);
-    this->jne(lrn_loop, this->T_NEAR);
+    this->jne(lrn_loop, jit_generator::T_NEAR);
 
     this->add(t, 64);
     this->postamble();
@@ -722,7 +722,7 @@ void jit_uni_lrn_fwd_kernel_t<isa, d_type>::generate(const nhwc_across_t &J) {
 
     this->dec(c);
     this->cmp(c, 0);
-    this->jne(lrn_loop, this->T_NEAR);
+    this->jne(lrn_loop, jit_generator::T_NEAR);
 
     this->vmovups(yc, this->ptr[src_]);
     this->vfmadd231ps(ysum, yc, yc);
@@ -912,7 +912,7 @@ void jit_uni_lrn_fwd_kernel_t<sse41, data_type::f32>::generate(
 
     this->dec(c);
     this->cmp(c, 0);
-    this->jne(lrn_loop, this->T_NEAR);
+    this->jne(lrn_loop, jit_generator::T_NEAR);
 
     /* compute last 3 blocks of channels:
      * block:       | -- low -- | -- hi --  |
@@ -1233,7 +1233,7 @@ void jit_uni_lrn_fwd_kernel_t<isa, d_type>::generate(const nchw_across_t &J) {
     if (pk_ != prop_kind::forward_inference) this->add(scratch_, J.HW * 4);
     this->dec(c);
     this->cmp(c, 0);
-    this->jne(lrn_loop, this->T_NEAR);
+    this->jne(lrn_loop, jit_generator::T_NEAR);
 
     this->vxorps(ye, ye, ye);
 
@@ -1410,7 +1410,7 @@ void jit_uni_lrn_fwd_kernel_t<sse41, data_type::f32>::generate(
     if (pk_ != prop_kind::forward_inference) add(scratch_, J.HW * 4);
     this->dec(c);
     this->cmp(c, 0);
-    this->jne(lrn_loop, this->T_NEAR);
+    this->jne(lrn_loop, jit_generator::T_NEAR);
 
     this->xorps(xe_lo, xe_lo);
     this->xorps(xe_hi, xe_hi);

--- a/src/cpu/x64/rnn/jit_gates_reduction.cpp
+++ b/src/cpu/x64/rnn/jit_gates_reduction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -67,9 +67,9 @@ std::vector<Xbyak::Zmm> jit_gates_reduction_t::reserve_acc_regs() {
     acc_regs.reserve(n_simd_w_blks_ + n_tail_);
 
     for (int i = 0; i < n_simd_w_blks_; ++i)
-        acc_regs.emplace_back(Xbyak::Zmm(reserve_vmm()));
+        acc_regs.emplace_back(reserve_vmm());
 
-    if (n_tail_) acc_regs.emplace_back(Xbyak::Zmm(reserve_vmm()));
+    if (n_tail_) acc_regs.emplace_back(reserve_vmm());
 
     return acc_regs;
 }


### PR DESCRIPTION
Partially addresses [MFDNN-13014](https://jira.devtools.intel.com/browse/MFDNN-13014) and a few others from the clang-tidy CI step.
