### PR TITLE
common, xe: fix missing -cl-intel-greater-than-4GB-buffer-required OpenCL flag

### DIFF
--- a/src/common/memory.cpp
+++ b/src/common/memory.cpp
@@ -59,12 +59,8 @@ size_t memory_desc_map_size(const memory_desc_t *md, int index = 0) {
     auto mdw = memory_desc_wrapper(md);
 
     if (mdw.has_runtime_dims_or_strides()) return DNNL_RUNTIME_SIZE_VAL;
-    if (mdw.offset0() == 0) return mdw.size(index);
 
-    memory_desc_t md_no_offset0 = *md;
-    md_no_offset0.offset0 = 0;
-    return memory_desc_wrapper(md_no_offset0).size(index)
-            + md->offset0 * mdw.data_type_size();
+    return mdw.size(index, true, true);
 }
 } // namespace
 

--- a/src/gpu/intel/compute/kernel_ctx.cpp
+++ b/src/gpu/intel/compute/kernel_ctx.cpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/compute/kernel_ctx.hpp"
+#include "gpu/intel/primitive_conf.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace compute {
+
+void kernel_ctx_t::register_buffer_size(const memory_desc_info_t &mdi) {
+    register_buffer_size(
+            mdi.size + mdi.offset0 * types::data_type_size(mdi.data_type));
+}
+
+} // namespace compute
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 #include "common/bit_cast.hpp"
+#include "common/type_helpers.hpp"
 #include "gpu/intel/gpu_primitive_attr.hpp"
 #include "gpu/intel/utils.hpp"
 
@@ -33,6 +34,9 @@ namespace dnnl {
 namespace impl {
 namespace gpu {
 namespace intel {
+
+struct memory_desc_info_t;
+
 namespace compute {
 
 class kernel_ctx_t {
@@ -73,8 +77,9 @@ public:
     }
 
     void register_buffer_size(const memory_desc_wrapper &mdw) {
-        register_buffer_size(mdw.size());
+        register_buffer_size(mdw.size(0, true, true));
     }
+    void register_buffer_size(const memory_desc_info_t &mdi);
 
     // Enable various optimizations when all buffers are < 2GB in size. In this
     // case, int32_t types can be used for data offsets and avoid int64_t

--- a/src/gpu/intel/ocl/gen9_pooling.cpp
+++ b/src/gpu/intel/ocl/gen9_pooling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -230,8 +230,8 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     def_offsets(off.src_off, kernel_ctx, "SRC", conf.ndims);
     def_offsets(off.dst_off, kernel_ctx, "DST", conf.ndims);
 
-    kernel_ctx.register_buffer_size(conf.src_md_info.size);
-    kernel_ctx.register_buffer_size(conf.dst_md_info.size);
+    kernel_ctx.register_buffer_size(conf.src_md_info);
+    kernel_ctx.register_buffer_size(conf.dst_md_info);
 
     CHECK(def_attr_info(kernel_ctx, conf.attr_info, post_ops, *dst_md));
 

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -474,7 +474,7 @@ void def_memory_desc_info(compute::kernel_ctx_t &kernel_ctx,
         const memory_desc_info_t &md_info, const char *prefix,
         bool with_punning) {
     def_data_type(kernel_ctx, md_info.data_type, prefix, with_punning);
-    kernel_ctx.register_buffer_size(md_info.size);
+    kernel_ctx.register_buffer_size(md_info);
 
     kernel_ctx.define_int(utils::format("%s_OFFSET0", prefix), md_info.offset0);
     kernel_ctx.define_int(utils::format("%s_NDIMS", prefix), md_info.ndims);


### PR DESCRIPTION
When offset0 is set, the maximum offset addressed by an OpenCL kernel is `offset0 + buffer_size`. If this value exceeds a 4GB offset, stateless addressing must be used, which requires setting the ` -cl-intel-greater-than-4GB-buffer-required` flag. This PR adds the missing checks against offset0. This required modifying `memory_desc_wrapper::size()` to return an appropriate size when `offset0` is set. 

Fixes [MFDNN-13205](https://jira.devtools.intel.com/browse/MFDNN-13205).