### PR TITLE
common:matmul: properly check default quantization mode support

### DIFF
--- a/src/cpu/matmul/cpu_matmul_pd.hpp
+++ b/src/cpu/matmul/cpu_matmul_pd.hpp
@@ -30,8 +30,10 @@ struct cpu_matmul_pd_t : public matmul_pd_t {
     using matmul_pd_t::matmul_pd_t;
     // NOLINTBEGIN(google-default-arguments)
     bool attr_scales_ok(const std::vector<int> &supported_args
-            = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) const override {
-        bool ok = matmul_pd_t::attr_scales_ok(supported_args);
+            = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST},
+            const std::vector<int> &supported_qmodes
+            = {quantization_mode::static_sazp}) const override {
+        bool ok = matmul_pd_t::attr_scales_ok(supported_args, supported_qmodes);
         const auto &scales = attr()->scales_;
         for (int arg : supported_args) {
             if (scales.has_default_values(arg)) { continue; }

--- a/src/cpu/matmul/ref_matmul.hpp
+++ b/src/cpu/matmul/ref_matmul.hpp
@@ -103,7 +103,11 @@ struct ref_matmul_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_MATMUL(ref_post_ops_t::post_ops_ok(attr()->post_ops_),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_MATMUL(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_MATMUL(attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS,
+                                                    DNNL_ARG_DST},
+                                     {quantization_mode::static_sazp,
+                                             quantization_mode::dynamic_mx}),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_MATMUL(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_MATMUL(


### PR DESCRIPTION
This allows to properly check scales support in matmul implementation and preserve default behavior.
Fix for MFDNN-14358.