### PR TITLE
[GPU] Fixup GEMM strategy override

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -260,11 +260,10 @@ status_t gen_gemm_kernel_desc_t::finalize(const char *tags) {
         // (typically requires extra benchmarking data not supplied with
         // the kernel override string)
         // Currently: assume the W model because it's simple
-        aux_params_.k0
-                = utils::rnd_up(utils::div_up(k_, driver_info_.wg[LoopK]),
-                        driver_info_.unroll[LoopK]);
+        aux_params_.k0 = utils::rnd_up(utils::div_up(k_, strategy_.wg[LoopK]),
+                strategy_.unroll[LoopK]);
         aux_params_.wgK = std::max(1,
-                std::min(driver_info_.wg[LoopK],
+                std::min(strategy_.wg[LoopK],
                         int(utils::div_up(k_, aux_params_.k0))));
     }
 #endif


### PR DESCRIPTION
# Description

Use strategy values rather than driver_info which may be uninitialized. 

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
