### PR TITLE
xe: sdpa: disable split Q barriers on xe2 [rls-v3.9]

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -499,7 +499,8 @@ status_t micro_sdpa_t::pd_t::init_conf(impl::engine_t *engine) {
         conf.prefetch_d_max = 0;
     }
 
-    conf.q_arrive_await_barrier = (d->queries() > 1);
+    const bool is_xe2 = pd->arch() == compute::gpu_arch_t::xe2;
+    conf.q_arrive_await_barrier = (d->queries() > 1) && !is_xe2;
     conf.softmax_inf_as_zero
             = (d->softmax_alg == alg_kind::softmax_accurate_inf_as_zero);
     conf.use_systolic_ukernel = pd->use_systolic_ukernel();


### PR DESCRIPTION
Backport of #4183.