### PR TITLE
gtests: graph: unit: fix constant cache hit and miss test

### DIFF
--- a/tests/gtests/graph/unit/backend/dnnl/test_large_partition.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_large_partition.cpp
@@ -17,7 +17,6 @@
 #include <functional>
 #include <random>
 
-#include "oneapi/dnnl/dnnl_graph.hpp"
 #include "gtest/gtest.h"
 
 #include "graph/unit/backend/dnnl/dnnl_test_common.hpp"
@@ -263,6 +262,10 @@ TEST(test_large_partition_execute, F32Resnet50Stage2Block) {
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
 
+    // set constant tensor cache capacity as 1GB
+    dnnl_graph_set_constant_tensor_cache_capacity(
+            static_cast<dnnl_engine_kind_t>(eng->kind()), 1024);
+
     // compile
     graph::partition_t p;
     p.init(part);
@@ -311,10 +314,6 @@ TEST(test_large_partition_execute, F32Resnet50Stage2Block) {
                 compiled_output, eng, ref_outputs_data.back());
     }
 
-    // set constant tensor cache capacity as 1GB
-    dnnl::graph::set_constant_tensor_cache_capacity(
-            static_cast<engine::kind>(eng->kind()), 1024);
-
     ASSERT_EQ(run_graph(g, inputs_ts, ref_outputs_ts, *eng, *strm),
             graph::status::success);
 
@@ -326,9 +325,11 @@ TEST(test_large_partition_execute, F32Resnet50Stage2Block) {
                       test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     // disable constant tensor cache and then to test constant cache miss
-    dnnl::graph::set_constant_tensor_cache_capacity(
-            static_cast<engine::kind>(eng->kind()), 0);
-    ASSERT_EQ(cp.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
+    dnnl_graph_set_constant_tensor_cache_capacity(
+            static_cast<dnnl_engine_kind_t>(eng->kind()), 0);
+    graph::compiled_partition_t cp1(p);
+    ASSERT_EQ(p.compile(&cp1, inputs, outputs, eng), graph::status::success);
+    ASSERT_EQ(cp1.execute(strm, test_tensor_t::to_graph_tensor(inputs_ts),
                       test_tensor_t::to_graph_tensor(outputs_ts)),
             graph::status::success);
     strm->wait();


### PR DESCRIPTION
A gtest issue was found during the daily test with constant tensor cache enabled through env var.
Constant tensor cache enable and disable API need to be called before partition compilation or it will take no effect and introduce unexpected results.

Before change:
```
export ONEDNN_GRAPH_CONSTANT_TENSOR_CACHE_CAPACITY="cpu:10240;gpu:20480"

./tests/gtests/graph/unit/test_graph_unit --gtest_filter=test_large_partition_execute.F32Resnet50Stage2Block
Note: Google Test filter = test_large_partition_execute.F32Resnet50Stage2Block:-*_GPU*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from test_large_partition_execute
[ RUN      ] test_large_partition_execute.F32Resnet50Stage2Block
index = 0, a = 1.13047e+07, b = 1.24032e+07, diff = 1.0985e+06, atol = 1e-05, rtol = 1e-05. Failed.
/home/sdp/xiangguo/onednn/oneDNN/tests/gtests/graph/unit/backend/dnnl/test_large_partition.cpp:338: Failure
Value of: allclose<float>(outputs_ts[0], ref_outputs_ts[0], 1e-5f, 1e-5f)
  Actual: false
Expected: true
[  FAILED  ] test_large_partition_execute.F32Resnet50Stage2Block (44 ms)
[----------] 1 test from test_large_partition_execute (44 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (44 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] test_large_partition_execute.F32Resnet50Stage2Block

 1 FAILED TEST
```
After change:
```
export ONEDNN_GRAPH_CONSTANT_TENSOR_CACHE_CAPACITY="cpu:10240;gpu:20480"

./tests/gtests/graph/unit/test_graph_unit --gtest_filter=test_large_partition_execute.F32Resnet50Stage2Block
Note: Google Test filter = test_large_partition_execute.F32Resnet50Stage2Block:-*_GPU*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from test_large_partition_execute
[ RUN      ] test_large_partition_execute.F32Resnet50Stage2Block
[       OK ] test_large_partition_execute.F32Resnet50Stage2Block (45 ms)
[----------] 1 test from test_large_partition_execute (45 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (45 ms total)
[  PASSED  ] 1 test.
```