### PR TITLE
Georgena/hybrid cache topology

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -32,6 +32,7 @@
 
 #if DNNL_X64
 #include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/platform.hpp"
 #elif DNNL_AARCH64
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #if defined(DNNL_AARCH64_USE_ACL)
@@ -269,16 +270,9 @@ unsigned get_per_core_cache_size(int level) {
             default: return 0U;
         }
     };
-
 #if DNNL_X64
-    using namespace x64;
-    if (cpu().getDataCacheLevels() == 0) return guess(level);
-
-    if (level > 0 && (unsigned)level <= cpu().getDataCacheLevels()) {
-        unsigned l = level - 1;
-        return cpu().getDataCacheSize(l) / cpu().getCoresSharingDataCache(l);
-    } else
-        return 0;
+    if (x64::cpu().getDataCacheLevels() == 0) return guess(level);
+    return x64::platform::get_per_core_cache_size(level);
 #elif DNNL_AARCH64
     const auto num_caches
             = static_cast<int>(aarch64::cpu().getLastDataCacheLevel());

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1655,13 +1655,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     // take L1 as 7/8 of the real size for L1
     brg_blocking_t::L1 = (platform::get_per_core_cache_size(1) * 7) / 8;
-    brg_blocking_t::L2 = platform::get_per_core_cache_size(2);
-    // here is hard-coded L2 size for avx2 performance cores
-    // TODO: get L2 size from the platform
-    if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2))
-        brg_blocking_t::L2 = 2 * 1024 * 1024;
     // take L2 as 3/4 of the real size for L2
-    brg_blocking_t::L2 = (brg_blocking_t::L2 * 3) / 4;
+    brg_blocking_t::L2 = (platform::get_per_core_cache_size(2) * 3) / 4;
 
     // These are rough estimates of the latency (relative) of access to various
     // cache levels. This is enough for an estimation of data access cost.

