### PR TITLE
doc: clarify saturation behavior

### DIFF
--- a/doc/programming_model/attributes_quantization.md
+++ b/doc/programming_model/attributes_quantization.md
@@ -65,8 +65,11 @@ During execution, primitives implementations avoid integer overflows
 and maintain integer accuracy by using wider datatypes (e.g. int32)
 for intermediate values and accumulators. Those are then converted as
 necessary before the result is written to the output memory objects.
-During that conversion, implementations typically saturate in case of
-underflow/overflow (e.g. when converting `s32` to int8).
+
+When converting to integral datatypes, implementations typically
+saturate, whereas for floating-point datatypes, underflow/overflow can
+occur. To force saturation in floating-point datatypes use
+@ref dev_guide_attributes_post_ops_eltwise with clip algorithm.
 
 @warning
 Depending on the architecture, the behavior of int8 computations might slightly

--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -112,6 +112,11 @@ intermediate data type (for example f16 or bf16), which may result in
 [double
 rounding](https://en.wikipedia.org/wiki/Rounding#Double_rounding).
 
+Conversions to integral datatypes saturate upon overflow, whereas
+conversions to floating-point datatypes don't. To force saturation behavior for 
+floating-point datatypes use @ref dev_guide_attributes_post_ops_eltwise with clip algorithm.
+
+
 ### Rounding mode and denormal handling
 
 oneDNN floating-point computation behavior follows the floating-point


### PR DESCRIPTION
this clarifies that:
- for conversion to integral types, we do saturate
- for conversions to floating-point types, we don't saturate (but saturation can be obtained with clip post-op).