### PR TITLE
cpu: aarch64: reorder: skip tr8x8 strategy when compensation needed

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -29,7 +29,6 @@ SKIPPED_TEST_FAILURES="test_benchdnn_modeC_matmul_multidims_cpu"
 #  We currently have some OS and config specific test failures.
 if [[ "$OS" == "Linux" ]]; then
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_ci_cpu"
-    SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_cpu"
 fi
 
 # Nightly failures

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -458,10 +458,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         static constexpr int desirable_node_size = 8;
         static constexpr int desirable_stride = 1;
 
-        // This processing is relied on swaping two innermost dimension.
-        // Therefore, input stride in second node and output stride in first node
-        // have to be equal to 1.
-
+        // This process relies on swapping the two innermost dimensions.
+        // Therefore, the input stride in the second node and output stride in
+        // first node have to be equal to 1.
         return mayiuse(sve_256) && prb_.ndims >= 2
                 && ((utils::one_of(prb_.itype, u8, data_type::s8, s32, f32)
                         && utils::one_of(
@@ -470,8 +469,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
                 && utils::everyone_is(desirable_stride, prb_.os(0), prb_.is(1))
                 && !prb_.is_tail_present
                 && prb_.src_scale_type == scale_type_t::NONE
-                && prb_.dst_scale_type == scale_type_t::NONE
-                && prb_.beta == 0.f;
+                && prb_.dst_scale_type == scale_type_t::NONE && prb_.beta == 0.f
+                && !compensation_needed_;
     }
 
     bool process_unroll_tr8x8(const int ndims, const int len) {

--- a/tests/benchdnn/inputs/reorder/harness_reorder_regression
+++ b/tests/benchdnn/inputs/reorder/harness_reorder_regression
@@ -18,3 +18,11 @@
 --sdt=bf16 --ddt=bf16
 --stag=aBcde4b --dtag=aBcde4b
 2x24x19x19x19
+
+# Test compensation with tr8x8 problem shape
+--reset
+--skip-impl=ref,simple #skip non-jit version
+--sdt=s8 --ddt=s8
+--stag=ab --dtag=ba
+--oflag=zp_comp:1
+8x8


### PR DESCRIPTION
# Description

The `tr8x8` strategy does not support compensation and needs to be skipped when this option is present. Also added a unit test that would have caught this in the reorder suite.

Fixes #2675 

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?
