### PR TITLE
cpu: matmul: support f32f32x8 and bf16bf16x8

### DIFF
--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -58,7 +58,7 @@ struct ref_matmul_t : public primitive_t {
                                      f8_e4m3, f4_e2m1, f4_e3m0, u8, s8, u4, s4),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_MATMUL(utils::one_of(dst_type, f32, bf16, f16, f8_e5m2,
-                                     f8_e4m3, f4_e2m1, f4_e3m0),
+                                     f8_e4m3, f4_e2m1, f4_e3m0, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_MATMUL((src_type == wei_type
                                      || utils::one_of(wei_type, bf16, f16, u8,
@@ -67,11 +67,6 @@ struct ref_matmul_t : public primitive_t {
             /* int8 weights decompression support */
             VDISPATCH_MATMUL(IMPLICATION(utils::one_of(wei_type, u8, s8),
                                      attr_.mayiconvert(wei_type, src_type)),
-                    VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_MATMUL(IMPLICATION(src_type == f32, dst_type == f32),
-                    VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_MATMUL(IMPLICATION(src_type == bf16,
-                                     utils::one_of(dst_type, f32, bf16)),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_MATMUL(IMPLICATION(src_type == f16,
                                      utils::one_of(dst_type, f32, f16)),


### PR DESCRIPTION
This PR adds support for f32:f32:u8, f32:f32:s8, bf16:bf16:u8 and bf16:bf16:s8 data types configurations in matmul.
Addresses [MFDNN-14030](https://jira.devtools.intel.com/browse/MFDNN-14030)
