### PR TITLE
eigen: Fix Eigen version comparison.

### DIFF
--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -101,7 +101,10 @@ inline int read_num_threads_from_env() {
 #include "Eigen/Core"
 #include "unsupported/Eigen/CXX11/ThreadPool"
 
-#if EIGEN_WORLD_VERSION + 10 * EIGEN_MAJOR_VERSION < 33
+#define EIGEN_VERSION \
+    EIGEN_WORLD_VERSION * 10000 + EIGEN_MAJOR_VERSION * 100 \
+            + EIGEN_MINOR_VERSION
+#if EIGEN_VERSION < 30300
 #define STR_(x) #x
 #define STR(x) STR_(x)
 #pragma message("EIGEN_WORLD_VERSION " STR(EIGEN_WORLD_VERSION))
@@ -109,7 +112,7 @@ inline int read_num_threads_from_env() {
 #error Unsupported Eigen version (need 3.3.x or higher)
 #endif
 
-#if EIGEN_MINOR_VERSION >= 90
+#if EIGEN_VERSION >= 30308
 using EigenThreadPool = Eigen::ThreadPool;
 #else
 using EigenThreadPool = Eigen::NonBlockingThreadPool;


### PR DESCRIPTION
# Description

The existing Eigen threadpool test uses an incorrect version comparison, which breaks with any new development branch or released version Eigen.  Setting the dependency to anything newer than 3.3.7 that is not a 3.x development branch will trigger a build error.  For example, with the recently released Eigen 5.0.0.

This change corrects the version comparison for the switch from `Eigen::NonBlockingThreadPool` to `Eigen::ThreadPool`, which happened with release 3.3.8.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?