### PR TITLE
ref:sycl: group norm backward

### DIFF
--- a/src/gpu/generic/sycl/README.md
+++ b/src/gpu/generic/sycl/README.md
@@ -95,7 +95,7 @@ The implementation supports both forward and backward directions.
 * Supported data types: `f32`, `bf16`, `f16`, `s32`, `s8`, `u8`
 
 ## Group Normalization
-* Supported Direction: forward data and forward inference.
+* Supported Direction:  Both forward and backward directions are supported.
 * Supported data types: All possible data combinations listed in the oneDNN specification are supported.
 * Support Data layouts: All data layouts are supported.
 

--- a/src/gpu/generic/sycl/ref_group_normalization.hpp
+++ b/src/gpu/generic/sycl/ref_group_normalization.hpp
@@ -52,6 +52,30 @@ private:
         return dynamic_cast<pd_t *>(primitive_t::pd().get());
     }
 };
+
+struct ref_group_normalization_bwd_t : public gpu::generic::sycl::primitive_t {
+    using gpu::generic::sycl::primitive_t::primitive_t;
+
+    struct pd_t : public group_normalization_bwd_pd_t {
+        using group_normalization_bwd_pd_t ::group_normalization_bwd_pd_t;
+        DECLARE_COMMON_PD_T("ref:sycl:group_normalization_bwd",
+                ref_group_normalization_bwd_t);
+
+        status_t init(impl::engine_t *engine);
+
+        ::sycl::nd_range<1> launch_range;
+        sycl_gnorm_bwd_conf_t conf_;
+    };
+
+    kernel_t kernel_;
+    status_t init(impl::engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+    const pd_t *pd() const {
+        return dynamic_cast<pd_t *>(primitive_t::pd().get());
+    }
+};
+
 } // namespace dnnl::impl::gpu::generic::sycl
 
 #endif

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -529,6 +529,18 @@ struct sycl_group_norm_conf_t {
     sycl_post_ops_t post_ops;
 };
 
+struct sycl_gnorm_bwd_conf_t {
+    xpu::sycl::md_t src_desc;
+    xpu::sycl::md_t diff_src_desc;
+    xpu::sycl::md_t diff_dst_desc;
+    int32_t num_groups;
+    int32_t num_channels_per_group;
+    bool scale_diff_required;
+    bool bias_diff_required;
+    bool used_global_stats;
+    float eta;
+};
+
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_binary_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_prelu_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_shuffle_conf_t);
@@ -550,6 +562,7 @@ CHECK_SYCL_KERNEL_ARG_TYPE(sycl_reduction_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_rnn_copy_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_rnn_bias_conf_t);
 CHECK_SYCL_KERNEL_ARG_TYPE(sycl_group_norm_conf_t);
+CHECK_SYCL_KERNEL_ARG_TYPE(sycl_gnorm_bwd_conf_t);
 
 } // namespace sycl
 } // namespace generic

--- a/src/gpu/gpu_group_normalization_list.cpp
+++ b/src/gpu/gpu_group_normalization_list.cpp
@@ -42,6 +42,7 @@ impl_list_map REG_GNORM_P({
     },
     {{backward}, REG_BWD_PK({
         GPU_INSTANCE_INTEL(intel::ocl::ref_group_normalization_bwd_t)
+        GPU_INSTANCE_GENERIC_SYCL(generic::sycl::ref_group_normalization_bwd_t)
         nullptr,
         })
     },

--- a/tests/gtests/test_group_normalization.cpp
+++ b/tests/gtests/test_group_normalization.cpp
@@ -180,12 +180,6 @@ protected:
     }
 
     void Backward(prop_kind pk, normalization_flags flags) {
-        SKIP_IF_CUDA(
-                true, "Group Normalization operator is not supported in CUDA");
-        SKIP_IF_HIP(
-                true, "Group Normalization operator is not supported in HIP");
-        SKIP_IF_GENERIC(true,
-                "Group Normalization operator is not supported in generic");
         SKIP_IF(unsupported_prop_kind(pk, p.src_dt, p.diff_src_dt, p.dst_dt),
                 "Engine does not support this prop kind with this data types");
         // group_normalization specific types and values


### PR DESCRIPTION
# Description

Add the implementation of group normalization's  backward pass for the reference sycl backend

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?