### PR TITLE
xe: jit: reduce register usage in epilogue

### DIFF
--- a/src/gpu/intel/jit/ir/epilogue.cpp
+++ b/src/gpu/intel/jit/ir/epilogue.cpp
@@ -935,7 +935,8 @@ private:
             auto t_allocs = t.allocs();
             allocs.insert(allocs.end(), t_allocs.begin(), t_allocs.end());
         }
-        stmt_ = jit::inject_alloc_stmts(stmt_, allocs, /*put_innermost=*/true);
+        stmt_ = jit::inject_alloc_stmts(stmt_, allocs, /*put_innermost=*/true,
+                /*update_existing=*/true);
     }
 
     // Builds statements for a tile iterating through all post-ops.

--- a/src/gpu/intel/jit/ir/ir.hpp
+++ b/src/gpu/intel/jit/ir/ir.hpp
@@ -289,8 +289,11 @@ private:
 // - If put_innermost is false, then `stmt` is nested to all allocations
 // - If put_innermost is true, then every allocation is injected as innermost
 //   as possible
+// - If update_existing is true, then all existing alloc statements are removed
+//   and reinserted in the innermost position. This flag requires put_innermost
+//   to be set to true.
 stmt_t inject_alloc_stmts(const stmt_t &stmt, const std::vector<stmt_t> &allocs,
-        bool put_innermost = false);
+        bool put_innermost = false, bool update_existing = false);
 
 // Similar to the previous function but allocations are taken from the buffer
 // manager, allocations are injected at innermost possible scope.


### PR DESCRIPTION
I found one failing case on Xe-LP:

```
--conv --engine=gpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:common:0.5+dst:common:4+wei:common:2 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor g34mb81ic34iw24oc34ow12kw8pw2dw1 
```

Which seems to be related to underestimated register usage. I found that for some buffers allocation statements are hard-coded. PR changes that to re-insert these allocs in the innermost position reducing the overall register usage.