### PR TITLE
cpu: x64: reorder: skip tr8x8 strategy when compensation needed

### DIFF
--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -567,9 +567,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         static constexpr size_t desirable_node_size = 8;
         static constexpr ptrdiff_t desirable_stride = 1;
 
-        // This processing is relied on swaping two innermost dimension.
-        // Therefore, input stride in second node and output stride in first node
-        // have to be equal to 1.
+        // This process relies on swapping the two innermost dimensions.
+        // Therefore, the input stride in the second node and output stride in
+        // first node have to be equal to 1.
 
         return mayiuse(avx2) && prb_.ndims >= 2
                 && ((utils::one_of(prb_.itype, u8, s8, f8_e5m2, f8_e4m3, s32,
@@ -580,8 +580,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 && utils::everyone_is(desirable_stride, prb_.os(0), prb_.is(1))
                 && !prb_.is_tail_present
                 && prb_.src_scale_type == scale_type_t::NONE
-                && prb_.dst_scale_type == scale_type_t::NONE
-                && prb_.beta == 0.f;
+                && prb_.dst_scale_type == scale_type_t::NONE && prb_.beta == 0.f
+                && !compensation_needed_;
     }
 
     bool process_unroll_tr8x8(const int ndims, const int len) {


### PR DESCRIPTION
[MFDNN-14096](https://jira.devtools.intel.com/browse/MFDNN-14096)
Fix for a correctness issue in the reorder primitive, observed in the nightly "test_benchdnn_modeC_reorder_all_cpu" test.
The solution is analogous to this [commit](https://github.com/uxlfoundation/oneDNN/pull/3789/files).