### PR TITLE
ci: aarch64: use RelWithAssert instead of Debug for CI

### DIFF
--- a/.github/automation/aarch64/build_acl.sh
+++ b/.github/automation/aarch64/build_acl.sh
@@ -54,9 +54,9 @@ else
 fi
 
 if [[ "$ACL_BUILD_TYPE" == "Release" ]]; then
-    ACL_DEBUG=0
-elif [[ "$ACL_BUILD_TYPE" == "Debug" ]]; then
-    ACL_DEBUG=1
+    ACL_ASSERTS=0
+elif [[ "$ACL_BUILD_TYPE" == "RelWithAssert" ]]; then
+    ACL_ASSERTS=1
 else
     echo "Unknown build config: $ACL_BUILD_TYPE"
     exit 1
@@ -70,7 +70,7 @@ elif [[ "$ACL_ACTION" == "build" ]]; then
     set -x
     cd $ACL_ROOT_DIR
     set -x
-    scons $MP Werror=0 debug=$ACL_DEBUG neon=1 opencl=0 embed_kernels=0 \
+    scons $MP Werror=0 asserts=${ACL_ASSERTS} neon=1 opencl=0 embed_kernels=0 \
         os=$ACL_OS arch=armv8.2-a build=native multi_isa=$ACL_MULTI_ISA_SUPPORT \
         fixed_format_kernels=1 cppthreads=0 openmp=$ACL_OPENMP examples=0 \
         validation_tests=0

--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -28,16 +28,6 @@ SKIPPED_TEST_FAILURES="test_benchdnn_modeC_matmul_multidims_cpu"
 
 #  We currently have some OS and config specific test failures.
 if [[ "$OS" == "Linux" ]]; then
-    if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
-        # as test_matmul is time consuming , we only run it in release mode to save time.
-        SKIPPED_TEST_FAILURES+="|test_matmul"
-        # The following graph tests are too time-consuming for Debug mode.
-        SKIPPED_TEST_FAILURES+="|cpu-graph-gated-mlp-int4-cpp"
-        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_cpu"
-        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
-        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
-    fi
-
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_ci_cpu"
     SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_cpu"
 fi

--- a/.github/automation/aarch64/test.sh
+++ b/.github/automation/aarch64/test.sh
@@ -23,8 +23,6 @@ set -o errexit -o pipefail -o noclobber
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
-export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
-
 # Defines MP, CC, CXX and OS.
 source ${SCRIPT_DIR}/common.sh
 

--- a/.github/workflows/aarch64-acl.yml
+++ b/.github/workflows/aarch64-acl.yml
@@ -33,9 +33,9 @@ jobs:
       max-parallel: 1
       matrix:
         config: [
-          { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release },
-          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: Release },
-          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug },
+          { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: RelWithAssert },
+          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: RelWithAssert },
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: RelWithAssert },
           { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: gcc, build: Release }
         ]
 

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -73,11 +73,11 @@ jobs:
     strategy:
       matrix:
         config: [
-          { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: Release, testset: SMOKE },
-          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: Release, testset: SMOKE },
-          { name: c6g, label: ah-ubuntu_22_04-c6g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI },
-          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: Debug, testset: SMOKE },
-          { name: c7g, label: ah-ubuntu_22_04-c7g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }
+          { name: MacOS, label: macos-14, threading: SEQ, toolset: clang, build: RelWithAssert, testset: SMOKE },
+          { name: cb100, label: ubuntu-24.04-arm, threading: OMP, toolset: gcc, build: RelWithAssert, testset: SMOKE },
+          { name: c6g, label: ah-ubuntu_22_04-c6g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI }, # Performance testing requires Release
+          { name: c6g, label: ah-ubuntu_22_04-c6g_2x-50, threading: OMP, toolset: clang, build: RelWithAssert, testset: SMOKE },
+          { name: c7g, label: ah-ubuntu_22_04-c7g_4x-50, threading: OMP, toolset: gcc, build: Release, testset: CI } # Performance testing requires Release
         ]
 
     name: ${{ matrix.config.name }}, ${{ matrix.config.toolset }}, ${{ matrix.config.threading }}, ${{ matrix.config.build }}
@@ -175,8 +175,6 @@ jobs:
         run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/test.sh
         working-directory: ${{ github.workspace }}/oneDNN/build
         env:
-          BUILD_TOOLSET: ${{ matrix.config.toolset }}
-          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
           CTEST_PARALLEL_LEVEL: 6
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
           ONEDNN_THREADING: ${{ matrix.config.threading }}


### PR DESCRIPTION
# Description

Switches out the `Debug` runner with a `RelWithAssert` build since the main value add are the `assert()` statements.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
