### PR TITLE
benchdnn: fix sycl graph testing using ctest

### DIFF
--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -88,7 +88,7 @@ function(register_benchdnn_test engine driver test_file)
         set(benchdnn_target ${target_name}_${engine})
 
         if(DNNL_TEST_SET_HAS_GRAPH_EXE EQUAL 1)
-            string(PREPEND cmd "--execution-mode=graph")
+            string(PREPEND cmd "--execution-mode=graph ")
         endif()
 
         if(NOT WIN32 OR DNNL_BUILD_FOR_CI)

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -385,7 +385,9 @@ int execute_and_wait(perf_function_t &exec_func, const dnnl_engine_t &engine,
         BENCHDNN_PRINT(
                 2, "%s\n", "[INFO] Using experimental SYCL graph execution.");
         sycl::ext::oneapi::experimental::command_graph graph {
-                queue.get_context(), queue.get_device()};
+                queue.get_context(), queue.get_device(),
+                {sycl::ext::oneapi::experimental::property::graph::
+                                assume_buffer_outlives_graph {}}};
 
         graph.begin_recording(queue);
         status = exec_func(stream, dnnl_args);


### PR DESCRIPTION
Fixes for `CI;GRAPH_EXE` test scope:
1. Missing space when invoked from `ctest`
2. Missing `assume_buffer_outlives_graph` property required by newer SYCL RT
