### PR TITLE
backport: cpu: x64: matmul weight decompression fix

### DIFF
--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -508,13 +508,13 @@ public:
             movups(addr, x);
     }
 
-    void uni_vmovdqu16(const Xbyak::Xmm &x, const Xbyak::Address &addr) {
+    void uni_vmovdqu16(const Xbyak::Xmm &x, const Xbyak::Operand &op) {
         if (is_valid_isa(avx512_core))
-            vmovdqu16(x, addr);
+            vmovdqu16(x, op);
         else if (is_valid_isa(avx))
-            vmovups(x, addr);
+            vmovups(x, op);
         else
-            movups(x, addr);
+            movups(x, op);
     }
 
     void uni_vmovups(const Xbyak::Address &addr, const Xbyak::Xmm &x) {

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1055,8 +1055,8 @@ void matmul_amx_blocking_params_micro_t::set_blocking_parameters(
 
         // TODO: review extendable_k_ condition to cover more cases
         extendable_k_ = (K % wei_k_blk != 0) && (brgemm_k_elems > wei_k_blk)
-                && wei_zp_type == none && !use_buffer_a
-                && !packed_sparse_weights && current_lda_ == K;
+                && wei_zp_type == none && !apply_scales_in_buffer_b
+                && !use_buffer_a && !packed_sparse_weights && current_lda_ == K;
 
         if (extendable_k_) {
             if (brgemm_k_elems >= K) {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -232,6 +232,8 @@ struct brgemm_matmul_conf_t {
     bool is_wei_batch_layout_trivial = false;
     bool is_dst_batch_layout_trivial = false;
 
+    // Attributes related to quantization
+    // Scales
     bool apply_scales_in_buffer_b = false;
     size_t wei_scales_dt_sz = 0;
     bool is_wei_scale_per_n = false;
@@ -240,6 +242,7 @@ struct brgemm_matmul_conf_t {
     dim_t wei_scales_k_gsize = 0;
     data_type_t wei_scales_dt = data_type::undef;
 
+    // Zero points
     dim_t wei_zp_k_gsize = 0;
     bool is_wei_zp_per_k = false;
     bool is_wei_zp_per_n = false;


### PR DESCRIPTION
Fixes [MFDNN-14290](https://jira.devtools.intel.com/browse/MFDNN-14290). 
- moved offset updating from copy routines to `get_buf_B_k_ptr()`;
- changed heuristics' behavior - made for scales the same as for ZP;
- minor changes related to masks usage and correct tail processing in copy routines.