### PR TITLE
ci: clang-tidy: run on PRs from forks

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install clang
         run: |


### PR DESCRIPTION
clang-tidy runs are currently broken if the head ref comes from a fork (see, e.g., https://github.com/oneapi-src/oneDNN/actions/runs/13798408419/job/38595447059?pr=2850, #2850).

This PR changes the repository to match that of the PR head repo.