### PR TITLE
ci: aarch64: fix typo in perf-test baseline version

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -3,6 +3,6 @@
         "acl": "v52.2.0",
         "gcc": "13",
         "clang": "17",
-        "onednn-base": "v3.8.0"
+        "onednn-base": "v3.8"
     }
 }


### PR DESCRIPTION
# Description
`v3.8.0` should be `v3.8`

Failing run: https://github.com/uxlfoundation/oneDNN/actions/runs/16741114342/job/47389789290
