### PR TITLE
ci: aarch64: fix performance test not showing up as failure

### DIFF
--- a/.github/workflows/performance-aarch64.yml
+++ b/.github/workflows/performance-aarch64.yml
@@ -117,7 +117,6 @@ jobs:
     runs-on: ${{ matrix.config.label }}
     permissions:
       contents: write
-    continue-on-error: true
     steps:
       - name: Checkout oneDNN
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
# Description
A failing performance test is showing up as a pass on the overall nightly pipeline
