### PR TITLE
cpu: x64: conv: update estimate_brgemm_ur for better blocking

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -109,7 +109,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         max_regs = isa == isa_undef ? 0 : isa_num_vregs(isa);
     }
 
-    int ur, ur_block, ur_block_tail;
+    int ur, ur_block, ur_block_tail, adj_ocblock;
     int nb_kd, nb_kh, nb_kw;
     int max_regs;
     float eff;
@@ -618,14 +618,31 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
             is_bf32);
+    if (exec_type == exec_vpad) {
+        brg.zp_type_a = src_zero_point ? brgemm_broadcast_t::per_tensor
+                                       : brgemm_broadcast_t::none;
+    }
+    brgemm_attr_t brgattr;
+    brgattr.max_bs = max_batch;
+    max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
+    brgattr.max_top_vpad = max_vpad;
+    brgattr.max_bottom_vpad = max_vpad;
+    CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     ur = brg.bd_block * (is_amx(isa) ? brg.bd_block2 : 1);
     ur_block = brg.bd_block;
-    if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {
+    adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
+    if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {
         brgemm_desc_t brg_sp_tail;
         brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr, src_dt,
                 wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC, M_tail,
                 vN, vK, nullptr, is_bf32);
+        if (exec_type == exec_vpad) {
+            brg_sp_tail.zp_type_a = src_zero_point
+                    ? brgemm_broadcast_t::per_tensor
+                    : brgemm_broadcast_t::none;
+        }
+        CHECK(brgemm_desc_set_attr(&brg_sp_tail, brgattr));
         CHECK(brgemm_utils::brgemm_blocking(&brg_sp_tail));
         ur_block_tail = brg_sp_tail.bd_block;
     } else {
@@ -767,10 +784,9 @@ bool brg_blocking_t::fast_check_oc_block() const {
 
 float brg_blocking_t::est_eff() {
     const auto jcp = *this;
-    const auto ocblock = oc_block / acc_simd_w;
 
-    const auto brgemm_microkernel_eff
-            = (static_cast<float>(ocblock) * ur) / ((ur + ocblock) * max_regs);
+    const auto brgemm_microkernel_eff = (static_cast<float>(adj_ocblock) * ur)
+            / ((ur + adj_ocblock) * max_regs);
 
     const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
     const auto brgemm_eff = squeeze_val(ur
@@ -899,7 +915,7 @@ float brg_blocking_t::est_eff() {
 
     src_is = kd * kh * rnd_inp_simd(sp_block, kw, ic);
 
-    auto wei_op = kd * kh * kw * ocblock * ic;
+    auto wei_op = kd * kh * kw * adj_ocblock * ic;
     if (loop_order == loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
@@ -913,8 +929,8 @@ float brg_blocking_t::est_eff() {
     // -- harness: loop by sp_blocks --
     l++;
     loop[l].src.set(src_is, 1);
-    const auto rnd_oc_for_sp
-            = simd_w * ((loop_order == loop_ndhwgc) ? nsimd_oc_thr : ocblock);
+    const auto rnd_oc_for_sp = simd_w
+            * ((loop_order == loop_ndhwgc) ? nsimd_oc_thr : adj_ocblock);
     loop[l].dst.set(sp_block * rnd_oc_for_sp, 1);
     loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
     // oh_block almost all is 1. TODO: manage oh_block != 1
@@ -1214,7 +1230,6 @@ bool brg_blocking_t::fast_check_oc_block_1x1() const {
 }
 
 float brg_blocking_t::est_eff_1x1() {
-    const auto ocblock = oc_block / acc_simd_w;
 
     auto calc_ave_blk = [&](int dim, int block, bool use_ave) -> float {
         const int nb = dim / block;
@@ -1246,7 +1261,8 @@ float brg_blocking_t::est_eff_1x1() {
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(ocb_ave) * spb_ave)
                     / (ocb_ave + spb_ave)
-            : (static_cast<float>(ocblock) * ur) / ((ur + ocblock) * max_regs);
+            : (static_cast<float>(adj_ocblock) * ur)
+                    / ((ur + adj_ocblock) * max_regs);
     const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
 
     // heuristic sp_block: for reduced rtus, prioritize a smaller sp_block
@@ -1389,7 +1405,7 @@ float brg_blocking_t::est_eff_1x1() {
     loop[l].src.set(sp_block * ic_blocking_size, 1);
     loop[l].dst.set(sp_block * oc_block, ic_chunks);
     auto wei_is = oc_blocking_size;
-    auto wei_op = ocblock * ic;
+    auto wei_op = adj_ocblock * ic;
     loop[l].wei.set(wei_is, 1);
 
     if (loop_order == loop_ndhwgc) {
@@ -1402,8 +1418,8 @@ float brg_blocking_t::est_eff_1x1() {
         loop[l].wei.set(wei_is, 1);
     }
 
-    const auto rnd_oc_for_sp
-            = simd_w * ((loop_order == loop_ndhwgc) ? nsimd_oc_thr : ocblock);
+    const auto rnd_oc_for_sp = simd_w
+            * ((loop_order == loop_ndhwgc) ? nsimd_oc_thr : adj_ocblock);
     if (is_os_blocking) {
         // -- harness: loop by os_blocks --
         l++;


### PR DESCRIPTION
Fixes MFDNN-12557

Missing initialized some variables in `estimate_brgemm_ur() `(like zp_type_a, max_vpad) may cause some shapes fall into `exec_base` instead of `exec_vpad`.

The perf data was collect on ADL with 6 core per sockets.
![image](https://github.com/user-attachments/assets/b73b4ea4-948e-4ad6-bf45-06b542eca1cb)
[brg_zp_avx2_vnni.xlsx](https://github.com/user-attachments/files/19017009/brg_zp_avx2_vnni.xlsx)

