### PR TITLE
benchdnn: graph: pass acc mode to ref path and more test cases

### DIFF
--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -91,6 +91,21 @@ bool get_graph_attr(const deserialized_op_t &base_op_ref,
     return true;
 }
 
+bool get_graph_attr(const deserialized_op_t &base_op_ref,
+        dnnl_accumulation_mode_t &acc_mode) {
+
+    const auto &op_kind = base_op_ref.kind_;
+    static const std::unordered_set<std::string> accept_acc_op {"MatMul"};
+
+    if (accept_acc_op.find(op_kind) != accept_acc_op.end()) {
+        std::string str_acc_mode;
+        if (base_op_ref.get_attr_string(str_acc_mode, "accumulation_mode")) {
+            acc_mode = str2accumulation_mode(str_acc_mode.c_str());
+        }
+    }
+    return true;
+}
+
 bool get_driver_tag_by_idx(const deserialized_op_t &base_op_ref,
         std::string &tag, int idx = 0, bool from_output = false) {
     logical_tensor::dims strides = from_output
@@ -1411,6 +1426,9 @@ bool get_matmul_bia_mask(const deserialized_op_t &base_op_ref, int &bia_mask) {
             res);
     DNN_GRAPH_CHECK_SETTINGS(
             get_graph_attr(base_op_ref, op_setting.fpmath_mode.front()), res);
+
+    DNN_GRAPH_CHECK_SETTINGS(
+            get_graph_attr(base_op_ref, op_setting.acc_mode.front()), res);
 
     return op_setting;
 }

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -198,5 +198,5 @@
 --reset --in-shapes=1:2x10x2304x64*acbd+2:2x10x77x64*acbd+3:2x10x77x64*acbd --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
 
 # accumulation mode: only QK in f16 acc, and both QK and VS in f16 acc.
---reset --op-attrs=0:accumulation_mode:f16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
---reset --op-attrs=7:accumulation_mode:f16 --dt=1:f16+3:f16+8:f16+16:f16+19:f16+20:f16 --case=complex_fusion/mha/gqa-plain-implicit-causal-mask-fp32-bs1.json
+--reset --op-attrs=0:accumulation_mode:f16,0:accumulation_mode:f16+4:accumulation_mode:f16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+--reset --op-attrs=7:accumulation_mode:f16,7:accumulation_mode:f16+22:accumulation_mode:f16 --dt=1:f16+3:f16+8:f16+16:f16+19:f16+20:f16 --case=complex_fusion/mha/gqa-plain-implicit-causal-mask-fp32-bs1.json


### PR DESCRIPTION
1. Pass the accumulation mode attribute to matmul driver in reference path.
2. Add test cases where both QK and VS are in f16 accumulation mode. Previously only QK in f16 accumulation.