--- a/src/cpu/x64/platform.cpp
+++ b/src/cpu/x64/platform.cpp
@@ -1,0 +1,367 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include "common/verbose.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/platform.hpp"
+#include "xbyak/xbyak_util.h"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace platform {
+
+namespace {
+
+#ifndef __APPLE__
+// Global CPU topology instance, initialized on first use
+// This is thread-safe due to C++11 magic statics
+// NOTE: xbyak::util::CpuTopology is not supported on macOS.
+struct cpu_topology_cache_t {
+    Xbyak::util::CpuTopology topology;
+    cpu_topology_cache_t() : topology(cpu()) {}
+};
+
+// Thread-safe lazy initialization using C++11 magic statics
+cpu_topology_cache_t &get_topology_cache() {
+    static cpu_topology_cache_t cache;
+    return cache;
+}
+
+// Map platform cache level (1=L1d, 2=L2, 3=L3) to Xbyak cache type.
+Xbyak::util::CacheType convert_cache_level(int level) {
+    switch (level) {
+        case 1: return Xbyak::util::L1d;
+        case 2: return Xbyak::util::L2;
+        case 3: return Xbyak::util::L3;
+        default: return Xbyak::util::CACHE_UNKNOWN;
+    }
+}
+
+// Filter used when searching for Efficient cores to distinguish between
+// regular E-cores (those sharing an L3) and LP E-cores (no L3 present).
+// For non-Efficient core types this filter is ignored.
+enum class l3_filter_t {
+    any, // no L3 filtering
+    with_l3, // only cores that have a non-zero L3 (regular E-cores)
+    without_l3, // only cores with L3 size == 0 (LP E-cores)
+};
+
+// Find the index of a representative logical CPU of the given core type.
+// For Efficient cores, l3_filter distinguishes regular E-cores (with L3)
+// from LP E-cores (without L3) and optionally restricts matches by L3 presence.
+// Returns the first matching CPU index, or SIZE_MAX if none is found.
+size_t find_representative_cpu(Xbyak::util::CoreType target_type,
+        l3_filter_t l3_filter = l3_filter_t::any) {
+    const auto &topo = get_topology_cache().topology;
+    size_t num_cpus = topo.getLogicalCpuNum();
+
+    for (size_t i = 0; i < num_cpus; i++) {
+        const auto &logical_cpu = topo.getLogicalCpu(i);
+        if (logical_cpu.coreType != target_type) continue;
+
+        if (target_type == Xbyak::util::Efficient
+                && l3_filter != l3_filter_t::any) {
+            const auto &l3 = topo.getCache(i, Xbyak::util::L3);
+            bool has_l3 = (l3.size > 0);
+            if (l3_filter == l3_filter_t::with_l3 && !has_l3) continue;
+            if (l3_filter == l3_filter_t::without_l3 && has_l3) continue;
+        }
+        return i;
+    }
+    return SIZE_MAX;
+}
+
+// Calculate per-core cache size for a specific cache level and CPU index.
+// Matches the legacy getCoresSharingDataCache semantics: divides by the number
+// of PHYSICAL cores sharing the cache, not logical CPUs.  The legacy Xbyak Cpu
+// path (CPUID leaf 4) uses L1d sharing count as the SMT width and divides it
+// out of every level's logical-CPU sharing count.  We replicate that here so
+// that non-hybrid results are identical to the legacy path.
+uint32_t calculate_per_core_cache(size_t cpu_index, int level) {
+    const auto &topo = get_topology_cache().topology;
+
+    Xbyak::util::CacheType cache_type = convert_cache_level(level);
+    if (cache_type == Xbyak::util::CACHE_UNKNOWN) { return 0; }
+
+    const auto &cache = topo.getCache(cpu_index, cache_type);
+    if (cache.size == 0) { return 0; }
+
+    // Number of logical CPUs (threads) sharing this cache instance.
+    size_t sharing_logical = cache.getSharedCpuNum();
+    if (sharing_logical == 0) sharing_logical = 1;
+
+    // SMT width = logical CPUs sharing L1d (L1 is always private to one
+    // physical core, so this count equals the number of HT threads per core).
+    size_t smt_width
+            = topo.getCache(cpu_index, Xbyak::util::L1d).getSharedCpuNum();
+    if (smt_width == 0) smt_width = 1;
+
+    // Physical cores sharing this cache (mirrors legacy smt_width division).
+    size_t sharing_cores = std::max(sharing_logical / smt_width, size_t(1));
+
+    return cache.size / sharing_cores;
+}
+
+struct cache_level_info_t {
+    uint32_t total_kb; // total physical cache capacity in KB
+    size_t sharing_cores; // number of physical cores sharing this instance
+    size_t smt_width; // logical threads per physical core (HT width)
+};
+
+cache_level_info_t get_cache_level_info(size_t cpu_index, int level) {
+    const auto &topo = get_topology_cache().topology;
+    Xbyak::util::CacheType cache_type = convert_cache_level(level);
+    if (cache_type == Xbyak::util::CACHE_UNKNOWN) return {0, 1, 1};
+    const auto &cache = topo.getCache(cpu_index, cache_type);
+    if (cache.size == 0) return {0, 1, 1};
+    size_t sharing_logical = cache.getSharedCpuNum();
+    if (sharing_logical == 0) sharing_logical = 1;
+    size_t smt = topo.getCache(cpu_index, Xbyak::util::L1d).getSharedCpuNum();
+    if (smt == 0) smt = 1;
+    size_t sharing_cores = std::max(sharing_logical / smt, size_t(1));
+    return {cache.size / 1024, sharing_cores, smt};
+}
+
+// Print hybrid per-core cache topology once per process at debuginfo=1 or higher.
+// One line per core type showing physical cache sizes.
+// Shared levels annotated: L{N}:{total}KB({N}cores,{per_core}KB/core)
+// Private levels:          L{N}:{total}KB
+// smt:{N} at end of each line: logical threads per physical core (HT width).
+// Final line: per-core cache size used, which is the minimum across all present core types.
+void print_hybrid_cache_debuginfo_once(
+        size_t pcore_cpu, size_t lp_core_cpu, size_t lpe_core_cpu) {
+    if (get_verbose(verbose_t::debuginfo) < 1) return;
+    static std::atomic_flag printed = ATOMIC_FLAG_INIT;
+    if (printed.test_and_set()) return;
+
+    auto print_core_line
+            = [](const char *tag, size_t cpu_idx, bool include_l3) {
+        auto l1 = get_cache_level_info(cpu_idx, 1);
+        auto l2 = get_cache_level_info(cpu_idx, 2);
+        char buf[256];
+        int offset = 0;
+        offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                "cpu,debuginfo,platform,%s,L1d:%uKB", tag, l1.total_kb);
+        if (l2.sharing_cores > 1)
+            offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                    ",L2:%uKB(%zucores,%uKB/core)", l2.total_kb,
+                    l2.sharing_cores, l2.total_kb / (uint32_t)l2.sharing_cores);
+        else
+            offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                    ",L2:%uKB", l2.total_kb);
+        if (include_l3) {
+            auto l3 = get_cache_level_info(cpu_idx, 3);
+            if (l3.total_kb > 0) {
+                if (l3.sharing_cores > 1)
+                    offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                            ",L3:%uMB(%zucores,%uKB/core)", l3.total_kb / 1024,
+                            l3.sharing_cores,
+                            l3.total_kb / (uint32_t)l3.sharing_cores);
+                else
+                    offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                            ",L3:%uMB", l3.total_kb / 1024);
+            }
+        }
+        snprintf(buf + offset, (int)sizeof(buf) - offset, ",smt:%zu\n",
+                l1.smt_width);
+        verbose_printf(verbose_t::debuginfo, "%s", buf);
+    };
+
+    print_core_line("pcore_cache", pcore_cpu, true);
+    print_core_line("lp_core_cache", lp_core_cpu, true);
+    if (lpe_core_cpu != SIZE_MAX)
+        print_core_line("lpe_core_cache", lpe_core_cpu, false);
+
+    uint32_t l1_used = (std::min)(calculate_per_core_cache(pcore_cpu, 1),
+            calculate_per_core_cache(lp_core_cpu, 1));
+    uint32_t l2_used = (std::min)(calculate_per_core_cache(pcore_cpu, 2),
+            calculate_per_core_cache(lp_core_cpu, 2));
+    uint32_t l3_used = (std::min)(calculate_per_core_cache(pcore_cpu, 3),
+            calculate_per_core_cache(lp_core_cpu, 3));
+    if (lpe_core_cpu != SIZE_MAX) {
+        l1_used = (std::min)(
+                l1_used, calculate_per_core_cache(lpe_core_cpu, 1));
+        l2_used = (std::min)(
+                l2_used, calculate_per_core_cache(lpe_core_cpu, 2));
+        // lpe_core has no L3 -- excluded to avoid zeroing L3 budget
+    }
+    verbose_printf(verbose_t::debuginfo,
+            "cpu,debuginfo,platform,per_core_cache(min),L1d:%uKB,L2:%uKB,L3:%"
+            "uKB\n",
+            l1_used / 1024, l2_used / 1024, l3_used / 1024);
+}
+
+// Cached per-core cache sizes for all core types and levels on hybrid systems.
+// Computed once at first use; all fields are bytes (not KB).
+// levels[0]=L1, levels[1]=L2, levels[2]=L3 (0 if not present).
+// lpe_core_cpu == SIZE_MAX means no LP E-core present; lpe_core[] is all zero.
+struct hybrid_core_cache_sizes_t {
+    size_t pcore_cpu;
+    size_t lp_core_cpu;
+    size_t lpe_core_cpu;
+    uint32_t pcore[3];
+    uint32_t lp_core[3];
+    uint32_t lpe_core[3];
+};
+
+hybrid_core_cache_sizes_t &get_hybrid_core_cache_sizes() {
+    static hybrid_core_cache_sizes_t result = []() {
+        hybrid_core_cache_sizes_t cache_sizes {};
+        cache_sizes.pcore_cpu
+                = find_representative_cpu(Xbyak::util::Performance);
+        cache_sizes.lp_core_cpu = find_representative_cpu(
+                Xbyak::util::Efficient, l3_filter_t::with_l3);
+        cache_sizes.lpe_core_cpu = find_representative_cpu(
+                Xbyak::util::Efficient, l3_filter_t::without_l3);
+
+        // If no P-core is found, use CPU 0 as a conservative fallback.
+        if (cache_sizes.pcore_cpu == SIZE_MAX) cache_sizes.pcore_cpu = 0;
+        // If no E-core with L3 is found, reuse P-core values for lp_core.
+        if (cache_sizes.lp_core_cpu == SIZE_MAX)
+            cache_sizes.lp_core_cpu = cache_sizes.pcore_cpu;
+        // LP E-core is optional: keep lpe_core_cpu as SIZE_MAX when absent.
+
+        for (int lvl = 1; lvl <= 3; lvl++) {
+            cache_sizes.pcore[lvl - 1]
+                    = calculate_per_core_cache(cache_sizes.pcore_cpu, lvl);
+            cache_sizes.lp_core[lvl - 1]
+                    = calculate_per_core_cache(cache_sizes.lp_core_cpu, lvl);
+            cache_sizes.lpe_core[lvl - 1]
+                    = (cache_sizes.lpe_core_cpu != SIZE_MAX)
+                    ? calculate_per_core_cache(cache_sizes.lpe_core_cpu, lvl)
+                    : 0;
+        }
+        return cache_sizes;
+    }();
+    return result;
+}
+
+// Print per-core cache sizes once (CPUID path, no CpuTopology init).
+// Format mirrors the hybrid path: shared levels show total, sharing count, and
+// per-core budget; private levels show just the total. smt field is appended.
+void print_cache_debuginfo_once() {
+    if (get_verbose(verbose_t::debuginfo) < 1) return;
+    static std::atomic_flag printed = ATOMIC_FLAG_INIT;
+    if (printed.test_and_set()) return;
+
+    // SMT width = L1d sharing count (L1d is private to one physical core).
+    uint32_t smt = cpu().getCoresSharingDataCache(0);
+    if (smt == 0) smt = 1;
+
+    char buf[256];
+    int offset = 0;
+    unsigned nlevels = cpu().getDataCacheLevels();
+    offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+            "cpu,debuginfo,platform,cache");
+    for (unsigned li = 0; li < nlevels && li < 3; li++) {
+        uint32_t total_kb = cpu().getDataCacheSize(li) / 1024;
+        uint32_t sharing = cpu().getCoresSharingDataCache(li);
+        if (sharing == 0) sharing = 1;
+        uint32_t per_core_kb = total_kb / sharing;
+        const char *label = (li == 0) ? "L1d" : (li == 1) ? "L2" : "L3";
+        if (li == 2) {
+            // L3: show total in MB, per-core in KB
+            if (sharing > 1)
+                offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                        ",%s:%uMB(%ucores,%uKB/core)", label, total_kb / 1024,
+                        sharing, per_core_kb);
+            else
+                offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                        ",%s:%uMB", label, total_kb / 1024);
+        } else {
+            if (sharing > 1)
+                offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                        ",%s:%uKB(%ucores,%uKB/core)", label, total_kb, sharing,
+                        per_core_kb);
+            else
+                offset += snprintf(buf + offset, (int)sizeof(buf) - offset,
+                        ",%s:%uKB", label, total_kb);
+        }
+    }
+    snprintf(buf + offset, (int)sizeof(buf) - offset, ",smt:%u\n", smt);
+    verbose_printf(verbose_t::debuginfo, "%s", buf);
+}
+
+#endif // !__APPLE__
+
+} // anonymous namespace
+
+bool is_hybrid() {
+#ifdef __APPLE__
+    // xbyak::util::CpuTopology is not supported on macOS; assume non-hybrid.
+    return false;
+#else
+    // Use the HYBRID bit from the already-cached Xbyak::Cpu instance
+    // (CPUID leaf 7 EDX[15]) to avoid triggering CpuTopology init.
+    return cpu().has(Xbyak::util::Cpu::tHYBRID);
+#endif
+}
+
+// CPUID-based implementation using Xbyak::util::Cpu (leaf 4).
+// Used on non-hybrid systems to avoid the expensive CpuTopology init.
+unsigned get_per_core_cache_size_cpuid(int level) {
+    if (level > 0 && (unsigned)level <= cpu().getDataCacheLevels()) {
+        unsigned l = level - 1;
+        return cpu().getDataCacheSize(l) / cpu().getCoresSharingDataCache(l);
+    }
+    return 0;
+}
+
+unsigned get_per_core_cache_size(int level) {
+    if (level < 1 || level > 3) { return 0; }
+
+#ifdef __APPLE__
+    return get_per_core_cache_size_cpuid(level);
+#else
+    // Fast path: on non-hybrid systems avoid the expensive CpuTopology init.
+    if (!is_hybrid()) {
+        print_cache_debuginfo_once();
+        return get_per_core_cache_size_cpuid(level);
+    }
+
+    const auto &cache_sizes = get_hybrid_core_cache_sizes();
+    const int li = level - 1; // 0-indexed
+
+    print_hybrid_cache_debuginfo_once(cache_sizes.pcore_cpu,
+            cache_sizes.lp_core_cpu, cache_sizes.lpe_core_cpu);
+
+    uint32_t min_cache_bytes
+            = (std::min)(cache_sizes.pcore[li], cache_sizes.lp_core[li]);
+    if (cache_sizes.lpe_core_cpu != SIZE_MAX && cache_sizes.lpe_core[li] > 0)
+        min_cache_bytes = (std::min)(min_cache_bytes, cache_sizes.lpe_core[li]);
+    return min_cache_bytes;
+#endif
+}
+
+bool has_lpe_core() {
+#ifdef __APPLE__
+    return false;
+#else
+    if (!is_hybrid()) return false;
+    return get_hybrid_core_cache_sizes().lpe_core_cpu != SIZE_MAX;
+#endif
+}
+
+} // namespace platform
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/platform.hpp
+++ b/src/cpu/x64/platform.hpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_PLATFORM_HPP
+#define CPU_X64_PLATFORM_HPP
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace platform {
+
+// Returns true if the CPU reports hybrid core types (P-cores and E-cores).
+// May return false on platforms where hybrid-core topology detection is unavailable.
+bool is_hybrid();
+
+// Returns true if a low-power E-core island (LP E-cores) is present,
+// i.e. Efficient cores with no L3 cache. Meaningful only on hybrid CPUs.
+bool has_lpe_core();
+
+// Returns the per-core cache size in bytes for the given level
+// (1=L1d, 2=L2, 3=L3).
+// On hybrid systems, returns a conservative value based on the smallest
+// per-core cache among present core types.
+unsigned get_per_core_cache_size(int level);
+
+} // namespace platform
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
## Description

