### PR TITLE
api: make md queries return const object

### DIFF
--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -4642,7 +4642,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns The requested memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     parameter of the specified kind or index.
-    memory::desc query_md(query what, int idx = 0) const {
+    const memory::desc query_md(query what, int idx = 0) const {
         std::vector<query> valid_q {query::src_md, query::diff_src_md,
                 query::weights_md, query::diff_weights_md, query::dst_md,
                 query::diff_dst_md, query::workspace_md, query::scratchpad_md,
@@ -4654,13 +4654,10 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
 
         const_dnnl_memory_desc_t cdesc = dnnl_primitive_desc_query_md(
                 get(), dnnl::convert_to_c(what), idx);
-        if (!cdesc) return memory::desc();
 
-        dnnl_memory_desc_t cloned_md = nullptr;
-        error::wrap_c_api(dnnl_memory_desc_clone(&cloned_md, cdesc),
-                "could not clone a memory descriptor");
+        auto nc_cdesc = const_cast<dnnl_memory_desc_t>(cdesc);
 
-        return memory::desc(cloned_md);
+        return nc_cdesc ? memory::desc(nc_cdesc) : memory::desc();
     }
 
     /// Returns a source memory descriptor.
@@ -4668,7 +4665,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns Source memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     source parameter with index @p idx.
-    memory::desc src_desc(int idx) const {
+    const memory::desc src_desc(int idx) const {
         return query_md(query::src_md, idx);
     }
 
@@ -4677,7 +4674,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns Destination memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     destination parameter with index @p idx.
-    memory::desc dst_desc(int idx) const {
+    const memory::desc dst_desc(int idx) const {
         return query_md(query::dst_md, idx);
     }
 
@@ -4686,7 +4683,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns Weights memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     weights parameter with index @p idx.
-    memory::desc weights_desc(int idx) const {
+    const memory::desc weights_desc(int idx) const {
         return query_md(query::weights_md, idx);
     }
 
@@ -4695,7 +4692,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns Diff source memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     diff source parameter with index @p idx.
-    memory::desc diff_src_desc(int idx) const {
+    const memory::desc diff_src_desc(int idx) const {
         return query_md(query::diff_src_md, idx);
     }
 
@@ -4704,7 +4701,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns Diff destination memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     diff destination parameter with index @p idx.
-    memory::desc diff_dst_desc(int idx) const {
+    const memory::desc diff_dst_desc(int idx) const {
         return query_md(query::diff_dst_md, idx);
     }
 
@@ -4713,7 +4710,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns Diff weights memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     diff weights parameter with index @p idx.
-    memory::desc diff_weights_desc(int idx) const {
+    const memory::desc diff_weights_desc(int idx) const {
         return query_md(query::diff_weights_md, idx);
     }
 
@@ -4724,43 +4721,45 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns Source memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     source parameter.
-    memory::desc src_desc() const { return src_desc(0); }
+    const memory::desc src_desc() const { return src_desc(0); }
 
     /// Returns a destination memory descriptor.
     /// @returns Destination memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     destination parameter.
-    memory::desc dst_desc() const { return dst_desc(0); }
+    const memory::desc dst_desc() const { return dst_desc(0); }
 
     /// Returns a weights memory descriptor.
     /// @returns Weights memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     weights parameter.
-    memory::desc weights_desc() const { return weights_desc(0); }
+    const memory::desc weights_desc() const { return weights_desc(0); }
 
     /// Returns a diff source memory descriptor.
     /// @returns Diff source memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     diff source memory with.
-    memory::desc diff_src_desc() const { return diff_src_desc(0); }
+    const memory::desc diff_src_desc() const { return diff_src_desc(0); }
 
     /// Returns a diff destination memory descriptor.
     /// @returns Diff destination memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     diff destination parameter.
-    memory::desc diff_dst_desc() const { return diff_dst_desc(0); }
+    const memory::desc diff_dst_desc() const { return diff_dst_desc(0); }
 
     /// Returns a diff weights memory descriptor.
     /// @returns Diff weights memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///     diff weights parameter.
-    memory::desc diff_weights_desc() const { return diff_weights_desc(0); }
+    const memory::desc diff_weights_desc() const {
+        return diff_weights_desc(0);
+    }
 
     /// Returns the workspace memory descriptor.
     /// @returns Workspace memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not require
     ///     workspace parameter.
-    memory::desc workspace_desc() const {
+    const memory::desc workspace_desc() const {
         return query_md(query::workspace_md, 0);
     }
 
@@ -4769,7 +4768,7 @@ struct primitive_desc_base : public handle<dnnl_primitive_desc_t> {
     /// @returns A zero memory descriptor if the primitive does not require
     ///     scratchpad parameter.
     /// @sa @ref dev_guide_attributes_scratchpad
-    memory::desc scratchpad_desc() const {
+    const memory::desc scratchpad_desc() const {
         return query_md(query::scratchpad_md, 0);
     }
 
@@ -5121,10 +5120,10 @@ struct reorder : public primitive {
         }
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
     };
 
     /// Default constructor. Produces an empty object.
@@ -5272,10 +5271,12 @@ struct concat : public primitive {
             : primitive_desc_base(pd, dnnl::primitive::kind::concat) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
-        memory::desc src_desc(int idx = 0) const { return base::src_desc(idx); }
+        const memory::desc src_desc(int idx = 0) const {
+            return base::src_desc(idx);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
     };
 
     /// Default constructor. Produces an empty object.
@@ -5393,10 +5394,12 @@ struct sum : public primitive {
             : primitive_desc_base(pd, dnnl::primitive::kind::sum) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
-        memory::desc src_desc(int idx = 0) const { return base::src_desc(idx); }
+        const memory::desc src_desc(int idx = 0) const {
+            return base::src_desc(idx);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
     };
 
     /// Default constructor. Produces an empty object.
@@ -5663,19 +5666,21 @@ struct convolution_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// Returns the bias memory descriptor.
         /// @returns The bias memory descriptor.
         /// @returns A zero memory descriptor of the primitive does not have a
         ///     bias parameter.
-        memory::desc bias_desc() const { return base::weights_desc(1); }
+        const memory::desc bias_desc() const { return base::weights_desc(1); }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -5862,13 +5867,19 @@ struct convolution_backward_data : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -6159,21 +6170,23 @@ struct convolution_backward_weights : public primitive {
                     dnnl::prop_kind::backward_weights) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
-        memory::desc diff_weights_desc() const {
+        const memory::desc diff_weights_desc() const {
             return base::diff_weights_desc(0);
         }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// Returns the diff bias memory descriptor.
         /// @returns The diff bias memory descriptor.
         /// @returns A zero memory descriptor of the primitive does not have a
         ///          diff bias parameter.
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return base::diff_weights_desc(1);
         }
 
@@ -6466,16 +6479,18 @@ struct deconvolution_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
-        memory::desc bias_desc() const { return base::weights_desc(1); }
+        const memory::desc bias_desc() const { return base::weights_desc(1); }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -6660,13 +6675,19 @@ struct deconvolution_backward_data : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -6953,18 +6974,20 @@ struct deconvolution_backward_weights : public primitive {
                     dnnl::prop_kind::backward_weights) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
-        memory::desc diff_weights_desc() const {
+        const memory::desc diff_weights_desc() const {
             return base::diff_weights_desc(0);
         }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::convolution_backward_weights::primitive_desc::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return base::diff_weights_desc(1);
         }
 
@@ -7114,13 +7137,15 @@ struct lrn_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -7222,13 +7247,19 @@ struct lrn_backward : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -7386,10 +7417,10 @@ struct eltwise_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         dnnl::algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -7560,13 +7591,17 @@ struct eltwise_backward : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         dnnl::algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -7692,10 +7727,10 @@ struct softmax_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         dnnl::algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -7784,13 +7819,17 @@ struct softmax_backward : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         dnnl::algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -7907,24 +7946,28 @@ struct batch_normalization_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// Returns memory descriptor for mean.
         /// @returns Memory descriptor for mean.
-        memory::desc mean_desc() const { return stat_desc(mean); }
+        const memory::desc mean_desc() const { return stat_desc(mean); }
 
         /// Returns memory descriptor for variance.
         /// @returns Memory descriptor for variance.
-        memory::desc variance_desc() const { return stat_desc(var); }
+        const memory::desc variance_desc() const { return stat_desc(var); }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         dnnl::prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -7943,7 +7986,7 @@ struct batch_normalization_forward : public primitive {
             mean = 1,
             var = 2,
         };
-        memory::desc stat_desc(int kind) const {
+        const memory::desc stat_desc(int kind) const {
             const bool use_global_stats
                     = (get_flags() & normalization_flags::use_global_stats)
                     != normalization_flags::none;
@@ -8038,35 +8081,45 @@ struct batch_normalization_backward : public primitive {
         }
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
-        memory::desc diff_weights_desc() const {
+        const memory::desc diff_weights_desc() const {
             return base::diff_weights_desc(0);
         }
 
         /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
-        memory::desc mean_desc() const { return query_md(query::src_md, 1); }
+        const memory::desc mean_desc() const {
+            return query_md(query::src_md, 1);
+        }
 
         /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
-        memory::desc variance_desc() const {
+        const memory::desc variance_desc() const {
             return query_md(query::src_md, 2);
         }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         dnnl::prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -8186,24 +8239,28 @@ struct group_normalization_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// Returns memory descriptor for mean.
         /// @returns Memory descriptor for mean.
-        memory::desc mean_desc() const { return stat_desc(mean); }
+        const memory::desc mean_desc() const { return stat_desc(mean); }
 
         /// Returns memory descriptor for variance.
         /// @returns Memory descriptor for variance.
-        memory::desc variance_desc() const { return stat_desc(var); }
+        const memory::desc variance_desc() const { return stat_desc(var); }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         dnnl::prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -8225,7 +8282,7 @@ struct group_normalization_forward : public primitive {
             mean = 1,
             var = 2,
         };
-        memory::desc stat_desc(int kind) const {
+        const memory::desc stat_desc(int kind) const {
             const bool use_global_stats
                     = (get_flags() & normalization_flags::use_global_stats)
                     != normalization_flags::none;
@@ -8321,35 +8378,45 @@ struct group_normalization_backward : public primitive {
         }
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
-        memory::desc diff_weights_desc() const {
+        const memory::desc diff_weights_desc() const {
             return base::diff_weights_desc(0);
         }
 
         /// @copydoc dnnl::group_normalization_forward::primitive_desc::mean_desc()const
-        memory::desc mean_desc() const { return query_md(query::src_md, 1); }
+        const memory::desc mean_desc() const {
+            return query_md(query::src_md, 1);
+        }
 
         /// @copydoc dnnl::group_normalization_forward::primitive_desc::variance_desc()const
-        memory::desc variance_desc() const {
+        const memory::desc variance_desc() const {
             return query_md(query::src_md, 2);
         }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         dnnl::prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -8549,22 +8616,26 @@ struct layer_normalization_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
-        memory::desc mean_desc() const { return stat_desc(mean); }
+        const memory::desc mean_desc() const { return stat_desc(mean); }
 
         /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
-        memory::desc variance_desc() const { return stat_desc(var); }
+        const memory::desc variance_desc() const { return stat_desc(var); }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         dnnl::prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -8583,7 +8654,7 @@ struct layer_normalization_forward : public primitive {
             mean = 1,
             var = 2,
         };
-        memory::desc stat_desc(int kind) const {
+        const memory::desc stat_desc(int kind) const {
             const bool use_global_stats
                     = (get_flags() & normalization_flags::use_global_stats)
                     != normalization_flags::none;
@@ -8815,35 +8886,45 @@ struct layer_normalization_backward : public primitive {
         }
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
-        memory::desc diff_weights_desc() const {
+        const memory::desc diff_weights_desc() const {
             return base::diff_weights_desc(0);
         }
 
         /// @copydoc dnnl::batch_normalization_forward::primitive_desc::mean_desc()const
-        memory::desc mean_desc() const { return query_md(query::src_md, 1); }
+        const memory::desc mean_desc() const {
+            return query_md(query::src_md, 1);
+        }
 
         /// @copydoc dnnl::batch_normalization_forward::primitive_desc::variance_desc()const
-        memory::desc variance_desc() const {
+        const memory::desc variance_desc() const {
             return query_md(query::src_md, 2);
         }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         dnnl::prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -8994,16 +9075,18 @@ struct inner_product_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
-        memory::desc bias_desc() const { return base::weights_desc(1); }
+        const memory::desc bias_desc() const { return base::weights_desc(1); }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -9111,13 +9194,19 @@ struct inner_product_backward_data : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const { return base::weights_desc(0); }
+        const memory::desc weights_desc() const {
+            return base::weights_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -9220,18 +9309,20 @@ struct inner_product_backward_weights : public primitive {
                     dnnl::prop_kind::backward_weights) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_weights_desc()const
-        memory::desc diff_weights_desc() const {
+        const memory::desc diff_weights_desc() const {
             return base::diff_weights_desc(0);
         }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::convolution_backward_weights::primitive_desc::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return base::diff_weights_desc(1);
         }
 
@@ -9312,13 +9403,13 @@ struct rnn_primitive_desc_base : public primitive_desc {
 
     /// Returns source layer memory descriptor.
     /// @returns Source layer memory descriptor.
-    memory::desc src_layer_desc() const {
+    const memory::desc src_layer_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_SRC_LAYER);
     }
 
     /// Returns AUGRU attention memory descriptor.
     /// @returns AUGRU attention memory descriptor.
-    memory::desc augru_attention_desc() const {
+    const memory::desc augru_attention_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_AUGRU_ATTENTION);
     }
 
@@ -9326,37 +9417,37 @@ struct rnn_primitive_desc_base : public primitive_desc {
     /// @returns Source iteration memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///          source iteration parameter.
-    memory::desc src_iter_desc() const {
+    const memory::desc src_iter_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_SRC_ITER);
     }
 
     /// Returns source recurrent cell state memory descriptor.
     /// @returns Source recurrent cell state memory descriptor.
-    memory::desc src_iter_c_desc() const {
+    const memory::desc src_iter_c_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_SRC_ITER_C);
     }
 
     /// Returns weights layer memory descriptor.
     /// @returns Weights layer memory descriptor.
-    memory::desc weights_layer_desc() const {
+    const memory::desc weights_layer_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_LAYER);
     }
 
     /// Returns weights iteration memory descriptor.
     /// @returns Weights iteration memory descriptor.
-    memory::desc weights_iter_desc() const {
+    const memory::desc weights_iter_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_ITER);
     }
 
     /// Returns weights peephole memory descriptor.
     /// @returns Weights peephole memory descriptor.
-    memory::desc weights_peephole_desc() const {
+    const memory::desc weights_peephole_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_PEEPHOLE);
     }
 
     /// Returns weights projection memory descriptor.
     /// @returns Weights projection memory descriptor.
-    memory::desc weights_projection_desc() const {
+    const memory::desc weights_projection_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_WEIGHTS_PROJECTION);
     }
 
@@ -9364,13 +9455,13 @@ struct rnn_primitive_desc_base : public primitive_desc {
     /// @returns Bias memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///          bias parameter.
-    memory::desc bias_desc() const {
+    const memory::desc bias_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_BIAS);
     }
 
     /// Returns destination layer memory descriptor.
     /// @returns Destination layer memory descriptor.
-    memory::desc dst_layer_desc() const {
+    const memory::desc dst_layer_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DST_LAYER);
     }
 
@@ -9378,25 +9469,25 @@ struct rnn_primitive_desc_base : public primitive_desc {
     /// @returns Destination iteration memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///          destination iteration parameter.
-    memory::desc dst_iter_desc() const {
+    const memory::desc dst_iter_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DST_ITER);
     }
 
     /// Returns destination recurrent cell state memory descriptor.
     /// @returns Destination recurrent cell state memory descriptor.
-    memory::desc dst_iter_c_desc() const {
+    const memory::desc dst_iter_c_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DST_ITER_C);
     }
 
     /// Returns diff source layer memory descriptor.
     /// @returns Diff source layer memory descriptor.
-    memory::desc diff_src_layer_desc() const {
+    const memory::desc diff_src_layer_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_SRC_LAYER);
     }
 
     /// Returns diff AUGRU attention memory descriptor.
     /// @returns Diff AUGRU attention memory descriptor.
-    memory::desc diff_augru_attention_desc() const {
+    const memory::desc diff_augru_attention_desc() const {
         return base::query_md(
                 query::exec_arg_md, DNNL_ARG_DIFF_AUGRU_ATTENTION);
     }
@@ -9405,38 +9496,38 @@ struct rnn_primitive_desc_base : public primitive_desc {
     /// @returns Diff source iteration memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///          diff source iteration parameter.
-    memory::desc diff_src_iter_desc() const {
+    const memory::desc diff_src_iter_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_SRC_ITER);
     }
 
     /// Returns diff source recurrent cell state memory descriptor.
     /// @returns Diff source recurrent cell state memory descriptor.
-    memory::desc diff_src_iter_c_desc() const {
+    const memory::desc diff_src_iter_c_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_SRC_ITER_C);
     }
 
     /// Returns diff weights layer memory descriptor.
     /// @returns Diff weights layer memory descriptor.
-    memory::desc diff_weights_layer_desc() const {
+    const memory::desc diff_weights_layer_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_LAYER);
     }
 
     /// Returns diff weights iteration memory descriptor.
     /// @returns Diff weights iteration memory descriptor.
-    memory::desc diff_weights_iter_desc() const {
+    const memory::desc diff_weights_iter_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_ITER);
     }
 
     /// Returns diff weights peephole memory descriptor.
     /// @returns Diff weights peephole memory descriptor.
-    memory::desc diff_weights_peephole_desc() const {
+    const memory::desc diff_weights_peephole_desc() const {
         return base::query_md(
                 query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_PEEPHOLE);
     }
 
     /// Returns diff weights projection memory descriptor.
     /// @returns Diff weights projection memory descriptor.
-    memory::desc diff_weights_projection_desc() const {
+    const memory::desc diff_weights_projection_desc() const {
         return base::query_md(
                 query::exec_arg_md, DNNL_ARG_DIFF_WEIGHTS_PROJECTION);
     }
@@ -9445,13 +9536,13 @@ struct rnn_primitive_desc_base : public primitive_desc {
     /// @returns Diff bias memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///          diff bias parameter.
-    memory::desc diff_bias_desc() const {
+    const memory::desc diff_bias_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_BIAS);
     }
 
     /// Returns diff destination layer memory descriptor.
     /// @returns Diff destination layer memory descriptor.
-    memory::desc diff_dst_layer_desc() const {
+    const memory::desc diff_dst_layer_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_DST_LAYER);
     }
 
@@ -9459,13 +9550,13 @@ struct rnn_primitive_desc_base : public primitive_desc {
     /// @returns Diff destination iteration memory descriptor.
     /// @returns A zero memory descriptor if the primitive does not have a
     ///          diff destination iteration parameter.
-    memory::desc diff_dst_iter_desc() const {
+    const memory::desc diff_dst_iter_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_DST_ITER);
     }
 
     /// Returns diff destination recurrent cell state memory descriptor.
     /// @returns Diff destination recurrent cell state memory descriptor.
-    memory::desc diff_dst_iter_c_desc() const {
+    const memory::desc diff_dst_iter_c_desc() const {
         return base::query_md(query::exec_arg_md, DNNL_ARG_DIFF_DST_ITER_C);
     }
 
@@ -9941,36 +10032,40 @@ struct vanilla_rnn_forward : public primitive {
                     dnnl::algorithm::vanilla_rnn) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
@@ -10209,71 +10304,75 @@ struct vanilla_rnn_backward : public primitive {
                     dnnl::algorithm::vanilla_rnn) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
-        memory::desc diff_src_layer_desc() const {
+        const memory::desc diff_src_layer_desc() const {
             return rnn_base::diff_src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
-        memory::desc diff_src_iter_desc() const {
+        const memory::desc diff_src_iter_desc() const {
             return rnn_base::diff_src_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
-        memory::desc diff_weights_layer_desc() const {
+        const memory::desc diff_weights_layer_desc() const {
             return rnn_base::diff_weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
-        memory::desc diff_weights_iter_desc() const {
+        const memory::desc diff_weights_iter_desc() const {
             return rnn_base::diff_weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return rnn_base::diff_bias_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
-        memory::desc diff_dst_layer_desc() const {
+        const memory::desc diff_dst_layer_desc() const {
             return rnn_base::diff_dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
-        memory::desc diff_dst_iter_desc() const {
+        const memory::desc diff_dst_iter_desc() const {
             return rnn_base::diff_dst_iter_desc();
         }
 
@@ -10542,56 +10641,60 @@ struct lstm_forward : public primitive {
                     dnnl::algorithm::vanilla_lstm) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_c_desc() const {
+        const memory::desc src_iter_c_desc() const {
             return rnn_base::src_iter_c_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_peephole_desc()const
-        memory::desc weights_peephole_desc() const {
+        const memory::desc weights_peephole_desc() const {
             return rnn_base::weights_peephole_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_projection_desc()const
-        memory::desc weights_projection_desc() const {
+        const memory::desc weights_projection_desc() const {
             return rnn_base::weights_projection_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc dst_iter_c_desc() const {
+        const memory::desc dst_iter_c_desc() const {
             return rnn_base::dst_iter_c_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
@@ -10972,111 +11075,115 @@ struct lstm_backward : public primitive {
                     dnnl::algorithm::vanilla_lstm) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_c_desc() const {
+        const memory::desc src_iter_c_desc() const {
             return rnn_base::src_iter_c_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_peephole_desc()const
-        memory::desc weights_peephole_desc() const {
+        const memory::desc weights_peephole_desc() const {
             return rnn_base::weights_peephole_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_projection_desc()const
-        memory::desc weights_projection_desc() const {
+        const memory::desc weights_projection_desc() const {
             return rnn_base::weights_projection_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc dst_iter_c_desc() const {
+        const memory::desc dst_iter_c_desc() const {
             return rnn_base::dst_iter_c_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
-        memory::desc diff_src_layer_desc() const {
+        const memory::desc diff_src_layer_desc() const {
             return rnn_base::diff_src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
-        memory::desc diff_src_iter_desc() const {
+        const memory::desc diff_src_iter_desc() const {
             return rnn_base::diff_src_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_c_desc()const
-        memory::desc diff_src_iter_c_desc() const {
+        const memory::desc diff_src_iter_c_desc() const {
             return rnn_base::diff_src_iter_c_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
-        memory::desc diff_weights_layer_desc() const {
+        const memory::desc diff_weights_layer_desc() const {
             return rnn_base::diff_weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
-        memory::desc diff_weights_iter_desc() const {
+        const memory::desc diff_weights_iter_desc() const {
             return rnn_base::diff_weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_peephole_desc()const
-        memory::desc diff_weights_peephole_desc() const {
+        const memory::desc diff_weights_peephole_desc() const {
             return rnn_base::diff_weights_peephole_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_projection_desc()const
-        memory::desc diff_weights_projection_desc() const {
+        const memory::desc diff_weights_projection_desc() const {
             return rnn_base::diff_weights_projection_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return rnn_base::diff_bias_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
-        memory::desc diff_dst_layer_desc() const {
+        const memory::desc diff_dst_layer_desc() const {
             return rnn_base::diff_dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
-        memory::desc diff_dst_iter_desc() const {
+        const memory::desc diff_dst_iter_desc() const {
             return rnn_base::diff_dst_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_c_desc()const
-        memory::desc diff_dst_iter_c_desc() const {
+        const memory::desc diff_dst_iter_c_desc() const {
             return rnn_base::diff_dst_iter_c_desc();
         }
 
@@ -11182,36 +11289,40 @@ struct gru_forward : public primitive {
                     dnnl::algorithm::vanilla_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
@@ -11343,71 +11454,75 @@ struct gru_backward : public primitive {
                     dnnl::algorithm::vanilla_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
-        memory::desc diff_src_layer_desc() const {
+        const memory::desc diff_src_layer_desc() const {
             return rnn_base::diff_src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
-        memory::desc diff_src_iter_desc() const {
+        const memory::desc diff_src_iter_desc() const {
             return rnn_base::diff_src_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
-        memory::desc diff_weights_layer_desc() const {
+        const memory::desc diff_weights_layer_desc() const {
             return rnn_base::diff_weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
-        memory::desc diff_weights_iter_desc() const {
+        const memory::desc diff_weights_iter_desc() const {
             return rnn_base::diff_weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return rnn_base::diff_bias_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
-        memory::desc diff_dst_layer_desc() const {
+        const memory::desc diff_dst_layer_desc() const {
             return rnn_base::diff_dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
-        memory::desc diff_dst_iter_desc() const {
+        const memory::desc diff_dst_iter_desc() const {
             return rnn_base::diff_dst_iter_desc();
         }
 
@@ -11513,36 +11628,40 @@ struct lbr_gru_forward : public primitive {
                     dnnl::algorithm::lbr_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
@@ -11673,71 +11792,75 @@ struct lbr_gru_backward : public primitive {
                     pd, dnnl::prop_kind::backward, dnnl::algorithm::lbr_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
-        memory::desc diff_src_layer_desc() const {
+        const memory::desc diff_src_layer_desc() const {
             return rnn_base::diff_src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
-        memory::desc diff_src_iter_desc() const {
+        const memory::desc diff_src_iter_desc() const {
             return rnn_base::diff_src_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
-        memory::desc diff_weights_layer_desc() const {
+        const memory::desc diff_weights_layer_desc() const {
             return rnn_base::diff_weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
-        memory::desc diff_weights_iter_desc() const {
+        const memory::desc diff_weights_iter_desc() const {
             return rnn_base::diff_weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return rnn_base::diff_bias_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
-        memory::desc diff_dst_layer_desc() const {
+        const memory::desc diff_dst_layer_desc() const {
             return rnn_base::diff_dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
-        memory::desc diff_dst_iter_desc() const {
+        const memory::desc diff_dst_iter_desc() const {
             return rnn_base::diff_dst_iter_desc();
         }
 
@@ -11846,41 +11969,45 @@ struct augru_forward : public primitive {
                     dnnl::algorithm::vanilla_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::augru_attention_desc()const
-        memory::desc attention_desc() const {
+        const memory::desc attention_desc() const {
             return rnn_base::augru_attention_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
@@ -12018,81 +12145,85 @@ struct augru_backward : public primitive {
                     dnnl::algorithm::vanilla_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::augru_attention_desc()const
-        memory::desc attention_desc() const {
+        const memory::desc attention_desc() const {
             return rnn_base::augru_attention_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
-        memory::desc diff_src_layer_desc() const {
+        const memory::desc diff_src_layer_desc() const {
             return rnn_base::diff_src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
-        memory::desc diff_src_iter_desc() const {
+        const memory::desc diff_src_iter_desc() const {
             return rnn_base::diff_src_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_augru_attention_desc()const
-        memory::desc diff_attention_desc() const {
+        const memory::desc diff_attention_desc() const {
             return rnn_base::diff_augru_attention_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
-        memory::desc diff_weights_layer_desc() const {
+        const memory::desc diff_weights_layer_desc() const {
             return rnn_base::diff_weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
-        memory::desc diff_weights_iter_desc() const {
+        const memory::desc diff_weights_iter_desc() const {
             return rnn_base::diff_weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return rnn_base::diff_bias_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
-        memory::desc diff_dst_layer_desc() const {
+        const memory::desc diff_dst_layer_desc() const {
             return rnn_base::diff_dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
-        memory::desc diff_dst_iter_desc() const {
+        const memory::desc diff_dst_iter_desc() const {
             return rnn_base::diff_dst_iter_desc();
         }
 
@@ -12203,41 +12334,45 @@ struct lbr_augru_forward : public primitive {
                     dnnl::algorithm::lbr_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::augru_attention_desc()const
-        memory::desc attention_desc() const {
+        const memory::desc attention_desc() const {
             return rnn_base::augru_attention_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
@@ -12374,81 +12509,85 @@ struct lbr_augru_backward : public primitive {
                     dnnl::algorithm::lbr_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
-        memory::desc src_layer_desc() const {
+        const memory::desc src_layer_desc() const {
             return rnn_base::src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_iter_desc()const
-        memory::desc src_iter_desc() const { return rnn_base::src_iter_desc(); }
+        const memory::desc src_iter_desc() const {
+            return rnn_base::src_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::augru_attention_desc()const
-        memory::desc attention_desc() const {
+        const memory::desc attention_desc() const {
             return rnn_base::augru_attention_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_layer_desc()const
-        memory::desc weights_layer_desc() const {
+        const memory::desc weights_layer_desc() const {
             return rnn_base::weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::weights_iter_desc()const
-        memory::desc weights_iter_desc() const {
+        const memory::desc weights_iter_desc() const {
             return rnn_base::weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::bias_desc()const
-        memory::desc bias_desc() const { return rnn_base::bias_desc(); }
+        const memory::desc bias_desc() const { return rnn_base::bias_desc(); }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_layer_desc()const
-        memory::desc dst_layer_desc() const {
+        const memory::desc dst_layer_desc() const {
             return rnn_base::dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::dst_iter_desc()const
-        memory::desc dst_iter_desc() const { return rnn_base::dst_iter_desc(); }
+        const memory::desc dst_iter_desc() const {
+            return rnn_base::dst_iter_desc();
+        }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const {
+        const memory::desc workspace_desc() const {
             return rnn_base::workspace_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_layer_desc()const
-        memory::desc diff_src_layer_desc() const {
+        const memory::desc diff_src_layer_desc() const {
             return rnn_base::diff_src_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_src_iter_desc()const
-        memory::desc diff_src_iter_desc() const {
+        const memory::desc diff_src_iter_desc() const {
             return rnn_base::diff_src_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_augru_attention_desc()const
-        memory::desc diff_attention_desc() const {
+        const memory::desc diff_attention_desc() const {
             return rnn_base::diff_augru_attention_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_layer_desc()const
-        memory::desc diff_weights_layer_desc() const {
+        const memory::desc diff_weights_layer_desc() const {
             return rnn_base::diff_weights_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_weights_iter_desc()const
-        memory::desc diff_weights_iter_desc() const {
+        const memory::desc diff_weights_iter_desc() const {
             return rnn_base::diff_weights_iter_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_bias_desc()const
-        memory::desc diff_bias_desc() const {
+        const memory::desc diff_bias_desc() const {
             return rnn_base::diff_bias_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_layer_desc()const
-        memory::desc diff_dst_layer_desc() const {
+        const memory::desc diff_dst_layer_desc() const {
             return rnn_base::diff_dst_layer_desc();
         }
 
         /// @copydoc dnnl::rnn_primitive_desc_base::diff_dst_iter_desc()const
-        memory::desc diff_dst_iter_desc() const {
+        const memory::desc diff_dst_iter_desc() const {
             return rnn_base::diff_dst_iter_desc();
         }
 
@@ -12546,10 +12685,10 @@ struct shuffle_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -12634,10 +12773,14 @@ struct shuffle_backward : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -12761,19 +12904,21 @@ struct binary : public primitive {
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::binary) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc(int)const
-        memory::desc src_desc(int idx = 0) const { return base::src_desc(idx); }
+        const memory::desc src_desc(int idx = 0) const {
+            return base::src_desc(idx);
+        }
 
         /// Returns the memory descriptor for source #0.
-        memory::desc src0_desc() const { return base::src_desc(0); }
+        const memory::desc src0_desc() const { return base::src_desc(0); }
 
         /// Returns the memory descriptor for source #1.
-        memory::desc src1_desc() const { return base::src_desc(1); }
+        const memory::desc src1_desc() const { return base::src_desc(1); }
 
         /// Returns the memory descriptor for source #2.
-        memory::desc src2_desc() const { return base::src_desc(2); }
+        const memory::desc src2_desc() const { return base::src_desc(2); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -12863,20 +13008,24 @@ struct matmul : public primitive {
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::matmul) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return query_md(query::src_md, 0); }
+        const memory::desc src_desc() const {
+            return query_md(query::src_md, 0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::weights_desc()const
-        memory::desc weights_desc() const {
+        const memory::desc weights_desc() const {
             return query_md(query::weights_md, 0);
         }
 
         /// @copydoc dnnl::convolution_forward::primitive_desc::bias_desc()const
-        memory::desc bias_desc() const {
+        const memory::desc bias_desc() const {
             return query_md(query::weights_md, 1);
         }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return query_md(query::dst_md, 0); }
+        const memory::desc dst_desc() const {
+            return query_md(query::dst_md, 0);
+        }
 
     private:
         primitive_desc(const engine &aengine, const memory::desc &src_desc,
@@ -13033,10 +13182,10 @@ struct resampling_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
     private:
         primitive_desc(const engine &aengine, prop_kind aprop_kind,
@@ -13157,10 +13306,14 @@ struct resampling_backward : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
     private:
         primitive_desc(const engine &aengine, algorithm aalgorithm,
@@ -13297,13 +13450,15 @@ struct pooling_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -13424,13 +13579,19 @@ struct pooling_backward : public primitive {
                     dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::workspace_desc()const
-        memory::desc workspace_desc() const { return base::workspace_desc(); }
+        const memory::desc workspace_desc() const {
+            return base::workspace_desc();
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_algorithm()const
         algorithm get_algorithm() const { return base::get_algorithm(); }
@@ -13540,10 +13701,10 @@ struct prelu_forward : public primitive {
                     dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -13626,13 +13787,17 @@ struct prelu_backward : public primitive {
                     dnnl::prop_kind::backward) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
-        memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
+        const memory::desc diff_src_desc() const {
+            return base::diff_src_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::diff_dst_desc()const
-        memory::desc diff_dst_desc() const { return base::diff_dst_desc(0); }
+        const memory::desc diff_dst_desc() const {
+            return base::diff_dst_desc(0);
+        }
 
         /// @copydoc dnnl::primitive_desc_base::get_prop_kind()const
         prop_kind get_prop_kind() const { return base::get_prop_kind(); }
@@ -13725,10 +13890,10 @@ struct reduction : public primitive {
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::reduction) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
-        memory::desc src_desc() const { return base::src_desc(0); }
+        const memory::desc src_desc() const { return base::src_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
-        memory::desc dst_desc() const { return base::dst_desc(0); }
+        const memory::desc dst_desc() const { return base::dst_desc(0); }
 
         /// @copydoc dnnl::primitive_desc_base::get_p()const
         float get_p() const { return base::get_p(); }


### PR DESCRIPTION
This is a draft PR to test change to md queries semantic:
- C++ API avoids the cloning
- md queries that can now return const memory::desc.