### PR TITLE
ci: aarch64: upgrade perf test baseline to v3.8.0

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -3,6 +3,6 @@
         "acl": "v52.2.0",
         "gcc": "13",
         "clang": "17",
-        "onednn-base": "v3.7"
+        "onednn-base": "v3.8.0"
     }
 }


### PR DESCRIPTION
All the current failing regression tests have been resolved, and the remaining failures have been deemed as intentional slow downs.


