### PR TITLE
xe: sycl: l0: use SYCL query for EU count

### DIFF
--- a/src/gpu/intel/sycl/device_info.cpp
+++ b/src/gpu/intel/sycl/device_info.cpp
@@ -131,16 +131,8 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
             CHECK(gpu::intel::ocl::get_ocl_device_eu_count(
                     ocl_dev, gpu_arch_, &eu_count_));
         } else {
-            auto slices = device.get_info<
-                    xpu::sycl::compat::ext_intel_gpu_slices>();
-            auto sub_slices = device.get_info<
-                    xpu::sycl::compat::ext_intel_gpu_subslices_per_slice>();
-            auto eus_per_subslice = device.get_info<::sycl::info::device::
-                            ext_intel_gpu_eu_count_per_subslice>();
-            if (gpu_arch_ == gpu::intel::compute::gpu_arch_t::xe2)
-                eus_per_subslice
-                        = 8; /* override incorrect driver information */
-            eu_count_ = slices * sub_slices * eus_per_subslice;
+            eu_count_ = device.get_info<
+                    ::sycl::info::device::max_compute_units>();
         }
     } else {
         eu_count_ = device.get_info<::sycl::info::device::max_compute_units>();


### PR DESCRIPTION
Backport of #4190 to `rls-v3.10`.