### PR TITLE
gpu: intel: compute: fix setting 4gb flag

### DIFF
--- a/src/gpu/intel/compute/dispatch_reusable.hpp
+++ b/src/gpu/intel/compute/dispatch_reusable.hpp
@@ -380,6 +380,12 @@ struct named_buffer_t : public memory_desc_t {
                 .nelems(with_padding);
     }
 
+    uint64_t size(int index = 0, bool include_additional_size = true,
+            bool include_offset0 = false) const {
+        return memory_desc_wrapper(static_cast<memory_desc_t>(*this))
+                .size(index, include_additional_size, include_offset0);
+    }
+
     const std::string &get_name() const { return name; }
     const std::vector<dim_idx_t> &get_dim_ids() const { return dim_ids; }
 
@@ -547,10 +553,10 @@ public:
             compile_params.buffer_types[buf_idx] = buffer.data_type;
 
             // Check buffer sizes to see if we can use int32_t offsets
+            // or do we need to use stateless addressing model
             max_buffer_size = std::max(max_buffer_size, buffer.nelems(true));
-            max_buffer_size_bytes = std::max(max_buffer_size_bytes,
-                    buffer.nelems(true)
-                            * types::data_type_size(buffer.data_type));
+            max_buffer_size_bytes = std::max(
+                    max_buffer_size_bytes, buffer.size(0, true, true));
         }
 
         compile_params.use_int32_offset = max_buffer_size <= INT32_MAX;

--- a/src/gpu/intel/compute/kernel_ctx.cpp
+++ b/src/gpu/intel/compute/kernel_ctx.cpp
@@ -23,9 +23,14 @@ namespace gpu {
 namespace intel {
 namespace compute {
 
+void kernel_ctx_t::register_buffer_size(const memory_desc_wrapper &mdw) {
+    register_buffer_size(mdw.nelems(true), mdw.size(0, true, true));
+}
+
 void kernel_ctx_t::register_buffer_size(const memory_desc_info_t &mdi) {
     register_buffer_size(
-            mdi.size + mdi.offset0 * types::data_type_size(mdi.data_type));
+            (mdi.size / types::data_type_size(mdi.data_type)) + mdi.offset0,
+            mdi.size + (mdi.offset0 * types::data_type_size(mdi.data_type)));
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -77,14 +77,7 @@ public:
         return oss.str();
     }
 
-    void register_buffer_size(size_t size) {
-        if (size > INT_MAX) use_int32_offset(false);
-        if (size > UINT32_MAX) require_large_buffers(true);
-    }
-
-    void register_buffer_size(const memory_desc_wrapper &mdw) {
-        register_buffer_size(mdw.size(0, true, true));
-    }
+    void register_buffer_size(const memory_desc_wrapper &mdw);
     void register_buffer_size(const memory_desc_info_t &mdi);
 
     // Enable various optimizations when all buffers are < 2GB in size. In this
@@ -167,6 +160,11 @@ public:
     bool has_custom_headers() const { return !custom_headers_.empty(); }
 
 private:
+    void register_buffer_size(dim_t nelems, size_t size) {
+        if (nelems > INT_MAX) use_int32_offset(false);
+        if (size > UINT32_MAX) require_large_buffers(true);
+    }
+
     void set_default_options(const primitive_attr_t *attr) {
         // By default fp32 division and sqrt are not IEEE-compliant
         add_option("-cl-fp32-correctly-rounded-divide-sqrt");

--- a/src/gpu/intel/reduction/atomic.cpp
+++ b/src/gpu/intel/reduction/atomic.cpp
@@ -234,6 +234,7 @@ status_t atomic_conf_t::init_dispatcher(
             dims::subgroup,
     };
     compute::named_buffer_t src("SRC");
+    src.data_type = conf.src_type;
     std::array<dim_t, 6> sizes = {
             outer_block.block,
             conf.global_acc,
@@ -253,6 +254,7 @@ status_t atomic_conf_t::init_dispatcher(
             = dim_t(outer_block.stride / conf.vect_size);
 
     compute::named_buffer_t dst("DST", src);
+    dst.data_type = conf.dst_type;
     dst.remove_dim(dims::loop);
     dst.remove_dim(dims::local); // broadcasted
     dst.remove_dim(dims::global); // broadcasted

--- a/src/gpu/intel/reduction/reusable_ref.cpp
+++ b/src/gpu/intel/reduction/reusable_ref.cpp
@@ -69,10 +69,12 @@ status_t ref_conf_t::init_dispatcher(const subproblem_t &subprb,
         const intel::engine_t &engine, gpu_primitive_attr_t *gpu_attr) {
 
     compute::named_buffer_t src_buf("SRC");
+    src_buf.data_type = conf.src_dt;
     src_buf.append_block(dims::outer, subprb.outer_block.block);
     src_buf.append_block(dims::reduction, subprb.reduction_block.block);
     src_buf.append_block(dims::inner, subprb.inner_block.block);
     compute::named_buffer_t dst_buf("DST", src_buf);
+    dst_buf.data_type = conf.dst_dt;
     dst_buf.remove_dim(dims::reduction);
 
     compute::reusable_dispatch_config_t config(&engine, dispatch_dims);

--- a/src/gpu/intel/softmax/reusable.cpp
+++ b/src/gpu/intel/softmax/reusable.cpp
@@ -146,9 +146,11 @@ status_t reusable_fwd_t::pd_t::init_dispatch_workgroup_per_reduction(
 
     // source buffer gets new dimension: multiple workers per reduction block
     compute::named_buffer_t src_buf("SRC");
+    src_buf.data_type = conf.src_data_type;
 
     // keep original input buffer geometry for addressing
     compute::named_buffer_t ori_buf("ORIGINAL");
+    ori_buf.data_type = conf.src_data_type;
     for (size_t i = 0; i < dims_ids.size(); i++) {
         ori_buf.append_block(dims_ids[i], sizes[i]);
     }
@@ -174,6 +176,7 @@ status_t reusable_fwd_t::pd_t::init_dispatch_workgroup_per_reduction(
     }
 
     compute::named_buffer_t dst_buf("DST", src_buf);
+    dst_buf.data_type = conf.dst_data_type;
 
     // dispatch: all dims except reduction dimension plus workers dimension
     std::vector<dim_idx_t> dispatch_dims = std::move(dims_ids);


### PR DESCRIPTION
Named buffers data type was not always set which led to incorrect buffer size calculation:
1. Added missing data types
2. Used memory wrapper `size()` method to calculate buffer size
3. Fixed `USE_INT32_OFFSET` option setting, which should be set based on number of elements and not size in bytes

Fixes: [MFDNN-14379](https://jira.devtools.intel.com/browse/MFDNN-14379)