### PR TITLE
generic: sycl: Add check on number of post-ops used

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -137,9 +137,7 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     std::vector<dnnl_data_type_t> dts = {prb->sdt[0], prb->sdt[1], prb->ddt};
     skip_unimplemented_data_type(dts, prb->dir, res);
-    skip_unimplemented_arg_scale(prb->attr, res);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_binary);
+    skip_unimplemented_attr(prb->attr, res, dnnl_binary, dnnl_data_type_undef);
 
     if (is_gpu()) {
         // N.B: Adding this for gpu as cfg is not supported in POST-OPS

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -453,10 +453,7 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->dt}, prb->dir, res);
-    skip_unimplemented_sum_po(
-            prb->attr, res, dnnl_batch_normalization, prb->dt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_batch_normalization);
+    skip_unimplemented_attr(prb->attr, res, dnnl_batch_normalization, prb->dt);
 
     // Non-zero alpha is not supported for training in general.
     const auto &po = prb->attr.post_ops;

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -493,10 +493,8 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type(
             {prb->src_dt(), prb->wei_dt(), prb->bia_dt, prb->dst_dt()},
             prb->dir, res);
-    skip_unimplemented_sum_po(
+    skip_unimplemented_attr(
             prb->attr, res, dnnl_gemm, prb->src_dt(), prb->dst_dt());
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_gemm);
 
     // Unconditionally skip remaining unimplemented cases.
     // TODO: stop doing it.

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -115,10 +115,7 @@ int fill_src(int input_idx, dnnl_data_type_t dt, dnn_mem_t &mem_dt,
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->sdt, prb->ddt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_concat, prb->sdt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_concat);
-    skip_unimplemented_arg_scale(prb->attr, res);
+    skip_unimplemented_attr(prb->attr, res, dnnl_concat, prb->sdt);
 
     // ref concat is reorder-based, hence, inherits some reorder limitations.
     // bf16, f16 reorders on cpu supports only [bf16, f16]<->f32

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -378,10 +378,8 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->get_dt(SRC), prb->get_dt(WEI),
                                          prb->get_dt(BIA), prb->get_dt(DST)},
             prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_convolution,
-            prb->get_dt(SRC), prb->get_dt(DST));
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_convolution);
+    skip_unimplemented_attr(prb->attr, res, dnnl_convolution, prb->get_dt(SRC),
+            prb->get_dt(DST));
 
     if (is_cpu()) {
         // Specific configurations are not supported.

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -348,10 +348,8 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->get_dt(SRC), prb->get_dt(WEI),
                                          prb->get_dt(BIA), prb->get_dt(DST)},
             prb->dir, res);
-    skip_unimplemented_sum_po(
+    skip_unimplemented_attr(
             prb->attr, res, dnnl_deconvolution, prb->get_dt(SRC));
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_deconvolution);
 
     // GPU supports only post ops and all but x8s8bf16 and f32xf16f32 cfg
     if (is_gpu()) {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -849,6 +849,29 @@ void skip_unimplemented_arg_scale(const attr_t &attr, res_t *res) {
     }
 }
 
