### PR TITLE
[GPU] Restore conv blocking idx_t hash to string

### DIFF
--- a/src/gpu/intel/jit/dsl/tensor.hpp
+++ b/src/gpu/intel/jit/dsl/tensor.hpp
@@ -80,7 +80,7 @@ private:
         size_t length() const { return std::strlen(data_); }
         bool is_empty() const { return data_[0] == 0; }
         size_t get_hash() const {
-            return std::hash<uint64_t> {}(numeric_value());
+            return std::hash<std::string> {}(std::string(data_));
         };
         std::string str() const { return data_; }
 


### PR DESCRIPTION
# Description

use string name to hash `idx_t` restores blocking pre-sort ordering behavior to pre- 5766c76b7b4d55b56ecb53299a84016420a5d9f2 . This eliminates a regression caused by the changed ordering of blockings with identical scores.

Fixes # [MFDNN-13945](https://jira.devtools.intel.com/browse/MFDNN-13945)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
