### PR TITLE
graph: backend: enable genindex ref implementation for gpu

### DIFF
--- a/src/gpu/intel/ocl/graph/gen_index.cl
+++ b/src/gpu/intel/ocl/graph/gen_index.cl
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+__kernel void gen_index(__global int *dst, int axis) {
+    long id = get_global_id(0);
+    long result, offset = 0;
+    long idx;
+
+    idx = id % D0;
+    id = id / D0;
+    offset += idx * S0;
+    if (axis == 0) result = idx;
+
+    idx = id % D1;
+    id = id / D1;
+    offset += idx * S1;
+    if (axis == 1) result = idx;
+
+    idx = id % D2;
+    id = id / D2;
+    offset += idx * S2;
+    if (axis == 2) result = idx;
+
+    idx = id % D3;
+    id = id / D3;
+    offset += idx * S3;
+    if (axis == 3) result = idx;
+
+    idx = id % D4;
+    id = id / D4;
+    offset += idx * S4;
+    if (axis == 4) result = idx;
+
+    idx = id % D5;
+    id = id / D5;
+    offset += idx * S5;
+    if (axis == 5) result = idx;
+
+    dst[offset] = result;
+}

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -25,6 +25,11 @@
 #include "graph/backend/dnnl/passes/utils.hpp"
 
 #include "graph/backend/dnnl/op_executable.hpp"
