### PR TITLE
tests: gtests: fix win failure in mem api test

### DIFF
--- a/tests/gtests/api/test_memory.cpp
+++ b/tests/gtests/api/test_memory.cpp
@@ -285,7 +285,7 @@ TEST(cpp_api_host_scalar_mem, TestDataTypeMismatch) {
         memory scalar_mem(scalar_md, scalar_value);
     } catch (const dnnl::error &e) {
         EXPECT_EQ(e.status, dnnl_invalid_arguments);
-        EXPECT_EQ(e.message,
+        EXPECT_EQ(std::string(e.message),
                 "scalar type size does not match memory descriptor data type "
                 "size");
     }
@@ -298,7 +298,7 @@ TEST(cpp_api_host_scalar_mem, TestDataTypeMismatch) {
         scalar_mem.set_host_scalar_value(1);
     } catch (const dnnl::error &e) {
         EXPECT_EQ(e.status, dnnl_invalid_arguments);
-        EXPECT_EQ(e.message,
+        EXPECT_EQ(std::string(e.message),
                 "scalar type size does not match memory descriptor data type "
                 "size");
     }
@@ -307,7 +307,7 @@ TEST(cpp_api_host_scalar_mem, TestDataTypeMismatch) {
         (void)scalar_mem.get_host_scalar_value<int>();
     } catch (const dnnl::error &e) {
         EXPECT_EQ(e.status, dnnl_invalid_arguments);
-        EXPECT_EQ(e.message,
+        EXPECT_EQ(std::string(e.message),
                 "scalar type size does not match memory descriptor data type "
                 "size");
     }


### PR DESCRIPTION
- (only) win debug build is currently unhappy when comparing two strings in `EXPECT_EQ` (message thrown, that is `char *`, vs message expected, that is `std::string`), according to [gtests documentation](https://google.github.io/googletest/reference/assertions.html#c-strings) string objects could be used explicitly, so that we get proper string comparison vs pointer comparison in `EXPECT_EQ`
- locally PASSED + [relevant portion of weekly run](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f08d0f7e-83d5-f13c-8dcb-d4f5ef20c6a0) 

