### PR TITLE
benchdnn: inputs: graph: sdpa: add tests for d_qk != d_v

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -39,7 +39,7 @@ bool sdp_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
     batch_size = src1_user_dims[0];
     num_head_q = src1_user_dims[1];
     seq_len_q = src1_user_dims[2];
-    size_per_head = src1_user_dims[3];
+    head_size_qk = src1_user_dims[3];
 
     dims wei1_user_dims = ltw(inputs[graph_inport[1]]).vdims();
     num_head_kv = wei1_user_dims[1];
@@ -52,6 +52,7 @@ bool sdp_decomp_config_t::initial_check(const std::shared_ptr<subgraph_t> &sg,
             "Batch size mismatch, batch_size: %lld, wei1: %lld, wei2: %lld",
             batch_size, wei1_user_dims[0], wei2_user_dims[0]);
 
+    head_size_v = wei2_user_dims[3];
     // Check scale size
     if (graph_inport[2] != -1) {
         auto scale_sz = ltw(inputs[graph_inport[2]]).nelems();
@@ -137,7 +138,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
     sub_reorder0_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     // per-head: reorder src1 to dense, for first matmul
-    dims sub_src1_dims = {1, 1, seq_len_q, size_per_head};
+    dims sub_src1_dims = {1, 1, seq_len_q, head_size_qk};
     src1_strides = ltw(inputs[graph_inport[0]]).vstrides();
     sub_src1_md = memory::desc(sub_src1_dims, dt_src_user,
             {1, 1, src1_strides[2], src1_strides[3]});
@@ -152,7 +153,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
     // create reorder1 primitive attr
     dnnl::primitive_attr sub_reorder1_attr
             = make_primitive_attr(sdp_op[0], mgr);
-    dims sub_wei1_dims = {1, 1, size_per_head, seq_len_kv};
+    dims sub_wei1_dims = {1, 1, head_size_qk, seq_len_kv};
     auto wei_md = make_dnnl_memory_desc(
             sdp_op[1]->get_input_value(1)->get_logical_tensor());
     wei1_strides = wei_md.get_strides();
@@ -167,8 +168,8 @@ impl::status_t sdp_decomp_config_t::construct_params(
     // first matmul
     // create first matmul primitive attr
     dnnl::primitive_attr sub_matmul1_attr = make_primitive_attr(sdp_op[1], mgr);
-    dims sub_mm1_src_dims = {1, 1, seq_len_q, size_per_head};
-    dims sub_mm1_wei_dims = {1, 1, size_per_head, seq_len_kv};
+    dims sub_mm1_src_dims = {1, 1, seq_len_q, head_size_qk};
+    dims sub_mm1_wei_dims = {1, 1, head_size_qk, seq_len_kv};
     dims sub_mm1_dst_dims = {1, 1, seq_len_q, seq_len_kv};
 
     sub_mm1_src_md = memory::desc(sub_mm1_src_dims, dt_src_user, tag::abcd);
@@ -209,7 +210,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
     // create reorder2 primitive attr
     dnnl::primitive_attr sub_reorder2_attr
             = make_primitive_attr(sdp_op[3], mgr);
-    dims sub_wei2_dims = {1, 1, seq_len_kv, size_per_head};
+    dims sub_wei2_dims = {1, 1, seq_len_kv, head_size_v};
     wei2_strides = ltw(inputs[graph_inport[4]]).vstrides();
     sub_wei2_user_md = memory::desc(sub_wei2_dims, dt_wei_user,
             {1, 1, wei2_strides[2], wei2_strides[3]});
@@ -223,8 +224,8 @@ impl::status_t sdp_decomp_config_t::construct_params(
     // create second matmul primitive attr
     dnnl::primitive_attr sub_matmul2_attr = make_primitive_attr(sdp_op[4], mgr);
     dims sub_mm2_src_dims = {1, 1, seq_len_q, seq_len_kv};
-    dims sub_mm2_wei_dims = {1, 1, seq_len_kv, size_per_head};
-    dims sub_mm2_dst_dims = {1, 1, seq_len_q, size_per_head};
+    dims sub_mm2_wei_dims = {1, 1, seq_len_kv, head_size_v};
+    dims sub_mm2_dst_dims = {1, 1, seq_len_q, head_size_v};
     auto sub_mm2_src_md
             = memory::desc(sub_mm2_src_dims, dt_src_user, tag::abcd);
     sub_mm2_wei_md = memory::desc(sub_mm2_wei_dims, dt_wei, tag::abcd);
@@ -236,7 +237,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
     // per-head: reorder dst2 from dense to strided
     primitive_attr sub_reorder3_attr;
     sub_reorder3_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    dims sub_dst_dims = {1, 1, seq_len_q, size_per_head};
+    dims sub_dst_dims = {1, 1, seq_len_q, head_size_v};
     auto out_lt = sdp_op[4]->get_output_value(0)->get_logical_tensor();
     dst_strides = ltw(out_lt).vstrides();
     sub_dst_md = memory::desc(sub_dst_dims, dt_src_user, tag::abcd);

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,8 +74,8 @@ public:
     sdp_decomp_config_t() = default;
 
     // SDP input dimension
-    dim_t batch_size, num_head_q, num_head_kv, seq_len_q, seq_len_kv,
-            size_per_head;
+    dim_t batch_size, num_head_q, num_head_kv, seq_len_q, seq_len_kv;
+    dim_t head_size_qk, head_size_v;
 
     // SDP input and output strides
     dims src1_strides, wei1_strides, wei2_strides, dst_strides,

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -109,3 +109,7 @@
 --reset --dt=0:s8+2:s8+6:s8+8:s8 --case=complex_fusion/mha/sdpa-compressed-kv-int4-gs32.json
 # Change group size to 128. It also affects the shapes of the scales and zps.
 --reset --dt=0:s8+2:s8+6:s8+8:s8 --op-attrs=0:group_shape:1x1x128x1+99:group_shape:1x1x1x128 --in-shapes=1:1x32x1x32+2:1x32x1x32+7:1x32x32x1+8:1x32x32x1 --case=complex_fusion/mha/sdpa-compressed-kv-int4-gs32.json
+
+# d_qk != d_v
+--reset --dt=f32,bf16,f16 --in-shapes=8:1x16x384x32,8:1x16x384x63,8:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
+--reset --dt=f32,bf16,f16 --in-shapes=11:1x16x384x32,11:1x16x384x63,11:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -111,5 +111,5 @@
 --reset --dt=0:s8+2:s8+6:s8+8:s8 --op-attrs=0:group_shape:1x1x128x1+99:group_shape:1x1x1x128 --in-shapes=1:1x32x1x32+2:1x32x1x32+7:1x32x32x1+8:1x32x32x1 --case=complex_fusion/mha/sdpa-compressed-kv-int4-gs32.json
 
 # d_qk != d_v
---reset --dt=f32,bf16,f16 --in-shapes=8:1x16x384x32,8:1x16x384x63,8:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
---reset --dt=f32,bf16,f16 --in-shapes=11:1x16x384x32,11:1x16x384x63,11:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
+--reset --dt=f32,bf16,f16 --in-shapes=8:1x16x384x32,8:1x16x384x64,8:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
+--reset --dt=f32,bf16,f16 --in-shapes=11:1x16x384x32,11:1x16x384x64,11:1x16x384x128 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json


### PR DESCRIPTION
MFDNN-13232

Add test cases where the head size of QK is different from the head size of V.
The decomposition kernel on CPU is fixed to support the cases.