### PR TITLE
Revert "cpu: x64: binary: Supporting per_w broadcast strategy (#2778)"

### DIFF
--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -29,7 +29,6 @@ namespace x64 {
 static bcast_set_t get_supported_postops_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
             broadcasting_strategy_t::per_oc_spatial,
-            broadcasting_strategy_t::per_w,
             broadcasting_strategy_t::no_broadcast};
 }
 

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -29,7 +29,6 @@ namespace x64 {
 static bcast_set_t get_supported_postops_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
             broadcasting_strategy_t::per_oc_spatial,
-            broadcasting_strategy_t::per_w,
             broadcasting_strategy_t::no_broadcast};
 }
 

--- a/tests/benchdnn/inputs/binary/harness_binary_regression
+++ b/tests/benchdnn/inputs/binary/harness_binary_regression
@@ -6,6 +6,3 @@
 
 # Mixed src1/post-op src broadcast
 --reset --attr-post-ops=add:f32:2 1x17:1x1
-
-# per_w broadcasting strategy
---reset --attr-post-ops=mul:f32:4+add:f32:4 --alg=add 1x20x768:1x20x1


### PR DESCRIPTION
Revert [#2778](https://github.com/uxlfoundation/oneDNN/pull/2778), which is causing a segfault in [PR](https://jira.devtools.intel.com/browse/MFDNN-13940).