### PR TITLE
cpu: riscv: ci: add ci workflow

### DIFF
--- a/.github/automation/riscv/build.sh
+++ b/.github/automation/riscv/build.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Build oneDNN for RISC-V.
+
+set -o errexit -o pipefail -o noclobber
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Defines MP, CC, CXX, OS and RISC-V specific variables.
+source ${SCRIPT_DIR}/common.sh
+
+CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Release"}
+ONEDNN_TEST_SET=${ONEDNN_TEST_SET:-"SMOKE"}
+ONEDNN_BUILD_GRAPH=${ONEDNN_BUILD_GRAPH:-"ON"}
+ONEDNN_THREADING=${ONEDNN_THREADING:-"OMP"}
+
+if [[ "$ONEDNN_ACTION" == "configure" ]]; then
+    set -x
+
+    CMAKE_ARGS=(
+        -Bbuild -S.
+        -DONEDNN_BUILD_GRAPH=$ONEDNN_BUILD_GRAPH
+        -DDNNL_CPU_RUNTIME=$ONEDNN_THREADING
+        -DONEDNN_WERROR=ON
+        -DDNNL_BUILD_FOR_CI=ON
+        -DONEDNN_TEST_SET=$ONEDNN_TEST_SET
+        -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+        -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE"
+    )
+
+    cmake "${CMAKE_ARGS[@]}"
+    set +x
+
+elif [[ "$ONEDNN_ACTION" == "build" ]]; then
+    set -x
+    cmake --build build --parallel ${MP#-j}
+    set +x
+
+else
+    echo "Unknown action: $ONEDNN_ACTION"
+    exit 1
+fi

--- a/.github/automation/riscv/ci.json
+++ b/.github/automation/riscv/ci.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "gcc": "14"
+    }
+}

--- a/.github/automation/riscv/common.sh
+++ b/.github/automation/riscv/common.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+
+# *******************************************************************************
+# Copyright 2024-2025 Arm Limited and affiliates.
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Common variables for RISC-V CI. Exports:
+# CC, CXX, OS, QEMU_PREFIX
+
+set -o errexit -o pipefail -o noclobber
+
+export OS=$(uname)
+
+# Num threads on system.
+if [[ "$OS" == "Linux" ]]; then
+    export MP="-j$(nproc)"
+fi
+
+# Cross-compilation mode
+if [[ "$BUILD_TOOLSET" == "gcc" ]]; then
+    export CC=riscv64-linux-gnu-gcc-${GCC_VERSION}
+    export CXX=riscv64-linux-gnu-g++-${GCC_VERSION}
+fi
+export CMAKE_TOOLCHAIN_FILE="$(dirname "$(readlink -f "$0")")/../../../cmake/toolchains/riscv64.cmake"
+
+# Print every exported variable.
+echo "Cross-compilation mode for RISC-V"
+echo "OS: $OS"
+echo "CC: $CC"
+echo "CXX: $CXX"
+echo "CMAKE_TOOLCHAIN_FILE: $CMAKE_TOOLCHAIN_FILE"

--- a/.github/automation/riscv/skipped-tests.sh
+++ b/.github/automation/riscv/skipped-tests.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Tests to skip for RISC-V architecture.
+
+set -eo pipefail
+
+OS=${OS:-"Linux"}
+
+# described in issue: https://github.com/uxlfoundation/oneDNN/issues/2175
+SKIPPED_TESTS="test_benchdnn_modeC_matmul_multidims_cpu"
+
+#  We currently have some OS and config specific test failures.
+if [[ "$OS" == "Linux" ]]; then
+    SKIPPED_TESTS+="|test_benchdnn_modeC_graph_ci_cpu"
+fi
+
+# Skip these tests that will fail on CI for the RISC-V architecture.
+SKIPPED_TESTS+="|cpu-matmul-coo-cpp|cpu-matmul-csr-cpp|test_sum"
+
+# Skip time-consuming tests (QEMU is slow)
+SKIPPED_TESTS+="|cpu-cnn-training-f32-cpp"
+SKIPPED_TESTS+="|cpu-cnn-inference-f32-cpp"
+SKIPPED_TESTS+="|cpu-cnn-training-f32-c"
+SKIPPED_TESTS+="|cpu-graph-gated-mlp-int4-cpp"
+SKIPPED_TESTS+="|cpu-performance-profiling-cpp"
+SKIPPED_TESTS+="|cpu-rnn-training-f32-cpp"
+SKIPPED_TESTS+="|test_convolution_backward_data_f32"
+SKIPPED_TESTS+="|test_convolution_backward_weights_f32"
+SKIPPED_TESTS+="|test_convolution_eltwise_forward_f32"
+SKIPPED_TESTS+="|test_convolution_eltwise_forward_x8s8f32s32"
+SKIPPED_TESTS+="|test_convolution_forward_f32"
+SKIPPED_TESTS+="|test_pooling_backward"
+SKIPPED_TESTS+="|test_pooling_forward"
+SKIPPED_TESTS+="|test_gemm_f32"
+SKIPPED_TESTS+="|test_gemm_s8s8s32"
+SKIPPED_TESTS+="|test_gemm_u8s8s32"
+SKIPPED_TESTS+="|test_graph_unit_dnnl_mqa_decomp_cpu"
+SKIPPED_TESTS+="|test_graph_unit_dnnl_sdp_decomp_cpu"
+SKIPPED_TESTS+="|cpu-graph-sdpa-cpp"
+
+echo "$SKIPPED_TESTS"

