### PR TITLE
Minor improvements for arg_usage and post-ops verbose

### DIFF
--- a/src/common/batch_normalization_pd.hpp
+++ b/src/common/batch_normalization_pd.hpp
@@ -154,8 +154,9 @@ struct batch_normalization_fwd_pd_t : public batch_normalization_pd_t {
 
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC) return arg_usage_t::input;
-        if (arg == DNNL_ARG_SRC_1 && fuse_norm_add_relu())
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_SRC_1)
+            return fuse_norm_add_relu() ? arg_usage_t::input
+                                        : arg_usage_t::unused;
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
         if (utils::one_of(arg, DNNL_ARG_MEAN, DNNL_ARG_VARIANCE)) {
@@ -164,11 +165,14 @@ struct batch_normalization_fwd_pd_t : public batch_normalization_pd_t {
             return arg_usage_t::unused;
         }
 
-        if (arg == DNNL_ARG_SCALE && use_scale()) return arg_usage_t::input;
-        if (arg == DNNL_ARG_SHIFT && use_shift()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_SCALE)
+            return use_scale() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_SHIFT)
+            return use_shift() ? arg_usage_t::input : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_WORKSPACE && !types::is_zero_md(workspace_md()))
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::output
+                                                      : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }
@@ -256,20 +260,24 @@ struct batch_normalization_bwd_pd_t : public batch_normalization_pd_t {
                     DNNL_ARG_DIFF_DST))
             return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_SCALE && use_scale()) return arg_usage_t::input;
-        if (arg == DNNL_ARG_SHIFT && use_shift()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_SCALE)
+            return use_scale() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_SHIFT)
+            return use_shift() ? arg_usage_t::input : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_WORKSPACE && !types::is_zero_md(workspace_md()))
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::input
+                                                      : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DIFF_SRC) return arg_usage_t::output;
-        if (arg == DNNL_ARG_DIFF_SRC_1 && fuse_norm_add_relu())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DIFF_SRC_1)
+            return fuse_norm_add_relu() ? arg_usage_t::output
+                                        : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_DIFF_SCALE && use_scale())
-            return arg_usage_t::output;
-        if (arg == DNNL_ARG_DIFF_SHIFT && use_shift())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DIFF_SCALE)
+            return use_scale() ? arg_usage_t::output : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_SHIFT)
+            return use_shift() ? arg_usage_t::output : arg_usage_t::unused;
         return primitive_desc_t::arg_usage(arg);
     }
 

--- a/src/common/convolution_pd.hpp
+++ b/src/common/convolution_pd.hpp
@@ -264,7 +264,8 @@ struct convolution_fwd_pd_t : public convolution_pd_t {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_WEIGHTS))
             return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_BIAS && with_bias()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_BIAS)
+            return with_bias() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
@@ -426,8 +427,8 @@ struct convolution_bwd_weights_pd_t : public convolution_pd_t {
 
         if (arg == DNNL_ARG_DIFF_WEIGHTS) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_DIFF_BIAS && with_bias())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DIFF_BIAS)
+            return with_bias() ? arg_usage_t::output : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }

--- a/src/common/deconvolution_pd.hpp
+++ b/src/common/deconvolution_pd.hpp
@@ -209,7 +209,8 @@ struct deconvolution_fwd_pd_t : public deconvolution_pd_t {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_WEIGHTS))
             return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_BIAS && with_bias()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_BIAS)
+            return with_bias() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
@@ -335,8 +336,8 @@ struct deconvolution_bwd_weights_pd_t : public deconvolution_pd_t {
 
         if (arg == DNNL_ARG_DIFF_WEIGHTS) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_DIFF_BIAS && with_bias())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DIFF_BIAS)
+            return with_bias() ? arg_usage_t::output : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }

--- a/src/common/eltwise_pd.hpp
+++ b/src/common/eltwise_pd.hpp
@@ -196,8 +196,10 @@ struct eltwise_bwd_pd_t : public eltwise_pd_t {
     using hint_class = eltwise_fwd_pd_t;
 
     arg_usage_t arg_usage(int arg) const override {
-        if (use_dst() ? arg == DNNL_ARG_DST : arg == DNNL_ARG_SRC)
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_SRC)
+            return !use_dst() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DST)
+            return use_dst() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DIFF_DST) return arg_usage_t::input;
         if (arg == DNNL_ARG_DIFF_SRC) return arg_usage_t::output;

