### PR TITLE
github: workflows: Update ACL in CI

### DIFF
--- a/.github/automation/aarch64/build.sh
+++ b/.github/automation/aarch64/build.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Build oneDNN for aarch64.
+
+set -o errexit -o pipefail -o noclobber
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Defines MP, CC, CXX and OS.
+source ${SCRIPT_DIR}/common.sh
+
+export ACL_ROOT_DIR=${ACL_ROOT_DIR:-"${PWD}/ComputeLibrary"}
+
+CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
+ONEDNN_TEST_SET=${ONEDNN_TEST_SET:-"SMOKE"}
+ONEDNN_BUILD_GRAPH=${ONEDNN_BUILD_GRAPH:-"ON"}
+
+if [[ "$ONEDNN_ACTION" == "configure" ]]; then
+    set -x
+    cmake \
+        -Bbuild -S. \
+        -DDNNL_AARCH64_USE_ACL=ON \
+        -DONEDNN_BUILD_GRAPH=$ONEDNN_BUILD_GRAPH \
+        -DDNNL_CPU_RUNTIME=$ONEDNN_THREADING \
+        -DONEDNN_WERROR=ON \
+        -DDNNL_BUILD_FOR_CI=ON \
+        -DONEDNN_TEST_SET=$ONEDNN_TEST_SET \
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+    set +x
+elif [[ "$ONEDNN_ACTION" == "build" ]]; then
+    set -x
+    cmake --build build 
+    set +x
+else
+    echo "Unknown action: $ONEDNN_ACTION"
+    exit 1
+fi

--- a/.github/automation/aarch64/build_acl.sh
+++ b/.github/automation/aarch64/build_acl.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # *******************************************************************************
-# Copyright 2020-2024 Arm Limited and affiliates.
+# Copyright 2020-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,9 +24,9 @@ set -o errexit -o pipefail -o noclobber
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Defines MP, CC, CXX and OS.
-source ${SCRIPT_DIR}/common_aarch64.sh
+source ${SCRIPT_DIR}/common.sh
 
-CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
+ACL_BUILD_TYPE=${ACL_BUILD_TYPE:-"Release"}
 ACL_ROOT_DIR=${ACL_ROOT_DIR:-"${PWD}/ComputeLibrary"}
 ACL_REPO="https://github.com/ARM-software/ComputeLibrary.git"
 
@@ -36,24 +36,44 @@ elif [[ "$ACL_THREADING" == "SEQ" ]]; then
     ACL_OPENMP=0
 fi
 
+if [[ "$OS" == "Linux" ]]; then
+    ACL_MULTI_ISA_SUPPORT=1
+    if [[ "$ACL_THREADING" == "OMP" ]]; then
+        ACL_OPENMP=1
+    elif [[ "$ACL_THREADING" == "SEQ" ]]; then
+        ACL_OPENMP=0
+    fi
+    ACL_OS="linux"
+elif [[ "$OS" == "Darwin" ]]; then
+    ACL_MULTI_ISA_SUPPORT=0
+    ACL_OPENMP=0
+    ACL_OS="macos"
+else
+    echo "Unknown OS: $OS"
+    exit 1
+fi
+
+if [[ "$ACL_BUILD_TYPE" == "Release" ]]; then
+    ACL_DEBUG=0
+elif [[ "$ACL_BUILD_TYPE" == "Debug" ]]; then
+    ACL_DEBUG=1
+else
+    echo "Unknown build config: $ACL_BUILD_TYPE"
+    exit 1
+fi
+
 if [[ "$ACL_ACTION" == "clone" ]]; then
     set -x
     git clone --branch $ACL_VERSION --depth 1 $ACL_REPO $ACL_ROOT_DIR
     set +x
-elif [[ "$ACL_ACTION" == "configure" ]]; then
-    set -x
-    cmake \
-    -S$ACL_ROOT_DIR -B$ACL_ROOT_DIR/build \
-	-DARM_COMPUTE_OPENMP=$ACL_OPENMP \
-	-DARM_COMPUTE_CPPTHREADS=0 \
-	-DARM_COMPUTE_WERROR=0 \
-	-DARM_COMPUTE_BUILD_EXAMPLES=1 \
-	-DARM_COMPUTE_BUILD_TESTING=1 \
-    -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
-    set +x
 elif [[ "$ACL_ACTION" == "build" ]]; then
     set -x
