### PR TITLE
generic: sycl: Skip all tests that use block format for generic backend

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -140,6 +140,10 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_arg_scale(prb->attr, res);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_binary);
+    for (const auto &tag : prb->stag) {
+        skip_unsupported_block_format(tag, res);
+    }
+    skip_unsupported_block_format(prb->dtag, res);
 
     if (is_gpu()) {
         // N.B: Adding this for gpu as cfg is not supported in POST-OPS

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -457,6 +457,7 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             prb->attr, res, dnnl_batch_normalization, prb->dt);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_batch_normalization);
+    skip_unsupported_block_format(prb->tag, res);
 
     // Non-zero alpha is not supported for training in general.
     const auto &po = prb->attr.post_ops;

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -119,6 +119,10 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_concat);
     skip_unimplemented_arg_scale(prb->attr, res);
+    for (const auto &tag : prb->stag) {
+        skip_unsupported_block_format(tag, res);
+    }
+    skip_unsupported_block_format(prb->dtag, res);
 
     // ref concat is reorder-based, hence, inherits some reorder limitations.
     // bf16, f16 reorders on cpu supports only [bf16, f16]<->f32

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -382,6 +382,9 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             prb->get_dt(SRC), prb->get_dt(DST));
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_convolution);
+    skip_unsupported_block_format(prb->stag, res);
+    skip_unsupported_block_format(prb->wtag, res);
+    skip_unsupported_block_format(prb->dtag, res);
 
     if (is_cpu()) {
         // Specific configurations are not supported.

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -353,6 +353,10 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_deconvolution);
 
+    skip_unsupported_block_format(prb->dtag, res);
+    skip_unsupported_block_format(prb->stag, res);
+    skip_unsupported_block_format(prb->wtag, res);
+
     // GPU supports only post ops and all but x8s8bf16 and f32xf16f32 cfg
     if (is_gpu()) {
         const bool is_x8s8bf16_cfg

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -849,6 +849,20 @@ void skip_unimplemented_arg_scale(const attr_t &attr, res_t *res) {
     }
 }
 
+void skip_unsupported_block_format(const std::string &format_tag, res_t *res) {
+    if (is_generic_gpu()) {
+        // if the user provided tag has a capital letter,
+        // that indicates it's a blocked format, otherwise it's plain
+        for (const auto &c : format_tag) {
+            if (std::isupper(c)) {
+                res->state = SKIPPED;
+                res->reason = skip_reason::case_not_supported;
+                return;
+            }
+        }
+    }
+}
+
 void skip_invalid_inplace(res_t *res, dnnl_data_type_t sdt,
         dnnl_data_type_t ddt, const std::string &stag,
         const std::string &dtag) {

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -269,6 +269,8 @@ void skip_invalid_inplace(res_t *res, dnnl_data_type_t sdt,
         dnnl_data_type_t ddt, const std::string &stag, const std::string &dtag);
 void skip_unimplemented_arg_scale(const attr_t &attr, res_t *res);
 
+void skip_unsupported_block_format(const std::string &format_tag, res_t *res);
+
 template <typename prb_t>
 int check_caches(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &primw,
         const prb_t *prb, res_t *res) {

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -289,6 +289,7 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_eltwise, prb->dt);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_eltwise);
+    skip_unsupported_block_format(prb->tag, res);
 
     if (is_gpu() && (prb->dt == dnnl_f8_e5m2 || prb->dt == dnnl_f8_e4m3)
             && prb->dir == BWD_D) {

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -500,6 +500,9 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
 
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->dt[0], prb->dt[1]}, prb->dir, res);
+    for (const auto &tag : prb->tag) {
+        skip_unsupported_block_format(tag, res);
+    }
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -248,6 +248,9 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             prb->get_dt(SRC), prb->get_dt(DST));
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_inner_product);
+    skip_unsupported_block_format(prb->stag, res);
+    skip_unsupported_block_format(prb->wtag, res);
+    skip_unsupported_block_format(prb->dtag, res);
 
     if (is_cpu()) {
         auto is_dt_f16_or_f32 = [&](dnnl_data_type_t dt) {

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -457,6 +457,9 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             prb->attr, res, dnnl_layer_normalization, prb->dt[0]);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_layer_normalization);
+    for (const auto &tag : prb->tag) {
+        skip_unsupported_block_format(tag, res);
+    }
 
     if (is_gpu() && prb->attr.post_ops.len() != 0) {
         // GPU does not support post-ops

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -120,6 +120,7 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_lrn, prb->dt);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_lrn);
+    skip_unsupported_block_format(prb->tag, res);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {}

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -489,6 +489,9 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             prb->attr, res, dnnl_matmul, prb->src_dt(), prb->dst_dt());
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_matmul);
+    skip_unsupported_block_format(prb->stag, res);
+    skip_unsupported_block_format(prb->wtag, res);
+    skip_unsupported_block_format(prb->dtag, res);
 
     if ((is_nvidia_gpu() || is_amd_gpu()) && !prb->sparse_options.is_def()) {
         BENCHDNN_PRINT(2,

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -146,6 +146,7 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_pooling, prb->src_dt());
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_pooling);
+    skip_unsupported_block_format(prb->tag, res);
 
     if (is_cpu() && prb->src_dt() != prb->dst_dt()) {
         res->state = SKIPPED;

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -144,6 +144,9 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_prelu, prb->sdt[0]);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_prelu);
+    for (const auto &tag : prb->stag) {
+        skip_unsupported_block_format(tag, res);
+    }
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {}

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -206,6 +206,8 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_reduction, prb->sdt);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_reduction);
+    skip_unsupported_block_format(prb->dtag, res);
+    skip_unsupported_block_format(prb->stag, res);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -412,15 +412,6 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             res->reason = skip_reason::case_not_supported;
             return;
         }
