### PR TITLE
xe: make includes of gemmstone headers path-agnostic

### DIFF
--- a/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
+++ b/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
@@ -14,9 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "gemmstone/config.hpp"
 #include "gemmstone/strategy.hpp"
 #include "gpu/intel/gemm/jit/generator_dsl/kernel_desc.hpp"
-#include "gpu/intel/gemm/jit/include/gemmstone/config.hpp"
 #include "gpu/intel/jit/dsl/dsl.hpp"
 #include "gpu/intel/jit/pass/pass.hpp"
 #include "gpu/intel/jit/utils/trace.hpp"

--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -20,7 +20,7 @@
 #include <functional>
 
 #include "common/utils.hpp"
-#include "gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp"
+#include "gemmstone/../../generator/pieces/copy_plan.hpp"
 #include "gpu/intel/jit/codegen/operand.hpp"
 #include "gpu/intel/jit/codegen/register_scope.hpp"
 #include "gpu/intel/jit/ir/reorder.hpp"


### PR DESCRIPTION
This is to allow using a standalone (or third-party) gemmstone repository for building.