### PR TITLE
[SDPA] add scale type to SDPA verbose

### DIFF
--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1632,7 +1632,11 @@ std::string init_info_sdpa(const engine_t *e, const pd_t *pd) {
             ss << "div:";
         else
             ss << "mul:";
-        ss << dnnl_dt2str(pd->scale_md()->data_type);
+        ss << dnnl_dt2str(pd->scale_md()->data_type) << ":";
+        if (pd->with_host_scale())
+            ss << "host";
+        else
+            ss << "device";
     }
 
     ss << "," << md2dim_str(pd->qry_md()) << ":" << md2dim_str(pd->key_md())


### PR DESCRIPTION
Follow-up of https://github.com/uxlfoundation/oneDNN/pull/3909 - PR adds kind of SDPA scale (host|device) to verbose info.
For example:
onednn_verbose,v1,primitive,exec,gpu,sdpa,ocl:micro:reusable,undef,query:f32::blocked:abcd::f0 key:f32::blocked:abdc::f0 val:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,alg:softmax_accurate_inf_as_zero scl:div:f32:**host**,1x2x1x128:1x2x128x385:1x2x385x128,0.234863

