### PR TITLE
cpu: x64: matmul: do not dispatch to gemm for certain shapes

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1791,7 +1791,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         // We need to exclude certain shapes as brgemm matmul performs better
         // for them.
         const bool exception
-                = bgmmc.M >= 1000 && bgmmc.K <= 16 && bgmmc.N <= 16;
+                = (bgmmc.M >= 1000 && bgmmc.K <= 16 && bgmmc.N <= 16)
+                || (bgmmc.M <= 256 && bgmmc.K <= 8 && bgmmc.N <= 1024);
         VCONDCHECK_BG(
                 IMPLICATION(bgmmc.ndims == 2,
                         exception || !small_K || !can_use_gemm_fallback()),


### PR DESCRIPTION
Temporary fix for MFDNN-14349 and MFDNN-14343. This fix should not affect shapes from MFDNN-13919.

A proper fix for closing the perf gap for the small K cases is in progress.