### PR TITLE
cpu: rv64: matmul: add dropout attribute check

### DIFF
--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -59,6 +59,9 @@ struct rvv_matmul_t : public primitive_t {
             VDISPATCH_MATMUL(attr()->scales_.has_default_values(),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
 
+            VDISPATCH_MATMUL(attr()->dropout_.has_default_values(),
+                    VERBOSE_UNSUPPORTED_ATTR);
+
             VDISPATCH_MATMUL(rvv_postops_t::post_ops_ok(attr()->post_ops_),
                     VERBOSE_UNSUPPORTED_POSTOP);
 

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -36,6 +36,7 @@ struct rvv_matmul_t : public primitive_t {
 
         status_t init(engine_t *engine) {
             UNUSED(engine);
+            using smask_t = primitive_attr_t::skip_mask_t;
 
             const memory_desc_wrapper src_mdw(src_md(0));
             const memory_desc_wrapper weights_mdw(weights_md(0));
@@ -56,10 +57,8 @@ struct rvv_matmul_t : public primitive_t {
                     && desc()->accum_data_type == d_type;
             VDISPATCH_MATMUL(types_ok, VERBOSE_UNSUPPORTED_DT);
 
-            VDISPATCH_MATMUL(attr()->scales_.has_default_values(),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
-
-            VDISPATCH_MATMUL(attr()->dropout_.has_default_values(),
+            VDISPATCH_MATMUL(
+                    attr()->has_default_values(smask_t::post_ops, d_type),
                     VERBOSE_UNSUPPORTED_ATTR);
 
             VDISPATCH_MATMUL(rvv_postops_t::post_ops_ok(attr()->post_ops_),


### PR DESCRIPTION
# Description
This issue was introduced by #3784, and the error occurs as follows:
```bash
./tests/benchdnn/benchdnn --matmul --stag=ab --dtag=ab --attr-dropout=0.5:12345678 1x1:1x1
Error: Function 'initialize_memory_create' at (/data/zhangfei/oneDNN/tests/benchdnn/dnnl_memory.cpp:880) returned 'invalid_arguments'
[CHECK_MEM][ERROR]: Allocations were not cleared
[CHECK_MEM][ERROR]: Total size wasn't reduced to 0
```

Therefore, add a check for the dropout attribute to fall back to the generic implementation and avoid the error. The effect of applying this PR is as follows:
```bash
./tests/benchdnn/benchdnn --matmul --stag=ab --dtag=ab --attr-dropout=0.5:12345678 1x1:1x1
0:PASSED (13 ms) __REPRO: --matmul --stag=ab --dtag=ab --attr-dropout=0.5:12345678 1x1:1x1
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| ref:any : 1 (100%)                                       |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.01s; create_pd: 0.00s (2%); create_prim: 0.00s (0%); fill: 0.00s (6%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.01s (78%);
```