### PR TITLE
src: gpu: intel: jit: eliminate thread_local expr_t for tgs

### DIFF
--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -305,15 +305,20 @@ public:
         // Bind grid indices.
         int r0_sub_idxs[] = {1, 6, 7};
         for (int i = 0; i < 3; i++) {
-            auto tmp = ra_.template alloc_sub<int32_t>();
-            mov(1, tmp, r0.ud(r0_sub_idxs[i]));
-            expr_binding.bind(ir_builder_t::tg_idxs()[i], tmp);
+            auto tg_idx = alloc_mgr.find_let(ir_builder_t::tg_idx(i), true);
+            if (!tg_idx.is_empty()) {
+                auto tmp = ra_.template alloc_sub<int32_t>();
+                mov(1, tmp, r0.ud(r0_sub_idxs[i]));
+                expr_binding.bind(tg_idx, tmp);
+            }
         }
 
         // Bind local IDs.
         for (int i = 0; i < 3; i++) {
-            expr_binding.bind(
-                    ir_builder_t::local_ids()[i], getLocalID(i).uw(0));
+            auto local_id = alloc_mgr.find_let(ir_builder_t::local_id(i), true);
+            if (!local_id.is_empty()) {
+                expr_binding.bind(local_id, getLocalID(i).uw(0));
+            }
         }
 
         // Bind arguments.

--- a/src/gpu/intel/jit/ir/config.hpp
+++ b/src/gpu/intel/jit/ir/config.hpp
@@ -448,9 +448,7 @@ public:
                 dims[i] *= ir_utils::safe_divide(padded_dim(d), tg_block);
             }
         }
-        auto &tg_idxs = ir_builder_t::tg_idxs();
-        set_kernel_grid(grid_info_t(
-                dims, std::vector<expr_t>(tg_idxs.begin(), tg_idxs.end())));
+        set_kernel_grid(grid_info_t(dims, ir_builder_t::tg_idx));
     }
 
     void init_thread_group_grid(const std::array<pvar_tile_t, 3> &grid) {
@@ -459,7 +457,7 @@ public:
             for (auto &d : grid[i])
                 dims[i] *= thread_group_dim(d);
         }
-        set_thread_group_grid(grid_info_t(dims, "thr_idx"));
+        set_thread_group_grid(grid_info_t(dims, ir_builder_t::thr_idx));
     }
 
 protected:

