### PR TITLE
generic: sycl: Skip f64 data type for generic backend

### DIFF
--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -689,9 +689,23 @@ bool check_md_consistency_with_tag(
     return dnnl_memory_desc_equal(md_new_tag, md);
 }
 
+void skip_unimplemented_generic_f64(
+        const std::vector<dnnl_data_type_t> &v_dt, res_t *res) {
+    if (is_generic_gpu()) {
+        for (const auto &i_dt : v_dt) {
+            if (i_dt == dnnl_f64) {
+                res->state = SKIPPED;
+                res->reason = skip_reason::data_type_not_supported;
+                return;
+            }
+        }
+    }
+}
+
 void skip_unimplemented_data_type(
         const std::vector<dnnl_data_type_t> &v_dt, dir_t dir, res_t *res) {
     const bool has_f64_support = is_f64_supported();
+    skip_unimplemented_generic_f64(v_dt, res);
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
     using namespace dnnl::impl::cpu::platform;
     // bf16 is supported on AVX512-CORE+

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -257,6 +257,8 @@ inline bool should_stop(const timer::timer_t &t) {
     return stop;
 }
 
+void skip_unimplemented_generic_f64(
+        const std::vector<dnnl_data_type_t> &v_dt, res_t *res);
 void skip_unimplemented_data_type(
         const std::vector<dnnl_data_type_t> &v_dt, dir_t dir, res_t *res);
 void skip_unimplemented_sum_po(const attr_t &attr, res_t *res,


### PR DESCRIPTION
# Description

This PR disable tests if data type is f64 since, due to current limitation, generic backend doesn't support f64 data type.  

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?