### PR TITLE
benchdnn: revert enabling mode p on windows

### DIFF
--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -76,6 +76,7 @@ function(register_benchdnn_test engine driver test_file)
     # Additionally, only needed for speeding up JIT compilation of OCL kernels.
     set(mode_modifier "")
     if(${engine} MATCHES "gpu"
+       AND NOT WIN32
        AND NOT ${DNNL_GPU_VENDOR} MATCHES "NVIDIA"
        AND NOT ${DNNL_GPU_VENDOR} MATCHES "AMD")
         set(mode_modifier "--mode-modifier=P")


### PR DESCRIPTION
This reverts commit d5e144c9432aaeae4f77f214c355c5f580f2fb7a.

# Description

Revert change pending resolution of [GSD-11900](https://jira.devtools.intel.com/browse/GSD-11900). Currently the desired effect of this change is disabled at the driver level. 
Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?
