### PR TITLE
build: explicitly set compile PDB names

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,6 +215,14 @@ if(DNNL_LIBRARY_TYPE STREQUAL "STATIC")
     target_link_libraries_install(${LIB_PACKAGE_NAME} "${EXTRA_STATIC_LIBS}")
 endif()
 
+foreach(object_library IN LISTS LIB_DEPS)
+    string(REPLACE "$<TARGET_OBJECTS:" "" object_library "${object_library}")
+    string(REPLACE ">" "" object_library "${object_library}")
+
+    # explicitly set compile PDB name as with Ninja, all targets have the same pdb name like vc<vc_ver>.pdb
+    set_target_properties(${object_library} PROPERTIES COMPILE_PDB_NAME ${object_library})
+endforeach()
+
 set(LIB_EXPORT_NAME "${LIB_PACKAGE_NAME}-targets")
 install(TARGETS ${LIB_PACKAGE_NAME}
     EXPORT "${LIB_EXPORT_NAME}"


### PR DESCRIPTION
# Description

Cmake: explicitly set compile PDB names for object libraries, because the behavior is different between MSVC and Ninja generators:
- MSVC uses target name as default name for compile PDB
- Ninja uses vc<vs version>.pdb

When you want to re-distribute such PDB files and move all files into a single folder, in later cases all files will override each other.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
