### PR TITLE
xe: conv: drop incorrect move

### DIFF
--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -1564,7 +1564,7 @@ public:
         : prb_(prb) {
         for (auto &d : tile) {
             auto bmnk = to_gemm(d, prb);
-            if (!utils::one_of(std::move(bmnk), pvars::m, pvars::n)) continue;
+            if (!utils::one_of(bmnk, pvars::m, pvars::n)) continue;
 
             entries_.emplace_back();
             entry_t &e = entries_.back();


### PR DESCRIPTION
Backport of https://github.com/uxlfoundation/oneDNN/pull/3356