### PR TITLE
cpu: x64: matmul: add a robust check for fallback compatibility

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -71,6 +71,13 @@ struct brgemm_matmul_t : public primitive_t {
     private:
         brgemm_desc_t brg_descs_[max_num_brg_kernels_matmul];
         brgemm_matmul_conf_t bgmmc_;
+
+        /**
+         * This function checks whether the current problem can be handled by
+         * the GEMM-based matmul implementation to avoid falling back to the
+         * reference implementation.
+         */
+        bool can_use_gemm_fallback(engine_t *engine) const;
     };
 
     brgemm_matmul_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -463,7 +463,8 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
 status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         const matmul_desc_t &mmd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
-        memory_desc_t &bias_md, primitive_attr_t &attr);
+        memory_desc_t &bias_md, primitive_attr_t &attr,
+        const std::function<bool()> &can_use_gemm_fallback);
 
 void init_scratchpad(memory_tracking::registrar_t &scratchpad,
         const brgemm_matmul_conf_t &bgmmc);


### PR DESCRIPTION
Fixes MFDNN-14255.

This PR adds a robust fallback compatibility check. When the BRGEMM-based matmul decides to fall back to the GEMM-based matmul, we must ensure that the GEMM implementation can handle the problem, otherwise, we risk falling back to the reference implementation.