### PR TITLE
graph: backend: dnnl: fix softmax fusion patterns

### DIFF
--- a/src/graph/backend/dnnl/patterns/softmax_post_ops.cpp
+++ b/src/graph/backend/dnnl/patterns/softmax_post_ops.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -52,6 +52,15 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_softmax_post_ops)
                     pm::pb_op_t *softmax_base
                             = pgraph->append_op(graph::op_kind::SoftMax);
 
+                    // optional typecast
+                    auto tc_graph = std::make_shared<pb_graph_t>();
+                    pm::pb_op_t *ptypecast
+                            = tc_graph->append_op(graph::op_kind::TypeCast);
+                    tc_graph->create_input_port(0, ptypecast, 0);
+                    tc_graph->create_output_port(0, ptypecast, 0);
+                    auto pre_tc = pgraph->append_optional(
+                            tc_graph, in_edges_t {in_edge(0, softmax_base, 0)});
+
                     // repetition(alternation(unary | binary))
                     auto alt_unary_binary = std::make_shared<pb_graph_t>();
                     auto palt = alt_unary_binary->append_alternation(
@@ -61,16 +70,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_softmax_post_ops)
                     alt_unary_binary->create_output_port(0, palt, 0);
                     auto prep = pgraph->append_repetition(alt_unary_binary,
                             {0, 0}, 0, MAX_REPETITION,
-                            in_edges_t {in_edge(0, softmax_base, 0)});
-
-                    // optional typecast
-                    auto tc_graph = std::make_shared<pb_graph_t>();
-                    pm::pb_op_t *ptypecast
-                            = tc_graph->append_op(graph::op_kind::TypeCast);
-                    tc_graph->create_input_port(0, ptypecast, 0);
-                    tc_graph->create_output_port(0, ptypecast, 0);
-                    auto pre_tc = pgraph->append_optional(
-                            tc_graph, in_edges_t {in_edge(0, prep, 0)});
+                            in_edges_t {in_edge(0, pre_tc, 0)});
 
                     // optional quantize
                     auto q_graph = std::make_shared<pb_graph_t>();
@@ -79,7 +79,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_softmax_post_ops)
                     q_graph->create_input_port(0, pquantize, 0);
                     q_graph->create_output_port(0, pquantize, 0);
                     pgraph->append_optional(
-                            q_graph, in_edges_t {in_edge(0, pre_tc, 0)});
+                            q_graph, in_edges_t {in_edge(0, prep, 0)});
                 })
         .set_attr<FCreateKernel>("FCreateKernel", []() -> kernel_ptr {
             return std::make_shared<softmax_fwd_t>();


### PR DESCRIPTION
Adjust the order of epilogue ops.

Now the optional TypeCast is between softmax and unary/binary post-ops. Before the change, it was after the unary/binary post-ops.