### PR TITLE
tests: fix include directory prefix for old shells

### DIFF
--- a/tests/generate_c_symbols_refs.sh
+++ b/tests/generate_c_symbols_refs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #===============================================================================
-# Copyright 2016-2020 Intel Corporation
+# Copyright 2016-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,12 +19,17 @@ dnnl_root="$1"
 output="$2"
 shift 2
 
+for element do
+  set -- "$@" "-I$element"
+  shift
+done
+
 {
     echo '#include "oneapi/dnnl/dnnl.h"'
     echo "const void *c_functions[] = {"
     # -xc++ to get rid of c++-style comments that are part of c99,
     # but -xc -std=c99 doesn't work on macOS for whatever reason...
-    cpp -xc++ -w "${@/#/-I}" "${dnnl_root}/include/oneapi/dnnl/dnnl.h" \
+    cpp -xc++ -w "${@}" "${dnnl_root}/include/oneapi/dnnl/dnnl.h" \
         | grep -o 'dnnl_\w\+(' \
         | sed 's/\(.*\)(/(void*)\1,/g' \
         | sort -u


### PR DESCRIPTION
Default Ubuntu shell is `dash` which is unable to do the `${parameter/#pattern/string}` pattern substitution. It is causing `Bad substitution` error and is generating empty `build/tests/test_c_symbols.c` file.