### PR TITLE
xe, common: conv: exclude grouped scales from check as not supported

### DIFF
--- a/src/common/convolution.cpp
+++ b/src/common/convolution.cpp
@@ -175,7 +175,7 @@ status_t conv_attr_check(const convolution_desc_t &desc, const engine_t *engine,
         const bool enable_quantization = is_int8 || is_fp8;
         if (enable_quantization)
             fwd_attr_mask |= smask_t::zero_points_data_type
-                    | smask_t::scales_groups | smask_t::scales_data_type;
+                    | smask_t::scales_data_type;
 
         VCHECK_CONV_UNIMPL(attr->has_default_values(fwd_attr_mask, dst_dt),
                 VERBOSE_UNSUPPORTED_ATTR);

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -978,7 +978,7 @@ bool post_ops_ok(const conv_problem_t &prb, const hw_t &hw) {
     auto attr_skip_mask = sm::fpmath_mode | sm::accumulation_mode;
     if (prb.is_fwd || prb.is_bwd_d) {
         attr_skip_mask |= sm::post_ops | sm::sum_dt | sm::zero_points_data_type
-                | sm::rounding_mode | sm::scales_groups | sm::scales_data_type;
+                | sm::rounding_mode | sm::scales_data_type;
         if (!attr->has_default_values(attr_skip_mask)) return false;
     } else {
         if (!attr->has_default_values(attr_skip_mask)) return false;


### PR DESCRIPTION
PR updates convolution to report grouped scales as unimplemented as there is no support for them in the library or benchdnn.