### PR TITLE
benchdnn: utils: cfg: return fixed safe_n_acc for low precision dt (fixes MFDNN-13520)

### DIFF
--- a/tests/benchdnn/brgemm/cfg.cpp
+++ b/tests/benchdnn/brgemm/cfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,7 +51,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
         return density;
 
     const int64_t safe_n_acc = get_safe_n_acc();
-    assert(safe_n_acc > 0);
 
     // Bump density for some empiric value for int8 validation to hit saturation
     // bound.

--- a/tests/benchdnn/conv/cfg.cpp
+++ b/tests/benchdnn/conv/cfg.cpp
@@ -82,7 +82,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
 
     if (density_args.data_kind == allowed_non_dense_kind) {
         int64_t safe_n_acc = get_safe_n_acc();
-        assert(safe_n_acc > 0);
         safe_n_acc_str = std::to_string(safe_n_acc);
 
         // Bump density for some empiric value for int8 validation to hit

--- a/tests/benchdnn/deconv/cfg.cpp
+++ b/tests/benchdnn/deconv/cfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -65,7 +65,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
 
     if (density_args.data_kind == allowed_non_dense_kind) {
         int64_t safe_n_acc = get_safe_n_acc();
-        assert(safe_n_acc > 0);
         safe_n_acc_str = std::to_string(safe_n_acc);
 
         // Bump density for some empiric value for int8 validation to hit

--- a/tests/benchdnn/ip/cfg.cpp
+++ b/tests/benchdnn/ip/cfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -65,7 +65,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
     if (density_args.data_kind != SRC) return density;
 
     const auto safe_n_acc = get_safe_n_acc();
-    assert(safe_n_acc > 0);
 
     // Bump density for some empiric value for int8 validation to hit saturation
     // bound.

--- a/tests/benchdnn/matmul/cfg.cpp
+++ b/tests/benchdnn/matmul/cfg.cpp
@@ -46,7 +46,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
     if (density_args.data_kind != SRC) return density;
 
     const int64_t safe_n_acc = get_safe_n_acc();
-    assert(safe_n_acc > 0);
 
     // Bump density for some empiric value for int8 validation to hit saturation
     // bound.


### PR DESCRIPTION
MFDNN-13520

Motivation and resolution in the code comments.