### PR TITLE
ref: sycl: fix group norm build after quant refactor part 3

### DIFF
--- a/src/gpu/generic/sycl/ref_group_normalization.cpp
+++ b/src/gpu/generic/sycl/ref_group_normalization.cpp
@@ -39,7 +39,7 @@ status_t ref_group_normalization_fwd_t::pd_t::init(impl::engine_t *engine) {
             "sycl post op initialization returns false");
 
     const primitive_attr_t::skip_mask_t attr_mask
-            = primitive_attr_t::skip_mask_t::scales_runtime
+            = primitive_attr_t::skip_mask_t::scales
             | primitive_attr_t::skip_mask_t::post_ops;
     VDISPATCH_GNORM(
             attr()->has_default_values(attr_mask), VERBOSE_UNSUPPORTED_ATTR);


### PR DESCRIPTION
# Description

#2746 got merged after #2733 , which did not reflect the changes for the scale/zero-point refactor.
This PR fixes the build issue of main when GPU_VENDOR is set to GENERIC 

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
