### PR TITLE
Revert "xe: reduction: reduce register spills"

### DIFF
--- a/src/gpu/intel/reduction/ref_reduction.cl
+++ b/src/gpu/intel/reduction/ref_reduction.cl
@@ -67,13 +67,6 @@
 #define _SRC_OFF(x0, x1, x2, x3, x4, x5) OFF_MD(SRC, x0, x1, x2, x3, x4, x5)
 #define _DST_OFF(x0, x1, x2, x3, x4, x5) OFF_MD(DST, x0, x1, x2, x3, x4, x5)
 
-// the compiler likes to aggressively unroll loops with compile-time upper
-// bounds, causing register spills. Limit the maximum unrolling to prevent this.
-// XXX: Re-use the for_ definition for nicer formatting
-#undef for_
-#define MAX_UNROLL 32
-#define for_ unroll_for_by(MAX_UNROLL)
-
 __kernel void ref_reduce(
         __global SRC_DATA_T *src, __global DST_DATA_T *dst POST_OP_ARGS) {
     off_t d0 = GWS_GET_D0();


### PR DESCRIPTION
This reverts commit 877ecf4b1a9d1b4076f0a84c08ee52ebe9735296. It didn't solve all of the related register spill issues, and in fact it created some out-of-memory issues during CI.

The issue is that this attempted to limit the maximum loop unrolling (as suggested in the added comment), but in some cases the compiler actually would have decided on a smaller unroll without spills, in which case this change exacerbated the problem by increasing the loop unrolling. Instead of reducing the unroll further, I decided to just revert it for now.