### PR TITLE
example: add backward propagation to vanilla rnn example

### DIFF
--- a/examples/primitives/vanilla_rnn.cpp
+++ b/examples/primitives/vanilla_rnn.cpp
@@ -338,7 +338,7 @@ void vanilla_rnn(engine::kind engine_kind) {
     vanilla_rnn_bwd_args.insert({DNNL_ARG_DIFF_BIAS, diff_bias_mem});
     vanilla_rnn_bwd_args.insert({DNNL_ARG_DIFF_DST_LAYER, diff_dst_layer_mem});
     vanilla_rnn_bwd_args.insert({DNNL_ARG_DIFF_SRC_ITER, diff_src_iter_mem});
-    vanilla_rnn_bwd_args.insert({DNNL_ARG_DIFF_DST_ITER, dst_iter_mem});
+    vanilla_rnn_bwd_args.insert({DNNL_ARG_DIFF_DST_ITER, diff_dst_iter_mem});
     vanilla_rnn_bwd_args.insert({DNNL_ARG_WORKSPACE, workspace_memory});
 
     // Primitive execution: vanilla rnn backward


### PR DESCRIPTION
# Description

Adding backward propagation primitive to vanilla_rnn.cpp example.

Fixes # [(github issue)](https://github.com/uxlfoundation/oneDNN/issues/3257)

# Checklist

## General
only tested the new example with oneDNN v3.8 

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

