### PR TITLE
gpu: generic: fix checks for scales datatype

### DIFF
--- a/src/gpu/generic/sycl/ref_binary.hpp
+++ b/src/gpu/generic/sycl/ref_binary.hpp
@@ -87,6 +87,8 @@ struct ref_binary_t : public gpu::generic::sycl::primitive_t {
             const auto &scales = attr()->scales_;
             bool dt_ok = true;
             for (auto arg : supported_args) {
+                if (scales.has_default_values(arg)) continue;
+
                 dt_ok = dt_ok && is_supported_type(scales.get_data_type(arg));
             }
             return dt_ok && attr_scales_ok(supported_args);

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -66,6 +66,8 @@ inline bool check_convolution_scales_types(const primitive_attr_t *attr) {
 
     const auto &scales = attr->scales_;
     for (auto arg : supported_args) {
+        if (scales.has_default_values(arg)) continue;
+
         const auto dt = scales.get_data_type(arg);
         if (!is_supported_type(dt)) { return false; }
     }

--- a/src/gpu/generic/sycl/ref_layer_normalizations.hpp
+++ b/src/gpu/generic/sycl/ref_layer_normalizations.hpp
@@ -81,6 +81,8 @@ struct ref_layer_normalization_fwd_t : public gpu::generic::sycl::primitive_t {
 
             const auto &scales = attr()->scales_;
             for (auto arg : supported_args) {
+                if (scales.has_default_data_type(arg)) continue;
+
                 const auto dt = scales.get_data_type(arg);
                 if (!is_supported_type(dt)) { return false; }
             }

--- a/src/gpu/generic/sycl/ref_reorder.hpp
+++ b/src/gpu/generic/sycl/ref_reorder.hpp
@@ -103,6 +103,8 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
 
             const auto &scales = attr()->scales_;
             for (auto arg : supported_args) {
+                if (scales.has_default_values(arg)) continue;
+
                 const auto dt = scales.get_data_type(arg);
                 if (!is_supported_type(dt)) { return false; }
             }

--- a/src/gpu/generic/sycl/ref_sum.hpp
+++ b/src/gpu/generic/sycl/ref_sum.hpp
@@ -64,9 +64,9 @@ struct ref_sum_t : public gpu::generic::sycl::primitive_t {
                                 && src_d.ndims() <= xpu::sycl::md_t::max_dims,
                         VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "src");
 
-                VDISPATCH_SUM(attr()->scales_.has_default_values()
-                                || is_supported_type(
-                                        scales.get_data_type(DNNL_ARG_SRC + i)),
+                VDISPATCH_SUM(IMPLICATION(!attr()->scales_.has_default_values(),
+                                      is_supported_type(scales.get_data_type(
+                                              DNNL_ARG_SRC + i))),
                         VERBOSE_UNSUPPORTED_ATTR);
             }
 


### PR DESCRIPTION
# Description

This PR fixes several checks for the datatype of scales which were incorrectly returning `unimplemented`. 

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?