-    cmake --build $ACL_ROOT_DIR/build 
+    cd $ACL_ROOT_DIR
+    set -x
+    scons $MP Werror=0 debug=$ACL_DEBUG neon=1 opencl=0 embed_kernels=0 \
+        os=$ACL_OS arch=armv8.2-a build=native multi_isa=$ACL_MULTI_ISA_SUPPORT \
+        fixed_format_kernels=1 cppthreads=0 openmp=$ACL_OPENMP examples=0 \
+        validation_tests=0
     set +x
 else
     echo "Unknown action: $ACL_ACTION"

--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "acl": "v24.11.1",
+        "acl": "v25.02",
         "gcc": "13",
         "clang": "17"
     }

--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": {
+        "acl": "v24.11.1",
+        "gcc": "13",
+        "clang": "17"
+    }
+}

--- a/.github/automation/aarch64/common.sh
+++ b/.github/automation/aarch64/common.sh
@@ -1,0 +1,46 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024-2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Common variables for aarch64 ci. Exports: 
+# CC, CXX, OS
+
+set -o errexit -o pipefail -o noclobber
+
+export OS=$(uname)
+
+# Num threads on system.
+if [[ "$OS" == "Darwin" ]]; then
+    export MP="-j$(sysctl -n hw.ncpu)"
+elif [[ "$OS" == "Linux" ]]; then
+    export MP="-j$(nproc)"
+fi
+
+if [[ "$BUILD_TOOLSET" == "gcc" ]]; then
+    export CC=gcc-${GCC_VERSION}
+    export CXX=g++-${GCC_VERSION}
+elif [[ "$BUILD_TOOLSET" == "clang" ]]; then
+    export CC=clang
+    export CXX=clang++
+fi
+
+# Print every exported variable.
+echo "OS: $OS"
+echo "Toolset: $BUILD_TOOLSET"
+echo "CC: $CC"
+echo "CXX: $CXX"

--- a/.github/automation/aarch64/get_acl.sh
+++ b/.github/automation/aarch64/get_acl.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # *******************************************************************************
-# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2024-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -1,7 +1,7 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,12 +19,9 @@
 
 # Test oneDNN for aarch64.
 
-set -o errexit -o pipefail -o noclobber
+set -eo pipefail
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-
-# Defines MP, CC, CXX and OS.
-source ${SCRIPT_DIR}/common_aarch64.sh
+OS=${OS:-"Linux"}
 
 # AArch64 does not officially support graph for now.
 SKIPPED_GRAPH_TEST_FAILURES="test_graph_unit_dnnl_sdp_decomp_cpu"
@@ -47,6 +44,8 @@ if [[ "$OS" == "Linux" ]]; then
     SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-mqa-cpp"
     SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
     SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
+    # TODO: Issue: https://github.com/oneapi-src/oneDNN/issues/2572
+    SKIPPED_GRAPH_TEST_FAILURES+="|test_graph_unit_dnnl_convolution"
     SKIPPED_GRAPH_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_cpu"
 fi
 
@@ -64,11 +63,4 @@ SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_graph_int8_cpu"
 
 SKIPPED_TEST_FAILURES+="|${SKIPPED_GRAPH_TEST_FAILURES}|${SKIPPED_NIGHTLY_TEST_FAILURES}"
 
-# Sequential (probably macOS) builds should use num proc parallelism.
-if [[ "$ONEDNN_THREADING" == "SEQ" ]]; then
-    export CTEST_PARALLEL_LEVEL=""
-fi
-
-set -x
-ctest --no-tests=error --output-on-failure -E "$SKIPPED_TEST_FAILURES"
-set +x
+printf "${SKIPPED_TEST_FAILURES}"

--- a/.github/automation/performance/bench_performance.sh
+++ b/.github/automation/performance/bench_performance.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Usage: bash bench_performance.sh {baseline_benchdnn_executable} {benchdnn_executable} {baseline_results_file} {new_results_file}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+for i in {1..5}
+do
+    $1 --matmul --mode=P --perf-template=%prb%,%-time% --batch=${SCRIPT_DIR}/inputs/matmul >> $3
+    $2 --matmul --mode=P --perf-template=%prb%,%-time% --batch=${SCRIPT_DIR}/inputs/matmul >> $4
+    $1 --conv --mode=P --perf-template=%prb%,%-time% --batch=${SCRIPT_DIR}/inputs/conv >> $3
+    $2 --conv --mode=P --perf-template=%prb%,%-time% --batch=${SCRIPT_DIR}/inputs/conv >> $4
+done

