### PR TITLE
github: workflows: Speed up clang-tidy build

### DIFF
--- a/.github/automation/build_linters.sh
+++ b/.github/automation/build_linters.sh
@@ -33,7 +33,7 @@ if [[ "$ONEDNN_ACTION" == "configure" ]]; then
     fi
 elif [[ "$ONEDNN_ACTION" == "build" ]]; then
     set -x
-    cmake --build build
+    cmake --build build -j`nproc`
     set +x
 else
     echo "Unknown action: $ONEDNN_ACTION"


### PR DESCRIPTION
Adding a -j flag to speed things up, as this is the longest part of the CI. In the future, we could also look into running this only when x64 code is touched.