--- a/src/common/group_normalization_pd.hpp
+++ b/src/common/group_normalization_pd.hpp
@@ -123,8 +123,10 @@ struct group_normalization_fwd_pd_t : public group_normalization_pd_t {
             return arg_usage_t::unused;
         }
 
-        if (arg == DNNL_ARG_SCALE && use_scale()) return arg_usage_t::input;
-        if (arg == DNNL_ARG_SHIFT && use_shift()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_SCALE)
+            return use_scale() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_SHIFT)
+            return use_shift() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
         return primitive_desc_t::arg_usage(arg);
@@ -216,17 +218,16 @@ struct group_normalization_bwd_pd_t : public group_normalization_pd_t {
                     DNNL_ARG_DIFF_DST))
             return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_SCALE && use_scale()) return arg_usage_t::input;
-
-        if (arg == DNNL_ARG_WORKSPACE && !types::is_zero_md(workspace_md()))
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_SCALE)
+            return use_scale() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DIFF_SRC) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_DIFF_SCALE && use_scale())
-            return arg_usage_t::output;
-        if (arg == DNNL_ARG_DIFF_SHIFT && use_shift())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DIFF_SCALE)
+            return use_scale() ? arg_usage_t::output : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_SHIFT)
+            return use_shift() ? arg_usage_t::output : arg_usage_t::unused;
+
         return primitive_desc_t::arg_usage(arg);
     }
 

--- a/src/common/inner_product_pd.hpp
+++ b/src/common/inner_product_pd.hpp
@@ -204,7 +204,8 @@ struct inner_product_fwd_pd_t : public inner_product_pd_t {
         if (utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_WEIGHTS))
             return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_BIAS && with_bias()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_BIAS)
+            return with_bias() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
@@ -342,8 +343,8 @@ struct inner_product_bwd_weights_pd_t : public inner_product_pd_t {
 
         if (arg == DNNL_ARG_DIFF_WEIGHTS) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_DIFF_BIAS && with_bias())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DIFF_BIAS)
+            return with_bias() ? arg_usage_t::output : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }

--- a/src/common/layer_normalization_pd.hpp
+++ b/src/common/layer_normalization_pd.hpp
@@ -170,8 +170,10 @@ struct layer_normalization_fwd_pd_t : public layer_normalization_pd_t {
             return arg_usage_t::unused;
         }
 
-        if (arg == DNNL_ARG_SCALE && use_scale()) return arg_usage_t::input;
-        if (arg == DNNL_ARG_SHIFT && use_shift()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_SCALE)
+            return use_scale() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_SHIFT)
+            return use_shift() ? arg_usage_t::input : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }
@@ -275,15 +277,15 @@ struct layer_normalization_bwd_pd_t : public layer_normalization_pd_t {
                     DNNL_ARG_DIFF_DST))
             return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_SCALE && use_scale()) return arg_usage_t::input;
-        if (arg == DNNL_ARG_SHIFT && use_shift()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_SCALE)
+            return use_scale() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DIFF_SRC) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_DIFF_SCALE && use_scale())
-            return arg_usage_t::output;
-        if (arg == DNNL_ARG_DIFF_SHIFT && use_shift())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DIFF_SCALE)
+            return use_scale() ? arg_usage_t::output : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_SHIFT)
+            return use_shift() ? arg_usage_t::output : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }
@@ -332,7 +334,7 @@ struct layer_normalization_bwd_pd_t : public layer_normalization_pd_t {
         return index == 0 ? &diff_scaleshift_md_ : &glob_zero_md;
     }
 
-    int n_inputs() const override { return 4 + use_scale() + use_shift(); }
+    int n_inputs() const override { return 4 + use_scale(); }
     int n_outputs() const override {
         return 1
                 + (desc_.prop_kind == prop_kind::backward)

--- a/src/common/lrn_pd.hpp
+++ b/src/common/lrn_pd.hpp
@@ -106,8 +106,9 @@ struct lrn_fwd_pd_t : public lrn_pd_t {
 
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_WORKSPACE && (!types::is_zero_md(workspace_md())))
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::output
+                                                      : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }
@@ -166,8 +167,9 @@ struct lrn_bwd_pd_t : public lrn_pd_t {
 
         if (arg == DNNL_ARG_DIFF_SRC) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_WORKSPACE && (!types::is_zero_md(workspace_md())))
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::input
+                                                      : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -60,9 +60,11 @@ struct matmul_pd_t : public primitive_desc_t {
         const bool input = utils::one_of(arg, DNNL_ARG_SRC, DNNL_ARG_WEIGHTS);
         if (input) return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_BIAS && with_bias()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_BIAS)
