### PR TITLE
cpu, test: aarch64: fix vector register clobbering in uni_reorder

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -17,10 +17,7 @@
 *******************************************************************************/
 
 #include <algorithm>
-#include <assert.h>
-#include <numeric>
-
-#include "oneapi/dnnl/dnnl_debug.h"
+#include <cassert>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
@@ -1159,13 +1156,11 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         }
 
         if (compensation_needed_) {
-            const uint32_t xmm_begin = 9;
-            const uint32_t xmm_end = 11;
-            uint32_t xmm_id = xmm_begin;
+            uint32_t xmm_id = 0;
             const auto get_temp_xmm = [&] {
-                const Xbyak_aarch64::VReg temp {xmm_id++};
+                const Xbyak_aarch64::VReg temp {tmp_vec_idx[xmm_id]};
 
-                if (xmm_id > xmm_end) { xmm_id = xmm_begin; }
+                xmm_id = (xmm_id + 1) % tmp_vec_idx.size();
 
                 return temp;
             };

--- a/tests/benchdnn/inputs/reorder/harness_reorder_compensation
+++ b/tests/benchdnn/inputs/reorder/harness_reorder_compensation
@@ -3,7 +3,7 @@
 --sdt=f32
 --ddt=s8
 --attr-scales=, \
-    src:common:2, \
+    src:common:2+dst:common:2, \
     src:per_dim_0, \
     src:per_dim_1, \
     src:per_dim_01, \


### PR DESCRIPTION
# Description
Fixes a register clobbering bug in `jit_uni_reorder_kernel_f32_t`. The previous mechanism for getting temporary registers can sometimes return a register that is in use for compensation calculations.

Fixes #2412

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?
