### PR TITLE
cpu: aarch64: fix segfault in eltwise_log injector

### DIFF
--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -100,9 +100,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     && one_of(entry.eltwise.alg,
                             // these fail due to label offset being too large
                             alg_kind::eltwise_tanh, alg_kind::eltwise_gelu_tanh,
-                            alg_kind::eltwise_gelu_erf,
-                            // this po segfaults TODO: check issues with f32
-                            alg_kind::eltwise_log);
+                            alg_kind::eltwise_gelu_erf);
             VDISPATCH_CONV(!is_failing_po, VERBOSE_BAD_ALGORITHM);
         }
     }

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -491,9 +491,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     && one_of(entry.eltwise.alg,
                             // these fail due to label offset being too large
                             alg_kind::eltwise_tanh, alg_kind::eltwise_gelu_tanh,
-                            alg_kind::eltwise_gelu_erf,
-                            // this po segfaults TODO: check issues with f32
-                            alg_kind::eltwise_log);
+                            alg_kind::eltwise_gelu_erf);
             VDISPATCH_CONV(!is_failing_po, VERBOSE_BAD_ALGORITHM);
         }
     }

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -420,3 +420,8 @@ mb1_g50ic50oc50_ih28oh26_kh3sh1ph0_n"dw_post-op_ngroups-tail"
 # test big oc tail processing in brgemm kernel
 --reset
 --dir=BWD_D --dt=f16:f16:f16 mb1ic1iw2oc1387ow2kw2pw0_n"brgemm_big_oc_tail"
+
+# Test chained post-ops on brgemm kernels
+# See github.com/uxlfoundation/oneDNN issue #4055, and #4089
+--reset
+--impl=brg --dt=bf16 --attr-post-ops=relu+log g1mb1ic32ih128iw128oc32oh128ow128kh2kw2sh1sw1ph0pw0dh0dw0_n"brgemm_chained_post_ops"


### PR DESCRIPTION
# Description

Fixes a segfault that could happen because of a use-after-free bug in `eltwise_injector`.

Fixes: #4055

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