+            return with_bias() ? arg_usage_t::input : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_REDUCE && with_reduce()) return arg_usage_t::output;
+        if (arg == DNNL_ARG_REDUCE)
+            return with_reduce() ? arg_usage_t::output : arg_usage_t::unused;
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
         return primitive_desc_t::arg_usage(arg);

--- a/src/common/pooling_pd.hpp
+++ b/src/common/pooling_pd.hpp
@@ -184,8 +184,9 @@ struct pooling_fwd_pd_t : public pooling_pd_t {
 
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_WORKSPACE && (!types::is_zero_md(workspace_md())))
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::output
+                                                      : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }
@@ -254,8 +255,9 @@ struct pooling_bwd_pd_t : public pooling_pd_t {
 
         if (arg == DNNL_ARG_DIFF_SRC) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_WORKSPACE && (!types::is_zero_md(workspace_md())))
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::input
+                                                      : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -152,32 +152,33 @@ struct primitive_desc_t : public c_compatible {
         using types::is_zero_md;
         if (arg & DNNL_ARG_ATTR_ZERO_POINTS) {
             int zp_arg = arg & ~DNNL_ARG_ATTR_ZERO_POINTS;
-            if (!attr()->zero_points_.has_default_values(zp_arg))
-                return arg_usage_t::input;
+            return !attr()->zero_points_.has_default_values(zp_arg)
+                    ? arg_usage_t::input
+                    : arg_usage_t::unused;
         }
         if (arg & DNNL_ARG_ATTR_SCALES) {
             int scale_arg = arg & ~DNNL_ARG_ATTR_SCALES;
-            if (!attr()->scales_.has_default_values(scale_arg))
-                return arg_usage_t::input;
+            return !attr()->scales_.has_default_values(scale_arg)
+                    ? arg_usage_t::input
+                    : arg_usage_t::unused;
         }
-        if ((arg == (DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0))
-                && !attr()->scales_.has_default_values(DNNL_ARG_SRC_0))
-            return arg_usage_t::input;
-        if ((arg == (DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_1))
-                && !attr()->scales_.has_default_values(DNNL_ARG_SRC_1))
-            return arg_usage_t::input;
-        if (arg == DNNL_ARG_SCRATCHPAD && !is_zero_md(scratchpad_md()))
-            return arg_usage_t::output;
-        if (arg == DNNL_ARG_ATTR_DROPOUT_MASK
-                && !attr()->dropout_.has_default_values())
-            return arg_usage_t::output;
-        if ((arg == DNNL_ARG_ATTR_DROPOUT_PROBABILITY
-                    || arg == DNNL_ARG_ATTR_DROPOUT_SEED)
-                && !attr()->dropout_.has_default_values())
-            return arg_usage_t::input;
-        if ((arg == DNNL_ARG_ATTR_ROUNDING_SEED)
-                && !attr()->rounding_mode_.has_default_values())
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_SCRATCHPAD)
+            return !is_zero_md(scratchpad_md()) ? arg_usage_t::output
+                                                : arg_usage_t::unused;
+        if (arg == DNNL_ARG_ATTR_DROPOUT_MASK)
+            return !attr()->dropout_.has_default_values() ? arg_usage_t::output
+                                                          : arg_usage_t::unused;
+        if (arg == DNNL_ARG_ATTR_DROPOUT_PROBABILITY)
+            return !attr()->dropout_.has_default_values() ? arg_usage_t::input
+                                                          : arg_usage_t::unused;
+        if (arg == DNNL_ARG_ATTR_DROPOUT_SEED)
+            return !attr()->dropout_.has_default_values() ? arg_usage_t::input
+                                                          : arg_usage_t::unused;
+        if (arg == DNNL_ARG_ATTR_ROUNDING_SEED)
+            return !attr()->rounding_mode_.has_default_values()
+                    ? arg_usage_t::input
+                    : arg_usage_t::unused;
+
         for (int idx = 0; idx < attr()->post_ops_.len(); ++idx) {
             using namespace primitive_kind;
             if (post_op_has_proper_input(

--- a/src/common/rnn_pd.hpp
+++ b/src/common/rnn_pd.hpp
@@ -255,36 +255,41 @@ struct rnn_fwd_pd_t : public rnn_pd_t {
     arg_usage_t arg_usage(int arg) const override {
         if (arg == DNNL_ARG_SRC_LAYER) return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_AUGRU_ATTENTION && with_augru_attention())
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_AUGRU_ATTENTION)
+            return with_augru_attention() ? arg_usage_t::input
+                                          : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_SRC_ITER && with_src_iter())
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_SRC_ITER)
+            return with_src_iter() ? arg_usage_t::input : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_SRC_ITER_C && with_src_iter_c())
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_SRC_ITER_C)
+            return with_src_iter_c() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (utils::one_of(arg, DNNL_ARG_WEIGHTS_LAYER, DNNL_ARG_WEIGHTS_ITER))
             return arg_usage_t::input;
 
