### PR TITLE
fixup: ci: aarch64: add clang-tidy workflow for AArch64

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -22,14 +22,15 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     paths:
-      - ".github/automation/x64/**"
       - ".github/automation/aarch64/**"
+      - ".github/automation/x64/**"
       - ".github/workflows/clang-tidy.yml"
       - "cmake/**"
       - "examples/**"
       - "include/**"
       - "src/common/**"
       - "src/cpu/*"
+      - "src/cpu/aarch64/**"
       - "src/cpu/gemm/**"
       - "src/cpu/matmul/**"
       - "src/cpu/reorder/**"


### PR DESCRIPTION
# Description

Was missing the `src/cpu/aarch64` directory from the paths list

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?