### PR TITLE
cpu: risc-v: build: fix dynamic selection bug

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -123,6 +123,9 @@ endif()
 
 if (DNNL_TARGET_ARCH STREQUAL "RV64")
     # Check if the RVV Intrinsics can be compiled with the current toolchain and flags
+    set(ARCH_SIMD_TEST_FLAGS "-march=rv64gcv")
+    set(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
+    set(CMAKE_REQUIRED_FLAGS "${ARCH_SIMD_TEST_FLAGS}")
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("#if !defined(__riscv) || !defined(__riscv_v)
                                #error \"RISC-V or vector extension(RVV) is not supported by the compiler\"
@@ -139,6 +142,7 @@ if (DNNL_TARGET_ARCH STREQUAL "RV64")
                                CAN_COMPILE_RVV_INTRINSICS
     )
     
+    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_SAVE})
     # Set CAN_COMPILE_RVV_INTRINSICS to TRUE / FALSE instead of 1 / "" (Undefined)
     if (CAN_COMPILE_RVV_INTRINSICS)
         set(CAN_COMPILE_RVV_INTRINSICS TRUE)
@@ -327,7 +331,6 @@ elseif(UNIX OR MINGW)
                  append(DEF_ARCH_OPT_FLAGS "-march=native")
              endif()
         elseif(DNNL_TARGET_ARCH STREQUAL "RV64")
-             # G = General-purpose extensions, C = Compression extension (very common).
              append(DEF_ARCH_OPT_FLAGS "${RV64_MARCH_FLAG}")
         elseif(DNNL_TARGET_ARCH STREQUAL "X64")
              platform_clang_x64_arch_ccxx_flags(DEF_ARCH_OPT_FLAGS)
@@ -439,7 +442,6 @@ elseif(UNIX OR MINGW)
                 append(DEF_ARCH_OPT_FLAGS "-march=native")
             endif()
         elseif(DNNL_TARGET_ARCH STREQUAL "RV64")
-            # G = General-purpose extensions, C = Compression extension (very common).
             append(DEF_ARCH_OPT_FLAGS "${RV64_MARCH_FLAG}")
         elseif(DNNL_TARGET_ARCH STREQUAL "X64")
             platform_gnu_x64_arch_ccxx_flags(DEF_ARCH_OPT_FLAGS)


### PR DESCRIPTION
## Overview

#3455 introduced support for dynamically detecting whether the current RISC-V toolchain supports RVV intrinsics (version 1.0) during CMake configuration, but this did not work.
<details> <summary>CMake configuration log</summary>
<pre>
zhangfei@zhangfei-desktop:~/oneDNN/build% export CC=clang-17 CXX=clang++-17
zhangfei@zhangfei-desktop:~/oneDNN/build% cmake ..
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
-- The C compiler identification is Clang 17.0.6
-- The CXX compiler identification is Clang 17.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang-17 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++-17 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- DNNL_TARGET_ARCH: RV64
-- DNNL_LIBRARY_NAME: dnnl
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found OpenMP_C: -fopenmp=libomp (found version "5.1")
-- Found OpenMP_CXX: -fopenmp=libomp (found version "5.1")
-- Found OpenMP: TRUE (found version "5.1")
-- Performing Test CAN_COMPILE_RVV_INTRINSICS
-- Performing Test CAN_COMPILE_RVV_INTRINSICS - Failed
-- Can compile RVV Intrinsics: FALSE
-- DNNL_RISCV_USE_RVV_INTRINSICS: FALSE
-- Using RV64 march flag: -march=rv64gc
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- Could NOT find Doxyrest (missing: DOXYREST_EXECUTABLE)
-- Found Python: /usr/bin/python3 (found suitable version "3.12.3", minimum required is "3.7") found components: Interpreter
-- Could NOT find Sphinx (missing: SPHINX_EXECUTABLE)
-- Found Git: /usr/bin/git (found version "2.43.0")
-- Enabled testing coverage: CI
-- Enabled workload: TRAINING
-- Enabled primitives: ALL
-- Enabled primitive CPU ISA: ALL
-- Enabled primitive GPU ISA: ALL
-- Enabled GeMM kernels ISA: ALL
-- Primitive cache is enabled
-- Graph component is enabled
-- Configuring done (12.0s)
-- Generating done (2.2s)
-- Build files have been written to: /home/zhangfei/oneDNN/build
</details>

