### PR TITLE
xe: gemm: avoid leaking nested grantor memory

### DIFF
--- a/src/gpu/intel/gemm/conv.hpp
+++ b/src/gpu/intel/gemm/conv.hpp
@@ -212,8 +212,7 @@ struct conv_t : public primitive_t {
         args[DNNL_ARG_DST] = {c.get(), false};
         if (bias) args[DNNL_ARG_BIAS] = {bias.get(), true};
 
-        auto exec_ctx = ctx.into_exec_ctx_t(std::move(args));
-
+        impl::exec_ctx_t exec_ctx {ctx, std::move(args)};
         auto *nested_grantor
                 = create_nested_grantor(exec_ctx.get_scratchpad_grantor(),
                         memory_tracking::names::key_nested,

--- a/src/gpu/intel/gemm/exec_types.hpp
+++ b/src/gpu/intel/gemm/exec_types.hpp
@@ -53,54 +53,20 @@ struct exec_args_t {
     impl::exec_args_t exec_args;
 };
 
-struct exec_ctx_t {
+struct exec_ctx_t : impl::exec_ctx_t {
     exec_ctx_t(impl::stream_t *stream, const exec_args_t &args,
             const desc_t *desc = nullptr)
-        : stream_(stream), args_(args), desc_(desc) {}
+        : impl::exec_ctx_t(stream), args_(args), desc_(desc) {}
     exec_ctx_t(const impl::exec_ctx_t &other, const exec_args_t &args,
             const desc_t *desc = nullptr)
-        : stream_(other.stream())
-        , args_(args)
-        , desc_(desc)
-        , resource_mapper_(other.get_resource_mapper())
-        , scratchpad_grantor_(&other.get_scratchpad_grantor()) {}
+        : impl::exec_ctx_t(other, {}), args_(args), desc_(desc) {}
 
-    impl::stream_t *stream() const { return stream_; }
     const exec_args_t &args() const { return args_; }
     const desc_t *desc() const { return desc_; }
 
-    impl::exec_ctx_t into_exec_ctx_t(impl::exec_args_t &&args) const {
-        impl::exec_ctx_t ctx(stream(), std::move(args));
-        ctx.set_scratchpad_grantor(scratchpad_grantor_);
-        ctx.set_resource_mapper(resource_mapper_);
-        return ctx;
-    };
-
-    void set_scratchpad_grantor(
-            const memory_tracking::grantor_t *scratchpad_grantor) {
-        scratchpad_grantor_ = scratchpad_grantor;
-    }
-
-    const memory_tracking::grantor_t &get_scratchpad_grantor() const {
-        assert(scratchpad_grantor_);
-        return *scratchpad_grantor_;
-    }
-
-    const resource_mapper_t *get_resource_mapper() const {
-        assert(resource_mapper_);
-        return resource_mapper_;
-    }
-
-    void set_resource_mapper(const resource_mapper_t *resource_mapper) {
-        resource_mapper_ = resource_mapper;
-    }
-
 private:
-    impl::stream_t *stream_;
     exec_args_t args_;
     const desc_t *desc_ = nullptr;
-    const resource_mapper_t *resource_mapper_ = nullptr;
-    const memory_tracking::grantor_t *scratchpad_grantor_ = nullptr;
 };
 
 } // namespace gemm

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -16,7 +16,7 @@
 
 #include "gpu/intel/gemm/jit/pd.hpp"
 #include "common/c_types_map.hpp"
-#include "common/tag_traits.hpp"
+#include "gpu/intel/gemm/exec_types.hpp"
 #include "gpu/intel/jit/eltwise_injector.hpp"
 #include "gpu/intel/utils.hpp"
 

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -235,16 +235,11 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
 
         nested_args.c = c_mem_before_po_worker->memory_storage();
     }
-    impl::exec_ctx_t tmp_ctx(ctx.stream());
-    tmp_ctx.set_resource_mapper(ctx.get_resource_mapper());
-    tmp_ctx.set_scratchpad_grantor(&ctx.get_scratchpad_grantor());
-    auto *nested_grantor
-            = create_nested_grantor(tmp_ctx.get_scratchpad_grantor(),
-                    memory_tracking::names::key_nested_multiple,
-                    prim_->pd()->scratchpad_registry());
 
-    exec_ctx_t nested_ctx(ctx.stream(), nested_args, ctx.desc());
-    nested_ctx.set_resource_mapper(ctx.get_resource_mapper());
+    exec_ctx_t nested_ctx(ctx, nested_args, ctx.desc());
+    auto *nested_grantor = create_nested_grantor(ctx.get_scratchpad_grantor(),
+            memory_tracking::names::key_nested_multiple,
+            prim_->pd()->scratchpad_registry());
     nested_ctx.set_scratchpad_grantor(nested_grantor);
 
     CHECK(gemm(prim_)->execute(nested_ctx));

--- a/src/gpu/intel/primitive.hpp
+++ b/src/gpu/intel/primitive.hpp
@@ -26,7 +26,6 @@
 #include "gpu/intel/compute/kernel.hpp"
 #include "gpu/intel/compute/types_interop.hpp"
 #include "gpu/intel/engine.hpp"
-#include "gpu/intel/gemm/exec_types.hpp"
 #include "gpu/intel/kernel_cache.hpp"
 #include "gpu/intel/stream.hpp"
 #include "xpu/context.hpp"
@@ -138,16 +137,6 @@ struct primitive_t : public gpu::primitive_t {
                 VERBOSE_KERNEL_CREATION_FAIL, kernel_name);
         kernel = kernels[0];
         return status::success;
-    }
-
-    // TODO: use inheritance for exec_ctx_t to get rid of such places...
-    static status_t parallel_for(const gemm::exec_ctx_t &ctx,
-            const compute::nd_range_t &range, const compute::kernel_t &kernel,
-            const compute::kernel_arg_list_t &arg_list) {
-        auto compute_stream = utils::downcast<intel::stream_t *>(ctx.stream());
-        return parallel_for(*compute_stream, range, kernel, arg_list,
-                compute_stream->ctx().get_deps(),
-                compute_stream->ctx().get_deps());
     }
 
     static status_t parallel_for(const exec_ctx_t &ctx,


### PR DESCRIPTION
Addresses Coverity CIDs 7949387-9, 7949391-2.

`gemm::exec_ctx_t` holds a pointer to its scratchpad grantor, and would own _nested_ grantors, but didn't free them at end of scope. These changes use the existing `exec_ctx_t` logic to track ownership and clean up where appropriate.