### PR TITLE
Fix ngen_asm copyright

### DIFF
--- a/third_party/ngen/ngen_asm.hpp
+++ b/third_party/ngen/ngen_asm.hpp
@@ -1,3 +1,19 @@
+/*******************************************************************************
+* Copyright 2019-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
 #ifndef NGEN_ASM_HPP
 #define NGEN_ASM_HPP
 #if NGEN_ASM


### PR DESCRIPTION
# Description

Fix missing copyright in `ngen_asm.hpp`
