### PR TITLE
@yair-obodovsky, @inteldimitrius, @asimonov1 as code owners for x64 component

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -145,6 +145,7 @@ Team: @uxlfoundation/onednn-cpu-x64
 | ------------------- | --------------------- | ----------------- | ---------- |
 | Andrey Kalinin      | @ankalinin            | Intel Corporation | Maintainer |
 | Tatyana Primak      | @tprimak              | Intel Corporation | Maintainer |
+| Alexander Simonov   | @asimonov1            | Intel Corporation | Code Owner |
 | Alexey Makarevich   | @amakarev             | Intel Corporation | Code Owner |
 | David Eberius       | @davideberius         | Intel Corporation | Code Owner |
 | Dmitriy Ovchinnikov | @inteldimitrius       | Intel Corporation | Code Owner |


### PR DESCRIPTION
I would like to nominate @yair-obodovsky, @inteldimitrius, @asimonov1 for the role of code owners for x64 component. These gentlemen are members of CPU optimizations team at Intel and have history of material contributions x64 component:
* @yair-obodovsky: [PR list](https://github.com/uxlfoundation/oneDNN/pulls?q=author%3Ayair-obodovsky+is%3Aclosed)
* @inteldimitrius: [PR list](https://github.com/uxlfoundation/oneDNN/pulls?q=author%3Ainteldimitrius+is%3Aclosed)
* @asimonov1: [PR list](https://github.com/uxlfoundation/oneDNN/pulls?q=author%3Aasimonov1+is%3Aclosed)


