### PR TITLE
xe: remove ngen relative directories

### DIFF
--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -40,7 +40,7 @@
 #include "gpu/intel/jit/ir/tensor.hpp"
 #include "gpu/intel/jit/ir/walk_order.hpp"
 #include "ngen.hpp"
-#include "ngen/ngen_register_allocator.hpp"
+#include "ngen_register_allocator.hpp"
 #include "xpu/utils.hpp"
 
 namespace dnnl {

--- a/src/gpu/intel/jit/codegen/ngen_helpers.hpp
+++ b/src/gpu/intel/jit/codegen/ngen_helpers.hpp
@@ -20,7 +20,7 @@
 #include "gpu/intel/jit/ir/core.hpp"
 #include "gpu/intel/jit/utils/ngen_proxy.hpp"
 #include "ngen.hpp"
-#include "ngen/ngen_register_allocator.hpp"
+#include "ngen_register_allocator.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/codegen/register_allocator.hpp
+++ b/src/gpu/intel/jit/codegen/register_allocator.hpp
@@ -20,7 +20,7 @@
 #include "common/z_magic.hpp"
 #include "gpu/intel/jit/utils/utils.hpp"
 #include "ngen.hpp"
-#include "ngen/ngen_register_allocator.hpp"
+#include "ngen_register_allocator.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/codegen/register_scope.hpp
+++ b/src/gpu/intel/jit/codegen/register_scope.hpp
@@ -20,7 +20,7 @@
 #include "gpu/intel/jit/codegen/ngen_helpers.hpp"
 #include "gpu/intel/jit/codegen/reg_buf.hpp"
 #include "ngen.hpp"
-#include "ngen/ngen_register_allocator.hpp"
+#include "ngen_register_allocator.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/emulated_generator.hpp
+++ b/src/gpu/intel/jit/emulated_generator.hpp
@@ -24,7 +24,7 @@
 #include "gpu/intel/jit/codegen/register_allocator.hpp"
 #include "gpu/intel/jit/emulation.hpp"
 #include "gpu/intel/jit/generator.hpp"
-#include "ngen/ngen_core.hpp"
+#include "ngen_core.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/gemm/generator/microkernel_provider.cpp
+++ b/src/gpu/intel/jit/gemm/generator/microkernel_provider.cpp
@@ -20,7 +20,7 @@
 #include "generator.hpp"
 #include "kernel_selector.hpp"
 #include "strategy_parser.hpp"
-#include "ngen/npack/neo_packager.hpp"
+#include "npack/neo_packager.hpp"
 
 #include "internal/namespace_start.hxx"
 

--- a/src/gpu/intel/jit/gemm/include/internal/ngen_includes.hpp
+++ b/src/gpu/intel/jit/gemm/include/internal/ngen_includes.hpp
@@ -16,6 +16,6 @@
 
 #include "../config.hpp"
 
-#   include "ngen/ngen_opencl.hpp"
-#   include "ngen/ngen_register_allocator.hpp"
-#   include "ngen/ngen_asm.hpp"
+#   include "ngen_opencl.hpp"
+#   include "ngen_register_allocator.hpp"
+#   include "ngen_asm.hpp"

--- a/src/gpu/intel/jit/generator.hpp
+++ b/src/gpu/intel/jit/generator.hpp
@@ -32,7 +32,7 @@
 #include "gpu/intel/ocl/engine.hpp"
 #include "xpu/utils.hpp"
 
-#include "ngen/ngen_opencl.hpp"
+#include "ngen_opencl.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/pooling/gen_pooling.cpp
+++ b/src/gpu/intel/jit/pooling/gen_pooling.cpp
@@ -26,7 +26,7 @@
 #include "gpu/intel/jit/pooling/pooling_kernel.hpp"
 #include "gpu/intel/jit/utils/utils.hpp"
 #include "gpu/intel/primitive_conf.hpp"
-#include "ngen/ngen_register_allocator.hpp"
+#include "ngen_register_allocator.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/reduction_generator.hpp
+++ b/src/gpu/intel/jit/reduction_generator.hpp
@@ -25,8 +25,8 @@
 #include "gpu/intel/jit/generator.hpp"
 #include "gpu/intel/jit/reduction_injector.hpp"
 #include "gpu/intel/utils.hpp"
-#include "ngen/ngen_core.hpp"
-#include "ngen/ngen_interface.hpp"
+#include "ngen_core.hpp"
+#include "ngen_interface.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/reduction_injector.cpp
+++ b/src/gpu/intel/jit/reduction_injector.cpp
@@ -25,7 +25,7 @@
 #include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/jit/emulation.hpp"
 #include "gpu/intel/jit/reduction_injector.hpp"
-#include "ngen/ngen_core.hpp"
+#include "ngen_core.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/reduction_injector.hpp
+++ b/src/gpu/intel/jit/reduction_injector.hpp
@@ -25,7 +25,7 @@
 #include "gpu/intel/jit/codegen/register_allocator.hpp"
 #include "gpu/intel/jit/emulation.hpp"
 #include "gpu/intel/jit/generator.hpp"
-#include "ngen/ngen_core.hpp"
+#include "ngen_core.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/sycl/l0/utils.cpp
+++ b/src/gpu/intel/sycl/l0/utils.cpp
@@ -19,7 +19,7 @@
 
 #include "gpu/intel/jit/binary_format.hpp"
 #include "gpu/intel/jit/utils/ngen_type_bridge.hpp"
-#include "ngen/ngen_level_zero.hpp"
+#include "ngen_level_zero.hpp"
 
 #if defined(__linux__)
 #include <dlfcn.h>


### PR DESCRIPTION
For third party builds, the relative directory will resolve to the wrong path.

Forward port of #2860