### PR TITLE
cpu: aarch64: matmul: fix brgemm multidims tag detection

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -23,15 +23,12 @@ set -eo pipefail
 
 OS=${OS:-"Linux"}
 
-# described in issue: https://github.com/uxlfoundation/oneDNN/issues/2175
-SKIPPED_TEST_FAILURES="test_benchdnn_modeC_matmul_multidims_cpu"
+# Nightly failures
+SKIPPED_TEST_FAILURES+="test_benchdnn_modeC_graph_fusions_cpu"
 
 #  We currently have some OS and config specific test failures.
 if [[ "$OS" == "Linux" ]]; then
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_ci_cpu"
 fi
-
-# Nightly failures
-SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_fusions_cpu"
 
 printf "${SKIPPED_TEST_FAILURES}"

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -19,7 +19,6 @@
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
-#include "common/tag_traits.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
@@ -1127,11 +1126,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     // Auxiliary functions for getting offsets with pre-calculated memory
-    // strides for each tensor to get general sulution for all possible
+    // strides for each tensor to get general solution for all possible
     // dimension without significant overhead
     dim_t get_data_A_off(int b, int m, int k) const {
         using namespace format_tag;
-        if (bgmmc_.src_tag == acbd || bgmmc_.src_tag == adbc) {
+        if (one_of(bgmmc_.src_tag, acbd, adbc)
+                /* this is a special case when src can be represented
+                   by plain and transposed tags due to a batch dim equal to 1 */
+                || (one_of(bgmmc_.src_tag, abcd, abdc)
+                        && bgmmc_.A_ptr_shift_b != 0)) {
             dim_t b_off = 0;
             if (!bgmmc_.bcast_A_desc.bcast_mask) { // no broadcast
                 const dim_t batch_dim1 = bgmmc_.bcast_A_desc.batch_dims[1];
@@ -1148,7 +1151,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     dim_t get_data_B_off(int b, int k, int n) const {
         using namespace format_tag;
-        if (bgmmc_.wei_tag == acbd || bgmmc_.wei_tag == adbc) {
+        if (one_of(bgmmc_.wei_tag, acbd, adbc)
+                /* this is a special case when weights can be represented
+                   by plain and transposed tags due to a batch dim equal to 1 */
+                || (one_of(bgmmc_.wei_tag, abcd, abdc)
+                        && bgmmc_.B_ptr_shift_b != 0)) {
             dim_t b_off = 0;
             if (!bgmmc_.bcast_B_desc.bcast_mask) { // no broadcast
                 const dim_t batch_dim1 = bgmmc_.bcast_B_desc.batch_dims[1];
@@ -1185,7 +1192,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     dim_t get_data_C_off(int b, int m, int n) const {
         using namespace format_tag;
         assert(bgmmc_.dst_tag != adbc);
-        if (bgmmc_.dst_tag == acbd) {
+        if (bgmmc_.dst_tag == acbd
+                || (one_of(bgmmc_.dst_tag, abcd, abdc)
+                        && bgmmc_.C_ptr_shift_b != 0)) {
             const dim_t batch_dim1 = bgmmc_.bcast_A_desc.batch_dims[1];
             dim_t b_off = bgmmc_.C_strides[2] * (b % batch_dim1)
                     + (b / batch_dim1) * bgmmc_.C_ptr_shift_b;


### PR DESCRIPTION
# Description

This fix for AArch64 is analogous to b646838bc25d3f02ff98e015930ae7461206e15f

Fixes #2008

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?
