### PR TITLE
jit: ir: remove custom IR types from the core headers

### DIFF
--- a/src/gpu/intel/jit/ir/core.cpp
+++ b/src/gpu/intel/jit/ir/core.cpp
@@ -424,7 +424,6 @@ void object_impl_t::_visit(ir_visitor_t &visitor) const {}
 DECL_TRAVERSE_LEAF(bool_imm_t)
 DECL_TRAVERSE_LEAF(const_var_t)
 DECL_TRAVERSE_LEAF(float_imm_t)
-DECL_TRAVERSE_LEAF(func_impl_t)
 DECL_TRAVERSE_LEAF(int_imm_t)
 DECL_TRAVERSE_LEAF(var_t)
 
@@ -492,16 +491,14 @@ void ir_visitor_t::_visit(const for_t &obj) {
 }
 
 object_t ir_mutator_t::_mutate(const func_call_t &obj) {
-    auto func = mutate(obj.func);
     auto args = mutate(obj.args);
 
-    if (func.is_same(obj.func) && ir_utils::is_same(args, obj.args)) return obj;
+    if (ir_utils::is_same(args, obj.args)) return obj;
 
-    return func_call_t::make(func, args, obj.attr);
+    return func_call_t::make(obj.func, args, obj.attr);
 }
 
 void ir_visitor_t::_visit(const func_call_t &obj) {
-    visit(obj.func);
     visit(obj.args);
 }
 
@@ -688,23 +685,6 @@ object_t ir_mutator_t::_mutate(const while_t &obj) {
 void ir_visitor_t::_visit(const while_t &obj) {
     visit(obj.cond);
     visit(obj.body);
-}
-
-// Catch missing mutates that are not expected to dispatch to the base
-// mutator
-object_t ir_mutator_t::_mutate(const nary_op_t &obj) {
-    gpu_error_not_expected() << "Can't handle type: nary_op_t";
-    return {};
-}
-void ir_visitor_t::_visit(const nary_op_t &obj) {
-    gpu_error_not_expected() << "Can't handle type: nary_op_t";
-}
-object_t ir_mutator_t::_mutate(const pexpr_t &obj) {
-    gpu_error_not_expected() << "Can't handle type: pexpr_t";
-    return {};
-}
-void ir_visitor_t::_visit(const pexpr_t &obj) {
-    gpu_error_not_expected() << "Can't handle type: pexpr_t";
 }
 
 } // namespace jit

