### PR TITLE
Benchdnn: Enable mode p on windows

### DIFF
--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -76,7 +76,6 @@ function(register_benchdnn_test engine driver test_file)
     # Additionally, only needed for speeding up JIT compilation of OCL kernels.
     set(mode_modifier "")
     if(${engine} MATCHES "gpu"
-       AND NOT WIN32
        AND NOT ${DNNL_GPU_VENDOR} MATCHES "NVIDIA"
        AND NOT ${DNNL_GPU_VENDOR} MATCHES "AMD")
         set(mode_modifier "--mode-modifier=P")


### PR DESCRIPTION
# Description

Drop restriction on `--mode-modifier=p` on windows, testing shows this appears to work without stability issues: https://intel-ci.intel.com/f0a8568a-0ff2-f1ef-85cc-d4f5ef20c6a0 .

Fixes timeouts on windows platforms in GPU testing. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
