### PR TITLE
xe: conv: remove punning from attributes for ref_conv

### DIFF
--- a/src/gpu/intel/conv/ref.cpp
+++ b/src/gpu/intel/conv/ref.cpp
@@ -162,7 +162,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
                     : conf.attr_info.sum_data_type,
             "SUM", false);
 
-    CHECK(def_attr_info(kernel_ctx, conf.attr_info, post_ops, *dst_md));
+    CHECK(def_attr_info(kernel_ctx, conf.attr_info, post_ops, *dst_md, false));
     return status::success;
 }
 


### PR DESCRIPTION
Another fixup commit for #3819.

Fixes [MFDNN-14125](https://jira.devtools.intel.com/browse/MFDNN-14125).