### PR TITLE
cpu: x64: fix condition for detecting f32 conf

### DIFF
--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -368,6 +368,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::init_masks(
 
     if (reduce_kind_ == matmul_reduce_kind::src
             && utils::one_of(bia_dt_, data_type::f16, data_type::bf16)) {
+        assert(isa_has_masks(brg_.isa_impl));
         mov(reg_mask, 1);
         kmovq(k_store_mask, reg_mask);
     }

--- a/src/cpu/x64/matmul_inner_product.hpp
+++ b/src/cpu/x64/matmul_inner_product.hpp
@@ -205,9 +205,11 @@ struct matmul_inner_product_bwd_weights_t : public primitive_t {
             const auto src_dt = invariant_src_md()->data_type;
             const auto diff_wei_dt = invariant_wei_md()->data_type;
             const auto diff_dst_dt = invariant_dst_md()->data_type;
+            const auto diff_bia_dt = invariant_bia_md()->data_type;
 
             const bool is_f32
-                    = utils::everyone_is(f32, src_dt, diff_wei_dt, diff_dst_dt);
+                    = utils::everyone_is(f32, src_dt, diff_wei_dt, diff_dst_dt)
+                    && IMPLICATION(with_bias(), diff_bia_dt == f32);
 
             VDISPATCH_INNER_PRODUCT(mayiuse(avx2), VERBOSE_UNSUPPORTED_ISA);
             VDISPATCH_INNER_PRODUCT(IMPLICATION(!is_f32, mayiuse(avx512_core)),


### PR DESCRIPTION
The lack of the check for data type of bias caused the reduction kernel to generate illegal instruction. Only "all f32" configuration is supported for avx2.

Another fix is to skip brgemm-based IP on avx2 for non-f32 configurations.