### PR TITLE
[cpu] riscv64: update intrinsics

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -474,8 +474,7 @@ if (DNNL_TARGET_ARCH STREQUAL "RV64")
 
                                #include <riscv_vector.h>
                                int main() {
-                                size_t size = 64;
-                                return __riscv_vsetvl_e32m2(size);
+                                return 0;
                                };"
                                CAN_COMPILE_RVV_INTRINSICS
     )

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -464,10 +464,18 @@ endif()
 if (DNNL_TARGET_ARCH STREQUAL "RV64")
     # Check if the RVV Intrinsics can be compiled with the current toolchain and flags
     include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles("#include <riscv_vector.h>
+    check_cxx_source_compiles("#if !defined(__riscv) || !defined(__riscv_v)
+                               #error \"RISC-V or vector extension(RVV) is not supported by the compiler\"
+                               #endif
+
+                               #if defined(__riscv_v_intrinsic) && __riscv_v_intrinsic < 12000
+                               #error \"Wrong intrinsics version, v0.12 or higher is required for gcc or clang\"
+                               #endif
+
+                               #include <riscv_vector.h>
                                int main() {
                                 size_t size = 64;
-                                return vsetvl_e32m2(size);
+                                return __riscv_vsetvl_e32m2(size);
                                };"
                                CAN_COMPILE_RVV_INTRINSICS
     )

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -469,7 +469,7 @@ if (DNNL_TARGET_ARCH STREQUAL "RV64")
                                #endif
 
                                #if defined(__riscv_v_intrinsic) && __riscv_v_intrinsic < 12000
-                               #error \"Wrong intrinsics version, v0.12 or higher is required for gcc or clang\"
+                               #error \"RISC-V intrinsics v0.12 or higher is required\"
                                #endif
 
                                #include <riscv_vector.h>

--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -81,7 +81,7 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                                 }
 
                                 size_t tailLength