--- a/src/gpu/intel/jit/ir/eltwise.hpp
+++ b/src/gpu/intel/jit/ir/eltwise.hpp
@@ -31,7 +31,7 @@ namespace jit {
 
 class eltwise_t : public func_impl_t {
 public:
-    IR_DECL_DERIVED_TYPE_ID(eltwise_t, func_impl_t)
+    IR_DECL_TYPE(eltwise_t)
 
     static func_t make(alg_kind_t alg_kind, float scale, float alpha,
             float beta, expr_t &seed, ngen::DataType dst_dt) {

--- a/src/gpu/intel/jit/ir/fma.hpp
+++ b/src/gpu/intel/jit/ir/fma.hpp
@@ -100,7 +100,7 @@ private:
 // Function representing DPAS instruction.
 class dpas_t : public func_impl_t {
 public:
-    IR_DECL_DERIVED_TYPE_ID(dpas_t, func_impl_t)
+    IR_DECL_TYPE(dpas_t)
 
     static func_t make(bool is_dpasw, int exec_size, uint8_t sdepth,
             uint8_t rcount, const type_t &dst_type, const type_t &src1_type,
@@ -206,7 +206,7 @@ private:
 // Function representing MAD instruction.
 class mad_t : public func_impl_t {
 public:
-    IR_DECL_DERIVED_TYPE_ID(mad_t, func_impl_t)
+    IR_DECL_TYPE(mad_t)
 
     static func_t make(const hw_t &hw, const type_t &dst_type, int exec_size,
             const type_t &src1_type, int src1_stride, const type_t src2_type,

--- a/src/gpu/intel/jit/ir/ir.cpp
+++ b/src/gpu/intel/jit/ir/ir.cpp
@@ -100,8 +100,6 @@ public:
         out_ << obj.line_str() << "\n";
     }
 
-    void _visit(const func_impl_t &obj) override { out_ << obj.str(); }
-
     void _visit(const if_t &obj) override {
         print_indent();
         out_ << obj.line_str() << " {\n";
@@ -284,7 +282,7 @@ public:
         return ir_mutator_t::_mutate(obj); \
     };
 
-    HANDLE_TRAVERSE_TARGETS()
+    HANDLE_CORE_IR_OBJECTS()
 
 #undef HANDLE_IR_OBJECT
 
@@ -346,7 +344,7 @@ public:
         return _mutate_after(obj); \
     };
 
-    HANDLE_ALL_IR_OBJECTS()
+    HANDLE_CORE_IR_OBJECTS()
 
 #undef HANDLE_IR_OBJECT
 
@@ -366,7 +364,7 @@ public:
         if (obj.is_stmt()) stmts.emplace_back(obj); \
     }
 
-    HANDLE_ALL_IR_OBJECTS()
+    HANDLE_CORE_IR_OBJECTS()
 
 #undef HANDLE_IR_OBJECT
 
@@ -405,7 +403,7 @@ private:
     template <typename T>
     object_t mutate_stmt(const T &obj) {
         if (in_ctor_) return ir_mutator_t::_mutate(obj);
-        if (T::_type_id() == ir_type_id_t::stmt_seq_t) {
+        if (T::_type_info().type_id == stmt_seq_t::_type_info().type_id) {
             return mutate_stmt_seq(obj);
         }
         auto undef_bufs = get_undef_bufs();
@@ -768,12 +766,12 @@ int count_object(const object_t &root, const object_t &obj) {
     std::vector<object_t> found;
     do {
 #define HANDLE_IR_OBJECT(type) \
-    if (obj.dispatch_type_id() == type::_dispatch_type_id()) { \
+    if (obj.type_info() == type::_type_info()) { \
         found = find_objects<type>(root); \
         break; \
     }
 
-        HANDLE_ALL_IR_OBJECTS()
+        HANDLE_CORE_IR_OBJECTS()
 
 #undef HANDLE_IR_OBJECT
 

--- a/src/gpu/intel/jit/ir/message.hpp
+++ b/src/gpu/intel/jit/ir/message.hpp
@@ -131,7 +131,7 @@ struct block_2d_info_t {
 // Function representing send messages.
 class send_t : public func_impl_t {
 public:
-    IR_DECL_DERIVED_TYPE_ID(send_t, func_impl_t)
+    IR_DECL_TYPE(send_t)
 
     static func_t make(const hw_t &hw, send_op_t op, send_address_t address,
             const type_t &type, int slots, bool zero_out,

--- a/src/gpu/intel/jit/ir/message_patterns.hpp
+++ b/src/gpu/intel/jit/ir/message_patterns.hpp
@@ -522,10 +522,10 @@ public:
         return matcher.is_match_;
     };
 
-    void _visit(const func_impl_t &obj) override {
-        if (!obj.is<send_t>()) return;
+    void _visit(const func_call_t &obj) override {
+        if (!is_func_call<send_t>(obj)) return;
 
-        auto &s = obj.as<send_t>();
+        auto &s = obj.func.as<send_t>();
 
         if (pattern.is_uniform_blocked()) {
             // Larger blocked or 2D messages are a strict improvement

--- a/src/gpu/intel/jit/ir/reduce.hpp
+++ b/src/gpu/intel/jit/ir/reduce.hpp
@@ -30,7 +30,7 @@ namespace jit {
 // Implements reduction of GRF buffer for given layout.
 class reduce_t : public func_impl_t {
 public:
-    IR_DECL_DERIVED_TYPE_ID(reduce_t, func_impl_t)
+    IR_DECL_TYPE(reduce_t)
 
     static func_t make(const layout_t &src_layout, const layout_t &dst_layout) {
         return func_t(new reduce_t(src_layout, dst_layout));

--- a/src/gpu/intel/jit/ir/reorder.hpp
+++ b/src/gpu/intel/jit/ir/reorder.hpp
@@ -31,7 +31,7 @@ namespace jit {
 // data types is supported.
 class reorder_t : public func_impl_t {
 public:
-    IR_DECL_DERIVED_TYPE_ID(reorder_t, func_impl_t)
+    IR_DECL_TYPE(reorder_t)
 
     static func_t make(layout_t src_layout, layout_t dst_layout) {
         reorder::normalize(src_layout, dst_layout);


### PR DESCRIPTION
PR is to get rid of centralized handling of IR objects. For non-core types we can use the IR object name for type information purposes - no need in updating the type id enumeration.

With that we will be able to extend the IR object system with custom IR objects without updating the core headers.

@rjoursler please take a look.