### PR TITLE
oneDNN v3.7.1 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.7.0")
+set(PROJECT_VERSION "3.7.1")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.7:
* Fixed correctness issue in `int8` matmul primitive with `int4` weights on on Intel Arc graphics (b16184d155b578036c94e44fbc960e25b3c522f7)
* Fixed matmul performance regression on Intel Arc graphics (41e406bfb448a0600a50ef213c5237d4a3ce3155)
* Fixed potential integer overflow in `bf16` convolution for processors with Intel AVX-512 instruction set support (f882861fe0d0f2ed61b42377408ad62e5a665bc2)
* Fixed functional issue in matmul with dropout attribute on generic GPUs (83033303c072c3b18e070d1abfedfd1f50248eac)
* Fixed functional issues in matmul with scales on NVIDIA GPUs (e8d8594956a626be1debf359618024d1cb7c702a)
* Fixed integer overflows for large shapes in convolution for x64 processors (fc3f17ad469b8a6da7192ae12d32625faa509f1e, 31b079f482a80836cd4192f85e703d424876febc)
* Worked around an MSVC 19.29.30158.0 bug that results in crash at binary primitive creation on x64 processors (50dd6cc832732ff0ea07e993bb07f61343ca1375)