-        if (arg == DNNL_ARG_WEIGHTS_PEEPHOLE && is_lstm_peephole())
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_WEIGHTS_PEEPHOLE)
+            return is_lstm_peephole() ? arg_usage_t::input
+                                      : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_WEIGHTS_PROJECTION && is_lstm_projection())
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_WEIGHTS_PROJECTION)
+            return is_lstm_projection() ? arg_usage_t::input
+                                        : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_BIAS && with_bias()) return arg_usage_t::input;
+        if (arg == DNNL_ARG_BIAS)
+            return with_bias() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_DST_LAYER) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_DST_ITER && with_dst_iter())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DST_ITER)
+            return with_dst_iter() ? arg_usage_t::output : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_DST_ITER_C && with_dst_iter() && is_lstm())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_DST_ITER_C)
+            return with_dst_iter_c() ? arg_usage_t::output
+                                     : arg_usage_t::unused;
 
-        if (arg == DNNL_ARG_WORKSPACE && is_training())
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return is_training() ? arg_usage_t::output : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }
@@ -341,53 +346,52 @@ struct rnn_bwd_pd_t : public rnn_pd_t {
                     DNNL_ARG_DIFF_WEIGHTS_LAYER, DNNL_ARG_DIFF_WEIGHTS_ITER))
             return arg_usage_t::output;
 
-        if (with_augru_attention()) {
-            if (arg == DNNL_ARG_AUGRU_ATTENTION) return arg_usage_t::input;
-            if (arg == DNNL_ARG_DIFF_AUGRU_ATTENTION)
-                return arg_usage_t::output;
-        }
+        if (arg == DNNL_ARG_AUGRU_ATTENTION)
+            return with_augru_attention() ? arg_usage_t::input
+                                          : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_AUGRU_ATTENTION)
+            return with_augru_attention() ? arg_usage_t::output
+                                          : arg_usage_t::unused;
 
-        if (is_lstm_peephole()) {
-            if (arg == DNNL_ARG_WEIGHTS_PEEPHOLE) return arg_usage_t::input;
+        if (arg == DNNL_ARG_WEIGHTS_PEEPHOLE)
+            return is_lstm_peephole() ? arg_usage_t::input
+                                      : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE)
+            return is_lstm_peephole() ? arg_usage_t::output
+                                      : arg_usage_t::unused;
 
-            if (arg == DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE)
-                return arg_usage_t::output;
-        }
+        if (arg == DNNL_ARG_WEIGHTS_PROJECTION)
+            return is_lstm_projection() ? arg_usage_t::input
+                                        : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_WEIGHTS_PROJECTION)
+            return is_lstm_projection() ? arg_usage_t::output
+                                        : arg_usage_t::unused;
 
-        if (is_lstm_projection()) {
-            if (arg == DNNL_ARG_WEIGHTS_PROJECTION) return arg_usage_t::input;
+        if (arg == DNNL_ARG_BIAS)
+            return with_bias() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_BIAS)
+            return with_bias() ? arg_usage_t::output : arg_usage_t::unused;
 
-            if (arg == DNNL_ARG_DIFF_WEIGHTS_PROJECTION)
-                return arg_usage_t::output;
-        }
+        if (arg == DNNL_ARG_SRC_ITER)
+            return with_src_iter() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_SRC_ITER)
+            return with_src_iter() ? arg_usage_t::output : arg_usage_t::unused;
 
-        if (with_bias()) {
-            if (arg == DNNL_ARG_BIAS) return arg_usage_t::input;
+        if (arg == DNNL_ARG_SRC_ITER_C)
+            return with_src_iter_c() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_SRC_ITER_C)
+            return with_src_iter_c() ? arg_usage_t::output
+                                     : arg_usage_t::unused;
 
-            if (arg == DNNL_ARG_DIFF_BIAS) return arg_usage_t::output;
-        }
+        if (arg == DNNL_ARG_DST_ITER)
+            return with_dst_iter() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_DST_ITER)
+            return with_dst_iter() ? arg_usage_t::input : arg_usage_t::unused;
 
