### PR TITLE
governance: make Ryo Suzuki code-owner for onednn-devops

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -241,6 +241,7 @@ Team: @uxlfoundation/onednn-devops
 | Sergey Razumovskiy | @srazumov             | Intel Corporation | Maintainer |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
 | Hamza Butt         | @theComputeKid        | Arm Ltd           | Code Owner |
+| Ryo Suzuki         | @Ryo-not-rio          | Arm Ltd           | Code Owner |
 
 ### Release management
 


### PR DESCRIPTION
# Description

I would like to propose Ryo Suzuki (@Ryo-not-rio) as code-owner for @uxlfoundation/onednn-devops. Ryo [has made many contributions](https://github.com/uxlfoundation/oneDNN/pulls?q=is%3Apr+author%3ARyo-not-rio) and is responsible in a large part for the infrastructure and performance testing for AArch64.

cc: @vpirogov 

