### PR TITLE
[GPU] GEMM fix pre-init query support

### DIFF
--- a/src/gpu/intel/gemm/with_post_ops.hpp
+++ b/src/gpu/intel/gemm/with_post_ops.hpp
@@ -43,6 +43,7 @@ struct with_post_ops_t : public primitive_t {
             return use_scratchpad_with_post_op_worker;
         }
         status_t query(query_t what, int idx, void *result) const override {
+            if (!pd_) return gemm::pd_t::query(what, idx, result);
             return pd_->query(what, idx, result);
         }
 


### PR DESCRIPTION
# Description

Add case to fallback to default `query` API when nested `pd` is uninitialized. 

Fixes # [MFDNN-14238](https://jira.devtools.intel.com/browse/MFDNN-14238)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?