-        if (with_src_iter()) {
-            if (arg == DNNL_ARG_SRC_ITER) return arg_usage_t::input;
-
-            if (arg == DNNL_ARG_DIFF_SRC_ITER) return arg_usage_t::output;
-        }
-
-        if (with_src_iter_c()) {
-            if (arg == DNNL_ARG_SRC_ITER_C) return arg_usage_t::input;
-
-            if (arg == DNNL_ARG_DIFF_SRC_ITER_C) return arg_usage_t::output;
-        }
-
-        if (with_dst_iter()
-                && utils::one_of(
-                        arg, DNNL_ARG_DST_ITER, DNNL_ARG_DIFF_DST_ITER))
-            return arg_usage_t::input;
-
-        if (with_dst_iter_c()
-                && utils::one_of(
-                        arg, DNNL_ARG_DST_ITER_C, DNNL_ARG_DIFF_DST_ITER_C))
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_DST_ITER_C)
+            return with_dst_iter_c() ? arg_usage_t::input : arg_usage_t::unused;
+        if (arg == DNNL_ARG_DIFF_DST_ITER_C)
+            return with_dst_iter_c() ? arg_usage_t::input : arg_usage_t::unused;
 
         if (arg == DNNL_ARG_WORKSPACE) return arg_usage_t::input;
 

--- a/src/common/sdpa_pd.hpp
+++ b/src/common/sdpa_pd.hpp
@@ -48,6 +48,9 @@ struct sdpa_pd_t : public primitive_desc_t {
     }
 
     arg_usage_t arg_usage(int arg) const override {
+        // TODO: this is broken for cases when the user passes quantization
+        // memories unconditionally but the primitive desc is not set up for
+        // quantization.
         if (utils::one_of(arg, DNNL_ARG_QUERIES, DNNL_ARG_KEYS, DNNL_ARG_VALUES,
                     DNNL_ARG_ATTN_MASK, DNNL_ARG_SCALE,
                     DNNL_ARG_ATTR_SCALES | DNNL_ARG_KEYS,

--- a/src/common/softmax_pd.hpp
+++ b/src/common/softmax_pd.hpp
@@ -128,8 +128,9 @@ struct softmax_fwd_pd_t : public softmax_pd_t {
 
         if (arg == DNNL_ARG_DST) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_WORKSPACE && (!types::is_zero_md(workspace_md())))
-            return arg_usage_t::output;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::output
+                                                      : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }
@@ -203,8 +204,9 @@ struct softmax_bwd_pd_t : public softmax_pd_t {
 
         if (arg == DNNL_ARG_DIFF_SRC) return arg_usage_t::output;
 
-        if (arg == DNNL_ARG_WORKSPACE && (!types::is_zero_md(workspace_md())))
-            return arg_usage_t::input;
+        if (arg == DNNL_ARG_WORKSPACE)
+            return !types::is_zero_md(workspace_md()) ? arg_usage_t::input
+                                                      : arg_usage_t::unused;
 
         return primitive_desc_t::arg_usage(arg);
     }

--- a/src/cpu/ref_fused_convolution.hpp
+++ b/src/cpu/ref_fused_convolution.hpp
@@ -159,9 +159,9 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
 
-            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS)
-                    && attr_post_op_dw_inputs() > 1)
-                return arg_usage_t::input;
+            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return attr_post_op_dw_inputs() > 1 ? arg_usage_t::input
+                                                    : arg_usage_t::unused;
 
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_SRC))
                 return arg_usage_t::input;

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -29,6 +29,9 @@ namespace x64 {
 
 namespace eltwise_injector {
 
+#define VCHECK_ELT_INJ_BOOL(cond, msg) \
+    VCONDCHECK(primitive, create, check, binary_injector, cond, false, msg);
+
 bool is_isa_supported(cpu_isa_t isa) {
     return is_superset(isa, sse41);
 }
@@ -48,10 +51,13 @@ bool is_alg_supported(alg_kind_t alg) {
 }
 
 bool is_supported(cpu_isa_t isa, alg_kind_t alg, data_type_t dt) {
-    if (dt != data_type::f32) return false;
-
-    return is_isa_supported(isa) && is_alg_supported(alg);
+    VCHECK_ELT_INJ_BOOL(dt == data_type::f32, VERBOSE_UNSUPPORTED_DT);
+    VCHECK_ELT_INJ_BOOL(is_isa_supported(isa), VERBOSE_UNSUPPORTED_ISA);
+    VCHECK_ELT_INJ_BOOL(is_alg_supported(alg), "Unsupported algorithm");
+    return true;
 }
+
+#undef VCHECK_ELT_INJ_BOOL
 
 } // namespace eltwise_injector
 

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -118,9 +118,9 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
 
-            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS)
-                    && attr_post_op_dw_inputs() > 1)
-                return arg_usage_t::input;
+            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return attr_post_op_dw_inputs() > 1 ? arg_usage_t::input
+                                                    : arg_usage_t::unused;
 
             return convolution_fwd_pd_t::arg_usage(arg);
         }

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -122,9 +122,9 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
 
