### PR TITLE
cpu: risc-v: pooling: further optimize the rv64 maxpool

### DIFF
--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -17,6 +17,7 @@
 
 #include "rvv_nchw_pooling.hpp"
 #include <algorithm>
+#include "common/dnnl_thread.hpp"
 #include <riscv_vector.h>
 
 namespace dnnl {
@@ -31,79 +32,64 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
         const dim_t kerD, const dim_t kerH, const dim_t kerW,
         const dim_t strideD, const dim_t strideH, const dim_t strideW,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft) {
-    float arr_flt_min
-            [riscv_nchw_pooling_fwd_t<data_type::f32>::max_kernel_width];
-    for (int i = 0;
-            i < riscv_nchw_pooling_fwd_t<data_type::f32>::max_kernel_width; i++)
-        arr_flt_min[i] = -__FLT_MAX__;
 
-    for (int mb = 0; mb < batch; mb++)
-        for (int c = 0; c < channels; c++)
-            for (int od = 0; od < outD; od++)
-                for (int oh = 0; oh < outH; oh++)
-                    for (int ow = 0; ow < outW; ow++) {
-                        const size_t dst_offset
-                                = (size_t)outW * outH * outD * channels * mb
-                                + (size_t)outW * outH * outD * c
-                                + (size_t)outW * outH * od + (size_t)outW * oh
-                                + (size_t)ow;
-                        const auto src_offset = ((size_t)inW * inH * inD)
-                                * ((size_t)channels * mb + c);
-                        const auto local_src = &src[src_offset];
-                        const auto IWH = (size_t)inW * inH;
+    parallel_nd(batch, channels, outD, outH, outW,
+            [&](dim_t mb, dim_t c, dim_t od, dim_t oh, dim_t ow) {
+                const size_t dst_offset
+                        = (size_t)outW * outH * outD * channels * mb
+                        + (size_t)outW * outH * outD * c
+                        + (size_t)outW * outH * od + (size_t)outW * oh
+                        + (size_t)ow;
+                const auto src_offset = ((size_t)inW * inH * inD)
+                        * ((size_t)channels * mb + c);
+                const auto local_src = &src[src_offset];
+                const auto IWH = (size_t)inW * inH;
 
-                        int od_offset = od * strideD - padFront;
-                        int oh_offset = oh * strideH - padTop;
-                        int ow_offset = ow * strideW - padLeft;
-                        size_t size = std::min(ow_offset + kerW, inW)
-                                - std::max(ow_offset, 0);
-                        size_t cycleLength = __riscv_vsetvl_e32m8(size);
-                        vfloat32m8_t vmax = __riscv_vle32_v_f32m8(
-                                &arr_flt_min[0], cycleLength);
+                int od_offset = od * strideD - padFront;
+                int oh_offset = oh * strideH - padTop;
+                int ow_offset = ow * strideW - padLeft;
+                size_t size = std::min(ow_offset + kerW, inW)
+                        - std::max(ow_offset, 0);
+                size_t cycleLength = __riscv_vsetvl_e32m1(size);
+                vfloat32m1_t vmax
+                        = __riscv_vfmv_v_f_f32m1(-__FLT_MAX__, cycleLength);
 
-                        for (int id = std::max(od_offset, 0);
-                                id < std::min(od_offset + kerD, inD); id++)
-                            for (int ih = std::max(oh_offset, 0);
-                                    ih < std::min(oh_offset + kerH, inH);
-                                    ih++) {
-                                const auto local_src_offset = IWH * id
-                                        + (size_t)inW * ih
-                                        + std::max(ow_offset, 0);
+                for (int id = std::max(od_offset, 0);
+                        id < std::min(od_offset + kerD, inD); id++)
+                    for (int ih = std::max(oh_offset, 0);
+                            ih < std::min(oh_offset + kerH, inH); ih++) {
+                        const auto local_src_offset = IWH * id
+                                + (size_t)inW * ih + std::max(ow_offset, 0);
 
-                                size_t iw = 0;
-                                for (; iw < size - cycleLength;
-                                        iw += cycleLength) {
-                                    vfloat32m8_t vsrc = __riscv_vle32_v_f32m8(
-                                            &local_src[local_src_offset + iw],
-                                            cycleLength);
-                                    vmax = __riscv_vfmax_vv_f32m8(
-                                            vsrc, vmax, cycleLength);
-                                }
+                        size_t iw = 0;
+                        for (; iw < size - cycleLength; iw += cycleLength) {
+                            vfloat32m1_t vsrc = __riscv_vle32_v_f32m1(
+                                    &local_src[local_src_offset + iw],
+                                    cycleLength);
+                            vmax = __riscv_vfmax_vv_f32m1(
+                                    vsrc, vmax, cycleLength);
+                        }
 
-                                size_t tailLength
-                                        = __riscv_vsetvl_e32m8(size - iw);
-                                {
-                                    vfloat32m8_t vsrc = __riscv_vle32_v_f32m8(
-                                            &local_src[local_src_offset + iw],
-                                            tailLength);
-                                    vmax = __riscv_vfmax_vv_f32m8(
-                                            vsrc, vmax, tailLength);
-                                }
-                            }
-
-                        vfloat32m1_t min_scalar;
-                        float min = -__FLT_MAX__;
-                        min_scalar = __riscv_vle32_v_f32m1(&min, 1);
-
-                        cycleLength = __riscv_vsetvl_e32m8(size);
-                        vfloat32m1_t vred_res;
-                        vred_res = __riscv_vfredmax_vs_f32m8_f32m1(
-                                vmax, min_scalar, cycleLength);
-
-                        float red_res;
-                        __riscv_vse32_v_f32m1(&red_res, vred_res, 1);
-                        dst[dst_offset] = red_res;
+                        size_t tailLength = __riscv_vsetvl_e32m1(size - iw);
+                        {
+                            vfloat32m1_t vsrc = __riscv_vle32_v_f32m1(
+                                    &local_src[local_src_offset + iw],
+                                    tailLength);
+                            vmax = __riscv_vfmax_vv_f32m1(
+                                    vsrc, vmax, tailLength);
+                        }
                     }
+
+                vfloat32m1_t min_scalar
+                        = __riscv_vfmv_v_f_f32m1(-__FLT_MAX__, 1);
+
+                cycleLength = __riscv_vsetvl_e32m1(size);
+                vfloat32m1_t vred_res;
+                vred_res = __riscv_vfredmax_vs_f32m1_f32m1(
+                        vmax, min_scalar, cycleLength);
+
+                __riscv_vse32_v_f32m1(&dst[dst_offset], vred_res, 1);
+            });
 }
 } // namespace
 

