### PR TITLE
xe: jit: gemm: remove Xe2/3 block 2D manual masking

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/register_layout.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/register_layout.cpp
@@ -714,16 +714,6 @@ RegisterBlock::RegisterBlock(HW hw_, Type T, int r, int c, const MatrixAddressin
                 byteGlue = true;
                 crosspack /= T.perByte();
             }
-
-            // Xe2: manually mask in the height dimension to work around slow LSC
-            //      out-of-bounds checks.
-            bool remainderH = memCM ? remainderC : remainderR;
-            if (hw >= HW::Xe2 && remainderH) {
-                auto &vymask = memCM ? colMask.variable : rowMask.variable;
-                vymask.isFixed = false;
-                vymask.bitRep = vymask.maskRep = vymask.rsize = 1;
-                vymask.rshift = 0;
-            }
             break;
         }
         case AccessType::CacheLine: {


### PR DESCRIPTION
Removes a prior workaround for slow HW handling of block 2D loads that are completely out of bounds.

This seems to be triggering another HW bug on Xe3 (MFDNN-14292) and may not be necessary with current Xe2/Xe3 HW steppings.