### PR TITLE
fixup: api: threadpool: add wait() method for proper async support

### DIFF
--- a/src/cpu/cpu_stream.hpp
+++ b/src/cpu/cpu_stream.hpp
@@ -41,7 +41,7 @@ struct cpu_stream_t : public stream_t {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
         dnnl::threadpool_interop::threadpool_iface *tp;
         auto rc = this->get_threadpool(&tp);
-        if (rc == status::success) {
+        if (rc == status::success && tp) {
             if (tp->get_flags()
                     & threadpool_interop::threadpool_iface::ASYNCHRONOUS)
                 tp->wait();


### PR DESCRIPTION
[MFDNN-14377](https://jira.devtools.intel.com/browse/MFDNN-14377)

Lacks the check for nullptr.