### PR TITLE
api: graph: remove dnnl_graph_op_last_symbol

### DIFF
--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -842,8 +842,6 @@ public:
         Wildcard = dnnl_graph_op_wildcard,
         GenIndex = dnnl_graph_op_gen_index,
         GreaterEqual = dnnl_graph_op_greater_equal,
-        // Sentinel
-        LastSymbol = dnnl_graph_op_last_symbol,
     };
 
     /// Attributes of operations. Different operations support different

--- a/include/oneapi/dnnl/dnnl_graph_types.h
+++ b/include/oneapi/dnnl/dnnl_graph_types.h
@@ -261,7 +261,6 @@ typedef enum {
     dnnl_graph_op_group_norm,
     dnnl_graph_op_gen_index,
     dnnl_graph_op_greater_equal,
-    dnnl_graph_op_last_symbol,
 } dnnl_graph_op_kind_t;
 
 /// Attributes of operations

--- a/src/graph/interface/c_types_map.hpp
+++ b/src/graph/interface/c_types_map.hpp
@@ -213,7 +213,8 @@ const op_kind_t Tanh = dnnl_graph_op_tanh;
 const op_kind_t TanhBackward = dnnl_graph_op_tanh_backward;
 const op_kind_t TypeCast = dnnl_graph_op_type_cast;
 const op_kind_t Wildcard = dnnl_graph_op_wildcard;
-const op_kind_t LastSymbol = dnnl_graph_op_last_symbol;
+// Increase it once a new op is added.
+const op_kind_t LastSymbol = static_cast<op_kind_t>(87);
 } // namespace op_kind
 
 using op_attr_t = typename std::underlying_type<dnnl_graph_op_attr_t>::type;

--- a/tests/benchdnn/graph/flex_rewrite.cpp
+++ b/tests/benchdnn/graph/flex_rewrite.cpp
@@ -896,8 +896,7 @@ void flex_rewrite_t::infer_output_shape(
             // infer_unsupported_output_shape
             case dnnl::graph::op::kind::Wildcard:
             // no output, do nothing
-            case dnnl::graph::op::kind::End:
-            case dnnl::graph::op::kind::LastSymbol: break;
+            case dnnl::graph::op::kind::End: break;
         }
 
         for (auto &lt : aop.in_lts_) {
@@ -1348,12 +1347,6 @@ void flex_rewrite_t::op_kind_rewrite(deserialized_graph_t &dgraph) {
         if (v.second == "default") return;
 
         auto target_kind = opstr2kind(v.second);
-        if (target_kind == dnnl::graph::op::kind::LastSymbol) {
-            BENCHDNN_PRINT(0,
-                    "graph: rewrite: invalid target op kind %s is provided\n",
-                    v.second.c_str());
-            SAFE_V(FAIL);
-        }
 
         // Only support op kind rewrite for binary and eltwise ops.
         auto target_driver = opkind2driver(target_kind);

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -356,8 +356,9 @@ dnnl::graph::op::kind opstr2kind(const std::string &kind) {
         fprintf(stderr, "graph: ERROR: Unsupported opkind: `%s`, exiting...\n",
                 kind.c_str());
         SAFE_V(FAIL);
+        // Should not reach here, but the function still needs to return.
+        return dnnl::graph::op::kind::Wildcard;
     }
-    return dnnl::graph::op::kind::LastSymbol;
 }
 
 dnnl::graph::op::attr attrstr2kind(const std::string &attr_name) {

--- a/tests/gtests/graph/api/test_cpp_api_op.cpp
+++ b/tests/gtests/graph/api/test_cpp_api_op.cpp
@@ -24,7 +24,7 @@
 TEST(APIOp, CreateAllOps) {
     using namespace dnnl::graph;
     dnnl_graph_op_kind_t first_op = dnnl_graph_op_abs;
-    dnnl_graph_op_kind_t last_op = dnnl_graph_op_last_symbol;
+    dnnl_graph_op_kind_t last_op = dnnl_graph_op_greater_equal;
 
     // This list should be the same as the definition of `op::kind` in
     // dnnl_graph.hpp.
@@ -121,7 +121,7 @@ TEST(APIOp, CreateAllOps) {
 
     const auto num_ops = all_kind_enums.size();
     for (size_t i = static_cast<size_t>(first_op);
-            i < static_cast<size_t>(last_op); ++i) {
+            i <= static_cast<size_t>(last_op); ++i) {
         ASSERT_LT(i, num_ops);
         op::kind kind = all_kind_enums[i];
         ASSERT_EQ(i, static_cast<size_t>(kind));


### PR DESCRIPTION
Fixes MFDNN-13011

The op kind is not intended for public usage. But with it in the list, we have seen ABI compatibility issue every time when a new op kind is added to the library and API. Now moving it to internal.