### PR TITLE
Backport: cpu: x64: fix perf issue for f32 conv (#4108)

### DIFF
--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2380,12 +2380,18 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                             = B_offset(prefetch_count_B++, rd)
                             + static_cast<dim_t>(brg.LDB) * brg.rd_block
                                     * brg.typesize_B;
-                    if (is_superset(brg.isa_impl, avx512_core)) {
-                        prefetcht0(EVEX_compress_addr_safe(reg_aux_B,
-                                prefetch_offset, reg_tmp_microkernel));
+                    // Only use EVEX_compress_addr_safe/make_safe_addr
+                    // when prefetch_offset > INT_MAX forr perf purpose
+                    if (prefetch_offset <= INT_MAX) {
+                        prefetcht0(ptr[reg_aux_B + prefetch_offset]);
                     } else {
-                        prefetcht0(make_safe_addr(reg_aux_B, prefetch_offset,
-                                reg_tmp_microkernel));
+                        if (is_superset(brg.isa_impl, avx512_core)) {
+                            prefetcht0(EVEX_compress_addr_safe(reg_aux_B,
+                                    prefetch_offset, reg_tmp_microkernel));
+                        } else {
+                            prefetcht0(make_safe_addr(reg_aux_B,
+                                    prefetch_offset, reg_tmp_microkernel));
+                        }
                     }
                 }
                 for (dim_t ld = 0; ld < ld_block2; ld++) {


### PR DESCRIPTION
Backport of https://github.com/uxlfoundation/oneDNN/pull/4107

This one is needed to support TF's oneDNN update to v3.8 in pair with dev-v3.8-thunk-preview which received the same update.
Branches will be used with sync and async runtime correspondently.