### PR TITLE
x64: brdgmm kernel: do not pollute rbp by reg_zp_compensation

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -226,9 +226,8 @@ private:
             regscratchpad_, rax, r23};
     const injector_utils::reg64_savable_t reg_src_zero_point {
             regscratchpad_, rax, r24};
-    // TODO: Make use of rbp under condition in reg_zp_compensation
     const injector_utils::reg64_savable_t reg_zp_compensation {
-            regscratchpad_, rbp, r25};
+            regscratchpad_, r12, r25};
     // abi_param1 is used in post-ops injector and by reg_aux_B,
     // so need to be savable or use other registers
     const injector_utils::reg64_savable_t reg_binary_params {


### PR DESCRIPTION
This is final fix (after quick fix by #4301 ) of seg-fault in brdgmm kernel.
We may use r12 for reg_zp_compensation 