### PR TITLE
[backport] gpu: generic: Fix dropout tests

### DIFF
--- a/src/gpu/generic/sycl/matmul_kernels.hpp
+++ b/src/gpu/generic/sycl/matmul_kernels.hpp
@@ -286,14 +286,14 @@ struct matmul_kernel_fwd_t {
             }
         }
 
-        void dropout(xpu::sycl::out_memory_arg_t dropout_mask, int threshold,
-                int seed, int inv_q, int offset, int row_stride) {
+        void dropout(xpu::sycl::out_memory_arg_t dropout_mask, uint threshold,
+                uint seed, float inv_q, int offset, int row_stride) {
             for (int row = 0; row < Rows; row++) {
                 for (int col = 0; col < Cols / vec_len; col++) {
                     for (int vec_el = 0; vec_el < vec_len; vec_el++) {
                         int dst_off = offset + row * row_stride + col * vec_len
                                 + vec_el;
-                        int random
+                        uint random
                                 = ::dnnl::impl::math::philox4x32(dst_off, seed);
                         char dropout = random > threshold;
                         data[row][col][vec_el]


### PR DESCRIPTION
# Description

Backport from https://github.com/oneapi-src/oneDNN/pull/2677 to fix matmul postop.  

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
Done in https://github.com/oneapi-src/oneDNN/pull/2677.