--- a/.github/automation/performance/benchdnn_comparison.py
+++ b/.github/automation/performance/benchdnn_comparison.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+import sys
+import os
+from collections import defaultdict
+from scipy.stats import ttest_ind
+
+
+def compare_two_benchdnn(file1, file2, tolerance=0.05):
+    """
+    Compare two benchdnn output files
+    """
+    with open(file1) as f:
+        r1 = f.readlines()
+
+    with open(file2) as f:
+        r2 = f.readlines()
+
+    # Trim non-formatted lines and split the problem from time
+    r1 = [x.split(",") for x in r1 if x[0:8] == "--mode=P"]
+    r2 = [x.split(",") for x in r2 if x[0:8] == "--mode=P"]
+
+    if (len(r1) == 0) or (len(r2) == 0):
+        raise Exception("One or both of the test results have zero lines")
+    if len(r1) != len(r2):
+        raise Exception("The number of benchdnn runs do not match")
+
+    r1_samples = defaultdict(list)
+    r2_samples = defaultdict(list)
+
+    for k, v in r1:
+        r1_samples[k].append(float(v[:-1]))
+    for k, v in r2:
+        r2_samples[k].append(float(v[:-1]))
+
+    passed = True
+    failed_tests = []
+    for prb, r1_times in r1_samples.items():
+        if prb not in r2_samples:
+            raise Exception(f"{prb} exists in {file1} but not {file2}")
+        r2_times = r2_samples[prb]
+
+        res = ttest_ind(r2_times, r1_times, alternative='greater')
+
+        if res.pvalue < 0.05:
+            failed_tests.append(prb)
+            passed = False
+
+        print(prb + (" passed" if passed else " failed"))
+
+    if "GITHUB_OUTPUT" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            print(f"pass={passed}", file=f)
+
+    if passed:
+        print("Regression tests passed")
+    else:
+        message = "\n----The following regression tests failed:----\n" + \
+                    "\n".join(failed_tests) + "\n"
+        if "GITHUB_OUTPUT" in os.environ:
+            out_message = message.replace("\n", "%0A")
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                print(f'message={out_message}', file=f)
+        print(message)
+        raise Exception("Some regression tests failed")
+
+if __name__ == "__main__":
+    compare_two_benchdnn(sys.argv[1], sys.argv[2])

--- a/.github/automation/performance/inputs/conv
+++ b/.github/automation/performance/inputs/conv
@@ -1,7 +1,5 @@
-#! /bin/bash
-
 # *******************************************************************************
-# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,23 +15,8 @@
 # limitations under the License.
 # *******************************************************************************
 
-# Common variables for aarch64 ci. Exports: 
-# CC, CXX, OS
-
-set -o errexit -o pipefail -o noclobber
-
-export OS=$(uname)
-
-if [[ "$BUILD_TOOLSET" == "gcc" ]]; then
-    export CC=gcc-${GCC_VERSION}
-    export CXX=g++-${GCC_VERSION}
-elif [[ "$BUILD_TOOLSET" == "clang" ]]; then
-    export CC=clang
-    export CXX=clang++
-fi
-
-# Print every exported variable.
-echo "OS: $OS"
-echo "Toolset: $BUILD_TOOLSET"
-echo "CC: $CC"
-echo "CXX: $CXX"
+# From Resnet
+--reset
+--dir=FWD_D
+--dt=f32
+mb1_ic64oc256_ih200oh200kh1sh1dh0ph0_iw267ow267kw1sw1dw0pw0

--- a/.github/automation/performance/inputs/matmul
+++ b/.github/automation/performance/inputs/matmul
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+--reset
+--dt=bf16,f32
+1500x384:384x384

