### PR TITLE
xe: ocl: prevent double->float literal conversion in post ops

### DIFF
--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -178,6 +178,9 @@ private:
         if (gpu_utils::dev_getenv("ocl_debug", 0)) {
             add_option("-DOCL_DEBUG");
         }
+
+        if (gpu_utils::dev_getenv("enable_ocl_werror", is_dev_mode()))
+            add_option("-Werror ");
     }
     void set_default_macros(const primitive_attr_t *attr) {
         if (attr) { define_int("DETERMINISTIC", attr->deterministic_); }

--- a/src/gpu/intel/ocl/device_info.cpp
+++ b/src/gpu/intel/ocl/device_info.cpp
@@ -191,18 +191,6 @@ std::string device_info_t::get_cl_ext_options() const {
             opts += std::string("-D") + ext2cl_str(ext) + " ";
     }
 
-#ifdef DNNL_DEV_MODE
-    // Preferably this would be in `kernel_ctx::set_default_options()`, but
-    // warnings are emitted for the automatic down conversions of double
-    // literals to float. This behavior is desirable to avoid duplicate
-    // implementations, so -Werror is disabled when fp64 support is not
-    // available instead.
-    bool enabled_werror = gpu_utils::dev_getenv(
-            "enable_ocl_werror", has(device_ext_t::khr_fp64));
-
-    if (enabled_werror) opts += "-Werror ";
-#endif
-
     return opts;
 }
 


### PR DESCRIPTION
When cl_khr_f64 is unsupported, the compiler warns about double literals.