--- a/src/gpu/intel/jit/ir/ir_builder.cpp
+++ b/src/gpu/intel/jit/ir/ir_builder.cpp
@@ -25,23 +25,19 @@ namespace jit {
 void ir_builder_t::init_kernel_grid(const grid_info_t &kernel_grid,
         const grid_info_t &tg_grid, int simd_size, constraint_set_t &cset,
         std::vector<stmt_t> &init_stmts) {
-    dim_idx_t grid_ndims = kernel_grid.ndims();
-    for (dim_idx_t i = 0; i < grid_ndims; i++) {
+    for (dim_idx_t i = 0; i < kernel_grid.ndims(); i++) {
+        auto local_id = var_t::make(type_t::u16(), ir_builder_t::local_id(i));
         int local_id_bound = into<int>(tg_grid.dim(i));
         if (i == dim_idx_t(0)) local_id_bound *= simd_size;
-        cset.add_constraint(local_ids()[i] >= 0);
-        cset.add_constraint(local_ids()[i] < local_id_bound);
-        cset.add_constraint(tg_idxs()[i] >= 0);
-        cset.add_constraint(tg_idxs()[i] < kernel_grid.dim(i));
+        cset.add_constraint(local_id >= 0);
+        cset.add_constraint(local_id < local_id_bound);
+        cset.add_constraint(kernel_grid.idx(i) >= 0);
+        cset.add_constraint(kernel_grid.idx(i) < kernel_grid.dim(i));
         cset.add_constraint(tg_grid.idx(i) >= 0);
         cset.add_constraint(tg_grid.idx(i) < tg_grid.dim(i));
-    }
-
-    for (dim_idx_t i = 0; i < grid_ndims; i++) {
-        auto value = local_ids()[i];
-        if (i == 0) value /= simd_size;
+        if (i == 0) local_id /= simd_size;
         auto &type = tg_grid.idx(i).type();
-        init_stmts.push_back(let_t::make(tg_grid.idx(i), cast(value, type)));
+        init_stmts.push_back(let_t::make(tg_grid.idx(i), cast(local_id, type)));
     }
 }
 

--- a/src/gpu/intel/jit/ir/ir_builder.hpp
+++ b/src/gpu/intel/jit/ir/ir_builder.hpp
@@ -20,7 +20,6 @@
 #include <array>
 
 #include "gpu/intel/jit/ir/ir.hpp"
-#include "gpu/intel/jit/ir/kernel_info.hpp"
 #include "gpu/intel/jit/ir/tensor.hpp"
 
 namespace dnnl {
@@ -33,21 +32,12 @@ class ir_builder_t {
 public:
     const stmt_t &stmt() const { return stmt_; }
 
-    static const std::array<expr_t, 3> &local_ids() {
-        static thread_local std::array<expr_t, 3> vars
-                = {var_t::make(type_t::u16(), "local_id0"),
-                        var_t::make(type_t::u16(), "local_id1"),
-                        var_t::make(type_t::u16(), "local_id2")};
-        return vars;
-    }
-
-    static const std::array<expr_t, 3> &tg_idxs() {
-        static thread_local std::array<expr_t, 3> vars
-                = {var_t::make(type_t::s32(), "tg_idx0"),
-                        var_t::make(type_t::s32(), "tg_idx1"),
-                        var_t::make(type_t::s32(), "tg_idx2")};
-        return vars;
-    }
+#define GENNAME(prefix) \
+    static std::string prefix(int idx) { return #prefix + std::to_string(idx); }
+    GENNAME(tg_idx)
+    GENNAME(thr_idx)
+    GENNAME(local_id)
+#undef GENNAME
 
 protected:
     void init_kernel_grid(const grid_info_t &kernel_grid,

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -152,8 +152,8 @@ public:
     grid_info_t(dim_idx_t ndims) : dims_(ndims), offs_(ndims), idxs_(ndims) {}
     grid_info_t(const std::vector<dim_t> &dims, const std::vector<expr_t> &idxs)
         : grid_info_t(dims, {}, idxs) {}
-    grid_info_t(const std::vector<dim_t> &dims, const std::string &prefix)
-        : grid_info_t(dims, make_idxs(prefix, into<dim_idx_t>(dims.size()))) {}
+    grid_info_t(const std::vector<dim_t> &dims, std::string (*genname)(int))
+        : grid_info_t(dims, make_idxs(genname, into<dim_idx_t>(dims.size()))) {}
     grid_info_t(const std::vector<dim_t> &dims, const std::vector<dim_t> &offs,
             const std::vector<expr_t> &idxs)
         : dims_(dims), offs_(offs), idxs_(idxs) {
@@ -269,12 +269,11 @@ public:
     IR_DEFINE_DUMP()
 
 private:
-    static std::vector<expr_t> make_idxs(const std::string &prefix, int n) {
+    static std::vector<expr_t> make_idxs(std::string (*genname)(int), int n) {
         std::vector<expr_t> ret;
         ret.reserve(n);
         for (int i = 0; i < n; i++)
-            ret.push_back(
-                    var_t::make(type_t::s32(), prefix + std::to_string(i)));
+            ret.push_back(var_t::make(type_t::s32(), genname(i)));
         return ret;
     }
 

--- a/src/gpu/intel/jit/pooling/config.hpp
+++ b/src/gpu/intel/jit/pooling/config.hpp
@@ -497,12 +497,10 @@ public:
         kg[0] *= utils::div_up(oc, lg[1]);
         kg[1] *= utils::div_up(mb, lg[0]);
 
-        set_dims_padded(grid_info_t(padded, ""));
-        set_loop_grid(grid_info_t(lg, "lg_idx"));
-        auto &tg_idxs = ir_builder_t::tg_idxs();
-        set_kernel_grid(grid_info_t(
-                kg, std::vector<expr_t>(tg_idxs.begin(), tg_idxs.end())));
-        set_thread_group_grid(grid_info_t(tg, "tg_idx"));
+        set_dims_padded(grid_info_t(padded, ir_builder_t::local_id));
+        set_loop_grid(grid_info_t(lg, ir_builder_t::local_id));
+        set_kernel_grid(grid_info_t(kg, ir_builder_t::tg_idx));
+        set_thread_group_grid(grid_info_t(tg, ir_builder_t::thr_idx));
     }
 
     compute::nd_range_t nd_range() const {

--- a/src/gpu/intel/jit/reorder/ir_builder.cpp
+++ b/src/gpu/intel/jit/reorder/ir_builder.cpp
@@ -333,10 +333,8 @@ void reorder_ir_builder_t::compute_grid(const layout_t &src,
         kernel_grid_dims[grid_idx] *= outer;
         if (outer != 1 && grid_idx != max_grid_idx) grid_idx++;
     }
-    auto &tg_idxs = ir_builder_t::tg_idxs();
-    kernel_grid = grid_info_t(kernel_grid_dims,
-            std::vector<expr_t>(tg_idxs.begin(), tg_idxs.end()));
-    tg_grid = grid_info_t(tg_grid_dims, "thr_idx");
+    kernel_grid = grid_info_t(kernel_grid_dims, ir_builder_t::tg_idx);
+    tg_grid = grid_info_t(tg_grid_dims, ir_builder_t::thr_idx);
 }
 
 compute::nd_range_t reorder_ir_builder_t::nd_range(

--- a/src/gpu/intel/jit/v2/conv/builder.cpp
+++ b/src/gpu/intel/jit/v2/conv/builder.cpp
@@ -763,7 +763,7 @@ public:
                     = const_var_t::make(type_t::s32(), "sk_iters_per_tg");
             sk_params.iters_per_tile
                     = const_var_t::make(type_t::s32(), "sk_iters_per_tile");
-            sk_params.tg_idx = jit::ir_builder_t::tg_idxs()[0];
+            sk_params.tg_idx = plan_.tg_grid.index_var(0);
 
             auto iter = alloc_var(type_t::s32(), "sk_iter");
             iter = sk_params.tg_idx * sk_params.iters_per_tg;
@@ -915,7 +915,8 @@ private:
 
     void emit_thread_index_let() {
         for (int i = 0; i < 3; i++) {
-            auto value = jit::ir_builder_t::local_ids()[i];
+            auto value = var_t::make(
+                    type_t::u16(), jit::ir_builder_t::local_id(i));
             if (i == 0) value /= plan_.desc.simd;
             auto thr_idx = plan_.thr_grid.index_var(i);
             let(thr_idx, cast(value, thr_idx.type()));

--- a/src/gpu/intel/jit/v2/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/v2/conv/gen_convolution.cpp
@@ -80,7 +80,7 @@ bool has_large_buffers(const convolution_pd_t *pd) {
     auto is_large = [](const memory_desc_t &md) {
         memory_desc_wrapper mdw(md);
         gpu_assert(!mdw.format_any());
-        return mdw.size() > std::numeric_limits<int32_t>::max();
+        return mdw.size() > size_t(std::numeric_limits<int32_t>::max());
     };
     if (is_large(*pd->invariant_src_md())) return true;
     if (is_large(*pd->invariant_wei_md())) return true;

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -985,7 +985,7 @@ void kernel_desc_t::show_help() {
 }
 
 grid_t create_thread_group_grid(const kernel_desc_t &desc) {
-    grid_t grid(jit::ir_builder_t::tg_idxs());
+    grid_t grid(jit::ir_builder_t::tg_idx);
     auto set = [&](const pvar_t dim, int idx) {
         grid.add_mapping(dim, desc.use_stream_k ? 0 : idx);
     };
@@ -1020,7 +1020,7 @@ grid_t create_thread_group_grid(const kernel_desc_t &desc) {
 }
 
 grid_t create_thread_grid(const kernel_desc_t &desc) {
-    grid_t grid("thr_idx");
+    grid_t grid(jit::ir_builder_t::thr_idx);
     switch (desc.prop) {
         case prop_kind::forward:
             grid.add_mapping(pvars::oc, 0);

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -391,10 +391,9 @@ public:
     static const int N = 3;
 
     grid_t() = default;
-    grid_t(const std::string &prefix) {
+    grid_t(std::string (*genname)(int)) {
         for (int i = 0; i < N; i++)
-            entries_[i].idx_var
-                    = var_t::make(type_t::s32(), prefix + std::to_string(i));
+            entries_[i].idx_var = var_t::make(type_t::s32(), genname(i));
     }
     grid_t(const std::array<expr_t, N> &idx_vars) {
         for (int i = 0; i < N; i++) {


### PR DESCRIPTION
This should resolve MFDNN-13019 by eliminating thread-local `expr_t`-s which could accidentally spill into other threads.