--- a/.github/workflows/aarch64-acl.yml
+++ b/.github/workflows/aarch64-acl.yml
@@ -1,0 +1,124 @@
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+name: "Build ACL cache"
+
+#* To avoid duplicate jobs running when both push and PR is satisfied, we use this:
+#* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
+on:
+  workflow_call:
+  workflow_dispatch:
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  # Cache is built sequentially to avoid cache-hit race conditions
+  build-cache:
+    strategy:
+      max-parallel: 1
+      matrix:
+        config: [
+          { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release },
+          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: Release },
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug },
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: gcc, build: Release }
+        ]
+
+    name: ${{ matrix.config.name }}, ${{ matrix.config.toolset }}, ${{ matrix.config.threading }}, ${{ matrix.config.build }}
+    runs-on: ${{ matrix.config.label }}
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: oneDNN
+
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/aarch64/ci.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
+
+      - name: Clone ACL
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build_acl.sh
+        env:
+          ACL_ACTION: clone
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          ACL_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.acl }}
+
+      - name: Get ACL commit hash for cache key
+        id: get_acl_commit_hash
+        run: (cd ${{ github.workspace }}/ComputeLibrary && echo "ACLCommitHash=$(git rev-parse --short HEAD)") >> $GITHUB_OUTPUT
+
+      - name: Get system name
+        id: get_system_name
+        run: (echo "SystemName=$(uname)") >> $GITHUB_OUTPUT
+
+      - name: Restore cached ACL
+        id: cache-acl-restore
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
+          path: ${{ github.workspace }}/ComputeLibrary/build
+
+      - name: Install Scons (MacOS)
+        if: ${{ matrix.config.name == 'MacOS' && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        run: brew install scons
+
+      - name: Install scons (Linux)
+        if: ${{ matrix.config.name != 'MacOS' && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        run: |
+          sudo apt update -y
+          sudo apt install -y scons
+
+      - if: ${{ contains(matrix.config.label,'ubuntu') && (matrix.config.threading == 'OMP') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        name: Install openmp
+        run: |
+          sudo apt install -y libomp-dev
+
+      - if: ${{ contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'gcc') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        name: Install gcc
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt update -y
+          sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
+
+      - if: ${{ contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'clang') && (steps.cache-acl-restore.outputs.cache-hit != 'true') }}
+        name: Install clang
+        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
+        with:
+          version: ${{ fromJson(steps.get-versions.outputs.output).dependencies.clang }}
+
+      - name: Build ACL
+        if: ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build_acl.sh
+        env:
+          ACL_ACTION: build
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          ACL_THREADING: ${{ matrix.config.threading }}
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          ACL_BUILD_TYPE: ${{ matrix.config.build }}
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
+
+      - name: Save ACL in cache
+        id: cache-acl_build-save
+        if: ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
+          path: ${{ github.workspace }}/ComputeLibrary/build

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2024-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,29 +21,31 @@ name: "CI AArch64"
 #* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
 on:
   push:
-    branches: [ main, 'rls-*' ]
+    branches: [main, "rls-*"]
     paths:
-      - '.github/**'
-      - 'cmake/**'
-      - 'examples/**'
-      - 'include/**'
-      - 'src/common/**'
-      - 'src/cpu/*'
-      - 'src/cpu/aarch64/**'
-      - 'tests/**'
-      - 'CMakeLists.txt'
+      - ".github/**"
+      - "cmake/**"
+      - "examples/**"
+      - "include/**"
+      - "src/common/**"
+      - "src/cpu/*"
+      - "src/cpu/aarch64/**"
+      - "tests/**"
+      - "CMakeLists.txt"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - '.github/**'
-      - 'cmake/**'
-      - 'examples/**'
-      - 'include/**'
-      - 'src/common/**'
-      - 'src/cpu/*'
-      - 'src/cpu/aarch64/**'
-      - 'tests/**'
-      - 'CMakeLists.txt'
+      - ".github/**"
+      - "cmake/**"
+      - "examples/**"
+      - "include/**"
+      - "src/common/**"
+      - "src/cpu/*"
+      - "src/cpu/aarch64/**"
+      - "tests/**"
+      - "CMakeLists.txt"
+  #* allow manual trigger of workflow when needed.
+  workflow_dispatch:
 
 #* Stop stale workflows when pull requests are updated: https://stackoverflow.com/a/70972844
 #* Does not apply to the main branch.
@@ -55,11 +57,16 @@ concurrency:
 permissions: read-all
 
 jobs:
+  build-acl-cache:
+    uses: ./.github/workflows/aarch64-acl.yml
+
   build-and-test:
+    needs: build-acl-cache
     strategy:
       matrix:
         config: [
           { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release, testset: SMOKE },
+          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: Release, testset: SMOKE },
           { name: c6g, label: ah-ubuntu_22_04-c6g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI },
           { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug, testset: SMOKE },
           { name: c7g, label: ah-ubuntu_22_04-c7g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }
@@ -68,42 +75,58 @@ jobs:
     name: ${{ matrix.config.name }}, ${{ matrix.config.toolset }}, ${{ matrix.config.threading }}, ${{ matrix.config.build }}
     runs-on: ${{ matrix.config.label }}
     steps:
-
       - name: Checkout oneDNN
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: oneDNN
 
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/aarch64/ci.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
+
+      # Note: This will create a github actions cache
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@8567b9d9b63052b8430ef30042e13c3ba5288f16 # v3.31.3
+        uses: lukka/get-cmake@5f6e04f5267c8133f1273bf2103583fc72c46b17 # v3.31.5
         with:
           cmakeVersion: 3.31.0
           ninjaVersion: 1.12.0
 
-      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.threading == 'OMP')) }}
+      - if: ${{ (contains(matrix.config.label,'ubuntu') && (matrix.config.threading == 'OMP')) }}
         name: Install openmp
         run: |
           sudo apt install -y libomp-dev
 
-      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'gcc')) }}
+      - if: ${{ (contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'gcc')) }}
         name: Install gcc
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt update -y
-          sudo apt install -y g++-13
+          sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
 
