### PR TITLE
ci:aarch64: add performance comparison to performance testing workflow

### DIFF
--- a/.github/workflows/performance-aarch64.yml
+++ b/.github/workflows/performance-aarch64.yml
@@ -19,6 +19,26 @@ name: "Performance AArch64"
 
 on:
   workflow_call:
+    inputs:
+      onednn_base_hash:
+        required: false
+        description: 'Baseline onednn commit'
+      onednn_new_hash:
+        required: false
+        description: 'New onednn commit'
+      acl_base_hash:
+        required: false
+        description: 'Baseline acl commit'
+      acl_new_hash: 
+        required: false
+        description: 'New acl commit'
+      num_threads:
+        required: false
+        description: 'Number of threads to use'
+      benchdnn_command:
+        required: false
+        description: 'benchdnn command to run'
+      
 
 #* Stop stale workflows
 concurrency:
@@ -83,12 +103,19 @@ jobs:
         if: ${{ matrix.config.build == 'Release' }}
         run: pip install scipy statistics
 
-      - name: Clone ACL
+      - name: Clone ACL base
         run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build_acl.sh
         env:
           ACL_ACTION: clone
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
-          ACL_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.acl }}
+          ACL_VERSION: ${{ inputs.acl_base_hash || fromJson(steps.get-versions.outputs.output).dependencies.acl }}
+
+      - name: Clone ACL New
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build_acl.sh
+        env:
+          ACL_ACTION: clone
+          ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+          ACL_VERSION: ${{ inputs.acl_new_hash || fromJson(steps.get-versions.outputs.output).dependencies.acl }}
 
       - name: Get ACL commit hash for cache key
         id: get_acl_commit_hash
@@ -127,7 +154,13 @@ jobs:
       - name: Checkout oneDNN base
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ fromJson(steps.get-versions.outputs.output).dependencies.onednn-base }}
+          ref: ${{inputs.onednn_base_hash || fromJson(steps.get-versions.outputs.output).dependencies.onednn-base }}
+          path: oneDNN_base
+
+      - name: Checkout oneDNN new
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{inputs.onednn_new_hash || fromJson(steps.get-versions.outputs.output).dependencies.onednn-base }}
           path: oneDNN_base
 
       - name: Configure oneDNN base
@@ -155,6 +188,10 @@ jobs:
           OMP_NUM_THREADS=16 bash ${{ github.workspace }}/oneDNN/.github/automation/performance/bench_nightly_performance.sh ${{ github.workspace }}/oneDNN_base/build/tests/benchdnn/benchdnn ${{ github.workspace }}/oneDNN/build/tests/benchdnn/benchdnn base.txt new.txt
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
+
+      - name: Compare benchmark results
+        run: |
+          python3 ${{ github.workspace }}/oneDNN/.github/automation/performance/benchdnn_comparison.py base.txt new.txt
 
       - name: Compare 16 threads performance test results
         run: |


### PR DESCRIPTION
Extends the current performance testing workflow used in nightly runs to support a new performance comparison mode.

This CI pipeline accepts the following inputs:
- Baseline and new hashes for two libraries
- Number of threads to run the benchmark with
- A benchdnn command for the specific test

It runs on a c7g.metal instance.

This enables CI-based performance regression testing between arbitrary versions, leveraging the same infrastructure used for nightly benchmarking.
