### PR TITLE
xe: sdpa: disable split Q barriers on xe2

### DIFF
--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -522,7 +522,8 @@ status_t micro_t::pd_t::init_conf(impl::engine_t *engine) {
         conf.prefetch_d_max = 0;
     }
 
-    conf.q_arrive_await_barrier = (Q > 1);
+    const bool is_xe2 = pd->arch() == compute::gpu_arch_t::xe2;
+    conf.q_arrive_await_barrier = (Q > 1) && !is_xe2;
     conf.softmax_inf_as_zero
             = (d->softmax_alg == alg_kind::softmax_accurate_inf_as_zero);
     conf.use_systolic_ukernel = pd->use_systolic_ukernel();


### PR DESCRIPTION
# Description

Split barriers for loading Q to shared memory are causing rare, non-deterministic failures on LNL. This may be caused by a driver bug, nonetheless this PR reverts the split-barrier change for 3.10 until the root cause can be determined due to difficulties in consistently and promptly recreating the issue.

This is a WA for MFDNN-14228.

## General
- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?