### PR TITLE
common: update memory_arg_t abstraction to prolong memory lifetime

### DIFF
--- a/src/common/primitive_exec_types.hpp
+++ b/src/common/primitive_exec_types.hpp
@@ -60,8 +60,25 @@ struct grantor_t;
 } // namespace memory_tracking
 
 struct memory_arg_t {
-    memory_t *mem;
-    bool is_const;
+    memory_arg_t() = default;
+    memory_arg_t(memory_t *mem, bool is_const);
+
+    ~memory_arg_t();
+
+    // All operators are mandatory to handle ref counter for underlying memory
+    // object.
+    memory_arg_t(const memory_arg_t &other);
+    memory_arg_t &operator=(const memory_arg_t &other);
+
+    memory_arg_t(memory_arg_t &&other);
+    memory_arg_t &operator=(memory_arg_t &&other);
+
+    memory_t *mem() const { return mem_; }
+    bool is_const() const { return is_const_; }
+
+private:
+    memory_t *mem_ = nullptr;
+    bool is_const_ = false;
 };
 
 struct primitive_desc_t;

--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -46,8 +46,8 @@ namespace {
 // A proper approach would be an implementation-specific unpoisoning.
 void unpoison_outputs(const exec_args_t &args) {
     for (const auto &arg : args) {
-        if (arg.second.is_const) continue;
-        auto *mem = arg.second.mem;
+        if (arg.second.is_const()) continue;
+        auto *mem = arg.second.mem();
         void *p;
         mem->get_data_handle(&p);
         size_t s = memory_desc_wrapper(*mem->md()).size();

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -481,10 +481,10 @@ status_t ref_deconvolution_fwd_t::execute(const exec_ctx_t &ctx) const {
         conv_args[DNNL_ARG_BIAS] = args.at(DNNL_ARG_BIAS);
 
     // Create intermediate memory for f32 output if needed.
-    auto dst = args.at(DNNL_ARG_DST);
+    const auto &dst = args.at(DNNL_ARG_DST);
     std::unique_ptr<memory_t, memory_deleter_t> tmp_memory;
     CHECK(safe_ptr_assign(tmp_memory,
-            new memory_t(dst.mem->engine(), pd()->conv_pd_->diff_src_md(),
+            new memory_t(dst.mem()->engine(), pd()->conv_pd_->diff_src_md(),
                     scratchpad.get_memory_storage(key_deconv_bias))));
     memory_arg_t tmp_conv_output = {tmp_memory.get(), false};
 

--- a/src/cpu/ref_fused_convolution.hpp
+++ b/src/cpu/ref_fused_convolution.hpp
@@ -427,8 +427,8 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
                     inout_memory.emplace_back(new memory_t(engine, &arg_info.md,
                             inout_buffer->get_sub_storage(arg_info.offset,
                                     memory_desc_wrapper(arg_info.md).size())));
-                    exec_args[arg_info.op_arg].mem = inout_memory.back().get();
-                    exec_args[arg_info.op_arg].is_const = arg_info.is_const;
+                    exec_args[arg_info.op_arg]
+                            = {inout_memory.back().get(), arg_info.is_const};
                 }
             }
 

--- a/src/cpu/sycl/stream_cpu_thunk.cpp
+++ b/src/cpu/sycl/stream_cpu_thunk.cpp
@@ -42,7 +42,7 @@ void dnnl_impl_sycl_cpu_thunk(const thunk_params_t *params) {
     prim_iface->execute(submit_ctx->exec_ctx);
 
     for (auto &m : submit_ctx->exec_ctx.args())
-        m.second.mem->release();
+        m.second.mem()->release();
 
     const_cast<primitive_iface_t *>(prim_iface)->release();
 

--- a/src/cpu/sycl/stream_submit_cpu_primitive.cpp
+++ b/src/cpu/sycl/stream_submit_cpu_primitive.cpp
@@ -111,15 +111,15 @@ void submit_cpu_primitive(stream_t *stream, const primitive_iface_t *prim_iface,
 
     std::vector<const memory_storage_t *> sycl_mem_storages;
     for (auto &a : exec_ctx.args()) {
-        a.second.mem->retain();
-        if (a.second.mem->engine() == nullptr) {
-            const auto mdw = memory_desc_wrapper(a.second.mem->md());
+        a.second.mem()->retain();
+        if (a.second.mem()->engine() == nullptr) {
+            const auto mdw = memory_desc_wrapper(a.second.mem()->md());
             if (mdw.is_host_scalar_desc()) {
                 continue; // Skip host scalar memory objects
             }
         }
-        if (a.second.mem->engine()->runtime_kind() == runtime_kind::sycl) {
-            auto *mem_storage = a.second.mem->memory_storage();
+        if (a.second.mem()->engine()->runtime_kind() == runtime_kind::sycl) {
+            auto *mem_storage = a.second.mem()->memory_storage();
             if (!mem_storage->is_null()) {
                 // Skip USM memory storages as they do not require special
                 // handling and can be accessed directly

--- a/src/gpu/generic/sycl/ref_group_normalization.cpp
+++ b/src/gpu/generic/sycl/ref_group_normalization.cpp
@@ -96,9 +96,9 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
     // use_global_stats is set, to avoid creating 2 kernels just
     // for this
     cloned_args[DNNL_ARG_MEAN]
-            = memory_arg_t {cloned_args[DNNL_ARG_MEAN].mem, false};
+            = memory_arg_t {cloned_args[DNNL_ARG_MEAN].mem(), false};
     cloned_args[DNNL_ARG_VARIANCE]
-            = memory_arg_t {cloned_args[DNNL_ARG_VARIANCE].mem, false};
+            = memory_arg_t {cloned_args[DNNL_ARG_VARIANCE].mem(), false};
 
     exec_ctx_t exec_ctx(ctx.stream(), std::move(cloned_args));
     auto &conf_ = pd()->conf_;

--- a/src/gpu/generic/sycl/ref_sum_many_inputs.cpp
+++ b/src/gpu/generic/sycl/ref_sum_many_inputs.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,8 +42,8 @@ status_t ref_sum_many_inputs_t::init(engine_t *engine) {
 }
 
 status_t ref_sum_many_inputs_t::execute(const exec_ctx_t &ctx) const {
-    memory_arg_t dst_mem_arg = {ctx.args().at(DNNL_ARG_DST).mem, false};
-    memory_arg_t dst_read_mem_arg = {ctx.args().at(DNNL_ARG_DST).mem, true};
+    memory_arg_t dst_mem_arg = {ctx.args().at(DNNL_ARG_DST).mem(), false};
+    memory_arg_t dst_read_mem_arg = {ctx.args().at(DNNL_ARG_DST).mem(), true};
 
     int n_remaining = pd()->conf_.n;
     int in_arg_offset = 0;

--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -366,7 +366,8 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                                   .exec_args
                                   .at(DNNL_ARG_ATTR_MULTIPLE_POST_OP(src.index)
                                           | DNNL_ARG_SRC_1)
-                                  .mem->memory_storage();
+                                  .mem()
+                                  ->memory_storage();
                 break;
             case pd_t::binary_src_t::prelu:
                 po_srcs[i]
@@ -374,7 +375,8 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
                                   .exec_args
                                   .at(DNNL_ARG_ATTR_MULTIPLE_POST_OP(src.index)
                                           | DNNL_ARG_WEIGHTS)
-                                  .mem->memory_storage();
+                                  .mem()
+                                  ->memory_storage();
                 break;
             case pd_t::binary_src_t::bias: po_srcs[i] = &bias; break;
             case pd_t::binary_src_t::scales:

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -983,7 +983,8 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
                                   .exec_args
                                   .at(DNNL_ARG_ATTR_MULTIPLE_POST_OP(src.index)
                                           | DNNL_ARG_SRC_1)
-                                  .mem->memory_storage();
+                                  .mem()
+                                  ->memory_storage();
                 break;
             case pd_t::binary_src_t::prelu:
                 po_srcs[i]
@@ -991,7 +992,8 @@ status_t xe_hp_systolic_t::execute(const exec_ctx_t &ctx) const {
                                   .exec_args
                                   .at(DNNL_ARG_ATTR_MULTIPLE_POST_OP(src.index)
                                           | DNNL_ARG_WEIGHTS)
-                                  .mem->memory_storage();
+                                  .mem()
+                                  ->memory_storage();
                 break;
             case pd_t::binary_src_t::bias: po_srcs[i] = &bias; break;
             case pd_t::binary_src_t::scales:

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -645,10 +645,10 @@ int append_post_ops_to_arg_list_base(const exec_args_t &args,
         if (e.is_binary() || e.is_prelu()) {
             auto arg = args.at(DNNL_ARG_ATTR_MULTIPLE_POST_OP(po_idx)
                     | (e.is_binary() ? DNNL_ARG_SRC_1 : DNNL_ARG_WEIGHTS));
-            gpu_assert(arg.is_const);
+            gpu_assert(arg.is_const());
 
-            auto &binary_arg = arg.mem
-                    ? *(arg.mem->memory_storage())
+            auto &binary_arg = arg.mem()
+                    ? *(arg.mem()->memory_storage())
                     : dnnl::impl::memory_storage_t::empty_storage();
             arg_list.set(post_op_idx++, binary_arg);
 


### PR DESCRIPTION
`memory_arg_t` starts tracking ref_count available in `memory_t` object to make sure that memory objects allocated on stack for nested primitives are lifetime aligned with places use them asynchronously.