### PR TITLE
cpu: aarch64: brgemm: Add support for int8 in brgemm kernel

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2025 Intel Corporation
-* Copyright 2023-2024 FUJITSU LIMITED
+* Copyright 2023-2025 FUJITSU LIMITED
 * Copyright 2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -229,12 +229,11 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
     brg->LDD = LDD;
     const auto dt_d = dst_md->data_type;
 
-    if ((brg->dt_a == data_type::u8 && brg->dt_b == data_type::s8)
-            && (!one_of(dt_d, data_type::u8, data_type::s8, data_type::s32,
-                    data_type::f32))
-            && (!one_of(dt_bias, data_type::undef, data_type::u8, data_type::s8,
-                    data_type::s32, data_type::f32, data_type::bf16)))
-        return status::unimplemented;
+    if (brg->is_int8) {
+        if ((brg->dt_a == data_type::s8 && brg->dt_b == data_type::u8)
+                || (dt_bias != data_type::f32) || (dt_d != data_type::f32))
+            return status::unimplemented;
+    }
     if ((brg->dt_a == data_type::bf16 && brg->dt_b == data_type::bf16)
             && (!one_of(dt_d, data_type::bf16, data_type::f32))
             && (!one_of(dt_bias, data_type::undef, data_type::bf16,
@@ -248,7 +247,7 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
     brg->dt_d = dt_d;
     brg->typesize_D = types::data_type_size(brg->dt_d);
 
-    if (brg->is_int8 || (brg->dt_d == bf16)) return status::unimplemented;
+    if (brg->dt_d == bf16) return status::unimplemented;
 
     if (!brg->attr) return status::success;
 

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2022-2023 Intel Corporation
-* Copyright 2023-2024 FUJITSU LIMITED
+* Copyright 2023-2025 FUJITSU LIMITED
 * Copyright 2024-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -325,7 +325,8 @@ status_t init_brgemm_conf(brgemm_t *brg, cpu_isa_t isa,
     brg->has_int8_vnni = true;
 
     set_brg_vmm(brg); // TODO: Investigate if it is really needed here.
-    brg->req_s8s8_compensation = brg->is_int8 && brg->dt_a == data_type::s8;
+    brg->req_s8s8_compensation = (brg->is_int8 && (brg->dt_a == data_type::s8)
+            && !isa_has_s8s8(brg->isa_impl));
 
     brg->LDA = (brg->is_row_major()) ? static_cast<int>(LDA)
                                      : static_cast<int>(LDB);
@@ -344,9 +345,7 @@ status_t init_brgemm_conf(brgemm_t *brg, cpu_isa_t isa,
     brg->bdb2 = 0;
     brg->bdb2_tail = 0;
 
-    const bool is_b_in_vnni_format = false;
-    brg->ld_step
-            = is_b_in_vnni_format ? data_type_vnni_granularity(brg->dt_b) : 1;
+    brg->ld_step = data_type_vnni_granularity(brg->dt_b);
 
     const bool has_no_vnni_compute_instruction = false;
     brg->rd_step = has_no_vnni_compute_instruction


### PR DESCRIPTION
# Description

This PR extends the BRGEMM (Batch-Reduce General Matrix Multiplication) kernel to support additional INT8 data types, enabling broader applicability for low-precision computations, particularly in deep learning workloads.

Supported Data Type Tags
The following source:weight:destination (src:wei:dst) combinations are now supported:

- s8:s8:f32
- u8:u8:f32
- u8:s8:f32



# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

1. make test output 

```
98% tests passed, 4 tests failed out of 224
 
Total Test time (real) = 1058.22 sec
 
The following tests FAILED:
        172 - test_graph_unit_dnnl_large_partition_cpu (Failed)
        195 - test_benchdnn_modeC_binary_ci_cpu (Failed)
        196 - test_benchdnn_modeC_binary_different_dt_ci_cpu (Failed)
        204 - test_benchdnn_modeC_graph_ci_cpu (Failed)
```
Output is same before and after the code changes.



2. brgemm_test_all output 
command used : 

`./benchdnn --brgemm --batch=inputs/brgemm/test_brgemm_all`

Before 
```
tests:660480 passed:18496 skipped:641984 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 24.50s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 7.30s (30%); execute: 0.00s (0%); compute_ref: 4.30s (18%); compare: 5.34s (22%);
```
After
```   
tests:660480 passed:20480 skipped:640000 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 23.11s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 6.83s (30%); execute: 0.00s (0%); compute_ref: 3.82s (17%); compare: 4.40s (19%);
```
- [x] Have you formatted the code using clang-format?
Yes