-            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS)
-                    && attr_post_op_dw_inputs() > 1)
-                return arg_usage_t::input;
+            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return attr_post_op_dw_inputs() > 1 ? arg_usage_t::input
+                                                    : arg_usage_t::unused;
 
             return convolution_fwd_pd_t::arg_usage(arg);
         }

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -130,9 +130,9 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
 
-            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS)
-                    && attr_post_op_dw_inputs() > 1)
-                return arg_usage_t::input;
+            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return attr_post_op_dw_inputs() > 1 ? arg_usage_t::input
+                                                    : arg_usage_t::unused;
 
             return convolution_fwd_pd_t::arg_usage(arg);
         }

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -150,9 +150,9 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
 
-            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS)
-                    && attr_post_op_dw_inputs() > 1)
-                return arg_usage_t::input;
+            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return attr_post_op_dw_inputs() > 1 ? arg_usage_t::input
+                                                    : arg_usage_t::unused;
 
             return convolution_fwd_pd_t::arg_usage(arg);
         }

--- a/src/cpu/x64/jit_sse41_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.hpp
@@ -105,9 +105,9 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
 
-            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS)
-                    && attr_post_op_dw_inputs() > 1)
-                return arg_usage_t::input;
+            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return attr_post_op_dw_inputs() > 1 ? arg_usage_t::input
+                                                    : arg_usage_t::unused;
 
             return convolution_fwd_pd_t::arg_usage(arg);
         }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -150,9 +150,9 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
 
-            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS)
-                    && attr_post_op_dw_inputs() > 1)
-                return arg_usage_t::input;
+            if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_BIAS))
+                return attr_post_op_dw_inputs() > 1 ? arg_usage_t::input
+                                                    : arg_usage_t::unused;
 
             return convolution_fwd_pd_t::arg_usage(arg);
         }

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1721,7 +1721,9 @@ int sparse_options_t::from_str(const std::string &s) {
     int options_count = 0;
     size_t start_pos = 0;
     while (start_pos != std::string::npos) {
-        auto subs = parser::get_substr(s, start_pos, ':');
+        // Note: `csr+0.99::` is a valid input, dangling `:` is legit.
+        auto subs = parser::get_substr(
+                s, start_pos, ':', /* allow_dangling = */ true);
 
         if (subs.empty()) {
             add(get_arg(options_count), sparse_options_t::def_encoding,

--- a/tests/benchdnn/utils/parser.hpp
+++ b/tests/benchdnn/utils/parser.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -309,13 +309,16 @@ int parse_last_argument();
 // Function returns a substring of a given string @p `s`, using @p `start_pos`
 // to start a search from this index in string and @p `delim` as a stop symbol
 // and sets a @p `start_pos` to the next symbol after `delim` or to `npos`.
+// `allow_dangling` skips a check for dangling symbol at the end of the string
+// as some inputs ending on a `delim` in rare cases are legit.
 // E.g. 1) s=apple:juice, start_pos=0, delim=':'
 //         get_substr -> apple && start_pos -> 6
 //      2) s=apple:juice, start_pos=6, delim=':'
 //         get_substr -> juice && start_pos -> npos
 //      3) s=apple:juice, start_pos=0, delim=';'
 //         get_substr -> apple:juice && start_pos -> npos
-std::string get_substr(const std::string &s, size_t &start_pos, char delim);
+std::string get_substr(const std::string &s, size_t &start_pos, char delim,
+        bool allow_dangling = false);
 
 } // namespace parser
 


### PR DESCRIPTION
PR includes:
* Better handling of dangling symbols on the benchdnn input line.
* `arg_usage` function improvements not to fallback on known arguments but decide on the spot if it's needed or not.
* Verbose diagnostics improvements for post-ops injector and underlying calls.

Last two items are asked by @EgorDuplensky from OV team.