### PR TITLE
{include, benchdnn}: graph: fix clang-tidy warnings in headers

### DIFF
--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -365,7 +365,7 @@ public:
             layout_type ltype, property_type ptype = property_type::undef) {
         dnnl_graph_logical_tensor_t val;
         // if dimension size equals to 0, it's a scalar
-        if (adims.size() == 0)
+        if (adims.empty())
             error::wrap_c_api(dnnl_graph_logical_tensor_init(&val, tid,
                                       convert_to_c(dtype), 0,
                                       convert_to_c(ltype), convert_to_c(ptype)),
@@ -420,7 +420,7 @@ public:
             property_type ptype = property_type::undef) {
         dnnl_graph_logical_tensor_t val;
 
-        if (adims.size() == 0) {
+        if (adims.empty()) {
             error::wrap_c_api(dnnl_graph_logical_tensor_init(&val, tid,
                                       convert_to_c(dtype), 0,
                                       convert_to_c(layout_type::opaque),

--- a/tests/benchdnn/graph/allocator.hpp
+++ b/tests/benchdnn/graph/allocator.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public:
 
 private:
     graph_mem_manager_t() : need_mem_check_(false) {}
-    ~graph_mem_manager_t() {};
+    ~graph_mem_manager_t() = default;
 
 #ifdef DNNL_WITH_SYCL
     void *default_sycl_malloc(

--- a/tests/benchdnn/graph/bench_graph.cpp
+++ b/tests/benchdnn/graph/bench_graph.cpp
@@ -33,9 +33,9 @@ void check_correctness(const settings_t &s) {
     for_(const auto &i_dt : s.dt)
     for_(const auto &i_dt_map : s.dt_map)
     for (const auto &i_mb : s.mb) {
-        deserialized_graph dg;
+        deserialized_graph_t dg;
         dg.load(locate_file(s.json_file));
-        flex_rewrite fw(
+        flex_rewrite_t fw(
                 i_in_shapes, i_op_attrs, i_fpmath_mode, i_mb, i_dt, i_dt_map);
         fw.rewrite(dg);
         BENCHDNN_PRINT(7, "[INFO] Graph dump:\n%s\n", dg.get_string().c_str());

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -30,7 +30,7 @@ namespace graph {
 using namespace dnnl::graph;
 using namespace dnnl::impl::graph;
 
-void deserialized_attr::load(utils::json::json_reader_t *reader) {
+void deserialized_attr_t::load(utils::json::json_reader_t *reader) {
     reader->begin_object();
     std::string key_entry;
     std::string value_entry;
@@ -124,7 +124,7 @@ void deserialized_lt::load(utils::json::json_reader_t *reader) {
     helper.read_fields(reader);
 }
 
-void deserialized_op::load(utils::json::json_reader_t *reader) {
+void deserialized_op_t::load(utils::json::json_reader_t *reader) {
     utils::json::read_helper_t helper;
 
     helper.declare_field("id", &id_);
@@ -136,7 +136,7 @@ void deserialized_op::load(utils::json::json_reader_t *reader) {
     helper.read_fields(reader);
 }
 
-op deserialized_op::create() const {
+op deserialized_op_t::create() const {
     op aop(id_, opstr2kind(kind_), name_);
     for (auto it = attrs_.begin(); it != attrs_.end(); ++it) {
         const auto &attr = attrstr2kind(it->first);
@@ -173,49 +173,49 @@ op deserialized_op::create() const {
     return aop;
 }
 
-bool deserialized_op::get_attr_string(
+bool deserialized_op_t::get_attr_string(
         std::string &attr, const std::string &attr_name) const {
     auto it = attrs_.find(attr_name);
     if (it == attrs_.end()) return false;
     return attr = it->second.str_value_, true;
 }
 
-bool deserialized_op::get_attr_bool(
+bool deserialized_op_t::get_attr_bool(
         bool &attr, const std::string &attr_name) const {
     auto it = attrs_.find(attr_name);
     if (it == attrs_.end()) return false;
     return attr = it->second.bool_value_, true;
 }
 
-bool deserialized_op::get_attr_f32(
+bool deserialized_op_t::get_attr_f32(
         float &attr, const std::string &attr_name) const {
     auto it = attrs_.find(attr_name);
     if (it == attrs_.end()) return false;
     return attr = it->second.f32_value_, true;
 }
 
-bool deserialized_op::get_attr_s64(
+bool deserialized_op_t::get_attr_s64(
         int64_t &attr, const std::string &attr_name) const {
     auto it = attrs_.find(attr_name);
     if (it == attrs_.end()) return false;
     return attr = it->second.s64_value_, true;
 }
 
-bool deserialized_op::get_attr_f32_vector(
+bool deserialized_op_t::get_attr_f32_vector(
         std::vector<float> &attr, const std::string &attr_name) const {
     auto it = attrs_.find(attr_name);
     if (it == attrs_.end()) return false;
     return attr = it->second.f32_vector_, true;
 }
 
-bool deserialized_op::get_attr_s64_vector(
+bool deserialized_op_t::get_attr_s64_vector(
         std::vector<int64_t> &attr, const std::string &attr_name) const {
     auto it = attrs_.find(attr_name);
     if (it == attrs_.end()) return false;
     return attr = it->second.s64_vector_, true;
 }
 
-bool deserialized_op::has_NXC_format() const {
+bool deserialized_op_t::has_NXC_format() const {
     std::string data_format;
     if (get_attr_string(data_format, "data_format")) {
         return data_format == "NXC";
@@ -234,14 +234,14 @@ bool deserialized_op::has_NXC_format() const {
     }
 }
 
-logical_tensor::dims deserialized_op::get_NCX_shape(
+logical_tensor::dims deserialized_op_t::get_NCX_shape(
         size_t idx, bool input) const {
     auto src_dims = input ? in_lts_.at(idx).shape_ : out_lts_.at(idx).shape_;
     if (has_NXC_format()) { change_format_to_ncx(src_dims); }
     return src_dims;
 }
 
-void deserialized_graph::load(const std::string &pass_config_json) {
+void deserialized_graph_t::load(const std::string &pass_config_json) {
     std::ifstream fs(pass_config_json.c_str());
     utils::json::json_reader_t read(&fs);
     utils::json::read_helper_t helper;
@@ -284,7 +284,7 @@ void deserialized_graph::load(const std::string &pass_config_json) {
     }
 
     std::map<size_t, size_t> deg; // record indegree for each op
-    std::map<size_t, deserialized_op> ops_map; // op_id -> op
+    std::map<size_t, deserialized_op_t> ops_map; // op_id -> op
     for (const auto &aop : ops_) {
         ops_map[aop.id_] = aop;
         deg[aop.id_] = 0;
@@ -382,7 +382,7 @@ std::string deserialized_lt::get_string() const {
 //     In: { lt0, lt1, ... }
 //     Out: { lt0, lt1, ... }
 //     Attrs: { Scales: { val0, ... } }  // <-- if any available.
-std::ostream &operator<<(std::ostream &s, const deserialized_op &dop) {
+std::ostream &operator<<(std::ostream &s, const deserialized_op_t &dop) {
     s << "{(" << dop.id_ << ") " << dop.kind_ << "}\n";
 
     s << "    In: { ";
@@ -441,26 +441,26 @@ std::ostream &operator<<(std::ostream &s, const deserialized_op &dop) {
     return s;
 }
 
-std::string deserialized_op::get_string() const {
+std::string deserialized_op_t::get_string() const {
     std::stringstream ss;
     ss << *this;
     return ss.str();
 }
 
-std::ostream &operator<<(std::ostream &s, const deserialized_graph &dg) {
+std::ostream &operator<<(std::ostream &s, const deserialized_graph_t &dg) {
     for (const auto &op : dg.ops_) {
         s << op;
     }
     return s;
 }
 
-std::string deserialized_graph::get_string() const {
+std::string deserialized_graph_t::get_string() const {
     std::stringstream ss;
     ss << *this;
     return ss.str();
 }
 
-dnnl::graph::graph deserialized_graph::to_graph(
+dnnl::graph::graph deserialized_graph_t::to_graph(
         const graph_fpmath_mode_t &fpmath_mode) const {
     const auto &engine = get_graph_engine();
     dnnl::graph::graph g(engine.get_kind());
@@ -480,38 +480,38 @@ dnnl::graph::graph deserialized_graph::to_graph(
     return g;
 }
 
-const deserialized_op &deserialized_graph::get_op(size_t id) const {
+const deserialized_op_t &deserialized_graph_t::get_op(size_t id) const {
     for (const auto &op : ops_) {
         if (op.id_ == id) return op;
     }
     assert(!"Given id was not found in the deserialized graph.");
-    static deserialized_op dummy;
+    static deserialized_op_t dummy;
     return dummy;
 }
 
-const deserialized_op &deserialized_graph::get_op_by_out_lt(
+const deserialized_op_t &deserialized_graph_t::get_op_by_out_lt(
         size_t out_lt_id) const {
     for_(const auto &op : ops_)
     for (const auto &out_lt : op.out_lts_) {
         if (out_lt.id_ == out_lt_id) return op;
     }
 
-    static deserialized_op dummy;
+    static deserialized_op_t dummy;
     return dummy;
 }
 
-const deserialized_op &deserialized_graph::get_op_by_in_lt(
+const deserialized_op_t &deserialized_graph_t::get_op_by_in_lt(
         size_t in_lt_id) const {
     for_(const auto &op : ops_)
     for (const auto &in_lt : op.in_lts_) {
         if (in_lt.id_ == in_lt_id) return op;
     }
 
-    static deserialized_op dummy;
+    static deserialized_op_t dummy;
     return dummy;
 }
 
-bool deserialized_graph::check_tensor_with_mb(size_t tensor_id,
+bool deserialized_graph_t::check_tensor_with_mb(size_t tensor_id,
         std::unordered_map<size_t, bool> &mb_rewrite_ret) const {
     if (in_lt_2_ops_.find(tensor_id) == in_lt_2_ops_.end()) return true;
     if (mb_rewrite_ret.find(tensor_id) != mb_rewrite_ret.end())

--- a/tests/benchdnn/graph/deserialize.hpp
+++ b/tests/benchdnn/graph/deserialize.hpp
@@ -31,7 +31,7 @@ namespace graph {
 using namespace dnnl::graph;
 using namespace dnnl::impl::graph;
 
-struct deserialized_attr {
+struct deserialized_attr_t {
     std::string type_;
     std::string str_value_;
     bool bool_value_;
@@ -63,14 +63,14 @@ struct deserialized_lt {
 };
 std::ostream &operator<<(std::ostream &s, const deserialized_lt &dlt);
 
-struct deserialized_op {
+struct deserialized_op_t {
     size_t id_;
     std::string name_;
     std::string kind_;
     std::string fpmath_mode_;
     std::string fpmath_mode_apply_to_int_;
 
-    std::unordered_map<std::string, deserialized_attr> attrs_;
+    std::unordered_map<std::string, deserialized_attr_t> attrs_;
     std::vector<deserialized_lt> in_lts_;
     std::vector<deserialized_lt> out_lts_;
 
@@ -98,21 +98,21 @@ struct deserialized_op {
 
     logical_tensor::dims get_NCX_shape(size_t idx, bool input) const;
 
-    // Returns `true` if `deserialized_op` wasn't created.
+    // Returns `true` if `deserialized_op_t` wasn't created.
     bool empty() const { return kind_.empty(); }
 };
-std::ostream &operator<<(std::ostream &s, const deserialized_op &dop);
+std::ostream &operator<<(std::ostream &s, const deserialized_op_t &dop);
 
-using op_ref_t = std::reference_wrapper<const deserialized_op>;
+using op_ref_t = std::reference_wrapper<const deserialized_op_t>;
 using op_ref_list_t = std::list<op_ref_t>;
 
-struct deserialized_graph {
+struct deserialized_graph_t {
     void load(const std::string &pass_config_json);
 
     dnnl::graph::graph to_graph(const graph_fpmath_mode_t &fpmath_mode) const;
     const std::vector<size_t> &get_input_ports() const { return input_ports_; };
 
-    std::vector<deserialized_op> ops_;
+    std::vector<deserialized_op_t> ops_;
     // record all tensors id and its dims
     std::map<size_t, logical_tensor::dims> graph_tensors_;
     // reorder logical tensor id to memory tag.
@@ -122,11 +122,11 @@ struct deserialized_graph {
     std::vector<size_t> graph_inputs_with_mb_;
 
     // Returns an op based on its ID.
-    const deserialized_op &get_op(size_t id) const;
+    const deserialized_op_t &get_op(size_t id) const;
     // Returns an op based on its output logical tensor ID.
-    const deserialized_op &get_op_by_out_lt(size_t out_lt_id) const;
+    const deserialized_op_t &get_op_by_out_lt(size_t out_lt_id) const;
     // Returns an op based on its input logical tensor ID.
-    const deserialized_op &get_op_by_in_lt(size_t in_lt_id) const;
+    const deserialized_op_t &get_op_by_in_lt(size_t in_lt_id) const;
 
     // Outputs the information about graph from operator<< into a string.
     std::string get_string() const;
@@ -149,8 +149,8 @@ private:
     std::vector<size_t> input_ports_;
     std::vector<size_t> output_ports_;
 
-    std::map<size_t, std::vector<deserialized_op>> in_lt_2_ops_;
-    std::map<size_t, deserialized_op> out_lt_2_op_;
+    std::map<size_t, std::vector<deserialized_op_t>> in_lt_2_ops_;
+    std::map<size_t, deserialized_op_t> out_lt_2_op_;
     std::vector<std::string> binary_ops_ {"Add", "BiasAdd", "Divide", "Maximum",
             "Minimum", "Multiply", "Substract"};
     // need change dst_shape or weight_shape attribute value
@@ -172,7 +172,7 @@ private:
     bool check_tensor_with_mb(size_t tensor_id,
             std::unordered_map<size_t, bool> &mb_rewrite_ret) const;
 };
-std::ostream &operator<<(std::ostream &s, const deserialized_graph &dg);
+std::ostream &operator<<(std::ostream &s, const deserialized_graph_t &dg);
 
 } // namespace graph
 

--- a/tests/benchdnn/graph/deserialize.hpp
+++ b/tests/benchdnn/graph/deserialize.hpp
@@ -132,7 +132,7 @@ struct deserialized_graph_t {
     std::string get_string() const;
 
     // Return the fpmath mode attribute
-    const std::pair<std::string, std::string> get_fpmath_mode() const {
+    std::pair<std::string, std::string> get_fpmath_mode() const {
         return std::make_pair(fpmath_mode_, fpmath_mode_apply_to_int_);
     }
 

--- a/tests/benchdnn/graph/flex_rewrite.cpp
+++ b/tests/benchdnn/graph/flex_rewrite.cpp
@@ -26,7 +26,8 @@
 
 namespace graph {
 
-void flex_rewrite::rewrite_linked_shape_and_attr(deserialized_graph &dgraph) {
+void flex_rewrite_t::rewrite_linked_shape_and_attr(
+        deserialized_graph_t &dgraph) {
     for (auto &aop : dgraph.ops_) {
         if (aop.kind_ == "DynamicDequantize") {
             auto &attr = aop.attrs_;
@@ -189,7 +190,7 @@ void flex_rewrite::rewrite_linked_shape_and_attr(deserialized_graph &dgraph) {
     }
 }
 
-void flex_rewrite::rewrite(deserialized_graph &dgraph) {
+void flex_rewrite_t::rewrite(deserialized_graph_t &dgraph) {
     bool change_stride = false;
     inports_shape_rewrite(dgraph, change_stride);
     if (!(op_attrs_.size() == 1 && op_attrs_.count(0)
@@ -204,7 +205,7 @@ void flex_rewrite::rewrite(deserialized_graph &dgraph) {
     dt_map_rewrite(dgraph);
 }
 
-void flex_rewrite::split_ncx(const std::string &data_format, dims_t &in,
+void flex_rewrite_t::split_ncx(const std::string &data_format, dims_t &in,
         int64_t &n, int64_t &c, dims_t &x) const {
     x.clear();
     n = in[0];
@@ -221,7 +222,7 @@ void flex_rewrite::split_ncx(const std::string &data_format, dims_t &in,
     }
 }
 
-void flex_rewrite::merge_ncx(const std::string &data_format, dims_t &out,
+void flex_rewrite_t::merge_ncx(const std::string &data_format, dims_t &out,
         int64_t n, int64_t c, const dims_t &x) const {
     out.clear();
     out.push_back(n);
@@ -238,7 +239,7 @@ void flex_rewrite::merge_ncx(const std::string &data_format, dims_t &out,
     }
 }
 
-void flex_rewrite::split_oix(const std::string &data_format, dims_t &in,
+void flex_rewrite_t::split_oix(const std::string &data_format, dims_t &in,
         dims_t &oi, dims_t &x) const {
     x.clear();
     if (data_format == "OIX" || data_format == "IOX") {
@@ -277,7 +278,7 @@ std::string stdvec2string(const std::vector<T> &v) {
     return s;
 }
 
-void flex_rewrite::broadcast(const dims_t &x, const dims_t &y, dims_t &z,
+void flex_rewrite_t::broadcast(const dims_t &x, const dims_t &y, dims_t &z,
         const std::string &x_str, const std::string &y_str) const {
     const size_t x_rank = x.size();
     const size_t y_rank = y.size();
@@ -308,8 +309,8 @@ void flex_rewrite::broadcast(const dims_t &x, const dims_t &y, dims_t &z,
     }
 }
 
-void flex_rewrite::cal_pads(dims_t &pads_begin, dims_t &pads_end,
-        const deserialized_op &aop, const dims_t &spatial_dims,
+void flex_rewrite_t::cal_pads(dims_t &pads_begin, dims_t &pads_end,
+        const deserialized_op_t &aop, const dims_t &spatial_dims,
         const dims_t &strides, const dims_t &kernel, bool deconv) const {
     pads_begin.clear();
     pads_end.clear();
@@ -347,8 +348,8 @@ void flex_rewrite::cal_pads(dims_t &pads_begin, dims_t &pads_end,
     }
 }
 
-void flex_rewrite::infer_output_shape(
-        deserialized_graph &dgraph, bool change_stride) {
+void flex_rewrite_t::infer_output_shape(
+        deserialized_graph_t &dgraph, bool change_stride) {
     auto &gi = dgraph.graph_tensors_;
     for (auto &aop : dgraph.ops_) {
         auto kind = opstr2kind(aop.kind_);
@@ -916,7 +917,7 @@ void flex_rewrite::infer_output_shape(
 /// @param msg Error message info when function returns `false` value.
 /// @return `true` if an inport info is valid and `false` otherwise. A message `msg`
 /// describes an error occurred.
-bool flex_rewrite::get_inport_shape_stride(const std::string &in_shape,
+bool flex_rewrite_t::get_inport_shape_stride(const std::string &in_shape,
         std::string &shape, std::string &stride, std::string &msg) {
     assert(shape.empty() && stride.empty());
     if (in_shape == "0" || in_shape == "-") {
@@ -973,12 +974,12 @@ bool flex_rewrite::get_inport_shape_stride(const std::string &in_shape,
     }
 }
 
-void flex_rewrite::inports_shape_rewrite(
-        deserialized_graph &dgraph, bool &change_stride) {
+void flex_rewrite_t::inports_shape_rewrite(
+        deserialized_graph_t &dgraph, bool &change_stride) {
     // reminder mb rewrite status
     if (mb_ != 0 && dgraph.graph_inputs_with_mb_.empty()) {
         BENCHDNN_PRINT(0,
-                "Error: flex_rewrite: can't rewrite mb value with \'%ld\'.\n",
+                "Error: flex_rewrite_t: can't rewrite mb value with \'%ld\'.\n",
                 (long)mb_);
     }
 
@@ -1124,7 +1125,7 @@ void flex_rewrite::inports_shape_rewrite(
     }
 }
 
-void flex_rewrite::op_attrs_rewrite(deserialized_graph &dgraph) {
+void flex_rewrite_t::op_attrs_rewrite(deserialized_graph_t &dgraph) {
     std::vector<size_t> op_ids_;
     op_ids_.reserve(dgraph.ops_.size());
     for (const auto &aop : dgraph.ops_) {
@@ -1170,7 +1171,7 @@ void flex_rewrite::op_attrs_rewrite(deserialized_graph &dgraph) {
     }
 }
 
-inline bool is_int8_quantization(const deserialized_op &aop) {
+inline bool is_int8_quantization(const deserialized_op_t &aop) {
     if (aop.kind_ == "Dequantize") {
         const auto dt = aop.in_lts_.front().get_data_type();
         return (dt == logical_tensor::data_type::u8
@@ -1185,7 +1186,7 @@ inline bool is_int8_quantization(const deserialized_op &aop) {
     }
 }
 
-void flex_rewrite::quantized_graph_rewrite(deserialized_graph &dgraph) {
+void flex_rewrite_t::quantized_graph_rewrite(deserialized_graph_t &dgraph) {
     for (auto &aop : dgraph.ops_) {
         if (aop.kind_ != "Dequantize" && aop.kind_ != "Quantize") continue;
 
@@ -1227,7 +1228,7 @@ void flex_rewrite::quantized_graph_rewrite(deserialized_graph &dgraph) {
 }
 
 // Select: only rewrite src_1/src_2/dst as `cond` is always `bool`.
-void dt_rewrite_select(deserialized_op &select, const std::string &dt) {
+void dt_rewrite_select(deserialized_op_t &select, const std::string &dt) {
     select.in_lts_[1].data_type_ = dt;
     select.in_lts_[2].data_type_ = dt;
     select.out_lts_[0].data_type_ = dt;
@@ -1237,7 +1238,7 @@ void dt_rewrite_select(deserialized_op &select, const std::string &dt) {
 // normalization still requires f32 for gamma/beta/etc. This is good for most of
 // the cases. But there is a potential issue if gamma/beta/etc is connected to
 // another op which will rewrite the data type at other places.
-void dt_rewrite_norm(deserialized_op &norm, const std::string &dt) {
+void dt_rewrite_norm(deserialized_op_t &norm, const std::string &dt) {
     if (norm.kind_ == "BatchNormTrainingBackward"
             || norm.kind_ == "LayerNormBackward") {
         // rewrite for src/diff_dst/diff_src.
@@ -1251,7 +1252,7 @@ void dt_rewrite_norm(deserialized_op &norm, const std::string &dt) {
     }
 }
 
-void flex_rewrite::dt_rewrite(deserialized_graph &dgraph) {
+void flex_rewrite_t::dt_rewrite(deserialized_graph_t &dgraph) {
     if (dt_ == dnnl_data_type_undef) return;
 
     // We can only do data type rewriting for pure floating-point graph.
@@ -1328,7 +1329,7 @@ void flex_rewrite::dt_rewrite(deserialized_graph &dgraph) {
     }
 }
 
-void flex_rewrite::dt_map_rewrite(deserialized_graph &dgraph) {
+void flex_rewrite_t::dt_map_rewrite(deserialized_graph_t &dgraph) {
     // check the IDs and data types in dt_map.
     for (const auto &v : dt_map_) {
         if (v.second == dnnl_data_type_undef) return;
@@ -1367,7 +1368,7 @@ void flex_rewrite::dt_map_rewrite(deserialized_graph &dgraph) {
     }
 }
 
-void flex_rewrite::graph_attrs_rewrite(deserialized_graph &dgraph) {
+void flex_rewrite_t::graph_attrs_rewrite(deserialized_graph_t &dgraph) {
 
     // if the fpmath mode is specified by users through cml, replace the fpmath
     // mode from JSON file with the value from cml.
@@ -1386,8 +1387,8 @@ void flex_rewrite::graph_attrs_rewrite(deserialized_graph &dgraph) {
 /// @param dgraph A deserialized graph
 /// @param change_stride A boolean value indicating whether the graph input strides
 /// have been changed.
-void flex_rewrite::update_output_info(
-        deserialized_op &aop, deserialized_graph &dgraph, bool change_stride) {
+void flex_rewrite_t::update_output_info(deserialized_op_t &aop,
+        deserialized_graph_t &dgraph, bool change_stride) {
     auto kind = opstr2kind(aop.kind_);
     auto &gi = dgraph.graph_tensors_;
     // if a input stride is not changed, the output stride should not be changed as well

--- a/tests/benchdnn/graph/flex_rewrite.hpp
+++ b/tests/benchdnn/graph/flex_rewrite.hpp
@@ -25,8 +25,8 @@
 
 namespace graph {
 
-struct flex_rewrite {
-    flex_rewrite(const std::map<size_t, std::string> &in_shapes,
+struct flex_rewrite_t {
+    flex_rewrite_t(const std::map<size_t, std::string> &in_shapes,
             const std::map<size_t, std::string> &op_attrs,
             const graph_fpmath_mode_t &fpmath_mode, const int64_t mb,
             const dnnl_data_type_t dt,
@@ -38,7 +38,7 @@ struct flex_rewrite {
         , dt_(dt)
         , dt_map_(dt_map) {}
 
-    void rewrite(deserialized_graph &dgraph);
+    void rewrite(deserialized_graph_t &dgraph);
 
 private:
     // input shape info from CML
@@ -61,23 +61,24 @@ private:
             const std::string &x_str = "", const std::string &y_str = "") const;
     // Returns `pad_begin` and `pad_end` for each dimension.
     void cal_pads(dims_t &pads_begin, dims_t &pads_end,
-            const deserialized_op &aop, const dims_t &spatial_dims,
+            const deserialized_op_t &aop, const dims_t &spatial_dims,
             const dims_t &strides, const dims_t &kernel, bool deconv) const;
-    void infer_output_shape(deserialized_graph &dgraph, bool change_stride);
-    void inports_shape_rewrite(deserialized_graph &dgraph, bool &change_stride);
+    void infer_output_shape(deserialized_graph_t &dgraph, bool change_stride);
+    void inports_shape_rewrite(
+            deserialized_graph_t &dgraph, bool &change_stride);
     bool get_inport_shape_stride(const std::string &in_shape,
             std::string &shape, std::string &stride, std::string &msg);
-    void op_attrs_rewrite(deserialized_graph &dgraph);
-    void quantized_graph_rewrite(deserialized_graph &dgraph);
-    void update_output_info(deserialized_op &aop, deserialized_graph &dgraph,
-            bool change_stride);
-    void graph_attrs_rewrite(deserialized_graph &dgraph);
-    void dt_rewrite(deserialized_graph &dgraph);
-    void dt_map_rewrite(deserialized_graph &dgraph);
+    void op_attrs_rewrite(deserialized_graph_t &dgraph);
+    void quantized_graph_rewrite(deserialized_graph_t &dgraph);
+    void update_output_info(deserialized_op_t &aop,
+            deserialized_graph_t &dgraph, bool change_stride);
+    void graph_attrs_rewrite(deserialized_graph_t &dgraph);
+    void dt_rewrite(deserialized_graph_t &dgraph);
+    void dt_map_rewrite(deserialized_graph_t &dgraph);
     // Rewrite some linked attribute and shapes, such as group-shape and
     // scale/zp shape of dynamic dequantization for per-group quantization, to
     // simplify the cml input of rewriting.
-    void rewrite_linked_shape_and_attr(deserialized_graph &dgraph);
+    void rewrite_linked_shape_and_attr(deserialized_graph_t &dgraph);
 };
 
 } // namespace graph

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -34,7 +34,7 @@ namespace {
 /// @param partitions a list of partitions
 /// @param id_to_set_any_layout a set of ids of logical tensors with any layout
 ///     type
-void set_any_layout(const graph::deserialized_graph &dg,
+void set_any_layout(const graph::deserialized_graph_t &dg,
         const std::vector<dnnl::graph::partition> &partitions,
         std::unordered_set<size_t> &id_to_set_any_layout) {
     // mapping from output tensor id to the all supported flags of
@@ -176,7 +176,7 @@ void record_queried_logical_tensors(
 /// @param alt a deserialized logical tensor to be updated
 /// @param is_input a boolean flag to indicate to search input or output lts
 int find_logical_tensor(size_t lt_id, const graph::op_ref_list_t &ops,
-        graph::deserialized_op &aop, graph::deserialized_lt &alt,
+        graph::deserialized_op_t &aop, graph::deserialized_lt &alt,
         const bool is_input) {
 
     for (const auto &op : ops) {
@@ -245,7 +245,7 @@ int make_input_tensors(std::vector<dnnl::graph::tensor> &input_ts,
         const auto &in = ins[idx];
         const auto &lt_id = in.get_id();
         graph::deserialized_lt lt;
-        graph::deserialized_op op;
+        graph::deserialized_op_t op;
         if (find_logical_tensor(lt_id, ops, op, lt, true) != OK) {
             BENCHDNN_PRINT(0,
                     "FAIL: Cannot find logical tensor with id %zu! \n", lt_id);
@@ -284,7 +284,7 @@ int make_output_tensors(std::vector<dnnl::graph::tensor> &output_ts,
         // find the op id of the output logical tensor
         const auto &out = outs[idx];
         const auto &lt_id = out.get_id();
-        graph::deserialized_op op;
+        graph::deserialized_op_t op;
         graph::deserialized_lt lt;
         if (find_logical_tensor(lt_id, ops, op, lt, false) != OK) {
             BENCHDNN_PRINT(0,
@@ -404,7 +404,7 @@ std::string case_to_str(const std::string &json_file,
 }
 
 void skip_unimplemented_ops(const dnnl::graph::partition &partition,
-        const deserialized_graph &dg, res_t *res) {
+        const deserialized_graph_t &dg, res_t *res) {
     // Unconditionally skip all unimplemented cases for Graph Compiler. They got
     // triggered when `_DNNL_DISABLE_DNNL_BACKEND=1` is utilized.
     // TODO: extend with `getenv` call if limits too much.
@@ -421,7 +421,7 @@ void skip_unimplemented_ops(const dnnl::graph::partition &partition,
     const auto &eng = get_graph_engine();
     bool is_gpu = eng.get_kind() == dnnl::engine::kind::gpu;
     // For an unsupported partition, retrieve all operation IDs, find a
-    // correspondent operation kind in a deserialized_graph and match it against
+    // correspondent operation kind in a deserialized_graph_t and match it against
     // a list of known unsupported ops.
     const std::vector<size_t> &partition_op_ids = partition.get_ops();
     for (const size_t op_id : partition_op_ids) {

--- a/tests/benchdnn/graph/graph.hpp
+++ b/tests/benchdnn/graph/graph.hpp
@@ -89,7 +89,7 @@ std::string case_to_str(const std::string &json_file,
         const std::map<size_t, dnnl_data_type_t> &dt_map);
 
 struct perf_report_t : public base_perf_report_t {
-    perf_report_t(const std::string case_str, const char *perf_template)
+    perf_report_t(const std::string &case_str, const char *perf_template)
         : base_perf_report_t(perf_template), case_str_(case_str) {}
     void dump_desc(std::ostream &s) const override { s << case_str_; }
     void dump_desc_csv(std::ostream &s) const override { dump_desc(s); }

--- a/tests/benchdnn/graph/graph.hpp
+++ b/tests/benchdnn/graph/graph.hpp
@@ -42,7 +42,8 @@ struct settings_t : public base_settings_t {
 
     // ctor to save certain fields from resetting
     settings_t(const char *perf_template) : settings_t() {
-        this->perf_template = perf_template;
+        this->perf_template
+                = perf_template; // NOLINT(cppcoreguidelines-prefer-member-initializer)
     }
     std::string json_file;
     std::vector<std::map<size_t, std::string>> in_shapes_vec {{{0, "default"}}};

--- a/tests/benchdnn/graph/graph.hpp
+++ b/tests/benchdnn/graph/graph.hpp
@@ -67,7 +67,7 @@ struct settings_t : public base_settings_t {
 
 // TODO evaluate prb_t struct
 struct prb_t {
-    prb_t(const deserialized_graph &dg, const size_t &expected_n_partition)
+    prb_t(const deserialized_graph_t &dg, const size_t &expected_n_partition)
         : dg(dg), expected_n_partition(expected_n_partition) {
 
         const auto &fpmath = dg.get_fpmath_mode();
@@ -75,7 +75,7 @@ struct prb_t {
         fpmath_mode.apply_to_int_ = str2bool(fpmath.second.c_str());
     }
 
-    deserialized_graph dg;
+    deserialized_graph_t dg;
     size_t expected_n_partition;
     graph_fpmath_mode_t fpmath_mode;
 };

--- a/tests/benchdnn/graph/graph_memory.hpp
+++ b/tests/benchdnn/graph/graph_memory.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ private:
     graph_memory_req_args_t() {
         req_ = std::vector<std::vector<size_t>>(2, std::vector<size_t>(3, 0));
     }
-    ~graph_memory_req_args_t() {};
+    ~graph_memory_req_args_t() = default;
     BENCHDNN_DISALLOW_COPY_AND_ASSIGN(graph_memory_req_args_t);
 
     // The detailed memory size requrest for specific path and devices.

--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -23,7 +23,7 @@
 namespace graph {
 
 partition_data_displacer_t::partition_data_displacer_t(
-        const deserialized_graph &dg, const dnnl::graph::partition &par)
+        const deserialized_graph_t &dg, const dnnl::graph::partition &par)
     : dg_(&dg) {
     const auto &op_ids = par.get_ops();
     op_ids_set_ = std::unordered_set<size_t>(op_ids.begin(), op_ids.end());
@@ -39,7 +39,7 @@ partition_data_displacer_t::partition_data_displacer_t(
     static const std::unordered_set<std::string> f8_main_op_kind {
             "MatMul", "Convolution"};
 
-    // The logic below relies on the assumption that deserialized_graph is
+    // The logic below relies on the assumption that deserialized_graph_t is
     // sorted in the chronological order.
     for (const auto &aop : dg_->ops_) {
         // Skip the check if op is not in the partition.
@@ -333,7 +333,7 @@ int partition_data_displacer_t::displace_input_data(
             && op_ids_set_.find(parent_op->id_) != op_ids_set_.end()) {
         backward_path_launched = true;
         // generate the reverse op based on OP kind
-        // make a copy of deserialized_op to avoid impact on graph execution
+        // make a copy of deserialized_op_t to avoid impact on graph execution
         // Currently, we support the following OPs' reverse execution:
         // All of the execution need to swap the input lt and output lt first
 
@@ -440,10 +440,10 @@ int partition_data_displacer_t::displace_input_data(
 }
 
 int partition_data_displacer_t::gen_quantize_filling(
-        const ::graph::deserialized_op &main_op, int arg, dnn_mem_t &mem,
+        const ::graph::deserialized_op_t &main_op, int arg, dnn_mem_t &mem,
         const ::std::string &dt, res_t *res) {
     // clone a deserialized op object and modify to specified data type
-    ::graph::deserialized_op op = main_op;
+    ::graph::deserialized_op_t op = main_op;
     auto driver = opkind2driver(opstr2kind(op.kind_));
     bool is_f8_quantization = (dt == "f8_e5m2" || dt == "f8_e4m3");
 

--- a/tests/benchdnn/graph/input_displacer.hpp
+++ b/tests/benchdnn/graph/input_displacer.hpp
@@ -48,24 +48,24 @@ enum class filling_type_t {
 //     the tensor as a displace starting point,
 //     filling_type
 // >
-using displace_t = ::std::tuple<::graph::deserialized_op, size_t,
+using displace_t = ::std::tuple<::graph::deserialized_op_t, size_t,
         ::graph::deserialized_lt, filling_type_t>;
 
 class partition_data_displacer_t {
 public:
     partition_data_displacer_t() = default;
     partition_data_displacer_t(
-            const deserialized_graph &dg, const dnnl::graph::partition &par);
+            const deserialized_graph_t &dg, const dnnl::graph::partition &par);
     int displace_input_data(size_t lt_id, dnn_mem_t &mem, res_t *res);
 
 private:
-    const deserialized_graph *dg_ = nullptr;
+    const deserialized_graph_t *dg_ = nullptr;
     // A set of op_id values from a partition came to a displacer. Used to
     // identify at displacement stage if Deq is the starting point or not.
     std::unordered_set<size_t> op_ids_set_;
     ::std::unordered_map<size_t, displace_t> quantize_displace_;
 
-    int gen_quantize_filling(const ::graph::deserialized_op &main_op, int arg,
+    int gen_quantize_filling(const ::graph::deserialized_op_t &main_op, int arg,
             dnn_mem_t &mem, const ::std::string &dt, res_t *res);
     // Generates values in the target memory based on predefined set of values
     // from `fill_cfg`.

--- a/tests/benchdnn/graph/memory_pool.hpp
+++ b/tests/benchdnn/graph/memory_pool.hpp
@@ -63,7 +63,7 @@ static void *ocl_malloc_device(
 }
 
 static void ocl_free(
-        void *ptr, cl_device_id dev, const cl_context ctx, cl_event event) {
+        void *ptr, cl_device_id dev, cl_context ctx, cl_event event) {
     if (nullptr == ptr) return;
     using F = cl_int (*)(cl_context, void *);
     if (event) { OCL_CHECK(clWaitForEvents(1, &event)); }
@@ -173,7 +173,7 @@ private:
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     struct ocl_deletor_t {
         ocl_deletor_t() = delete;
-        ocl_deletor_t(const cl_device_id dev, const cl_context ctx)
+        ocl_deletor_t(cl_device_id dev, cl_context ctx)
             : dev_(dev), ctx_(ctx) {}
         void operator()(void *ptr) {
             if (ptr) ocl_free(ptr, dev_, ctx_, {});

--- a/tests/benchdnn/graph/memory_pool.hpp
+++ b/tests/benchdnn/graph/memory_pool.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -125,7 +125,7 @@ public:
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
             auto sh_ptr = std::shared_ptr<void> {
                     ocl_malloc_device(size, alignment, dev, ctx),
-                    ocl_deletor {dev, ctx}};
+                    ocl_deletor_t {dev, ctx}};
 #endif
             ptr = sh_ptr.get();
             // record the map of mm size and its ptr for reuse
@@ -171,9 +171,9 @@ private:
         ::sycl::context ctx_;
     };
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    struct ocl_deletor {
-        ocl_deletor() = delete;
-        ocl_deletor(const cl_device_id dev, const cl_context ctx)
+    struct ocl_deletor_t {
+        ocl_deletor_t() = delete;
+        ocl_deletor_t(const cl_device_id dev, const cl_context ctx)
             : dev_(dev), ctx_(ctx) {}
         void operator()(void *ptr) {
             if (ptr) ocl_free(ptr, dev_, ctx_, {});

--- a/tests/benchdnn/graph/memory_pool.hpp
+++ b/tests/benchdnn/graph/memory_pool.hpp
@@ -139,13 +139,11 @@ public:
     void deallocate(void *ptr) {
         std::lock_guard<std::mutex> pool_guard(pool_lock);
         is_free_ptr_[ptr] = true;
-        return;
     }
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     void deallocate(void *ptr) {
         std::lock_guard<std::mutex> pool_guard(pool_lock);
         is_free_ptr_[ptr] = true;
-        return;
     }
 #endif
 

--- a/tests/benchdnn/graph/parser.cpp
+++ b/tests/benchdnn/graph/parser.cpp
@@ -244,7 +244,7 @@ std::map<std::string, std::string> parse_attrs(const std::string &attrs_str) {
         val_end = attrs_str.find('*', val_pos);
         std::string key_str = attrs_str.substr(key_pos, key_end - key_pos);
         std::string val_str = attrs_str.substr(val_pos, val_end - val_pos);
-        // Validation of input happens at `deserialized_op::create()`.
+        // Validation of input happens at `deserialized_op_t::create()`.
         if (attrs_map.count(key_str)) {
             attrs_map[key_str] = val_str;
             BENCHDNN_PRINT(0, "Repeat attr: %s, will use last value for it.\n",

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -38,7 +38,7 @@ void check_memory_fit(
 
 } // namespace
 
-ref_partition_t::ref_partition_t(const deserialized_graph &dg,
+ref_partition_t::ref_partition_t(const deserialized_graph_t &dg,
         const dnnl::graph::partition &par,
         const std::vector<dnnl::graph::logical_tensor> &ins,
         const std::vector<dnnl::graph::logical_tensor> &outs)
@@ -367,7 +367,7 @@ int ref_partition_t::check_partition_correctness(
 }
 
 bool ref_partition_t::has_parent_op(
-        const deserialized_op &op, bool check_all_in_lts) const {
+        const deserialized_op_t &op, bool check_all_in_lts) const {
     if (partition_ops_ref_.size() < 2) return false;
 
     for (const auto &in_lt : op.in_lts_) {
@@ -389,8 +389,8 @@ bool ref_partition_t::has_parent_op(
 }
 
 // TODO: add get_child and remove the second arg.
-bool ref_partition_t::has_child_op(
-        const deserialized_op &op, const deserialized_op **child_op_ptr) const {
+bool ref_partition_t::has_child_op(const deserialized_op_t &op,
+        const deserialized_op_t **child_op_ptr) const {
     if (partition_ops_ref_.size() < 2) return false;
 
     for (const auto &out_lt : op.out_lts_) {
@@ -411,7 +411,7 @@ bool ref_partition_t::has_child_op(
     return false;
 }
 
-const deserialized_op *ref_partition_t::get_parent_op(size_t in_lt_id) const {
+const deserialized_op_t *ref_partition_t::get_parent_op(size_t in_lt_id) const {
     if (partition_ops_ref_.size() < 2) return nullptr;
 
     // Check if a parent op exists for an `op`.
@@ -430,8 +430,8 @@ const deserialized_op *ref_partition_t::get_parent_op(size_t in_lt_id) const {
 // This function decides when unfusable transcendental op output should be
 // reordered to lower data type and back to f32 for a reference path.
 bool ref_partition_t::need_unfusable_output_crop(
-        const deserialized_op &op, dnnl_data_type_t &dt) const {
-    const deserialized_op *child_op = nullptr;
+        const deserialized_op_t &op, dnnl_data_type_t &dt) const {
+    const deserialized_op_t *child_op = nullptr;
     // First of all, the output should have a child op...
     if (!has_child_op(op, &child_op)) return false;
     // If the child op is not a TypeCast, it's safe to crop.
@@ -443,7 +443,7 @@ bool ref_partition_t::need_unfusable_output_crop(
     // When it is a TypeCast (it always changes `cur_dt` <-> f32, both ways are
     // possible), there are options:
     // * If it's the last one, no crop, as f32 will happen on the other end.
-    const deserialized_op *next_child_op = nullptr;
+    const deserialized_op_t *next_child_op = nullptr;
     if (!has_child_op(*child_op, &next_child_op)) return false;
     // * If there's a child Quantize, no crop either, since output would
     //   perform a reorder with a proper scale value to match the other end.
@@ -461,7 +461,7 @@ bool ref_partition_t::need_unfusable_output_crop(
     return true;
 }
 
-bool ref_partition_t::is_output_op(const deserialized_op &op) const {
+bool ref_partition_t::is_output_op(const deserialized_op_t &op) const {
     return std::any_of(op.out_lts_.begin(), op.out_lts_.end(),
             [this](const deserialized_lt &lt) {
                 return std::find(partition_out_ids_.begin(),
@@ -472,7 +472,7 @@ bool ref_partition_t::is_output_op(const deserialized_op &op) const {
 
 // check the partition memory footprint of the graph path
 int ref_partition_t::check_partition_total_size(
-        const deserialized_op &op, res_t *res) {
+        const deserialized_op_t &op, res_t *res) {
 
     // Prepare the memory limit for benchdnn graph
     static size_t benchdnn_cpu_limit = get_benchdnn_cpu_limit();
@@ -579,7 +579,7 @@ int ref_partition_t::check_partition_total_size(
 // Return the logical tensor ids of the given op which is the input/output of
 // the partition.
 std::vector<size_t> ref_partition_t::get_in_out_lt_ids(
-        const deserialized_op &op) const {
+        const deserialized_op_t &op) const {
     std::vector<size_t> in_out_lt_ids;
     std::for_each(op.in_lts_.begin(), op.in_lts_.end(),
             [&in_out_lt_ids, this](const deserialized_lt &lt) {

--- a/tests/benchdnn/graph/ref_partition.hpp
+++ b/tests/benchdnn/graph/ref_partition.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public:
     ref_partition_t() = default;
     // to get a Topo ordered partition OPs reference and save the map
     // of input/output logical tensors ids to partition OPs reference
-    ref_partition_t(const deserialized_graph &dg,
+    ref_partition_t(const deserialized_graph_t &dg,
             const dnnl::graph::partition &par,
             const std::vector<dnnl::graph::logical_tensor> &ins,
             const std::vector<dnnl::graph::logical_tensor> &outs);
@@ -50,7 +50,7 @@ public:
             partition_mem_map_t &partition_mem_map, res_t *res);
 
     // check the partition memory footprint of graph path
-    int check_partition_total_size(const deserialized_op &op, res_t *res);
+    int check_partition_total_size(const deserialized_op_t &op, res_t *res);
 
     // check the partition memory footprint of reference path
     int check_partition_total_size(
@@ -67,31 +67,32 @@ private:
     // its logical tensors.
     // When `check_all_in_lts` is set to true, returns `true` if only the op has
     // a parent for each of its logical tensors.
-    bool has_parent_op(const deserialized_op &op, bool check_all_in_lts) const;
+    bool has_parent_op(
+            const deserialized_op_t &op, bool check_all_in_lts) const;
 
     // Returns `true` if an `op` has a child op in the partition.
     // If `child_op_ptr` is not empty, updates the pointer with a child op.
     //
     // Note: double pointer is needed to initialize a pointer. A pointer is
     // needed to avoid a copy of an `child_op` object.
-    bool has_child_op(const deserialized_op &op,
-            const deserialized_op **child_op_ptr) const;
+    bool has_child_op(const deserialized_op_t &op,
+            const deserialized_op_t **child_op_ptr) const;
 
     // Returns a pointer to parent op for a given input lt id. If the parent is
     // not found, an empty pointer is returned.
-    const deserialized_op *get_parent_op(size_t in_lt_id) const;
+    const deserialized_op_t *get_parent_op(size_t in_lt_id) const;
 
     // Returns `true` if unfusable transcendental op should have cropped output.
     // `dt` is a target data type for following transform. Updated only when the
     // function returns `true`.
     bool need_unfusable_output_crop(
-            const deserialized_op &op, dnnl_data_type_t &dt) const;
+            const deserialized_op_t &op, dnnl_data_type_t &dt) const;
 
-    bool is_input_op(const deserialized_op &op) const;
-    bool is_output_op(const deserialized_op &op) const;
-    std::vector<size_t> get_in_out_lt_ids(const deserialized_op &op) const;
+    bool is_input_op(const deserialized_op_t &op) const;
+    bool is_output_op(const deserialized_op_t &op) const;
+    std::vector<size_t> get_in_out_lt_ids(const deserialized_op_t &op) const;
 
-    const deserialized_graph *dg_;
+    const deserialized_graph_t *dg_;
     // Objects below are constructed.
     // OPs in the partition, which is Topo ordered
     op_ref_list_t partition_ops_ref_;

--- a/tests/benchdnn/graph/ref_primitive.cpp
+++ b/tests/benchdnn/graph/ref_primitive.cpp
@@ -19,7 +19,7 @@
 
 namespace graph {
 
-ref_primitive_t::ref_primitive_t(const deserialized_op &op)
+ref_primitive_t::ref_primitive_t(const deserialized_op_t &op)
     : op_(op), kind_(opstr2kind(op_.kind_)), driver_(opkind2driver(kind_)) {
 
     static const ::std::unordered_set<::std::string> special_backward_op = {

--- a/tests/benchdnn/graph/ref_primitive.hpp
+++ b/tests/benchdnn/graph/ref_primitive.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ inline const prb_t *prb_wrapper_base_t::get() const {
 class ref_primitive_t {
 public:
     ref_primitive_t() = default;
-    ref_primitive_t(const deserialized_op &op);
+    ref_primitive_t(const deserialized_op_t &op);
 
     int init_prb(res_t *res);
     // By default, the reference primitives are created with f32 data type.
@@ -99,7 +99,7 @@ public:
 private:
     BENCHDNN_DISALLOW_COPY_AND_ASSIGN(ref_primitive_t);
 
-    deserialized_op op_;
+    deserialized_op_t op_;
     ::dnnl::graph::op::kind kind_;
     dnnl_driver_t driver_;
     bool is_special_backward_op_;

--- a/tests/benchdnn/graph/ref_primitive.hpp
+++ b/tests/benchdnn/graph/ref_primitive.hpp
@@ -38,7 +38,7 @@ public:
 template <typename prb_t>
 class prb_wrapper_t : public prb_wrapper_base_t {
 public:
-    prb_wrapper_t(const std::shared_ptr<prb_t> prb) { prb_ = prb; }
+    prb_wrapper_t(const std::shared_ptr<prb_t> prb) : prb_(prb) {}
     // get raw pointer of prb object
     const prb_t *get() const { return prb_.get(); }
 

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -73,7 +73,7 @@ void assign_shape_val(int64_t &c, int64_t &w, int64_t &h, int64_t &d,
     d = has_d ? ncx_shape[2] : 1;
 };
 
-bool get_graph_attr(const deserialized_op &base_op_ref,
+bool get_graph_attr(const deserialized_op_t &base_op_ref,
         attr_t::fpmath_mode_t &arg_fpmath_mode) {
 
     const auto &op_kind = base_op_ref.kind_;
@@ -91,8 +91,8 @@ bool get_graph_attr(const deserialized_op &base_op_ref,
     return true;
 }
 
-bool get_driver_tag_by_idx(const deserialized_op &base_op_ref, std::string &tag,
-        int idx = 0, bool from_output = false) {
+bool get_driver_tag_by_idx(const deserialized_op_t &base_op_ref,
+        std::string &tag, int idx = 0, bool from_output = false) {
     logical_tensor::dims strides = from_output
             ? base_op_ref.out_lts_[idx].stride_
             : base_op_ref.in_lts_[idx].stride_;
@@ -104,19 +104,19 @@ bool get_driver_tag_by_idx(const deserialized_op &base_op_ref, std::string &tag,
     return true;
 }
 
-bool get_driver_tag(const deserialized_op &base_op_ref, std::string &tag,
+bool get_driver_tag(const deserialized_op_t &base_op_ref, std::string &tag,
         bool from_output = false) {
     return get_driver_tag_by_idx(base_op_ref, tag, 0, from_output);
 }
 
-bool get_driver_stag_and_dtag(const deserialized_op &base_op_ref,
+bool get_driver_stag_and_dtag(const deserialized_op_t &base_op_ref,
         std::string &stag, std::string &dtag, bool from_output = false) {
     bool ret = get_driver_tag(base_op_ref, stag, from_output);
     dtag = stag;
     return ret;
 }
 
-bool get_driver_axis(const deserialized_op &base_op_ref, int &axis) {
+bool get_driver_axis(const deserialized_op_t &base_op_ref, int &axis) {
     int64_t val = 0;
     base_op_ref.get_attr_s64(val, "axis");
     axis = val >= 0
@@ -125,7 +125,7 @@ bool get_driver_axis(const deserialized_op &base_op_ref, int &axis) {
     return true;
 }
 
-bool get_driver_bia_dt(const deserialized_op &base_op_ref,
+bool get_driver_bia_dt(const deserialized_op_t &base_op_ref,
         dnnl_data_type_t &bia_dt, const dnnl_data_type_t dt) {
     if (base_op_ref.in_lts_.size() <= 2)
         bia_dt = dnnl_data_type_undef;
@@ -137,7 +137,7 @@ bool get_driver_bia_dt(const deserialized_op &base_op_ref,
     return true;
 }
 
-bool get_prb_dims(const deserialized_op &base_op_ref, prb_dims_t &prb_dims) {
+bool get_prb_dims(const deserialized_op_t &base_op_ref, prb_dims_t &prb_dims) {
     prb_dims.dims = base_op_ref.in_lts_.front().shape_;
     prb_dims.ndims = static_cast<int>(prb_dims.dims.size());
     return true;
@@ -161,7 +161,7 @@ void extend_dims(::graph::deserialized_lt &lt, size_t ndims) {
 namespace custom {
 
 ::custom::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::custom::settings_t op_setting;
     auto opkind = opstr2kind(base_op_ref.kind_);
     switch (opkind) {
@@ -223,10 +223,10 @@ namespace custom {
 
 namespace binary {
 bool get_binary_prb_vdims(
-        const deserialized_op &base_op_ref, prb_vdims_t &prb_vdims) {
+        const deserialized_op_t &base_op_ref, prb_vdims_t &prb_vdims) {
     // since base_op_ref is a copy from the original
     // it is safe to modify it
-    deserialized_op &base_op = const_cast<deserialized_op &>(base_op_ref);
+    deserialized_op_t &base_op = const_cast<deserialized_op_t &>(base_op_ref);
 
     auto &src0_dims = base_op.in_lts_[0].shape_;
     auto &src1_dims = base_op.in_lts_[1].shape_;
@@ -270,8 +270,8 @@ bool get_binary_prb_vdims(
     return true;
 }
 
-bool get_binary_sdt_and_ddt(
-        const deserialized_op &base_op_ref, ::binary::settings_t &op_setting) {
+bool get_binary_sdt_and_ddt(const deserialized_op_t &base_op_ref,
+        ::binary::settings_t &op_setting) {
     auto sdt0 = convert_dt(base_op_ref.in_lts_[0].get_data_type());
     auto sdt1 = convert_dt(base_op_ref.in_lts_[1].get_data_type());
     auto ddt = convert_dt(base_op_ref.out_lts_[0].get_data_type());
@@ -281,8 +281,8 @@ bool get_binary_sdt_and_ddt(
     return true;
 }
 
-bool get_binary_stag_and_dtag(
-        const deserialized_op &base_op_ref, ::binary::settings_t &op_setting) {
+bool get_binary_stag_and_dtag(const deserialized_op_t &base_op_ref,
+        ::binary::settings_t &op_setting) {
     // src1, src2 and dst could have different tags.
     std::string stag0, stag1, dtag;
     if (!get_driver_tag_by_idx(base_op_ref, dtag, 0, true)
@@ -295,7 +295,8 @@ bool get_binary_stag_and_dtag(
     return true;
 }
 
-bool get_binary_alg(const deserialized_op &base_op_ref, ::binary::alg_t &alg) {
+bool get_binary_alg(
+        const deserialized_op_t &base_op_ref, ::binary::alg_t &alg) {
     static const std::unordered_map<std::string, ::binary::alg_t>
             map_kind_to_alg {{"Add", ::binary::alg_t::ADD},
                     {"BiasAdd", ::binary::alg_t::ADD},
@@ -314,7 +315,7 @@ bool get_binary_alg(const deserialized_op &base_op_ref, ::binary::alg_t &alg) {
 }
 
 ::binary::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::binary::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             binary::get_binary_prb_vdims(base_op_ref, op_setting.prb_vdims),
@@ -338,7 +339,7 @@ bool get_binary_alg(const deserialized_op &base_op_ref, ::binary::alg_t &alg) {
 
 namespace bnorm {
 
-bool get_bnorm_desc(const deserialized_op &base_op_ref, ::bnorm::desc_t &d) {
+bool get_bnorm_desc(const deserialized_op_t &base_op_ref, ::bnorm::desc_t &d) {
     const auto &src_ncx_shape = base_op_ref.get_NCX_shape(0, true);
     d.mb = src_ncx_shape[0];
     d.ndims = static_cast<int>(src_ncx_shape.size());
@@ -347,7 +348,7 @@ bool get_bnorm_desc(const deserialized_op &base_op_ref, ::bnorm::desc_t &d) {
     return true;
 }
 
-bool get_bnorm_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_bnorm_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "BatchNormForwardTraining") {
         dir = dir_t::FWD_D;
@@ -368,13 +369,13 @@ bool get_bnorm_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 }
 
-bool get_bnorm_dt(const deserialized_op &base_op_ref, dnnl_data_type_t &dt) {
+bool get_bnorm_dt(const deserialized_op_t &base_op_ref, dnnl_data_type_t &dt) {
     dt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     return true;
 }
 
 bool get_bnorm_flag(
-        const deserialized_op &base_op_ref, ::bnorm::flags_t &flag) {
+        const deserialized_op_t &base_op_ref, ::bnorm::flags_t &flag) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "BatchNormForwardTraining") {
         if (base_op_ref.in_lts_.size() == 3) {
@@ -402,7 +403,7 @@ bool get_bnorm_flag(
 }
 
 ::bnorm::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::bnorm::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             bnorm::get_bnorm_desc(base_op_ref, op_setting.desc), res);
@@ -424,7 +425,7 @@ bool get_bnorm_flag(
 namespace concat {
 
 bool get_concat_prb_vdims(
-        const deserialized_op &base_op_ref, prb_vdims_t &prb_vdims) {
+        const deserialized_op_t &base_op_ref, prb_vdims_t &prb_vdims) {
     std::vector<dims_t> vdims;
     vdims.reserve(base_op_ref.in_lts_.size());
     for (const auto &in : base_op_ref.in_lts_) {
@@ -434,16 +435,16 @@ bool get_concat_prb_vdims(
     return true;
 }
 
-bool get_concat_sdt_and_ddt(
-        const deserialized_op &base_op_ref, ::concat::settings_t &op_setting) {
+bool get_concat_sdt_and_ddt(const deserialized_op_t &base_op_ref,
+        ::concat::settings_t &op_setting) {
     const auto &dt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     op_setting.sdt.front() = dt;
     op_setting.ddt.front() = dt;
     return true;
 }
 
-bool get_concat_stag_and_dtag(
-        const deserialized_op &base_op_ref, ::concat::settings_t &op_setting) {
+bool get_concat_stag_and_dtag(const deserialized_op_t &base_op_ref,
+        ::concat::settings_t &op_setting) {
     size_t in_size = base_op_ref.in_lts_.size();
     std::vector<std::string> stags(in_size);
     std::string dtag;
@@ -458,7 +459,7 @@ bool get_concat_stag_and_dtag(
 }
 
 ::concat::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::concat::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             concat::get_concat_prb_vdims(base_op_ref, op_setting.prb_vdims),
@@ -481,7 +482,7 @@ bool get_concat_stag_and_dtag(
 
 namespace conv {
 
-bool get_conv_desc(const deserialized_op &base_op_ref, ::conv::desc_t &d) {
+bool get_conv_desc(const deserialized_op_t &base_op_ref, ::conv::desc_t &d) {
     d.g = 1;
     d.sd = d.sh = d.sw = 1;
     d.pd = d.ph = d.pw = -1;
@@ -557,7 +558,7 @@ bool get_conv_desc(const deserialized_op &base_op_ref, ::conv::desc_t &d) {
     return true;
 }
 
-bool get_conv_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_conv_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "Convolution") {
         dir = dir_t::FWD_I;
@@ -572,8 +573,8 @@ bool get_conv_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 }
 
-bool get_conv_dt(
-        const deserialized_op &base_op_ref, std::vector<dnnl_data_type_t> &dt) {
+bool get_conv_dt(const deserialized_op_t &base_op_ref,
+        std::vector<dnnl_data_type_t> &dt) {
     dnnl_data_type_t src_dt, wei_dt, dst_dt;
     auto in_lt0_dt = convert_dt(base_op_ref.in_lts_[0].get_data_type());
     auto in_lt1_dt = convert_dt(base_op_ref.in_lts_[1].get_data_type());
@@ -603,7 +604,7 @@ bool get_conv_dt(
     return true;
 }
 
-bool get_conv_wtag(const deserialized_op &base_op_ref, std::string &tag) {
+bool get_conv_wtag(const deserialized_op_t &base_op_ref, std::string &tag) {
     std::string weights_format {};
     if (!base_op_ref.get_attr_string(weights_format, "weights_format"))
         return false;
@@ -641,7 +642,7 @@ bool get_conv_wtag(const deserialized_op &base_op_ref, std::string &tag) {
 }
 
 bool get_conv_stag_and_dtag(
-        const deserialized_op &base_op_ref, ::conv::settings_t &op_setting) {
+        const deserialized_op_t &base_op_ref, ::conv::settings_t &op_setting) {
     std::string stag, dtag;
     if (base_op_ref.kind_ == "Convolution") {
         if (!get_driver_tag_by_idx(base_op_ref, stag, 0)
@@ -667,7 +668,8 @@ bool get_conv_stag_and_dtag(
     return true;
 }
 
-::conv::settings_t get_setting(const deserialized_op &base_op_ref, res_t *res) {
+::conv::settings_t get_setting(
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::conv::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             conv::get_conv_desc(base_op_ref, op_setting.desc), res);
@@ -693,7 +695,8 @@ bool get_conv_stag_and_dtag(
 
 namespace deconv {
 
-bool get_deconv_desc(const deserialized_op &base_op_ref, ::deconv::desc_t &d) {
+bool get_deconv_desc(
+        const deserialized_op_t &base_op_ref, ::deconv::desc_t &d) {
     d.g = 1;
     d.sd = d.sh = d.sw = 1;
     d.pd = d.ph = d.pw = -1;
@@ -764,7 +767,7 @@ bool get_deconv_desc(const deserialized_op &base_op_ref, ::deconv::desc_t &d) {
     return true;
 }
 
-bool get_deconv_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_deconv_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "ConvTranspose") {
         dir = dir_t::FWD_I;
@@ -779,8 +782,8 @@ bool get_deconv_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 }
 
-bool get_deconv_dt(
-        const deserialized_op &base_op_ref, std::vector<dnnl_data_type_t> &dt) {
+bool get_deconv_dt(const deserialized_op_t &base_op_ref,
+        std::vector<dnnl_data_type_t> &dt) {
     dnnl_data_type_t src_dt, wei_dt, dst_dt;
     auto in_lt0_dt = convert_dt(base_op_ref.in_lts_[0].get_data_type());
     auto in_lt1_dt = convert_dt(base_op_ref.in_lts_[1].get_data_type());
@@ -809,7 +812,7 @@ bool get_deconv_dt(
     return true;
 }
 
-bool get_deconv_wtag(const deserialized_op &base_op_ref, std::string &tag) {
+bool get_deconv_wtag(const deserialized_op_t &base_op_ref, std::string &tag) {
     std::string weights_format {};
     if (!base_op_ref.get_attr_string(weights_format, "weights_format"))
         return false;
@@ -850,7 +853,7 @@ bool get_deconv_wtag(const deserialized_op &base_op_ref, std::string &tag) {
 }
 
 ::deconv::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::deconv::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             deconv::get_deconv_desc(base_op_ref, op_setting.desc), res);
@@ -917,13 +920,13 @@ get_eltwise_kind_map() {
     return map_;
 }
 
-bool get_flag_use_dst_for_bwd_compute(const deserialized_op &base_op_ref) {
+bool get_flag_use_dst_for_bwd_compute(const deserialized_op_t &base_op_ref) {
     const auto it = base_op_ref.attrs_.find("use_dst");
     if (it == base_op_ref.attrs_.end()) return false;
     return it->second.bool_value_;
 }
 
-bool get_eltwise_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_eltwise_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind.rfind("Backward") == std::string::npos) {
         dir = dir_t::FWD_D;
@@ -933,13 +936,14 @@ bool get_eltwise_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 }
 
-bool get_eltwise_dt(const deserialized_op &base_op_ref, dnnl_data_type_t &dt) {
+bool get_eltwise_dt(
+        const deserialized_op_t &base_op_ref, dnnl_data_type_t &dt) {
     dt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     return true;
 }
 
 bool get_eltwise_alg(
-        const deserialized_op &base_op_ref, ::eltwise::alg_t &alg) {
+        const deserialized_op_t &base_op_ref, ::eltwise::alg_t &alg) {
     static const std::unordered_map<std::string, ::eltwise::alg_t>
             map_kind_to_alg_dst {
                     {"ClampBackward", ::eltwise::alg_t::CLIP_V2_DST},
@@ -964,7 +968,7 @@ bool get_eltwise_alg(
     return true;
 }
 
-bool get_eltwise_alpha(const deserialized_op &base_op_ref, float &alpha) {
+bool get_eltwise_alpha(const deserialized_op_t &base_op_ref, float &alpha) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "Clamp" || op_kind == "ClampBackward") {
         base_op_ref.get_attr_f32(alpha, "min");
@@ -985,7 +989,7 @@ bool get_eltwise_alpha(const deserialized_op &base_op_ref, float &alpha) {
     return true;
 }
 
-bool get_eltwise_beta(const deserialized_op &base_op_ref, float &beta) {
+bool get_eltwise_beta(const deserialized_op_t &base_op_ref, float &beta) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "Reciprocal") {
         beta = -1; // Reciprocal is pow(-1)
@@ -1001,7 +1005,7 @@ bool get_eltwise_beta(const deserialized_op &base_op_ref, float &beta) {
 }
 
 ::eltwise::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::eltwise::settings_t op_setting;
     const auto &map_kind_to_alg = get_eltwise_kind_map();
     DNN_GRAPH_CHECK_SETTINGS(
@@ -1035,7 +1039,7 @@ bool get_eltwise_beta(const deserialized_op &base_op_ref, float &beta) {
 
 namespace gnorm {
 
-bool get_gnorm_desc(const deserialized_op &base_op_ref, ::gnorm::desc_t &d) {
+bool get_gnorm_desc(const deserialized_op_t &base_op_ref, ::gnorm::desc_t &d) {
     auto src_dims = base_op_ref.in_lts_[0].shape_;
     if (base_op_ref.has_NXC_format()) {
         src_dims = base_op_ref.get_NCX_shape(0, true);
@@ -1055,7 +1059,7 @@ bool get_gnorm_desc(const deserialized_op &base_op_ref, ::gnorm::desc_t &d) {
     return true;
 }
 
-bool get_gnorm_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_gnorm_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "GroupNorm") {
         bool keep_stats = false;
@@ -1083,8 +1087,8 @@ bool get_gnorm_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 }
 
-bool get_gnorm_dt(
-        const deserialized_op &base_op_ref, std::vector<dnnl_data_type_t> &dt) {
+bool get_gnorm_dt(const deserialized_op_t &base_op_ref,
+        std::vector<dnnl_data_type_t> &dt) {
     auto src_dt = convert_dt(base_op_ref.in_lts_[0].get_data_type());
     auto dst_dt = convert_dt(base_op_ref.out_lts_[0].get_data_type());
     dt = {src_dt, dst_dt};
@@ -1092,7 +1096,7 @@ bool get_gnorm_dt(
 }
 
 bool get_gnorm_flags(
-        const deserialized_op &base_op_ref, ::bnorm::flags_t &flags) {
+        const deserialized_op_t &base_op_ref, ::bnorm::flags_t &flags) {
     bool use_affine = false;
     base_op_ref.get_attr_bool(use_affine, "use_affine");
     const auto &op_kind = base_op_ref.kind_;
@@ -1123,7 +1127,7 @@ bool get_gnorm_flags(
     return true;
 }
 
-bool get_gnorm_stag_and_dtag(const deserialized_op &base_op_ref,
+bool get_gnorm_stag_and_dtag(const deserialized_op_t &base_op_ref,
         std::vector<std::vector<std::string>> &tag) {
     // src and dst may have different tags.
     std::string stag, dtag;
@@ -1137,7 +1141,7 @@ bool get_gnorm_stag_and_dtag(const deserialized_op &base_op_ref,
 }
 
 ::gnorm::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::gnorm::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(get_gnorm_desc(base_op_ref, op_setting.desc), res);
     DNN_GRAPH_CHECK_SETTINGS(
@@ -1157,7 +1161,7 @@ bool get_gnorm_stag_and_dtag(const deserialized_op &base_op_ref,
 
 namespace lnorm {
 
-bool get_lnorm_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_lnorm_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "LayerNorm") {
         bool keep_stats = false;
@@ -1184,13 +1188,13 @@ bool get_lnorm_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 }
 
-bool get_lnorm_dt(const deserialized_op &base_op_ref, dnnl_data_type_t &dt) {
+bool get_lnorm_dt(const deserialized_op_t &base_op_ref, dnnl_data_type_t &dt) {
     dt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     return true;
 }
 
 bool get_lnorm_flags(
-        const deserialized_op &base_op_ref, ::bnorm::flags_t &flags) {
+        const deserialized_op_t &base_op_ref, ::bnorm::flags_t &flags) {
     bool use_affine = false;
     base_op_ref.get_attr_bool(use_affine, "use_affine");
     const auto &op_kind = base_op_ref.kind_;
@@ -1233,7 +1237,7 @@ bool get_lnorm_flags(
 }
 
 ::lnorm::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::lnorm::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             get_prb_dims(base_op_ref, op_setting.prb_dims), res);
@@ -1256,9 +1260,9 @@ bool get_lnorm_flags(
 namespace matmul {
 
 bool get_matmul_prb_vdims(
-        const deserialized_op &base_op_ref, prb_vdims_t &prb_vdims) {
+        const deserialized_op_t &base_op_ref, prb_vdims_t &prb_vdims) {
 
-    deserialized_op &base_op = const_cast<deserialized_op &>(base_op_ref);
+    deserialized_op_t &base_op = const_cast<deserialized_op_t &>(base_op_ref);
 
     auto &src_dims = base_op.in_lts_[0].shape_;
     auto &wei_dims = base_op.in_lts_[1].shape_;
@@ -1290,8 +1294,8 @@ bool get_matmul_prb_vdims(
     return true;
 }
 
-bool get_matmul_dt(
-        const deserialized_op &base_op_ref, std::vector<dnnl_data_type_t> &dt) {
+bool get_matmul_dt(const deserialized_op_t &base_op_ref,
+        std::vector<dnnl_data_type_t> &dt) {
     auto src_dt = convert_dt(base_op_ref.in_lts_[0].get_data_type());
     auto wei_dt = convert_dt(base_op_ref.in_lts_[1].get_data_type());
     auto dst_dt = convert_dt(base_op_ref.out_lts_[0].get_data_type());
@@ -1300,7 +1304,7 @@ bool get_matmul_dt(
     return true;
 }
 
-bool get_matmul_tags(const deserialized_op &base_op_ref, std::string &stag,
+bool get_matmul_tags(const deserialized_op_t &base_op_ref, std::string &stag,
         std::string &wtag, std::string &dtag, const int &ndims) {
     logical_tensor::dims src_strides = base_op_ref.in_lts_[0].stride_;
     logical_tensor::dims wei_strides = base_op_ref.in_lts_[1].stride_;
@@ -1321,7 +1325,7 @@ bool get_matmul_tags(const deserialized_op &base_op_ref, std::string &stag,
     return true;
 }
 
-bool get_matmul_bia_mask(const deserialized_op &base_op_ref, int &bia_mask) {
+bool get_matmul_bia_mask(const deserialized_op_t &base_op_ref, int &bia_mask) {
     if (base_op_ref.in_lts_.size() <= 2) return true;
 
     const logical_tensor::dims &bias_shape = base_op_ref.in_lts_[2].shape_;
@@ -1345,7 +1349,7 @@ bool get_matmul_bia_mask(const deserialized_op &base_op_ref, int &bia_mask) {
 }
 
 ::matmul::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::matmul::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             matmul::get_matmul_prb_vdims(base_op_ref, op_setting.prb_vdims),
@@ -1374,7 +1378,7 @@ bool get_matmul_bia_mask(const deserialized_op &base_op_ref, int &bia_mask) {
 
 namespace pool {
 
-bool get_pool_desc(const deserialized_op &base_op_ref, ::pool::desc_t &d) {
+bool get_pool_desc(const deserialized_op_t &base_op_ref, ::pool::desc_t &d) {
 
     d.sd = d.sh = d.sw = 1;
     d.pd = d.ph = d.pw = -1;
@@ -1437,7 +1441,7 @@ bool get_pool_desc(const deserialized_op &base_op_ref, ::pool::desc_t &d) {
     return true;
 }
 
-bool get_pool_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_pool_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     bool ret = false;
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "MaxPool" || op_kind == "AvgPool") {
@@ -1454,15 +1458,15 @@ bool get_pool_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return ret;
 }
 
-bool get_pool_dt(
-        const deserialized_op &base_op_ref, std::vector<dnnl_data_type_t> &dt) {
+bool get_pool_dt(const deserialized_op_t &base_op_ref,
+        std::vector<dnnl_data_type_t> &dt) {
     auto src_dt = convert_dt(base_op_ref.in_lts_[0].get_data_type());
     auto dst_dt = convert_dt(base_op_ref.out_lts_[0].get_data_type());
     dt = {src_dt, dst_dt};
     return true;
 }
 
-bool get_pool_alg(const deserialized_op &base_op_ref, ::pool::alg_t &alg) {
+bool get_pool_alg(const deserialized_op_t &base_op_ref, ::pool::alg_t &alg) {
 
     const auto op_kind_ = base_op_ref.kind_;
     if (op_kind_ == "MaxPool" || op_kind_ == "MaxPoolBackward") {
@@ -1489,7 +1493,8 @@ bool get_pool_alg(const deserialized_op &base_op_ref, ::pool::alg_t &alg) {
     return true;
 }
 
-::pool::settings_t get_setting(const deserialized_op &base_op_ref, res_t *res) {
+::pool::settings_t get_setting(
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::pool::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             pool::get_pool_desc(base_op_ref, op_setting.desc), res);
@@ -1510,7 +1515,7 @@ bool get_pool_alg(const deserialized_op &base_op_ref, ::pool::alg_t &alg) {
 namespace prelu {
 
 bool get_prelu_prb_vdims(
-        const deserialized_op &base_op_ref, prb_vdims_t &prb_vdims) {
+        const deserialized_op_t &base_op_ref, prb_vdims_t &prb_vdims) {
 
     auto src_dims = base_op_ref.in_lts_[0].shape_;
     auto wei_dims = base_op_ref.in_lts_[1].shape_;
@@ -1542,7 +1547,7 @@ bool get_prelu_prb_vdims(
     return true;
 }
 
-bool get_prelu_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_prelu_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     bool ret = false;
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "PReLU") {
@@ -1558,15 +1563,15 @@ bool get_prelu_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return ret;
 }
 
-bool get_prelu_sdt(
-        const deserialized_op &base_op_ref, std::vector<dnnl_data_type_t> &dt) {
+bool get_prelu_sdt(const deserialized_op_t &base_op_ref,
+        std::vector<dnnl_data_type_t> &dt) {
     const auto &_dt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     dt = {_dt, _dt};
     return true;
 }
 
 bool get_prelu_stag(
-        const deserialized_op &base_op_ref, ::prelu::settings_t &op_setting) {
+        const deserialized_op_t &base_op_ref, ::prelu::settings_t &op_setting) {
     std::string tag0, tag1;
     if (!get_driver_tag_by_idx(base_op_ref, tag0)
             || !get_driver_tag_by_idx(base_op_ref, tag1, 1))
@@ -1576,7 +1581,7 @@ bool get_prelu_stag(
 }
 
 ::prelu::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::prelu::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             prelu::get_prelu_prb_vdims(base_op_ref, op_setting.prb_vdims), res);
@@ -1597,7 +1602,7 @@ bool get_prelu_stag(
 namespace reduction {
 
 bool get_reduction_prb_vdims(
-        const deserialized_op &base_op_ref, prb_vdims_t &prb_vdims) {
+        const deserialized_op_t &base_op_ref, prb_vdims_t &prb_vdims) {
     const auto &src_dims = base_op_ref.in_lts_[0].shape_;
     auto dst_dims = base_op_ref.out_lts_[0].shape_;
 
@@ -1627,15 +1632,15 @@ bool get_reduction_prb_vdims(
     return true;
 }
 
-bool get_reduction_dt(const deserialized_op &base_op_ref, dnnl_data_type_t &sdt,
-        dnnl_data_type_t &ddt) {
+bool get_reduction_dt(const deserialized_op_t &base_op_ref,
+        dnnl_data_type_t &sdt, dnnl_data_type_t &ddt) {
     sdt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     ddt = convert_dt(base_op_ref.out_lts_.front().get_data_type());
     return true;
 }
 
 bool get_reduction_alg(
-        const deserialized_op &base_op_ref, ::reduction::alg_t &alg) {
+        const deserialized_op_t &base_op_ref, ::reduction::alg_t &alg) {
     static const std::unordered_map<std::string, ::reduction::alg_t>
             map_kind_to_alg {{"ReduceSum", ::reduction::alg_t::sum},
                     {"ReduceProd", ::reduction::alg_t::mul},
@@ -1649,14 +1654,14 @@ bool get_reduction_alg(
     return true;
 }
 
-bool get_reduction_p(const deserialized_op &base_op_ref, float &p) {
+bool get_reduction_p(const deserialized_op_t &base_op_ref, float &p) {
     const auto &op_kind = base_op_ref.kind_;
     p = (op_kind == "ReduceL2") ? 2.f : 1.f;
     return true;
 }
 
 ::reduction::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::reduction::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(reduction::get_reduction_prb_vdims(
                                      base_op_ref, op_setting.prb_vdims),
@@ -1684,7 +1689,7 @@ bool get_reduction_p(const deserialized_op &base_op_ref, float &p) {
 
 namespace reorder {
 
-bool get_reorder_dt(const deserialized_op &base_op_ref, dnnl_data_type_t &sdt,
+bool get_reorder_dt(const deserialized_op_t &base_op_ref, dnnl_data_type_t &sdt,
         dnnl_data_type_t &ddt) {
     sdt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     ddt = convert_dt(base_op_ref.out_lts_.front().get_data_type());
@@ -1697,7 +1702,7 @@ bool get_reorder_dt(const deserialized_op &base_op_ref, dnnl_data_type_t &sdt,
     return true;
 }
 
-bool get_reorder_stag_and_dtag(const deserialized_op &base_op_ref,
+bool get_reorder_stag_and_dtag(const deserialized_op_t &base_op_ref,
         std::string &stag, std::string &dtag) {
     bool ret = get_driver_stag_and_dtag(base_op_ref, stag, dtag);
     if (!ret) return false;
@@ -1705,7 +1710,7 @@ bool get_reorder_stag_and_dtag(const deserialized_op &base_op_ref,
     return ret;
 }
 
-bool get_reorder_attrs(const deserialized_op &base_op_ref,
+bool get_reorder_attrs(const deserialized_op_t &base_op_ref,
         attr_t::arg_scales_t &arg_scales, attr_t::zero_points_t &zp) {
 
     const auto &op_kind = base_op_ref.kind_;
@@ -1793,7 +1798,7 @@ bool get_reorder_attrs(const deserialized_op &base_op_ref,
 }
 
 ::reorder::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::reorder::settings_t op_setting;
     const auto op_kind = base_op_ref.kind_;
 
@@ -1827,7 +1832,7 @@ bool get_reorder_attrs(const deserialized_op &base_op_ref,
 namespace resampling {
 
 bool get_resampling_desc(
-        const deserialized_op &base_op_ref, ::resampling::desc_t &d) {
+        const deserialized_op_t &base_op_ref, ::resampling::desc_t &d) {
     std::string data_format {};
     base_op_ref.get_attr_string(data_format, "data_format");
 
@@ -1852,7 +1857,7 @@ bool get_resampling_desc(
     return true;
 }
 
-bool get_resampling_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_resampling_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
 
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "Interpolate") {
@@ -1866,7 +1871,7 @@ bool get_resampling_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 }
 
-bool get_resampling_dt(const deserialized_op &base_op_ref,
+bool get_resampling_dt(const deserialized_op_t &base_op_ref,
         dnnl_data_type_t &sdt, dnnl_data_type_t &ddt) {
     sdt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     ddt = convert_dt(base_op_ref.out_lts_.front().get_data_type());
@@ -1874,7 +1879,7 @@ bool get_resampling_dt(const deserialized_op &base_op_ref,
 }
 
 bool get_resampling_alg(
-        const deserialized_op &base_op_ref, ::resampling::alg_t &alg) {
+        const deserialized_op_t &base_op_ref, ::resampling::alg_t &alg) {
     std::string alg_value {};
     base_op_ref.get_attr_string(alg_value, "mode");
     if (alg_value == "linear" || alg_value == "bilinear"
@@ -1890,7 +1895,7 @@ bool get_resampling_alg(
 }
 
 ::resampling::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::resampling::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             resampling::get_resampling_desc(base_op_ref, op_setting.desc), res);
@@ -1914,7 +1919,7 @@ bool get_resampling_alg(
 
 namespace softmax {
 
-bool get_softmax_dir(const deserialized_op &base_op_ref, dir_t &dir) {
+bool get_softmax_dir(const deserialized_op_t &base_op_ref, dir_t &dir) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "SoftMax" || op_kind == "LogSoftmax") {
         dir = dir_t::FWD_D;
@@ -1928,8 +1933,8 @@ bool get_softmax_dir(const deserialized_op &base_op_ref, dir_t &dir) {
     return true;
 };
 
-bool get_softmax_sdt_and_ddt(
-        const deserialized_op &base_op_ref, ::softmax::settings_t &op_setting) {
+bool get_softmax_sdt_and_ddt(const deserialized_op_t &base_op_ref,
+        ::softmax::settings_t &op_setting) {
     const auto &dt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
     op_setting.sdt.front() = dt;
     op_setting.ddt.front() = dt;
@@ -1937,7 +1942,7 @@ bool get_softmax_sdt_and_ddt(
 }
 
 bool get_softmax_alg(
-        const deserialized_op &base_op_ref, ::softmax::alg_t &alg) {
+        const deserialized_op_t &base_op_ref, ::softmax::alg_t &alg) {
     const auto &op_kind = base_op_ref.kind_;
     if (op_kind == "SoftMax" || op_kind == "SoftMaxBackward") {
         alg = ::softmax::alg_t::SOFTMAX;
@@ -1951,7 +1956,7 @@ bool get_softmax_alg(
 };
 
 ::softmax::settings_t get_setting(
-        const deserialized_op &base_op_ref, res_t *res) {
+        const deserialized_op_t &base_op_ref, res_t *res) {
     ::softmax::settings_t op_setting;
     DNN_GRAPH_CHECK_SETTINGS(
             get_prb_dims(base_op_ref, op_setting.prb_dims), res);

--- a/tests/benchdnn/graph/setting_handler.hpp
+++ b/tests/benchdnn/graph/setting_handler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ namespace graph {
 #define DECLARE_GET_SETTING(driver) \
     namespace driver { \
     ::driver::settings_t get_setting( \
-            const deserialized_op &base_op_ref, res_t *res); \
+            const deserialized_op_t &base_op_ref, res_t *res); \
     }
 
 DECLARE_GET_SETTING(binary);
@@ -67,8 +67,8 @@ using req = typename std::enable_if<B, bool>::type;
 #define DECLARE_TEMPLATE_GET_SETTING(driver) \
     template <typename setting_t, \
             req<std::is_same<setting_t, ::driver::settings_t>::value> = true> \
-    setting_t get_setting(const deserialized_op &base_op_ref, res_t *res) { \
-        deserialized_op base_op = base_op_ref; \
+    setting_t get_setting(const deserialized_op_t &base_op_ref, res_t *res) { \
+        deserialized_op_t base_op = base_op_ref; \
         for (size_t i = 0; i < base_op.in_lts_.size(); i++) { \
             if (base_op.in_lts_[i].shape_.size() == 0) \
                 base_op.in_lts_[i].shape_.emplace_back(1); \
@@ -104,7 +104,7 @@ DECLARE_TEMPLATE_GET_SETTING(softmax);
 
 namespace eltwise {
 
-bool get_flag_use_dst_for_bwd_compute(const deserialized_op &base_op_ref);
+bool get_flag_use_dst_for_bwd_compute(const deserialized_op_t &base_op_ref);
 
 const std::unordered_map<std::string, ::eltwise::alg_t> &get_eltwise_kind_map();
 

--- a/tests/benchdnn/graph/setting_handler.hpp
+++ b/tests/benchdnn/graph/setting_handler.hpp
@@ -70,15 +70,15 @@ using req = typename std::enable_if<B, bool>::type;
     setting_t get_setting(const deserialized_op_t &base_op_ref, res_t *res) { \
         deserialized_op_t base_op = base_op_ref; \
         for (size_t i = 0; i < base_op.in_lts_.size(); i++) { \
-            if (base_op.in_lts_[i].shape_.size() == 0) \
+            if (base_op.in_lts_[i].shape_.empty()) \
                 base_op.in_lts_[i].shape_.emplace_back(1); \
-            if (base_op.in_lts_[i].stride_.size() == 0) \
+            if (base_op.in_lts_[i].stride_.empty()) \
                 base_op.in_lts_[i].stride_.emplace_back(1); \
         } \
         for (size_t i = 0; i < base_op.out_lts_.size(); i++) { \
-            if (base_op.out_lts_[i].shape_.size() == 0) \
+            if (base_op.out_lts_[i].shape_.empty()) \
                 base_op.out_lts_[i].shape_.emplace_back(1); \
-            if (base_op.out_lts_[i].stride_.size() == 0) \
+            if (base_op.out_lts_[i].stride_.empty()) \
                 base_op.out_lts_[i].stride_.emplace_back(1); \
         } \
         return driver::get_setting(base_op, res); \

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -85,22 +85,22 @@ enum { CRIT = 0x001, WARN = 0x002, NEED_CLEANUP = 0x004 };
 #define DNN_GRAPH_SAFE(f, s, ss) \
     do { \
         try { \
-            f; \
+            (f); \
         } catch (const dnnl::error &e) { \
-            if ((s & CRIT) || (s & WARN)) { \
+            if (((s)&CRIT) || ((s)&WARN)) { \
                 bdnn_state_t bs = convert_state(e.status); \
-                ss->state = bs.state; \
-                if (ss->state == res_state_t::SKIPPED) { \
-                    ss->reason = bs.reason; \
+                (ss)->state = bs.state; \
+                if ((ss)->state == res_state_t::SKIPPED) { \
+                    (ss)->reason = bs.reason; \
                 } else { \
                     BENCHDNN_PRINT(0, \
                             "Error: Function '%s' at (%s:%d) returned '%s'\n", \
                             __FUNCTION__, __FILE__, __LINE__, e.what()); \
                 } \
                 fflush(0); \
-                if (s & CRIT) exit(2); \
+                if ((s)&CRIT) exit(2); \
             } \
-            if (!(s & NEED_CLEANUP)) return FAIL; \
+            if (!((s)&NEED_CLEANUP)) return FAIL; \
         } \
     } while (0)
 

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -104,10 +104,9 @@ enum { CRIT = 0x001, WARN = 0x002, NEED_CLEANUP = 0x004 };
         } \
     } while (0)
 
-typedef std::function<void(dnnl::stream &,
+using perf_function_t = std::function<void(dnnl::stream &,
         const std::vector<dnnl::graph::tensor> &inputs,
-        const std::vector<dnnl::graph::tensor> &outputs)>
-        perf_function_t;
+        const std::vector<dnnl::graph::tensor> &outputs)>;
 
 void compiled_partition_executor(dnnl::graph::compiled_partition &cp,
         dnnl::stream &stream, const std::vector<dnnl::graph::tensor> &inputs,


### PR DESCRIPTION
MFDNN-13013: fix clang-tidy warning in headers.

Corresponding violations are explained by the commit messages.