### PR TITLE
cpu: aarch64: implement brgdeconv non-strided

### DIFF
--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -79,10 +79,12 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             weights_md_, dst_md_, bias_md_, attr_, dnnl_get_max_threads()));
 
     // brgemm is slower than jit_sve when combined with reorders for shapes where strides < 2
-    if (one_of(data_type::f32, src_type, wei_type)
+    const convolution_desc_t &cd = *desc();
+    if (!cd.use_inversion && one_of(data_type::f32, src_type, wei_type)
             && (jcp_.stride_w < 2 || jcp_.stride_h < 2)) {
         return status::unimplemented;
     }
+
     brgs_ = std::make_shared<brgemm_containers::brgemm_desc_container_t>(16);
 
     const float alpha = 1.0;

--- a/src/cpu/aarch64/jit_brgemm_deconv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_deconv.hpp
@@ -1,0 +1,117 @@
+/*******************************************************************************
+* Copyright 2022-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_JIT_BRGEMM_DECONV_HPP
+#define CPU_AARCH64_JIT_BRGEMM_DECONV_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/utils.hpp"
+#include "cpu/aarch64/brgemm/brgemm_types.hpp"
+#include "cpu/aarch64/cpu_isa_traits.hpp"
+
+#include "cpu/cpu_deconvolution_pd.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <cpu_isa_t isa>
+struct brgemm_deconvolution_fwd_t : public primitive_t {
+
+    struct pd_t : public cpu_deconvolution_fwd_pd_t {
+        using cpu_deconvolution_fwd_pd_t::cpu_deconvolution_fwd_pd_t;
+
+        pd_t(const pd_t &other)
+            : cpu_deconvolution_fwd_pd_t(other)
+            , conv_pd_(other.conv_pd_->clone())
+            , has_strides_(other.has_strides_)
+            , name_(other.name_) {}
+
+        DECLARE_COMMON_PD_T(name_.c_str(), brgemm_deconvolution_fwd_t);
+
+        status_t init(engine_t *engine);
+
+        bool post_ops_ok() const {
+            return attr()->post_ops_.find(primitive_kind::convolution) == -1;
+        }
+
+        bool zero_points_ok() const {
+            const auto &zp = attr()->zero_points_;
+
+            using namespace data_type;
+            bool ok = IMPLICATION(!utils::one_of(src_md()->data_type, s8, u8),
+                    zp.has_default_values());
+            if (!ok) return false;
+
+            if (!zp.has_default_values(DNNL_ARG_SRC)) {
+                int mask_src = zp.get_mask(DNNL_ARG_SRC);
+                ok = utils::one_of(mask_src, 0, (1 << 1));
+                if (!ok) return false;
+            }
+            if (!zp.has_default_values(DNNL_ARG_DST)) {
+                int mask_dst = zp.get_mask(DNNL_ARG_DST);
+                ok = utils::one_of(mask_dst, 0, (1 << 1));
+                if (!ok) return false;
+            }
+
+            return zp.has_default_values(DNNL_ARG_WEIGHTS);
+        }
+
+        brgemm_broadcast_t get_zp_type(int arg) const {
+            return attr()->zero_points_.has_default_values(arg)
+                    ? brgemm_broadcast_t::none
+                    : brgemm_broadcast_t::per_tensor;
+        }
+
+        std::shared_ptr<primitive_desc_t> conv_pd_;
+        bool has_strides_ = false;
+
+    private:
+        std::string name_;
+
+        void init_name() {
+            name_ = JIT_IMPL_NAME_HELPER("brg_deconv:", isa, "");
+            name_.append("+");
+            name_.append(conv_pd_->name());
+        }
+    };
+
+    brgemm_deconvolution_fwd_t(const pd_t *apd) : primitive_t(apd) {};
+
+    ~brgemm_deconvolution_fwd_t() override = default;
+
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const {
+        return static_cast<const pd_t *>(primitive_t::pd().get());
+    }
+
+    std::shared_ptr<primitive_t> conv_p_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/cpu_deconvolution_list.cpp
+++ b/src/cpu/cpu_deconvolution_list.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2022, 2024 Arm Ltd. and affiliates
+* Copyright 2022, 2024-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 #include "cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp"
 using namespace dnnl::impl::cpu::x64;
 #elif DNNL_AARCH64
+#include "cpu/aarch64/jit_brgemm_deconv.hpp"
 #include "cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp"
 #if defined(DNNL_AARCH64_USE_ACL)
 #include "cpu/aarch64/acl_deconvolution.hpp"
@@ -65,6 +66,8 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AVX2(jit_uni_x8s8s32x_deconvolution_fwd_t<avx2>)
             CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_1x1_deconvolution_fwd_t<sse41>)
             CPU_INSTANCE_SSE41(jit_uni_x8s8s32x_deconvolution_fwd_t<sse41>)
+            CPU_INSTANCE_AARCH64(brgemm_deconvolution_fwd_t<sve_256>)
+            CPU_INSTANCE_AARCH64(brgemm_deconvolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_512_core_x8s8s32x_deconvolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_deconvolution_fwd_t)
             CPU_INSTANCE(ref_deconvolution_fwd_t)


### PR DESCRIPTION
This change implements non-strided brgdeconv on aarch64 based on existing x64 implementation. Since it uses brgconv and brgconv_1x1 for deconvolution, once #3838 is merged this impl will support bf16 and once #3979 is merged -- s8, u8, s32 will also be supported.


All unit and benchdnn tests pass locally and we get a broader coverage in the 10 relevant units tests (with the two above PRs used):
```
deconvolution tests:
	cpu-primitives-deconvolution-cpp
	test_deconvolution
	test_benchdnn_modeC_deconv_all_cpu
	test_benchdnn_modeC_deconv_all_f32_nxc_cpu
	test_benchdnn_modeC_deconv_bfloat16_cpu
	test_benchdnn_modeC_deconv_bfloat16_nxc_cpu
	test_benchdnn_modeC_deconv_bfloat16_ymm_cpu
	test_benchdnn_modeC_deconv_float16_nxc_cpu
	test_benchdnn_modeC_deconv_fp8_nxc_cpu
	test_benchdnn_modeC_deconv_int8_cpu
	
baseline:
    total tests: 16829  passed: 2177  skipped: 14652  failed: 0
    
with this change:
    total: 16829  passed: 5953  skipped: 10876  failed: 0
```

Performance-wise, brgdeconv covers a lot of problems not covered by existing ACL implementation but for covered shapes in `inputs/deconv/shapes_2d` and with `dt=f32`, brgdeconv is about 1.08x faster on average (c8g instance, 64 threads), but has quite a variance with min being 0.77x and max being  3.94x.
