### PR TITLE
[rls-v3.8pc] sdpa: tests: fix build error because of SKIP_IF_(CUDA,HIP) macros

### DIFF
--- a/tests/gtests/internals/test_sdpa.cpp
+++ b/tests/gtests/internals/test_sdpa.cpp
@@ -1139,12 +1139,16 @@ sdpa_tensors_t get_descriptors(dnnl::engine &eng, const sdpa_dims_t &p) {
 
     return out;
 }
+
 class sdpa_test_t : public ::testing::TestWithParam<sdpa_dims_t> {
 public:
     void SetUp() override {
-        p = GetParam();
-        SKIP_IF_CUDA(true, "SDPA primitive tests do not support CUDA");
-        SKIP_IF_HIP(true, "SDPA primitive tests do not support HIP");
+#ifdef DNNL_SYCL_CUDA
+        GTEST_SKIP() << "SDPA primitive tests do not support CUDA";
+#endif
+#ifdef DNNL_SYCL_HIP
+        GTEST_SKIP() << "SDPA primitive tests do not support HIP";
+#endif
 #ifdef DNNL_TEST_WITH_ENGINE_PARAM
         SKIP_IF(get_test_engine_kind() != dnnl::engine::kind::gpu,
                 "This test requires GPU engine");
@@ -1155,6 +1159,7 @@ public:
         eng = dnnl::engine(engine::kind::gpu, 0);
 #endif
         strm = dnnl::stream(eng);
+        p = GetParam();
         t = get_descriptors(eng, p);
     }
 


### PR DESCRIPTION
# Description

Fixes a build error in test_sdpa.cpp when building to target the CUDA and HIP devices using the SYCL runtime. This is because the test_internals tests do not accept the engine type as an input argument to the executable and therefore the get_test_engine_type functions are not defined.

Fixes [MFDNN-13273](https://jira.devtools.intel.com/browse/MFDNN-13273)