The desired output was `-march=rv64gcv`, but it was not achieved.  
Therefore, this PR fixes the bug introduced in #3455 by adding the test compilation flag `-march=rv64gcv` to `check_cxx_source_compiles`, in order to verify whether the current compiler supports RVV, thereby achieving the expected effect of #3455.

## Test Plan
Tested separately using gcc-13.2 and clang-17.

<details> <summary>use gcc-13.2 CMake configuration log</summary>
<pre>
zhangfei@zhangfei-desktop:~/oneDNN/build% cmake ..
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
-- The C compiler identification is GNU 13.2.0
-- The CXX compiler identification is GNU 13.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- DNNL_TARGET_ARCH: RV64
-- DNNL_LIBRARY_NAME: dnnl
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5")
-- Performing Test CAN_COMPILE_RVV_INTRINSICS
-- Performing Test CAN_COMPILE_RVV_INTRINSICS - Failed
-- Can compile RVV Intrinsics: FALSE
-- DNNL_RISCV_USE_RVV_INTRINSICS: FALSE
-- Using RV64 march flag: -march=rv64gc
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- Could NOT find Doxyrest (missing: DOXYREST_EXECUTABLE)
-- Found Python: /usr/bin/python3 (found suitable version "3.12.3", minimum required is "3.7") found components: Interpreter
-- Could NOT find Sphinx (missing: SPHINX_EXECUTABLE)
-- Found Git: /usr/bin/git (found version "2.43.0")
-- Enabled testing coverage: CI
-- Enabled workload: TRAINING
-- Enabled primitives: ALL
-- Enabled primitive CPU ISA: ALL
-- Enabled primitive GPU ISA: ALL
-- Enabled GeMM kernels ISA: ALL
-- Primitive cache is enabled
-- Graph component is enabled
-- Configuring done (9.7s)
-- Generating done (2.3s)
-- Build files have been written to: /home/zhangfei/oneDNN/build
</details>

<details> <summary>use clang-17 CMake configuration log</summary>
<pre>
zhangfei@zhangfei-desktop:~/oneDNN/build% cmake ..
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
-- The C compiler identification is Clang 17.0.6
-- The CXX compiler identification is Clang 17.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang-17 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++-17 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- DNNL_TARGET_ARCH: RV64
-- DNNL_LIBRARY_NAME: dnnl
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found OpenMP_C: -fopenmp=libomp (found version "5.1")
-- Found OpenMP_CXX: -fopenmp=libomp (found version "5.1")
-- Found OpenMP: TRUE (found version "5.1")
-- Performing Test CAN_COMPILE_RVV_INTRINSICS
-- Performing Test CAN_COMPILE_RVV_INTRINSICS - Success
-- Can compile RVV Intrinsics: TRUE
-- DNNL_RISCV_USE_RVV_INTRINSICS: TRUE
-- Using RV64 march flag: -march=rv64gcv
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- Could NOT find Doxyrest (missing: DOXYREST_EXECUTABLE)
-- Found Python: /usr/bin/python3 (found suitable version "3.12.3", minimum required is "3.7") found components: Interpreter
-- Could NOT find Sphinx (missing: SPHINX_EXECUTABLE)
-- Found Git: /usr/bin/git (found version "2.43.0")
-- Enabled testing coverage: CI
-- Enabled workload: TRAINING
-- Enabled primitives: ALL
-- Enabled primitive CPU ISA: ALL
-- Enabled primitive GPU ISA: ALL
-- Enabled GeMM kernels ISA: ALL
-- Primitive cache is enabled
-- Graph component is enabled
-- Configuring done (12.8s)
-- Generating done (2.2s)
-- Build files have been written to: /home/zhangfei/oneDNN/build
</details>