### PR TITLE
examples: graph: smaller sdpa sizes to save time in CI

### DIFF
--- a/examples/graph/gqa.cpp
+++ b/examples/graph/gqa.cpp
@@ -277,7 +277,7 @@ void bench(engine::kind ekind, dnnl_data_type_t dt, const gqa_dims_t &p,
 
 void gqa_perf(engine::kind ekind, int argc, char **argv) {
     // default testing parameters
-    gqa_dims_t params = {32, 384, 16, 2, 64};
+    gqa_dims_t params = {2, 128, 16, 2, 64};
 
     if (argc > 2) {
         if (argc == 7) {

--- a/examples/graph/mqa.cpp
+++ b/examples/graph/mqa.cpp
@@ -268,7 +268,7 @@ void bench(engine::kind ekind, dnnl_data_type_t dt, const mqa_dims_t &p,
 
 void mqa_perf(engine::kind ekind, int argc, char **argv) {
     // default testing parameters
-    mqa_dims_t params = {32, 384, 16, 64};
+    mqa_dims_t params = {2, 128, 16, 64};
 
     if (argc > 2) {
         if (argc == 6) {

--- a/examples/graph/sdpa_bottom_right_causal_mask.cpp
+++ b/examples/graph/sdpa_bottom_right_causal_mask.cpp
@@ -323,7 +323,7 @@ void bench(engine::kind ekind, dnnl_data_type_t dt, const sdpa_dims_t &p,
 
 void sdpa_perf(engine::kind ekind, int argc, char **argv) {
     // default testing parameters
-    sdpa_dims_t params = {32, 384, 16, 64, 384};
+    sdpa_dims_t params = {2, 128, 16, 64, 128};
 
     if (argc > 2) {
         if (argc == 6) {

--- a/examples/graph/sdpa_stacked_qkv.cpp
+++ b/examples/graph/sdpa_stacked_qkv.cpp
@@ -299,7 +299,7 @@ void bench(engine::kind ekind, dnnl_data_type_t dt, const sdpa_dims_t &p,
 
 void sdpa_perf(engine::kind ekind, int argc, char **argv) {
     // default testing parameters
-    sdpa_dims_t params = {32, 384, 16, 64};
+    sdpa_dims_t params = {2, 128, 16, 64};
 
     if (argc > 2) {
         if (argc == 6) {


### PR DESCRIPTION
We don't need such big problem sizes in examples where the main purpose is to demonstrate API usages.

Changing them to smaller sizes to save the time and resource in CI, especially on lower end platforms.