### PR TITLE
[GPU] a non-blocking, profiler-based verbose mode for execution time tracking

### DIFF
--- a/doc/performance_considerations/verbose.md
+++ b/doc/performance_considerations/verbose.md
@@ -119,6 +119,59 @@ Please see the profiling example [here](@ref performance_profiling_cpp), as it
 uses ONEDNN_VERBOSE output to tune oneDNN code to align with
 [best practices](@ref dev_guide_inference).
 
+#### Asynchronous Verbose Mode for GPU engines
+
+When oneDNN verbose mode is enabled for primitive execution profiling, the 
+execution time for synchronous runtimes is calculated based on the wall time 
+measured before and after primitive execution. 
+For GPU runtimes, which are generally asynchronous, using synchronizing 
+methodology can lead to additional overhead due to host-to-device stream 
+synchronization on entry and on exit in the `dnnl::primitive::execute()` call.
+
+To ensure accurate tracking of timing information for GPU runtimes, the verbose 
+mode uses a non-blocking approach which prints device-measured 
+times for primitive execution instead of relying on the wall time 
+measurements. Asynchronous profiling is currently supported only for OpenCL 
+and SYCL runtimes on Intel GPUs and can be optionally disabled by using 
+`ONEDNN_VERBOSE_USE_SYNC=1` environment variable:
+
+##### Example Output (with the asynchronous mode enabled):
+~~~sh
+# DNNL_VERBOSE_USE_SYNC is 0 by default
+DNNL_VERBOSE=profile_exec ./examples/primitives-matmul-cpp gpu
+~~~
+
+~~~sh
+onednn_verbose,v1,info,oneDNN v3.13.0 (commit 0fadac14800ba792a9d991b93b4917509eada63b)
+onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
+onednn_verbose,v1,info,cpu,isa:Intel AVX10.1 and Intel AMX with bfloat16 and 8-bit integer support
+onednn_verbose,v1,info,gpu,runtime:OpenCL
+onednn_verbose,v1,info,gpu,engine,opencl device count:2 
+onednn_verbose,v1,info,gpu,engine,0,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
+onednn_verbose,v1,info,gpu,engine,1,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
+onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
+onednn_verbose,v1,primitive,exec,gpu:0,matmul,jit:gemm:any,undef,src:f32::blocked:abc::f0 wei:f32::blocked:abc::f0 bia:f32::blocked:abc::f0_mask4 dst:f32::blocked:abc::f0,attr-post-ops:eltwise_relu,,3x128x256:3x256x512,0.01904
+Example passed on GPU.
+~~~
+
+##### Example Output (with the asynchronous mode disabled):
+~~~sh
+DNNL_VERBOSE=profile_exec DNNL_VERBOSE_USE_SYNC=1 ./examples/primitives-matmul-cpp gpu
+~~~
+
+~~~sh
+onednn_verbose,v1,info,oneDNN v3.13.0 (commit 0fadac14800ba792a9d991b93b4917509eada63b)
+onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
+onednn_verbose,v1,info,cpu,isa:Intel AVX10.1 and Intel AMX with bfloat16 and 8-bit integer support
+onednn_verbose,v1,info,gpu,runtime:OpenCL
+onednn_verbose,v1,info,gpu,engine,opencl device count:2 
+onednn_verbose,v1,info,gpu,engine,0,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
+onednn_verbose,v1,info,gpu,engine,1,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
+onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
+onednn_verbose,v1,primitive,exec,gpu:0,matmul,jit:gemm:any,undef,src:f32::blocked:abc::f0 wei:f32::blocked:abc::f0 bia:f32::blocked:abc::f0_mask4 dst:f32::blocked:abc::f0,attr-post-ops:eltwise_relu,,3x128x256:3x256x512,0.473145
+Example passed on GPU.
+~~~
+
 ### Understanding why a given implementation is dispatched
 
 When performance is lower than expected, it is usually likely due to
@@ -231,12 +284,6 @@ where:
    memory is dense, the field will be empty.
 5. `extra_flags` is unspecified information that is intended for development
    purposes.
-
-@note
-When oneDNN verbose mode is enabled with GPU engines, oneDNN adds extra stream
-synchronization on entry and on exit in the dnnl::primitive::execute() call.
-The execution time is calculated based on wall time measured before and after
-primitive execution.
 
 @note
 When oneDNN verbose mode is enabled for builds with

