### PR TITLE
ci: aarch64: Fix permission issues and input data handling

### DIFF
--- a/.github/workflows/aarch64-acl.yml
+++ b/.github/workflows/aarch64-acl.yml
@@ -28,24 +28,8 @@ on:
 
   workflow_dispatch:
 
-# Declare default permissions as read only.
-# We have to declare each permission individually as
-# setting this to read-all causes issues with the id-tokens permission
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: read
-  discussions: read
-  issues: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
-  attestations: read
-  models: read
   id-token: none
 
 jobs:

--- a/.github/workflows/nightly-aarch64.yml
+++ b/.github/workflows/nightly-aarch64.yml
@@ -40,21 +40,7 @@ jobs:
 
   test-performance:
     permissions:
-      # We need a full list because setting one sets the rest to 'none'
-      actions: read
-      checks: read
       contents: write
-      deployments: read
-      discussions: read
-      issues: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
-      security-events: read
-      statuses: read
-      attestations: read
-      models: read
     uses: ./.github/workflows/performance-aarch64.yml
 
   build-and-test:

--- a/.github/workflows/performance-aarch64.yml
+++ b/.github/workflows/performance-aarch64.yml
@@ -52,23 +52,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-performance
   cancel-in-progress: true
 
-# Declare default permissions as read only.
 # Setting this to read-all causes issues with the id-tokens permission
 permissions:
-  actions: read
-  checks: read
   contents: read
-  deployments: read
-  discussions: read
-  issues: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
-  attestations: read
-  models: read
   id-token: none
 
 jobs:
@@ -95,7 +81,6 @@ jobs:
     permissions:
       contents: write
     steps:
-
       - name: Checkout oneDNN
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
- fixed default permissions as write-all is being flagged in the OSSF scorecard
- fixed unsafe input data handling
