### PR TITLE
[TEST ONLY] benchdnn: enable parallel creation for Windows

### DIFF
--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -76,7 +76,7 @@ function(register_benchdnn_test engine driver test_file)
     endif()
 
     set(mode_modifier "")
-    if(${engine} MATCHES "gpu" AND NOT WIN32)
+    if(${engine} MATCHES "gpu")
         set(mode_modifier "--mode-modifier=P")
     endif()
 


### PR DESCRIPTION
This is to verify that parallel creation on Windows for benchdnn is still bugged.