### PR TITLE
gpu: intel: concat: multi: use nested scratchpad grantor properly

### DIFF
--- a/src/gpu/intel/concat/multi.hpp
+++ b/src/gpu/intel/concat/multi.hpp
@@ -115,20 +115,25 @@ struct multi_t : public primitive_t {
         const auto max_batch_size = pd()->max_batch_size();
         if (max_batch_size == pd_t::batch_failure) return status::runtime_error;
 
-        auto execute_concat =
-                [&](const std::shared_ptr<impl::primitive_t> &concat, int c_num,
-                        int n_inputs) {
-                    exec_args_t r_args;
-                    const auto arg_offset = DNNL_ARG_MULTIPLE_SRC;
-                    for (int i = 0; i < n_inputs; ++i)
-                        r_args[arg_offset + i] = ctx.args().at(
-                                arg_offset + max_batch_size * c_num + i);
-                    r_args[DNNL_ARG_DST] = ctx.args().at(DNNL_ARG_DST);
-                    exec_ctx_t r_ctx(ctx, std::move(r_args));
+        auto execute_concat
+                = [&](const std::shared_ptr<impl::primitive_t> &concat,
+                          int c_num, int n_inputs) {
+                      exec_args_t r_args;
+                      const auto arg_offset = DNNL_ARG_MULTIPLE_SRC;
+                      for (int i = 0; i < n_inputs; ++i)
+                          r_args[arg_offset + i] = ctx.args().at(
+                                  arg_offset + max_batch_size * c_num + i);
+                      r_args[DNNL_ARG_DST] = ctx.args().at(DNNL_ARG_DST);
+                      exec_ctx_t r_ctx(ctx, std::move(r_args));
 
-                    r_ctx.set_scratchpad_grantor(&ctx.get_scratchpad_grantor());
-                    return concat->execute(r_ctx);
-                };
+                      // There's actually no scratchpad allocated for this impl.
+                      auto *nested_grantor = create_nested_grantor(
+                              ctx.get_scratchpad_grantor(),
+                              memory_tracking::names::key_nested,
+                              concat->pd()->scratchpad_registry());
+                      r_ctx.set_scratchpad_grantor(nested_grantor);
+                      return concat->execute(r_ctx);
+                  };
 
         const auto n_batches = utils::div_up(n, max_batch_size);
         for (int i = 0; i < n_batches; ++i) {


### PR DESCRIPTION
[MFDNN-14352](https://jira.devtools.intel.com/browse/MFDNN-14352)

The implementation used grantor incorrectly. The fun fact is this implementation doesn't even use scratchpad.