### PR TITLE
[backport] xe: sdpa: fix f16_accumulate config selection query

### DIFF
--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -36,6 +36,7 @@ inline property operator&(property a, property b) {
 inline property operator^(property a, property b) {
     return (property)((int)a ^ (int)b);
 }
+
 inline property &operator|=(property &a, property b) {
     return (property &)((int &)a |= (int)b);
 }
@@ -588,19 +589,20 @@ static std::vector<config_record_t> sorted_configs = []() {
 }();
 
 property set_properties(bool is_thin_q, bool is_quantized, bool is_integrated,
-        bool is_fma, bool is_f32) {
+        bool is_fma, bool is_f32, bool is_f16_accumulate) {
     property properties = property::none;
     if (is_thin_q) { properties |= property::second_token; }
     if (is_quantized) { properties |= property::quantized; }
     if (is_integrated) { properties |= property::integrated; }
     if (is_fma) { properties |= property::fma; }
     if (is_f32) { properties |= property::f32; }
+    if (is_f16_accumulate) { properties |= property::f32; }
     return properties;
 }
 
 config_t *choose_config(compute::gpu_arch_t arch, dim_t head_size, dim_t seq,
         bool is_thin_q, bool is_quantized, bool is_integrated, bool is_fma,
-        bool is_f32) {
+        bool is_f32, bool is_f16_accumulate) {
     // quantized FMA for f16 on MTL not implemented in gemmstone
     if (arch == compute::gpu_arch_t::xe_hpg && is_fma && !is_f32
             && is_quantized)
@@ -617,8 +619,8 @@ config_t *choose_config(compute::gpu_arch_t arch, dim_t head_size, dim_t seq,
     compute::gpu_arch_t arch_query = (arch >= compute::gpu_arch_t::xe3)
             ? compute::gpu_arch_t::xe2
             : arch;
-    property query_properties = set_properties(
-            is_thin_q, is_quantized, is_integrated, is_fma, is_f32);
+    property query_properties = set_properties(is_thin_q, is_quantized,
+            is_integrated, is_fma, is_f32, is_f16_accumulate);
 
     config_query_t query(arch_query, static_cast<int>(head_size),
             static_cast<int>(seq), query_properties);
@@ -639,9 +641,9 @@ config_t *choose_config(compute::gpu_arch_t arch, dim_t head_size, dim_t seq,
 // excessive recompilation with smaller power of 2 sizes
 dim_t nearest_conf_seq_interval(compute::gpu_arch_t arch, dim_t head_size,
         dim_t seq, bool is_thin_q, bool is_quantized, bool is_integrated,
-        bool is_fma, bool is_f32) {
-    property query_properties = set_properties(
-            is_thin_q, is_quantized, is_integrated, is_fma, is_f32);
+        bool is_fma, bool is_f32, bool is_f16_accumulate) {
+    property query_properties = set_properties(is_thin_q, is_quantized,
+            is_integrated, is_fma, is_f32, is_f16_accumulate);
 
     compute::gpu_arch_t arch_query = (arch >= compute::gpu_arch_t::xe3)
             ? compute::gpu_arch_t::xe2

--- a/src/gpu/intel/sdpa/configs.hpp
+++ b/src/gpu/intel/sdpa/configs.hpp
@@ -100,12 +100,12 @@ bool operator<(const config_record_t &lhs, const config_record_t &rhs);
 
 config_t *choose_config(compute::gpu_arch_t arch, dim_t head_size, dim_t seq,
         bool is_thin_q, bool is_quantized, bool is_integrated, bool is_fma,
-        bool is_f32);
+        bool is_f32, bool is_f16_accumulate);
 dim_t round_up_seq_interval(dim_t seq, compute::gpu_arch_t arch);
 
 dim_t nearest_conf_seq_interval(compute::gpu_arch_t arch, dim_t head_size,
         dim_t seq, bool is_thin_q, bool is_quantized, bool is_integrated,
-        bool is_fma, bool is_f32);
+        bool is_fma, bool is_f32, bool is_f16_accumulate);
 
 // serializable options for microkernel configuration
 // follows reduced subset of structs from gemmstone that

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -127,8 +127,13 @@ status_t micro_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
             && !is_f32; // f32 -> non-systolic kernel only
 
     bool use_fma_config = !use_systolic_ukernel_;
+    bool is_f16_accumulate_gemm = (kq_acc_dt() == data_type::f16)
+            || (vs_acc_dt() == data_type::f16);
+    VCHECK_SDPA_COND(
+            IMPLICATION(is_f16_accumulate_gemm, !use_systolic_ukernel_),
+            "f16 accumulate only available with FMA matmul."); //TODO: update once matmul primitive supports systolic f16 accumulate for testing
     config = choose_config(arch_, d->head_size(), d->keys(), thin_q, quantized,
-            is_integrated, use_fma_config, is_f32);
+            is_integrated, use_fma_config, is_f32, is_f16_accumulate_gemm);
 
     VCHECK_SDPA_COND(config != nullptr,
             "No suitable kernel configuration found for the given problem "
@@ -218,12 +223,6 @@ status_t micro_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     problem.Ts = problem.Tc;
 
     auto problem_kq = problem;
-
-    bool is_f16_accumulate_gemm = (kq_acc_dt() == data_type::f16)
-            || (vs_acc_dt() == data_type::f16);
-    VCHECK_SDPA_COND(
-            IMPLICATION(is_f16_accumulate_gemm, !use_systolic_ukernel_),
-            "f16 accumulate only available with FMA matmul."); //TODO: update once matmul primitive supports systolic f16 accumulate for testing
     problem_kq.Tc = problem_kq.Ts
             = (kq_acc_dt() == data_type::f16) ? Type::f16 : Type::f32;
 
@@ -282,9 +281,9 @@ status_t micro_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     SizeParams heuristic_sizes;
     // quanatizing sizes to large intervals allows kernel
     // selection search while avoiding recompilation for every new size
-    heuristic_sizes.m
-            = nearest_conf_seq_interval(arch_, d->head_size(), d->keys(),
-                    thin_q, quantized, is_integrated, use_fma_config, is_f32);
+    heuristic_sizes.m = nearest_conf_seq_interval(arch_, d->head_size(),
+            d->keys(), thin_q, quantized, is_integrated, use_fma_config, is_f32,
+            is_f16_accumulate_gemm);
     // query size is only tuned to thin_q/non-thin_q cases
     heuristic_sizes.n = (queries <= thin_q_threshold)
             ? thin_q_threshold


### PR DESCRIPTION
# Description

This pull request fixes the configuration selection logic for Intel GPU SDPA microkernels with the f16_accumulate property. This change fixes several functions and updating the property-setting logic to handle this case.
Backport of #4084 
