### PR TITLE
Fixes for broken links in documentation

### DIFF
--- a/doc/primitives/lrn.md
+++ b/doc/primitives/lrn.md
@@ -14,7 +14,7 @@ The LRN primitive performs a forward or backward local response normalization.
 The LRN operation is defined by the following formulas (the variable names
 follow the standard @ref dev_guide_conventions):
 
-LRN [across channels](#dnnl_lrn_across_channels):
+LRN across channels:
 
 \f[
     \dst(n, c, h, w) =
@@ -26,7 +26,7 @@ LRN [across channels](#dnnl_lrn_across_channels):
         \src(n, c, h, w),
 \f]
 
-LRN [within channel](#dnnl_lrn_within_channel):
+LRN within a single channel:
 
 \f[
     \dst(n, c, h, w) =

--- a/examples/bnorm_u8_via_binary_postops.cpp
+++ b/examples/bnorm_u8_via_binary_postops.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,9 +45,6 @@
 #include "example_utils.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void bnorm_u8_via_binary_postops(dnnl::engine::kind engine_kind) {
 
@@ -102,12 +99,18 @@ void bnorm_u8_via_binary_postops(dnnl::engine::kind engine_kind) {
             oscale_data.begin(), oscale_data.end(), []() { return 0.5f; });
 
     // Create descriptors.
-    auto src_md = memory::desc(src_dims, dt::u8, tag::nhwc);
-    auto mean_md = memory::desc(params_dims, dt::f32, tag::nhwc);
-    auto variance_md = memory::desc(params_dims, dt::f32, tag::nhwc);
-    auto scale_md = memory::desc(params_dims, dt::f32, tag::nhwc);
-    auto shift_md = memory::desc(params_dims, dt::f32, tag::nhwc);
-    auto oscale_md = memory::desc(params_dims, dt::f32, tag::nhwc);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::u8, memory::format_tag::nhwc);
+    auto mean_md = memory::desc(
+            params_dims, memory::data_type::f32, memory::format_tag::nhwc);
+    auto variance_md = memory::desc(
+            params_dims, memory::data_type::f32, memory::format_tag::nhwc);
+    auto scale_md = memory::desc(
+            params_dims, memory::data_type::f32, memory::format_tag::nhwc);
+    auto shift_md = memory::desc(
+            params_dims, memory::data_type::f32, memory::format_tag::nhwc);
+    auto oscale_md = memory::desc(
+            params_dims, memory::data_type::f32, memory::format_tag::nhwc);
 
     // Create src memory objects.
     auto src_mem = memory(src_md, engine);

--- a/examples/cnn_inference_f32.cpp
+++ b/examples/cnn_inference_f32.cpp
@@ -91,9 +91,9 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     std::vector<float> conv1_bias(product(conv1_bias_tz));
     //[Allocate buffers]
 
-    /// Create memory that describes data layout in the buffers. This example uses
-    /// tag::nchw (batch-channels-height-width) for input data and tag::oihw
-    /// for weights.
+    /// Create memory that describes data layout in the buffers. This example
+    /// uses dnnl::memory::format_tag::nchw (batch-channels-height-width)
+    /// for input data and dnnl::memory::format_tag::oihw for weights.
     /// @snippet cnn_inference_f32.cpp Create user memory
     //[Create user memory]
     auto user_src_memory = memory({{conv1_src_tz}, dt::f32, tag::nchw}, eng);
@@ -106,12 +106,13 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     write_to_dnnl_memory(conv1_bias.data(), conv1_user_bias_memory);
     //[Create user memory]
 
-    /// Create memory descriptors with layout tag::any. The `any` format enables
-    /// the convolution primitive to choose the data format that will result in
-    /// best performance based on its input parameters (convolution kernel
-    /// sizes, strides, padding, and so on). If the resulting format is different
-    /// from `nchw`, the user data must be transformed to the format required for
-    /// the convolution (as explained below).
+    /// Create memory descriptors with layout dnnl::memory::format_tag::any.
+    /// The `any` format enables the convolution primitive to choose the data
+    /// format that will result in best performance based on its input
+    /// parameters (convolution kernel sizes, strides, padding, and so on).
+    /// If the resulting format is different from `nchw`, the user data must be
+    /// transformed to the format required for the convolution (as explained
+    /// below).
     /// @snippet cnn_inference_f32.cpp Create convolution memory descriptors
     //[Create convolution memory descriptors]
     auto conv1_src_md = memory::desc({conv1_src_tz}, dt::f32, tag::any);
@@ -136,9 +137,9 @@ void simple_net(engine::kind engine_kind, int times = 100) {
             conv1_strides, conv1_padding, conv1_padding);
     //[Create convolution primitive descriptor]
 
-    /// Check whether data and weights formats required by convolution is different
-    /// from the user format. In case it is different change the layout using
-    /// reorder primitive.
+    /// Check whether data and weights formats required by convolution is
+    /// different from the user format. In case it is different change the
+    /// layout using reorder primitive.
     /// @snippet cnn_inference_f32.cpp Reorder data and weights
     //[Reorder data and weights]
     auto conv1_src_memory = user_src_memory;
@@ -180,7 +181,8 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     /// Create the relu primitive. For better performance, keep the input data
     /// format for ReLU (as well as for other operation primitives until another
     /// convolution or inner product is encountered) the same as the one chosen
-    /// for convolution. Also note that ReLU is done in-place by using conv1 memory.
+    /// for convolution. Also note that ReLU is done in-place by using conv1
+    /// memory.
     /// @snippet cnn_inference_f32.cpp Create relu primitive
     //[Create relu primitive]
     auto relu1_prim_desc
@@ -227,8 +229,8 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     auto pool1_dst_md = memory::desc({pool1_dst_tz}, dt::f32, tag::any);
 
     /// For training execution, pooling requires a private workspace memory
-    /// to perform the backward pass. However, pooling should not use 'workspace'
-    /// for inference, because this is detrimental to performance.
+    /// to perform the backward pass. However, pooling should not use
+    /// 'workspace' for inference, because this is detrimental to performance.
     /// @snippet cnn_inference_f32.cpp Create pooling primitive
     ///
     /// The example continues to create more layers according

--- a/examples/cnn_inference_f32.cpp
+++ b/examples/cnn_inference_f32.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,9 +51,6 @@
 using namespace dnnl;
 
 void simple_net(engine::kind engine_kind, int times = 100) {
-    using tag = memory::format_tag;
-    using dt = memory::data_type;
-
     /// Initialize an engine and stream. The last parameter in the call represents
     /// the index of the engine.
     /// @snippet cnn_inference_f32.cpp Initialize engine and stream
@@ -96,13 +93,18 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     /// for input data and dnnl::memory::format_tag::oihw for weights.
     /// @snippet cnn_inference_f32.cpp Create user memory
     //[Create user memory]
-    auto user_src_memory = memory({{conv1_src_tz}, dt::f32, tag::nchw}, eng);
+    auto user_src_memory = memory(
+            {{conv1_src_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            eng);
     write_to_dnnl_memory(user_src.data(), user_src_memory);
     auto user_weights_memory
-            = memory({{conv1_weights_tz}, dt::f32, tag::oihw}, eng);
+            = memory({{conv1_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::oihw},
+                    eng);
     write_to_dnnl_memory(conv1_weights.data(), user_weights_memory);
-    auto conv1_user_bias_memory
-            = memory({{conv1_bias_tz}, dt::f32, tag::x}, eng);
+    auto conv1_user_bias_memory = memory(
+            {{conv1_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv1_bias.data(), conv1_user_bias_memory);
     //[Create user memory]
 
@@ -115,10 +117,14 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     /// below).
     /// @snippet cnn_inference_f32.cpp Create convolution memory descriptors
     //[Create convolution memory descriptors]
-    auto conv1_src_md = memory::desc({conv1_src_tz}, dt::f32, tag::any);
-    auto conv1_bias_md = memory::desc({conv1_bias_tz}, dt::f32, tag::any);
-    auto conv1_weights_md = memory::desc({conv1_weights_tz}, dt::f32, tag::any);
-    auto conv1_dst_md = memory::desc({conv1_dst_tz}, dt::f32, tag::any);
+    auto conv1_src_md = memory::desc(
+            {conv1_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv1_bias_md = memory::desc(
+            {conv1_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv1_weights_md = memory::desc({conv1_weights_tz},
+            memory::data_type::f32, memory::format_tag::any);
+    auto conv1_dst_md = memory::desc(
+            {conv1_dst_tz}, memory::data_type::f32, memory::format_tag::any);
     //[Create convolution memory descriptors]
 
     /// Create a convolution primitive descriptor by specifying engine,
@@ -226,7 +232,8 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     memory::dims pool_dilation = {0, 0};
     memory::dims pool_padding = {0, 0};
 
-    auto pool1_dst_md = memory::desc({pool1_dst_tz}, dt::f32, tag::any);
+    auto pool1_dst_md = memory::desc(
+            {pool1_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     /// For training execution, pooling requires a private workspace memory
     /// to perform the backward pass. However, pooling should not use
@@ -262,17 +269,24 @@ void simple_net(engine::kind engine_kind, int times = 100) {
 
     // create memory for user data
     auto conv2_user_weights_memory
-            = memory({{conv2_weights_tz}, dt::f32, tag::goihw}, eng);
+            = memory({{conv2_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::goihw},
+                    eng);
     write_to_dnnl_memory(conv2_weights.data(), conv2_user_weights_memory);
-    auto conv2_user_bias_memory
-            = memory({{conv2_bias_tz}, dt::f32, tag::x}, eng);
+    auto conv2_user_bias_memory = memory(
+            {{conv2_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv2_bias.data(), conv2_user_bias_memory);
 
     // create memory descriptors for convolution data w/ no specified format
-    auto conv2_src_md = memory::desc({conv2_src_tz}, dt::f32, tag::any);
-    auto conv2_bias_md = memory::desc({conv2_bias_tz}, dt::f32, tag::any);
-    auto conv2_weights_md = memory::desc({conv2_weights_tz}, dt::f32, tag::any);
-    auto conv2_dst_md = memory::desc({conv2_dst_tz}, dt::f32, tag::any);
+    auto conv2_src_md = memory::desc(
+            {conv2_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv2_bias_md = memory::desc(
+            {conv2_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv2_weights_md = memory::desc({conv2_weights_tz},
+            memory::data_type::f32, memory::format_tag::any);
+    auto conv2_dst_md = memory::desc(
+            {conv2_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a convolution
     auto conv2_prim_desc = convolution_forward::primitive_desc(eng,
@@ -350,7 +364,8 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     memory::dims pool2_dilation = {0, 0};
     memory::dims pool2_padding = {0, 0};
 
-    auto pool2_dst_md = memory::desc({pool2_dst_tz}, dt::f32, tag::any);
+    auto pool2_dst_md = memory::desc(
+            {pool2_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a pooling
     auto pool2_pd = pooling_forward::primitive_desc(eng,
@@ -379,17 +394,24 @@ void simple_net(engine::kind engine_kind, int times = 100) {
 
     // create memory for user data
     auto conv3_user_weights_memory
-            = memory({{conv3_weights_tz}, dt::f32, tag::oihw}, eng);
+            = memory({{conv3_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::oihw},
+                    eng);
     write_to_dnnl_memory(conv3_weights.data(), conv3_user_weights_memory);
-    auto conv3_user_bias_memory
-            = memory({{conv3_bias_tz}, dt::f32, tag::x}, eng);
+    auto conv3_user_bias_memory = memory(
+            {{conv3_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv3_bias.data(), conv3_user_bias_memory);
 
     // create memory descriptors for convolution data w/ no specified format
-    auto conv3_src_md = memory::desc({conv3_src_tz}, dt::f32, tag::any);
-    auto conv3_bias_md = memory::desc({conv3_bias_tz}, dt::f32, tag::any);
-    auto conv3_weights_md = memory::desc({conv3_weights_tz}, dt::f32, tag::any);
-    auto conv3_dst_md = memory::desc({conv3_dst_tz}, dt::f32, tag::any);
+    auto conv3_src_md = memory::desc(
+            {conv3_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv3_bias_md = memory::desc(
+            {conv3_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv3_weights_md = memory::desc({conv3_weights_tz},
+            memory::data_type::f32, memory::format_tag::any);
+    auto conv3_dst_md = memory::desc(
+            {conv3_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a convolution
     auto conv3_prim_desc = convolution_forward::primitive_desc(eng,
@@ -452,17 +474,24 @@ void simple_net(engine::kind engine_kind, int times = 100) {
 
     // create memory for user data
     auto conv4_user_weights_memory
-            = memory({{conv4_weights_tz}, dt::f32, tag::goihw}, eng);
+            = memory({{conv4_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::goihw},
+                    eng);
     write_to_dnnl_memory(conv4_weights.data(), conv4_user_weights_memory);
-    auto conv4_user_bias_memory
-            = memory({{conv4_bias_tz}, dt::f32, tag::x}, eng);
+    auto conv4_user_bias_memory = memory(
+            {{conv4_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv4_bias.data(), conv4_user_bias_memory);
 
     // create memory descriptors for convolution data w/ no specified format
-    auto conv4_src_md = memory::desc({conv4_src_tz}, dt::f32, tag::any);
-    auto conv4_bias_md = memory::desc({conv4_bias_tz}, dt::f32, tag::any);
-    auto conv4_weights_md = memory::desc({conv4_weights_tz}, dt::f32, tag::any);
-    auto conv4_dst_md = memory::desc({conv4_dst_tz}, dt::f32, tag::any);
+    auto conv4_src_md = memory::desc(
+            {conv4_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv4_bias_md = memory::desc(
+            {conv4_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv4_weights_md = memory::desc({conv4_weights_tz},
+            memory::data_type::f32, memory::format_tag::any);
+    auto conv4_dst_md = memory::desc(
+            {conv4_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a convolution
     auto conv4_prim_desc = convolution_forward::primitive_desc(eng,
@@ -524,17 +553,24 @@ void simple_net(engine::kind engine_kind, int times = 100) {
 
     // create memory for user data
     auto conv5_user_weights_memory
-            = memory({{conv5_weights_tz}, dt::f32, tag::goihw}, eng);
+            = memory({{conv5_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::goihw},
+                    eng);
     write_to_dnnl_memory(conv5_weights.data(), conv5_user_weights_memory);
-    auto conv5_user_bias_memory
-            = memory({{conv5_bias_tz}, dt::f32, tag::x}, eng);
+    auto conv5_user_bias_memory = memory(
+            {{conv5_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv5_bias.data(), conv5_user_bias_memory);
 
     // create memory descriptors for convolution data w/ no specified format
-    auto conv5_src_md = memory::desc({conv5_src_tz}, dt::f32, tag::any);
-    auto conv5_weights_md = memory::desc({conv5_weights_tz}, dt::f32, tag::any);
-    auto conv5_bias_md = memory::desc({conv5_bias_tz}, dt::f32, tag::any);
-    auto conv5_dst_md = memory::desc({conv5_dst_tz}, dt::f32, tag::any);
+    auto conv5_src_md = memory::desc(
+            {conv5_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv5_weights_md = memory::desc({conv5_weights_tz},
+            memory::data_type::f32, memory::format_tag::any);
+    auto conv5_bias_md = memory::desc(
+            {conv5_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv5_dst_md = memory::desc(
+            {conv5_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a convolution
     auto conv5_prim_desc = convolution_forward::primitive_desc(eng,
@@ -593,7 +629,8 @@ void simple_net(engine::kind engine_kind, int times = 100) {
 
     std::vector<float> pool5_dst(product(pool5_dst_tz));
 
-    auto pool5_dst_md = memory::desc({pool5_dst_tz}, dt::f32, tag::any);
+    auto pool5_dst_md = memory::desc(
+            {pool5_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a pooling
     auto pool5_pd = pooling_forward::primitive_desc(eng,
@@ -620,16 +657,24 @@ void simple_net(engine::kind engine_kind, int times = 100) {
 
     // create memory for user data
     auto fc6_user_weights_memory
-            = memory({{fc6_weights_tz}, dt::f32, tag::oihw}, eng);
+            = memory({{fc6_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::oihw},
+                    eng);
     write_to_dnnl_memory(fc6_weights.data(), fc6_user_weights_memory);
-    auto fc6_user_bias_memory = memory({{fc6_bias_tz}, dt::f32, tag::x}, eng);
+    auto fc6_user_bias_memory = memory(
+            {{fc6_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(fc6_bias.data(), fc6_user_bias_memory);
 
     // create memory descriptors for convolution data w/ no specified format
-    auto fc6_src_md = memory::desc({fc6_src_tz}, dt::f32, tag::any);
-    auto fc6_bias_md = memory::desc({fc6_bias_tz}, dt::f32, tag::any);
-    auto fc6_weights_md = memory::desc({fc6_weights_tz}, dt::f32, tag::any);
-    auto fc6_dst_md = memory::desc({fc6_dst_tz}, dt::f32, tag::any);
+    auto fc6_src_md = memory::desc(
+            {fc6_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto fc6_bias_md = memory::desc(
+            {fc6_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto fc6_weights_md = memory::desc(
+            {fc6_weights_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto fc6_dst_md = memory::desc(
+            {fc6_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a inner_product
     auto fc6_prim_desc = inner_product_forward::primitive_desc(eng,
@@ -669,17 +714,23 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     std::vector<float> fc7_bias(product(fc7_bias_tz));
 
     // create memory for user data
-    auto fc7_user_weights_memory
-            = memory({{fc7_weights_tz}, dt::f32, tag::nc}, eng);
+    auto fc7_user_weights_memory = memory(
+            {{fc7_weights_tz}, memory::data_type::f32, memory::format_tag::nc},
+            eng);
     write_to_dnnl_memory(fc7_weights.data(), fc7_user_weights_memory);
 
-    auto fc7_user_bias_memory = memory({{fc7_bias_tz}, dt::f32, tag::x}, eng);
+    auto fc7_user_bias_memory = memory(
+            {{fc7_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(fc7_bias.data(), fc7_user_bias_memory);
 
     // create memory descriptors for convolution data w/ no specified format
-    auto fc7_bias_md = memory::desc({fc7_bias_tz}, dt::f32, tag::any);
-    auto fc7_weights_md = memory::desc({fc7_weights_tz}, dt::f32, tag::any);
-    auto fc7_dst_md = memory::desc({fc7_dst_tz}, dt::f32, tag::any);
+    auto fc7_bias_md = memory::desc(
+            {fc7_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto fc7_weights_md = memory::desc(
+            {fc7_weights_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto fc7_dst_md = memory::desc(
+            {fc7_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a inner_product
     auto fc7_prim_desc = inner_product_forward::primitive_desc(eng,
@@ -711,18 +762,26 @@ void simple_net(engine::kind engine_kind, int times = 100) {
     std::vector<float> fc8_bias(product(fc8_bias_tz));
 
     // create memory for user data
-    auto fc8_user_weights_memory
-            = memory({{fc8_weights_tz}, dt::f32, tag::nc}, eng);
+    auto fc8_user_weights_memory = memory(
+            {{fc8_weights_tz}, memory::data_type::f32, memory::format_tag::nc},
+            eng);
     write_to_dnnl_memory(fc8_weights.data(), fc8_user_weights_memory);
-    auto fc8_user_bias_memory = memory({{fc8_bias_tz}, dt::f32, tag::x}, eng);
+    auto fc8_user_bias_memory = memory(
+            {{fc8_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(fc8_bias.data(), fc8_user_bias_memory);
-    auto user_dst_memory = memory({{fc8_dst_tz}, dt::f32, tag::nc}, eng);
+    auto user_dst_memory = memory(
+            {{fc8_dst_tz}, memory::data_type::f32, memory::format_tag::nc},
+            eng);
     write_to_dnnl_memory(user_dst.data(), user_dst_memory);
 
     // create memory descriptors for convolution data w/ no specified format
-    auto fc8_bias_md = memory::desc({fc8_bias_tz}, dt::f32, tag::any);
-    auto fc8_weights_md = memory::desc({fc8_weights_tz}, dt::f32, tag::any);
-    auto fc8_dst_md = memory::desc({fc8_dst_tz}, dt::f32, tag::any);
+    auto fc8_bias_md = memory::desc(
+            {fc8_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto fc8_weights_md = memory::desc(
+            {fc8_weights_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto fc8_dst_md = memory::desc(
+            {fc8_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a inner_product
     auto fc8_prim_desc = inner_product_forward::primitive_desc(eng,

--- a/examples/cnn_inference_int8.cpp
+++ b/examples/cnn_inference_int8.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,9 +33,6 @@
 using namespace dnnl;
 
 void simple_net_int8(engine::kind engine_kind) {
-    using tag = memory::format_tag;
-    using dt = memory::data_type;
-
     auto eng = engine(engine_kind, 0);
     stream s(eng);
 
@@ -89,12 +86,18 @@ void simple_net_int8(engine::kind engine_kind) {
     /// The user data will be in its original 32-bit floating point format.
     /// @snippet cnn_inference_int8.cpp Allocate buffers
     //[Allocate buffers]
-    auto user_src_memory = memory({{conv_src_tz}, dt::f32, tag::nchw}, eng);
+    auto user_src_memory = memory(
+            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            eng);
     write_to_dnnl_memory(user_src.data(), user_src_memory);
     auto user_weights_memory
-            = memory({{conv_weights_tz}, dt::f32, tag::oihw}, eng);
+            = memory({{conv_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::oihw},
+                    eng);
     write_to_dnnl_memory(conv_weights.data(), user_weights_memory);
-    auto user_bias_memory = memory({{conv_bias_tz}, dt::f32, tag::x}, eng);
+    auto user_bias_memory = memory(
+            {{conv_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv_bias.data(), user_bias_memory);
     //[Allocate buffers]
 
@@ -112,10 +115,14 @@ void simple_net_int8(engine::kind engine_kind) {
     ///  > Bias does not support quantization.
     /// @snippet cnn_inference_int8.cpp Create convolution memory descriptors
     //[Create convolution memory descriptors]
-    auto conv_src_md = memory::desc({conv_src_tz}, dt::u8, tag::any);
-    auto conv_bias_md = memory::desc({conv_bias_tz}, dt::f32, tag::any);
-    auto conv_weights_md = memory::desc({conv_weights_tz}, dt::s8, tag::any);
-    auto conv_dst_md = memory::desc({conv_dst_tz}, dt::u8, tag::any);
+    auto conv_src_md = memory::desc(
+            {conv_src_tz}, memory::data_type::u8, memory::format_tag::any);
+    auto conv_bias_md = memory::desc(
+            {conv_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv_weights_md = memory::desc(
+            {conv_weights_tz}, memory::data_type::s8, memory::format_tag::any);
+    auto conv_dst_md = memory::desc(
+            {conv_dst_tz}, memory::data_type::u8, memory::format_tag::any);
     //[Create convolution memory descriptors]
 
     /// Configuring int8-specific parameters in an int8 primitive is done
@@ -129,7 +136,8 @@ void simple_net_int8(engine::kind engine_kind) {
     conv_attr.set_scales_mask(DNNL_ARG_DST, dst_mask);
 
     // Prepare dst scales
-    auto dst_scale_md = memory::desc({1}, dt::f32, tag::x);
+    auto dst_scale_md
+            = memory::desc({1}, memory::data_type::f32, memory::format_tag::x);
     auto dst_scale_memory = memory(dst_scale_md, eng);
     write_to_dnnl_memory(dst_scales.data(), dst_scale_memory);
     //[Configure scaling]
@@ -194,7 +202,8 @@ void simple_net_int8(engine::kind engine_kind) {
     auto conv_src_memory = memory(conv_prim_desc.src_desc(), eng);
     primitive_attr src_attr;
     src_attr.set_scales_mask(DNNL_ARG_DST, src_mask);
-    auto src_scale_md = memory::desc({1}, dt::f32, tag::x);
+    auto src_scale_md
+            = memory::desc({1}, memory::data_type::f32, memory::format_tag::x);
     auto src_scale_memory = memory(src_scale_md, eng);
     write_to_dnnl_memory(src_scales.data(), src_scale_memory);
     auto src_reorder_pd
@@ -208,7 +217,8 @@ void simple_net_int8(engine::kind engine_kind) {
     auto conv_weights_memory = memory(conv_prim_desc.weights_desc(), eng);
     primitive_attr weight_attr;
     weight_attr.set_scales_mask(DNNL_ARG_DST, weight_mask);
-    auto wei_scale_md = memory::desc({1}, dt::f32, tag::x);
+    auto wei_scale_md
+            = memory::desc({1}, memory::data_type::f32, memory::format_tag::x);
     auto wei_scale_memory = memory(wei_scale_md, eng);
     write_to_dnnl_memory(weight_scales.data(), wei_scale_memory);
     auto weight_reorder_pd
@@ -251,7 +261,9 @@ void simple_net_int8(engine::kind engine_kind) {
     /// computation output data.
     /// @snippet cnn_inference_int8.cpp Dequantize the result
     ///[Dequantize the result]
-    auto user_dst_memory = memory({{conv_dst_tz}, dt::f32, tag::nchw}, eng);
+    auto user_dst_memory = memory(
+            {{conv_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            eng);
     write_to_dnnl_memory(user_dst.data(), user_dst_memory);
     primitive_attr dst_attr;
     dst_attr.set_scales_mask(DNNL_ARG_SRC, dst_mask);

--- a/examples/cnn_training_f32.cpp
+++ b/examples/cnn_training_f32.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,9 +35,6 @@
 using namespace dnnl;
 
 void simple_net(engine::kind engine_kind) {
-    using tag = memory::format_tag;
-    using dt = memory::data_type;
-
     auto eng = engine(engine_kind, 0);
     stream s(eng);
 
@@ -75,23 +72,32 @@ void simple_net(engine::kind engine_kind) {
         conv_bias[i] = sinf((float)i);
 
     // create memory for user data
-    auto conv_user_src_memory
-            = memory({{conv_src_tz}, dt::f32, tag::nchw}, eng);
+    auto conv_user_src_memory = memory(
+            {{conv_src_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            eng);
     write_to_dnnl_memory(net_src.data(), conv_user_src_memory);
     auto conv_user_weights_memory
-            = memory({{conv_weights_tz}, dt::f32, tag::oihw}, eng);
+            = memory({{conv_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::oihw},
+                    eng);
     write_to_dnnl_memory((void *)conv_weights.data(), conv_user_weights_memory);
-    auto conv_user_bias_memory = memory({{conv_bias_tz}, dt::f32, tag::x}, eng);
+    auto conv_user_bias_memory = memory(
+            {{conv_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv_bias.data(), conv_user_bias_memory);
 
     // create memory descriptors for convolution data w/ no specified
     // format tag(`any`)
     // tag `any` lets a primitive(convolution in this case)
     // chose the memory format preferred for best performance.
-    auto conv_src_md = memory::desc({conv_src_tz}, dt::f32, tag::any);
-    auto conv_bias_md = memory::desc({conv_bias_tz}, dt::f32, tag::any);
-    auto conv_weights_md = memory::desc({conv_weights_tz}, dt::f32, tag::any);
-    auto conv_dst_md = memory::desc({conv_dst_tz}, dt::f32, tag::any);
+    auto conv_src_md = memory::desc(
+            {conv_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv_bias_md = memory::desc(
+            {conv_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv_weights_md = memory::desc(
+            {conv_weights_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv_dst_md = memory::desc(
+            {conv_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a convolution primitive descriptor
     auto conv_pd = convolution_forward::primitive_desc(eng, prop_kind::forward,
@@ -189,12 +195,14 @@ void simple_net(engine::kind engine_kind) {
     memory::dims pool_padding = {0, 0};
 
     // create memory for pool dst data in user format
-    auto pool_user_dst_memory
-            = memory({{pool_dst_tz}, dt::f32, tag::nchw}, eng);
+    auto pool_user_dst_memory = memory(
+            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            eng);
     write_to_dnnl_memory(net_dst.data(), pool_user_dst_memory);
 
     // create pool dst memory descriptor in format any
-    auto pool_dst_md = memory::desc({pool_dst_tz}, dt::f32, tag::any);
+    auto pool_dst_md = memory::desc(
+            {pool_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create a pooling primitive descriptor
     auto pool_pd = pooling_forward::primitive_desc(eng, prop_kind::forward,
@@ -233,14 +241,17 @@ void simple_net(engine::kind engine_kind) {
         net_diff_dst[i] = sinf((float)i);
 
     // create memory for user diff dst data
-    auto pool_user_diff_dst_memory
-            = memory({{pool_dst_tz}, dt::f32, tag::nchw}, eng);
+    auto pool_user_diff_dst_memory = memory(
+            {{pool_dst_tz}, memory::data_type::f32, memory::format_tag::nchw},
+            eng);
     write_to_dnnl_memory(net_diff_dst.data(), pool_user_diff_dst_memory);
 
     // Backward pooling
     // create memory descriptors for pooling
-    auto pool_diff_src_md = memory::desc({lrn_data_tz}, dt::f32, tag::any);
-    auto pool_diff_dst_md = memory::desc({pool_dst_tz}, dt::f32, tag::any);
+    auto pool_diff_src_md = memory::desc(
+            {lrn_data_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto pool_diff_dst_md = memory::desc(
+            {pool_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // backward primitive descriptor needs to hint forward descriptor
     auto pool_bwd_pd = pooling_backward::primitive_desc(eng,
@@ -269,7 +280,8 @@ void simple_net(engine::kind engine_kind) {
             {DNNL_ARG_WORKSPACE, pool_workspace_memory}});
 
     // Backward lrn
-    auto lrn_diff_dst_md = memory::desc({lrn_data_tz}, dt::f32, tag::any);
+    auto lrn_diff_dst_md = memory::desc(
+            {lrn_data_tz}, memory::data_type::f32, memory::format_tag::any);
     const auto &lrn_diff_src_md = lrn_diff_dst_md;
 
     // create backward lrn primitive descriptor
@@ -299,8 +311,10 @@ void simple_net(engine::kind engine_kind) {
             {DNNL_ARG_WORKSPACE, lrn_workspace_memory}});
 
     // Backward relu
-    auto relu_diff_src_md = memory::desc({relu_data_tz}, dt::f32, tag::any);
-    auto relu_diff_dst_md = memory::desc({relu_data_tz}, dt::f32, tag::any);
+    auto relu_diff_src_md = memory::desc(
+            {relu_data_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto relu_diff_dst_md = memory::desc(
+            {relu_data_tz}, memory::data_type::f32, memory::format_tag::any);
     auto relu_src_md = conv_pd.dst_desc();
 
     // create backward relu primitive_descriptor
@@ -333,18 +347,25 @@ void simple_net(engine::kind engine_kind) {
     std::vector<float> conv_diff_bias_buffer(product(conv_bias_tz));
 
     auto conv_user_diff_weights_memory
-            = memory({{conv_weights_tz}, dt::f32, tag::nchw}, eng);
+            = memory({{conv_weights_tz}, memory::data_type::f32,
+                             memory::format_tag::nchw},
+                    eng);
     write_to_dnnl_memory(conv_user_diff_weights_buffer.data(),
             conv_user_diff_weights_memory);
-    auto conv_diff_bias_memory = memory({{conv_bias_tz}, dt::f32, tag::x}, eng);
+    auto conv_diff_bias_memory = memory(
+            {{conv_bias_tz}, memory::data_type::f32, memory::format_tag::x},
+            eng);
     write_to_dnnl_memory(conv_diff_bias_buffer.data(), conv_diff_bias_memory);
 
     // create memory descriptors
-    auto conv_bwd_src_md = memory::desc({conv_src_tz}, dt::f32, tag::any);
-    auto conv_diff_bias_md = memory::desc({conv_bias_tz}, dt::f32, tag::any);
-    auto conv_diff_weights_md
-            = memory::desc({conv_weights_tz}, dt::f32, tag::any);
-    auto conv_diff_dst_md = memory::desc({conv_dst_tz}, dt::f32, tag::any);
+    auto conv_bwd_src_md = memory::desc(
+            {conv_src_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv_diff_bias_md = memory::desc(
+            {conv_bias_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv_diff_weights_md = memory::desc(
+            {conv_weights_tz}, memory::data_type::f32, memory::format_tag::any);
+    auto conv_diff_dst_md = memory::desc(
+            {conv_dst_tz}, memory::data_type::f32, memory::format_tag::any);
 
     // create backward convolution primitive descriptor
     auto conv_bwd_weights_pd = convolution_backward_weights::primitive_desc(eng,

--- a/examples/cpu_matmul_coo.cpp
+++ b/examples/cpu_matmul_coo.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,9 +35,6 @@
 #include "example_utils.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 bool check_result(dnnl::memory dst_mem) {
     // clang-format off
@@ -76,9 +73,12 @@ void sparse_matmul() {
 
     // Create a memory descriptor for COO format by providing information
     // about number of non-zero entries and data types of metadata.
-    const auto src_coo_md = memory::desc::coo({M, K}, dt::f32, nnz, dt::s32);
-    const auto wei_md = memory::desc({K, N}, dt::f32, tag::oi);
-    const auto dst_md = memory::desc({M, N}, dt::f32, tag::nc);
+    const auto src_coo_md = memory::desc::coo(
+            {M, K}, memory::data_type::f32, nnz, memory::data_type::s32);
+    const auto wei_md = memory::desc(
+            {K, N}, memory::data_type::f32, memory::format_tag::oi);
+    const auto dst_md = memory::desc(
+            {M, N}, memory::data_type::f32, memory::format_tag::nc);
 
     // This memory is created for the given values and metadata of COO format.
     memory src_coo_mem(src_coo_md, engine,

--- a/examples/cpu_matmul_csr.cpp
+++ b/examples/cpu_matmul_csr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,9 +35,6 @@
 #include "example_utils.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 bool check_result(dnnl::memory dst_mem) {
     // clang-format off
@@ -77,10 +74,12 @@ void sparse_matmul() {
 
     // Create a memory descriptor for CSR format by providing information
     // about number of non-zero entries and data types of metadata.
-    const auto src_csr_md
-            = memory::desc::csr({M, K}, dt::f32, nnz, dt::s32, dt::s32);
-    const auto wei_md = memory::desc({K, N}, dt::f32, tag::oi);
-    const auto dst_md = memory::desc({M, N}, dt::f32, tag::nc);
+    const auto src_csr_md = memory::desc::csr({M, K}, memory::data_type::f32,
+            nnz, memory::data_type::s32, memory::data_type::s32);
+    const auto wei_md = memory::desc(
+            {K, N}, memory::data_type::f32, memory::format_tag::oi);
+    const auto dst_md = memory::desc(
+            {M, N}, memory::data_type::f32, memory::format_tag::nc);
 
     // This memory is created for the given values and metadata of CSR format.
     memory src_csr_mem(src_csr_md, engine,

--- a/examples/cpu_matmul_weights_compression.cpp
+++ b/examples/cpu_matmul_weights_compression.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,9 +36,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void matmul_example(dnnl::engine::kind engine_kind) {
     // Create execution dnnl::engine.
@@ -79,22 +76,31 @@ void matmul_example(dnnl::engine::kind engine_kind) {
     const memory::dim nnz = std::count_if(weights_data.begin(),
             weights_data.end(), [](float v) { return v != 0.0f; });
 
-    auto src_md = memory::desc(src_dims, dt::f32, tag::ab);
-    auto dst_md = memory::desc(dst_dims, dt::f32, tag::ab);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::ab);
+    auto dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::ab);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);
 
-    auto user_src_mem = memory({src_dims, dt::f32, tag::ab}, engine);
-    auto user_weights_mem = memory({weights_dims, dt::f32, tag::ab}, engine);
-    auto user_dst_mem = memory({dst_dims, dt::f32, tag::ab}, engine);
+    auto user_src_mem = memory(
+            {src_dims, memory::data_type::f32, memory::format_tag::ab}, engine);
+    auto user_weights_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::ab},
+            engine);
+    auto user_dst_mem = memory(
+            {dst_dims, memory::data_type::f32, memory::format_tag::ab}, engine);
 
     write_to_dnnl_memory(src_data.data(), src_mem);
     write_to_dnnl_memory(weights_data.data(), user_weights_mem);
 
-    auto matmul_src_md = memory::desc(src_dims, dt::u8, tag::any);
-    auto matmul_weights_md = memory::desc::packed(weights_dims, dt::s8, nnz);
-    auto matmul_dst_md = memory::desc(dst_dims, dt::u8, tag::any);
+    auto matmul_src_md = memory::desc(
+            src_dims, memory::data_type::u8, memory::format_tag::any);
+    auto matmul_weights_md
+            = memory::desc::packed(weights_dims, memory::data_type::s8, nnz);
+    auto matmul_dst_md = memory::desc(
+            dst_dims, memory::data_type::u8, memory::format_tag::any);
 
     matmul::primitive_desc matmul_pd;
     try {

--- a/examples/graph/gated_mlp.cpp
+++ b/examples/graph/gated_mlp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@
 #include "graph_example_utils.hpp"
 
 using namespace dnnl;
-using tag = memory::format_tag;
 
 using namespace dnnl::graph;
 using layout_type = logical_tensor::layout_type;

--- a/examples/graph/gated_mlp_int4.cpp
+++ b/examples/graph/gated_mlp_int4.cpp
@@ -29,7 +29,6 @@
 #include "graph_example_utils.hpp"
 
 using namespace dnnl;
-using tag = memory::format_tag;
 
 using namespace dnnl::graph;
 using data_type = logical_tensor::data_type;

--- a/examples/graph/gated_mlp_wei_combined.cpp
+++ b/examples/graph/gated_mlp_wei_combined.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@
 #include "graph_example_utils.hpp"
 
 using namespace dnnl;
-using tag = memory::format_tag;
 
 using namespace dnnl::graph;
 using layout_type = logical_tensor::layout_type;

--- a/examples/graph/gqa.cpp
+++ b/examples/graph/gqa.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@
 #include "graph_example_utils.hpp"
 
 using namespace dnnl;
-using tag = memory::format_tag;
 
 using namespace dnnl::graph;
 using layout_type = logical_tensor::layout_type;

--- a/examples/graph/mqa.cpp
+++ b/examples/graph/mqa.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@
 #include "graph_example_utils.hpp"
 
 using namespace dnnl;
-using tag = memory::format_tag;
 
 using namespace dnnl::graph;
 using layout_type = logical_tensor::layout_type;

--- a/examples/graph/sdpa.cpp
+++ b/examples/graph/sdpa.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@
 #include "graph_example_utils.hpp"
 
 using namespace dnnl;
-using tag = memory::format_tag;
 
 using namespace dnnl::graph;
 using layout_type = logical_tensor::layout_type;
@@ -109,11 +108,11 @@ void bench_sdpa_primitives(engine::kind ekind, memory::data_type dt,
     // scaled_score = score / scale
     // masked_score = scaled_score + mask
     // All combined in a single matmul primitive.
-    auto query_md = memory::desc(q_sz, dt, tag::abcd);
-    auto key_md = memory::desc(k_sz, dt, tag::abdc);
-    auto score_md = memory::desc(score_sz, dt, tag::abcd);
-    auto scale_md = memory::desc(scale_sz, dt, tag::abcd);
-    auto mask_md = memory::desc(mask_sz, dt, tag::abcd);
+    auto query_md = memory::desc(q_sz, dt, memory::format_tag::abcd);
+    auto key_md = memory::desc(k_sz, dt, memory::format_tag::abdc);
+    auto score_md = memory::desc(score_sz, dt, memory::format_tag::abcd);
+    auto scale_md = memory::desc(scale_sz, dt, memory::format_tag::abcd);
+    auto mask_md = memory::desc(mask_sz, dt, memory::format_tag::abcd);
 
     primitive_attr bmm1_attr;
     bmm1_attr.set_scratchpad_mode(scratchpad_mode::user);
@@ -135,8 +134,8 @@ void bench_sdpa_primitives(engine::kind ekind, memory::data_type dt,
     auto softmax_prim = softmax_forward(softmax_pd);
 
     // attention_output = attention_probs x value
-    auto value_md = memory::desc(v_sz, dt, tag::abcd);
-    auto output_md = memory::desc(q_sz, dt, tag::abcd);
+    auto value_md = memory::desc(v_sz, dt, memory::format_tag::abcd);
+    auto output_md = memory::desc(q_sz, dt, memory::format_tag::abcd);
     primitive_attr bmm2_attr;
     bmm2_attr.set_scratchpad_mode(scratchpad_mode::user);
     auto bmm2_pd = matmul::primitive_desc(
@@ -180,7 +179,7 @@ void bench_sdpa_primitives(engine::kind ekind, memory::data_type dt,
     }
     auto scratchpad_md
             = memory::desc({static_cast<memory::dim>(max_scratchpad_size)},
-                    memory::data_type::u8, tag::a);
+                    memory::data_type::u8, memory::format_tag::a);
 
     // allocate intermediate memory
     auto m_score = memory(score_md, eng);

--- a/examples/graph/sdpa_stacked_qkv.cpp
+++ b/examples/graph/sdpa_stacked_qkv.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@
 #include "graph_example_utils.hpp"
 
 using namespace dnnl;
-using tag = memory::format_tag;
 
 using namespace dnnl::graph;
 using layout_type = logical_tensor::layout_type;

--- a/examples/primitives/augru.cpp
+++ b/examples/primitives/augru.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void augru_example(dnnl::engine::kind engine_kind) {
 
@@ -100,10 +97,14 @@ void augru_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src, bias, and dst.
-    auto src_layer_md = memory::desc(src_dims, dt::f32, tag::tnc);
-    auto attention_md = memory::desc(attention_dims, dt::f32, tag::tnc);
-    auto bias_md = memory::desc(bias_dims, dt::f32, tag::ldgo);
-    auto dst_layer_md = memory::desc(dst_dims, dt::f32, tag::tnc);
+    auto src_layer_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::tnc);
+    auto attention_md = memory::desc(
+            attention_dims, memory::data_type::f32, memory::format_tag::tnc);
+    auto bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::ldgo);
+    auto dst_layer_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::tnc);
 
     auto src_layer_mem = memory(src_layer_md, engine);
     auto attention_mem = memory(attention_md, engine);
@@ -112,10 +113,12 @@ void augru_example(dnnl::engine::kind engine_kind) {
 
     // Create memory objects for weights using user's memory layout. In this
     // example, LDIGO is assumed.
-    auto user_weights_layer_mem
-            = memory({weights_dims, dt::f32, tag::ldigo}, engine);
-    auto user_weights_iter_mem
-            = memory({weights_dims, dt::f32, tag::ldigo}, engine);
+    auto user_weights_layer_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::ldigo},
+            engine);
+    auto user_weights_iter_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::ldigo},
+            engine);
 
     // Write data to memory object's handle.
     write_to_dnnl_memory(src_layer_data.data(), src_layer_mem);
@@ -126,8 +129,10 @@ void augru_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors for weights with format_tag::any. This enables
     // the AUGRU primitive to choose the optimized memory layout.
-    auto augru_weights_layer_md = memory::desc(weights_dims, dt::f32, tag::any);
-    auto augru_weights_iter_md = memory::desc(weights_dims, dt::f32, tag::any);
+    auto augru_weights_layer_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
+    auto augru_weights_iter_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Optional memory descriptors for recurrent data.
     auto src_iter_md = memory::desc();

--- a/examples/primitives/batch_normalization.cpp
+++ b/examples/primitives/batch_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,9 +43,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void batch_normalization_example(dnnl::engine::kind engine_kind) {
 
@@ -91,9 +88,12 @@ void batch_normalization_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create src and scale/shift memory descriptors and memory objects.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto scaleshift_md = memory::desc(scaleshift_dims, dt::f32, tag::x);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto scaleshift_md = memory::desc(
+            scaleshift_dims, memory::data_type::f32, memory::format_tag::x);
 
     auto src_mem = memory(src_md, engine);
     auto scale_mem = memory(scaleshift_md, engine);

--- a/examples/primitives/binary.cpp
+++ b/examples/primitives/binary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,9 +42,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void binary_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -78,9 +75,12 @@ void binary_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create src and dst memory descriptors.
-    auto src_0_md = memory::desc(src_0_dims, dt::f32, tag::nchw);
-    auto src_1_md = memory::desc(src_1_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(src_0_dims, dt::f32, tag::nchw);
+    auto src_0_md = memory::desc(
+            src_0_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto src_1_md = memory::desc(
+            src_1_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            src_0_dims, memory::data_type::f32, memory::format_tag::nchw);
 
     // Create src memory objects.
     auto src_0_mem = memory(src_0_md, engine);

--- a/examples/primitives/concat.cpp
+++ b/examples/primitives/concat.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,9 +43,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void concat_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -85,7 +82,8 @@ void concat_example(dnnl::engine::kind engine_kind) {
     std::vector<memory> src_mems;
 
     for (int n = 0; n < num_src; ++n) {
-        auto md = memory::desc(src_dims, dt::f32, tag::nchw);
+        auto md = memory::desc(
+                src_dims, memory::data_type::f32, memory::format_tag::nchw);
         auto mem = memory(md, engine);
 
         // Write data to memory object's handle.

--- a/examples/primitives/convolution.cpp
+++ b/examples/primitives/convolution.cpp
@@ -43,9 +43,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void convolution_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -106,22 +103,32 @@ void convolution_example(dnnl::engine::kind engine_kind) {
 
     // Create memory objects for tensor data (src, weights, dst). In this
     // example, NCHW layout is assumed for src and dst, and OIHW for weights.
-    auto user_src_mem = memory({src_dims, dt::f32, tag::nchw}, engine);
-    auto user_weights_mem = memory({weights_dims, dt::f32, tag::oihw}, engine);
-    auto user_dst_mem = memory({dst_dims, dt::f32, tag::nchw}, engine);
+    auto user_src_mem = memory(
+            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
+    auto user_weights_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::oihw},
+            engine);
+    auto user_dst_mem = memory(
+            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
 
     // Create memory descriptors with format_tag::any for the primitive. This
     // enables the convolution primitive to choose memory layouts for an
     // optimized primitive implementation, and these layouts may differ from the
     // ones provided by the user.
-    auto conv_src_md = memory::desc(src_dims, dt::f32, tag::any);
-    auto conv_weights_md = memory::desc(weights_dims, dt::f32, tag::any);
-    auto conv_dst_md = memory::desc(dst_dims, dt::f32, tag::any);
+    auto conv_src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::any);
+    auto conv_weights_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
+    auto conv_dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Create memory descriptor and memory object for input bias.
     auto user_bias_md = bias_dims.empty()
             ? memory::desc()
-            : memory::desc(bias_dims, dt::f32, tag::a);
+            : memory::desc(
+                    bias_dims, memory::data_type::f32, memory::format_tag::a);
     auto user_bias_mem = memory(user_bias_md, engine);
 
     // Write data to memory object's handle.
@@ -258,20 +265,30 @@ void depthwise_convolution_example(dnnl::engine::kind engine_kind) {
 
     // Create memory objects for tensor data (src, weights, dst). In this
     // example, NCHW layout is assumed for src and dst, and OIHW for weights.
-    auto user_src_mem = memory({src_dims, dt::f32, tag::nchw}, engine);
-    auto user_weights_mem = memory({weights_dims, dt::f32, tag::goihw}, engine);
-    auto user_dst_mem = memory({dst_dims, dt::f32, tag::nchw}, engine);
+    auto user_src_mem = memory(
+            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
+    auto user_weights_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::goihw},
+            engine);
+    auto user_dst_mem = memory(
+            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
 
     // Create memory descriptors with format_tag::any for the primitive. This
     // enables the convolution primitive to choose memory layouts for an
     // optimized primitive implementation, and these layouts may differ from the
     // ones provided by the user.
-    auto conv_src_md = memory::desc(src_dims, dt::f32, tag::any);
-    auto conv_weights_md = memory::desc(weights_dims, dt::f32, tag::any);
-    auto conv_dst_md = memory::desc(dst_dims, dt::f32, tag::any);
+    auto conv_src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::any);
+    auto conv_weights_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
+    auto conv_dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Create memory descriptor and memory object for input bias.
-    auto user_bias_md = memory::desc(bias_dims, dt::f32, tag::a);
+    auto user_bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::a);
     auto user_bias_mem = memory(user_bias_md, engine);
 
     // Write data to memory object's handle.

--- a/examples/primitives/deconvolution.cpp
+++ b/examples/primitives/deconvolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,9 +42,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void deconvolution_example(dnnl::engine::kind engine_kind) {
 
@@ -111,20 +108,30 @@ void deconvolution_example(dnnl::engine::kind engine_kind) {
 
     // Create memory objects for tensor data (src, weights, dst). In this
     // example, NCHW layout is assumed for src and dst, and OIHW for weights.
-    auto user_src_mem = memory({src_dims, dt::f32, tag::nchw}, engine);
-    auto user_weights_mem = memory({weights_dims, dt::f32, tag::oihw}, engine);
-    auto user_dst_mem = memory({dst_dims, dt::f32, tag::nchw}, engine);
+    auto user_src_mem = memory(
+            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
+    auto user_weights_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::oihw},
+            engine);
+    auto user_dst_mem = memory(
+            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
 
     // Create memory descriptors with format_tag::any for the primitive. This
     // enables the deconvolution primitive to choose memory layouts for an
     // optimized primitive implementation, and these layouts may differ from the
     // ones provided by the user.
-    auto deconv_src_md = memory::desc(src_dims, dt::f32, tag::any);
-    auto deconv_weights_md = memory::desc(weights_dims, dt::f32, tag::any);
-    auto deconv_dst_md = memory::desc(dst_dims, dt::f32, tag::any);
+    auto deconv_src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::any);
+    auto deconv_weights_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
+    auto deconv_dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Create memory descriptor and memory object for input bias.
-    auto user_bias_md = memory::desc(bias_dims, dt::f32, tag::a);
+    auto user_bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::a);
     auto user_bias_mem = memory(user_bias_md, engine);
 
     // Write data to memory object's handle.

--- a/examples/primitives/eltwise.cpp
+++ b/examples/primitives/eltwise.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,9 +39,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void eltwise_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -73,8 +70,10 @@ void eltwise_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create src and dst memory descriptors and memory objects.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(dst_dims, dt::f32, tag::nchw);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);

--- a/examples/primitives/group_normalization.cpp
+++ b/examples/primitives/group_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,9 +42,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void group_normalization_example(engine::kind engine_kind) {
     // Create execution dnnl::engine.
@@ -93,9 +90,12 @@ void group_normalization_example(engine::kind engine_kind) {
     });
 
     // Create src and scale/shift memory descriptors and memory objects.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::ncdhw);
-    auto dst_md = memory::desc(src_dims, dt::f32, tag::ncdhw);
-    auto scaleshift_md = memory::desc(scaleshift_dims, dt::f32, tag::x);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::ncdhw);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::ncdhw);
+    auto scaleshift_md = memory::desc(
+            scaleshift_dims, memory::data_type::f32, memory::format_tag::x);
 
     auto src_mem = memory(src_md, engine);
     auto scale_mem = memory(scaleshift_md, engine);

--- a/examples/primitives/inner_product.cpp
+++ b/examples/primitives/inner_product.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void inner_product_example(dnnl::engine::kind engine_kind) {
 
@@ -89,9 +86,12 @@ void inner_product_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors and memory objects for src and dst. In this
     // example, NCHW layout is assumed.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto bias_md = memory::desc(bias_dims, dt::f32, tag::a);
-    auto dst_md = memory::desc(dst_dims, dt::f32, tag::nc);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::a);
+    auto dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::nc);
 
     auto src_mem = memory(src_md, engine);
     auto bias_mem = memory(bias_md, engine);
@@ -99,7 +99,9 @@ void inner_product_example(dnnl::engine::kind engine_kind) {
 
     // Create memory object for user's layout for weights. In this example, OIHW
     // is assumed.
-    auto user_weights_mem = memory({weights_dims, dt::f32, tag::oihw}, engine);
+    auto user_weights_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::oihw},
+            engine);
 
     // Write data to memory object's handles.
     write_to_dnnl_memory(src_data.data(), src_mem);
@@ -110,8 +112,8 @@ void inner_product_example(dnnl::engine::kind engine_kind) {
     // the inner product primitive to choose the memory layout for an optimized
     // primitive implementation, and this format may differ from the one
     // provided by the user.
-    auto inner_product_weights_md
-            = memory::desc(weights_dims, dt::f32, tag::any);
+    auto inner_product_weights_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Create primitive post-ops (ReLU).
     const float alpha = 0.f;

--- a/examples/primitives/layer_normalization.cpp
+++ b/examples/primitives/layer_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,9 +42,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void layer_normalization_example(dnnl::engine::kind engine_kind) {
 
@@ -89,9 +86,12 @@ void layer_normalization_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create src memory descriptor and memory objects.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::tnc);
-    auto dst_md = memory::desc(src_dims, dt::f32, tag::tnc);
-    auto scaleshift_md = memory::desc(scaleshift_dims, dt::f32, tag::x);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::tnc);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::tnc);
+    auto scaleshift_md = memory::desc(
+            scaleshift_dims, memory::data_type::f32, memory::format_tag::x);
 
     auto src_mem = memory(src_md, engine);
     auto scale_mem = memory(scaleshift_md, engine);
@@ -105,7 +105,8 @@ void layer_normalization_example(dnnl::engine::kind engine_kind) {
     // Create primitive descriptor.
     const float epsilon = 1.e-10f;
     auto lnorm_pd = layer_normalization_forward::primitive_desc(engine,
-            prop_kind::forward_training, src_md, dst_md, dt::f32, epsilon,
+            prop_kind::forward_training, src_md, dst_md, memory::data_type::f32,
+            epsilon,
             normalization_flags::use_scale | normalization_flags::use_shift);
 
     // Use the memory descriptors from the primitive to create memory objects

--- a/examples/primitives/lbr_gru.cpp
+++ b/examples/primitives/lbr_gru.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 #include "example_utils.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void lbr_gru_example(dnnl::engine::kind engine_kind) {
     // Create execution dnnl::engine.
@@ -98,9 +95,12 @@ void lbr_gru_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src, bias, and dst.
-    auto src_layer_md = memory::desc(src_dims, dt::f32, tag::tnc);
-    auto bias_md = memory::desc(bias_dims, dt::f32, tag::ldgo);
-    auto dst_layer_md = memory::desc(dst_layer_dims, dt::f32, tag::tnc);
+    auto src_layer_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::tnc);
+    auto bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::ldgo);
+    auto dst_layer_md = memory::desc(
+            dst_layer_dims, memory::data_type::f32, memory::format_tag::tnc);
 
     auto src_layer_mem = memory(src_layer_md, engine);
     auto bias_mem = memory(bias_md, engine);
@@ -110,9 +110,13 @@ void lbr_gru_example(dnnl::engine::kind engine_kind) {
     // example, LDIGO (num_layers, num_directions, input_channels, num_gates,
     // output_channels) is assumed.
     auto user_weights_layer_mem
-            = memory({weights_layer_dims, dt::f32, tag::ldigo}, engine);
+            = memory({weights_layer_dims, memory::data_type::f32,
+                             memory::format_tag::ldigo},
+                    engine);
     auto user_weights_iter_mem
-            = memory({weights_iter_dims, dt::f32, tag::ldigo}, engine);
+            = memory({weights_iter_dims, memory::data_type::f32,
+                             memory::format_tag::ldigo},
+                    engine);
 
     // Write data to memory object's handle.
     // For GRU cells, the gates order is update, reset and output
@@ -125,8 +129,10 @@ void lbr_gru_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors for weights with format_tag::any. This enables
     // the lbr_gru primitive to choose the optimized memory layout.
-    auto weights_layer_md = memory::desc(weights_layer_dims, dt::f32, tag::any);
-    auto weights_iter_md = memory::desc(weights_iter_dims, dt::f32, tag::any);
+    auto weights_layer_md = memory::desc(weights_layer_dims,
+            memory::data_type::f32, memory::format_tag::any);
+    auto weights_iter_md = memory::desc(
+            weights_iter_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Optional memory descriptors for recurrent data.
     // Default memory descriptor for initial hidden states of the GRU cells

--- a/examples/primitives/lrn.cpp
+++ b/examples/primitives/lrn.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,9 +39,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void lrn_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -69,8 +66,10 @@ void lrn_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create src and dst memory descriptors and memory objects.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(src_dims, dt::f32, tag::nchw);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(src_md, engine);
 

--- a/examples/primitives/lstm.cpp
+++ b/examples/primitives/lstm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void lstm_example(dnnl::engine::kind engine_kind) {
 
@@ -90,9 +87,12 @@ void lstm_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src, bias, and dst.
-    auto src_layer_md = memory::desc(src_dims, dt::f32, tag::tnc);
-    auto bias_md = memory::desc(bias_dims, dt::f32, tag::ldgo);
-    auto dst_layer_md = memory::desc(dst_dims, dt::f32, tag::tnc);
+    auto src_layer_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::tnc);
+    auto bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::ldgo);
+    auto dst_layer_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::tnc);
 
     auto src_layer_mem = memory(src_layer_md, engine);
     auto bias_mem = memory(bias_md, engine);
@@ -100,10 +100,12 @@ void lstm_example(dnnl::engine::kind engine_kind) {
 
     // Create memory objects for weights using user's memory layout. In this
     // example, LDIGO is assumed.
-    auto user_weights_layer_mem
-            = memory({weights_dims, dt::f32, tag::ldigo}, engine);
-    auto user_weights_iter_mem
-            = memory({weights_dims, dt::f32, tag::ldigo}, engine);
+    auto user_weights_layer_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::ldigo},
+            engine);
+    auto user_weights_iter_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::ldigo},
+            engine);
 
     // Write data to memory object's handle.
     write_to_dnnl_memory(src_layer_data.data(), src_layer_mem);
@@ -113,8 +115,10 @@ void lstm_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors for weights with format_tag::any. This enables
     // the LSTM primitive to choose the optimized memory layout.
-    auto lstm_weights_layer_md = memory::desc(weights_dims, dt::f32, tag::any);
-    auto lstm_weights_iter_md = memory::desc(weights_dims, dt::f32, tag::any);
+    auto lstm_weights_layer_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
+    auto lstm_weights_iter_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Optional memory descriptors for recurrent data.
     auto src_iter_md = memory::desc();

--- a/examples/primitives/matmul.cpp
+++ b/examples/primitives/matmul.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void matmul_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -84,10 +81,14 @@ void matmul_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors and memory objects for src, weights, bias, and
     // dst.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::abc);
-    auto weights_md = memory::desc(weights_dims, dt::f32, tag::abc);
-    auto bias_md = memory::desc(bias_dims, dt::f32, tag::abc);
-    auto dst_md = memory::desc(dst_dims, dt::f32, tag::abc);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::abc);
+    auto weights_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::abc);
+    auto bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::abc);
+    auto dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::abc);
 
     auto src_mem = memory(src_md, engine);
     auto weights_mem = memory(weights_md, engine);

--- a/examples/primitives/pooling.cpp
+++ b/examples/primitives/pooling.cpp
@@ -39,9 +39,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void pooling_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -103,10 +100,12 @@ void pooling_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src and dst.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
     auto src_mem = memory(src_md, engine);
 
-    auto dst_md = memory::desc(dst_dims, dt::f32, tag::nchw);
+    auto dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
     auto dst_mem = memory(dst_md, engine);
 
     // Write data to memory object's handle.

--- a/examples/primitives/prelu.cpp
+++ b/examples/primitives/prelu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,9 +38,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void prelu_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -78,18 +75,27 @@ void prelu_example(dnnl::engine::kind engine_kind) {
 
     // Create memory objects for tensor data (src, weights, dst). In this
     // example, NCHW layout is assumed for src, weights and dst.
-    auto user_src_mem = memory({src_dims, dt::f32, tag::nchw}, engine);
-    auto user_weights_mem = memory({weights_dims, dt::f32, tag::nchw}, engine);
-    auto user_dst_mem = memory({dst_dims, dt::f32, tag::nchw}, engine);
+    auto user_src_mem = memory(
+            {src_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
+    auto user_weights_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
+    auto user_dst_mem = memory(
+            {dst_dims, memory::data_type::f32, memory::format_tag::nchw},
+            engine);
 
     // Create memory descriptors for the primitive. Src tag is set
     // to match src memory object. Setting weights tag to format_tag::any
     // enables the PReLU primitive to choose memory layout for an optimized
     // primitive implementation, and that layout may differ from the one
     // provided by the user.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto weights_md = memory::desc(weights_dims, dt::f32, tag::any);
-    auto dst_md = memory::desc(src_dims, dt::f32, tag::any);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto weights_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Write data to memory object's handle.
     write_to_dnnl_memory(src_data.data(), user_src_mem);

--- a/examples/primitives/reduction.cpp
+++ b/examples/primitives/reduction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,9 +34,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void reduction_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -66,8 +63,10 @@ void reduction_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create src and dst memory descriptors and memory objects.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(dst_dims, dt::f32, tag::nchw);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);

--- a/examples/primitives/reorder.cpp
+++ b/examples/primitives/reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void reorder_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -72,8 +69,10 @@ void reorder_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src and dst.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(src_dims, dt::s8, tag::nhwc);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::s8, memory::format_tag::nhwc);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);
@@ -94,7 +93,8 @@ void reorder_example(dnnl::engine::kind engine_kind) {
     // Create primitive post-ops (per-channel output scales)
     primitive_attr reorder_attr;
     reorder_attr.set_scales_mask(DNNL_ARG_DST, 1 << ic_dim);
-    auto dst_scales_mem = memory({{IC}, dt::f32, tag::x}, engine);
+    auto dst_scales_mem = memory(
+            {{IC}, memory::data_type::f32, memory::format_tag::x}, engine);
     write_to_dnnl_memory(scales.data(), dst_scales_mem);
 
     // Create primitive descriptor.

--- a/examples/primitives/resampling.cpp
+++ b/examples/primitives/resampling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,9 +39,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void resampling_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -73,8 +70,10 @@ void resampling_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src and dst.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(dst_dims, dt::f32, tag::nchw);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            dst_dims, memory::data_type::f32, memory::format_tag::nchw);
 
     auto src_mem = memory(src_md, engine);
     auto dst_mem = memory(dst_md, engine);

--- a/examples/primitives/shuffle.cpp
+++ b/examples/primitives/shuffle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void shuffle_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -76,11 +73,15 @@ void shuffle_example(dnnl::engine::kind engine_kind) {
     const int group_size = 4;
 
     // Create memory descriptor and memory objects for src and dst.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nchw);
-    auto dst_md = memory::desc(src_dims, dt::f32, tag::nchw);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nchw);
     auto src_mem = memory(src_md, engine);
 
-    auto dst_mem = memory({src_dims, dt::f32, tag::abcd}, engine);
+    auto dst_mem = memory(
+            {src_dims, memory::data_type::f32, memory::format_tag::abcd},
+            engine);
 
     // Write data to memory object's handle.
     write_to_dnnl_memory(src_data.data(), src_mem);

--- a/examples/primitives/softmax.cpp
+++ b/examples/primitives/softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,9 +43,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void softmax_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -70,8 +67,10 @@ void softmax_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create src memory descriptor and memory object.
-    auto src_md = memory::desc(src_dims, dt::f32, tag::nc);
-    auto dst_md = memory::desc(src_dims, dt::f32, tag::nc);
+    auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nc);
+    auto dst_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::nc);
     auto src_mem = memory(src_md, engine);
 
     // Write data to memory object's handle.

--- a/examples/primitives/sum.cpp
+++ b/examples/primitives/sum.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 
 using namespace dnnl;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void sum_example(dnnl::engine::kind engine_kind) {
 
     // Create execution dnnl::engine.
@@ -84,7 +81,8 @@ void sum_example(dnnl::engine::kind engine_kind) {
     std::vector<memory> src_mem;
 
     for (int n = 0; n < num_src; ++n) {
-        auto md = memory::desc(src_dims, dt::f32, tag::nchw);
+        auto md = memory::desc(
+                src_dims, memory::data_type::f32, memory::format_tag::nchw);
         auto mem = memory(md, engine);
 
         // Write data to memory object's handle.

--- a/examples/primitives/vanilla_rnn.cpp
+++ b/examples/primitives/vanilla_rnn.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 #include "example_utils.hpp"
 
 using namespace dnnl;
-
-using tag = memory::format_tag;
-using dt = memory::data_type;
 
 void vanilla_rnn_example(dnnl::engine::kind engine_kind) {
     // Create execution dnnl::engine.
@@ -95,9 +92,12 @@ void vanilla_rnn_example(dnnl::engine::kind engine_kind) {
     });
 
     // Create memory descriptors and memory objects for src, bias, and dst.
-    auto src_layer_md = memory::desc(src_dims, dt::f32, tag::tnc);
-    auto bias_md = memory::desc(bias_dims, dt::f32, tag::ldgo);
-    auto dst_layer_md = memory::desc(dst_layer_dims, dt::f32, tag::tnc);
+    auto src_layer_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::tnc);
+    auto bias_md = memory::desc(
+            bias_dims, memory::data_type::f32, memory::format_tag::ldgo);
+    auto dst_layer_md = memory::desc(
+            dst_layer_dims, memory::data_type::f32, memory::format_tag::tnc);
 
     auto src_layer_mem = memory(src_layer_md, engine);
     auto bias_mem = memory(bias_md, engine);
@@ -106,10 +106,12 @@ void vanilla_rnn_example(dnnl::engine::kind engine_kind) {
     // Create memory objects for weights using user's memory layout. In this
     // example, LDIGO (num_layers, num_directions, input_channels, num_gates,
     // output_channels) is assumed.
-    auto user_weights_layer_mem
-            = memory({weights_dims, dt::f32, tag::ldigo}, engine);
-    auto user_weights_iter_mem
-            = memory({weights_dims, dt::f32, tag::ldigo}, engine);
+    auto user_weights_layer_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::ldigo},
+            engine);
+    auto user_weights_iter_mem = memory(
+            {weights_dims, memory::data_type::f32, memory::format_tag::ldigo},
+            engine);
 
     // Write data to memory object's handle.
     write_to_dnnl_memory(src_layer_data.data(), src_layer_mem);
@@ -119,8 +121,10 @@ void vanilla_rnn_example(dnnl::engine::kind engine_kind) {
 
     // Create memory descriptors for weights with format_tag::any. This enables
     // the Vanilla primitive to choose the optimized memory layout.
-    auto weights_layer_md = memory::desc(weights_dims, dt::f32, tag::any);
-    auto weights_iter_md = memory::desc(weights_dims, dt::f32, tag::any);
+    auto weights_layer_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
+    auto weights_iter_md = memory::desc(
+            weights_dims, memory::data_type::f32, memory::format_tag::any);
 
     // Optional memory descriptors for recurrent data.
     // Default memory descriptor for initial hidden states of the GRU cells

--- a/examples/tutorials/matmul/cpu_matmul_quantization.cpp
+++ b/examples/tutorials/matmul/cpu_matmul_quantization.cpp
@@ -219,14 +219,13 @@ const engine &eng() {
 // - X_int_m -- prepared oneDNN memory that would hold quantized values
 void quantize(const std::vector<float> &X_f32, float scale_X, int32_t zp_X,
         memory &X_int_m) {
-    using dt = memory::data_type;
-
     stream s(eng());
 
     memory::desc x_int_md = X_int_m.get_desc();
     const auto &dims = x_int_md.get_dims();
 
-    memory::desc x_f32_md({dims[0], dims[1]}, dt::f32, {dims[1], 1});
+    memory::desc x_f32_md(
+            {dims[0], dims[1]}, memory::data_type::f32, {dims[1], 1});
     memory X_f32_m(x_f32_md, eng(), (void *)X_f32.data());
 
     primitive_attr q10n_attr;
@@ -235,8 +234,8 @@ void quantize(const std::vector<float> &X_f32, float scale_X, int32_t zp_X,
 
     reorder::primitive_desc q10n_pd(
             eng(), x_f32_md, eng(), x_int_md, q10n_attr);
-    memory dst_scale_X_m({{1}, dt::f32, {1}}, eng(), &scale_X);
-    memory zp_X_m({{1}, dt::s32, {1}}, eng(), &zp_X);
+    memory dst_scale_X_m({{1}, memory::data_type::f32, {1}}, eng(), &scale_X);
+    memory zp_X_m({{1}, memory::data_type::s32, {1}}, eng(), &zp_X);
     reorder(q10n_pd).execute(s,
             {{DNNL_ARG_SRC, X_f32_m}, {DNNL_ARG_DST, X_int_m},
                     {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, dst_scale_X_m},

--- a/examples/ukernels/cpu_brgemm.cpp
+++ b/examples/ukernels/cpu_brgemm.cpp
@@ -36,9 +36,6 @@
 using namespace dnnl;
 using namespace dnnl::ukernel;
 
-using tag = memory::format_tag;
-using dt = memory::data_type;
-
 void brgemm_example() {
 
     // Create execution dnnl::engine. Needed for reorders to operate over input
@@ -57,10 +54,10 @@ void brgemm_example() {
     }
     const memory::dim n_calls = K / K_k;
 
-    memory::data_type a_dt = dt::u8;
-    memory::data_type b_dt = dt::s8;
-    memory::data_type c_dt = dt::s32; // Accumulator data type.
-    memory::data_type d_dt = dt::f32; // Output data type.
+    memory::data_type a_dt = memory::data_type::u8;
+    memory::data_type b_dt = memory::data_type::s8;
+    memory::data_type c_dt = memory::data_type::s32; // Accumulator data type.
+    memory::data_type d_dt = memory::data_type::f32; // Output data type.
 
     // Query the packing requirement from the ukernel. It's enough to query
     // packing requirements once for multiple objects.
@@ -131,11 +128,16 @@ void brgemm_example() {
 
     // Create f32 memories. They are used as data holders and reorder into
     // memories passed to the ukernel.
-    auto A_f32_md = memory::desc(A_dims, dt::f32, tag::ab);
-    auto B_f32_md = memory::desc(B_dims, dt::f32, tag::ab);
-    auto binary_add_f32_md = memory::desc(binary_add_dims, dt::f32, tag::ab);
-    auto B_scales_f32_md = memory::desc(B_scales_dims, dt::f32, tag::ab);
-    auto D_f32_md = memory::desc(D_dims, dt::f32, tag::ab);
+    auto A_f32_md = memory::desc(
+            A_dims, memory::data_type::f32, memory::format_tag::ab);
+    auto B_f32_md = memory::desc(
+            B_dims, memory::data_type::f32, memory::format_tag::ab);
+    auto binary_add_f32_md = memory::desc(
+            binary_add_dims, memory::data_type::f32, memory::format_tag::ab);
+    auto B_scales_f32_md = memory::desc(
+            B_scales_dims, memory::data_type::f32, memory::format_tag::ab);
+    auto D_f32_md = memory::desc(
+            D_dims, memory::data_type::f32, memory::format_tag::ab);
 
     auto A_f32_mem = memory(A_f32_md, engine, A_user_data.data());
     auto B_f32_mem = memory(B_f32_md, engine, B_user_data.data());
@@ -147,12 +149,14 @@ void brgemm_example() {
 
     // Create ukernel memories in requested data types.
     // Note that all formats are `ab`.
-    auto A_md = memory::desc(A_dims, a_dt, tag::ab);
-    auto B_md = memory::desc(B_dims, b_dt, tag::ab);
-    auto binary_add_md = memory::desc(binary_add_dims, dt::f32, tag::ab);
-    auto B_scales_md = memory::desc(B_scales_dims, dt::f32, tag::ab);
-    auto C_md = memory::desc(C_dims, c_dt, tag::ab);
-    auto D_md = memory::desc(D_dims, d_dt, tag::ab);
+    auto A_md = memory::desc(A_dims, a_dt, memory::format_tag::ab);
+    auto B_md = memory::desc(B_dims, b_dt, memory::format_tag::ab);
+    auto binary_add_md = memory::desc(
+            binary_add_dims, memory::data_type::f32, memory::format_tag::ab);
+    auto B_scales_md = memory::desc(
+            B_scales_dims, memory::data_type::f32, memory::format_tag::ab);
+    auto C_md = memory::desc(C_dims, c_dt, memory::format_tag::ab);
+    auto D_md = memory::desc(D_dims, d_dt, memory::format_tag::ab);
 
     auto A_mem = memory(A_md, engine);
     auto B_mem = memory(B_md, engine);
@@ -233,7 +237,7 @@ void brgemm_example() {
         // Specify post-ops for the brgemm object.
         brg_po.set_post_ops(ldd, d_dt, brgemm_ops);
         // Specify quantization scales for B.
-        if (b_dt == dt::s8 || b_dt == dt::u8) {
+        if (b_dt == memory::data_type::s8 || b_dt == memory::data_type::u8) {
             brg_po.set_B_scales(/* mask = */ 2);
         }
         // Finalize the initialization.


### PR DESCRIPTION
Fixes broken links:
* [Supported Primitives -> LRN](https://oneapi-src.github.io/oneDNN/dev_guide_lrn.html) has links at 'across channels' and 'within channels' that lead nowhere.
* [Examples -> CNN f32 inference](https://oneapi-src.github.io/oneDNN/page_cnn_inference_f32_cpp.html#doxid-cnn-inference-f32-cpp) has broken link to `tag::nchw`, `tag::iohw`, and `tag::any`.

Also removed `dt` and `tag` namespace shortcuts as these create confusion in annotated examples like [this one](https://oneapi-src.github.io/oneDNN/page_cnn_inference_f32_cpp.html#doxid-cnn-inference-f32-cpp).