-        auto is_blocked_format = [](const std::string &format_tag) {
-            // if the user provided tag has a capital letter,
-            // that indicates it's a blocked format, otherwise it's plain
-
-            for (const auto &c : format_tag) {
-                if (std::isupper(c)) { return true; }
-            }
-            return false;
-        };
         // Skip blocked format tags and 4 bit formats for Nvidia/AMD/Generic SYCL backends
         if (is_generic_gpu()) {
             const bool is_4bit_format
@@ -430,9 +421,10 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             bool zero_point_has_groups = !prb->attr.scales.is_def();
             bool scales_has_groups = !prb->attr.zero_points.is_def();
 
-            if (is_blocked_format(prb->stag) || is_blocked_format(prb->dtag)
-                    || is_4bit_format || scales_has_groups
-                    || zero_point_has_groups) {
+            skip_unsupported_block_format(prb->stag, res);
+            skip_unsupported_block_format(prb->dtag, res);
+
+            if (is_4bit_format || scales_has_groups || zero_point_has_groups) {
                 res->state = SKIPPED;
                 res->reason = skip_reason::case_not_supported;
             }

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -113,6 +113,7 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_resampling, prb->sdt);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_resampling);
+    skip_unsupported_block_format(prb->tag, res);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {}

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -230,6 +230,8 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_softmax, prb->sdt);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_softmax);
+    skip_unsupported_block_format(prb->stag, res);
+    skip_unsupported_block_format(prb->dtag, res);
 
     if (prb->attr.post_ops.find(attr_t::post_ops_t::kind_t::SUM) != -1) {
         res->state = SKIPPED;

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -101,6 +101,10 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_sum_po(prb->attr, res, dnnl_sum, prb->sdt[0]);
     skip_unimplemented_binary_po(prb->attr, res);
     skip_unimplemented_prelu_po(prb->attr, res, dnnl_sum);
+    for (const auto &tag : prb->stag) {
+        skip_unsupported_block_format(tag, res);
+    }
+    skip_unsupported_block_format(prb->dtag, res);
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {


### PR DESCRIPTION
# Description

Generic backend doesn't support block format. This PR implement a skip function to check if the format tag and skip the test in case of generic backend.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?