### PR TITLE
xe: gemm: jit: use stable sort in getEntries

### DIFF
--- a/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
@@ -179,8 +179,9 @@ const std::vector<const kcatalog::Entry *> getEntries(const kcatalog::Catalog &c
                       if (lhsFallback && lessAligned(lhsAlignA, lhsAlignB, rhsAlignA, rhsAlignB)) return false;
                       double lhs_score = evaluate(*lhs, eparams, thisAux);
                       double rhs_score = evaluate(*rhs, eparams, thisAux);
-                      return lhs_score < rhs_score;
-
+                      if (lhs_score < rhs_score) return true;
+                      if (lhs_score > rhs_score) return false;
+                      return (lhs < rhs);
     };
     std::sort(entries.begin(), entries.end(), less);
     if (entries.size() > 0)


### PR DESCRIPTION
closes [MFDNN-14274](https://jira.devtools.intel.com/browse/MFDNN-14274).
In cases where two entries have the same score, maintain pre-existing ordering.