### PR TITLE
xe: copy plan: expand bfn support

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/bfn.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/bfn.cpp
@@ -29,7 +29,7 @@ BFN::operator uint8_t() const {
     }
 }
 
-BFN::operator std::string() const {
+std::string BFN::str() const {
     if (op == ngen::Opcode::mov) {
         if (left == 0x00) return "0";
         if (left == 0xFF) return "1";
@@ -42,7 +42,7 @@ BFN::operator std::string() const {
         return "???";
     }
     std::string op_name = (op == ngen::Opcode::and_ ? "&" : op == ngen::Opcode::or_ ? "|" : "^");
-    return (std::string)nodes[left] + op_name + (std::string)nodes[right];
+    return nodes[left].str() + op_name + nodes[right].str();
 }
 
 BFN BFN::operator~() const {

--- a/src/gpu/intel/gemm/jit/generator/pieces/bfn.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/bfn.hpp
@@ -28,7 +28,7 @@ struct BFN {
     uint8_t left = 0, right = 0;
 
     operator uint8_t() const;
-    operator std::string() const;
+    std::string str() const;
 
     bool operator==(const BFN& other) const {
         return (uint8_t)*this == (uint8_t)other;


### PR DESCRIPTION
Adds a complete set of boolean function emulation sequences to the GEMM copy planner + nice pretty printing for control values.