--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
-* Copyright 2023 Intel Corporation
-* Copyright 2023 KNS Group LLC (YADRO)
+* Copyright 2023-2025 Intel Corporation
+* Copyright 2023-2025 KNS Group LLC (YADRO)
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "rvv_nchw_pooling.hpp"
 #include <algorithm>
-#include "common/dnnl_thread.hpp"
 #include <riscv_vector.h>
+
+#include "common/dnnl_thread.hpp"
+#include "cpu/rv64/rvv_nchw_pooling.hpp"
 
 namespace dnnl {
 namespace impl {


### PR DESCRIPTION
## Overview

This PR further optimizes the RV64 maxpool implementation :
1. Add multi-threading optimization;
2. Remove some memory access operations;
3. Changed the vector register combination method from m8 to m1.

## Previous related work
- #1521
- #2929
- #3036

## Functional test
The test running platform is the BPI-F3 board.

`test_pooling_forward` all runs passed, and the results can be viewed here: 
[test_pooling_forward.log](https://github.com/user-attachments/files/20813142/test_pooling_forward.log)


## Performance comparison
before:
```plaintext
[----------] 3 tests from TestPooling3Dunet_ncdhw_CPU/pooling_test_float
[ RUN      ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/0
onednn_verbose,v1,primitive,exec,cpu,pooling,RISCV64GCV,forward_inference,src:f32::blocked:abcde::f0 dst:f32::blocked:abcde::f0,,alg:pooling_max,mb1ic64_id64od64kd2sd1dd0pd0_ih64oh64kh2sh1dh0ph0_iw64ow64kw2sw1dw0pw0,2005.96
[       OK ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/0 (7182 ms)
[ RUN      ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/1
onednn_verbose,v1,primitive,exec,cpu,pooling,RISCV64GCV,forward_inference,src:f32::blocked:abcde::f0 dst:f32::blocked:abcde::f0,,alg:pooling_max,mb1ic128_id28od28kd2sd1dd0pd0_ih28oh28kh2sh1dh0ph0_iw28ow28kw2sw1dw0pw0,356.34
[       OK ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/1 (1211 ms)
[ RUN      ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/2
onednn_verbose,v1,primitive,exec,cpu,pooling,RISCV64GCV,forward_inference,src:f32::blocked:abcde::f0 dst:f32::blocked:abcde::f0,,alg:pooling_max,mb1ic256_id12od12kd2sd1dd0pd0_ih12oh12kh2sh1dh0ph0_iw12ow12kw2sw1dw0pw0,52.4861
[       OK ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/2 (190 ms)
[----------] 3 tests from TestPooling3Dunet_ncdhw_CPU/pooling_test_float (8584 ms total)
```

after:
```plaintext
[----------] 3 tests from TestPooling3Dunet_ncdhw_CPU/pooling_test_float
[ RUN      ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/0
onednn_verbose,v1,primitive,exec,cpu,pooling,RISCV64GCV,forward_inference,src:f32::blocked:abcde::f0 dst:f32::blocked:abcde::f0,,alg:pooling_max,mb1ic64_id64od64kd2sd1dd0pd0_ih64oh64kh2sh1dh0ph0_iw64ow64kw2sw1dw0pw0,310.084
[       OK ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/0 (5487 ms)
[ RUN      ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/1
onednn_verbose,v1,primitive,exec,cpu,pooling,RISCV64GCV,forward_inference,src:f32::blocked:abcde::f0 dst:f32::blocked:abcde::f0,,alg:pooling_max,mb1ic128_id28od28kd2sd1dd0pd0_ih28oh28kh2sh1dh0ph0_iw28ow28kw2sw1dw0pw0,54.241
[       OK ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/1 (912 ms)
[ RUN      ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/2
onednn_verbose,v1,primitive,exec,cpu,pooling,RISCV64GCV,forward_inference,src:f32::blocked:abcde::f0 dst:f32::blocked:abcde::f0,,alg:pooling_max,mb1ic256_id12od12kd2sd1dd0pd0_ih12oh12kh2sh1dh0ph0_iw12ow12kw2sw1dw0pw0,9.43799
[       OK ] TestPooling3Dunet_ncdhw_CPU/pooling_test_float.TestsPooling/2 (134 ms)
[----------] 3 tests from TestPooling3Dunet_ncdhw_CPU/pooling_test_float (6535 ms total)
```

The maxpool test runtime is significantly reduced.