### PR TITLE
[GPU] Fix GEMM Xe3 strategy selection

### DIFF
--- a/src/gpu/intel/jit/gemm/selector/kernel_selector.cpp
+++ b/src/gpu/intel/jit/gemm/selector/kernel_selector.cpp
@@ -333,7 +333,7 @@ MatchParamsBase::MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isInt
         case ngen::HW::XeHPG:   selector.hw = kcatalog::HWTagXeHPG;   break;
         case ngen::HW::XeHPC:   selector.hw = kcatalog::HWTagXeHPC;   break;
         case ngen::HW::Xe2:     selector.hw = kcatalog::HWTagXe2;     break;
-        case ngen::HW::Xe3:     selector.hw = kcatalog::HWTagXeHPC;   break;
+        case ngen::HW::Xe3:     selector.hw = kcatalog::HWTagXe3;   break;
     }
 
     auto &C = problem.C;


### PR DESCRIPTION
# Description

Looks like this got dropped during downstream from gemmstone. Its causing performance issues on Xe3. 

Fixes # [MFDNN-14014](https://jira.devtools.intel.com/browse/MFDNN-14014)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
