### PR TITLE
src: cpu: aarch64: reorder: Fix f32 acl reorders

### DIFF
--- a/src/cpu/aarch64/acl_reorder.hpp
+++ b/src/cpu/aarch64/acl_reorder.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Arm Ltd. and affiliates
+* Copyright 2023-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -147,13 +147,17 @@ struct acl_reorder_fwd_t : public primitive_t {
             switch (src_md->ndims) {
                 case 2: {
                     if (src_tag == format_tag::ab
-                            && dst_md->data_type == data_type::bf16) { // bf16
+                            && dst_md->data_type == data_type::bf16
+                            && utils::one_of(dst_tag, format_tag::BA8b4a, format_tag::BA4b4a)
+                        ) { // bf16
                         acl_tensor_shape_in = arm_compute::TensorShape(
                                 src_md->dims[0], src_md->dims[1]);
                         acl_tensor_shape_out = arm_compute::TensorShape(
                                 dst_md->padded_dims[0], dst_md->padded_dims[1]);
                     } else if (src_tag == format_tag::ba
-                            && dst_md->data_type == data_type::f32) { // f32
+                            && dst_md->data_type == data_type::f32
+                            && !utils::one_of(dst_tag, format_tag::BA8b4a, format_tag::BA4b4a)
+                        ) { // f32
                         acl_tensor_shape_in = arm_compute::TensorShape(
                                 src_md->dims[1], src_md->dims[0]);
                         acl_tensor_shape_out = arm_compute::TensorShape(

--- a/src/cpu/aarch64/acl_reorder.hpp
+++ b/src/cpu/aarch64/acl_reorder.hpp
@@ -148,16 +148,16 @@ struct acl_reorder_fwd_t : public primitive_t {
                 case 2: {
                     if (src_tag == format_tag::ab
                             && dst_md->data_type == data_type::bf16
-                            && utils::one_of(dst_tag, format_tag::BA8b4a, format_tag::BA4b4a)
-                        ) { // bf16
+                            && utils::one_of(dst_tag, format_tag::BA8b4a,
+                                    format_tag::BA4b4a)) { // bf16
                         acl_tensor_shape_in = arm_compute::TensorShape(
                                 src_md->dims[0], src_md->dims[1]);
                         acl_tensor_shape_out = arm_compute::TensorShape(
                                 dst_md->padded_dims[0], dst_md->padded_dims[1]);
                     } else if (src_tag == format_tag::ba
                             && dst_md->data_type == data_type::f32
-                            && !utils::one_of(dst_tag, format_tag::BA8b4a, format_tag::BA4b4a)
-                        ) { // f32
+                            && !utils::one_of(dst_tag, format_tag::BA8b4a,
+                                    format_tag::BA4b4a)) { // f32
                         acl_tensor_shape_in = arm_compute::TensorShape(
                                 src_md->dims[1], src_md->dims[0]);
                         acl_tensor_shape_out = arm_compute::TensorShape(


### PR DESCRIPTION
Some reorder cases calling ACL reorder kernels are currently giving incorrect results as the kernels do not support them. This commit adds a guard so those cases do not call ACL reorders.

Reproducers:
```
./benchdnn --reorder --stag=ba --dtag=BA8b4a 512x512
./benchdnn --reorder --stag=ba --dtag=BA4b4a 512x512
./benchdnn --reorder --stag=ab --dtag=Ab4a --ddt=bf16 512x512
```