-      - if: ${{ (startsWith(matrix.config.label,'ah-ubuntu') && (matrix.config.toolset == 'clang')) }}
+      - if: ${{ (contains(matrix.config.label,'ubuntu') && (matrix.config.toolset == 'clang')) }}
         name: Install clang
         uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181
         with:
-          version: "17"
+          version: ${{ fromJson(steps.get-versions.outputs.output).dependencies.clang }}
+
+      - name: setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install scipy
+        if: ${{ matrix.config.build == 'Release' }}
+        run: pip install scipy
 
       - name: Clone ACL
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build_acl.sh
         env:
           ACL_ACTION: clone
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_VERSION: v24.11.1
+          ACL_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.acl }}
 
       - name: Get ACL commit hash for cache key
         id: get_acl_commit_hash
@@ -120,53 +143,27 @@ jobs:
           key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
           path: ${{ github.workspace }}/ComputeLibrary/build
 
-      - name: Configure ACL
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: configure
-          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_THREADING: ${{ matrix.config.threading }}
-          BUILD_TOOLSET: ${{ matrix.config.toolset }}
-          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
-          CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
-
-      - name: Build ACL
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: build
-
-      - name: Save ACL in cache
-        if:  ${{ steps.cache-acl-restore.outputs.cache-hit != 'true' }}
-        id: cache-acl_build-save
-        uses: actions/cache/save@v4
-        with:
-          key: ${{ steps.cache-acl-restore.outputs.cache-primary-key }}
-          path: ${{ github.workspace }}/ComputeLibrary/build
-
       - name: Configure oneDNN
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
         working-directory: ${{ github.workspace }}/oneDNN
         env:
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
           ONEDNN_ACTION: configure
           ONEDNN_TEST_SET: ${{ matrix.config.testset }}
           ONEDNN_THREADING: ${{ matrix.config.threading }}
 
       - name: Build oneDNN
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
         working-directory: ${{ github.workspace }}/oneDNN
         env:
           ONEDNN_ACTION: build
 
       - name: Run oneDNN tests
-        run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/test.sh
         working-directory: ${{ github.workspace }}/oneDNN/build
         env:
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
@@ -174,6 +171,55 @@ jobs:
           CTEST_PARALLEL_LEVEL: 6
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
           ONEDNN_THREADING: ${{ matrix.config.threading }}
