### PR TITLE
aarch64: conv: disable s8/u8 -> s32 brg conv for SVE256

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -234,7 +234,8 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
                 || (!one_of(dt_bias, data_type::undef, data_type::s8,
                         data_type::u8, data_type::f32))
                 || (!one_of(dt_d, data_type::s8, data_type::u8, data_type::s32,
-                        data_type::f32)))
+                        data_type::f32))
+                || (dt_d == data_type::s32 && get_max_cpu_isa() == sve_256))
             return status::unimplemented;
     }
     if ((brg->dt_a == data_type::bf16 && brg->dt_b == data_type::bf16)


### PR DESCRIPTION
s8/u8 -> s32 brg conv is causing unit test failures for PyTorch. Disable these until a permanent fix can be found
