### PR TITLE
src: gpu: intel: allow fp32 mask for xf16 SDPA in ukernel

### DIFF
--- a/src/gpu/intel/micro_sdpa.hpp
+++ b/src/gpu/intel/micro_sdpa.hpp
@@ -124,9 +124,18 @@ struct micro_sdpa_t : public gpu_primitive_t {
                 VCHECK_SDPA_COND(
                         attn_mask_md()->dims[mask_k_index] == desc()->keys(),
                         VERBOSE_INVALID_BROADCAST, "attn_mask", mask_k_index);
+            }
+            if (qry_md()->data_type == data_type::f32) {
                 VCHECK_SDPA_COND(
                         attn_mask_md()->data_type == qry_md()->data_type,
                         "Mask data type should match Qry/Dst data type.");
+            } else {
+                VCHECK_SDPA_COND(
+                        (attn_mask_md()->data_type == qry_md()->data_type)
+                                || (attn_mask_md()->data_type
+                                        == data_type::f32),
+                        "Mask data type should be xf16 or f32 when Qry/Dst is "
+                        "xf16.");
             }
             VCHECK_SDPA_COND(
                     (utils::everyone_is(data_type::f16, qry_md()->data_type,


### PR DESCRIPTION
For case `tests\benchdnn\inputs\graph\complex_fusion\mha\sdpa-plain-simplified-f16-f32.json`, when `mask_add` src1 dtype is f32, SDPA can't be dispatched to ukernel due to this check, so I change it to allow xf16 SDPA uses f32 mask.