### PR TITLE
xe: jit: conv: improve walk order heuristic

### DIFF
--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -1644,6 +1644,25 @@ walk_order_t compute_walk_order(const config_t &cfg) {
         size_t ab_bytes = get_memory_footprint(cfg, inner, outer);
         if (ab_bytes <= l3_size) grid_inner = std::move(outer);
     }
+
+    // Prefer square spatial dimensions to increase cache reuse due to iteration
+    // over kernel spatial dimensions.
+    if (cfg.prb().is_fwd && cfg.loop_dim(pvars::kh) > 1 && cfg.prb().sh == 1) {
+        auto &w_inner = grid_inner[pvars::ow];
+        auto &h_inner = grid_inner[pvars::oh];
+        auto rebalance_spatial = [&]() {
+            if (grid_tile[pvars::oh] % (h_inner * 2)) return false;
+            if (w_inner % 2) return false;
+            if (w_inner < h_inner * 4) return false;
+            return true;
+        };
+
+        while (rebalance_spatial()) {
+            w_inner /= 2;
+            h_inner *= 2;
+        }
+    }
+
     // Add the blocks in this order:
     // - Step 1. Add grid_inner blocks (fitting L3 cache)
     // - Step 2. Add the remaining M/N blocks


### PR DESCRIPTION
Fix for a regression identified in [MFDNN-14350](https://jira.devtools.intel.com/browse/MFDNN-14350). The regressions is ultimately due to a non-deterministic choice of tiling (see #4267), and one of the tiling resulting in significantly worse performance. Modifying the walk-order as done in this PR restores much of the performance of the poorly performing tiling without adversely effecting many workloads.

```
tile_id=0 enable_rebalance=0:  regs=256 simd=16 fma=dpas l=ic4kd1kh3kw3 T=mb4oc2 i=ic32mb32oc64 P=u p=x3 src=axb wei=xba.axb dst=axb bia=a walk-order=ow64oh64,,
perf,gpu,jit:ir,,--mode=P --conv --engine=gpu --dir=FWD_D --dt=bf16:bf16:bf16 --stag=acdb --wtag=acdb --dtag=acdb --attr-scratchpad=user mb128ic128ih64oc128oh64kh3ph1,151.414,55.032,9.32323,16240.6,9.49201,15951.8
tile_id=0 enable_rebalance=1:  regs=256 simd=16 fma=dpas l=ic4kd1kh3kw3 T=mb4oc2 i=ic32mb32oc64 P=u p=x3 src=axb wei=xba.axb dst=axb bia=a walk-order=ow16oh16ow4oh4,,
perf,gpu,jit:ir,,--mode=P --conv --engine=gpu --dir=FWD_D --dt=bf16:bf16:bf16 --stag=acdb --wtag=acdb --dtag=acdb --attr-scratchpad=user mb128ic128ih64oc128oh64kh3ph1,151.414,53.5513,1.7901,84584.1,2.07077,73120

tile_id=1 enable_rebalance=0:  regs=256 simd=16 fma=dpas l=ic4kd1kh3kw3 T=oc2ow4 i=ic32mb32oc64 P=u p=x3 src=axb wei=xba.axb dst=axb bia=a walk-order=ow16oh64mb4,,
perf,gpu,jit:ir,,--mode=P --conv --engine=gpu --dir=FWD_D --dt=bf16:bf16:bf16 --stag=acdb --wtag=acdb --dtag=acdb --attr-scratchpad=user mb128ic128ih64oc128oh64kh3ph1,151.414,59.9968,1.56094,97002.2,1.81964,83211
tile_id=1 enable_rebalance=1:  regs=256 simd=16 fma=dpas l=ic4kd1kh3kw3 T=oc2ow4 i=ic32mb32oc64 P=u p=x3 src=axb wei=xba.axb dst=axb bia=a walk-order=ow16oh64mb4,,
perf,gpu,jit:ir,,--mode=P --conv --engine=gpu --dir=FWD_D --dt=bf16:bf16:bf16 --stag=acdb --wtag=acdb --dtag=acdb --attr-scratchpad=user mb128ic128ih64oc128oh64kh3ph1,151.414,48.407,1.5576,97209.8,1.82184,83110.5
```