### PR TITLE
[rls-v3.10] xe: copy plan: double SIMD for qw -> 2d dw decomposition

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -2523,6 +2523,7 @@ void CopyPlan::legalizeRegions()
             i.src0.offset *= 2;
             if (i.dst.stride == 2) {
                 /* Use 2D regioned src */
+                i.simd *= 2;
                 i.dst.stride = 1;
                 i.src0.vs = i.src0.stride;
                 i.src0.stride = 1;


### PR DESCRIPTION
Backport of #4250.