### PR TITLE
test: adjust test cases to match dt in post_ops

### DIFF
--- a/tests/benchdnn/inputs/binary/harness_binary_f16
+++ b/tests/benchdnn/inputs/binary/harness_binary_f16
@@ -12,7 +12,7 @@
 ## post_ops
 --attr-post-ops=,sum:0.5,linear:2:0.125,sum:0.25+relu:-0.01, \
                 relu:-0.01+sum:2+ge:f32,add:f32:per_oc, \
-                add:bf16:per_oc+linear:2:1,mul:s8+add:f32:common+sum:0.5+abs
+                add:f16:per_oc+linear:2:1,mul:s8+add:f32:common+sum:0.5+abs
 --batch=option_set_all
 --batch=option_set_src0_bcast
 

--- a/tests/benchdnn/inputs/binary/harness_binary_f32
+++ b/tests/benchdnn/inputs/binary/harness_binary_f32
@@ -15,9 +15,8 @@
                 linear:2:0.125, \
                 sum:0.25+relu:-0.01+gt:f32, \
                 relu:-0.01+sum:2, \
-                add:f32:per_oc, \
                 ge:f32, \
-                add:bf16:per_oc+linear:2:1, \
+                add:f32:per_oc+linear:2:1, \
                 mul:s8+add:f32:common+sum:0.5+abs
 --batch=option_set_all
 --batch=option_set_src0_bcast


### PR DESCRIPTION

# Description
Fixes certain UNIMPLEMENTED failures caused by 229fbb58 (PR #3634).

Fixes #3923

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?