+
+#define VCHECK_GENINDEX(cond, status, msg, ...) \
+    VCONDCHECK(graph, create, check, genindex_t, (cond), status, msg, \
+            ##__VA_ARGS__);
+
 namespace dnnl {
 namespace impl {
 namespace graph {
@@ -40,6 +45,16 @@ status_t genindex_t::compile_impl(const dnnl_partition_impl_t *part,
     subgraph_ = std::make_shared<subgraph_t>(part->get_ops(), p_engine_,
             part->get_fpmath_mode(), part->get_use_blocked_layout(), true);
     BACKEND_DNNL_CHECK(set_given_inputs_outputs(subgraph_, inputs, outputs));
+
+#if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE
+    if (p_engine_.get_kind() == engine::kind::gpu) {
+        int ndims = inputs[0].ndims;
+        VCHECK_GENINDEX(ndims <= MAX_NDIMS, status::invalid_arguments,
+                "only tensors of 6 or fewer dimensions are supported for "
+                "genindex GPU, but got %dD",
+                ndims);
+    }
+#endif
 
     subgraph_visualizer_t vis(part->id(), [this](const value_t *val) {
         return this->memory_planner_.get_memory_info(val);
@@ -84,7 +99,7 @@ status_t genindex_t::compile_impl(const dnnl_partition_impl_t *part,
 
 void genindex_t::prepare_args_set(const execution_args_set_t *res,
         const std::vector<tensor_t> &inputs,
-        const std::vector<tensor_t> &outputs, const scratchpad_t &scratchpad) {
+        const std::vector<tensor_t> &outputs) {
     // update the data of partition in/outputs args
     for (const auto &mem_idx : res->get_mems_use_external_inputs()) {
         mem_idx.first.set_data_handle(inputs[mem_idx.second].get_data_handle());
@@ -92,13 +107,6 @@ void genindex_t::prepare_args_set(const execution_args_set_t *res,
     for (const auto &mem_idx : res->get_mems_use_external_outputs()) {
         mem_idx.first.set_data_handle(
                 outputs[mem_idx.second].get_data_handle());
-    }
-
-    grantor_t var_grantor = memory_planner_.internal_temporary_grantor(
-            scratchpad.get_buffer());
-
-    for (auto &mem_offkey : res->get_mems_use_internal_temporary()) {
-        mem_offkey.first.set_data_handle(var_grantor.get(mem_offkey.second));
     }
 }
 
@@ -111,14 +119,7 @@ status_t genindex_t::execute_impl(const stream_t *g_stream,
     thread_local_cache_t<execution_args_set_t> res_cache;
     execution_args_set_t *res = res_cache.get_or_add(
             reinterpret_cast<size_t>(this), resource_ctor_);
-
-    temporary_scratchpad_t scratchpad(
-            memory_planner_.total_internal_temporary_size(), p_engine_,
-            *g_alloc_);
-    assertm(scratchpad.size()
-                    >= memory_planner_.total_internal_temporary_size(),
-            "no enough scratchpad memory");
-    prepare_args_set(res, inputs, outputs, scratchpad);
+    prepare_args_set(res, inputs, outputs);
 
     constant_cache_t::cached_t c_buffer;
 
@@ -135,7 +136,26 @@ status_t genindex_t::sycl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &outputs,
         const std::vector<::sycl::event> &sycl_deps,
         ::sycl::event *sycl_event) {
-    if (p_engine_.get_kind() == engine::kind::gpu) return status::unimplemented;
+    if (p_engine_.get_kind() == engine::kind::gpu) {
+        auto deps = sycl_deps;
+        ::sycl::event returned_event;
+        dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+
+        thread_local_cache_t<execution_args_set_t> res_cache;
+        execution_args_set_t *res = res_cache.get_or_add(
+                reinterpret_cast<size_t>(this), resource_ctor_);
+        prepare_args_set(res, inputs, outputs);
+        for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
+            if (subgraph_->is_constant_[i]) continue;
+            returned_event = subgraph_->execs_[i]->execute_sycl(
+                    p_stream, res->get_exec_args()[i], deps);
+            deps = {returned_event};
+        }
+
+        if (sycl_event) *sycl_event = returned_event;
+
+        return status::success;
+    }
     return execute_impl(g_stream, inputs, outputs);
 }
 #endif
@@ -144,8 +164,27 @@ status_t genindex_t::ocl_execute_impl(const stream_t *g_stream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs,
         const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
-    // TODO: add support
-    return status::unimplemented;
+    auto deps = ocl_deps;
+    cl_event returned_event {};
+    dnnl::stream p_stream = make_dnnl_stream(p_engine_, *g_stream);
+
+    // each thread's own local resource
+    thread_local_cache_t<execution_args_set_t> res_cache;
+    execution_args_set_t *res = res_cache.get_or_add(
+            reinterpret_cast<size_t>(this), resource_ctor_);
+
+    prepare_args_set(res, inputs, outputs);
+
+    for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
+        if (subgraph_->is_constant_[i]) continue;
+        returned_event = subgraph_->execs_[i]->execute_ocl(
+                p_stream, res->get_exec_args()[i], deps);
+        deps = {returned_event};
+    }
+
+    if (ocl_event) *ocl_event = returned_event;
+
+    return status::success;
 }
 #endif
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/gen_index.hpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.hpp
@@ -57,8 +57,7 @@ public:
     }
     void prepare_args_set(const execution_args_set_t *res,
             const std::vector<tensor_t> &inputs,
-            const std::vector<tensor_t> &outputs,
-            const scratchpad_t &scratchpad);
+            const std::vector<tensor_t> &outputs);
     status_t compile_impl(const dnnl_partition_impl_t *part,
             const engine_t *g_engine,
             const std::vector<logical_tensor_t> &inputs,

--- a/src/graph/backend/dnnl/patterns/single_op_pattern.cpp
+++ b/src/graph/backend/dnnl/patterns/single_op_pattern.cpp
@@ -425,10 +425,8 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, reduce_pass)
             return std::make_shared<float_reduction>();
         });
 
-// GenIndex currently is CPU only
 DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, gen_index_pass)
         .set_priority(DEFAULT_P)
-        .set_engine_kind(engine_kind::cpu)
         .set_kind(partition_kind_t::misc_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",
                 [](const std::shared_ptr<pb_graph_t> &pgraph) -> void {

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -416,10 +416,7 @@ void skip_unimplemented_ops(const dnnl::graph::partition &partition,
 
     // A list of ops that don't have DNNL backend support so far.
     static const std::vector<std::string> unimplemented_ops {"Pow"};
-    // A list of ops that don't have DNNL backend support so far on GPU.
-    static const std::vector<std::string> unimplemented_ops_gpu {"GenIndex"};
-    const auto &eng = get_graph_engine();
-    bool is_gpu = eng.get_kind() == dnnl::engine::kind::gpu;
+
     // For an unsupported partition, retrieve all operation IDs, find a
     // correspondent operation kind in a deserialized_graph_t and match it against
     // a list of known unsupported ops.
@@ -437,21 +434,6 @@ void skip_unimplemented_ops(const dnnl::graph::partition &partition,
             res->state = SKIPPED;
             res->reason = skip_reason::case_not_supported;
             return;
-        }
-
-        if (is_gpu) {
-            const bool has_unimplemented_op_gpu = std::any_of(
-                    unimplemented_ops_gpu.begin(), unimplemented_ops_gpu.end(),
-                    [&dg_op_kind](const std::string &kind) {
-                        return dg_op_kind == kind;
-                    });
-            if (has_unimplemented_op_gpu) {
-                BENCHDNN_PRINT(2, "[INFO]: Unimplemented op on GPU: %s.\n",
-                        dg_op_kind.c_str());
-                res->state = SKIPPED;
-                res->reason = skip_reason::case_not_supported;
-                return;
-            }
         }
     }
 }


### PR DESCRIPTION
# Description
The GenIndex op is used to construct SDPA with an implicit causal mask. Since no primitive supports this op, we implement a reference kernel with OCL in Graph. 
