### PR TITLE
x64: brgemm matmul: update fp8 dispatching

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1665,6 +1665,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         const dim_t buffer_a_chunk_sz_limit = 126;
         is_small_shapes = is_small_shapes
                 && bgmmc.buffer_a_gb_stride <= buffer_a_chunk_sz_limit;
+    } else if (bm_conf_utils.is_f8() || bm_conf_utils.is_bf8()) {
+        is_small_shapes = false;
     } else {
         is_small_shapes = is_small_shapes && bgmmc.ndims < 3
                 && ((bgmmc.M == 1 && bgmmc.K == 256)


### PR DESCRIPTION
I suppose fp8 matmul should not take into account the condition of small size. Since the lower implementations go through fp8 -> f16 conversion and f16 calculation.
Example: 
--matmul --dt=f8_e4m3:f8_e4m3:f8_e4m3 32768x13:13x512 goes to avx10_1_512_amx_fp16 instead of avx10_2_512_amx_2