### PR TITLE
build: bumped version to v3.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.8.1")
+set(PROJECT_VERSION "3.8.2")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.8.1:
* Fixed performance regression for `f32` convolution primitive on processors with Intel AVX-512 instruction set support (5f3af68b6beb52377d40082f9c5a9a47b16c3753)
* Introduced support for `f16` destination in `int8` matmul and `int8` inner product on x64 CPUs (53fd12abd898d2540ab203036bd8980ca4d1b383, 22e252c8e4f6a9e0242758fe4a06f482f453e8ae, f5b2d7f7cf943ed4e02858bb2ebf849b6c3b3499, e4e2f1cba595fbb593a29755c39d447eb6489ea9)
* Improved RNN primitive performance on processors with Intel AVX2 instruction set support (71e5d81b5a0a673ecdba39fad54bdc734f469b83, eb27db21e6c22f81ffdd7362ce1c5f1624ccbac8, dd4e6272877c83cdd1c76da6da4521252f486c13, ff134e0c22775d5c10b8c6b5f00bec8574dd184d, 5a86c1f0c4ede1ca714538d667a0490ca7adea1f, e9395ae868d3fe35ab30edc4f47ddd0b70fe988c)
* Improved `fp32` matmul performance on processors with Intel AVX-512 instruction set support (11193399a8c2b8b1b8578cabb47fe986a19e3623)
* Fixed segmentation fault in `f32` binary primitive with broadcast on x64 processors (2082e9879e7db168ca4eb93a8d2dfe823b79d0c0)
* Fixed correctness issue in `f64` convolution weight gradient with bias on Intel Arc GPUs (a00bfabdd89afff020de91c8f68e3366b64135f4)
* Updated `spdlog` component to version 1.15.3 (dbb362929a7aa5769b58855a857da34db336148e)
* Fixed potential undefined behavior in convolution on Intel GPUs (5ac3e31d61fb0184a12f97221d55cb707b406952)
* Fixed segmentation fault in convolution implementation with trivial filter on Intel CPUs (908c5fcb5579fd133931311c18fd28ceca7adc75, f0a0eee94ed0a600c859f37d82e70792fe0d2f69)
* Fixed segmentation fault in `f16` convolution with odd dimensions on processors with Intel AVX10.1 instruction set support (78d683508d1ac89e60e24c0681f7658a4a1d2558)
* Improved convolution primitive descriptor creation time on x64 processors (e9c5366361c9c9db55cdeba4108b5151c5ab2836, fd9dc580d0af14763d06088a567e70c4ca6d4c25, f1d038e9e2292c6cc5e4f93f5fd59a410e23e368)
* Fixed performance regression in `f16` matmul with `int4` weights on Intel Arc Graphics B-series (38d761b1c630a117078ebdd3952b97736f33fe61)
* Improved `bf16` matmul performance on processors with Intel AMX instruction set support (0887aec3af524cd8d8b0518544253019118744ca)
* Fixed correctness issue in `f32` RNN primitive on processors with Intel AMX instruction set support (460a014c9400d8d43f78e466594b5306b4313a8f)
