### PR TITLE
[WIP] [Do Not Review] ci: add experimental script to watch pr comments

### DIFF
--- a/.github/automation/aarch64/pr_comment_bot.py
+++ b/.github/automation/aarch64/pr_comment_bot.py
@@ -1,0 +1,67 @@
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+import argparse
+import subprocess
+import sys
+
+
+def benchdnn_cmd_builder(args):
+    driver = args[0]
+    batch = args[1]
+    return [
+        "./build/tests/benchdnn/benchdnn",
+        "--" + driver,
+        "--mode=L",
+        "--batch=" + batch,
+    ]
+
+
+def ctest_cmd_builder(args):
+    pattern = args[0]
+    return ["ctest", "--test-dir", "./build", "-R", pattern]
+
+
+def main():
+    script = sys.argv[1].split("\n")[1:]
+
+    cmds = []
+
+    for line in script:
+        line_parts = line.split(" ")
+        test_type = line_parts[0]
+        args = line_parts[1:]
+
+        cmd = []
+
+        if test_type == "batch":
+            cmd = benchdnn_cmd_builder(args)
+        elif test_type == "ctest":
+            cmd = ctest_cmd_builder(args)
+        else:
+            raise ValueError("Unrecognised test_type!")
+
+        cmds.append(cmd)
+
+        print(f"{cmd=}")
+
+    # for cmd in cmds:
+    #    subprocess.run(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pr-comment-bot.yml
+++ b/.github/workflows/pr-comment-bot.yml
@@ -1,0 +1,38 @@
+# *******************************************************************************
+# Copyright 2025 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+name: PR comment bot
+on: 
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  parse_tests:
+    name: Parse tests
+    runs-on: ubuntu-24.04-arm
+    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '!test')
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: oneDNN
+          fetch-depth: 0
+      - name: Run script
+        run:
+          python ${{ github.workspace }}/oneDNN/.github/automation/aarch64/pr_comment_bot.py "${{github.event.comment.body}}"
+        env:
+          NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
# Description

Experimenting with workflows that trigger on PR comments.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
