### PR TITLE
x64: brdgmm kernel: fix reg_zp_compensation register

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -226,8 +226,9 @@ private:
             regscratchpad_, rax, r23};
     const injector_utils::reg64_savable_t reg_src_zero_point {
             regscratchpad_, rax, r24};
+    // TODO: Make use of rbp under condition in reg_zp_compensation
     const injector_utils::reg64_savable_t reg_zp_compensation {
-            regscratchpad_, abi_param1, r25};
+            regscratchpad_, rbp, r25};
     // abi_param1 is used in post-ops injector and by reg_aux_B,
     // so need to be savable or use other registers
     const injector_utils::reg64_savable_t reg_binary_params {


### PR DESCRIPTION
This is a quick fix of segfault in brdgmm kernel for cases where both binary and zero-points used. Like:
 --conv --dt=u8:s8:u8 --stag=axb --dtag=axb --attr-zero-points=src:per_dim_1 --attr-post-ops=add:f32:per_oc g8mb1ic8ih4oc8kh3ph1
 
TODO: investigate it and make rbp usage for reg_zp_compensation conditional