### PR TITLE
x64: pool: Accuracy issue in benchnn pooling test

### DIFF
--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -269,6 +269,8 @@ private:
         return jpp.is_fp8 && is_superset(isa, avx512_core_fp16);
     }
 
+    static bool has_large_buffers(const pooling_pd_t *ppd);
+
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
     std::unique_ptr<fp8_emulation_e5m2_t> f8_e5m2_emu_;
     std::unique_ptr<fp8_emulation_e4m3_t> f8_e4m3_emu_;


### PR DESCRIPTION
Opening one more time this PR. The previous one was [here](https://github.com/oneapi-src/oneDNN/pull/2678).

It is similar use case as https://github.com/oneapi-src/oneDNN/pull/2627. The problem is with huge input sizes, so I decided disable src_size <= INT_MAX for jit:avx512_core implementation.