--- a/.github/automation/riscv/test.sh
+++ b/.github/automation/riscv/test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# *******************************************************************************
+# Copyright 2024-2025 Arm Limited and affiliates.
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# Test oneDNN for RISC-V.
+
+set -o errexit -o pipefail -o noclobber
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Cross-compilation mode - need QEMU
+echo "Using QEMU for test execution"
+export QEMU_LD_PREFIX=/usr/riscv64-linux-gnu
+
+set -x
+ctest --no-tests=error --output-on-failure -E $("${SCRIPT_DIR}"/skipped-tests.sh)
+set +x

--- a/.github/workflows/ci-riscv.yml
+++ b/.github/workflows/ci-riscv.yml
@@ -1,0 +1,195 @@
+# *******************************************************************************
+# Copyright 2024-2025 Arm Limited and affiliates.
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+name: "CI RISC-V"
+
+#* To avoid duplicate jobs running when both push and PR is satisfied, we use this:
+#* https://github.com/orgs/community/discussions/26940#discussioncomment-5686753
+on:
+  push:
+    branches: [main, "rls-*"]
+    paths:
+      - ".github/automation/riscv/**"
+      - ".github/workflows/ci-riscv.yml"
+      - "cmake/**"
+      - "examples/**"
+      - "include/**"
+      - "src/common/**"
+      - "src/cpu/*"
+      - "src/cpu/rv64/**"
+      - "tests/**"
+      - "CMakeLists.txt"
+  pull_request:
+     types: [opened, synchronize, reopened]
+     paths:
+      - ".github/automation/riscv/**"
+      - ".github/workflows/ci-riscv.yml"
+      - "cmake/**"
+      - "examples/**"
+      - "include/**"
+      - "src/common/**"
+      - "src/cpu/*"
+      - "src/cpu/rv64/**"
+      - "tests/**"
+      - "CMakeLists.txt"
+  #* allow manual trigger of workflow when needed.
+  workflow_dispatch:
+
+#* Stop stale workflows when pull requests are updated: https://stackoverflow.com/a/70972844
+#* Does not apply to the main branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        config: [
+          { name: riscv-build, label: ubuntu-24.04, threading: OMP, toolset: gcc, build: RelWithAssert, testset: SMOKE }
+        ]
+
+    name: ${{ matrix.config.name }}, ${{ matrix.config.toolset }}, ${{ matrix.config.threading }}, ${{ matrix.config.build }}
+    runs-on: ${{ matrix.config.label }}
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: oneDNN
+
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/riscv/ci.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
+
+      # Note: This will create a github actions cache
+      - name: Get latest CMake and Ninja
+        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6 # v3.31.6
+        with:
+          cmakeVersion: 3.31.0
+          ninjaVersion: 1.12.0
+
+      # Install cross-compilation tools
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}-riscv64-linux-gnu g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}-riscv64-linux-gnu
+
+      - name: Configure oneDNN
+        run: ${{ github.workspace }}/oneDNN/.github/automation/riscv/build.sh
+        working-directory: ${{ github.workspace }}/oneDNN
+        env:
+          BUILD_TOOLSET: ${{ matrix.config.toolset }}
+          CMAKE_BUILD_TYPE: ${{ matrix.config.build }}
+          CMAKE_GENERATOR: Ninja
+          GCC_VERSION: ${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}
+          ONEDNN_ACTION: configure
+          ONEDNN_TEST_SET: ${{ matrix.config.testset }}
+          ONEDNN_THREADING: ${{ matrix.config.threading }}
+
+      - name: Build oneDNN
+        run: ${{ github.workspace }}/oneDNN/.github/automation/riscv/build.sh
+        working-directory: ${{ github.workspace }}/oneDNN
+        env:
+          ONEDNN_ACTION: build
+
+      - name: Create archive with preserved permissions
+        working-directory: ${{ github.workspace }}/oneDNN
+        run: |
+          tar -czf build.tar.gz build
+
+      # Upload build artifacts
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: build-artifact
+          path: |
+            ${{ github.workspace }}/oneDNN/build.tar.gz
+          retention-days: 1
+
+  test:
+    needs: build
+    strategy:
+      matrix:
+        config: [
+          # Test with different vector lengths and threading modes
+          { name: riscv-test-vlen128, threading: OMP, testset: SMOKE, vlen: 128, build: RelWithAssert },
+          { name: riscv-test-vlen256, threading: OMP, testset: SMOKE, vlen: 256, build: RelWithAssert }
+        ]
+
+    name: ${{ matrix.config.name }}, ${{ matrix.config.threading }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: oneDNN
+
+      - name: Read version file
+        id: get-versions
+        run: |
+          content=`cat ${{ github.workspace }}/oneDNN/.github/automation/riscv/ci.json`
+          content="${content//[$'\t\r\n$ ']}"
+          echo "output=$content" >> $GITHUB_OUTPUT
+
+      # Setup QEMU for RISC-V platform support
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.0.0
+        with:
+          platforms: riscv64
+
+      # Install cross-compilation tools
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}-riscv64-linux-gnu g++-${{ fromJson(steps.get-versions.outputs.output).dependencies.gcc }}-riscv64-linux-gnu
+
+      # Download build artifacts
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-artifact
+          path: ${{ github.workspace }}/oneDNN/
+
+      - name: Extract archive
+        working-directory: ${{ github.workspace }}/oneDNN/
+        run: |
+          tar -xzf build.tar.gz
+
+      - name: Run oneDNN tests
+        run: ${{ github.workspace }}/oneDNN/.github/automation/riscv/test.sh
+        working-directory: ${{ github.workspace }}/oneDNN/build
+        env:
+          CTEST_PARALLEL_LEVEL: 4
+          ONEDNN_THREADING: ${{ matrix.config.threading }}
+          QEMU_CPU: "rv64,v=true,vlen=${{ matrix.config.vlen }},vext_spec=v1.0"
+
+  # This job adds a check named "CI RISC-V" that represents overall
+  # workflow status and can be used in branch rulesets
+  status:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    name: "CI RISC-V"
+    steps:
+      - name: Print success
+        run: echo Success

