### PR TITLE
x64: matmul: Enable f16 scales for AVX2 VNNI 2

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -140,7 +140,10 @@ void set_isa_impl(brgemm_desc_t *brg) {
     } else if (brg->is_f32) {
         brg->isa_impl = utils::map(true, isa_undef,
                 is_isa_ok(avx512_core) || is_isa_ok(avx512_core_amx) /*bf32*/,
-                avx512_core, is_isa_ok(avx2), avx2,
+                avx512_core,
+                is_isa_ok(avx2_vnni_2) /*f16 cvtph2ps scales quant*/
+                        || is_isa_ok(avx2),
+                avx2,
                 // Allow avx512_core_fp16 isa in case of a f16 primitive that
                 // is implemented using pre-conversion of inputs to f32.
                 // This is needed to support f16 binary post-ops.

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -2375,7 +2375,7 @@ protected:
                 uni_vpmovzxwd(masked_vmm, op);
                 uni_vpslld(vmm, vmm, 16);
                 break;
-            case data_type::f16: vcvtph2ps(masked_vmm, op); break;
+            case data_type::f16: vcvtph2psx(masked_vmm, op); break;
             default: assert(!"unsupported wei_scales data type");
         }
     }
@@ -4440,7 +4440,15 @@ private:
                 vpbroadcastw(masked_vmm, addr);
                 uni_vpslld(vmm_wei_scales, vmm_wei_scales, 16);
                 break;
-            case data_type::f16: vcvtph2psx(vmm_wei_scales, addr); break;
+            case data_type::f16: {
+                // AVX2 can only convert, not broadcast f16 value
+                if (conf_->isa == avx2_vnni_2) {
+                    vpbroadcastw(vmm_wei_scales, addr);
+                    vcvtph2ps(vmm_wei_scales, Xmm(vmm_wei_scales.getIdx()));
+                } else
+                    vcvtph2psx(vmm_wei_scales, addr);
+                break;
+            }
             default: assert(!"unsupported wei_scales data type");
         }
     }


### PR DESCRIPTION
# Description
Enables `f16` scales for AVX2 VNNI 2 for the case `f32:int4/int8:f32`. 
ISA supports only conversion to f32 and it's sufficient to use in matmul [weight decompression feature #3554](https://github.com/uxlfoundation/oneDNN/pull/3554). 
