### PR TITLE
doc:specifying number of jobs for make j command

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -51,7 +51,7 @@ cmake .. <extra build options>
 
 - Build the library
 ~~~sh
-make -j
+make -j$(nproc)
 ~~~
 
 #### Intel oneAPI DPC++/C++ Compiler with SYCL runtime
@@ -86,7 +86,7 @@ it is installed in a custom location.
 
 - Build the library
 ~~~sh
-make -j
+make -j$(nproc)
 ~~~
 
 #### GCC targeting AArch64 on x64 host
@@ -106,7 +106,7 @@ cmake .. \
 
 - Build the library
 ~~~sh
-make -j
+make -j$(nproc)
 ~~~
 
 #### GCC with Arm Compute Library (ACL) on AArch64 host
@@ -123,7 +123,7 @@ cmake .. \
 
 - Build the library
 ~~~sh
-make -j
+make -j$(nproc)
 ~~~
 
 ### Windows


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?

@vpirogov 
As discussed previously, it seems the system will be unresponsive if the number of jobs is not specified for the make -j command present in the build from source guide. Creating a PR to address this. 

Please review when you have a moment.
