### PR TITLE
cpu: x64: matmul: enable gemv code path for m=1

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -282,13 +282,13 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
 status_t brgemv_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_x, bool transA, float alpha, float beta, dim_t LDA,
-        dim_t INCY, dim_t M, dim_t N) {
+        dim_t INCY, dim_t M, dim_t N, bool treat_y_as_row) {
 
     // Only f32 is supported for now.
     if (!utils::everyone_is(data_type::f32, dt_a, dt_x))
         return status::unimplemented;
 
-    // y = x*A^t is not yet implemented.
+    // y = A^t * x is not yet implemented.
     if (transA) return status::unimplemented;
 
     CHECK(brgemm_desc_init(brg, isa, type, dt_a, dt_x, transA, false,
@@ -296,6 +296,7 @@ status_t brgemv_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
             false));
 
     brg->is_gemv = true;
+    brg->treat_y_as_row = treat_y_as_row;
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -80,6 +80,7 @@ status_t DNNL_API brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
 ///     The data type of output vector y depends on dt_a and dt_x:
 ///     - If dt_a and dt_x are integer types (u8/s8), y has int32 data type.
 ///     - If dt_a and dt_x are bf16, f16, or f32, y has f32 data type.
+///
 /// @param transA  Specifies whether matrix A is transposed:
 ///                'false' - A is not transposed,
 ///                'true'  - A is transposed.
@@ -92,13 +93,19 @@ status_t DNNL_API brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
 ///                transposed. Also the size of output vector y.
 /// @param N       Number of columns of matrix A if not transposed, or rows if
 ///                transposed. Also the size of input vector x.
+/// @param treat_y_as_row Specifies whether the y vector should be treated as
+///                a row when the post-ops are applied.
+///                Some post-op parameters can be scalars or vectors of size M.
+///                'true'  - parameter is a vector of size M (applied elementwise)
+///                'false' - parameter is a scalar broadcast over the M
+///                          elements of the output vector y.
 ///
 /// @return status::success on success and a status describing the error
 ///     otherwise.
 status_t brgemv_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_x, bool transA, float alpha, float beta, dim_t LDA,
-        dim_t INCY, dim_t M, dim_t N);
+        dim_t INCY, dim_t M, dim_t N, bool treat_y_as_row);
 
 /// Initializes a BRGEMM descriptor with B matrix as a diagonal matrix
 /// represented in packed vector format.

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -362,6 +362,7 @@ struct brgemm_desc_t {
     bool is_runtime_ldd = false;
 
     bool is_gemv = false;
+    bool treat_y_as_row = false;
 
     static constexpr int MAX_VPAD = 100;
     static constexpr int AMX_TILES_NUM = 8;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -251,6 +251,11 @@ struct brgemm_matmul_conf_t {
     data_type_t wei_zp_dt = data_type::undef;
 
     bool is_gemv = false;
+    // Currently, it's only used to enable the N=1 code path for M=1, when B
+    // is transposed.
+    // TODO: Generalize when a new code path to support M=1, when B is plain
+    // is added.
+    bool gemv_swap_a_b = false;
 
     inline bool lda_big_pow2() const {
         const dim_t big_stride_threshold_in_bytes = 8192;


### PR DESCRIPTION
This PR enables the M=1 case when tensor B is transposed by leveraging the recently introduced GEMV code path for the N=1 case.
The idea is to swap the original tensors A and B, effectively turning it into the N=1 case.

One important point is the extended support for bias in the brgemv interface. It now supports a non-broadcast way of applying bias to handle the swapped case. Since we use the N=1 code path and swap M and N, the destination vector for the swapped case has a length of M, and the bias vector also has a length of M. Therefore, we need to apply the bias elementwise.

Performance data shows that the performance of the autogenerated GEMM and this new case is on par.

<img width="441" height="351" alt="image" src="https://github.com/user-attachments/assets/c1cbe249-8651-447c-a965-55db08a2ddb0" />