### PR TITLE
cpu: x64: fix for test_internals segfault in debug build

### DIFF
--- a/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
@@ -205,7 +205,7 @@ private:
     const Xbyak::Xmm xmm_aux4 = xmm5;
     const Xbyak::Xmm xmm_aux5 = xmm6;
     const Xbyak::Opmask kmask_aux = k1;
-    const Xbyak::Reg64 reg64_aux = abi_not_param1;
+    const Xbyak::Reg64 reg64_aux = abi_param3;
     const Xbyak::Reg64 reg64_out = abi_param1;
     const Xbyak::Reg64 reg64_inp = abi_param2;
     void generate() override;


### PR DESCRIPTION
`test_internals` on Windows ICX Debug builds (with at least 2 threads) crashes with Access Violation on write to `reg64_aux` in `jit_cvt_fp8_t::generate()`. Assigning it `abi_param3` instead of `abi_not_param1` fixes the issue.

Fixes: [MFDNN-13190](https://jira.devtools.intel.com/browse/MFDNN-13190).