+
+      ## Performance test steps ##
+      - name: Checkout oneDNN base
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.base_ref }}
+          path: oneDNN_base
+
+      - name: Configure oneDNN base
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
+        working-directory: ${{ github.workspace }}/oneDNN_base
+        env:
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
+          CMAKE_GENERATOR: Ninja
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
+          ONEDNN_ACTION: configure
+          ONEDNN_TEST_SET: ${{ matrix.config.testset }}
+          ONEDNN_THREADING: ${{ matrix.config.threading }}
+
+      - name: Build oneDNN base
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
+        working-directory: ${{ github.workspace }}/oneDNN_base
+        env:
+          ONEDNN_ACTION: build
+
+      - name: Run performance tests
+        shell: bash
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
+        run: |
+          OMP_NUM_THREADS=4 bash ${{ github.workspace }}/oneDNN/.github/automation/performance/bench_performance.sh ${{ github.workspace }}/oneDNN_base/build/tests/benchdnn/benchdnn ${{ github.workspace }}/oneDNN/build/tests/benchdnn/benchdnn base.txt new.txt
+          OMP_NUM_THREADS=16 bash ${{ github.workspace }}/oneDNN/.github/automation/performance/bench_performance.sh ${{ github.workspace }}/oneDNN_base/build/tests/benchdnn/benchdnn ${{ github.workspace }}/oneDNN/build/tests/benchdnn/benchdnn base.txt new.txt
+        env:
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
+
+      - name: Compare performance test results
+        if: ${{ github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
+        id: performance-test
+        continue-on-error: true
+        run: python ${{ github.workspace }}/oneDNN/.github/automation/performance/benchdnn_comparison.py base.txt new.txt
+
+      - name: Check performance test failure
+        if: ${{ steps.performance-test.outputs.pass != 'True' && github.event_name == 'pull_request' && matrix.config.build == 'Release' && matrix.config.name != 'cb100' }}
+        run: echo "::warning file=.github/workflows/ci-aarch64.yml,line=1,col=1::${{ steps.performance-test.outputs.message }}"
+
   # This job adds a check named "CI AArch64" that represents overall
   # workflow status and can be used in branch rulesets
   status:

--- a/.github/workflows/nightly-aarch64.yml
+++ b/.github/workflows/nightly-aarch64.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2024-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,11 @@ concurrency:
 permissions: read-all
 
 jobs:
+  build-acl-cache:
+    uses: ./.github/workflows/aarch64-acl.yml
+
   build-and-test:
+    needs: build-acl-cache
     strategy:
       matrix:
         config: [
@@ -52,8 +56,9 @@ jobs:
         with:
           path: oneDNN
 
+      # Note: This will create a github actions cache
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@8567b9d9b63052b8430ef30042e13c3ba5288f16 # v3.31.3
+        uses: lukka/get-cmake@5f6e04f5267c8133f1273bf2103583fc72c46b17 # v3.31.5
         with:
           cmakeVersion: 3.31.0
           ninjaVersion: 1.12.0
@@ -63,56 +68,62 @@ jobs:
         run: |
           sudo apt install -y libomp-dev
 
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/aarch64/ci.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
+
       - name: Install gcc
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt update -y
-          sudo apt install -y g++-13
+          sudo apt install -y g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
 
       - name: Clone ACL
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build_acl.sh
         env:
           ACL_ACTION: clone
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_VERSION: v24.11.1
+          ACL_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.acl }}
 
-      - name: Configure ACL
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: configure
-          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_THREADING: ${{ matrix.config.threading }}
-          BUILD_TOOLSET: ${{ matrix.config.toolset }}
-          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
-          CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
+      - name: Get ACL commit hash for cache key
+        id: get_acl_commit_hash
+        run: (cd ${{ github.workspace }}/ComputeLibrary && echo "ACLCommitHash=$(git rev-parse --short HEAD)") >> $GITHUB_OUTPUT
 
-      - name: Build ACL
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_acl.sh
-        env:
-          ACL_ACTION: build
+      - name: Get system name
+        id: get_system_name
+        run: (echo "SystemName=$(uname)") >> $GITHUB_OUTPUT
+
+      - name: Restore cached ACL
+        id: cache-acl-restore
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
+          path: ${{ github.workspace }}/ComputeLibrary/build
 
       - name: Configure oneDNN
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
         working-directory: ${{ github.workspace }}/oneDNN
         env:
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
           CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           CMAKE_GENERATOR: Ninja
-          GCC_VERSION: 13
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
           ONEDNN_ACTION: configure
           ONEDNN_TEST_SET: ${{ matrix.config.testset }}
           ONEDNN_THREADING: ${{ matrix.config.threading }}
 
       - name: Build oneDNN
-        run: ${{ github.workspace }}/oneDNN/.github/automation/build_aarch64.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh
         working-directory: ${{ github.workspace }}/oneDNN
         env:
           ONEDNN_ACTION: build
 
       - name: Run oneDNN tests
-        run: ${{ github.workspace }}/oneDNN/.github/automation/test_aarch64.sh
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/test.sh
         working-directory: ${{ github.workspace }}/oneDNN/build
         env:
           BUILD_TOOLSET: ${{ matrix.config.toolset }}


### PR DESCRIPTION
Backport to https://github.com/oneapi-src/oneDNN/pull/2713 for v3.7

Edit: This was more tedious than I thought. We have changed the CI so much since 3.6 that it was easier to backport the whole AArch64 CI folder to maintain consistency, otherwise there were errors that would take time to debug, and would be pointless to debug anyways.

For convenience, I will backport the CI in one commit (a 1:1 copy of CI in main), and then upgrade ACL in the other.

I ran a nightly just to be sure: https://github.com/oneapi-src/oneDNN/actions/runs/13381628230