+void skip_unimplemented_po_quantity(const attr_t &attr, res_t *res) {
+    // Generic SYCL backend currently cannot support port more than 5 post-ops.
+    if (is_generic_gpu()) {
+        if (attr.post_ops.len() > 5) {
+            res->state = SKIPPED;
+            res->reason = skip_reason::case_not_supported;
+            return;
+        }
+    }
+}
+
+void skip_unimplemented_attr(const attr_t &attr, res_t *res,
+        dnnl_primitive_kind_t prim_kind, dnnl_data_type_t src_dt,
+        dnnl_data_type_t dst_t) {
+
+    skip_unimplemented_sum_po(attr, res, prim_kind, src_dt, dst_t);
+    skip_unimplemented_binary_po(attr, res);
+    skip_unimplemented_prelu_po(attr, res, prim_kind);
+    skip_unimplemented_arg_scale(attr, res);
+
+    skip_unimplemented_po_quantity(attr, res);
+}
+
 void skip_invalid_inplace(res_t *res, dnnl_data_type_t sdt,
         dnnl_data_type_t ddt, const std::string &stag,
         const std::string &dtag) {

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -268,6 +268,10 @@ void skip_unimplemented_prelu_po(
 void skip_invalid_inplace(res_t *res, dnnl_data_type_t sdt,
         dnnl_data_type_t ddt, const std::string &stag, const std::string &dtag);
 void skip_unimplemented_arg_scale(const attr_t &attr, res_t *res);
+void skip_unimplemented_po_quantity(const attr_t &attr, res_t *res);
+void skip_unimplemented_attr(const attr_t &attr, res_t *res,
+        dnnl_primitive_kind_t prim_kind, dnnl_data_type_t src_dt,
+        dnnl_data_type_t dst_t = dnnl_data_type_undef);
 
 template <typename prb_t>
 int check_caches(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &primw,

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -286,9 +286,7 @@ int fill_data(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->dt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_eltwise, prb->dt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_eltwise);
+    skip_unimplemented_attr(prb->attr, res, dnnl_eltwise, prb->dt);
 
     if (is_gpu() && (prb->dt == dnnl_f8_e5m2 || prb->dt == dnnl_f8_e4m3)
             && prb->dir == BWD_D) {

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -500,6 +500,8 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->dt[0], prb->dt[1]}, prb->dir, res);
+    skip_unimplemented_attr(
+            prb->attr, res, dnnl_group_normalization, dnnl_data_type_undef);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -244,10 +244,8 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->get_dt(SRC), prb->get_dt(WEI),
                                          prb->get_dt(BIA), prb->get_dt(DST)},
             prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_inner_product,
+    skip_unimplemented_attr(prb->attr, res, dnnl_inner_product,
             prb->get_dt(SRC), prb->get_dt(DST));
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_inner_product);
 
     if (is_cpu()) {
         auto is_dt_f16_or_f32 = [&](dnnl_data_type_t dt) {

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -453,10 +453,8 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type(
             {prb->dt[0], prb->dt[1], prb->ss_dt}, prb->dir, res);
-    skip_unimplemented_sum_po(
+    skip_unimplemented_attr(
             prb->attr, res, dnnl_layer_normalization, prb->dt[0]);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_layer_normalization);
 
     if (is_gpu() && prb->attr.post_ops.len() != 0) {
         // GPU does not support post-ops

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -117,9 +117,7 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->dt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_lrn, prb->dt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_lrn);
+    skip_unimplemented_attr(prb->attr, res, dnnl_lrn, prb->dt);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {}

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -485,10 +485,8 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type(
             {prb->src_dt(), prb->wei_dt(), prb->bia_dt, prb->dst_dt()},
             prb->dir, res);
-    skip_unimplemented_sum_po(
+    skip_unimplemented_attr(
             prb->attr, res, dnnl_matmul, prb->src_dt(), prb->dst_dt());
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_matmul);
 
     if ((is_nvidia_gpu() || is_amd_gpu()) && !prb->sparse_options.is_def()) {
         BENCHDNN_PRINT(2,

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -143,9 +143,7 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->src_dt(), prb->dst_dt()}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_pooling, prb->src_dt());
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_pooling);
+    skip_unimplemented_attr(prb->attr, res, dnnl_pooling, prb->src_dt());
 
     if (is_cpu() && prb->src_dt() != prb->dst_dt()) {
         res->state = SKIPPED;

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -141,9 +141,7 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type(prb->sdt, FWD_D, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_prelu, prb->sdt[0]);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_prelu);
+    skip_unimplemented_attr(prb->attr, res, dnnl_prelu, prb->sdt[0]);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {}

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -203,9 +203,7 @@ int fill_dst(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->sdt, prb->ddt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_reduction, prb->sdt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_reduction);
+    skip_unimplemented_attr(prb->attr, res, dnnl_reduction, prb->sdt);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -207,9 +207,7 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     const auto sdt = prb->sdt;
     const auto ddt = prb->ddt;
     skip_unimplemented_data_type({sdt, ddt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_reorder, sdt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_reorder);
+    skip_unimplemented_attr(prb->attr, res, dnnl_reorder, sdt);
 
     const bool s32_src_ok = IMPLICATION(sdt == dnnl_s32,
             ddt != dnnl_f8_e5m2 && ddt != dnnl_f8_e4m3 && ddt != dnnl_bf16

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -110,9 +110,7 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->sdt, prb->ddt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_resampling, prb->sdt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_resampling);
+    skip_unimplemented_attr(prb->attr, res, dnnl_resampling, prb->sdt);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {}

--- a/tests/benchdnn/rnn/rnn.cpp
+++ b/tests/benchdnn/rnn/rnn.cpp
@@ -777,9 +777,7 @@ void skip_unimplemented_prb(const prb_t *prb_, res_t *res) {
     const prb_t &prb = *prb_;
     dir_t dir = str2dir(prop2str(prb.prop));
     skip_unimplemented_data_type({prb.cfg[SRC_LAYER].dt}, dir, res);
-    skip_unimplemented_sum_po(prb.attr, res, dnnl_rnn, prb.cfg[SRC_LAYER].dt);
-    skip_unimplemented_binary_po(prb.attr, res);
-    skip_unimplemented_prelu_po(prb.attr, res, dnnl_rnn);
+    skip_unimplemented_attr(prb_->attr, res, dnnl_rnn, prb_->cfg[SRC_LAYER].dt);
 
     if (is_cpu()) {
 #if !defined(DNNL_X64) || DNNL_X64 == 0 \

--- a/tests/benchdnn/shuffle/shuffle.cpp
+++ b/tests/benchdnn/shuffle/shuffle.cpp
@@ -101,9 +101,7 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->dt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_shuffle, prb->dt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_shuffle);
+    skip_unimplemented_attr(prb->attr, res, dnnl_shuffle, prb->dt);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {}

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -227,9 +227,7 @@ int fill_data_bwd(data_kind_t data_kind, const prb_t *prb, dnn_mem_t &mem_dt,
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->sdt, prb->ddt}, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_softmax, prb->sdt);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_softmax);
+    skip_unimplemented_attr(prb->attr, res, dnnl_softmax, prb->sdt);
 
     if (prb->attr.post_ops.find(attr_t::post_ops_t::kind_t::SUM) != -1) {
         res->state = SKIPPED;

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -98,9 +98,7 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     std::vector<dnnl_data_type_t> dts = prb->sdt;
     dts.push_back(prb->ddt);
     skip_unimplemented_data_type(dts, prb->dir, res);
-    skip_unimplemented_sum_po(prb->attr, res, dnnl_sum, prb->sdt[0]);
-    skip_unimplemented_binary_po(prb->attr, res);
-    skip_unimplemented_prelu_po(prb->attr, res, dnnl_sum);
+    skip_unimplemented_attr(prb->attr, res, dnnl_sum, prb->sdt[0]);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {


### PR DESCRIPTION
# Description

Due to technical limitation the generic backend cannot support more than 5 post-ops. This PR implement a check during test to skip those tests instead of reporting unimplemented.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

The issue was presented to us as part of `deconv` testing, so I re-run that test suite to confirm it doesn't break anything. I attach here tests with this PR and master. These changes reduce the number of unimplemented without compromising correctness of other tests. The number of tests run is the same

- PR: [test-deconv-generic-intel-pvc.txt](https://github.com/user-attachments/files/20900577/test-deconv-generic-intel-pvc.txt)
- main: [test-deconv-main-generic-pvc.txt](https://github.com/user-attachments/files/20900582/test-deconv-main-generic-pvc.txt)


- [x] Have you formatted the code using clang-format?

