### PR TITLE
benchdnn: xnorm: skip filling for empty tensors

### DIFF
--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -41,12 +41,13 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-        // Mean must be computed unless it is passed by user directly.
-        if (!(prb->flags & GLOB_STATS)) return OK;
-
+        // If the library doesn't expect input mean, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(mem_dt, mem_fp, nullptr);
     }
     if (has_bench_mode_bit(mode_bit_t::perf)) {
+        // If the library doesn't expect input mean, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(
                 mem_dt, mem_fp, nullptr, get_perf_fill_cfg(mem_dt.dt()));
     }
@@ -124,15 +125,16 @@ int fill_variance(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-        // Variance must be computed unless it is passed by user directly.
-        if (!(prb->flags & GLOB_STATS)) return OK;
-
+        // If the library doesn't expect input variance, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         // Variance must be always positive by definition.
         fill_cfg_t fill_cfg(dnnl_f32, 0.f, 16.f, /* int = */ false,
                 attr_t::post_ops_t::kind_t::ADD, "variance");
         return fill_random_real(mem_dt, mem_fp, nullptr, fill_cfg);
     }
     if (has_bench_mode_bit(mode_bit_t::perf)) {
+        // If the library doesn't expect input variance, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(
                 mem_dt, mem_fp, nullptr, get_perf_fill_cfg(mem_dt.dt()));
     }

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -37,12 +37,13 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-        // Mean must be computed unless it is passed by user directly.
-        if (!(prb->flags & GLOB_STATS) && !(prb->dir & FLAG_BWD)) return OK;
-
+        // If the library doesn't expect input mean, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(mem_dt, mem_fp, nullptr);
     }
     if (has_bench_mode_bit(mode_bit_t::perf)) {
+        // If the library doesn't expect input mean, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(
                 mem_dt, mem_fp, nullptr, get_perf_fill_cfg(mem_dt.dt()));
     }
@@ -187,15 +188,16 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-        // Variance must be computed unless it is passed by user directly.
-        if (!(prb->flags & GLOB_STATS)) return OK;
-
+        // If the library doesn't expect input variance, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         // Variance must be always positive by definition.
         fill_cfg_t fill_cfg(dnnl_f32, 0.f, 16.f, /* int = */ false,
                 attr_t::post_ops_t::kind_t::ADD, "variance");
         return fill_random_real(mem_dt, mem_fp, nullptr, fill_cfg);
     }
     if (has_bench_mode_bit(mode_bit_t::perf)) {
+        // If the library doesn't expect input variance, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(
                 mem_dt, mem_fp, nullptr, get_perf_fill_cfg(mem_dt.dt()));
     }

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -44,12 +44,13 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-        // Mean must be computed unless it is passed by user directly.
-        if (!(prb->flags & GLOB_STATS) && !(prb->dir & FLAG_BWD)) return OK;
-
+        // If the library doesn't expect input mean, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(mem_dt, mem_fp, nullptr);
     }
     if (has_bench_mode_bit(mode_bit_t::perf)) {
+        // If the library doesn't expect input mean, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(
                 mem_dt, mem_fp, nullptr, get_perf_fill_cfg(mem_dt.dt()));
     }
@@ -149,15 +150,16 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
-        // Variance must be computed unless it is passed by user directly.
-        if (!(prb->flags & GLOB_STATS)) return OK;
-
+        // If the library doesn't expect input variance, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         // Variance must be always positive by definition.
         fill_cfg_t fill_cfg(dnnl_f32, 0.f, 16.f, /* int = */ false,
                 attr_t::post_ops_t::kind_t::ADD, "variance");
         return fill_random_real(mem_dt, mem_fp, nullptr, fill_cfg);
     }
     if (has_bench_mode_bit(mode_bit_t::perf)) {
+        // If the library doesn't expect input variance, don't fill it.
+        if (mem_dt.nelems() == 0) return OK;
         return fill_random_real(
                 mem_dt, mem_fp, nullptr, get_perf_fill_cfg(mem_dt.dt()));
     }

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -372,6 +372,9 @@ bool fill_from_file(int exec_arg, dnn_mem_t &mem, dnn_mem_t &ref_mem) {
     auto prefix = buffer_prefix;
     if (prefix.empty()) return false;
 
+    // `mem` is not supposed to be filled.
+    if (mem.nelems() == 0) return false;
+
     prefix += "." + std::to_string(exec_arg) + ".bin";
 
     FILE *file = nullptr;


### PR DESCRIPTION
[MFDNN-14261](https://jira.devtools.intel.com/browse/MFDNN-14261)

A dropped change from #4043, lnorm problems were caused by #4049.