### PR TITLE
oneDNN v3.9.2 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.9.1")
+set(PROJECT_VERSION "3.9.2")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.9.1:
* Fixed correctness issue in `int8` convolution on processors with Intel AVX2 and Intel DL Boost instruction set support (a7c4079bfe6aacd997cc18631152845dcf3aa631, 78e781f6bbec4cf622a23426830ae4b531432295)
* Fixed performance degradation for `f32` convolution primitive on processors with Intel AVX-512 instruction set support (74f23b48e0779e5e39ea14ebdb80eca9afdb92aa)
* Fixed performance regression for RNN primitive with LBR GRU cell type on Intel Arc GPUs (ae2844e6ffbb71f27d28fd30ea7686acecea8dd6)
* Fixed performance degradation for `int8` convolution primitive when using zero points (dbb848437d2f93b3e8a5b407a5e9cc2f266fefd7)
* Fixed segmentation fault in matmul primitive when using `ONEDNN_VERBOSE=all`  (7310aa249749f82fcfc77df5e30902c37e150bfb)
* Fixed correctness issue in multi-dimensional matmul primitive on Intel Xeon processors with Intel AMX instruction set support (formerly Sapphire Rapids and Granite Rapids) (642d18b7fe4648e8aa8390c580d6fa6e2d8771a6)
* Reduced problem size in `test_sdpa_decomp` test (9bff06eaff33c3e3129fa5f577d2a56732113789)
* Restricted `test_sdpa_decomp` and `test_mqa_decomp` tests to `OMP` or `THREADPOOL` CPU runtimes (3cd917075c92d05a95993bfea23f434c9beb1882)
* Fixed illegal instruction issue in pooling primitive on processors with Intel SSE4.1 support (d907c47ae77035da420fd6ef37b9184629fecfb0)
* Fixed segmentation fault issue in `f16` backward convolution primitive on processors with Intel AVX2 with Intel DL Boost with float16 and bfloat16 support (50cc2282324d2527e04c3f0f7b9c2a36e53f5e0a, fcc7e5ebc8dd2274f7a996c70c07e8db3aa685c4)
* Restored support for `int8` matmul with `per_oc` scales and zero points on Intel Arc GPUs (1a5a454270d9bcfe580228c67f348a24e2727872, 04c22c96de0776a76d86ef283fcd37eed30dcbb4)
