### PR TITLE
src: address static analyzers hits

### DIFF
--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -181,7 +181,7 @@ status_t dnnl_binary_primitive_desc_create_v2(
 
     bod.src_desc[0] = *src0_md;
     bod.src_desc[1] = *src1_md;
-    if (alg_kind == binary_select) bod.src_desc[2] = *src2_md;
+    if (src2_md) bod.src_desc[2] = *src2_md;
     bod.dst_desc = *dst_md;
 
     CHECK(binary_attr_check(bod, engine, attr));

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -254,7 +254,7 @@ status_t post_ops_t::append_binary(alg_kind_t alg,
     e.binary.user_src1_desc = *user_src1_desc;
     e.binary.src1_desc = *user_src1_desc;
 
-    if (alg == alg_kind::binary_select) {
+    if (user_src2_desc) {
         e.binary.user_src2_desc = *user_src2_desc;
         e.binary.src2_desc = *user_src2_desc;
     }

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -166,11 +166,11 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
                         const size_t end_oc
                                 = (os == last_os) ? last_oc : jcp.oc - 1;
 
-                        const data_t *__restrict bia_arr
-                                = bia_base ? bia_base + g * jcp.oc : nullptr;
                         data_t *__restrict dst_arr = dst + os * dst_os_stride;
 
                         if (jcp.with_bias) {
+                            const data_t *__restrict bia_arr
+                                    = bia_base + g * jcp.oc;
                             PRAGMA_OMP_SIMD()
                             for (size_t oc = start_oc; oc <= end_oc; oc++) {
                                 dst_arr[oc] += bia_arr[oc];

--- a/src/cpu/sycl/stream_submit_cpu_primitive.cpp
+++ b/src/cpu/sycl/stream_submit_cpu_primitive.cpp
@@ -49,6 +49,8 @@ void init_thunk_params(
 template <typename... param_types>
 status_t submit_cpu_primitive_with_params_impl(
         submit_ctx_t *submit_ctx, ::sycl::handler &cgh, param_types... params) {
+    // Prevents dereferencing an empty pointer in a host task.
+    if (!submit_ctx) return status::invalid_arguments;
 
     xpu::sycl::compat::host_task(cgh, [=]() {
         thunk_params_t thunk_params;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -60,7 +60,9 @@ jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::maybe_adjust_dw_oscales(
         const float *dw_wei_scales) const {
     if (!pd()->jcp_.with_dw_conv) return nullptr;
 
-    const auto &jcp_dw = pd()->jcp_dw_;
+    const auto *jcp_dw = pd()->jcp_dw_;
+    if (!jcp_dw) return nullptr;
+
     memory_tracking::grantor_t dw_scratchpad(
             scratchpad, memory_tracking::names::prefix_fusion);
     auto dw_loc_scales
@@ -193,7 +195,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             : jcp.nb_load_blocking_max;
 
     // Begin: declare Variables needed for dw conv.
-    const auto jcp_dw = pd()->jcp_dw_;
+    const auto *jcp_dw = pd()->jcp_dw_;
     const auto &dw_pd = pd()->dw_conv_pd_;
     memory_tracking::grantor_t dw_scratchpad(
             scratchpad, memory_tracking::names::prefix_fusion);

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -90,8 +90,8 @@ status_t jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward(
     }
 
     const float *dw_oscales = nullptr;
-    if (pd()->jcp_.with_dw_conv) {
-        auto jcp_dw = pd()->jcp_dw_;
+    if (pd()->jcp_.with_dw_conv && pd()->jcp_dw_) {
+        const auto *jcp_dw = pd()->jcp_dw_;
         memory_tracking::grantor_t dw_scratchpad(
                 scratchpad, memory_tracking::names::prefix_fusion);
         auto attr_dw = pd()->dw_conv_pd_->attr();
@@ -181,7 +181,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             : jcp.nb_load_blocking_max;
 
     // Begin: declare Variables needed for dw conv.
-    const auto jcp_dw = pd()->jcp_dw_;
+    const auto *jcp_dw = pd()->jcp_dw_;
     const auto &dw_pd = pd()->dw_conv_pd_;
     memory_tracking::grantor_t dw_scratchpad(
             scratchpad, memory_tracking::names::prefix_fusion);

--- a/src/gpu/gpu_primitive.hpp
+++ b/src/gpu/gpu_primitive.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -74,6 +74,8 @@ struct primitive_t : public impl::primitive_t {
             std::shared_ptr<impl::primitive_t> &primitive,
             const std::shared_ptr<primitive_desc_t> &pd,
             impl::engine_t *engine) {
+        if (!pd) return status::invalid_arguments;
+
         std::pair<std::shared_ptr<impl::primitive_t>, cache_state_t> p;
         CHECK(pd->create_primitive_nested(p, engine, cache_blob()));
 


### PR DESCRIPTION
[MFDNN-14150](https://jira.devtools.intel.com/browse/MFDNN-14150)

This PR addresses latest Coverity hits (gpu_primitive.hpp and stream_submit_cpu_primitive.cpp) and and some less intelligent hits produced by clang-tidy while trying to find an option that would mimic Coverity behavior.
I failed with the latter task.