### PR TITLE
cpu: aarch64: fix readability-identifier-naming failures

### DIFF
--- a/src/cpu/aarch64/acl_benchmark_scheduler.cpp
+++ b/src/cpu/aarch64/acl_benchmark_scheduler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023, 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,25 +23,25 @@ namespace cpu {
 namespace aarch64 {
 using namespace arm_compute;
 
-BenchmarkScheduler::BenchmarkScheduler(IScheduler &real_scheduler)
+benchmark_scheduler_t::benchmark_scheduler_t(IScheduler &real_scheduler)
     : _real_scheduler(real_scheduler) {}
 
-BenchmarkScheduler::~BenchmarkScheduler() = default;
+benchmark_scheduler_t::~benchmark_scheduler_t() = default;
 
-void BenchmarkScheduler::set_num_threads(unsigned int num_threads) {
+void benchmark_scheduler_t::set_num_threads(unsigned int num_threads) {
     _real_scheduler.set_num_threads(num_threads);
 }
 
-void BenchmarkScheduler::set_num_threads_with_affinity(
+void benchmark_scheduler_t::set_num_threads_with_affinity(
         unsigned int num_threads, BindFunc func) {
     _real_scheduler.set_num_threads_with_affinity(num_threads, func);
 }
 
-unsigned int BenchmarkScheduler::num_threads() const {
+unsigned int benchmark_scheduler_t::num_threads() const {
     return _real_scheduler.num_threads();
 }
 
-void BenchmarkScheduler::schedule(ICPPKernel *kernel, const Hints &hints) {
+void benchmark_scheduler_t::schedule(ICPPKernel *kernel, const Hints &hints) {
     double start_ms = get_msec();
     _real_scheduler.schedule(kernel, hints);
     double duration_ms = get_msec() - start_ms;
@@ -49,7 +49,7 @@ void BenchmarkScheduler::schedule(ICPPKernel *kernel, const Hints &hints) {
     VPROF(start_ms, primitive, exec, VERBOSE_external, name, duration_ms);
 }
 
-void BenchmarkScheduler::schedule_op(ICPPKernel *kernel, const Hints &hints,
+void benchmark_scheduler_t::schedule_op(ICPPKernel *kernel, const Hints &hints,
         const Window &window, ITensorPack &tensors) {
     double start_ms = get_msec();
     _real_scheduler.schedule_op(kernel, hints, window, tensors);
@@ -58,7 +58,7 @@ void BenchmarkScheduler::schedule_op(ICPPKernel *kernel, const Hints &hints,
     VPROF(start_ms, primitive, exec, VERBOSE_external, name, duration_ms);
 }
 
-void BenchmarkScheduler::run_tagged_workloads(
+void benchmark_scheduler_t::run_tagged_workloads(
         std::vector<Workload> &workloads, const char *tag) {
     double start_ms = get_msec();
     _real_scheduler.run_tagged_workloads(workloads, tag);
@@ -67,7 +67,7 @@ void BenchmarkScheduler::run_tagged_workloads(
     VPROF(start_ms, primitive, exec, VERBOSE_external, name, duration_ms);
 }
 
-void BenchmarkScheduler::run_workloads(std::vector<Workload> &workloads) {
+void benchmark_scheduler_t::run_workloads(std::vector<Workload> &workloads) {
     ARM_COMPUTE_UNUSED(workloads);
     ARM_COMPUTE_ERROR("Can't be reached");
 }

--- a/src/cpu/aarch64/acl_benchmark_scheduler.hpp
+++ b/src/cpu/aarch64/acl_benchmark_scheduler.hpp
@@ -26,11 +26,11 @@ namespace aarch64 {
 // BenchmarkScheduler implement's ACL IScheduler interface and acts as an interceptor scheduler
 // when DNNL_VERBOSE=profile,profile_externals. It intercepts calls made by the actual scheduler used by ACL and adds
 // timers to benchmark execution time of ACL kernels and store kernel information.
-class BenchmarkScheduler final : public arm_compute::IScheduler {
+class benchmark_scheduler_t final : public arm_compute::IScheduler {
 public:
-    BenchmarkScheduler(IScheduler &real_scheduler);
+    benchmark_scheduler_t(IScheduler &real_scheduler);
 
-    ~BenchmarkScheduler() override;
+    ~benchmark_scheduler_t() override;
 
     void set_num_threads(unsigned int num_threads) override;
     unsigned int num_threads() const override;

--- a/src/cpu/aarch64/acl_thread.cpp
+++ b/src/cpu/aarch64/acl_thread.cpp
@@ -44,7 +44,7 @@ void acl_set_benchmark_scheduler_default() {
     static std::once_flag flag_once;
     arm_compute::IScheduler *_real_scheduler = &arm_compute::Scheduler::get();
     std::shared_ptr<arm_compute::IScheduler> benchmark_scheduler
-            = std::make_unique<BenchmarkScheduler>(*_real_scheduler);
+            = std::make_unique<benchmark_scheduler_t>(*_real_scheduler);
     // set Benchmark scheduler in ACL
     std::call_once(flag_once, [&]() {
         arm_compute::Scheduler::set(

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -338,14 +338,14 @@ struct brgemm_kernel_params_t {
 
 struct jit_brgemm_kernel_t;
 struct jit_brdgmm_kernel_base_t;
-class jit_generator;
+class jit_generator_t;
 
 struct brgemm_kernel_t {
     brgemm_kernel_t() = default;
     virtual ~brgemm_kernel_t() = default;
     virtual status_t create_kernel() = 0;
     virtual void operator()(brgemm_kernel_params_t *) const = 0;
-    virtual const jit_generator *get_jit_generator() const = 0;
+    virtual const jit_generator_t *get_jit_generator() const = 0;
 };
 
 struct brgemm_kernel_common_t : public brgemm_kernel_t {
@@ -354,7 +354,7 @@ struct brgemm_kernel_common_t : public brgemm_kernel_t {
 
     status_t create_kernel() override;
     void operator()(brgemm_kernel_params_t *) const override;
-    const jit_generator *get_jit_generator() const override;
+    const jit_generator_t *get_jit_generator() const override;
 
 private:
     jit_brgemm_kernel_t *brgemm_kernel_ = nullptr;
@@ -368,7 +368,7 @@ struct brdgmm_kernel_t : public brgemm_kernel_t {
 
     status_t create_kernel() override;
     void operator()(brgemm_kernel_params_t *) const override;
-    const jit_generator *get_jit_generator() const override;
+    const jit_generator_t *get_jit_generator() const override;
 
 private:
     jit_brdgmm_kernel_base_t *brgemm_kernel_ = nullptr;

--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
@@ -40,7 +40,7 @@ namespace aarch64 {
 using namespace dnnl::impl::utils;
 
 jit_brdgmm_kernel_base_t::jit_brdgmm_kernel_base_t(const brgemm_t &abrd)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true, sve_512)
+    : jit_generator_t(nullptr, MAX_CODE_SIZE, true, sve_512)
     , brg(abrd)
     , simd_w_(cpu_isa_traits<sve_512>::vlen / brg.typesize_C) {
 
@@ -918,7 +918,7 @@ void brdgmm_kernel_t::operator()(brgemm_kernel_params_t *params) const {
     (*brgemm_kernel_)(params);
 }
 
-const jit_generator *brdgmm_kernel_t::get_jit_generator() const {
+const jit_generator_t *brdgmm_kernel_t::get_jit_generator() const {
     return brgemm_kernel_;
 }
 

--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
@@ -32,7 +32,7 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
-struct jit_brdgmm_kernel_base_t : public jit_generator {
+struct jit_brdgmm_kernel_base_t : public jit_generator_t {
     jit_brdgmm_kernel_base_t(const brgemm_t &abrd);
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brdgmm_kernel_base_t)

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -62,9 +62,9 @@ namespace aarch64 {
 
 using namespace dnnl::impl::utils;
 
-struct jit_brgemm_kernel_t : public jit_generator {
+struct jit_brgemm_kernel_t : public jit_generator_t {
     jit_brgemm_kernel_t(const brgemm_t &abrg)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true, sve_512)
+        : jit_generator_t(nullptr, MAX_CODE_SIZE, true, sve_512)
         , brg(abrg)
         , postops_injector_(nullptr)
         , max_effective_vregs(
@@ -2011,7 +2011,7 @@ void brgemm_kernel_common_t::operator()(brgemm_kernel_params_t *params) const {
     (*brgemm_kernel_)(params);
 }
 
-const jit_generator *brgemm_kernel_common_t::get_jit_generator() const {
+const jit_generator_t *brgemm_kernel_common_t::get_jit_generator() const {
     return brgemm_kernel_;
 }
 

--- a/src/cpu/aarch64/cpu_barrier.cpp
+++ b/src/cpu/aarch64/cpu_barrier.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,7 +27,7 @@ namespace aarch64 {
 
 namespace simple_barrier {
 
-void generate(jit_generator &code, Xbyak_aarch64::XReg reg_ctx,
+void generate(jit_generator_t &code, Xbyak_aarch64::XReg reg_ctx,
         Xbyak_aarch64::XReg reg_nthr, bool usedAsFunc) {
 #define BAR_CTR_OFF offsetof(ctx_t, ctr)
 #define BAR_SENSE_OFF offsetof(ctx_t, sense)
@@ -95,7 +96,7 @@ void generate(jit_generator &code, Xbyak_aarch64::XReg reg_ctx,
 }
 
 /** jit barrier generator */
-struct jit_t : public jit_generator {
+struct jit_t : public jit_generator_t {
 
     void generate() override {
         simple_barrier::generate(*this, abi_param1, abi_param2, true);

--- a/src/cpu/aarch64/cpu_barrier.hpp
+++ b/src/cpu/aarch64/cpu_barrier.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,7 +70,7 @@ void barrier(ctx_t *ctx, int nthr);
  *   reg_ctx   -- read-only register with pointer to the barrier context
  *   reg_nnthr -- read-only register with the # of synchronizing threads
  */
-void generate(jit_generator &code, Xbyak_aarch64::XReg reg_ctx,
+void generate(jit_generator_t &code, Xbyak_aarch64::XReg reg_ctx,
         Xbyak_aarch64::XReg reg_nthr, bool usedAsFunc = false);
 
 } // namespace simple_barrier

--- a/src/cpu/aarch64/cpu_reducer.cpp
+++ b/src/cpu/aarch64/cpu_reducer.cpp
@@ -99,7 +99,7 @@ void reduce_balancer_t::balance() {
 using namespace Xbyak_aarch64;
 
 template <impl::data_type_t data_type, cpu_isa_t isa>
-struct reducer_2d_driver_t : public jit_generator {
+struct reducer_2d_driver_t : public jit_generator_t {
     using data_t = typename prec_traits_t<data_type>::type;
 
     reducer_2d_driver_t(int n_src, size_t src_ld, size_t src_step,
@@ -127,7 +127,7 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type, isa> {
 
     void operator()(
             data_t *dst, const data_t *srcs, size_t ny, size_t nx) override {
-        jit_generator::operator()(dst, srcs, ny, nx);
+        jit_generator_t::operator()(dst, srcs, ny, nx);
     }
 
     /* cpu specific part */

--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2021 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,7 +26,7 @@ namespace aarch64 {
 namespace injector_utils {
 
 template <cpu_isa_t isa>
-register_preserve_guard_t<isa>::register_preserve_guard_t(jit_generator *host,
+register_preserve_guard_t<isa>::register_preserve_guard_t(jit_generator_t *host,
         std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
         std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
     : host_(host)
@@ -127,7 +128,7 @@ size_t register_preserve_guard_t<isa>::stack_space_occupied() const {
 template <cpu_isa_t isa>
 conditional_register_preserve_guard_t<
         isa>::conditional_register_preserve_guard_t(bool condition_to_be_met,
-        jit_generator *host,
+        jit_generator_t *host,
         std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
         std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
     : register_preserve_guard_t<isa> {condition_to_be_met

--- a/src/cpu/aarch64/injectors/injector_utils.hpp
+++ b/src/cpu/aarch64/injectors/injector_utils.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2022 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -72,7 +73,7 @@ template <cpu_isa_t isa>
 class register_preserve_guard_t {
 
 public:
-    register_preserve_guard_t(jit_generator *host,
+    register_preserve_guard_t(jit_generator_t *host,
             std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
             std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve = {});
     register_preserve_guard_t(register_preserve_guard_t &&other) = default;
@@ -86,7 +87,7 @@ public:
     size_t stack_space_occupied() const;
 
 private:
-    jit_generator *host_;
+    jit_generator_t *host_;
     std::stack<Xbyak_aarch64::XReg> reg64_stack_;
     std::stack<Xbyak_aarch64::VReg> vmm_stack_;
     const uint64_t cpu_sveLen_ = get_sve_length();
@@ -98,7 +99,7 @@ class conditional_register_preserve_guard_t
     : public register_preserve_guard_t<isa> {
 public:
     conditional_register_preserve_guard_t(bool condition_to_be_met,
-            jit_generator *host,
+            jit_generator_t *host,
             std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
             std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve = {});
     DNNL_DISALLOW_COPY_AND_ASSIGN(conditional_register_preserve_guard_t);

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -391,7 +392,7 @@ class jit_uni_binary_injector_t {
 
 public:
     jit_uni_binary_injector_t(
-            jit_generator *host, const static_params_t &static_params);
+            jit_generator_t *host, const static_params_t &static_params);
 
     /*
      * Generates code of binary post_op injected to host primitive. Applied to
@@ -607,7 +608,7 @@ private:
      */
     rhs_address_t remove_bcast_bit(const rhs_address_t &rhs_addr) const;
 
-    jit_generator *host_;
+    jit_generator_t *host_;
     const rhs_arg_static_params_t rhs_arg_static_params_;
     const Xbyak_aarch64::XReg param1_;
     const bcast_set_t supported_strategy_set_;

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -71,7 +71,7 @@ bool is_supported(cpu_isa_t isa, alg_kind_t alg) {
 using namespace Xbyak_aarch64;
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::injector_preamble(
+void jit_uni_eltwise_injector_f32_t<isa>::injector_preamble(
         const injector_utils::vmm_index_set_t &vmm_idxs) {
     using namespace alg_kind;
     using namespace Xbyak_aarch64::util;
@@ -128,7 +128,7 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::injector_preamble_tail(
+void jit_uni_eltwise_injector_f32_t<isa>::injector_preamble_tail(
         const injector_utils::vmm_index_set_iterator_t start_idx_it) {
     size_t tail_vecs_to_preserve = std::distance(start_idx_it, start_idx_tail);
     if (tail_vecs_to_preserve == 0) return;
@@ -159,7 +159,7 @@ void jit_uni_eltwise_injector_f32<isa>::injector_preamble_tail(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::injector_postamble() {
+void jit_uni_eltwise_injector_f32_t<isa>::injector_postamble() {
     using namespace Xbyak_aarch64::util;
     const int reg_size = h->x0.getBit() / 8;
     if (!save_state_) return;
@@ -179,7 +179,7 @@ void jit_uni_eltwise_injector_f32<isa>::injector_postamble() {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::assign_regs() {
+void jit_uni_eltwise_injector_f32_t<isa>::assign_regs() {
     /* For translation of x64's memory operand instructions */
     z_tmp = TRegS(static_cast<uint32_t>(preserved_vec_idxs[0]));
 
@@ -195,7 +195,7 @@ void jit_uni_eltwise_injector_f32<isa>::assign_regs() {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::set_coef_to_regs() {
+void jit_uni_eltwise_injector_f32_t<isa>::set_coef_to_regs() {
     using namespace alg_kind;
 
     if (is_fwd_) {
@@ -271,7 +271,7 @@ void jit_uni_eltwise_injector_f32<isa>::set_coef_to_regs() {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::compute_cmp_mask(
+void jit_uni_eltwise_injector_f32_t<isa>::compute_cmp_mask(
         const TRegS &vmm_src, const TRegS &compare_operand, int cmp_predicate) {
     enum {
         EQ_OQ = 0,
@@ -422,13 +422,13 @@ void jit_uni_eltwise_injector_f32<isa>::compute_cmp_mask(
 // Uses injector masks objects: p_mask
 // Blends a result of second input into a first input w/ a stored mask.
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::blend_with_mask(
+void jit_uni_eltwise_injector_f32_t<isa>::blend_with_mask(
         const TRegS &vmm_dst, const TRegS &src) {
     h->sel(vmm_dst, p_mask / T_m, src, vmm_dst);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::exp_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::exp_compute_vector_fwd(
         const TRegS &vmm_src) {
 
     const auto &t0 = ZRegS(IDX(vmm_src));
@@ -455,7 +455,7 @@ void jit_uni_eltwise_injector_f32<isa>::exp_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::relu_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::relu_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->mov(ZRegD(vmm_aux0.getIdx()), ZRegD(vmm_src.getIdx()));
     h->fcmgt(p_mask.s, p_all, vmm_src, 0.0);
@@ -464,13 +464,13 @@ void jit_uni_eltwise_injector_f32<isa>::relu_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::relu_zero_ns_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::relu_zero_ns_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fmaxnm(vmm_src, p_all, 0.);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::elu_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::elu_compute_vector_fwd(
         const TRegS &vmm_src) {
     // IMPORTANT: we use vmm_aux3 for the mask as exp_compute does not use it.
     h->mov(ZRegD(vmm_aux3.getIdx()), ZRegD(vmm_src.getIdx()));
@@ -488,7 +488,7 @@ void jit_uni_eltwise_injector_f32<isa>::elu_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<
+void jit_uni_eltwise_injector_f32_t<
         isa>::tanh_polynomial_approx_compute_vector_fwd(const TRegS &vmm_src) {
 
     if (vlen != 512) return;
@@ -560,7 +560,7 @@ void jit_uni_eltwise_injector_f32<
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::tanh_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::tanh_compute_vector_fwd(
         const TRegS &vmm_src) {
 
     if (vlen == 512) {
@@ -614,7 +614,7 @@ void jit_uni_eltwise_injector_f32<isa>::tanh_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::gelu_tanh_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::gelu_tanh_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->mov(ZRegD(IDX(vmm_aux0)), ZRegD(IDX(vmm_src)));
 
@@ -650,39 +650,39 @@ void jit_uni_eltwise_injector_f32<isa>::gelu_tanh_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::square_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::square_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fmul(vmm_src, vmm_src, vmm_src);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::abs_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::abs_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fabs(vmm_src, p_all / T_m, vmm_src);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::sqrt_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::sqrt_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fsqrt(vmm_src, p_all / T_m, vmm_src);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::linear_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::linear_compute_vector_fwd(
         const TRegS &vmm_src) {
     // compute x = alpha * x + beta;
     h->fmad(vmm_src, p_all / T_m, z_tmp, vmm_aux0);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::clip_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::clip_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fmaxnm(vmm_src, p_all, z_tmp);
     h->fminnm(vmm_src, p_all, vmm_aux0);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::mish_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::mish_compute_vector_fwd(
         const TRegS &vmm_src) {
     // An equation other than mish(x) = x*tanh(srelu(x)) was used
     // to calculate mish, but it should be remembered that it is equivalent
@@ -715,7 +715,7 @@ void jit_uni_eltwise_injector_f32<isa>::mish_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::hardswish_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::hardswish_compute_vector_fwd(
         const TRegS &vmm_src) {
     // result = x * hardsigmoid(x)
     h->mov(ZRegD(vmm_aux1.getIdx()), ZRegD(vmm_src.getIdx()));
@@ -724,7 +724,7 @@ void jit_uni_eltwise_injector_f32<isa>::hardswish_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::hardsigmoid_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::hardsigmoid_compute_vector_fwd(
         const TRegS &vmm_src) {
     // alpha:z_tmp, beta:vmm_aux0
     // result = max(0, min(1, alpha * x + beta))
@@ -735,7 +735,7 @@ void jit_uni_eltwise_injector_f32<isa>::hardsigmoid_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::soft_relu_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::soft_relu_compute_vector_fwd(
         const TRegS &vmm_src) {
     // alpha scaling
     if (alpha_ == 1.f) {
@@ -870,7 +870,7 @@ void jit_uni_eltwise_injector_f32<isa>::soft_relu_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::logistic_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::logistic_compute_vector_fwd(
         const TRegS &vmm_src) {
     // To avoid exp(x) overflow happened at x > logf(FLT_MAX), negate positive,
     // compute exp(x), where x <= 0 to get 0 <= exp(x) <= 1 and restore value
@@ -905,7 +905,7 @@ void jit_uni_eltwise_injector_f32<isa>::logistic_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::swish_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::swish_compute_vector_fwd(
         const TRegS &vmm_src) {
     // Save src data on stack for later usage
     h->sub_imm(h->X_SP, h->X_SP, vlen, h->X_TMP_0);
@@ -924,7 +924,7 @@ void jit_uni_eltwise_injector_f32<isa>::swish_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::log_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::log_compute_vector_fwd(
         const TRegS &vmm_src) {
 
     const auto &t0 = ZRegS(IDX(vmm_src));
@@ -1009,7 +1009,7 @@ void jit_uni_eltwise_injector_f32<isa>::log_compute_vector_fwd(
     h->L(exitL);
 }
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<
+void jit_uni_eltwise_injector_f32_t<
         isa>::gelu_erf_minimax_approx_compute_vector_fwd(const TRegS &vmm_src) {
     if (vlen != 512) { // TODO: change this condition based on cpu id.
         return;
@@ -1082,7 +1082,7 @@ void jit_uni_eltwise_injector_f32<
     h->fmul(vmm_src, vmm_src, ZRegS(IDX(table_val(half, z_tmp))));
 }
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::gelu_erf_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::gelu_erf_compute_vector_fwd(
         const TRegS &vmm_src) {
 
     if (vlen == 512) { // TODO: consider performance improvement for lower ISA
@@ -1151,7 +1151,7 @@ void jit_uni_eltwise_injector_f32<isa>::gelu_erf_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::relu_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::relu_compute_vector_bwd(
         const TRegS &vmm_src) {
     h->fcmgt(p_mask.s, p_all / T_z, vmm_src, 0.);
     h->mov(ZRegD(vmm_src.getIdx()), ZRegD(z_tmp.getIdx()));
@@ -1161,7 +1161,7 @@ void jit_uni_eltwise_injector_f32<isa>::relu_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::elu_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::elu_compute_vector_bwd(
         const TRegS &vmm_src) {
     if (!use_dst_) {
         // R = exp(s)
@@ -1180,7 +1180,7 @@ void jit_uni_eltwise_injector_f32<isa>::elu_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::tanh_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::tanh_compute_vector_bwd(
         const TRegS &vmm_src) {
     // res = 1 - d^2 = 1 - tanh^2(s)
     if (!use_dst_) tanh_compute_vector_fwd(vmm_src);
@@ -1192,7 +1192,7 @@ void jit_uni_eltwise_injector_f32<isa>::tanh_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::gelu_tanh_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::gelu_tanh_compute_vector_bwd(
         const TRegS &vmm_src) {
     h->mov(ZRegD(IDX(vmm_aux0)), ZRegD(IDX(vmm_src)));
 
@@ -1237,14 +1237,14 @@ void jit_uni_eltwise_injector_f32<isa>::gelu_tanh_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::square_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::square_compute_vector_bwd(
         const TRegS &vmm_src) {
     // res = 2 * s
     h->fmul(vmm_src, p_all / T_m, 2.);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::abs_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::abs_compute_vector_bwd(
         const TRegS &vmm_src) {
     // replace positive values with 1.f
     compute_cmp_mask(vmm_src, table_val(zero, z_tmp), _cmp_gt_os);
@@ -1255,7 +1255,7 @@ void jit_uni_eltwise_injector_f32<isa>::abs_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::sqrt_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::sqrt_compute_vector_bwd(
         const TRegS &vmm_src) {
     // res = 0.5 / d = 0.5 / sqrt(s)
     if (!use_dst_) sqrt_compute_vector_fwd(vmm_src);
@@ -1265,13 +1265,13 @@ void jit_uni_eltwise_injector_f32<isa>::sqrt_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::linear_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::linear_compute_vector_bwd(
         const TRegS &vmm_src) {
     h->mov(ZRegD(IDX(vmm_src)), ZRegD(IDX(table_val(alpha, z_tmp))));
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::soft_relu_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::soft_relu_compute_vector_bwd(
         const TRegS &vmm_src) {
     if (alpha_ == 1.f) {
         // Skip an instruction.
@@ -1283,7 +1283,7 @@ void jit_uni_eltwise_injector_f32<isa>::soft_relu_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::mish_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::mish_compute_vector_bwd(
         const TRegS &vmm_src) {
     // IMPORTANT: we use vmm_aux3 to save src as exp does not use it.
     h->mov(ZRegD(vmm_aux3.getIdx()), ZRegD(vmm_src.getIdx())); // vmm_aux3 = x
@@ -1328,7 +1328,7 @@ void jit_uni_eltwise_injector_f32<isa>::mish_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::logistic_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::logistic_compute_vector_bwd(
         const TRegS &vmm_src) {
     // res = d * (1 - d) = d - d * d; d = logistic(s)
     if (!use_dst_) logistic_compute_vector_fwd(vmm_src);
@@ -1340,13 +1340,13 @@ void jit_uni_eltwise_injector_f32<isa>::logistic_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::exp_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::exp_compute_vector_bwd(
         const TRegS &vmm_src) {
     if (!use_dst_) exp_compute_vector_fwd(vmm_src);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::swish_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::swish_compute_vector_bwd(
         const TRegS &vmm_src) {
     // R = alpha * s
     h->fmul(vmm_src, vmm_src, ZRegS(IDX(table_val(alpha, z_tmp))));
@@ -1374,7 +1374,7 @@ void jit_uni_eltwise_injector_f32<isa>::swish_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::log_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::log_compute_vector_bwd(
         const TRegS &vmm_src) {
     // res = 1 / s
     /* Do not use 1.f, which is a float constant,
@@ -1385,7 +1385,7 @@ void jit_uni_eltwise_injector_f32<isa>::log_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::clip_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::clip_compute_vector_bwd(
         const TRegS &vmm_src) {
     using namespace alg_kind;
     // z_tmp:alpha, vmm_aux0:beta
@@ -1403,7 +1403,7 @@ void jit_uni_eltwise_injector_f32<isa>::clip_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::gelu_erf_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::gelu_erf_compute_vector_bwd(
         const TRegS &vmm_src) {
     // R = s / sqrt(2)
     h->fmul(vmm_src, vmm_src,
@@ -1477,7 +1477,7 @@ void jit_uni_eltwise_injector_f32<isa>::gelu_erf_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::hardswish_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::hardswish_compute_vector_bwd(
         const TRegS &vmm_src) {
     // alpha:z_tmp, beta:vmm_aux0, 1.f:vmm_aux1
     // Get mask for 0 < alpha * x + beta < 1
@@ -1495,7 +1495,7 @@ void jit_uni_eltwise_injector_f32<isa>::hardswish_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::hardsigmoid_compute_vector_bwd(
+void jit_uni_eltwise_injector_f32_t<isa>::hardsigmoid_compute_vector_bwd(
         const TRegS &vmm_src) {
     // alpha:z_tmp, beta:vmm_aux0, 1:vmm_aux1
     // Get mask for 0 < alpha * x + beta < 1
@@ -1512,7 +1512,7 @@ void jit_uni_eltwise_injector_f32<isa>::hardsigmoid_compute_vector_bwd(
 }
 
 template <cpu_isa_t isa>
-size_t jit_uni_eltwise_injector_f32<isa>::aux_gprs_count() {
+size_t jit_uni_eltwise_injector_f32_t<isa>::aux_gprs_count() {
     using namespace alg_kind;
     switch (alg_) {
         case eltwise_tanh_use_dst_for_bwd:
@@ -1524,13 +1524,13 @@ size_t jit_uni_eltwise_injector_f32<isa>::aux_gprs_count() {
 };
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::round_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<isa>::round_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->frintn(vmm_src, p_all / T_m, vmm_src);
 }
 
 template <cpu_isa_t isa>
-size_t jit_uni_eltwise_injector_f32<isa>::aux_vecs_count() {
+size_t jit_uni_eltwise_injector_f32_t<isa>::aux_vecs_count() {
     using namespace alg_kind;
 
     if (is_fwd_) {
@@ -1600,7 +1600,7 @@ size_t jit_uni_eltwise_injector_f32<isa>::aux_vecs_count() {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::compute_body(
+void jit_uni_eltwise_injector_f32_t<isa>::compute_body(
         const injector_utils::vmm_index_set_iterator_t &start_idx_it,
         const injector_utils::vmm_index_set_iterator_t &end_idx_it) {
     using namespace alg_kind;
@@ -1716,7 +1716,7 @@ void jit_uni_eltwise_injector_f32<isa>::compute_body(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::compute_vector_range(
+void jit_uni_eltwise_injector_f32_t<isa>::compute_vector_range(
         size_t start_idx, size_t end_idx) {
     injector_utils::vmm_index_set_t vmm_idxs;
     for (size_t i = start_idx; i < end_idx; i++)
@@ -1725,7 +1725,7 @@ void jit_uni_eltwise_injector_f32<isa>::compute_vector_range(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::compute_vector_range(
+void jit_uni_eltwise_injector_f32_t<isa>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs) {
     const auto &start_idx_it = vmm_idxs.begin();
     const auto &end_idx_it = vmm_idxs.end();
@@ -1740,7 +1740,7 @@ void jit_uni_eltwise_injector_f32<isa>::compute_vector_range(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::prepare_table(bool gen_table) {
+void jit_uni_eltwise_injector_f32_t<isa>::prepare_table(bool gen_table) {
     if (!gen_table) return;
 
     h->align(64);
@@ -1782,7 +1782,7 @@ void jit_uni_eltwise_injector_f32<isa>::prepare_table(bool gen_table) {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
+void jit_uni_eltwise_injector_f32_t<isa>::register_table_entries() {
     // This function is responsible to pick all necessary constants
     // for a given algorithm, compute right offset for them to be used
     // in table_val() and save the hexadecimal value of them, which
@@ -2411,24 +2411,24 @@ void jit_uni_eltwise_injector_f32<isa>::register_table_entries() {
 }
 
 template <>
-size_t jit_uni_eltwise_injector_f32<asimd>::get_vec_len() {
+size_t jit_uni_eltwise_injector_f32_t<asimd>::get_vec_len() {
     return 16;
 }
 
 template <>
-size_t jit_uni_eltwise_injector_f32<sve_128>::get_vec_len() {
+size_t jit_uni_eltwise_injector_f32_t<sve_128>::get_vec_len() {
     return get_sve_length();
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::relu_zero_ns_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::relu_zero_ns_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->movi(vmm_aux0, 0);
     h->fmaxnm(vmm_src, vmm_src, vmm_aux0);
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::relu_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::relu_compute_vector_fwd(
         const TRegS &vmm_src) {
     // vmm_tmp = alpha * vmm_tmp
     h->fmul(vmm_aux0, vmm_src, z_tmp);
@@ -2437,19 +2437,19 @@ void jit_uni_eltwise_injector_f32<asimd>::relu_compute_vector_fwd(
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::abs_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::abs_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fabs(vmm_src, vmm_src);
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::sqrt_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::sqrt_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fsqrt(vmm_src, vmm_src);
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::linear_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::linear_compute_vector_fwd(
         const TRegS &vmm_src) {
     // compute x = alpha * x + beta;
     h->fmul(vmm_src, vmm_src, z_tmp);
@@ -2457,14 +2457,14 @@ void jit_uni_eltwise_injector_f32<asimd>::linear_compute_vector_fwd(
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::clip_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::clip_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->fmaxnm(vmm_src, vmm_src, z_tmp);
     h->fminnm(vmm_src, vmm_src, vmm_aux0);
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::hardsigmoid_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::hardsigmoid_compute_vector_fwd(
         const TRegS &vmm_src) {
     // alpha:z_tmp, beta:vmm_aux0
     // result = max(0, min(1, alpha * x + beta))
@@ -2475,7 +2475,7 @@ void jit_uni_eltwise_injector_f32<asimd>::hardsigmoid_compute_vector_fwd(
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::hardswish_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::hardswish_compute_vector_fwd(
         const TRegS &vmm_src) {
     // result = x * hardsigmoid(x)
     h->mov(VReg16B(vmm_aux2.getIdx()), VReg16B(vmm_src.getIdx()));
@@ -2484,25 +2484,25 @@ void jit_uni_eltwise_injector_f32<asimd>::hardswish_compute_vector_fwd(
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::round_compute_vector_fwd(
+void jit_uni_eltwise_injector_f32_t<asimd>::round_compute_vector_fwd(
         const TRegS &vmm_src) {
     h->frintn(vmm_src, vmm_src);
 }
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::load_1word_replicate(
+void jit_uni_eltwise_injector_f32_t<asimd>::load_1word_replicate(
         const TRegS &vmm_src, Xbyak_aarch64::XReg x_addr) {
     h->ld1r(TRegS(vmm_src.getIdx()), ptr(x_addr));
 }
 template <>
-void jit_uni_eltwise_injector_f32<sve_128>::load_1word_replicate(
+void jit_uni_eltwise_injector_f32_t<sve_128>::load_1word_replicate(
         const TRegS &vmm_src, Xbyak_aarch64::XReg x_addr) {
     h->ldr(TReg(vmm_src.getIdx()), ptr(x_addr));
 }
 
 #define DEFINE_ASIMD_EMPTY_FUNC(func_name) \
     template <> \
-    void jit_uni_eltwise_injector_f32<asimd>::func_name(const TRegS &) {}
+    void jit_uni_eltwise_injector_f32_t<asimd>::func_name(const TRegS &) {}
 DEFINE_ASIMD_EMPTY_FUNC(exp_compute_vector_fwd);
 DEFINE_ASIMD_EMPTY_FUNC(mish_compute_vector_fwd);
 DEFINE_ASIMD_EMPTY_FUNC(elu_compute_vector_fwd);
@@ -2537,16 +2537,17 @@ DEFINE_ASIMD_EMPTY_FUNC(hardsigmoid_compute_vector_bwd);
 #undef DEFINE_ASIMD_EMPTY_FUNC
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::compute_cmp_mask(const TRegS &vmm_src,
-        const TRegS &compare_operand, int cmp_predicate) {};
+void jit_uni_eltwise_injector_f32_t<asimd>::compute_cmp_mask(
+        const TRegS &vmm_src, const TRegS &compare_operand,
+        int cmp_predicate) {};
 
 template <>
-void jit_uni_eltwise_injector_f32<asimd>::blend_with_mask(
+void jit_uni_eltwise_injector_f32_t<asimd>::blend_with_mask(
         const TRegS &vmm_dst, const TRegS &src) {};
 
 // We only need sve_128 as the injector is fully vector length agnostic.
-template struct jit_uni_eltwise_injector_f32<sve_128>;
-template struct jit_uni_eltwise_injector_f32<asimd>;
+template struct jit_uni_eltwise_injector_f32_t<sve_128>;
+template struct jit_uni_eltwise_injector_f32_t<asimd>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -81,7 +81,7 @@ bool is_supported(cpu_isa_t isa, alg_kind_t alg);
 } // namespace eltwise_injector
 
 template <cpu_isa_t isa>
-struct jit_uni_eltwise_injector_f32 {
+struct jit_uni_eltwise_injector_f32_t {
     using TReg = typename cpu_isa_traits<isa>::TReg;
     using TRegS = typename cpu_isa_traits<isa>::TRegS;
 
@@ -97,7 +97,7 @@ struct jit_uni_eltwise_injector_f32 {
     //   - algorithm derivative.
     // use_dst - defines whether source or destination point is passed to alg
     //   code. Depends on algorithm. See `_use_dst_for_bwd` algs definition.
-    jit_uni_eltwise_injector_f32(jit_generator *host, alg_kind_t alg,
+    jit_uni_eltwise_injector_f32_t(jit_generator_t *host, alg_kind_t alg,
             float alpha, float beta, float scale, bool save_state = true,
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
             Xbyak_aarch64::PReg p_mask = Xbyak_aarch64::PReg(1),
@@ -122,7 +122,7 @@ struct jit_uni_eltwise_injector_f32 {
         register_table_entries();
     }
 
-    jit_uni_eltwise_injector_f32(jit_generator *host,
+    jit_uni_eltwise_injector_f32_t(jit_generator_t *host,
             const post_ops_t::entry_t::eltwise_t &eltwise,
             bool save_state = true,
             Xbyak_aarch64::XReg x_table = Xbyak_aarch64::XReg(0),
@@ -130,7 +130,7 @@ struct jit_uni_eltwise_injector_f32 {
             Xbyak_aarch64::PReg p_tmp0 = Xbyak_aarch64::PReg(4),
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
-        : jit_uni_eltwise_injector_f32(host, eltwise.alg, eltwise.alpha,
+        : jit_uni_eltwise_injector_f32_t(host, eltwise.alg, eltwise.alpha,
                 eltwise.beta, eltwise.scale, save_state, x_table, p_mask,
                 p_tmp0, is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
 
@@ -146,7 +146,7 @@ private:
     const float beta_;
     const float scale_;
 
-    jit_generator *const h;
+    jit_generator_t *const h;
 
     const bool save_state_;
     const Xbyak_aarch64::XReg x_table;
@@ -163,13 +163,13 @@ private:
 
     // if only the injector was inherited from jit_generator...
     enum {
-        _cmp_eq_oq = jit_generator::_cmp_eq_oq,
-        _cmp_lt_os = jit_generator::_cmp_lt_os,
-        _cmp_le_os = jit_generator::_cmp_le_os,
-        _cmp_ge_os = jit_generator::_cmp_nlt_us,
-        _cmp_gt_os = jit_generator::_cmp_nle_us,
-        _op_floor = jit_generator::_op_floor,
-        _op_mxcsr = jit_generator::_op_mxcsr
+        _cmp_eq_oq = jit_generator_t::_cmp_eq_oq,
+        _cmp_lt_os = jit_generator_t::_cmp_lt_os,
+        _cmp_le_os = jit_generator_t::_cmp_le_os,
+        _cmp_ge_os = jit_generator_t::_cmp_nlt_us,
+        _cmp_gt_os = jit_generator_t::_cmp_nle_us,
+        _op_floor = jit_generator_t::_op_floor,
+        _op_mxcsr = jit_generator_t::_op_mxcsr
     };
 
     const size_t vlen = get_vec_len();

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -47,8 +47,8 @@ bool is_supported(const post_ops_ok_args_t &post_ops_ok_args) {
 }
 
 template <cpu_isa_t isa>
-jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
-        const post_ops_t &post_ops,
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
+        jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params,
         const lambda_jit_injectors_t &lambda_jit_injectors)
@@ -66,7 +66,7 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
         if (post_op.is_eltwise()) {
             is_eltwise = true;
             alg_to_eltwise_injector_.emplace(i,
-                    jit_uni_eltwise_injector_f32<to_vla_sve(isa)>(host_,
+                    jit_uni_eltwise_injector_f32_t<to_vla_sve(isa)>(host_,
                             post_op.eltwise, esp.save_state, esp.x_table,
                             esp.p_mask, esp.p_tmp0, esp.is_fwd, esp.use_dst));
         } else if (post_op.is_binary()) {
@@ -89,23 +89,23 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
 }
 
 template <cpu_isa_t isa>
-jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
-        const post_ops_t &post_ops,
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
+        jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
             eltwise_injector::static_params_t(), lambda_jit_injectors_t()) {}
 
 template <cpu_isa_t isa>
-jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
-        const post_ops_t &post_ops,
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
+        jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const lambda_jit_injectors_t &lambda_jit_injectors)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
             eltwise_injector::static_params_t(), lambda_jit_injectors) {}
 
 template <cpu_isa_t isa>
-jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(jit_generator *host,
-        const post_ops_t &post_ops,
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
+        jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.hpp
@@ -73,15 +73,19 @@ public:
      * @param lambda_jit_injectors <optional> - allows user specify custom injector
      * function for given post-op type
      */
-    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+    jit_uni_postops_injector_t(jit_generator_t *host,
+            const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params);
-    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+    jit_uni_postops_injector_t(jit_generator_t *host,
+            const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
             const lambda_jit_injectors_t &lambda_jit_injectors);
-    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+    jit_uni_postops_injector_t(jit_generator_t *host,
+            const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
             const eltwise_injector::static_params_t &eltwise_static_params);
-    jit_uni_postops_injector_t(jit_generator *host, const post_ops_t &post_ops,
+    jit_uni_postops_injector_t(jit_generator_t *host,
+            const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
             const eltwise_injector::static_params_t &eltwise_static_params,
             const lambda_jit_injectors_t &lambda_jit_injectors);
@@ -127,9 +131,9 @@ public:
 
 private:
     post_ops_t post_ops_;
-    jit_generator *host_;
+    jit_generator_t *host_;
     // Key is a numerical order of a post-op in attributes.
-    std::map<int, jit_uni_eltwise_injector_f32<to_vla_sve(isa)>>
+    std::map<int, jit_uni_eltwise_injector_f32_t<to_vla_sve(isa)>>
             alg_to_eltwise_injector_;
     std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa>>
             binary_injector_;

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -648,7 +648,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernel(
     bcfg->alpha = !is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer);
     bcfg->beta = is_init ? 0 : 1;
     CHECK(safe_ptr_assign(kernels_po_[ker_idx],
-            new jit_brgemm_kernel_post_ops<isa>(jcp, *bcfg, *_pd->attr())));
+            new jit_brgemm_kernel_post_ops_t<isa>(jcp, *bcfg, *_pd->attr())));
     kernels_po_[ker_idx]->create_kernel();
     return status::success;
 }

--- a/src/cpu/aarch64/jit_brgemm_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.hpp
@@ -250,11 +250,11 @@ private:
 
     brgemm_containers::brgemm_kernel_container_t brgemm_kernels_;
 
-    std::vector<std::unique_ptr<jit_brgemm_kernel_post_ops<isa>>> kernels_po_;
+    std::vector<std::unique_ptr<jit_brgemm_kernel_post_ops_t<isa>>> kernels_po_;
     std::unique_ptr<jit_sve_core_brgemm_conv_trans_kernel::
                     jit_sve_core_brgemm_conv_trans_kernel_t>
             copy_to_pbuffer_;
-    std::unique_ptr<jit_generator> comp_vpad_pbuffer_;
+    std::unique_ptr<jit_generator_t> comp_vpad_pbuffer_;
 
     size_t acc_dsz, bia_dsz, src_dsz, wei_dsz, dst_dsz;
 

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -38,7 +38,7 @@ struct jit_brgemm_conv_comp_pad_args_t {
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_brgemm_conv_comp_pad_kernel_t : public jit_generator {
+struct jit_uni_brgemm_conv_comp_pad_kernel_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_brgemm_conv_comp_pad_kernel_t)
 

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
@@ -40,7 +40,7 @@ struct jit_brgemm_conv_trans_kernel_args_t {
     size_t b_pad;
 };
 
-struct jit_sve_core_brgemm_conv_trans_kernel_t : public jit_generator {
+struct jit_sve_core_brgemm_conv_trans_kernel_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_core_brgemm_conv_trans_kernel_t)
 
     jit_sve_core_brgemm_conv_trans_kernel_t(const jit_brgemm_conv_conf_t &ajcp);

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -51,7 +51,7 @@ struct brgemm_kernel_diff_bias_t {
 
 #define GET_OFF(field) (uint32_t) offsetof(brgemm_kernel_diff_bias_t, field)
 
-struct jit_brgemm_kernel_diff_bias_t : public jit_generator {
+struct jit_brgemm_kernel_diff_bias_t : public jit_generator_t {
     jit_brgemm_kernel_diff_bias_t(
             const jit_brgemm_primitive_conf_t &ajbgp, const brgemm_t &abrg)
         : brg_(abrg)
@@ -276,9 +276,9 @@ struct brgemm_kernel_post_ops_t {
 };
 
 template <cpu_isa_t isa>
-struct jit_brgemm_kernel_post_ops : public jit_generator {
+struct jit_brgemm_kernel_post_ops_t : public jit_generator_t {
 
-    jit_brgemm_kernel_post_ops(const jit_brgemm_conv_conf_t &ajcp,
+    jit_brgemm_kernel_post_ops_t(const jit_brgemm_conv_conf_t &ajcp,
             const brgemm_t &abrg, const primitive_attr_t &aattr)
         : brg(abrg)
         , jcp(ajcp)
@@ -331,7 +331,7 @@ struct jit_brgemm_kernel_post_ops : public jit_generator {
         bia_typesize_ = (jcp.with_bias) ? types::data_type_size(bia_dt_) : 0;
     }
 
-    ~jit_brgemm_kernel_post_ops() override = default;
+    ~jit_brgemm_kernel_post_ops_t() override = default;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_post_ops)
 

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.cpp
@@ -37,14 +37,16 @@ using namespace Xbyak_aarch64;
 #define GET_OFF(x) offsetof(ctx_t, x)
 
 struct jit_brgemm_trans_m_k_f32_t : public jit_brgemm_trans_src_t,
-                                    public jit_generator {
+                                    public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_m_k_f32_t)
 
     jit_brgemm_trans_m_k_f32_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_src_t(conf) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     enum { typesize = sizeof(float), transpose_size = 16 };
@@ -178,13 +180,15 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
 }
 
 struct jit_brgemm_trans_m_k_bf16_t : public jit_brgemm_trans_src_t,
-                                     public jit_generator {
+                                     public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_m_k_bf16_t)
     jit_brgemm_trans_m_k_bf16_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_src_t(conf) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     enum {
@@ -376,15 +380,17 @@ void jit_brgemm_copy_to_coarse_t::generate() {
 }
 
 struct jit_trans_to_vnni_t : public jit_brgemm_trans_to_vnni_t,
-                             public jit_generator {
+                             public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_trans_to_vnni_t)
     jit_trans_to_vnni_t(const jit_brgemm_primitive_conf_t *conf,
             jit_brgemm_trans_to_vnni_t::matrix_to_transform_t
                     matrix_to_transform)
         : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     enum {
@@ -435,15 +441,17 @@ void jit_trans_to_vnni_t::generate() {
 }
 
 struct jit_copy_f32_t : public jit_brgemm_trans_to_vnni_t,
-                        public jit_generator {
+                        public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_copy_f32_t)
     jit_copy_f32_t(const jit_brgemm_primitive_conf_t *conf,
             jit_brgemm_trans_to_vnni_t::matrix_to_transform_t
                     matrix_to_transform)
         : jit_brgemm_trans_to_vnni_t(conf, matrix_to_transform) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     enum {
@@ -544,14 +552,16 @@ void jit_copy_f32_t::generate() {
 }
 
 struct jit_brgemm_trans_wei_f32_t : public jit_brgemm_trans_wei_t,
-                                    public jit_generator {
+                                    public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_wei_f32_t)
 
     jit_brgemm_trans_wei_f32_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_wei_t(conf) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     enum { typesize = sizeof(float), transpose_size = 16 };
@@ -706,14 +716,16 @@ void jit_brgemm_trans_wei_f32_t::generate() {
 }
 
 struct jit_brgemm_trans_wei_bf16_t : public jit_brgemm_trans_wei_t,
-                                     public jit_generator {
+                                     public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_trans_wei_bf16_t)
 
     jit_brgemm_trans_wei_bf16_t(const jit_brgemm_primitive_conf_t *conf)
         : jit_brgemm_trans_wei_t(conf) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     enum { typesize = sizeof(int16_t), transpose_size = 16 };

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
@@ -46,7 +46,7 @@ struct jit_brgemm_trans_src_t {
     const jit_brgemm_primitive_conf_t *conf_;
 };
 
-struct jit_brgemm_copy_to_coarse_t : public jit_generator {
+struct jit_brgemm_copy_to_coarse_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_copy_to_coarse_t)
 
     struct ctx_t {
@@ -57,8 +57,10 @@ struct jit_brgemm_copy_to_coarse_t : public jit_generator {
         dim_t last_row_blk;
     };
 
-    void operator()(ctx_t *ctx) { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
     jit_brgemm_copy_to_coarse_t(const jit_brgemm_primitive_conf_t *conf)
         : conf_(conf)

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -95,7 +95,8 @@ static const Xbyak_aarch64::XReg abi_param1(Xbyak_aarch64::Operand::X0),
         abi_not_param1(Xbyak_aarch64::Operand::X15);
 } // namespace
 
-class jit_generator : public Xbyak_aarch64::CodeGenerator, public c_compatible {
+class jit_generator_t : public Xbyak_aarch64::CodeGenerator,
+                        public c_compatible {
 public:
     using c_compatible::operator new;
     using c_compatible::operator new[];
@@ -703,15 +704,15 @@ public:
         L(label_tbl_end);
     }
 
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_generator);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_generator_t);
 
-    jit_generator(void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE,
+    jit_generator_t(void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE,
             bool use_autogrow = true, cpu_isa_t max_cpu_isa = isa_all)
         : Xbyak_aarch64::CodeGenerator(code_size,
                 (code_ptr == nullptr && use_autogrow) ? Xbyak_aarch64::AutoGrow
                                                       : code_ptr)
         , max_cpu_isa_(max_cpu_isa) {}
-    ~jit_generator() override = default;
+    ~jit_generator_t() override = default;
 
     virtual const char *name() const = 0;
     virtual const char *source_file() const = 0;

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
@@ -48,7 +48,7 @@ using namespace dnnl::impl::prop_kind;
 using namespace dnnl::impl::utils;
 
 template <cpu_isa_t isa_>
-jit_sve_1x1_conv_kernel<isa_>::jit_sve_1x1_conv_kernel(
+jit_sve_1x1_conv_kernel_t<isa_>::jit_sve_1x1_conv_kernel_t(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
     : jcp(ajcp), attr_(attr) {
@@ -75,7 +75,7 @@ jit_sve_1x1_conv_kernel<isa_>::jit_sve_1x1_conv_kernel(
 }
 
 template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel<isa_>::bcast_loop(int load_loop_blk) {
+void jit_sve_1x1_conv_kernel_t<isa_>::bcast_loop(int load_loop_blk) {
 
     mov(aux1_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_bcast_data, reg_bcast_data);
@@ -138,7 +138,7 @@ void jit_sve_1x1_conv_kernel<isa_>::bcast_loop(int load_loop_blk) {
 }
 
 template <cpu_isa_t isa_>
-Xbyak_aarch64::XReg jit_sve_1x1_conv_kernel<isa_>::output_ptr(
+Xbyak_aarch64::XReg jit_sve_1x1_conv_kernel_t<isa_>::output_ptr(
         const bool is_out_layout_nxc, const int i_load, const int i_ur,
         Xbyak_aarch64::XReg addr) {
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
@@ -180,7 +180,7 @@ static void iterate(const int load_loop_blk, const int ur, const F &fun) {
 }
 
 template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel<isa_>::apply_postops(
+void jit_sve_1x1_conv_kernel_t<isa_>::apply_postops(
         const bool is_out_layout_nxc, const int load_loop_blk, const int ur) {
     injector_utils::vmm_index_set_t vmm_idxs;
     if (jcp.with_binary) {
@@ -214,7 +214,7 @@ void jit_sve_1x1_conv_kernel<isa_>::apply_postops(
 }
 
 template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel<isa_>::reduce_loop(
+void jit_sve_1x1_conv_kernel_t<isa_>::reduce_loop(
         int load_loop_blk, int ur, int substep, bool wraparound) {
 
     const bool out_layout_nxc = is_out_layout_nxc(jcp);
@@ -451,7 +451,7 @@ void jit_sve_1x1_conv_kernel<isa_>::reduce_loop(
 }
 
 template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel<isa_>::generate() {
+void jit_sve_1x1_conv_kernel_t<isa_>::generate() {
     preamble();
 
     sub_imm(X_SP, X_SP, stack_space_needed, X_TMP_0);
@@ -614,7 +614,7 @@ void jit_sve_1x1_conv_kernel<isa_>::generate() {
 }
 
 template <cpu_isa_t isa_>
-status_t jit_sve_1x1_conv_kernel<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
+status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
         const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
         const memory_desc_wrapper &weights_d, const memory_desc_wrapper &dst_d,
         const primitive_attr_t &attr, int nthreads, bool reduce_src) {
@@ -1295,7 +1295,7 @@ status_t jit_sve_1x1_conv_kernel<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
     return status::success;
 }
 template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel<isa_>::init_scratchpad(
+void jit_sve_1x1_conv_kernel_t<isa_>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad,
         const jit_1x1_conv_conf_t &jcp) {
 
@@ -1324,7 +1324,7 @@ void jit_sve_1x1_conv_kernel<isa_>::init_scratchpad(
 
 /* BWD W*/
 template <cpu_isa_t isa_>
-void jit_sve_1x1_conv_kernel<isa_>::balance(jit_1x1_conv_conf_t &jcp) {
+void jit_sve_1x1_conv_kernel_t<isa_>::balance(jit_1x1_conv_conf_t &jcp) {
     int nthreads = jcp.nthr;
     // initialize jcp reduction threading properties
     jcp.nthr = jcp.nthr_mb = jcp.nthr_g = jcp.nthr_oc_b = jcp.nthr_ic_b = 1;
@@ -1390,8 +1390,8 @@ void jit_sve_1x1_conv_kernel<isa_>::balance(jit_1x1_conv_conf_t &jcp) {
     assert(jcp.nthr <= nthreads);
 }
 
-template struct jit_sve_1x1_conv_kernel<sve_512>;
-template struct jit_sve_1x1_conv_kernel<sve_256>;
+template struct jit_sve_1x1_conv_kernel_t<sve_512>;
+template struct jit_sve_1x1_conv_kernel_t<sve_256>;
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.hpp
@@ -38,8 +38,8 @@ namespace aarch64 {
 #define VL64_OFS(ofs) ((ofs) >> cpu_isa_traits<isa_>::vlen_shift)
 
 template <cpu_isa_t isa_ = isa_undef>
-struct jit_sve_1x1_conv_kernel : public jit_generator {
-    jit_sve_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
+struct jit_sve_1x1_conv_kernel_t : public jit_generator_t {
+    jit_sve_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_1x1_conv_kernel)

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
@@ -609,7 +609,7 @@ status_t jit_sve_1x1_convolution_bwd_weights_t<diff_dst_type, wei_type,
         diff_src_type, isa_>::init(engine_t *engine) {
 
     CHECK(safe_ptr_assign(kernel_,
-            new jit_sve_1x1_conv_kernel<isa_>(
+            new jit_sve_1x1_conv_kernel_t<isa_>(
                     pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
     CHECK(safe_ptr_assign(
             acc_ker_, new cpu_accumulator_1d_t<data_type::f32, isa_>()));

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
@@ -77,13 +77,13 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
             const memory_desc_t *src_d = src_md();
             rtus_prepare(this, conv_d, src_d, dst_md());
 
-            CHECK(jit_sve_1x1_conv_kernel<isa_>::init_conf(jcp_, *conv_d,
+            CHECK(jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jcp_, *conv_d,
                     *src_d, *weights_md(), *dst_md(), *attr(),
                     dnnl_get_max_threads(), rtus_.reduce_src_));
             if (jcp_.with_dw_conv) CHECK(depthwise_po_init(engine));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_sve_1x1_conv_kernel<isa_>::init_scratchpad(scratchpad, jcp_);
+            jit_sve_1x1_conv_kernel_t<isa_>::init_scratchpad(scratchpad, jcp_);
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
 
@@ -334,7 +334,7 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_sve_1x1_conv_kernel<isa_>(
+                new jit_sve_1x1_conv_kernel_t<isa_>(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         CHECK(kernel_->create_kernel());
 
@@ -363,7 +363,7 @@ private:
             const void *post_ops_binary_rhs_arg_vec_dw) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_sve_1x1_conv_kernel<isa_>> kernel_;
+    std::unique_ptr<jit_sve_1x1_conv_kernel_t<isa_>> kernel_;
     std::unique_ptr<rtus_driver_t<isa_>> rtus_driver_;
     using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_f32_t<isa_>;
     std::unique_ptr<dw_conv_kernel_t> kernel_dw_;
@@ -400,13 +400,13 @@ struct jit_sve_1x1_convolution_bwd_data_t : public primitive_t {
             const memory_desc_t *diff_src_d = diff_src_md();
             rtus_prepare(this, conv_d, diff_src_d, diff_dst_md());
 
-            status_t status = jit_sve_1x1_conv_kernel<isa_>::init_conf(jcp_,
+            status_t status = jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jcp_,
                     *conv_d, *diff_src_d, *weights_md(), *diff_dst_md(),
                     *attr(), dnnl_get_max_threads(), rtus_.reduce_src_);
             if (status != status::success) return status;
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_sve_1x1_conv_kernel<isa_>::init_scratchpad(scratchpad, jcp_);
+            jit_sve_1x1_conv_kernel_t<isa_>::init_scratchpad(scratchpad, jcp_);
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
 
@@ -489,7 +489,7 @@ struct jit_sve_1x1_convolution_bwd_data_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_sve_1x1_conv_kernel<isa_>(
+                new jit_sve_1x1_conv_kernel_t<isa_>(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         CHECK(kernel_->create_kernel());
         CHECK(init_rtus_driver<isa_>(this));
@@ -504,7 +504,7 @@ struct jit_sve_1x1_convolution_bwd_data_t : public primitive_t {
 private:
     void execute_backward_data(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_sve_1x1_conv_kernel<isa_>> kernel_;
+    std::unique_ptr<jit_sve_1x1_conv_kernel_t<isa_>> kernel_;
     std::unique_ptr<rtus_driver_t<isa_>> rtus_driver_;
 };
 using jit_sve_256_1x1_convolution_bwd_data_f32_t
@@ -541,7 +541,7 @@ struct jit_sve_1x1_convolution_bwd_weights_t : public primitive_t {
             const memory_desc_t *src_d = src_md();
             rtus_prepare(this, conv_d, src_d, diff_dst_md());
 
-            status_t status = jit_sve_1x1_conv_kernel<isa_>::init_conf(jcp_,
+            status_t status = jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jcp_,
                     *conv_d, *src_d, *diff_weights_md(), *diff_dst_md(),
                     *attr(), dnnl_get_max_threads(), rtus_.reduce_src_);
             if (status != status::success) return status;
@@ -549,7 +549,7 @@ struct jit_sve_1x1_convolution_bwd_weights_t : public primitive_t {
             init_balancers();
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_sve_1x1_conv_kernel<isa_>::init_scratchpad(scratchpad, jcp_);
+            jit_sve_1x1_conv_kernel_t<isa_>::init_scratchpad(scratchpad, jcp_);
 
             auto reducer_bia_scratchpad = memory_tracking::registrar_t(
                     scratchpad, memory_tracking::names::prefix_reducer_bia);
@@ -654,7 +654,7 @@ private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_sve_1x1_conv_kernel<isa_>> kernel_;
+    std::unique_ptr<jit_sve_1x1_conv_kernel_t<isa_>> kernel_;
     std::unique_ptr<cpu_accumulator_1d_t<data_type::f32, isa_>> acc_ker_;
     std::unique_ptr<cpu_reducer_t<data_type::f32, isa_>> reducer_bias_;
     // std::unique_ptr<jit_transpose4x16_src> trans_kernel_;

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
@@ -42,17 +42,18 @@ using namespace nstl;
                          : (d).blk_off(__VA_ARGS__))
 
 template <cpu_isa_t isa>
-jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::
-        jit_sve_512_core_x8s8s32x_deconv_fwd_kernel(const jit_conv_conf_t &ajcp,
-                const primitive_attr_t &attr, const memory_desc_t &dst_md)
+jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::
+        jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t(
+                const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
+                const memory_desc_t &dst_md)
     : jcp(ajcp), attr_(attr) {}
 
 template <cpu_isa_t isa>
-jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
-        isa>::~jit_sve_512_core_x8s8s32x_deconv_fwd_kernel()
+jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<
+        isa>::~jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t()
         = default;
 
-status_t _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel::init_conf(
+status_t jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_wrapper_t::init_conf(
         jit_conv_conf_t &jcp, const deconvolution_desc_t &cd,
         memory_desc_t &src_md, memory_desc_t &weights_md, memory_desc_t &dst_md,
         const bool with_bias, memory_desc_t &bias_md, primitive_attr_t &attr,
@@ -330,7 +331,7 @@ status_t _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel::init_conf(
     return status::success;
 }
 
-void _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel::init_scratchpad(
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_wrapper_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
     if (zp::should_calculate_deconv_zp_src_pad_str_comp(jcp)) {
@@ -342,13 +343,13 @@ void _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel::init_scratchpad(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::compute(
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::compute(
         const ZReg &vreg_acc, const ZReg &vreg_wei, const ZReg &vreg_src) {
     sdot(vreg_acc.s, vreg_src.b, vreg_wei.b);
 }
 
 template <cpu_isa_t isa>
-std::function<uint32_t()> jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
+std::function<uint32_t()> jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<
         isa>::prepare_round_robin_vmm_inp_generator(int ur_w) const noexcept {
     const uint32_t start_vmm_idx = vmm_inp(0, jcp.nb_oc_blocking).getIdx();
     const uint32_t end_vmm_idx
@@ -365,7 +366,7 @@ std::function<uint32_t()> jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<
         isa>::apply_zp_src_pad_str_comp(int ur_w, int l_overflow,
         int r_overflow, bool h_padded) {
     Label end_zp_pad, no_tail;
@@ -398,7 +399,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<
         isa>::append_zp_src_pad_str_comp(int ur_w, int l_overflow,
         int r_overflow, bool h_padded, bool last_oc_block) {
 
@@ -481,7 +482,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::compute_ker(int ur_w,
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::compute_ker(int ur_w,
         int l_overflow, int r_overflow, ker_block_t last_ic_block_flag,
         bool h_padded) {
 
@@ -629,7 +630,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::compute_ker(int ur_w,
 } // namespace aarch64
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::kh_loop(int ur_w,
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::kh_loop(int ur_w,
         int l_overflow, int r_overflow, ker_block_t last_ic_block_flag) {
 
     const bool unsigned_input_or_src_zp
@@ -822,20 +823,20 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::kh_loop(int ur_w,
     }
 }
 template <cpu_isa_t isa>
-int jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::get_tail_size()
+int jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::get_tail_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
                             : jcp.oc_without_padding % jcp.oc_block;
 }
 
 template <cpu_isa_t isa>
-int jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::get_blocking_size()
+int jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::get_blocking_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::prepare_output(
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::prepare_output(
         int ur_w) {
     for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++)
         for (int ur = 0; ur < ur_w; ur++)
@@ -851,7 +852,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::prepare_output(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::cvt2ps(
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::cvt2ps(
         data_type_t type_in, const ZReg &vmm_in, const ZReg &op,
         bool mask_flag) {
     PReg mask = P_ALL_ONE;
@@ -893,7 +894,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::cvt2ps(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::store_output(
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::store_output(
         int ur_w, bool last_oc_block) {
     add_imm(X_TMP_1, param1, GET_OFF(bias), X_TMP_0);
     ldr(reg_bias, ptr(X_TMP_1));
@@ -1118,7 +1119,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::store_output(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::icb_loop(
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::icb_loop(
         int ur_w, int l_overflow, int r_overflow, bool is_last_sp_block) {
 
     int shift_src_icb = jcp.typesize_in * jcp.ic_block;
@@ -1198,7 +1199,7 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::icb_loop(
 
 template <cpu_isa_t isa>
 ur_w_blks_params_t
-jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::get_ur_w_blks_params() {
+jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::get_ur_w_blks_params() {
     const int n_ur_blocks = jcp.ow / jcp.ur_w;
 
     ur_w_blks_params_t ur_w_blks_params;
@@ -1260,7 +1261,7 @@ jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::get_ur_w_blks_params() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<isa>::generate() {
+void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::generate() {
     preamble();
 
     assert(get_sve_length() >= isa_sveLen);
@@ -1837,9 +1838,9 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
     return status::success;
 }
 
-template struct jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<sve_512>;
-template struct jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<sve_256>;
-template struct jit_sve_512_core_x8s8s32x_deconv_fwd_kernel<sve_128>;
+template struct jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<sve_512>;
+template struct jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<sve_256>;
+template struct jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<sve_128>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2022 Intel Corporation
 * Copyright 2021-2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,7 +47,7 @@ void pick_loop_order(jit_conv_conf_t &jcp, int nthr) {
 }
 } // namespace
 
-void jit_sve_512_x8s8s32x_fwd_kernel::prepare_output(int ur_w) {
+void jit_sve_512_x8s8s32x_fwd_kernel_t::prepare_output(int ur_w) {
     int nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
     for (int k = 0; k < nb_oc_block; k++)
@@ -65,7 +66,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::prepare_output(int ur_w) {
     }
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::cvt2ps(data_type_t type_in,
+void jit_sve_512_x8s8s32x_fwd_kernel_t::cvt2ps(data_type_t type_in,
         const ZReg vmm_in, const XReg reg_base, const int offset,
         bool mask_flag) {
 
@@ -115,7 +116,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::cvt2ps(data_type_t type_in,
     if (type_in != data_type::f32) scvtf(vmm_in.s, mask_all_one, vmm_in.s);
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
+void jit_sve_512_x8s8s32x_fwd_kernel_t::store_output(
         int ur_w, bool last_oc_block_flag) {
     int nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
@@ -292,7 +293,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::store_output(
     }
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker_dw(int ur_w, int pad_l,
+void jit_sve_512_x8s8s32x_fwd_kernel_t::compute_ker_dw(int ur_w, int pad_l,
         int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
 
     if (sve_len_ != 64)
@@ -487,7 +488,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker_dw(int ur_w, int pad_l,
     }
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker(int ur_w, int pad_l,
+void jit_sve_512_x8s8s32x_fwd_kernel_t::compute_ker(int ur_w, int pad_l,
         int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
@@ -616,7 +617,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::compute_ker(int ur_w, int pad_l,
     }
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
+void jit_sve_512_x8s8s32x_fwd_kernel_t::kh_loop(
         int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
     Label f_overflow_label, no_f_overflow_label, d_h_f_overflow_label,
@@ -773,7 +774,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::kh_loop(
     }
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::icb_loop(
+void jit_sve_512_x8s8s32x_fwd_kernel_t::icb_loop(
         int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
     prepare_output(ur_w);
 
@@ -838,7 +839,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::icb_loop(
     }
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::vmm_mask_all_one() {
+void jit_sve_512_x8s8s32x_fwd_kernel_t::vmm_mask_all_one() {
     mask_gflag = false;
     if (sve_len_ == 64) {
         mask_gflag = true;
@@ -852,7 +853,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::vmm_mask_all_one() {
     }
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::vmm_load_src(
+void jit_sve_512_x8s8s32x_fwd_kernel_t::vmm_load_src(
         ZReg src, XReg reg_addr, bool mask_flag) {
     if (mask_flag) {
         eor(mask_tmp.b, mask_all_one, mask_tmp.b, mask_tmp.b);
@@ -873,7 +874,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::vmm_load_src(
     ld1b(src.b, mask_tmp, ptr(reg_addr));
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
+void jit_sve_512_x8s8s32x_fwd_kernel_t::generate() {
     Label permute_index_table;
     int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
                                         : jcp.ic_without_padding * jcp.ngroups;
@@ -1125,7 +1126,7 @@ void jit_sve_512_x8s8s32x_fwd_kernel::generate() {
     }
 }
 
-bool jit_sve_512_x8s8s32x_fwd_kernel::post_ops_ok(
+bool jit_sve_512_x8s8s32x_fwd_kernel_t::post_ops_ok(
         jit_conv_conf_t &jcp, const primitive_attr_t &attr) {
     using namespace primitive_kind;
     const auto &p = attr.post_ops_;
@@ -1134,7 +1135,7 @@ bool jit_sve_512_x8s8s32x_fwd_kernel::post_ops_ok(
     return 0 == p.len();
 }
 
-status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
+status_t jit_sve_512_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, const primitive_attr_t &attr, int nthreads) {
@@ -1437,7 +1438,7 @@ status_t jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
     return status::success;
 }
 
-void jit_sve_512_x8s8s32x_fwd_kernel::init_scratchpad(
+void jit_sve_512_x8s8s32x_fwd_kernel_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {}
 

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
@@ -32,12 +32,12 @@ namespace aarch64 {
 
 using namespace Xbyak_aarch64;
 
-struct jit_sve_512_x8s8s32x_fwd_kernel : public jit_generator {
+struct jit_sve_512_x8s8s32x_fwd_kernel_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_sve_512_x8s8s32x_conv_fwd_ker_t)
 
     enum { STATE_FIRST_DST_LOAD = 0x1U };
 
-    jit_sve_512_x8s8s32x_fwd_kernel(
+    jit_sve_512_x8s8s32x_fwd_kernel_t(
             const jit_conv_conf_t &ajcp, const primitive_attr_t &attr)
         : jcp(ajcp), attr_(attr) {
         if (jcp.with_eltwise) assert(!"not supported");
@@ -51,7 +51,7 @@ struct jit_sve_512_x8s8s32x_fwd_kernel : public jit_generator {
         }
     }
 
-    ~jit_sve_512_x8s8s32x_fwd_kernel() override = default;
+    ~jit_sve_512_x8s8s32x_fwd_kernel_t() override = default;
 
     jit_conv_conf_t jcp;
     const primitive_attr_t &attr_;

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
@@ -56,13 +56,13 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
                     && !has_zero_dim_memory();
             if (!ok) return status::unimplemented;
 
-            status_t status = jit_sve_512_x8s8s32x_fwd_kernel::init_conf(jcp_,
+            status_t status = jit_sve_512_x8s8s32x_fwd_kernel_t::init_conf(jcp_,
                     *desc(), src_md_, weights_md_, dst_md_, bias_md_, *attr(),
                     dnnl_get_max_threads());
             if (status != status::success) return status;
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_sve_512_x8s8s32x_fwd_kernel::init_scratchpad(
+            jit_sve_512_x8s8s32x_fwd_kernel_t::init_scratchpad(
                     scratchpad, jcp_, *attr());
 
             return status;
@@ -80,7 +80,7 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_sve_512_x8s8s32x_fwd_kernel(
+                new jit_sve_512_x8s8s32x_fwd_kernel_t(
                         pd()->jcp_, *pd()->attr())));
         return kernel_->create_kernel();
     }
@@ -106,7 +106,7 @@ private:
     status_t execute_forward_3d(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_sve_512_x8s8s32x_fwd_kernel> kernel_;
+    std::unique_ptr<jit_sve_512_x8s8s32x_fwd_kernel_t> kernel_;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/jit_sve_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.cpp
@@ -95,7 +95,7 @@ inline bool is_owb_prefetching(const jit_conv_conf_t &jcp) {
 } // namespace
 
 template <cpu_isa_t isa>
-void jit_sve_conv_fwd_kernel<isa>::prepare_output(int ur_w) {
+void jit_sve_conv_fwd_kernel_t<isa>::prepare_output(int ur_w) {
 
     auto zreg_out_s = [=](int i_ur, int i_oc) {
         int idx = i_ur + i_oc * jcp.ur_w;
@@ -125,7 +125,7 @@ void jit_sve_conv_fwd_kernel<isa>::prepare_output(int ur_w) {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_fwd_kernel<isa>::store_output(int ur_w) {
+void jit_sve_conv_fwd_kernel_t<isa>::store_output(int ur_w) {
 
     Label no_update_label, store_label, eltwise_label;
 
@@ -275,7 +275,7 @@ void jit_sve_conv_fwd_kernel<isa>::store_output(int ur_w) {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_fwd_kernel<isa>::compute_loop_fma_core(
+void jit_sve_conv_fwd_kernel_t<isa>::compute_loop_fma_core(
         int ur_w, int pad_l, int pad_r) {
     int kw = jcp.kw;
     int ic_block = jcp.ic_block;
@@ -533,7 +533,7 @@ void jit_sve_conv_fwd_kernel<isa>::compute_loop_fma_core(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_fwd_kernel<isa>::compute_loop(
+void jit_sve_conv_fwd_kernel_t<isa>::compute_loop(
         int ur_w, int pad_l, int pad_r) {
 
     if (jcp.ndims == 5) mov(reg_oi_org, reg_oi);
@@ -599,7 +599,7 @@ void jit_sve_conv_fwd_kernel<isa>::compute_loop(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_fwd_kernel<isa>::generate() {
+void jit_sve_conv_fwd_kernel_t<isa>::generate() {
     int iw = jcp.iw;
     int ow = jcp.ow;
     int ow_block = jcp.ow_block;
@@ -820,7 +820,7 @@ void jit_sve_conv_fwd_kernel<isa>::generate() {
 }
 
 template <cpu_isa_t isa>
-bool jit_sve_conv_fwd_kernel<isa>::post_ops_ok(
+bool jit_sve_conv_fwd_kernel_t<isa>::post_ops_ok(
         jit_conv_conf_t &jcp, const primitive_attr_t &attr) {
     const auto &p = attr.post_ops_;
 
@@ -838,7 +838,7 @@ bool jit_sve_conv_fwd_kernel<isa>::post_ops_ok(
 }
 
 template <cpu_isa_t isa>
-status_t jit_sve_conv_fwd_kernel<isa>::init_conf(jit_conv_conf_t &jcp,
+status_t jit_sve_conv_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, const primitive_attr_t &attr, int nthreads) {
@@ -1195,7 +1195,7 @@ status_t jit_sve_conv_fwd_kernel<isa>::init_conf(jit_conv_conf_t &jcp,
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_fwd_kernel<isa>::init_scratchpad(
+void jit_sve_conv_fwd_kernel_t<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
 
     if (jcp.with_bias && jcp.oc != jcp.oc_without_padding)
@@ -1203,7 +1203,7 @@ void jit_sve_conv_fwd_kernel<isa>::init_scratchpad(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_data_kernel_f32<isa>::prepare_output(int ur_w) {
+void jit_sve_conv_bwd_data_kernel_f32_t<isa>::prepare_output(int ur_w) {
     auto zreg_out_s = [=](int i_ur, int i_oc) {
         int idx = i_ur + i_oc * jcp.ur_w;
         assert(idx < ker_reg_base_idx);
@@ -1225,7 +1225,7 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::prepare_output(int ur_w) {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_data_kernel_f32<isa>::store_output(int ur_w) {
+void jit_sve_conv_bwd_data_kernel_f32_t<isa>::store_output(int ur_w) {
 
     int num_used_zreg = 32 - ker_reg_base_idx;
 
@@ -1336,7 +1336,7 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::store_output(int ur_w) {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_data_kernel_f32<isa>::compute_loop_fma(
+void jit_sve_conv_bwd_data_kernel_f32_t<isa>::compute_loop_fma(
         int ur_w, int l_overflow, int r_overflow) {
     Label kh_label, kd_label;
     int kw = jcp.kw;
@@ -1578,7 +1578,7 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::compute_loop_fma(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_data_kernel_f32<isa>::compute_loop_fma_core(
+void jit_sve_conv_bwd_data_kernel_f32_t<isa>::compute_loop_fma_core(
         int ur_w, int l_overflow, int r_overflow, int k_offset) {
     int kw = jcp.kw;
     int ow = jcp.ow;
@@ -1820,7 +1820,7 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::compute_loop_fma_core(
 }
 
 template <cpu_isa_t isa>
-inline void jit_sve_conv_bwd_data_kernel_f32<isa>::compute_loop(
+inline void jit_sve_conv_bwd_data_kernel_f32_t<isa>::compute_loop(
         int ur_w, int l_overflow, int r_overflow, int k_offset) {
     if (jcp.ndims == 5) mov(reg_oi_org, reg_oi);
 
@@ -1873,7 +1873,7 @@ inline void jit_sve_conv_bwd_data_kernel_f32<isa>::compute_loop(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_data_kernel_f32<isa>::generate() {
+void jit_sve_conv_bwd_data_kernel_f32_t<isa>::generate() {
     int iw = jcp.iw;
     int kw = jcp.kw;
     int ur_w = jcp.ur_w;
@@ -2066,9 +2066,10 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::generate() {
 }
 
 template <cpu_isa_t isa>
-status_t jit_sve_conv_bwd_data_kernel_f32<isa>::init_conf(jit_conv_conf_t &jcp,
-        const convolution_desc_t &cd, memory_desc_t &diff_src_md,
-        memory_desc_t &weights_md, memory_desc_t &diff_dst_md, int nthreads) {
+status_t jit_sve_conv_bwd_data_kernel_f32_t<isa>::init_conf(
+        jit_conv_conf_t &jcp, const convolution_desc_t &cd,
+        memory_desc_t &diff_src_md, memory_desc_t &weights_md,
+        memory_desc_t &diff_dst_md, int nthreads) {
     if (!mayiuse(isa)) return status::unimplemented;
 
     const memory_desc_wrapper diff_src_d(&diff_src_md);
@@ -2433,7 +2434,7 @@ status_t jit_sve_conv_bwd_data_kernel_f32<isa>::init_conf(jit_conv_conf_t &jcp,
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_data_kernel_f32<isa>::init_scratchpad(
+void jit_sve_conv_bwd_data_kernel_f32_t<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     UNUSED(scratchpad);
     UNUSED(jcp);
@@ -2441,12 +2442,12 @@ void jit_sve_conv_bwd_data_kernel_f32<isa>::init_scratchpad(
 
 // Initialize static data members
 template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
-const int jit_sve_conv_bwd_weights_kernel_f32<isa>::max_ur_w = 28;
+const int jit_sve_conv_bwd_weights_kernel_f32_t<isa>::max_ur_w = 28;
 template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
-const int jit_sve_conv_bwd_weights_kernel_f32<isa>::min_oh_reduce = 9;
+const int jit_sve_conv_bwd_weights_kernel_f32_t<isa>::min_oh_reduce = 9;
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::od_step_comeback_pointers() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::od_step_comeback_pointers() {
     Label kd_comeback_label;
 
     /* 'depth' loop count bound by 'kd_work_size' */
@@ -2471,7 +2472,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::od_step_comeback_pointers() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::oh_step_comeback_pointers() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::oh_step_comeback_pointers() {
     Label kh_comeback_label, kd_comeback_label;
     mov(kj, reg_kh);
     L(kh_comeback_label);
@@ -2494,7 +2495,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::oh_step_comeback_pointers() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_ic_block_step(int ur_w,
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_ic_block_step(int ur_w,
         int pad_l, int pad_r, int ic_block_step, int input_offset,
         int kernel_offset, int output_offset, bool input_wraparound) {
 
@@ -2789,7 +2790,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_ic_block_step(int ur_w,
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<
+void jit_sve_conv_bwd_weights_kernel_f32_t<
         isa>::compute_oh_step_unroll_ow_icblock(int ic_block_step,
         int max_ur_w) {
     UNUSED(max_ur_w);
@@ -2914,7 +2915,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_step_unroll_ow(
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_oh_step_unroll_ow(
         int ic_block_step, int max_ur_w) {
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
     const bool src_layout_nxc = is_src_layout_nxc();
@@ -3064,7 +3065,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_step_unroll_ow(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_step_common(
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_oh_step_common(
         int ic_block_step, int max_ur_w) {
     using namespace nstl;
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
@@ -3277,7 +3278,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_step_common(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_step_disp() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_oh_step_disp() {
     int ic_block_step;
     if (jcp.kernel_kind == expl_bcast)
         ic_block_step = jcp.kw <= 3 ? 4 : (jcp.kw <= 6 ? 2 : 1);
@@ -3322,7 +3323,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_step_disp() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::maybe_zero_kernel() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::maybe_zero_kernel() {
     Label skip_zeroing, zeroing_loop;
 
     ldr(reg_tmp, ptr(param, GET_OFF(channel)));
@@ -3379,7 +3380,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::maybe_zero_kernel() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::bias_kernel_2d() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::bias_kernel_2d() {
     assert(jcp.ndims == 4); // only supports 2d
     Label skip_bias, bias_loop;
 
@@ -3409,7 +3410,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::bias_kernel_2d() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::bias_kernel_3d() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::bias_kernel_3d() {
     assert(jcp.ndims == 5); // only supports 3d
     Label skip_bias, bias_loop, skip_load_bias;
 
@@ -3455,7 +3456,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::bias_kernel_3d() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_loop_common() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_oh_loop_common() {
     assert(one_of(jcp.harness, harness_mb_reduction, harness_3d_reduction));
 
     int b_pad = jcp.b_pad;
@@ -3662,7 +3663,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_loop_common() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_loop_partial() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_oh_loop_partial() {
     assert(jcp.harness == harness_2d_reduction);
     int ic_block = jcp.ic_block;
     int oc_block = jcp.oc_block;
@@ -3806,7 +3807,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_oh_loop_partial() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_od_loop_partial() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_od_loop_partial() {
     assert(jcp.harness == harness_3d_reduction);
     int ic_block = jcp.ic_block;
     int oc_block = jcp.oc_block;
@@ -3937,7 +3938,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_od_loop_partial() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_loop() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_loop() {
 
     maybe_zero_kernel();
 
@@ -3951,7 +3952,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::compute_loop() {
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::generate_kernel() {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::generate_kernel() {
     const int simd_w_ = cpu_isa_traits<isa>::vlen / sizeof(float);
 
     preamble();
@@ -3969,7 +3970,7 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::generate_kernel() {
 }
 
 template <cpu_isa_t isa>
-status_t jit_sve_conv_bwd_weights_kernel_f32<isa>::init_conf(
+status_t jit_sve_conv_bwd_weights_kernel_f32_t<isa>::init_conf(
         jit_conv_conf_t &jcp, const convolution_desc_t &cd,
         memory_desc_t &src_md, memory_desc_t &diff_weights_md,
         memory_desc_t &diff_bias_md, memory_desc_t &diff_dst_md, int nthreads) {
@@ -4355,7 +4356,7 @@ status_t jit_sve_conv_bwd_weights_kernel_f32<isa>::init_conf(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::init_scratchpad(
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     if (jcp.nthr_mb > 1) {
         const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
@@ -4378,9 +4379,9 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::init_scratchpad(
 }
 
 template <cpu_isa_t isa>
-void jit_sve_conv_bwd_weights_kernel_f32<isa>::balance(const jit_conv_conf_t &j,
-        int &nthr_, int &nthr_mb_, int &nthr_g_, int &nthr_oc_b_,
-        int &nthr_ic_b_, int nthreads) {
+void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::balance(
+        const jit_conv_conf_t &j, int &nthr_, int &nthr_mb_, int &nthr_g_,
+        int &nthr_oc_b_, int &nthr_ic_b_, int nthreads) {
     nthr_ = nthr_mb_ = nthr_g_ = nthr_oc_b_ = nthr_ic_b_ = 1;
 
     if (nthreads < j.ngroups) {
@@ -4457,12 +4458,12 @@ void jit_sve_conv_bwd_weights_kernel_f32<isa>::balance(const jit_conv_conf_t &j,
 }
 
 /*struct instantiation*/
-template struct jit_sve_conv_fwd_kernel<sve_512>;
-template struct jit_sve_conv_fwd_kernel<sve_256>;
-template struct jit_sve_conv_bwd_data_kernel_f32<sve_512>;
-template struct jit_sve_conv_bwd_data_kernel_f32<sve_256>;
-template struct jit_sve_conv_bwd_weights_kernel_f32<sve_512>;
-template struct jit_sve_conv_bwd_weights_kernel_f32<sve_256>;
+template struct jit_sve_conv_fwd_kernel_t<sve_512>;
+template struct jit_sve_conv_fwd_kernel_t<sve_256>;
+template struct jit_sve_conv_bwd_data_kernel_f32_t<sve_512>;
+template struct jit_sve_conv_bwd_data_kernel_f32_t<sve_256>;
+template struct jit_sve_conv_bwd_weights_kernel_f32_t<sve_512>;
+template struct jit_sve_conv_bwd_weights_kernel_f32_t<sve_256>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_sve_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.hpp
@@ -43,17 +43,17 @@ namespace cpu {
 namespace aarch64 {
 
 template <cpu_isa_t isa = isa_undef>
-struct jit_sve_conv_fwd_kernel : public jit_generator {
-    jit_sve_conv_fwd_kernel(
+struct jit_sve_conv_fwd_kernel_t : public jit_generator_t {
+    jit_sve_conv_fwd_kernel_t(
             const jit_conv_conf_t &ajcp, const primitive_attr_t &attr)
         : jcp(ajcp), attr_(attr), eltwise_injector_(nullptr) {
         if (jcp.with_eltwise)
             eltwise_injector_ = utils::make_unique<
-                    jit_uni_eltwise_injector_f32<to_vla_sve(isa)>>(
+                    jit_uni_eltwise_injector_f32_t<to_vla_sve(isa)>>(
                     this, jcp.eltwise);
     }
 
-    ~jit_sve_conv_fwd_kernel() override = default;
+    ~jit_sve_conv_fwd_kernel_t() override = default;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_conv_fwd_kernel)
 
@@ -163,7 +163,7 @@ private:
         }
     }
 
-    std::unique_ptr<jit_uni_eltwise_injector_f32<to_vla_sve(isa)>>
+    std::unique_ptr<jit_uni_eltwise_injector_f32_t<to_vla_sve(isa)>>
             eltwise_injector_;
 
     inline void prepare_output(int ur_w);
@@ -226,9 +226,10 @@ private:
 };
 
 template <cpu_isa_t isa = isa_undef>
-struct jit_sve_conv_bwd_data_kernel_f32 : public jit_generator {
+struct jit_sve_conv_bwd_data_kernel_f32_t : public jit_generator_t {
 
-    jit_sve_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp) : jcp(ajcp) {}
+    jit_sve_conv_bwd_data_kernel_f32_t(const jit_conv_conf_t &ajcp)
+        : jcp(ajcp) {}
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_conv_bwd_data_kernel_f32)
     jit_conv_conf_t jcp;
@@ -420,9 +421,9 @@ private:
 };
 
 template <cpu_isa_t isa = isa_undef>
-struct jit_sve_conv_bwd_weights_kernel_f32 : public jit_generator {
+struct jit_sve_conv_bwd_weights_kernel_f32_t : public jit_generator_t {
 
-    jit_sve_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_sve_conv_bwd_weights_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : jcp(ajcp) {}
 
     void generate() override {

--- a/src/cpu/aarch64/jit_sve_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_convolution.cpp
@@ -1148,7 +1148,7 @@ status_t jit_sve_convolution_bwd_weights_t<src_type, diff_dst_type,
     nthr_ic_b_ = j.nthr_ic_b;
 
     CHECK(safe_ptr_assign(
-            kernel_, new jit_sve_conv_bwd_weights_kernel_f32<isa>(j)));
+            kernel_, new jit_sve_conv_bwd_weights_kernel_f32_t<isa>(j)));
     CHECK(kernel_->create_kernel());
 
     if (nthr_mb_ > 1) {

--- a/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
@@ -121,7 +121,7 @@ inline void rtus_prepare_space_info(conv_pd_t *self,
 }
 
 template <cpu_isa_t isa>
-struct rtus_driver_t : public jit_generator {
+struct rtus_driver_t : public jit_generator_t {
 
     struct call_params_t {
         const void *ws; /* reduced image (w/ strides = 1) */

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -203,7 +203,7 @@ struct jit_bnorm_conf_t {
 };
 
 template <cpu_isa_t isa>
-struct jit_bnorm_t : public jit_generator {
+struct jit_bnorm_t : public jit_generator_t {
     struct call_params_t {
         // keep all sizes at 8 bytes -- jit code expects this
         size_t N_ithr, N_nthr;
@@ -2062,7 +2062,7 @@ struct jit_bnorm_t : public jit_generator {
         postamble();
     }
 
-    void operator()(const call_params_t *p) { jit_generator::operator()(p); }
+    void operator()(const call_params_t *p) { jit_generator_t::operator()(p); }
 
     ~jit_bnorm_t() override = default;
 };

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
@@ -49,7 +49,7 @@ struct jit_uni_bnorm_s8_call_params_t {
 };
 
 template <cpu_isa_t isa>
-struct jit_bnorm_base_t : public jit_generator {
+struct jit_bnorm_base_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_bnorm_s8_t)
 

--- a/src/cpu/aarch64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,7 +40,7 @@ namespace aarch64 {
 
 using namespace Xbyak_aarch64;
 
-struct binary_kernel_t : public jit_generator {
+struct binary_kernel_t : public jit_generator_t {
     using op_t = binary_op_t;
     using bcast_t = binary_bcast_t;
 
@@ -47,7 +48,9 @@ struct binary_kernel_t : public jit_generator {
             const jit_binary_conf_t conf, bool tail_kernel = false);
     ~binary_kernel_t() override = default;
 
-    void operator()(jit_uni_binary_args_t *p) { jit_generator::operator()(p); }
+    void operator()(jit_uni_binary_args_t *p) {
+        jit_generator_t::operator()(p);
+    }
 
     size_t simd_w() const noexcept { return simd_w_; }
     size_t vlen() const noexcept { return vlen_; }

--- a/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -169,8 +169,8 @@ void jit_uni_deconv_zp_pad_str_kernel_t<isa>::compute_step(
 }
 
 struct helper_store_t {
-    static void store(jit_generator *gen, const ZReg &vmm, const XReg &reg_dst,
-            const size_t size, const PReg &opmask) {
+    static void store(jit_generator_t *gen, const ZReg &vmm,
+            const XReg &reg_dst, const size_t size, const PReg &opmask) {
         gen->st1w(vmm.s, opmask, ptr(reg_dst));
     }
 };

--- a/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2022 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,12 +45,12 @@ struct jit_uni_deconv_zp_pad_str_call_params_t {
  *
  * output_format - dhwc
  */
-class jit_uni_deconv_zp_pad_str_kernel_base_t : public jit_generator {
+class jit_uni_deconv_zp_pad_str_kernel_base_t : public jit_generator_t {
 public:
     jit_uni_deconv_zp_pad_str_kernel_base_t(const jit_conv_conf_t &jcp);
 
     void operator()(const jit_uni_deconv_zp_pad_str_call_params_t *params) {
-        jit_generator::operator()(params);
+        jit_generator_t::operator()(params);
     }
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_deconv_zp_pad_str_kernel_base_t);

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -36,14 +36,14 @@ namespace cpu {
 namespace aarch64 {
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_fwd_kernel_f32_t : public jit_generator {
+struct jit_uni_dw_conv_fwd_kernel_f32_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_fwd_kernel_f32_t)
 
     jit_uni_dw_conv_fwd_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : jcp(ajcp), eltwise_injector_(nullptr) {
         if (jcp.with_eltwise)
             eltwise_injector_ = utils::make_unique<
-                    jit_uni_eltwise_injector_f32<to_vla_sve(isa)>>(
+                    jit_uni_eltwise_injector_f32_t<to_vla_sve(isa)>>(
                     this, jcp.eltwise);
     }
 
@@ -136,14 +136,14 @@ private:
                 format_tag::nwc);
     }
 
-    std::unique_ptr<jit_uni_eltwise_injector_f32<to_vla_sve(isa)>>
+    std::unique_ptr<jit_uni_eltwise_injector_f32_t<to_vla_sve(isa)>>
             eltwise_injector_;
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel_f32_t)
     void generate() override;
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_bwd_data_kernel_f32_t : public jit_generator {
+struct jit_uni_dw_conv_bwd_data_kernel_f32_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32_t)
 
     jit_uni_dw_conv_bwd_data_kernel_f32_t(const jit_conv_conf_t &ajcp)
@@ -189,7 +189,7 @@ private:
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_bwd_weights_kernel_f32_t : public jit_generator {
+struct jit_uni_dw_conv_bwd_weights_kernel_f32_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_weights_kernel_f32_t)
 

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -58,7 +58,7 @@ struct jit_uni_dw_conv_fwd_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    jit_generator *ker() const { return ker_.get(); }
+    jit_generator_t *ker() const { return ker_.get(); }
     void operator()(const jit_conv_args_t *p) const { (*ker_)(p); }
 
 private:

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -43,10 +43,10 @@ struct jit_args_t {
     size_t work_amount;
 };
 
-struct jit_uni_eltwise_kernel_t : public jit_generator {
+struct jit_uni_eltwise_kernel_t : public jit_generator_t {
     jit_uni_eltwise_kernel_t(const eltwise_pd_t *pd) : pd_(pd) {}
 
-    void operator()(jit_args_t *p) { jit_generator::operator()(p); }
+    void operator()(jit_args_t *p) { jit_generator_t::operator()(p); }
 
 protected:
     const eltwise_pd_t *pd_;
@@ -72,7 +72,7 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
         // there's no auxiliary vregs on fwd path
         const bool is_fwd = pd_->is_fwd();
         const bool save_state = is_fwd ? false : true;
-        eltwise_injector_.reset(new jit_uni_eltwise_injector_f32<isa>(this,
+        eltwise_injector_.reset(new jit_uni_eltwise_injector_f32_t<isa>(this,
                 desc.alg_kind, desc.alpha, desc.beta, 1.f, save_state,
                 reg_injector_table, injector_mask, injector_p_tmp0, is_fwd,
                 pd_->use_dst()));
@@ -226,7 +226,7 @@ private:
     TRegS vmm_diff_dst {2};
     TReg tmp0 {2};
     TReg tmp1 {7};
-    std::unique_ptr<jit_uni_eltwise_injector_f32<isa>> eltwise_injector_;
+    std::unique_ptr<jit_uni_eltwise_injector_f32_t<isa>> eltwise_injector_;
 
     PReg p_tmp0 {4}; /* Index is temporal. */
 

--- a/src/cpu/aarch64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,10 +39,10 @@ struct jit_args_t {
     size_t work_amount;
 };
 
-struct jit_uni_eltwise_int_kernel_t : public jit_generator {
+struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
     jit_uni_eltwise_int_kernel_t(const eltwise_desc_t &desc) : desc_(desc) {}
 
-    void operator()(jit_args_t *p) { jit_generator::operator()(p); }
+    void operator()(jit_args_t *p) { jit_generator_t::operator()(p); }
 
 protected:
     data_type_t data_type() const { return desc_.src_desc.data_type; }

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2022 Intel Corporation
 * Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,7 +59,7 @@ struct call_params_t {
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator {
+struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_i8i8_pooling_fwd_ker_t)
 
     using TReg = typename cpu_isa_traits<isa>::TReg;
@@ -178,7 +179,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator {
 
     jit_uni_i8i8_pooling_fwd_ker_t(
             const jit_pool_conf_t &jpp_, const memory_desc_t *dst_md)
-        : jit_generator(nullptr, MAX_CODE_SIZE, true), jpp(jpp_) {}
+        : jit_generator_t(nullptr, MAX_CODE_SIZE, true), jpp(jpp_) {}
 };
 
 template <>

--- a/src/cpu/aarch64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.hpp
@@ -38,12 +38,12 @@ namespace cpu {
 namespace aarch64 {
 
 template <cpu_isa_t isa>
-struct jit_uni_pool_kernel : public jit_generator {
+struct jit_uni_pool_kernel_t : public jit_generator_t {
 
-    jit_uni_pool_kernel(
+    jit_uni_pool_kernel_t(
             const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md);
     jit_pool_conf_t jpp;
-    ~jit_uni_pool_kernel() override;
+    ~jit_uni_pool_kernel_t() override;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_pool_kernel)
 

--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2017-2023 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -495,7 +496,7 @@ template <cpu_isa_t isa, impl::data_type_t d_type>
 status_t jit_uni_pooling_fwd_t<isa, d_type>::init(engine_t *engine) {
 
     CHECK(safe_ptr_assign(kernel_,
-            new jit_uni_pool_kernel<isa>(
+            new jit_uni_pool_kernel_t<isa>(
                     pd()->jpp_, pd()->invariant_dst_md())));
 
     if (pd()->jpp_.tag_kind == jit_memory_tag_kind_t::ncsp)
@@ -833,7 +834,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(const data_t *src,
 template <cpu_isa_t isa, data_type_t d_type>
 jit_uni_pooling_bwd_t<isa, d_type>::jit_uni_pooling_bwd_t(const pd_t *apd)
     : primitive_t(apd)
-    , kernel_(utils::make_unique<jit_uni_pool_kernel<isa>>(
+    , kernel_(utils::make_unique<jit_uni_pool_kernel_t<isa>>(
               pd()->jpp_, pd()->invariant_dst_md()))
     , trans_ctx_(nullptr) {}
 

--- a/src/cpu/aarch64/jit_uni_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_pooling.hpp
@@ -69,7 +69,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
 
             auto scratchpad = scratchpad_registry().registrar();
 
-            CHECK(jit_uni_pool_kernel<isa>::init_conf(
+            CHECK(jit_uni_pool_kernel_t<isa>::init_conf(
                     jpp_, scratchpad, attr_, this));
 
             return status::success;
@@ -108,7 +108,7 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     status_t init_ncsp_trans_ctx();
 
-    std::unique_ptr<jit_uni_pool_kernel<isa>> kernel_;
+    std::unique_ptr<jit_uni_pool_kernel_t<isa>> kernel_;
     std::unique_ptr<jit_uni_pooling_utils::trans_context_t> trans_ctx_;
     static constexpr data_type_t wsp_dt_ = data_type::f32;
 };
@@ -138,7 +138,7 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
 
             auto scratchpad = scratchpad_registry().registrar();
 
-            CHECK(jit_uni_pool_kernel<isa>::init_conf(
+            CHECK(jit_uni_pool_kernel_t<isa>::init_conf(
                     jpp_, scratchpad, attr_, this));
 
             return status::success;
@@ -177,7 +177,7 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     status_t init_ncsp_trans_ctx();
 
-    std::unique_ptr<jit_uni_pool_kernel<isa>> kernel_;
+    std::unique_ptr<jit_uni_pool_kernel_t<isa>> kernel_;
     std::unique_ptr<jit_uni_pooling_utils::trans_context_t> trans_ctx_;
     static constexpr data_type_t wsp_dt_ = data_type::f32;
 };

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -73,17 +73,19 @@ static bool prb_has_small_strides(const prb_t &prb) {
 const size_t ker_prb_size_min = 64;
 
 /* kernel */
-struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_reorder_kernel_f32)
 
     void operator()(const call_param_t *c) const override {
-        jit_generator::operator()(c);
+        jit_generator_t::operator()(c);
     }
     void operator()(const tail_call_param_t *c) const override {
-        jit_generator::operator()(c);
+        jit_generator_t::operator()(c);
     }
 
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
     enum class scale_arg_t { NONE, SRC, DST };
 
@@ -2040,7 +2042,7 @@ private:
 };
 
 // Seperate class for no unroll/threading burden
-struct jit_single_blk_kernel_t : public jit_generator {
+struct jit_single_blk_kernel_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_single_blk_kernel)
     static bool applicable(const prb_t &p) {
 

--- a/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
@@ -60,12 +60,12 @@ using namespace Xbyak_aarch64;
 
 template <cpu_isa_t isa>
 struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
-                                         public jit_generator {
+                                         public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_a_impl_t)
 
     jit_brgemm_matmul_copy_a_impl_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_a_t(conf)
-        , jit_generator()
+        , jit_generator_t()
         , typesize_(conf_->a_dt_sz)
         , tr_typesize_(conf_->tr_a_dt_sz)
         , vnni_granularity_(data_type_vnni_granularity(conf_->src_dt))
@@ -79,8 +79,10 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
         , k_loop_unroll_(is_sve256_ ? 7 : 16)
         , vmm_copy_idx_(29) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     using reg64_t = const Xbyak_aarch64::XReg;
@@ -232,7 +234,7 @@ template struct jit_brgemm_matmul_copy_a_impl_t<sve_256>;
 
 struct jit_brgemm_matmul_copy_a_transposed_impl_t
     : public jit_brgemm_matmul_copy_a_t,
-      public jit_generator {
+      public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_a_transposed_impl_t)
 
     jit_brgemm_matmul_copy_a_transposed_impl_t(const brgemm_matmul_conf_t *conf)
@@ -256,8 +258,10 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
         MAYBE_UNUSED(k_loop_dst_shift);
     }
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     using reg64_t = const Xbyak_aarch64::XReg;
@@ -357,12 +361,12 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t::generate() {
 
 template <cpu_isa_t isa>
 struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
-                                         public jit_generator {
+                                         public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_b_int8_t)
 
     jit_brgemm_matmul_copy_b_int8_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
-        , jit_generator()
+        , jit_generator_t()
         , src_stride_(conf->wei_tag == format_tag::acbd
                           ? conf->copy_B_wei_stride
                           : conf->N * sizeof(int8_t))
@@ -371,8 +375,10 @@ struct jit_brgemm_matmul_copy_b_int8_t : public jit_brgemm_matmul_copy_b_t,
                   conf->s8s8_compensation_required || conf->has_zero_point_a)
         , comp_acc_idx_(25) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 protected:
     using reg64_t = const Xbyak_aarch64::XReg;
@@ -497,7 +503,7 @@ void jit_brgemm_matmul_copy_b_int8_t<isa>::generate() {
 }
 
 struct jit_brgemm_matmul_copy_b_f32_t : public jit_brgemm_matmul_copy_b_t,
-                                        public jit_generator {
+                                        public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_b_f32_t)
 
     jit_brgemm_matmul_copy_b_f32_t(const brgemm_matmul_conf_t *conf)
@@ -511,8 +517,10 @@ struct jit_brgemm_matmul_copy_b_f32_t : public jit_brgemm_matmul_copy_b_t,
         MAYBE_UNUSED(tr_src_stride_);
     }
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     using reg64_t = const Xbyak_aarch64::XReg;
@@ -642,12 +650,12 @@ void jit_brgemm_matmul_copy_b_f32_t::generate() {
 template <cpu_isa_t isa>
 struct jit_brgemm_matmul_copy_b_transposed_t
     : public jit_brgemm_matmul_copy_b_t,
-      public jit_generator {
+      public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_matmul_copy_b_transposed_t)
 
     jit_brgemm_matmul_copy_b_transposed_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
-        , jit_generator()
+        , jit_generator_t()
         , typesize_(conf_->b_dt_sz)
         , tr_typesize_(conf_->tr_b_dt_sz)
         , vnni_granularity_(data_type_vnni_granularity(conf_->wei_dt))
@@ -663,8 +671,10 @@ struct jit_brgemm_matmul_copy_b_transposed_t
                           : conf_->K * typesize_)
         , tr_src_stride_(conf_->LDB * vnni_granularity_ * tr_typesize_) {}
 
-    void operator()(ctx_t *ctx) override { jit_generator::operator()(ctx); }
-    status_t create_kernel() override { return jit_generator::create_kernel(); }
+    void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
+    status_t create_kernel() override {
+        return jit_generator_t::create_kernel();
+    }
 
 private:
     using reg64_t = const Xbyak_aarch64::XReg;

--- a/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
@@ -26,7 +26,7 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-status_t brgemm_matmul_matrix_B_reorder_t::pd_t::init(
+status_t brgemm_matmul_copy_reorder_t::pd_t::init(
         engine_t *engine, engine_t *src_engine, engine_t *dst_engine) {
     using namespace status;
     using namespace format_tag;
@@ -134,9 +134,8 @@ status_t brgemm_matmul_matrix_B_reorder_t::pd_t::init(
     return status::success;
 }
 
-status_t brgemm_matmul_matrix_B_reorder_t::pd_t::create(
-        reorder_pd_t **reorder_pd, engine_t *engine,
-        const primitive_attr_t *attr, engine_t *src_engine,
+status_t brgemm_matmul_copy_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
+        engine_t *engine, const primitive_attr_t *attr, engine_t *src_engine,
         const memory_desc_t *src_md, engine_t *dst_engine,
         const memory_desc_t *dst_md) {
     using namespace status;
@@ -149,7 +148,7 @@ status_t brgemm_matmul_matrix_B_reorder_t::pd_t::create(
     return safe_ptr_assign<reorder_pd_t>(*reorder_pd, _pd.release());
 }
 
-status_t brgemm_matmul_matrix_B_reorder_t::execute_body(
+status_t brgemm_matmul_copy_reorder_t::execute_body(
         const exec_ctx_t &ctx) const {
     using namespace utils;
 

--- a/src/cpu/aarch64/matmul/brgemm_matmul_reorders.hpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_reorders.hpp
@@ -1,6 +1,8 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
+*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
@@ -25,12 +27,12 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-struct brgemm_matmul_matrix_B_reorder_t : public primitive_t {
+struct brgemm_matmul_copy_reorder_t : public primitive_t {
     struct pd_t : public cpu_reorder_pd_t {
         using cpu_reorder_pd_t::cpu_reorder_pd_t;
 
-        DECLARE_COMMON_PD_T("brgemm_matmul_matrix_B_reorder_t",
-                brgemm_matmul_matrix_B_reorder_t);
+        DECLARE_COMMON_PD_T(
+                "brgemm_matmul_copy_reorder_t", brgemm_matmul_copy_reorder_t);
 
         // required to re-use brgemm matmul copy_b jit kernels
         matmul::brgemm_matmul_conf_t matmul_conf_for_reorder_;
@@ -47,7 +49,7 @@ struct brgemm_matmul_matrix_B_reorder_t : public primitive_t {
         friend dnnl::impl::impl_list_item_t;
     };
 
-    brgemm_matmul_matrix_B_reorder_t(const pd_t *apd) : primitive_t(apd) {}
+    brgemm_matmul_copy_reorder_t(const pd_t *apd) : primitive_t(apd) {}
     status_t init(engine_t *engine) override {
         CHECK(matmul::create_brgemm_matmul_copy_b(
                 kernel_, &pd()->matmul_conf_for_reorder_));

--- a/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
@@ -73,7 +73,7 @@ using namespace nstl;
 
 using namespace data_type;
 
-struct jit_bf16_matmul_kernel_t : public jit_generator {
+struct jit_bf16_matmul_kernel_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_bf16_matmul_kernel_t)
 
@@ -98,7 +98,7 @@ struct jit_bf16_matmul_kernel_t : public jit_generator {
     call_params_t inp;
 
     void operator()(const call_params_t *p) {
-        return jit_generator::operator()(p);
+        return jit_generator_t::operator()(p);
     }
 
     ZReg loadb(int ld) { return ZReg(ld + 1); }

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -81,7 +81,7 @@ using namespace nstl;
 
 using namespace data_type;
 
-struct jit_int8_matmul_kernel_t : public jit_generator {
+struct jit_int8_matmul_kernel_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_int8_matmul_kernel_t)
 
@@ -121,7 +121,7 @@ struct jit_int8_matmul_kernel_t : public jit_generator {
     call_params_t inp;
 
     void operator()(const call_params_t *p) {
-        return jit_generator::operator()(p);
+        return jit_generator_t::operator()(p);
     }
 
     ZReg loadb(int ld) { return ZReg(ld + 1); }

--- a/src/cpu/aarch64/matmul/jit_int8_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul_utils.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +29,7 @@ namespace aarch64 {
 namespace matmul {
 
 using namespace Xbyak_aarch64;
-struct jit_int8_matmul_utils_kernel_t : public jit_generator {
+struct jit_int8_matmul_utils_kernel_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_int8_matmul_utils_kernel_t);
 
@@ -62,7 +63,7 @@ struct jit_int8_matmul_utils_kernel_t : public jit_generator {
     int f32_dt_sz = 4;
 
     void operator()(const dyn_params_t *p) {
-        return jit_generator::operator()(p);
+        return jit_generator_t::operator()(p);
     }
 
     jit_int8_matmul_utils_kernel_t(const dyn_vals_t &k) : dyn_(k) {}

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2024 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,7 +41,7 @@ static size_t get_padding_size(const jit_shuffle_conf_t &conf) {
 template <cpu_isa_t isa>
 jit_uni_shuffle_kernel_t<isa>::jit_uni_shuffle_kernel_t(
         const jit_shuffle_conf_t conf)
-    : jit_generator(nullptr, MAX_CODE_SIZE, true)
+    : jit_generator_t(nullptr, MAX_CODE_SIZE, true)
     , conf_(conf)
     , padding_size_(get_padding_size(conf)) {}
 

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2022 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@ namespace aarch64 {
 using namespace Xbyak_aarch64;
 
 template <cpu_isa_t isa>
-struct jit_uni_shuffle_kernel_t : public jit_generator {
+struct jit_uni_shuffle_kernel_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_shuffle_kernel_t)
 
     jit_uni_shuffle_kernel_t(const jit_shuffle_conf_t conf);

--- a/src/cpu/aarch64/utils/jit_io_helper.cpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2022 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,8 +59,9 @@ io_gather_conf_t::io_gather_conf_t(const std::size_t simd_w,
     , vmm_tmp_idx_(vmm_tmp_idx) {}
 
 template <typename Vmm>
-jit_io_helper_t<Vmm>::jit_io_helper_t(jit_generator *host, const cpu_isa_t &isa,
-        const data_type_t &data_type, const io_conf_t &io_conf,
+jit_io_helper_t<Vmm>::jit_io_helper_t(jit_generator_t *host,
+        const cpu_isa_t &isa, const data_type_t &data_type,
+        const io_conf_t &io_conf,
         const utils::optional_t<io_tail_conf_t> &tail_conf,
         const utils::optional_t<io_saturation_conf_t> &saturation_conf,
         const utils::optional_t<io_gather_conf_t> &gather_conf)
@@ -652,7 +654,7 @@ void jit_io_helper_t<Vmm>::store_i8(const Vmm &src_vmm,
 }
 
 template <typename Vmm>
-void uni_vpmovsxbd(jit_generator *host_, const Vmm &dst, const Vmm &src) {
+void uni_vpmovsxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     Xbyak_aarch64::ZReg z_dst(dst.getIdx());
     Xbyak_aarch64::ZReg z_src(src.getIdx());
     host_->zip1(z_dst.b, z_src.b, z_src.b);
@@ -661,7 +663,7 @@ void uni_vpmovsxbd(jit_generator *host_, const Vmm &dst, const Vmm &src) {
 }
 
 template <typename Vmm>
-void uni_vpmovzxbd(jit_generator *host_, const Vmm &dst, const Vmm &src) {
+void uni_vpmovzxbd(jit_generator_t *host_, const Vmm &dst, const Vmm &src) {
     Xbyak_aarch64::ZReg z_dst(dst.getIdx());
     Xbyak_aarch64::ZReg z_src(src.getIdx());
     host_->zip1(z_dst.b, z_src.b, z_src.b);
@@ -695,15 +697,15 @@ void jit_io_helper_t<Vmm>::convert_to_f32(const Vmm &dst_vmm,
 }
 
 template <typename Vmm>
-void uni_vbroadcastss(
-        jit_generator *host_, const Vmm &dst, const Xbyak_aarch64::XReg &src) {
+void uni_vbroadcastss(jit_generator_t *host_, const Vmm &dst,
+        const Xbyak_aarch64::XReg &src) {
     uint8_t dstIdx = dst.getIdx();
     host_->ld1rw(Xbyak_aarch64::ZRegS(dstIdx),
             host_->P_ALL_ONE / Xbyak_aarch64::T_z, Xbyak_aarch64::ptr(src));
 }
 template <typename Vmm>
-void uni_vbroadcastss(
-        jit_generator *host_, const Vmm &dst, const Xbyak_aarch64::VReg &src) {
+void uni_vbroadcastss(jit_generator_t *host_, const Vmm &dst,
+        const Xbyak_aarch64::VReg &src) {
     uint8_t dstIdx = dst.getIdx();
     uint8_t srcIdx = src.getIdx();
     host_->dup(Xbyak_aarch64::ZRegS(dstIdx), Xbyak_aarch64::ZRegS(srcIdx)[0]);
@@ -754,7 +756,7 @@ void jit_io_helper_t<Vmm>::broadcast(const Xbyak_aarch64::XReg &src_addr,
 }
 
 template <typename Vmm>
-jit_io_multi_dt_helper_t<Vmm>::jit_io_multi_dt_helper_t(jit_generator *host,
+jit_io_multi_dt_helper_t<Vmm>::jit_io_multi_dt_helper_t(jit_generator_t *host,
         const cpu_isa_t &isa, const data_types_t &data_types,
         const io_conf_t &io_conf,
         const utils::optional_t<io_tail_conf_t> &tail_conf,

--- a/src/cpu/aarch64/utils/jit_io_helper.hpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2022 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -107,7 +108,7 @@ class jit_io_helper_t {
 public:
     friend class jit_io_multi_dt_helper_t<Vmm>;
 
-    jit_io_helper_t(jit_generator *host, const cpu_isa_t &isa,
+    jit_io_helper_t(jit_generator_t *host, const cpu_isa_t &isa,
             const data_type_t &data_type, const io_conf_t &io_conf,
             const utils::optional_t<io_tail_conf_t> &tail_conf = utils::nullopt,
             const utils::optional_t<io_saturation_conf_t> &saturation_conf
@@ -167,7 +168,7 @@ private:
     void store_i8_udb(Xbyak_aarch64::XReg addr, const Vmm &src_vmm,
             const Xbyak_aarch64::PReg &mask);
 
-    jit_generator *host_;
+    jit_generator_t *host_;
     const cpu_isa_t isa_;
     const data_type_t data_type_;
     const io_conf_t io_conf_;
@@ -181,7 +182,7 @@ class jit_io_multi_dt_helper_t {
 public:
     using data_types_t = std::unordered_set<data_type_t, std::hash<int>>;
 
-    jit_io_multi_dt_helper_t(jit_generator *host, const cpu_isa_t &isa,
+    jit_io_multi_dt_helper_t(jit_generator_t *host, const cpu_isa_t &isa,
             const data_types_t &data_types, const io_conf_t &io_conf,
             const utils::optional_t<io_tail_conf_t> &tail_conf = utils::nullopt,
             const std::map<data_type_t, io_saturation_conf_t> &saturation_confs

--- a/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2024 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023, 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ const impl_list_map_t &regular_f32_f32_impl_list_map() {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
 
             DNNL_AARCH64_ACL_ONLY(CPU_REORDER_INSTANCE(aarch64::acl_reorder_fwd_t))
-            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::brgemm_matmul_matrix_B_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::brgemm_matmul_copy_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_blk_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
 
@@ -50,7 +50,7 @@ const impl_list_map_t &regular_f32_f32_impl_list_map() {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
 
-            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::brgemm_matmul_matrix_B_reorder_t))
+            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::brgemm_matmul_copy_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_blk_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
 


### PR DESCRIPTION
# Description
Fixes all instances of `readability-identifier-naming` clang-tidy failures in the `src/cpu/aarch64/`

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
