### PR TITLE
cpu: x64: binary: enable per_w strategy 

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -331,6 +331,7 @@ enum {
     key_wino_U,
     key_wino_V,
     key_wino_M,
+    key_binary_post_ops_expanded_rhs,
     // These two keys should always be the last ones,
     // even though they are not in alphabetical order
     key_nested,

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -63,6 +63,15 @@ bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
         const bcast_set_t &supported_strategy_set,
         const std::function<bool(const memory_desc_wrapper &)> &predicate);
 
+bool any_binary_postop_rhs_per_w_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+
+void extend_binary_args_per_w(const post_ops_t &post_ops,
+        const std::vector<const void *> &orig_post_ops_binary_rhs_arg_vec,
+        std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        uint8_t *expanded_rhs, const std::vector<dim_t> &expanded_elems_len);
+
 /*
  * Represents params related to all binary post-ops right-hand side arguments
  * (arg1) that don't change during jit_uni_binary_injector_t object lifetime

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -930,6 +930,8 @@ struct jit_binary_conf_t {
     bool broadcast_src1_value = false;
     bool use_stride_rhs_postops = false;
     bool postops_per_oc_broadcast_exists = false;
+    bool postops_per_w_broadcast_exists = false;
+    std::vector<dim_t> post_ops_expanded_rhs_elems_len;
     bool is_i8 = false;
     bool is_bf16 = false;
     bool is_f16 = false;

--- a/src/cpu/x64/jit_uni_binary.hpp
+++ b/src/cpu/x64/jit_uni_binary.hpp
@@ -63,6 +63,8 @@ struct jit_uni_binary_t : public primitive_t {
                 const memory_desc_wrapper &src1_d) const;
         bool is_applicable();
 
+        void init_scratchpad();
+
         jit_binary_conf_t conf_;
     };
 

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -43,7 +43,7 @@ struct binary_kernel_t : public jit_generator_t {
     using bcast_t = binary_bcast_t;
 
     binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
-            const jit_binary_conf_t conf, const char *name,
+            const jit_binary_conf_t &conf, const char *name,
             bool tail_kernel = false);
     ~binary_kernel_t() override = default;
 

--- a/tests/benchdnn/inputs/binary/harness_binary_bcast4d
+++ b/tests/benchdnn/inputs/binary/harness_binary_bcast4d
@@ -1,0 +1,7 @@
+--reset
+--alg=mul
+--sdt=f32:f32
+--ddt=f32
+--attr-post-ops=add:f32:8,mul:s8+add:f32:8+sum:0.5+abs
+--batch=option_set_bcast4d
+

--- a/tests/benchdnn/inputs/binary/option_set_bcast4d
+++ b/tests/benchdnn/inputs/binary/option_set_bcast4d
@@ -1,0 +1,35 @@
+# base full broadcasts (larger spatial)
+1x15x8x8:1x1x1x1
+1x17x7x5:1x1x1x1
+1x16x8x8:1x1x1x1
+
+# rhs per-channel (per_oc) to hit tails for C=15,17
+1x15x8x8:1x15x1x1
+1x17x7x5:1x17x1x1
+1x16x8x8:1x16x1x1
+
+# rhs per-width (per_w) patterns
+1x15x8x8:1x1x1x8
+1x17x7x5:1x1x1x5
+1x16x8x8:1x1x1x8
+
+# mixed spatial broadcasting
+1x15x9x7:1x1x9x1
+1x17x6x10:1x1x1x10
+1x16x5x11:1x16x1x1
+
+# batch >1 and tails
+2x15x8x8:2x1x1x1
+2x17x7x5:2x17x1x1
+3x16x4x4:3x1x1x1
+
+# uneven spatial sizes to stress alignment
+1x15x3x17:1x1x1x17
+1x17x5x15:1x1x5x1
+1x16x13x2:1x1x13x1
+
+# full per-element rhs (same shape)
+1x15x8x8:1x15x8x8
+1x17x7x5:1x17x7x5
+1x16x8x8:1x16x8x8
+

--- a/tests/benchdnn/inputs/binary/test_binary_all
+++ b/tests/benchdnn/inputs/binary/test_binary_all
@@ -6,4 +6,5 @@
 --batch=harness_binary_f16
 --batch=harness_binary_i8
 --batch=harness_binary_different_dt
+--batch=harness_binary_bcast4d
 --batch=harness_binary_regression


### PR DESCRIPTION
This is a [second solution](https://github.com/uxlfoundation/oneDNN/pull/3677) for [MFDNN-8594](https://jira.devtools.intel.com/browse/MFDNN-8594) Support per_dim_2 broadcast pattern in binary.

Example command
--binary --alg=mul --sdt=f32:f32 --ddt=f32 --attr-post-ops=binary_add:f32:8 1x2x2x2:1x2x1x1

Benchdnn prepared the following data:
<img width="1374" height="383" alt="image" src="https://github.com/user-attachments/assets/15cc67bd-726c-4f80-bf70-a46d8fa09e95" />

After the main binary operation was successfully executed, we obtained two vectors:

scr0: ymm1 = {-3.00000000, -1.00000000, 2.50000000, 0.00000000, ...}
rhs post-op: ymm10 = {0.50000000, -4.00000000, -431602080., -431602080., ...}

Parameters:
number of calculated = 4
len(rhs) = 2

JIT stored the pointer to the rhs post-op data in the r14 register.
This means the last two elements in rhs were garbage (uninitialized).

Solution
The fix is to correctly prepare the rhs data by expanding it and passing the expanded version as an argument to the kernel.

Steps taken:
Calculated the required expanded length of rhs and reserved a scratchpad buffer in the init method.
Performed the expansion and filled the buffer in the execution method.