### PR TITLE
common: extended check for empty stat_desc

### DIFF
--- a/src/common/layer_normalization.cpp
+++ b/src/common/layer_normalization.cpp
@@ -92,14 +92,14 @@ status_t lnorm_desc_init(layer_normalization_desc_t *lnorm_desc,
     if (!is_fwd) ld.diff_src_desc = *diff_src_desc;
     if (!is_fwd) ld.diff_dst_desc = *diff_dst_desc;
 
-    if (stat_desc)
-        ld.stat_desc = *stat_desc;
-    else
+    if (types::is_zero_md(stat_desc)) {
         VCHECK_LNORM(
                 memory_desc_init_by_tag(ld.stat_desc, ld.src_desc.ndims - 1,
                         ld.src_desc.dims, data_type::f32, format_tag::any)
                         == success,
                 VERBOSE_UNSUPPORTED_TAG_S, "stats");
+    } else
+        ld.stat_desc = *stat_desc;
 
     int ndims = src_desc->ndims;
     ld.data_scaleshift_desc = zero_md();


### PR DESCRIPTION
Layer Normalization documentation [states](https://github.com/uxlfoundation/oneDNN/blob/main/include/oneapi/dnnl/dnnl.h#L2519-L2523) that `stat_desc` argument is ignored when it's a zero memory descriptor. In reality we were only checking for `nullptr`. 

Fixes MFDNN-8547
