### PR TITLE
[backport rls-v3.9] xe: sdpa: Fix micro_sdpa_param_t padding

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -87,7 +87,7 @@ struct micro_sdpa_params_t : trivially_serializable_t<micro_sdpa_params_t> {
     bool d_full, arch_gte_hpc;
     bool block_q, block_a, block_2d_a;
     bool prefetch_mask, prefetch_k0, prefetch_k, prefetch_v, prefetch_remainder;
-    uint8_t padding2[5] = {0};
+    uint8_t padding2[6] = {0};
     int prefetch_d_max;
 
     bool softmax_inf_as_zero;


### PR DESCRIPTION
# Description

Fix micro_sdpa_param_t padding. This was not updated during my rebased in PR #4264 