### PR TITLE
cpu: x64: fix index for comp_ow_kw_s/f

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1197,10 +1197,13 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
 
             for_(int i = 0; i < comp_ow_f; i++)
             for (int ow = ow_b; ow <= ow_e; ow++) {
-                if (ow == ow_e) comp_owb[owb] = i;
-                if (ow_kw_b[ow] != comp_ow_kw_s[i + ow - ow_b]
-                        || ow_kw_e[ow] != comp_ow_kw_f[i + ow - ow_b]
-                        || comp_owb[owb] >= 0)
+                if (ow == ow_e) {
+                    comp_owb[owb] = i;
+                    break;
+                }
+                if (comp_owb[owb] >= 0 || (i + ow - ow_b) >= comp_ow_l
+                        || ow_kw_b[ow] != comp_ow_kw_s[i + ow - ow_b]
+                        || ow_kw_e[ow] != comp_ow_kw_f[i + ow - ow_b])
                     break;
             }
             assert(comp_owb[owb] >= 0);


### PR DESCRIPTION
Fixes MFDNN-14275

Because the range of `comp_ow_kw_s/f` and `ow_kw_b/e` are different, the index of `comp_ow_kw_s/f` may exceed its size and then cause failure.

Before commit on sdpdnn767744:
```
./tests/benchdnn/benchdnn -v5 --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:host_scalar:0.5+dst:host_scalar:4+wei:host_scalar:2 --attr-zero-points=src:host_scalar:2+dst:host_scalar:1 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor mb1ic272iw29oc368ow30kw1pw1
create: --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:host_scalar:0.5+dst:host_scalar:4+wei:host_scalar:2 --attr-zero-points=src:host_scalar:2+dst:host_scalar:1 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor mb1ic272iw29oc368ow30kw1pw1
oneDNN implementation: ocl:ref:any
/usr/include/c++/8/bits/stl_vector.h:932: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = int; _Alloc = std::allocator<int>; std::vector<_Tp, _Alloc>::reference = int&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.
Aborted (core dumped)
```
After commit on sdpdnn767744:
```
./tests/benchdnn/benchdnn -v5 --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:host_scalar:0.5+dst:host_scalar:4+wei:host_scalar:2 --attr-zero-points=src:host_scalar:2+dst:host_scalar:1 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor mb1ic272iw29oc368ow30kw1pw1
create: --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:host_scalar:0.5+dst:host_scalar:4+wei:host_scalar:2 --attr-zero-points=src:host_scalar:2+dst:host_scalar:1 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor mb1ic272iw29oc368ow30kw1pw1
oneDNN implementation: ocl:ref:any
CPU reference oneDNN implementation: brg_conv_fwd:avx2_vnni_2
run: --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:host_scalar:0.5+dst:host_scalar:4+wei:host_scalar:2 --attr-zero-points=src:host_scalar:2+dst:host_scalar:1 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor mb1ic272iw29oc368ow30kw1pw1
run ref: --conv --engine=cpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:host_scalar:0.5+dst:host_scalar:4+wei:host_scalar:2 --attr-zero-points=src:host_scalar:2+dst:host_scalar:1 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f32:per_tensor mb1ic272iw29oc368ow30kw1pw1
0:PASSED (3367 ms) __REPRO: --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s32 --attr-scales=src:host_scalar:0.5+dst:host_scalar:4+wei:host_scalar:2 --attr-zero-points=src:host_scalar:2+dst:host_scalar:1 --attr-post-ops=sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor mb1ic272iw29oc368ow30kw1pw1
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
```