This PR fixes inaccurate per-core cache size reporting on hybrid x86 CPUs
(Alder Lake, Raptor Lake, Meteor Lake, Lunar Lake, Nova Lake) by adding an
x64-specific platform layer that uses `Xbyak::util::CpuTopology` instead of
CPUID leaf 4.

### Problem

The legacy `get_per_core_cache_size(int level)` uses CPUID leaf 4 via
`Xbyak::util::Cpu`. On hybrid systems the CPUID sharing-count fields are buggy
or ambiguous, producing values that do not match what any core type actually
sees. Measured examples:

| Platform | Cache | Legacy (CPUID) | New (topology) | Issue |
|----------|-------|----------------|----------------|-------|
| ARL | L2 | 512 KB | 1024 KB (lp_core) | ~6x CPUID undercount |
| PTL | L2 | 384 KB | 1024 KB (lp_core) | ~8x CPUID undercount |
| PTL | L1d | 24 KB | 32 KB (lp_core) | CPUID halves L1d even with no HT |
| LNL | L2 | 320 KB | 1024 KB (lp_core) | ~8x CPUID undercount |
| NVL | L2 | 512 KB | 1024 KB (lp_core) | ~4x CPUID undercount |
| MTL | L2 | 512 KB | 2048 KB (p_core) | ~4x CPUID undercount |

