### PR TITLE
[Backport][GPU][RNN] Disable cell fusion for larger sizes systolic

### DIFF
--- a/src/gpu/intel/rnn/utils.cpp
+++ b/src/gpu/intel/rnn/utils.cpp
@@ -185,7 +185,7 @@ void init_conf(conf_t &conf, const desc_t &rd,
         if (rd.cell_kind == alg_kind::vanilla_lstm) {
             min_k = (min_k <= 256) ? 160 : 256;
         } else {
-            min_k = 256;
+            min_k = device_info.mayiuse_systolic() ? 64 : 256;
         }
         dim_t k_limit = tail_dhc ? 50 : nstl::min(min_k, ideal_k);
 


### PR DESCRIPTION
# Description

This is a backport of https://github.com/uxlfoundation/oneDNN/pull/4067

Fixes # (https://jira.devtools.intel.com/browse/MFDNN-14190)
