### PR TITLE
backport: cpu: aarch64: fix potential overflow in ACL strides

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.cpp
+++ b/src/cpu/aarch64/acl_convolution_utils.cpp
@@ -278,8 +278,8 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
             return status::unimplemented;
     }
 
-    acl_utils::reorder_to_weight_format(acp.wei_tensor_info, weights_md,
-            expected_weight_format, I_dim, O_dim, {W_dim, H_dim}, {});
+    CHECK(acl_utils::reorder_to_weight_format(acp.wei_tensor_info, weights_md,
+            expected_weight_format, I_dim, O_dim, {W_dim, H_dim}, {}));
 
     return status::success;
 }

--- a/src/cpu/aarch64/acl_inner_product.cpp
+++ b/src/cpu/aarch64/acl_inner_product.cpp
@@ -264,8 +264,8 @@ status_t acl_inner_product_fwd_t::pd_t::init_conf_ip(
     }
 
     const memory_desc_t weights_md_received = weights_md_;
-    acl_utils::reorder_to_weight_format(aip_.wei_tensor_info, weights_md_,
-            expected_weight_format, inner_dim, o_dim, remaining_dims, {});
+    CHECK(acl_utils::reorder_to_weight_format(aip_.wei_tensor_info, weights_md_,
+            expected_weight_format, inner_dim, o_dim, remaining_dims, {}));
 
     ACL_CHECK_SUPPORT((weights_format_kind_received == format_kind::blocked)
                     && !(dnnl_memory_desc_equal(

--- a/src/cpu/aarch64/acl_utils.hpp
+++ b/src/cpu/aarch64/acl_utils.hpp
@@ -92,9 +92,9 @@ int reorder_dimensions_by_stride(std::vector<memory_desc_t *> permuted_mds,
 //            matmul, ordered from innermost to outermost. ACL calls these
 //            the multi_stride_b. These will become the outermost (least dense)
 //            dimensions and will be collapsed.
-void reorder_to_weight_format(arm_compute::TensorInfo &info, memory_desc_t &md,
-        arm_compute::WeightFormat wf, dim_t I_dim, dim_t O_dim,
-        const std::vector<dim_t> &spatial_dims,
+status_t reorder_to_weight_format(arm_compute::TensorInfo &info,
+        memory_desc_t &md, arm_compute::WeightFormat wf, dim_t I_dim,
+        dim_t O_dim, const std::vector<dim_t> &spatial_dims,
         const std::vector<dim_t> &batch_dims = {});
 
 // Logs a custom 'info' line describing an unsupported case

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -215,8 +215,8 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
         for (dim_t i = K_dim - 1; i >= 0; --i)
             batch_dims.push_back(i);
 
-        acl_utils::reorder_to_weight_format(amp.wei_tensor_info, wei_md,
-                expected_weight_format, K_dim, N_dim, {}, batch_dims);
+        CHECK(acl_utils::reorder_to_weight_format(amp.wei_tensor_info, wei_md,
+                expected_weight_format, K_dim, N_dim, {}, batch_dims));
     }
 
     return status::success;


### PR DESCRIPTION
# Description

Backporting #4261

Fix potential overflow in ACL strides which are uint32 as they extend Dimensions<uint32_t> - See: https://github.com/ARM-software/ComputeLibrary/blob/main/arm_compute/core/Strides.h#L42

# Checklist

## General

- [Y] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [Y] Have you formatted the code using clang-format?

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
