### PR TITLE
gpu: intel: compute: add "-cl-intel-greater-than-4GB-buffer-required"

### DIFF
--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -220,6 +220,7 @@ public:
     size_t icache_size() const;
     size_t max_kernel_param_size() const { return max_kernel_param_size_; }
     uint32_t device_address_bits() const { return device_address_bits_; }
+    uint64_t max_allocation_size() const { return max_allocation_size_; }
 
     const xpu::runtime_version_t &runtime_version() const {
         return runtime_version_;
@@ -290,6 +291,7 @@ protected:
     size_t l3_cache_size_ = 0;
     size_t max_kernel_param_size_ = 1024;
     uint32_t device_address_bits_ = 64;
+    uint64_t max_allocation_size_ = 0;
 
     // extensions_ and gpu_arch_ describe effective extensions and GPU architecture.
     uint64_t extensions_ = 0;

--- a/src/gpu/intel/compute/dispatch_reusable.cpp
+++ b/src/gpu/intel/compute/dispatch_reusable.cpp
@@ -456,6 +456,7 @@ void dispatch_compile_params_t::def_kernel_macros(
         kernel_ctx_t &kernel_ctx, const char *suffix) const {
     kernel_ctx.define_int("GWS_WITH_RUNTIME_PARAMS", 1);
     kernel_ctx.use_int32_offset(use_int32_offset);
+    kernel_ctx.require_large_buffers(require_large_buffers);
 
     // Find a unique prefix (in case there are many kernels in a file).
     std::string gws_prefix;

--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -52,13 +52,7 @@ public:
         for (auto &opt : option_set_)
             oss << " " << opt;
 
-        if (use_int32_offset_) {
-            oss << " -DUSE_INT32_OFFSET";
-        } else {
-            // TODO: Determine if specialization for buffers between 2GB and 4GB
-            // is worthwhile
-            oss << " -cl-intel-greater-than-4GB-buffer-required";
-        }
+        if (use_int32_offset_) { oss << " -DUSE_INT32_OFFSET"; }
 
         for (auto &int_var : int_var_map_) {
             // C tokens are parsed as (-)(integer_literal). As abs(INT_MIN) >
@@ -85,6 +79,7 @@ public:
 
     void register_buffer_size(size_t size) {
         if (size > INT_MAX) use_int32_offset(false);
+        if (size > UINT32_MAX) require_large_buffers(true);
     }
 
     void register_buffer_size(const memory_desc_wrapper &mdw) {
@@ -96,6 +91,9 @@ public:
     // case, int32_t types can be used for data offsets and avoid int64_t
     // operations when native 64-bit operations are unsupported.
     void use_int32_offset(bool value) { use_int32_offset_ = value; }
+
+    void require_large_buffers(bool value) { require_large_buffers_ = value; }
+    bool has_large_buffers() const { return require_large_buffers_; }
 
     void define_int(const char *variable, int64_t value) {
         set_macro(variable, value, int_var_map_);
@@ -216,6 +214,7 @@ private:
     std::set<std::string> option_set_;
     std::unordered_map<std::string, std::string> custom_headers_;
     bool use_int32_offset_ = true;
+    bool require_large_buffers_ = false;
 };
 
 } // namespace compute

--- a/src/gpu/intel/ocl/device_info.cpp
+++ b/src/gpu/intel/ocl/device_info.cpp
@@ -152,6 +152,12 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
     OCL_CHECK(err);
     device_address_bits_ = device_address_bits;
 
+    cl_ulong max_allocation_size;
+    err = clGetDeviceInfo(device, CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+            sizeof(max_allocation_size), &max_allocation_size, nullptr);
+    OCL_CHECK(err);
+    max_allocation_size_ = max_allocation_size;
+
 #ifdef cl_intel_unified_shared_memory
     cl_device_unified_shared_memory_capabilities_intel
             system_memory_capabilities_intel

--- a/src/gpu/intel/ocl/engine.cpp
+++ b/src/gpu/intel/ocl/engine.cpp
@@ -243,6 +243,12 @@ status_t engine_t::build_program_from_source(
     auto *dev_info = utils::downcast<const device_info_t *>(device_info());
     options += " " + dev_info->get_cl_ext_options();
 
+    // Compile kernel in a stateless addressing model allowing usage of
+    // allocations of any size. Not needed if allowed allocation is already > 4GB.
+    if (kernel_ctx.has_large_buffers()
+            && dev_info->max_allocation_size() <= UINT32_MAX)
+        options += " -cl-intel-greater-than-4GB-buffer-required";
+
     cl_int err;
     stringstream_t pp_code;
     // The `cl_cache` requires using `clBuildProgram`. Unfortunately, unlike

--- a/src/gpu/intel/sycl/device_info.cpp
+++ b/src/gpu/intel/sycl/device_info.cpp
@@ -142,6 +142,8 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
             = device.get_info<::sycl::info::device::global_mem_cache_size>();
     mayiuse_system_memory_allocators_
             = device.has(::sycl::aspect::usm_system_allocations);
+    max_allocation_size_
+            = device.get_info<::sycl::info::device::max_mem_alloc_size>();
     return status::success;
 }
 


### PR DESCRIPTION
If required memory allocation is >4GB and driver does not normally allow it, compile modules in stateless addressing model.
Fix for [MFDNN-14249](https://jira.devtools.intel.com/browse/MFDNN-14249)