--- a/cmake/toolchains/riscv64.cmake
+++ b/cmake/toolchains/riscv64.cmake
@@ -1,0 +1,34 @@
+# *******************************************************************************
+# Copyright 2025 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# RISC-V Cross-Compilation Toolchain File
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+# Cross-compilation tools
+set(CMAKE_C_COMPILER riscv64-linux-gnu-gcc-14)
+set(CMAKE_CXX_COMPILER riscv64-linux-gnu-g++-14)
+
+# Search paths
+set(CMAKE_FIND_ROOT_PATH /usr/riscv64-linux-gnu)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# Explicitly set the target
+set(CMAKE_CROSSCOMPILING TRUE)


### PR DESCRIPTION
# RISC-V CI Workflow for oneDNN

With the increasing number of PRs targeting the RISC-V architecture, establishing a dedicated RISC-V CI pipeline has become essential.

This PR introduces a complete RISC-V architecture CI workflow for the oneDNN project. It is modeled after the existing `aarch64` workflow but customized to address RISC-V-specific requirements.

## Build Process

- Cross-compilation is performed on Ubuntu 24.04 using GCC 14.
- Build time: approximately 20 minutes.

## Test Process

- Tests are executed via QEMU emulation.
- A matrix strategy is employed to test across different vector widths (128-bit, 256-bit). Additional widths can be added in the future as needed.
- Due to the long simulation times for certain test cases under QEMU — potentially exceeding many hours for a full run — long-running tests have been skipped via `skipped-tests.sh` to facilitate timely PR reviews. These tests can be re-enabled later when real RISC-V hardware or dedicated RISC-V runners become available. The trimmed test suite completes in approximately 30 minutes.
- Three test cases currently fail in the CI environment and have also been skipped.
- The CI trigger mechanism is currently aligned with `aarch64`. This can be adjusted based on reviewer feedback.