-					 = __riscv_vsetvl_e32m8(size - iw);
+                                        = __riscv_vsetvl_e32m8(size - iw);
                                 {
                                     vfloat32m8_t vsrc = __riscv_vle32_v_f32m8(
                                             &local_src[local_src_offset + iw],

--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -57,9 +57,9 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                         int ow_offset = ow * strideW - padLeft;
                         size_t size = std::min(ow_offset + kerW, inW)
                                 - std::max(ow_offset, 0);
-                        size_t cycleLength = vsetvl_e32m8(size);
+                        size_t cycleLength = __riscv_vsetvl_e32m8(size);
                         vfloat32m8_t vmax
-                                = vle32_v_f32m8(&arr_flt_min[0], cycleLength);
+                                = __riscv_vle32_v_f32m8(&arr_flt_min[0], cycleLength);
 
                         for (int id = std::max(od_offset, 0);
                                 id < std::min(od_offset + kerD, inD); id++)
@@ -73,34 +73,34 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                                 size_t iw = 0;
                                 for (; iw < size - cycleLength;
                                         iw += cycleLength) {
-                                    vfloat32m8_t vsrc = vle32_v_f32m8(
+                                    vfloat32m8_t vsrc = __riscv_vle32_v_f32m8(
                                             &local_src[local_src_offset + iw],
                                             cycleLength);
-                                    vmax = vfmax_vv_f32m8(
+                                    vmax = __riscv_vfmax_vv_f32m8(
                                             vsrc, vmax, cycleLength);
                                 }
 
-                                size_t tailLength = vsetvl_e32m8(size - iw);
+                                size_t tailLength = __riscv_vsetvl_e32m8(size - iw);
                                 {
-                                    vfloat32m8_t vsrc = vle32_v_f32m8(
+                                    vfloat32m8_t vsrc = __riscv_vle32_v_f32m8(
                                             &local_src[local_src_offset + iw],
                                             tailLength);
-                                    vmax = vfmax_vv_f32m8(
+                                    vmax = __riscv_vfmax_vv_f32m8(
                                             vsrc, vmax, tailLength);
                                 }
                             }
 
                         vfloat32m1_t min_scalar;
                         float min = -__FLT_MAX__;
-                        min_scalar = vle32_v_f32m1(&min, 1);
+                        min_scalar = __riscv_vle32_v_f32m1(&min, 1);
 
-                        cycleLength = vsetvl_e32m8(size);
+                        cycleLength = __riscv_vsetvl_e32m8(size);
                         vfloat32m1_t vred_res;
-                        vred_res = vfredmax_vs_f32m8_f32m1(
-                                vred_res, vmax, min_scalar, cycleLength);
+                        vred_res = __riscv_vfredmax_vs_f32m8_f32m1(
+                                vmax, min_scalar, cycleLength);
 
                         float red_res;
-                        vse32_v_f32m1(&red_res, vred_res, 1);
+                        __riscv_vse32_v_f32m1(&red_res, vred_res, 1);
                         dst[dst_offset] = red_res;
                     }
 }

--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -58,8 +58,8 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                         size_t size = std::min(ow_offset + kerW, inW)
                                 - std::max(ow_offset, 0);
                         size_t cycleLength = __riscv_vsetvl_e32m8(size);
-                        vfloat32m8_t vmax
-                                = __riscv_vle32_v_f32m8(&arr_flt_min[0], cycleLength);
+                        vfloat32m8_t vmax = __riscv_vle32_v_f32m8(
+                                &arr_flt_min[0], cycleLength);
 
                         for (int id = std::max(od_offset, 0);
                                 id < std::min(od_offset + kerD, inD); id++)
@@ -81,7 +81,7 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                                 }
 
                                 size_t tailLength
-					= __riscv_vsetvl_e32m8(size - iw);
+					 = __riscv_vsetvl_e32m8(size - iw);
                                 {
                                     vfloat32m8_t vsrc = __riscv_vle32_v_f32m8(
                                             &local_src[local_src_offset + iw],

--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -80,7 +80,8 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                                             vsrc, vmax, cycleLength);
                                 }
 
-                                size_t tailLength = __riscv_vsetvl_e32m8(size - iw);
+                                size_t tailLength
+					= __riscv_vsetvl_e32m8(size - iw);
                                 {
                                     vfloat32m8_t vsrc = __riscv_vle32_v_f32m8(
                                             &local_src[local_src_offset + iw],


### PR DESCRIPTION
# Description

Currently, oneDNN can be compiled normally on RISC-V architecture platforms, but when using newer compilers and enabling vector extensions, it does not compile RVV-related code (specifically, the code introduced in #1521). Below is the configuration output information regarding RVV when using clang-17:
```shell
export CC=clang-17 CXX=clang++-17
cmake .. -DDNNL_CPU_RUNTIME=SEQ -DCMAKE_CXX_FLAGS=-march=rv64gcv -DCMAKE_C_FLAGS=-march=rv64gcv
```
```plaintext

-- Performing Test CAN_COMPILE_RVV_INTRINSICS
-- Performing Test CAN_COMPILE_RVV_INTRINSICS - Failed
-- Can compile RVV Intrinsics: FALSE
-- DNNL_RISCV_USE_RVV_INTRINSICS: FALSE

```
This is because the RVV intrinsics in #1521 are based on the old version specifications, and the new versions all have the __riscv64 prefix, as detailed in [rvv-intrinsic-doc](https://github.com/riscv-non-isa/rvv-intrinsic-doc). Currently, most open-source software projects (such as OpenCV, OpenBLAS, and SLEEF) have already adopted the new RVV intrinsics.

Based on #1521, the following modifications were made:

1. Updated intrinsics in rvv_nchw_pooling.cpp to the latest version;
2. Added version checks for intrinsics in CMake.

These changes enable Clang 17+ or GCC 14+ to properly compile RVV-related code, while older compiler versions will fall back to generic implementations.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

Tested on both QEMU and [Banana Pi BPI-F3](https://docs.banana-pi.org/en/BPI-F3/BananaPi_BPI-F3) (vector length is 256 bits). Due to the long testing time required for `matmul`, it has been omitted here, as this PR only modifies the names of intrinsics. Below are the test results:

[result.log](https://github.com/user-attachments/files/19380139/result.log)
