### PR TITLE
cpu: riscv: pool: add post_ops

### DIFF
--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -54,7 +54,11 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                 int iw_end = std::min(ow_offset + kerW, inW);
 
                 if (iw_start >= iw_end) {
-                    dst[dst_offset] = -__FLT_MAX__;
+                    size_t one = __riscv_vsetvl_e32m1(1);
+                    vfloat32m1_t vneg_inf
+                            = __riscv_vfmv_v_f_f32m1(-__FLT_MAX__, one);
+                    vfloat32m1_t vout = postops_handler.apply(vneg_inf, one);
+                    __riscv_vse32_v_f32m1(&dst[dst_offset], vout, 1);
                     return;
                 }
 

--- a/src/cpu/rv64/rvv_nchw_pooling.hpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.hpp
@@ -20,6 +20,7 @@
 
 #include "common/primitive.hpp"
 #include "cpu/cpu_pooling_pd.hpp"
+#include "cpu/rv64/rvv_postops.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -57,7 +58,11 @@ struct riscv_nchw_pooling_fwd_t : public primitive_t {
             VDISPATCH_POOLING(!is_dilated(), VERBOSE_UNSUPPORTED_FEATURE,
                     "does not support dilations");
             VDISPATCH_POOLING(
-                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+                    attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, d_type),
+                    VERBOSE_UNSUPPORTED_ATTR);
+            VDISPATCH_POOLING(rvv_postops_t::post_ops_ok(attr()->post_ops_),
+                    VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_POOLING(
                     memory_desc_matches_tag(*src_md(), desired_fmt_tag),
                     VERBOSE_UNSUPPORTED_TAG_S, "src");


### PR DESCRIPTION
# Description

This PR introduces post-ops support to the RISC-V Vector (RVV) optimized NCHW pooling forward (MaxPooling, AvgPoolingIncludePadding, AvgPoolingExcludePadding). 

