### PR TITLE
gpu: cuda: Fix matmul queue recording

### DIFF
--- a/src/gpu/nvidia/cudnn_matmul.cpp
+++ b/src/gpu/nvidia/cudnn_matmul.cpp
@@ -48,9 +48,12 @@ status_t cudnn_matmul_t::execute(const exec_ctx_t &ctx) const {
             matmul_impl_, pd()->params_, src_d, weights_d, dst_d, bias_d);
 
     if (pd()->params_->has_runtime_params_) {
-        auto &evts = cuda_stream->sycl_ctx().get_sycl_deps().events;
-        for (auto e : evts) {
-            e.wait();
+        if (cuda_stream->queue().ext_oneapi_get_state()
+                == sycl::ext::oneapi::experimental::queue_state::executing) {
+            auto &evts = cuda_stream->sycl_ctx().get_sycl_deps().events;
+            for (auto e : evts) {
+                e.wait();
+            }
         }
     }
     return status;

--- a/src/gpu/nvidia/cudnn_matmul_executor.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_executor.hpp
@@ -79,6 +79,8 @@ protected:
                     auto cudnn_handle
                             = cuda_stream->get_cudnn_handle(native_stream);
 
+                    cuda_stream->begin_recording_if_graph(ih, native_stream);
+
                     void *reorder_scratch
                             = arg_bias_scratch.get_native_pointer(ih);
                     void *bias = arg_bias.get_native_pointer(ih);
@@ -93,6 +95,8 @@ protected:
                     matmul_impl_->execute(cublas_handle, cudnn_handle, params,
                             weights, src, dst, bias, reorder_scratch, src_scale,
                             wei_scale, dst_scale);
+
+                    cuda_stream->end_recording_if_graph(ih, native_stream);
 
                     if (params->has_runtime_params_) {
                         sync_device();

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -378,9 +378,9 @@ int execute_and_wait(perf_function_t &exec_func, const dnnl_engine_t &engine,
         void *queue_ptr;
         DNN_SAFE(dnnl_sycl_interop_stream_get_queue(stream, &queue_ptr), CRIT);
         sycl::queue queue = *static_cast<sycl::queue *>(queue_ptr);
-        const bool can_run_sycl_graph = queue.get_device().get_backend()
-                == sycl::backend::ext_oneapi_level_zero;
-        if (!can_run_sycl_graph) break;
+        if (!queue.get_device().has(sycl::aspect::ext_oneapi_limited_graph)) {
+            break;
+        }
 
         BENCHDNN_PRINT(
                 2, "%s\n", "[INFO] Using experimental SYCL graph execution.");

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -155,7 +155,8 @@ a non-negative integer value. The default value is `0`. Refer to
 is set to `direct` (the default), the driver will execute normally. When `MODE`
 is set to `graph` it instructs the driver to execute on a graph backend.
 Currently this feature is limited to the experimental SYCL Graph feature on
-DPC++ runtime with Level Zero backend.
+DPC++ runtime for devices that support the `sycl_ext_oneapi_limited_graph`
+aspect.
 
 ## Correctness mode settings
 


### PR DESCRIPTION
When `sycl_ext_codeplay_enqueue_native_command` commands are used as part of sycl queue recording to a graph, then their usage should to be updated to put the underlying CUDA stream into recording mode to enable correct behavior. See https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_codeplay_enqueue_native_command.asciidoc#cuda-stream-record-native-graph-nodes

This patch updates the `sycl_ext_codeplay_enqueue_native_command()` callsites to that. Additionally, an `after_exec_hook()` implementation is added to the NVIDIA stream class to reset events after execution. Otherwise this results in an error when recording future oneDNN primitive, executions as they try to add a dependency on the previous events in this list, which is an error as the event represents a node in another graph.

With these fixes when building llama.cpp with oneDNN for the NVIDIA SYCL backend the `./bin/test-backend-ops -b SYCL0 -o MUL_MAT` tests now all complete successfully.

This patch is specific to `MUL_MAT` invocations of `compat::host_task`, rather than a generic `compat::host_task` solution because CUDA stream capture needs to be done after cuDNN and cuBLAS handles are created, and for the same native stream. Not every `compat::host_task` usage across the operations use the same patterns for these restrictions, so rather than making a large scope change that will need tested with many different `benchdnn` invocations, instead I've kept the scope of this PR to `MUL_MAT` as the critical operation that enables llama.cpp backend-ops testing with graphs, and can be verified with `benchdnn --matmul --execution-mode=graph`. Then follow-up PRs can be made for the other operations which can be verified with the respective benchdnn invocations.

With a DPC++ build after https://github.com/intel/llvm/pull/19091 using CUDA 12.9. I see the same results with `./benchdnn --execution-mode=graph  --engine=gpu --matmul --batch=inputs/matmul/test_matmul_ci` as without graph execution mode. For older DPC++ builds, or those with CUDA < 12.9, the operations using CUDA async malloc as part of the implementation don't pass. Note that I wasn't able to stress the `cudnn_matmul_lt_t` path, so i've not updated that `compat::host_task` usage as I didn't want to touch code I can't test the effects of, but I could do if maintainers desired.