--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -147,6 +147,7 @@ status_t primitive_execute(
 
     if (get_verbose(verbose_t::exec_profile,
                 prim_kind2_comp_kind(pd->impl()->kind()))) {
+        std::string pd_info;
         bool block_on_wait = true;
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
         dnnl::threadpool_interop::threadpool_iface *tp;
@@ -156,12 +157,7 @@ status_t primitive_execute(
                         & dnnl::threadpool_interop::threadpool_iface::
                                 ASYNCHRONOUS);
 #endif
-        if (block_on_wait) stream->wait();
-        double start_ms = get_msec();
-        status = stream->enqueue_primitive(primitive_iface, ctx);
-        if (block_on_wait) stream->wait();
 
-        double duration_ms = get_msec() - start_ms;
         if (pd->impl()->has_runtime_dims_or_strides()) {
             // Take out mds from `ctx` here to avoid primitive_desc dependency
             // on `exec_ctx_t` type.
@@ -174,14 +170,26 @@ status_t primitive_execute(
             const auto bia_md = ctx.memory_mdw(DNNL_ARG_BIAS, pd_bia_md).md_;
             const auto pd_dst_md = pd->impl()->invariant_dst_md();
             const auto dst_md = ctx.memory_mdw(DNNL_ARG_DST, pd_dst_md).md_;
-
-            std::string info = pd->info_with_runtime_dims(
+            pd_info = pd->info_with_runtime_dims(
                     src_md, wei_md, bia_md, dst_md);
-            VPROF(start_ms, primitive, exec, VERBOSE_profile, info.c_str(),
+        } else {
+            pd_info = primitive_iface->pd()->info();
+        }
+
+        if (!stream->is_verbose_profiler_enabled()) {
+            if (block_on_wait) stream->wait();
+            double start_ms = get_msec();
+            status = stream->enqueue_primitive(primitive_iface, ctx);
+            if (block_on_wait) stream->wait();
+            double duration_ms = get_msec() - start_ms;
+            VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(),
                     duration_ms);
         } else {
-            VPROF(start_ms, primitive, exec, VERBOSE_profile, pd->info(),
-                    duration_ms);
+            // For OpenCL/SYCL GPU streams, the verbose logs print device-
+            // measured execution times in a non-blocking manner.
+            double start_ms = get_msec();
+            status = stream->enqueue_primitive(primitive_iface, ctx);
+            CHECK(stream->run_verbose_profiler(pd_info, start_ms));
         }
     } else {
         status = stream->enqueue_primitive(primitive_iface, ctx);

--- a/src/common/stream.cpp
+++ b/src/common/stream.cpp
@@ -49,7 +49,21 @@ status_t dnnl_stream_create(
         return status::unimplemented;
     }
 
-    return engine->create_stream(stream, flags);
+    // Enables profiling capabilities to allow the verbose mode to print
+    // profiling info using device measured times.
+    // The verbose profiler state is fixed at stream initialization and does not
+    // respond to runtime changes made via set_dnnl_verbose().
+    // TODO: allow runtime control of the asynchronous verbose mode via
+    // set_dnnl_verbose()
+    const bool enable_verbose_profiler = engine->kind() == engine_kind::gpu
+            && get_verbose(verbose_t::exec_profile) && !get_verbose_sync_mode();
+
+    if (enable_verbose_profiler) { flags |= stream_flags::profiling; }
+
+    CHECK(engine->create_stream(stream, flags));
+    CHECK((*stream)->init_verbose_profiler(enable_verbose_profiler));
+
+    return status::success;
 }
 
 status_t dnnl_stream_get_engine(const stream_t *stream, engine_t **engine) {

--- a/src/common/stream.hpp
+++ b/src/common/stream.hpp
@@ -54,6 +54,10 @@ struct dnnl_stream : public dnnl::impl::c_compatible {
     virtual dnnl::impl::status_t reset_profiling() {
         if (!is_profiling_enabled())
             return dnnl::impl::status::invalid_arguments;
+        if (is_verbose_profiler_enabled())
+            VWARN(common, stream,
+                    "resetting profiler during DNNL_VERBOSE=profile_exec can "
+                    "can cause incorrect timing logs.");
         return dnnl::impl::status::unimplemented;
     }
 
@@ -73,6 +77,21 @@ struct dnnl_stream : public dnnl::impl::c_compatible {
 
     bool is_profiling_enabled() const { return impl_->is_profiling_enabled(); }
 
+    dnnl::impl::status_t init_verbose_profiler(bool enable_profiler) {
+        use_verbose_profiler_ = enable_profiler
+                && impl_->supports_verbose_profiling(engine_->kind());
+        return dnnl::impl::status::success;
+    }
+
+    bool is_verbose_profiler_enabled() const { return use_verbose_profiler_; }
+
+    virtual dnnl::impl::status_t run_verbose_profiler(
+            std::string &pd_info, double start_ms) const {
+        if (!is_verbose_profiler_enabled())
+            return dnnl::impl::status::invalid_arguments;
+        return dnnl::impl::status::unimplemented;
+    }
+
     virtual dnnl::impl::status_t zero_pad(const dnnl::impl::memory_t *memory,
             const dnnl::impl::exec_ctx_t &ctx);
 
@@ -91,6 +110,7 @@ struct dnnl_stream : public dnnl::impl::c_compatible {
 protected:
     dnnl::impl::engine_t *engine_;
     std::unique_ptr<dnnl::impl::stream_impl_t> impl_;
+    bool use_verbose_profiler_;
 };
 
 #endif

--- a/src/common/stream.hpp
+++ b/src/common/stream.hpp
@@ -28,7 +28,7 @@
 
 struct dnnl_stream : public dnnl::impl::c_compatible {
     dnnl_stream(dnnl::impl::engine_t *engine, dnnl::impl::stream_impl_t *impl)
-        : engine_(engine), impl_(impl) {}
+        : engine_(engine), impl_(impl), use_verbose_profiler_(false) {}
     virtual ~dnnl_stream() = default;
 
     /** returns stream's engine */
@@ -57,7 +57,7 @@ struct dnnl_stream : public dnnl::impl::c_compatible {
         if (is_verbose_profiler_enabled())
             VWARN(common, stream,
                     "resetting profiler during DNNL_VERBOSE=profile_exec can "
-                    "can cause incorrect timing logs.");
+                    "cause incorrect timing logs.");
         return dnnl::impl::status::unimplemented;
     }
 

--- a/src/common/stream_impl.hpp
+++ b/src/common/stream_impl.hpp
@@ -42,6 +42,10 @@ public:
         return (flags() & dnnl::impl::stream_flags::profiling);
     }
 
+    virtual bool supports_verbose_profiling(engine_kind_t) const {
+        return false;
+    }
+
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     status_t get_threadpool(
             threadpool_interop::threadpool_iface **threadpool) const {

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -313,6 +313,21 @@ bool get_verbose_timestamp() {
     return verbose_timestamp.get();
 }
 
+static setting_t<bool> verbose_sync_mode {false};
+bool get_verbose_sync_mode() {
+#if defined(DISABLE_VERBOSE)
+    return false;
+#endif
+    if (verbose.get() == 0) return false;
+
+    if (!verbose_sync_mode.initialized()) {
+        static bool val
+                = getenv_int_user("VERBOSE_USE_SYNC", verbose_sync_mode.get());
+        verbose_sync_mode.set(val);
+    }
+    return verbose_sync_mode.get();
+}
+
 std::ostream &operator<<(std::ostream &ss, engine_kind_t eng_kind) {
     ss << dnnl_engine_kind2str(eng_kind);
     return ss;

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -272,6 +272,9 @@ static inline uint32_t get_verbose_dev_mode(
 }
 
 bool get_verbose_timestamp();
+// determines if the asynchronous profiling mode for verbose logging
+// has been disabled at runtime
+bool get_verbose_sync_mode();
 
 // logging functionality for saving verbose outputs to logfiles
 #ifdef DNNL_EXPERIMENTAL_LOGGING

--- a/src/gpu/intel/ocl/kernel.cpp
+++ b/src/gpu/intel/ocl/kernel.cpp
@@ -233,6 +233,13 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
     }
 
     if (stream.is_profiling_enabled()) {
+        // updates the execution dependency for the primitive operation.
+        // The verbose profiler relies on ctx deps to compute primitive
+        // duration.
+        if (stream.is_verbose_profiler_enabled()) {
+            xpu::ocl::event_t::from(out_dep).events = {event};
+        }
+
         ocl_stream->profiler().register_event(
                 utils::make_unique<xpu::ocl::event_t>(std::move(event)));
     }

--- a/src/gpu/intel/ocl/stream.cpp
+++ b/src/gpu/intel/ocl/stream.cpp
@@ -120,6 +120,87 @@ void stream_t::after_exec_hook() {
     if (is_profiling_enabled()) profiler_->stop_profiling();
 }
 
+status_t stream_t::run_verbose_profiler(
+        std::string &pd_info, double start_ms) const {
+
+    // utilize the verbose profiler only for profile_exec verbose levels.
+    if (!is_verbose_profiler_enabled()) return status::invalid_arguments;
+
+    // failsafe for primitive executions without any enqueued kernels
+    auto &deps = xpu::ocl::event_t::from(ctx().get_deps());
+    if (deps.size() < 1) {
+        double duration_ms = get_msec() - start_ms;
+        VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(),
+                duration_ms);
+        return status::success;
+    }
+
+    // captured output event acts as the anchor to track primitive execution
+    // print profiling info asynchronously
+    cl_event out_evt = deps[0].get();
+
+    if (!profiler_->stamp()) {
+        VWARN(primitive, exec,
+                "%s, profiler error: failed to record events in context",
+                pd_info.c_str());
+        VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(), 0.f);
+        return status::success;
+    }
+
+    auto *ocl_profiler
+            = utils::downcast<xpu::ocl::stream_profiler_t *>(profiler_.get());
+
+    // The verbose callback uses a snapshot of queued primitive events
+    // to compute execution timing in a thread-safe manner.
+    std::vector<cl_event> evt_snap;
+    CHECK(ocl_profiler->extract_primitive_events(evt_snap));
+
+    struct payload_t {
+        double start;
+        xpu::ocl::stream_profiler_t *prof;
+        std::string info_str;
+        std::vector<cl_event> evt_snap;
+    };
+
+    std::unique_ptr<payload_t> payload(new payload_t());
+    payload->prof = ocl_profiler;
+    payload->info_str = pd_info;
+    payload->start = start_ms;
+    payload->evt_snap = std::move(evt_snap);
+
+    // The prompt ensures the verbose headers are printed if they aren't
+    // already. Printing the headers asynchronously during the callback can
+    // result in access failures when printing engine-specific info.
+    verbose_printf(verbose_t::exec_profile, "\r");
+
+    cl_int err = xpu::ocl::clSetEventCallback(
+            out_evt, CL_COMPLETE, [](cl_event ev, cl_int, void *user) {
+        std::unique_ptr<payload_t> hold(static_cast<payload_t *>(user));
+        double duration_ms = 0.0;
+
+        if (hold->prof) {
+            hold->prof->get_aggregate_exec_timing(duration_ms, hold->evt_snap);
+        } else {
+            VWARN(primitive, exec, "%s, profiler error: profiler absent",
+                    hold->info_str.c_str());
+        }
+        VPROF(hold->start, primitive, exec, VERBOSE_profile,
+                hold->info_str.c_str(), duration_ms);
+    }, payload.get());
+
+    if (err != CL_SUCCESS) {
+        VWARN(primitive, exec,
+                "%s, profiler error: failed to set event callback",
+                pd_info.c_str());
+        VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(), 0.f);
+        return status::success;
+    }
+
+    (void)payload.release();
+
+    return status::success;
+}
+
 status_t stream_t::copy(const memory_storage_t &src,
         const memory_storage_t &dst, size_t size, const xpu::event_t &deps,
         xpu::event_t &out_dep) {

--- a/src/gpu/intel/ocl/stream.cpp
+++ b/src/gpu/intel/ocl/stream.cpp
@@ -173,6 +173,8 @@ status_t stream_t::run_verbose_profiler(
     // result in access failures when printing engine-specific info.
     verbose_printf(verbose_t::exec_profile, "\r");
 
+    ocl_profiler->start_async_callback_tracking();
+
     cl_int err = xpu::ocl::clSetEventCallback(
             out_evt, CL_COMPLETE, [](cl_event ev, cl_int, void *user) {
         std::unique_ptr<payload_t> hold(static_cast<payload_t *>(user));
@@ -186,9 +188,12 @@ status_t stream_t::run_verbose_profiler(
         }
         VPROF(hold->start, primitive, exec, VERBOSE_profile,
                 hold->info_str.c_str(), duration_ms);
+
+        if (hold->prof) { hold->prof->end_async_callback_tracking(); }
     }, payload.get());
 
     if (err != CL_SUCCESS) {
+        ocl_profiler->end_async_callback_tracking();
         VWARN(primitive, exec,
                 "%s, profiler error: failed to set event callback",
                 pd_info.c_str());

--- a/src/gpu/intel/ocl/stream.hpp
+++ b/src/gpu/intel/ocl/stream.hpp
@@ -76,6 +76,9 @@ struct stream_t : public intel::stream_t {
         return profiler_->get_info(data_kind, num_entries, data);
     }
 
+    status_t run_verbose_profiler(
+            std::string &pd_info, double start_ms) const override;
+
     cl_command_queue queue() const { return impl()->queue(); }
 
     const mdapi_helper_t &mdapi_helper() const { return *mdapi_helper_; }

--- a/src/gpu/intel/ocl/stream.hpp
+++ b/src/gpu/intel/ocl/stream.hpp
@@ -92,7 +92,13 @@ struct stream_t : public intel::stream_t {
 
     status_t barrier() override;
 
-    ~stream_t() override = default;
+    ~stream_t() override {
+        if (!is_verbose_profiler_enabled()) return;
+        if (!profiler_) return;
+        // In the asynchronous profiling mode, this retains the profiler
+        // and event lifetimes till all the profiling info is logged.
+        profiler_->wait_for_async_profiling_completion();
+    }
 
     const xpu::ocl::context_t &ocl_ctx() const { return impl()->ocl_ctx(); }
     xpu::ocl::context_t &ocl_ctx() { return impl()->ocl_ctx(); }

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -96,6 +96,106 @@ void stream_t::after_exec_hook() {
     if (is_profiling_enabled()) profiler_->stop_profiling();
 }
 
+status_t stream_t::run_verbose_profiler(
+        std::string &pd_info, double start_ms) const {
+
+    // utilize the verbose profiler only for profile_exec verbose levels.
+    if (!is_verbose_profiler_enabled()) return status::invalid_arguments;
+
+    // failsafe for primitive executions without any enqueued kernels
+    auto &deps = xpu::sycl::event_t::from(ctx().get_deps());
+    if (deps.size() < 1) {
+        double duration_ms = get_msec() - start_ms;
+        VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(),
+                duration_ms);
+        return status::success;
+    }
+
+    // captured output event acts as the anchor to track primitive execution
+    // print profiling info asynchronously
+    ::sycl::event out_evt = deps[0];
+
+    if (!profiler_->stamp()) {
+        VWARN(primitive, exec,
+                "%s, profiling error: failed to record primitive events in "
+                "context",
+                pd_info.c_str());
+        VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(), 0.f);
+        return status::success;
+    }
+
+    auto *sycl_profiler
+            = utils::downcast<xpu::sycl::stream_profiler_t *>(profiler_.get());
+
+    // The verbose callback uses a snapshot of queued primitive events
+    // to compute execution timing in a thread-safe manner.
+    std::vector<::sycl::event> evt_snap;
+    CHECK(sycl_profiler->extract_primitive_events(evt_snap));
+
+    struct payload_t {
+        double start;
+        std::string info_str;
+        xpu::sycl::stream_profiler_t *prof;
+        std::vector<::sycl::event> evt_snap;
+    };
+
+    std::unique_ptr<payload_t> payload(new payload_t());
+    payload->prof = sycl_profiler;
+    payload->info_str = pd_info;
+    payload->start = start_ms;
+    payload->evt_snap = std::move(evt_snap);
+
+    // The prompt ensures the verbose headers are printed if they aren't
+    // already. Printing the headers asynchronously during the callback can
+    // result in access failures when printing engine-specific info.
+    verbose_printf(verbose_t::exec_profile, "\r");
+
+    sycl_profiler->start_async_callback_tracking();
+
+    try {
+        ::sycl::queue q = queue();
+        payload_t *user = payload.get();
+
+        q.submit([&](::sycl::handler &cgh) {
+            cgh.depends_on(out_evt);
+            cgh.host_task([user]() {
+                std::unique_ptr<payload_t> hold(user);
+
+                double duration_ms = 0.0;
+
+                if (hold->prof) {
+                    // aggregate execution times are calculated from the start and end times
+                    // of the first and last queued events for the primitive respectively
+                    hold->prof->get_aggregate_exec_timing(
+                            duration_ms, hold->evt_snap);
+                } else {
+                    VWARN(primitive, exec,
+                            "%s, profiling error: profiler absent",
+                            hold->info_str.c_str());
+                }
+
+                VPROF(hold->start, primitive, exec, VERBOSE_profile,
+                        hold->info_str.c_str(), duration_ms);
+
+                if (hold->prof) { hold->prof->end_async_callback_tracking(); }
+            });
+        });
+
+        (void)payload.release();
+
+    } catch (...) {
+        sycl_profiler->end_async_callback_tracking();
+        VWARN(primitive, exec,
+                "%s, profiling error: failed to submit host_task for async "
+                "verbose logging",
+                pd_info.c_str());
+        VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(), 0.f);
+        return status::success;
+    }
+
+    return status::success;
+}
+
 // The following code needs sycl::queue::ext_oneapi_get_graph(), but it may
 //  not be defined. Some SFINAE is needed to avoid compile errors in this case.
 namespace syclex = ::sycl::ext::oneapi::experimental;

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -76,6 +76,9 @@ struct stream_t : public gpu::intel::stream_t {
         return profiler_->get_info(data_kind, num_entries, data);
     }
 
+    status_t run_verbose_profiler(
+            std::string &pd_info, double start_ms) const override;
+
     ::sycl::queue &queue() const { return *impl()->queue(); }
 
     status_t enqueue_primitive(const primitive_iface_t *prim_iface,
@@ -96,6 +99,14 @@ struct stream_t : public gpu::intel::stream_t {
     }
 
     status_t barrier() override { return impl()->barrier(); }
+
+    ~stream_t() override {
+        if (!is_verbose_profiler_enabled()) return;
+        if (!profiler_) return;
+        // In the asynchronous profiling mode, this retains the profiler
+        // and event lifetimes till all the profiling info is logged.
+        profiler_->wait_for_async_profiling_completion();
+    }
 
     const xpu::sycl::context_t &sycl_ctx() const { return impl()->sycl_ctx(); }
     xpu::sycl::context_t &sycl_ctx() { return impl()->sycl_ctx(); }

--- a/src/xpu/ocl/capi/stream.cpp
+++ b/src/xpu/ocl/capi/stream.cpp
@@ -39,6 +39,17 @@ status_t dnnl_ocl_interop_stream_create(
     unsigned flags;
     CHECK(dnnl::impl::xpu::ocl::stream_impl_t::init_flags(&flags, queue));
 
+    // Enables profiling capabilities to allow the verbose mode to print
+    // profiling info using device measured times.
+    // The verbose profiler state is fixed at stream initialization and does not
+    // respond to runtime changes made via set_dnnl_verbose().
+    // TODO: allow runtime control of the asynchronous verbose mode via
+    // set_dnnl_verbose()
+    const bool enable_verbose_profiler = engine->kind() == engine_kind::gpu
+            && get_verbose(verbose_t::exec_profile) && !get_verbose_sync_mode();
+
+    if (enable_verbose_profiler) { flags |= stream_flags::profiling; }
+
     std::unique_ptr<dnnl::impl::stream_impl_t> stream_impl(
             new dnnl::impl::xpu::ocl::stream_impl_t(queue, flags));
     if (!stream_impl) return status::out_of_memory;
@@ -47,6 +58,9 @@ status_t dnnl_ocl_interop_stream_create(
     // stream (`s`) takes ownership of `stream_impl` if `create_stream` call
     // is successful.
     stream_impl.release();
+
+    CHECK((*stream)->init_verbose_profiler(enable_verbose_profiler));
+
     return status::success;
 }
 

--- a/src/xpu/ocl/stream_impl.cpp
+++ b/src/xpu/ocl/stream_impl.cpp
@@ -178,6 +178,13 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
     }
 
     if (is_profiling_enabled()) {
+        // updates the execution dependency for the copy operation.
+        // The verbose profiler relies on ctx deps to compute primitive
+        // duration.
+        if (stream->is_verbose_profiler_enabled()) {
+            xpu::ocl::event_t::from(out_dep).events = {out_event};
+        }
+
         auto ocl_event = utils::make_unique<xpu::ocl::event_t>(
                 std::vector<xpu::ocl::wrapper_t<cl_event>> {out_event});
         stream_profiler->register_event(std::move(ocl_event));
@@ -229,6 +236,13 @@ status_t stream_impl_t::fill(impl::stream_t *stream,
     }
 
     if (is_profiling_enabled()) {
+        // updates the execution dependency for the copy operation.
+        // The verbose profiler relies on ctx deps to compute primitive
+        // duration.
+        if (stream->is_verbose_profiler_enabled()) {
+            xpu::ocl::event_t::from(out_dep).events = {out_event};
+        }
+
         auto ocl_event = utils::make_unique<xpu::ocl::event_t>(
                 std::vector<xpu::ocl::wrapper_t<cl_event>> {out_event});
         stream_profiler->register_event(std::move(ocl_event));

--- a/src/xpu/ocl/stream_impl.hpp
+++ b/src/xpu/ocl/stream_impl.hpp
@@ -69,6 +69,14 @@ public:
 
     status_t barrier();
 
+    bool supports_verbose_profiling(engine_kind_t eng) const override {
+        // verbose profiling support is only for in-order OpenCL queues
+        if (eng != engine_kind::gpu) return false;
+        if (!is_profiling_enabled()) return false;
+        if (flags() & stream_flags::out_of_order) return false;
+        return true;
+    }
+
     const xpu::ocl::context_t &ocl_ctx() const;
     xpu::ocl::context_t &ocl_ctx();
     xpu::context_t &ctx();

--- a/src/xpu/ocl/stream_profiler.cpp
+++ b/src/xpu/ocl/stream_profiler.cpp
@@ -75,6 +75,50 @@ status_t stream_profiler_t::get_info(profiling_data_kind_t data_kind,
     return xpu::stream_profiler_t::get_info_impl(stamp2entry, data_kind, data);
 }
 
+status_t stream_profiler_t::get_aggregate_exec_timing(
+        double &duration_ms, std::vector<cl_event> &evt_snap) const {
+    duration_ms = 0.0;
+    if (evt_snap.empty()) return status::success;
+    cl_ulong agg_start = 0;
+    cl_ulong agg_end = 0;
+
+    // computation of execution timings is self-contained because of the event
+    // snapshot and immune to concurrent updates to profiler event list
+    for (auto ev : evt_snap) {
+        cl_ulong evbeg, evend;
+        OCL_CHECK(xpu::ocl::clGetEventProfilingInfo(ev,
+                CL_PROFILING_COMMAND_START, sizeof(evbeg), &evbeg, nullptr));
+        OCL_CHECK(xpu::ocl::clGetEventProfilingInfo(
+                ev, CL_PROFILING_COMMAND_END, sizeof(evend), &evend, nullptr));
+        agg_start = agg_start == 0 ? evbeg : std::min(agg_start, evbeg);
+        agg_end = std::max(agg_end, evend);
+    }
+    duration_ms = static_cast<double>(agg_end - agg_start) * 1e-6;
+
+    return status::success;
+}
+
+status_t stream_profiler_t::extract_primitive_events(
+        std::vector<cl_event> &evt_snap) {
+    evt_snap.clear();
+
+    // During the course of primitive execution, the current stamp marks the
+    // events enqueued for the current primitive.
+    for (auto it = events_.rbegin(); it != events_.rend(); ++it) {
+        if (it->stamp < stamp_) break;
+        if (it->stamp == stamp_) {
+            const auto &ocl_event = xpu::ocl::event_t::from(*it->event);
+            if (ocl_event.size() > 0) {
+                evt_snap.push_back(ocl_event[0].get());
+            }
+        }
+    }
+
+    std::reverse(evt_snap.begin(), evt_snap.end());
+
+    return status::success;
+}
+
 } // namespace ocl
 } // namespace xpu
 } // namespace impl

--- a/src/xpu/ocl/stream_profiler.cpp
+++ b/src/xpu/ocl/stream_profiler.cpp
@@ -79,7 +79,7 @@ status_t stream_profiler_t::get_aggregate_exec_timing(
         double &duration_ms, std::vector<cl_event> &evt_snap) const {
     duration_ms = 0.0;
     if (evt_snap.empty()) return status::success;
-    cl_ulong agg_start = 0;
+    cl_ulong agg_start = UINT64_MAX;
     cl_ulong agg_end = 0;
 
     // computation of execution timings is self-contained because of the event
@@ -90,7 +90,7 @@ status_t stream_profiler_t::get_aggregate_exec_timing(
                 CL_PROFILING_COMMAND_START, sizeof(evbeg), &evbeg, nullptr));
         OCL_CHECK(xpu::ocl::clGetEventProfilingInfo(
                 ev, CL_PROFILING_COMMAND_END, sizeof(evend), &evend, nullptr));
-        agg_start = agg_start == 0 ? evbeg : std::min(agg_start, evbeg);
+        agg_start = std::min(agg_start, evbeg);
         agg_end = std::max(agg_end, evend);
     }
     duration_ms = static_cast<double>(agg_end - agg_start) * 1e-6;
@@ -101,6 +101,7 @@ status_t stream_profiler_t::get_aggregate_exec_timing(
 status_t stream_profiler_t::extract_primitive_events(
         std::vector<cl_event> &evt_snap) {
     evt_snap.clear();
+    std::lock_guard<std::recursive_mutex> lock(m_);
 
     // During the course of primitive execution, the current stamp marks the
     // events enqueued for the current primitive.

--- a/src/xpu/ocl/stream_profiler.hpp
+++ b/src/xpu/ocl/stream_profiler.hpp
@@ -32,6 +32,11 @@ struct stream_profiler_t : public xpu::stream_profiler_t {
 
     status_t get_info(profiling_data_kind_t data_kind, int *num_entries,
             uint64_t *data) const override;
+
+    status_t get_aggregate_exec_timing(
+            double &duration_ms, std::vector<cl_event> &evt_snap) const;
+
+    status_t extract_primitive_events(std::vector<cl_event> &evt_snap);
 };
 
 } // namespace ocl

--- a/src/xpu/ocl/utils.hpp
+++ b/src/xpu/ocl/utils.hpp
@@ -159,6 +159,7 @@ INDIRECT_OCL_CALL(cl_int, clRetainKernel)
 INDIRECT_OCL_CALL(cl_int, clRetainMemObject)
 INDIRECT_OCL_CALL(cl_int, clRetainProgram)
 INDIRECT_OCL_CALL(cl_int, clRetainSampler)
+INDIRECT_OCL_CALL(cl_int, clSetEventCallback)
 INDIRECT_OCL_CALL(cl_int, clSetKernelArg)
 INDIRECT_OCL_CALL(cl_int, clWaitForEvents)
 #ifdef CL_VERSION_2_0

--- a/src/xpu/stream_profiler.hpp
+++ b/src/xpu/stream_profiler.hpp
@@ -22,6 +22,7 @@
 #include <map>
 #include <mutex>
 #include <vector>
+#include <condition_variable>
 
 #include "common/c_types_map.hpp"
 
@@ -91,6 +92,21 @@ struct stream_profiler_t {
         return status::success;
     }
 
+    void start_async_callback_tracking() {
+        std::lock_guard<std::recursive_mutex> lk(m_);
+        ++pending_callbacks_;
+    }
+
+    void end_async_callback_tracking() {
+        std::lock_guard<std::recursive_mutex> lk(m_);
+        if (--pending_callbacks_ == 0) { callback_cv_.notify_all(); }
+    }
+
+    virtual void wait_for_async_profiling_completion() {
+        std::unique_lock<std::recursive_mutex> lk(m_);
+        callback_cv_.wait(lk, [this] { return pending_callbacks_ == 0; });
+    }
+
 protected:
     status_t get_info_impl(const std::map<uint64_t, entry_t> &stamp2entry,
             profiling_data_kind_t data_kind, uint64_t *data) const {
@@ -118,6 +134,9 @@ protected:
     uint64_t stamp_;
     const stream_t *stream_;
     void (*callback_)(uint64_t, uint64_t) = nullptr;
+
+    std::condition_variable_any callback_cv_;
+    size_t pending_callbacks_ = 0;
 };
 
 } // namespace xpu

--- a/src/xpu/sycl/capi/capi_stream.cpp
+++ b/src/xpu/sycl/capi/capi_stream.cpp
@@ -41,6 +41,16 @@ status_t dnnl_sycl_interop_stream_create(
     unsigned flags;
     CHECK(dnnl::impl::xpu::sycl::stream_impl_t::init_flags(&flags, sycl_queue));
 
+    // Enables profiling capabilities to allow the verbose mode to print
+    // profiling info using device measured times.
+    // The verbose profiler state is fixed at stream initialization and does not
+    // respond to runtime changes made via set_dnnl_verbose().
+    // TODO: allow runtime control of the asynchronous verbose mode via
+    // set_dnnl_verbose()
+    const bool enable_verbose_profiler = engine->kind() == engine_kind::gpu
+            && get_verbose(verbose_t::exec_profile) && !get_verbose_sync_mode();
+    if (enable_verbose_profiler) { flags |= stream_flags::profiling; }
+
     std::unique_ptr<dnnl::impl::stream_impl_t> stream_impl(
             new dnnl::impl::xpu::sycl::stream_impl_t(sycl_queue, flags));
     if (!stream_impl) return status::out_of_memory;
@@ -50,6 +60,9 @@ status_t dnnl_sycl_interop_stream_create(
     // free of the same object, `stream_impl` releases it and delegates freeing
     // part to the stream.
     stream_impl.release();
+
+    CHECK((*stream)->init_verbose_profiler(enable_verbose_profiler));
+
     return status::success;
 }
 

--- a/src/xpu/sycl/stream_impl.hpp
+++ b/src/xpu/sycl/stream_impl.hpp
@@ -75,6 +75,18 @@ public:
 
     void register_deps(::sycl::handler &cgh) const;
 
+    bool supports_verbose_profiling(engine_kind_t eng) const override {
+        // verbose profiling support is only for in-order queues and Intel GPU runtimes
+        if (eng != engine_kind::gpu) return false;
+        if (!is_profiling_enabled()) return false;
+        if (flags() & stream_flags::out_of_order) return false;
+        const auto backend = queue_->get_backend();
+        if (!utils::one_of(backend, ::sycl::backend::ext_oneapi_level_zero,
+                    ::sycl::backend::opencl))
+            return false;
+        return true;
+    }
+
     static status_t init_flags(unsigned *flags, ::sycl::queue &queue) {
         *flags = queue.is_in_order() ? stream_flags::in_order
                                      : stream_flags::out_of_order;

--- a/src/xpu/sycl/stream_profiler.cpp
+++ b/src/xpu/sycl/stream_profiler.cpp
@@ -75,14 +75,14 @@ status_t stream_profiler_t::get_aggregate_exec_timing(
     using namespace ::sycl::info;
     duration_ms = 0.0;
     if (evt_snap.empty()) return status::success;
-    uint64_t agg_start = 0;
+    uint64_t agg_start = UINT64_MAX;
     uint64_t agg_end = 0;
 
     for (const auto &ev : evt_snap) {
         auto evbeg = ev.get_profiling_info<event_profiling::command_start>();
         auto evend = ev.get_profiling_info<event_profiling::command_end>();
 
-        agg_start = agg_start == 0 ? evbeg : std::min(agg_start, evbeg);
+        agg_start = std::min(agg_start, evbeg);
         agg_end = std::max(agg_end, evend);
     }
 
@@ -94,6 +94,8 @@ status_t stream_profiler_t::get_aggregate_exec_timing(
 status_t stream_profiler_t::extract_primitive_events(
         std::vector<::sycl::event> &evt_snap) {
     evt_snap.clear();
+
+    std::lock_guard<std::recursive_mutex> lock(m_);
 
     // During the course of primitive execution, the current stamp marks the
     // events enqueued for the current primitive.

--- a/src/xpu/sycl/stream_profiler.cpp
+++ b/src/xpu/sycl/stream_profiler.cpp
@@ -70,6 +70,50 @@ status_t stream_profiler_t::get_info(profiling_data_kind_t data_kind,
     return xpu::stream_profiler_t::get_info_impl(stamp2entry, data_kind, data);
 }
 
+status_t stream_profiler_t::get_aggregate_exec_timing(
+        double &duration_ms, std::vector<::sycl::event> &evt_snap) const {
+    using namespace ::sycl::info;
+    duration_ms = 0.0;
+    if (evt_snap.empty()) return status::success;
+    uint64_t agg_start = 0;
+    uint64_t agg_end = 0;
+
+    for (const auto &ev : evt_snap) {
+        auto evbeg = ev.get_profiling_info<event_profiling::command_start>();
+        auto evend = ev.get_profiling_info<event_profiling::command_end>();
+
+        agg_start = agg_start == 0 ? evbeg : std::min(agg_start, evbeg);
+        agg_end = std::max(agg_end, evend);
+    }
+
+    duration_ms = static_cast<double>(agg_end - agg_start) * 1e-6;
+
+    return status::success;
+}
+
+status_t stream_profiler_t::extract_primitive_events(
+        std::vector<::sycl::event> &evt_snap) {
+    evt_snap.clear();
+
+    // During the course of primitive execution, the current stamp marks the
+    // events enqueued for the current primitive.
+    for (auto it = events_.rbegin(); it != events_.rend(); ++it) {
+        if (it->stamp < stamp_) break;
+        if (it->stamp == stamp_) {
+            const auto *sycl_event
+                    = utils::downcast<const xpu::sycl::event_t *>(
+                            it->event.get());
+            if (sycl_event && sycl_event->size() > 0) {
+                evt_snap.push_back((*sycl_event)[0]);
+            }
+        }
+    }
+
+    std::reverse(evt_snap.begin(), evt_snap.end());
+
+    return status::success;
+}
+
 } // namespace sycl
 } // namespace xpu
 } // namespace impl

--- a/src/xpu/sycl/stream_profiler.hpp
+++ b/src/xpu/sycl/stream_profiler.hpp
@@ -20,6 +20,7 @@
 #include "common/c_types_map.hpp"
 
 #include "xpu/stream_profiler.hpp"
+#include "xpu/sycl/utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -32,6 +33,11 @@ struct stream_profiler_t : public xpu::stream_profiler_t {
 
     status_t get_info(profiling_data_kind_t data_kind, int *num_entries,
             uint64_t *data) const override;
+
+    status_t get_aggregate_exec_timing(
+            double &duration_ms, std::vector<::sycl::event> &evt_snap) const;
+
+    status_t extract_primitive_events(std::vector<::sycl::event> &evt_snap);
 };
 
 } // namespace sycl


### PR DESCRIPTION
# Description

The PR implements a non-blocking verbose profiling to record and print primitive execution times without relying on blocking, host-side `stream.wait()` calls. The implementation is aimed at triaging two issues associated with the previous blocked approach and highlighted in MFDNN-12088: 
(i) timing inaccuracies arising from host-to-device synchronization overheads and 
(ii) performance discrepancies related to blocking `stream.wait()` calls.

Following the discussions in the RFC (PR #3393) and the PoC implementation (PR #3055), the PR implements the non-blocking verbose by leveraging the [`stream_profiler`](https://github.com/uxlfoundation/oneDNN/blob/e69577c6336a815feb351a6da0604bc56cbd07cc/src/xpu/stream_profiler.hpp#L34) functionality to obtain device measured times for primitive execution and using asynchronous callback to print profiling info in a non-blocking manner. The implementation proposes the following changes to the verbose profiling:
- enable stream profiling capabilities when `DNNL_VERBOSE=profile_exec` for GPU streams.
- calculate primitive execution times by aggregating the timing data obtained from the stream profiler at the end of primtive execution.
- use asynchronous callbacks to print verbose profiling info upon output event completion.
 
Addresses MFDNN-12088.

### Considerations
- The non-blocking verbose mode is enabled for OpenCL and SYCL GPU streams only, defaulting to a blocked implementation for CPU streams and other runtimes.
- The non-blocking verbose mode is not supported for out-of-order queues and falls back to the blocked mode for such cases.
- The asynchronous mode can be user-disabled using `DNNL_DISABLE_ASYNC_VERBOSE` to default to a blocking implementation for all cases.

### Summary of Changes:
 - commit ([0af87f0](https://github.com/uxlfoundation/oneDNN/pull/4187/changes/0af87f0ac17247695e5eddbf6f2b460313ced9a5) ... [a780588](https://github.com/uxlfoundation/oneDNN/pull/4187/changes/a780588e4eacb50d9a431bbcd1964f655ba7f386)): defines API to enable asynchronous mode for supported runtimes when verbose profiling is enabled (`ONEDNN_VERBOSE=profile_exec` or `ONEDNN_VERBOSE=1`). 
Adds a runtime knob `ONEDNN_VERBOSE_USE_SYNC` to force disable the asynchronous mode during verbose logging.

 - commit ([89b0693](https://github.com/uxlfoundation/oneDNN/pull/4187/changes/89b0693eb90a58bdc2b590220108be34ad908ca5) ... [e51ee1e](https://github.com/uxlfoundation/oneDNN/pull/4187/changes/e51ee1eef62b610549e10355e5d721da44d1abdb)): Adds support for asynchronous profiling for OpenCL GPU runtimes. Defines logic for execution tracking via OpenCL event callbacks and computing device measured exec times.

 - commit ([c4b5c0d](https://github.com/uxlfoundation/oneDNN/pull/4187/changes/c4b5c0deede0d2ade0ecc1b47a7e41297340e58d) ... [7d6bd9b](https://github.com/uxlfoundation/oneDNN/pull/4187/changes/7d6bd9b0303456f6b28bbbf1d77f8796ba952e45)): Adds support for asynchronous profiling for SYCL GPU runtimes. Defines similar logic for execution tracking using `host_task`.

Thanks @echeresh for the suggested optimizations. 

#### Reproducer: 
```
DNNL_VERBOSE=profile_exec ./examples/primitives-matmul-cpp gpu
```

#### With `ONEDNN_VERBOSE_USE_SYNC=0`:
```
onednn_verbose,v1,info,oneDNN v3.13.0 (commit 0fadac14800ba792a9d991b93b4917509eada63b)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
onednn_verbose,v1,info,cpu,isa:Intel AVX10.1 and Intel AMX with bfloat16 and 8-bit integer support
onednn_verbose,v1,info,gpu,runtime:OpenCL
onednn_verbose,v1,info,gpu,engine,opencl device count:2 
onednn_verbose,v1,info,gpu,engine,0,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,1,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,primitive,exec,gpu:0,matmul,jit:gemm:any,undef,src:f32::blocked:abc::f0 wei:f32::blocked:abc::f0 bia:f32::blocked:abc::f0_mask4 dst:f32::blocked:abc::f0,attr-post-ops:eltwise_relu,,3x128x256:3x256x512,0.01904
Example passed on GPU.
```

####  With `ONEDNN_VERBOSE_USE_SYNC=1`:
```
onednn_verbose,v1,info,oneDNN v3.13.0 (commit 0fadac14800ba792a9d991b93b4917509eada63b)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
onednn_verbose,v1,info,cpu,isa:Intel AVX10.1 and Intel AMX with bfloat16 and 8-bit integer support
onednn_verbose,v1,info,gpu,runtime:OpenCL
onednn_verbose,v1,info,gpu,engine,opencl device count:2 
onednn_verbose,v1,info,gpu,engine,0,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,1,name:Intel(R) Data Center GPU Max 1100,driver_version:25.18.33578,binary_kernels:enabled
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,primitive,exec,gpu:0,matmul,jit:gemm:any,undef,src:f32::blocked:abc::f0 wei:f32::blocked:abc::f0 bia:f32::blocked:abc::f0_mask4 dst:f32::blocked:abc::f0,attr-post-ops:eltwise_relu,,3x128x256:3x256x512,0.473145
Example passed on GPU.
```

Related RFC: [[link](https://github.com/uxlfoundation/oneDNN/tree/amanerik/rfcs/async-verbose-mode/rfcs/20250527-async-verbose-mode)]
Related PoC and discussion: [[link](https://github.com/uxlfoundation/oneDNN/pull/3055)]

### RFC Checklist:
- [x] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?
