### PR TITLE
ngen: fix a build issue when DNNL_DEV_MODE is OFF

### DIFF
--- a/third_party/ngen/ngen_asm.hpp
+++ b/third_party/ngen/ngen_asm.hpp
@@ -1,6 +1,6 @@
 #ifndef NGEN_ASM_HPP
 #define NGEN_ASM_HPP
-#if NGEN_ASM
+#ifdef NGEN_ASM
 
 #include "ngen_config.hpp"
 


### PR DESCRIPTION
Taking over #2809 so that we can get it merged ASAP due to the release schedule.

The only effective change here is to fix the commit message formatting.