<img width="1069" height="597" alt="image" src="https://github.com/user-attachments/assets/dd1d0869-05ec-4d1e-8a90-3c25056f33cd" />

A hard-coded `jit_brgemm_conv_utils.cpp` L2 override of 2 MB for AVX2 was
masking part of this on those platforms. Changing the hard-coded L2 override addresses
[MFDNN-14078](https://jira.devtools.intel.com/browse/MFDNN-14078)

### Solution

A new x64-specific module (`src/cpu/x64/platform.cpp/.hpp`) uses
`Xbyak::util::CpuTopology` and distinguishes three core classes:

| Core class | Description |
|------------|-------------|
| P-core     | Intel Performance core |
| LP-core    | Efficient core sharing an L3 cache |
| LPE-core   | Efficient core with no L3 (e.g. Meteor Lake SoC tile) |

On hybrid systems the implementation now always returns a conservative cache
budget:

- `min` policy in code: `min(p_core, lp_core[, lpe_core])` per cache level.
- no runtime policy override.
- no policy enum exposed through the x64 platform API.

`min` is the default because over-committing cache is more costly than
under-utilising it: a blocking heuristic sized for P-cores would overflow the
smaller E-core caches when the workload runs there. Empirical comparison during
development (`p_core` vs `min` on NVL/PTL P-core-pinned runs) showed mixed
per-shape results with no stable rule, confirming `min` as the safer general
default.

<!-- optional: insert "At a glance" screenshot from
     percore_policy_presentation.xlsx showing the mixed NVL result -->

### Performance validation (A/B, hardcode vs min)

Convolution data was collected to validate that changing the hardcoded L2 cache size to
a size based on detected cache is the right behavior. A/B data collection was used to
help remove thermal and run-order issues, i.e. multiple runs in different call orders
to avoid spikes caused by thermal throttling.

Ratio = hardcode / min
- If ratio > 1.0, hardcode took more time than min, so min is faster.
- If ratio < 1.0, hardcode took less time than min, so hardcode is faster.
- If ratio ~= 1.0, they are effectively neutral.


<img width="586" height="222" alt="image" src="https://github.com/user-attachments/assets/9e38a514-c28d-4f86-be55-ab3e56896115" />

The MFDNN-14078 shape in standalone testing saw runtime increase from 41.7 ms to
98.6 ms (about 2.36x). However, with A/B testing, the MFDNN-14078 result shrank to
only slightly better than hardcoded performance (about 1.01x).

**Note:** data was collected with `--cold-cache=all` data was recollected without the `--cold-cache`
this resulted in small differences in performance but no outliers that would significantly change the
conclusion based on the `--cold-cache=all` results.

**Performance impact:** first call on a hybrid system costs ~25-30 ms to
initialise `CpuTopology` (magic static, paid once). On non-hybrid systems this
cost is bypassed entirely -- the non-hybrid fast path returns the CPUID value
immediately.

The default `get_per_core_cache_size(int level)` in `src/cpu/platform.cpp`
delegates to `x64::platform::get_per_core_cache_size(level)` on x64 and falls
back to the CPUID path on all other architectures.

All cache debuginfo logging for x64 now lives in `src/cpu/x64/platform.cpp`
(`print_cache_debuginfo_once` and `print_hybrid_cache_debuginfo_once`) behind
`ONEDNN_VERBOSE=debuginfo=1`.

### Files changed

| File | Change |
|------|--------|
| `src/cpu/x64/platform.hpp` | New x64 cache-topology API declaration for `get_per_core_cache_size(int level)` and hybrid helpers. |
| `src/cpu/x64/platform.cpp` | Implementation using `Xbyak::util::CpuTopology`. macOS guard (falls back to legacy). Thread-safe lazy init via C++11 magic statics. Non-hybrid fast path avoids `CpuTopology` init. Includes x64 cache debuginfo printing. |
| `src/cpu/platform.cpp` | Delegates `get_per_core_cache_size(int level)` to `x64::platform::get_per_core_cache_size(level)` on x64; AARCH64 path preserved. |
| `src/cpu/x64/jit_brgemm_conv_utils.cpp` | Removes hard-coded AVX2 L2 = 2 MB override. L2 is now always `get_per_core_cache_size(2) * 3/4`. |

### Known limitations

- `Xbyak::util::CpuTopology` is not available on macOS; all macOS paths fall
  back to legacy CPUID behaviour.
- All-E-core systems (e.g. Sierra Forest) are treated as non-hybrid.