### PR TITLE
ci: clang-tidy: speed up clang-tidy

### DIFF
--- a/.github/automation/x64/build_linters.sh
+++ b/.github/automation/x64/build_linters.sh
@@ -21,7 +21,9 @@ if [[ "$ONEDNN_ACTION" == "configure" ]]; then
           -DDNNL_CPU_RUNTIME=OMP \
           -DDNNL_GPU_RUNTIME=OCL \
           -DDNNL_WERROR=ON \
-          -DDNNL_BUILD_FOR_CI=ON
+          -DDNNL_BUILD_FOR_CI=ON \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      for file in `git diff --name-only "$1" | grep '\.cpp$'`; do clang-tidy --header-filter='' ../$file; done
       set +x
     elif [[ "$GITHUB_JOB" == "pr-format-tags" ]]; then
       set -x

--- a/.github/automation/x64/build_linters.sh
+++ b/.github/automation/x64/build_linters.sh
@@ -23,7 +23,6 @@ if [[ "$ONEDNN_ACTION" == "configure" ]]; then
           -DDNNL_WERROR=ON \
           -DDNNL_BUILD_FOR_CI=ON \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-      for file in `git diff --name-only "$1" | grep -E '\.cpp$'`; do clang-tidy --header-filter='' ../$file; done
       set +x
     elif [[ "$GITHUB_JOB" == "pr-format-tags" ]]; then
       set -x

--- a/.github/automation/x64/build_linters.sh
+++ b/.github/automation/x64/build_linters.sh
@@ -23,7 +23,7 @@ if [[ "$ONEDNN_ACTION" == "configure" ]]; then
           -DDNNL_WERROR=ON \
           -DDNNL_BUILD_FOR_CI=ON \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-      for file in `git diff --name-only "$1" | grep '\.cpp$'`; do clang-tidy --header-filter='' ../$file; done
+      for file in `git diff --name-only "$1" | grep -E '\.cpp$'`; do clang-tidy --header-filter='' ../$file; done
       set +x
     elif [[ "$GITHUB_JOB" == "pr-format-tags" ]]; then
       set -x

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout oneDNN
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
 
       - name: Install clang
         run: |
@@ -44,7 +46,11 @@ jobs:
           sudo apt-get install -y clang libomp-dev ocl-icd-libopencl1 ocl-icd-opencl-dev
 
       - name: Configure oneDNN
-        run: .github/automation/x64/build_linters.sh "${{ github.event.pull_request.base.sha }}"
+        run: |
+          .github/automation/x64/build_linters.sh
+          git log -n 10 --oneline
+          git diff --name-only ${{ github.event.pull_request.base.sha }} | grep -E '\.cpp'
+          for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} | grep -E '\.cpp'); do clang-tidy -p build --header-filter='' $file; done
         env:
           ONEDNN_ACTION: configure
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get install -y clang libomp-dev ocl-icd-libopencl1 ocl-icd-opencl-dev
 
       - name: Configure oneDNN
-        run: .github/automation/x64/build_linters.sh
+        run: .github/automation/x64/build_linters.sh "${{ github.event.pull_request.base.sha }}"
         env:
           ONEDNN_ACTION: configure
 

--- a/src/cpu/x64/cpu_barrier.cpp
+++ b/src/cpu/x64/cpu_barrier.cpp
@@ -32,7 +32,7 @@ void generate(
     using namespace Xbyak;
 
     Xbyak::Reg64 reg_tmp = [&]() {
-        /* returns register which is neither reg_ctx nor reg_nthr */
+        /* returns register which is neither reg_ctx nor reg_nthr a*/
         Xbyak::Reg64 regs[] = {util::rax, util::rbx, util::rcx};
         for (size_t i = 0; i < sizeof(regs) / sizeof(regs[0]); ++i)
             if (!utils::one_of(regs[i], reg_ctx, reg_nthr)) return regs[i];


### PR DESCRIPTION
This PR is to speed up clang-tidy builds by building only changed files.