### PR TITLE
cpu: rv64: pooling: add f16 support for nhwc pooling

### DIFF
--- a/src/cpu/rv64/rvv_nhwc_pooling.cpp
+++ b/src/cpu/rv64/rvv_nhwc_pooling.cpp
@@ -16,9 +16,13 @@
 *******************************************************************************/
 
 #include <algorithm>
+#include <float.h>
 #include <riscv_vector.h>
 
+#include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/type_helpers.hpp"
 #include "cpu/rv64/rvv_nhwc_pooling.hpp"
 
 namespace dnnl {
@@ -27,13 +31,17 @@ namespace cpu {
 namespace rv64 {
 
 namespace {
-void MaxPooling(const float *src, float *dst, const dim_t batch,
-        const dim_t channels, const dim_t outD, const dim_t outH,
-        const dim_t outW, const dim_t inD, const dim_t inH, const dim_t inW,
-        const dim_t kerD, const dim_t kerH, const dim_t kerW,
+
+static void MaxPooling_f32(const void *src_raw, void *dst_raw,
+        const dim_t batch, const dim_t channels, const dim_t outD,
+        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
+        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
         const dim_t strideD, const dim_t strideH, const dim_t strideW,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft,
         const rvv_postops_t &postops_handler) {
+
+    const float *src = static_cast<const float *>(src_raw);
+    float *dst = static_cast<float *>(dst_raw);
 
     parallel_nd(batch, outD, outH, outW,
             [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
@@ -91,14 +99,16 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
     });
 }
 
-void AvgPoolingIncludePadding(const float *src, float *dst, const dim_t batch,
-        const dim_t channels, const dim_t outD, const dim_t outH,
-        const dim_t outW, const dim_t inD, const dim_t inH, const dim_t inW,
-        const dim_t kerD, const dim_t kerH, const dim_t kerW,
+static void AvgPoolingIncludePadding_f32(const void *src_raw, void *dst_raw,
+        const dim_t batch, const dim_t channels, const dim_t outD,
+        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
+        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
         const dim_t strideD, const dim_t strideH, const dim_t strideW,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft,
         const rvv_postops_t &postops_handler) {
 
+    const float *src = static_cast<const float *>(src_raw);
+    float *dst = static_cast<float *>(dst_raw);
     const float kernel_volume = (float)(kerD * kerH * kerW);
 
     parallel_nd(batch, outD, outH, outW,
@@ -151,13 +161,16 @@ void AvgPoolingIncludePadding(const float *src, float *dst, const dim_t batch,
     });
 }
 
-void AvgPoolingExcludePadding(const float *src, float *dst, const dim_t batch,
-        const dim_t channels, const dim_t outD, const dim_t outH,
-        const dim_t outW, const dim_t inD, const dim_t inH, const dim_t inW,
-        const dim_t kerD, const dim_t kerH, const dim_t kerW,
+static void AvgPoolingExcludePadding_f32(const void *src_raw, void *dst_raw,
+        const dim_t batch, const dim_t channels, const dim_t outD,
+        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
+        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
         const dim_t strideD, const dim_t strideH, const dim_t strideW,
         const dim_t padFront, const dim_t padTop, const dim_t padLeft,
         const rvv_postops_t &postops_handler) {
+
+    const float *src = static_cast<const float *>(src_raw);
+    float *dst = static_cast<float *>(dst_raw);
 
     parallel_nd(batch, outD, outH, outW,
             [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
@@ -212,6 +225,236 @@ void AvgPoolingExcludePadding(const float *src, float *dst, const dim_t batch,
         }
     });
 }
+
+#if defined(DNNL_RISCV_USE_ZVFH_INTRINSICS)
+static void MaxPooling_f16(const void *src_raw, void *dst_raw,
+        const dim_t batch, const dim_t channels, const dim_t outD,
+        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
+        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
+        const dim_t strideD, const dim_t strideH, const dim_t strideW,
+        const dim_t padFront, const dim_t padTop, const dim_t padLeft,
+        const rvv_postops_t &postops_handler) {
+
+    const dnnl::impl::float16_t *src
+            = static_cast<const dnnl::impl::float16_t *>(src_raw);
+    dnnl::impl::float16_t *dst = static_cast<dnnl::impl::float16_t *>(dst_raw);
+
+    parallel_nd(batch, outD, outH, outW,
+            [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
+        const size_t dst_spatial_base
+                = ((((size_t)mb * outD + od) * outH + oh) * outW + ow)
+                * channels;
+
+        const int od_offset = (int)(od * strideD - padFront);
+        const int oh_offset = (int)(oh * strideH - padTop);
+        const int ow_offset = (int)(ow * strideW - padLeft);
+        const int id_start = std::max(od_offset, 0);
+        const int ih_start = std::max(oh_offset, 0);
+        const int iw_start = std::max(ow_offset, 0);
+        const int id_end = std::min(od_offset + (int)kerD, (int)inD);
+        const int ih_end = std::min(oh_offset + (int)kerH, (int)inH);
+        const int iw_end = std::min(ow_offset + (int)kerW, (int)inW);
+
+        const float f16_lowest
+                = (float)nstl::numeric_limits<dnnl::impl::float16_t>::lowest();
+
+        if (id_start >= id_end || ih_start >= ih_end || iw_start >= iw_end) {
+            size_t oc = 0;
+            while (oc < (size_t)channels) {
+                size_t vl = __riscv_vsetvl_e16m1((size_t)channels - oc);
+                vfloat16m1_t vfill
+                        = __riscv_vfmv_v_f_f16m1((_Float16)f16_lowest, vl);
+                // vfill = postops_handler.apply(vfill, vl); // TODO: f16 postops
+                __riscv_vse16_v_f16m1(
+                        (_Float16 *)&dst[dst_spatial_base + oc], vfill, vl);
+                oc += vl;
+            }
+            return;
+        }
+
+        size_t oc = 0;
+        while (oc < (size_t)channels) {
+            size_t vl = __riscv_vsetvl_e16m1((size_t)channels - oc);
+            vfloat16m1_t vmax
+                    = __riscv_vfmv_v_f_f16m1((_Float16)f16_lowest, vl);
+
+            for (int id = id_start; id < id_end; ++id) {
+                for (int ih = ih_start; ih < ih_end; ++ih) {
+                    for (int iw = iw_start; iw < iw_end; ++iw) {
+                        const size_t src_spatial_base
+                                = ((((size_t)mb * inD + id) * inH + ih) * inW
+                                          + iw)
+                                * channels;
+                        const dnnl::impl::float16_t *src_ptr
+                                = &src[src_spatial_base + oc];
+                        vfloat16m1_t vsrc = __riscv_vle16_v_f16m1(
+                                (const _Float16 *)src_ptr, vl);
+                        vmax = __riscv_vfmax_vv_f16m1(vmax, vsrc, vl);
+                    }
+                }
+            }
+
+            // vmax = postops_handler.apply(vmax, vl); // TODO: f16 postops
+            __riscv_vse16_v_f16m1(
+                    (_Float16 *)&dst[dst_spatial_base + oc], vmax, vl);
+            oc += vl;
+        }
+    });
+}
+
+static void AvgPoolingIncludePadding_f16(const void *src_raw, void *dst_raw,
+        const dim_t batch, const dim_t channels, const dim_t outD,
+        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
+        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
+        const dim_t strideD, const dim_t strideH, const dim_t strideW,
+        const dim_t padFront, const dim_t padTop, const dim_t padLeft,
+        const rvv_postops_t &postops_handler) {
+
+    const dnnl::impl::float16_t *src
+            = static_cast<const dnnl::impl::float16_t *>(src_raw);
+    dnnl::impl::float16_t *dst = static_cast<dnnl::impl::float16_t *>(dst_raw);
+    const float kernel_volume = (float)(kerD * kerH * kerW);
+
+    parallel_nd(batch, outD, outH, outW,
+            [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
+        const size_t dst_spatial_base
+                = ((((size_t)mb * outD + od) * outH + oh) * outW + ow)
+                * channels;
+
+        const int od_offset = (int)(od * strideD - padFront);
+        const int oh_offset = (int)(oh * strideH - padTop);
+        const int ow_offset = (int)(ow * strideW - padLeft);
+        const int id_start = std::max(od_offset, 0);
+        const int ih_start = std::max(oh_offset, 0);
+        const int iw_start = std::max(ow_offset, 0);
+        const int id_end = std::min(od_offset + (int)kerD, (int)inD);
+        const int ih_end = std::min(oh_offset + (int)kerH, (int)inH);
+        const int iw_end = std::min(ow_offset + (int)kerW, (int)inW);
+
+        size_t oc = 0;
+        while (oc < (size_t)channels) {
+            size_t vl = __riscv_vsetvl_e16m1((size_t)channels - oc);
+            vfloat32m2_t vsum_f32 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+
+            if (id_start < id_end && ih_start < ih_end && iw_start < iw_end) {
+                for (int id = id_start; id < id_end; ++id) {
+                    for (int ih = ih_start; ih < ih_end; ++ih) {
+                        for (int iw = iw_start; iw < iw_end; ++iw) {
+                            const size_t src_spatial_base
+                                    = ((((size_t)mb * inD + id) * inH + ih)
+                                                      * inW
+                                              + iw)
+                                    * channels;
+                            const dnnl::impl::float16_t *src_ptr
+                                    = &src[src_spatial_base + oc];
+                            vfloat16m1_t vsrc_f16 = __riscv_vle16_v_f16m1(
+                                    (const _Float16 *)src_ptr, vl);
+                            vfloat32m2_t vsrc_f32
+                                    = __riscv_vfwcvt_f_f_v_f32m2(vsrc_f16, vl);
+                            vsum_f32 = __riscv_vfadd_vv_f32m2(
+                                    vsum_f32, vsrc_f32, vl);
+                        }
+                    }
+                }
+            }
+
+            vfloat32m2_t vscale_f32
+                    = __riscv_vfmv_v_f_f32m2(1.0f / kernel_volume, vl);
+            vfloat32m2_t vout_f32
+                    = __riscv_vfmul_vv_f32m2(vsum_f32, vscale_f32, vl);
+
+            // vout_f32 = postops_handler.apply(vout_f32, vl); // TODO: f16 postops
+
+            vfloat16m1_t vout_f16 = __riscv_vfncvt_f_f_w_f16m1(vout_f32, vl);
+
+            __riscv_vse16_v_f16m1(
+                    (_Float16 *)&dst[dst_spatial_base + oc], vout_f16, vl);
+            oc += vl;
+        }
+    });
+}
+
+static void AvgPoolingExcludePadding_f16(const void *src_raw, void *dst_raw,
+        const dim_t batch, const dim_t channels, const dim_t outD,
+        const dim_t outH, const dim_t outW, const dim_t inD, const dim_t inH,
+        const dim_t inW, const dim_t kerD, const dim_t kerH, const dim_t kerW,
+        const dim_t strideD, const dim_t strideH, const dim_t strideW,
+        const dim_t padFront, const dim_t padTop, const dim_t padLeft,
+        const rvv_postops_t &postops_handler) {
+
+    const dnnl::impl::float16_t *src
+            = static_cast<const dnnl::impl::float16_t *>(src_raw);
+    dnnl::impl::float16_t *dst = static_cast<dnnl::impl::float16_t *>(dst_raw);
+
+    parallel_nd(batch, outD, outH, outW,
+            [&](dim_t mb, dim_t od, dim_t oh, dim_t ow) {
+        const size_t dst_spatial_base
+                = ((((size_t)mb * outD + od) * outH + oh) * outW + ow)
+                * channels;
+
+        const int od_offset = (int)(od * strideD - padFront);
+        const int oh_offset = (int)(oh * strideH - padTop);
+        const int ow_offset = (int)(ow * strideW - padLeft);
+
+        size_t oc = 0;
+        while (oc < (size_t)channels) {
+            size_t vl = __riscv_vsetvl_e16m1((size_t)channels - oc);
+            vfloat32m2_t vsum_f32 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+            float count_scalar = 0.0f;
+
+            for (int id = od_offset; id < od_offset + (int)kerD; ++id) {
+                if (id < 0 || id >= (int)inD) continue;
+                for (int ih = oh_offset; ih < oh_offset + (int)kerH; ++ih) {
+                    if (ih < 0 || ih >= (int)inH) continue;
+
+                    int iw_start = std::max(ow_offset, 0);
+                    int iw_end = std::min(ow_offset + (int)kerW, (int)inW);
+                    if (iw_start >= iw_end) continue;
+
+                    for (int iw = iw_start; iw < iw_end; ++iw) {
+                        const size_t src_spatial_base
+                                = ((((size_t)mb * inD + id) * inH + ih) * inW
+                                          + iw)
+                                * channels;
+                        const dnnl::impl::float16_t *src_ptr
+                                = &src[src_spatial_base + oc];
+                        vfloat16m1_t vsrc_f16 = __riscv_vle16_v_f16m1(
+                                (const _Float16 *)src_ptr, vl);
+                        vfloat32m2_t vsrc_f32
+                                = __riscv_vfwcvt_f_f_v_f32m2(vsrc_f16, vl);
+                        vsum_f32 = __riscv_vfadd_vv_f32m2(
+                                vsum_f32, vsrc_f32, vl);
+                        count_scalar += 1.0f;
+                    }
+                }
+            }
+
+            if (count_scalar == 0.0f) {
+                vfloat32m2_t vzero_f32 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+                // vzero_f32 = postops_handler.apply(vzero_f32, vl); // TODO: f16 postops
+                vfloat16m1_t vout_f16
+                        = __riscv_vfncvt_f_f_w_f16m1(vzero_f32, vl);
+                __riscv_vse16_v_f16m1(
+                        (_Float16 *)&dst[dst_spatial_base + oc], vout_f16, vl);
+            } else {
+                vfloat32m2_t vscale_f32
+                        = __riscv_vfmv_v_f_f32m2(1.0f / count_scalar, vl);
+                vfloat32m2_t vout_f32
+                        = __riscv_vfmul_vv_f32m2(vsum_f32, vscale_f32, vl);
+
+                // vout_f32 = postops_handler.apply(vout_f32, vl); // TODO: f16 postops
+
+                vfloat16m1_t vout_f16
+                        = __riscv_vfncvt_f_f_w_f16m1(vout_f32, vl);
+                __riscv_vse16_v_f16m1(
+                        (_Float16 *)&dst[dst_spatial_base + oc], vout_f16, vl);
+            }
+            oc += vl;
+        }
+    });
+}
+#endif // DNNL_RISCV_USE_ZVFH_INTRINSICS
+
 } // namespace
 
 riscv_nhwc_pooling_fwd_t::riscv_nhwc_pooling_fwd_t(const pd_t *apd)
@@ -219,14 +462,17 @@ riscv_nhwc_pooling_fwd_t::riscv_nhwc_pooling_fwd_t(const pd_t *apd)
 
 status_t riscv_nhwc_pooling_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
-    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
-    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
+
+    auto src_raw = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    auto dst_raw = CTX_OUT_MEM(void *, DNNL_ARG_DST);
 
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper dst_d(pd()->dst_md());
+    const auto dt = src_d.data_type();
+    const size_t dt_size = types::data_type_size(dt);
 
-    src += src_d.off_l(0);
-    dst += dst_d.off_l(0);
+    src_raw = (const uint8_t *)src_raw + src_d.off_l(0) * dt_size;
+    dst_raw = (uint8_t *)dst_raw + dst_d.off_l(0) * dt_size;
 
     const dim_t MB = pd()->MB();
     const dim_t C = pd()->OC();
@@ -254,16 +500,42 @@ status_t riscv_nhwc_pooling_fwd_t::execute_forward(
             = alg == alg_kind::pooling_avg_include_padding;
     const bool is_avg_pool_exclude
             = alg == alg_kind::pooling_avg_exclude_padding;
-    if (is_max_pool) {
-        MaxPooling(src, dst, MB, C, OD, OH, OW, ID, IH, IW, KD, KH, KW, SD, SH,
-                SW, padF, padT, padL, postops_handler);
-    } else if (is_avg_pool_exclude) {
-        AvgPoolingExcludePadding(src, dst, MB, C, OD, OH, OW, ID, IH, IW, KD,
-                KH, KW, SD, SH, SW, padF, padT, padL, postops_handler);
-    } else if (is_avg_pool_include) {
-        AvgPoolingIncludePadding(src, dst, MB, C, OD, OH, OW, ID, IH, IW, KD,
-                KH, KW, SD, SH, SW, padF, padT, padL, postops_handler);
-    } else {
+
+    if (dt == data_type::f32) {
+        if (is_max_pool) {
+            MaxPooling_f32(src_raw, dst_raw, MB, C, OD, OH, OW, ID, IH, IW, KD,
+                    KH, KW, SD, SH, SW, padF, padT, padL, postops_handler);
+        } else if (is_avg_pool_exclude) {
+            AvgPoolingExcludePadding_f32(src_raw, dst_raw, MB, C, OD, OH, OW,
+                    ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
+                    postops_handler);
+        } else if (is_avg_pool_include) {
+            AvgPoolingIncludePadding_f32(src_raw, dst_raw, MB, C, OD, OH, OW,
+                    ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
+                    postops_handler);
+        } else {
+            return status::unimplemented;
+        }
+    }
+#if defined(DNNL_RISCV_USE_ZVFH_INTRINSICS)
+    else if (dt == data_type::f16) {
+        if (is_max_pool) {
+            MaxPooling_f16(src_raw, dst_raw, MB, C, OD, OH, OW, ID, IH, IW, KD,
+                    KH, KW, SD, SH, SW, padF, padT, padL, postops_handler);
+        } else if (is_avg_pool_exclude) {
+            AvgPoolingExcludePadding_f16(src_raw, dst_raw, MB, C, OD, OH, OW,
+                    ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
+                    postops_handler);
+        } else if (is_avg_pool_include) {
+            AvgPoolingIncludePadding_f16(src_raw, dst_raw, MB, C, OD, OH, OW,
+                    ID, IH, IW, KD, KH, KW, SD, SH, SW, padF, padT, padL,
+                    postops_handler);
+        } else {
+            return status::unimplemented;
+        }
+    }
+#endif
+    else {
         return status::unimplemented;
     }
 


### PR DESCRIPTION
# Description
<del>This needs to wait for #4322 to be approved.</del>
This PR introduces f16 (half-precision) support for the NHWC pooling primitive on RISC-V 64-bit architecture, utilizing the zvfh vector extension. This builds upon the work in #4322 (runtime detection).

## Performance Verification

The implementation was validated against the standard oneDNN 2D pooling test suite (inputs/pool/shapes_2d).
* Coverage Rate: 89% (195/218 executed cases) were successfully handled by the optimized RISC-V Vector kernel (RISCV64GCV).
* Supported Algorithms: The kernel covers all algorithms, including: max, avg_include_padding, and avg_exclude_padding.
* Fallbacks: The remaining 11% fell back to the reference implementation. The fallback cases involve dilated pooling (dh > 0 or dw > 0), which is explicitly unsupported in this initial implementation.
* Across the covered test cases, we observed an average speedup of **15.10x** on the SG2044 platform.

### Speedup Data

<details>

| ﻿%engine% | %impl% | %prb% | speedup |
| --- | --- | --- | --- |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic8ih3oh3kh3ph1 | 1.230958529 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic8ih3oh3kh3ph1 | 1.232525909 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic8ih3oh3kh3ph1 | 1.216755203 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic128ih4oh2kh3ph0 | 1.869727194 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic128ih4oh2kh3ph0 | 1.801381712 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic128ih4oh2kh3ph0 | 1.722514316 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic96ih4oh2kh3ph0 | 1.691008448 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic96ih4oh2kh3ph0 | 1.674719649 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic96ih4oh2kh3ph0 | 1.621386307 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic64ih1oh1kh3ph1 | 1.99225544 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic64ih1oh1kh3ph1 | 1.920498843 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic64ih1oh1kh3ph1 | 1.870908825 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic4ih4oh4kh3ph1 | 1.99212791 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic4ih4oh4kh3ph1 | 1.679111508 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic4ih4oh4kh3ph1 | 1.634823771 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic32ih4oh4kh3ph1 | 1.857131582 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic32ih4oh4kh3ph1 | 1.540253968 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic32ih4oh4kh3ph1 | 1.51646503 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic32ih13oh12kh3ph0 | 8.059394748 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic32ih13oh12kh3ph0 | 4.57570678 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic32ih13oh12kh3ph0 | 4.118622449 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb16ic64ih32oh16kh3sh2ph0 | 14.38549945 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb16ic64ih32oh16kh3sh2ph0 | 8.07909084 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb16ic64ih32oh16kh3sh2ph0 | 6.542425848 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic16ih10oh10kh2ph1 | 3.963520364 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic16ih10oh10kh2ph1 | 3.938977993 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic16ih10oh10kh2ph1 | 3.840430444 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb64ic64ih56oh56kh3ph1 | 13.00101689 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb64ic64ih56oh56kh3ph1 | 7.046506637 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb64ic64ih56oh56kh3ph1 | 6.330832049 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1 | 17.98564722 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1 | 14.14942965 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1 | 10.63666051 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1 | 14.7760997 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1 | 4.615461513 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1 | 4.081747223 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic17ih6oh7kh2ph1 | 4.829917741 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic17ih6oh7kh2ph1 | 3.919749825 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic17ih6oh7kh2ph1 | 4.225370636 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1 | 53.21149622 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1 | 32.75887054 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1 | 21.33181937 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1 | 37.92323922 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1 | 19.61444191 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1 | 15.84716191 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1 | 48.74932754 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1 | 32.15212451 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1 | 17.69490638 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1 | 39.40300028 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1 | 24.13937697 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1 | 17.02279491 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1 | 35.23426201 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1 | 20.8499776 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1 | 16.35660202 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1 | 20.60610239 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1 | 13.44228065 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1 | 8.155963381 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1 | 1.193063338 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1 | 1.205707476 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1 | 1.223428923 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1 | 1.325400057 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1 | 1.34228413 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1 | 1.353712727 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1 | 3.091515505 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1 | 3.045138823 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1 | 2.779503055 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0 | 8.749719871 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0 | 7.065154297 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0 | 5.256511651 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic1ih32oh6kh6sh6ph2 | 1.655360386 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic1ih32oh6kh6sh6ph2 | 1.637770758 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic1ih32oh6kh6sh6ph2 | 1.433587827 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0 | 1.613114844 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0 | 1.691633969 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0 | 1.63516452 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0 | 22.77281421 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0 | 16.98268874 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0 | 11.00653609 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0 | 35.21018751 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0 | 29.66130572 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0 | 16.88698921 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0 | 23.02280731 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0 | 18.85054333 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0 | 12.43778369 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0 | 34.85110411 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0 | 19.81380855 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0 | 15.08131224 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih20iw15oh17ow14kh4kw3ph0pw1 | 26.07700109 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih20iw15oh17ow14kh4kw3ph0pw1 | 15.35005708 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih20iw15oh17ow14kh4kw3ph0pw1 | 9.741592684 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih20iw18oh17ow14kh4kw6ph0pw1 | 43.1969336 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih20iw18oh17ow14kh4kw6ph0pw1 | 27.71077887 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih20iw18oh17ow14kh4kw6ph0pw1 | 14.45788006 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih19iw16oh17ow14kh4kw3ph1pw0 | 26.0698473 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih19iw16oh17ow14kh4kw3ph1pw0 | 14.77732587 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih19iw16oh17ow14kh4kw3ph1pw0 | 10.51714485 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih19iw19oh17ow14kh4kw6ph1pw0 | 32.41516286 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih19iw19oh17ow14kh4kw6ph1pw0 | 23.7935171 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih19iw19oh17ow14kh4kw6ph1pw0 | 12.97144084 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 6.271473858 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 5.217201489 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 3.943731446 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0 | 1.544981 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0 | 1.64071641 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0 | 1.525298301 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic16ih20iw15oh17ow14kh4kw3ph0pw1 | 9.974652602 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic16ih20iw15oh17ow14kh4kw3ph0pw1 | 11.53739736 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic16ih20iw15oh17ow14kh4kw3ph0pw1 | 8.065314087 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic32ih20iw15oh17ow14kh4kw3ph0pw1 | 11.57511119 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic32ih20iw15oh17ow14kh4kw3ph0pw1 | 6.561963415 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic32ih20iw15oh17ow14kh4kw3ph0pw1 | 4.678420098 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic65ih20iw15oh17ow14kh4kw3ph0pw1 | 15.22113933 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic65ih20iw15oh17ow14kh4kw3ph0pw1 | 12.62687886 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic65ih20iw15oh17ow14kh4kw3ph0pw1 | 8.253417586 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 6.228090952 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 5.755964823 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 4.087754939 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 7.685730928 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 6.255617444 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 4.382784274 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 8.88181962 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 6.696119509 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_np ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0 | 4.1045019 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc mb1ic16ih10oh6kh5sh5ph10 | 1.724618187 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D16:D16 --tag=nhwc --alg=avg_p mb1ic16ih10oh6kh5sh5ph10 | 1.634193613 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D14:D14 --tag=nhwc ic20ih16oh3kh16sh16ph16 | 4.79109596 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D14:D14 --tag=nhwc --alg=avg_p ic20ih16oh3kh16sh16ph16 | 3.955990544 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D12:D12 --tag=nhwc mb3ic17ih13oh37kh17ph20 | 69.1503867 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D12:D12 --tag=nhwc --alg=avg_p mb3ic17ih13oh37kh17ph20 | 40.67056452 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D10:D10 --tag=nhwc ic35ih20iw13oh17ow14kh4kw3ph0pw3 | 20.52450766 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D10:D10 --tag=nhwc --alg=avg_p ic35ih20iw13oh17ow14kh4kw3ph0pw3 | 16.96004706 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D8:D8 --tag=nhwc ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3 | 24.0489338 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D8:D8 --tag=nhwc --alg=avg_p ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3 | 14.07925875 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D6:D6 --tag=nhwc ic35ih20iw13oh17ow14kh4kw6ph0pw6 | 32.53559595 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D6:D6 --tag=nhwc --alg=avg_p ic35ih20iw13oh17ow14kh4kw6ph0pw6 | 21.82241416 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D4:D4 --tag=nhwc ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6 | 24.7667856 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D4:D4 --tag=nhwc --alg=avg_p ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6 | 23.13943086 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D2:D2 --tag=nhwc ic35ih16iw16oh17ow14kh4kw3ph4pw0 | 20.7138494 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=D2:D2 --tag=nhwc --alg=avg_p ic35ih16iw16oh17ow14kh4kw3ph4pw0 | 16.72564786 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0 | 26.72804503 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0 | 14.89284222 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih16iw19oh17ow14kh4kw6ph4pw0 | 29.17195734 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih16iw19oh17ow14kh4kw6ph4pw0 | 29.28514222 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0 | 30.73383959 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0 | 25.18969495 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih16iw13oh17ow14kh4kw3ph4pw3 | 18.256714 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih16iw13oh17ow14kh4kw3ph4pw3 | 15.79389112 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3 | 20.53094053 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3 | 16.41546753 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih16iw13oh17ow14kh4kw6ph4pw6 | 27.02497327 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih16iw13oh17ow14kh4kw6ph4pw6 | 18.76752092 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6 | 27.37861239 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6 | 20.80268717 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0 | 23.80510243 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0 | 13.93861508 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0 | 9.843677891 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0 | 21.81784134 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0 | 15.90354829 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0 | 11.8441601 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0 | 28.03244746 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0 | 25.12871191 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0 | 13.69924142 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0 | 41.9949837 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0 | 25.84713959 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0 | 16.66124876 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0 | 22.95545889 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0 | 18.79598254 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0 | 11.30192331 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0 | 25.21107668 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0 | 18.34192794 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0 | 11.66455495 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0 | 30.96420556 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0 | 26.17411642 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0 | 14.08351795 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0 | 37.39454625 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0 | 28.53462442 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0 | 15.75340275 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0 | 24.92548552 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0 | 17.42081376 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0 | 10.77734093 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0 | 23.77190715 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0 | 19.06516703 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0 | 11.26764876 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0 | 34.41395827 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0 | 28.41452146 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0 | 12.17005538 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0 | 40.38521301 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0 | 22.93274765 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0 | 19.54982369 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc mb1ic8ih19oh10kh15sh2ph14 | 21.80195044 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p mb1ic8ih19oh10kh15sh2ph14 | 21.97852694 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np mb1ic8ih19oh10kh15sh2ph14 | 18.69585406 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc mb1ic8ih19oh10kh14sh2ph13 | 20.72680831 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_p mb1ic8ih19oh10kh14sh2ph13 | 19.47087414 |
| cpu | RISCV64GCV | =--mode=P --pool --dir=FWD_I --dt=#REF! --tag=nhwc --alg=avg_np mb1ic8ih19oh10kh14sh2ph13 | 18.41435716 |

</details>

### Benchmark Log With this PR

<details>

```
OMP_NUM_THREADS=16 OMP_PROC_BIND=true OMP_PLACES=threads nohup taskset -c 48-63 ./benchdnn --pool --mode=P --dt=f16 --tag=nhwc --alg=max,avg_p,avg_np --dir=FWD_I --batch=inputs/pool/shapes_2d > bench_with_f16_nhwc_pool.log &
```

```Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3oh3kh3ph1,0,0.415039,0.00708008,0,0.00758266,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3oh3kh3ph1,0,0.171875,0.00708008,0,0.00767007,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3oh3kh3ph1,0,0.171387,0.00732422,0,0.00767105,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic128ih4oh2kh3ph0,0,0.155273,0.00708008,0,0.00770107,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic128ih4oh2kh3ph0,0,0.147461,0.00732422,0,0.00785547,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic128ih4oh2kh3ph0,0,0.141357,0.0078125,0,0.00832115,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic96ih4oh2kh3ph0,0,0.161377,0.00708008,0,0.00763639,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic96ih4oh2kh3ph0,0,0.170166,0.00732422,0,0.00775903,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic96ih4oh2kh3ph0,0,0.166992,0.00756836,0,0.00805132,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic64ih1oh1kh3ph1,0,0.185547,0.00610352,0,0.00657752,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic64ih1oh1kh3ph1,0,0.174561,0.00634766,0,0.00663135,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic64ih1oh1kh3ph1,0,0.157227,0.00634766,0,0.00671262,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic4ih4oh4kh3ph1,0,0.171143,0.00708008,0,0.00760408,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic4ih4oh4kh3ph1,0,0.165283,0.00708008,0,0.00758949,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic4ih4oh4kh3ph1,0,0.159668,0.00732422,0,0.00771496,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic32ih4oh4kh3ph1,0,0.175049,0.00708008,0,0.0076021,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic32ih4oh4kh3ph1,0,0.182373,0.00708008,0,0.00770334,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic32ih4oh4kh3ph1,0,0.171875,0.00732422,0,0.00791769,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic32ih13oh12kh3ph0,0,0.163086,0.0090332,0,0.00967796,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic32ih13oh12kh3ph0,0,0.178223,0.00952148,0,0.0102012,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic32ih13oh12kh3ph0,0,0.164795,0.0114746,0,0.01176,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb16ic64ih32oh16kh3sh2ph0,0,0.167969,0.0649414,0,0.0671285,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb16ic64ih32oh16kh3sh2ph0,0,0.184814,0.098877,0,0.105284,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb16ic64ih32oh16kh3sh2ph0,0,0.150635,0.126709,0,0.130239,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic16ih10oh10kh2ph1,0,0.136719,0.00830078,0,0.00903134,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic16ih10oh10kh2ph1,0,0.139404,0.00854492,0,0.00912851,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic16ih10oh10kh2ph1,0,0.13501,0.0090332,0,0.00957338,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb64ic64ih56oh56kh3ph1,0,0.135254,2.81079,0,3.01901,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb64ic64ih56oh56kh3ph1,0,0.148926,4.88892,0,5.87142,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb64ic64ih56oh56kh3ph1,0,0.149414,6.38696,0,6.58062,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1,0,0.14624,0.0598145,0,0.0644753,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1,0,0.166748,0.079834,0,0.0811432,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1,0,0.183105,0.104248,0,0.105645,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1,0,0.188721,0.483643,0,0.59857,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1,0,0.18335,0.856689,0,1.2004,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1,0,0.182617,1.00146,0,1.3324,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic17ih6oh7kh2ph1,0,0.182373,0.00830078,0,0.00884278,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic17ih6oh7kh2ph1,0,0.185791,0.00878906,0,0.00936945,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih6oh7kh2ph1,0,0.168701,0.00952148,0,0.0100368,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1,0,0.175293,0.0456543,0,0.0478453,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1,0,0.176514,0.0644531,0,0.0655569,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1,0,0.184082,0.105713,0,0.107004,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1,0,0.211426,0.032959,0,0.0338402,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1,0,0.172119,0.0456543,0,0.0479798,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1,0,0.193359,0.0639648,0,0.0649681,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1,0,0.177734,0.0461426,0,0.0479582,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1,0,0.171631,0.0649414,0,0.0670556,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1,0,0.185547,0.119873,0,0.122251,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1,0,0.178223,0.0327148,0,0.0333769,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1,0,0.180908,0.0444336,0,0.0467423,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1,0,0.167236,0.060791,0,0.0616585,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1,0,0.186035,0.0471191,0,0.0481256,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1,0,0.181641,0.0671387,0,0.0685171,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1,0,0.169189,0.0935059,0,0.0945233,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1,0,0.186279,0.0483398,0,0.0493184,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1,0,0.192871,0.0698242,0,0.0718849,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1,0,0.179199,0.114502,0,0.117643,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1,0,0.179443,0.0065918,0,0.00719914,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1,0,0.177246,0.00683594,0,0.00721685,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1,0,0.169678,0.0065918,0,0.00709004,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1,0,0.171875,0.0065918,0,0.00717022,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1,0,0.184326,0.00683594,0,0.00724591,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1,0,0.186279,0.00683594,0,0.00717882,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1,0,0.174561,0.00756836,0,0.00816124,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1,0,0.182373,0.00805664,0,0.00840208,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1,0,0.170654,0.00878906,0,0.00925133,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0,0,0.182617,0.0131836,0,0.0138329,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0,0,0.178223,0.0163574,0,0.016883,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0,0,0.178711,0.0222168,0,0.0228859,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic1ih32oh6kh6sh6ph2,0,0.177246,0.00732422,0,0.00777444,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic1ih32oh6kh6sh6ph2,0,0.174561,0.00732422,0,0.00773985,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32oh6kh6sh6ph2,0,0.186035,0.00805664,0,0.00871143,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0,0,0.17627,0.00683594,0,0.00727115,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0,0,0.169922,0.00683594,0,0.00722278,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0,0,0.188965,0.00683594,0,0.00726141,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0,0,0.168945,0.013916,0,0.01464,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0,0,0.193604,0.0180664,0,0.0187508,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0,0,0.182861,0.0275879,0,0.0282126,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0,0,0.195557,0.0175781,0,0.0181909,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0,0,0.180664,0.0227051,0,0.0233603,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0,0,0.177979,0.0356445,0,0.036439,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0,0,0.185303,0.0134277,0,0.0139999,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0,0,0.175293,0.0175781,0,0.017945,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0,0,0.171387,0.0268555,0,0.0273843,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0,0,0.182617,0.0185547,0,0.0194364,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0,0,0.17627,0.0236816,0,0.02455,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0,0,0.180664,0.0366211,0,0.0373437,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw15oh17ow14kh4kw3ph0pw1,0,0.186523,0.0131836,0,0.013805,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw15oh17ow14kh4kw3ph0pw1,0,0.176025,0.0170898,0,0.01752,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw15oh17ow14kh4kw3ph0pw1,0,0.176758,0.0266113,0,0.0269884,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw18oh17ow14kh4kw6ph0pw1,0,0.177002,0.0168457,0,0.0173754,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw18oh17ow14kh4kw6ph0pw1,0,0.210205,0.0217285,0,0.0222259,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw18oh17ow14kh4kw6ph0pw1,0,0.206543,0.0351562,0,0.03585,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw16oh17ow14kh4kw3ph1pw0,0,0.181641,0.0134277,0,0.0138903,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw16oh17ow14kh4kw3ph1pw0,0,0.178955,0.0170898,0,0.0176783,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw16oh17ow14kh4kw3ph1pw0,0,0.17627,0.0266113,0,0.0273289,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw19oh17ow14kh4kw6ph1pw0,0,0.204102,0.017334,0,0.017899,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw19oh17ow14kh4kw6ph1pw0,0,0.177734,0.0224609,0,0.0231748,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw19oh17ow14kh4kw6ph1pw0,0,0.184326,0.0354004,0,0.0363386,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.175537,0.00805664,0,0.00866868,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.181641,0.00878906,0,0.00925385,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.182373,0.0107422,0,0.0111501,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0,0,0.172607,0.00708008,0,0.00749472,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0,0,0.181641,0.00708008,0,0.00756383,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0,0,0.177002,0.00708008,0,0.0076349,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic16ih20iw15oh17ow14kh4kw3ph0pw1,0,0.180908,0.00878906,0,0.00940925,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic16ih20iw15oh17ow14kh4kw3ph0pw1,0,0.198486,0.00952148,0,0.0100475,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic16ih20iw15oh17ow14kh4kw3ph0pw1,0,0.180664,0.0124512,0,0.0130171,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic32ih20iw15oh17ow14kh4kw3ph0pw1,0,0.178223,0.0109863,0,0.0115795,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic32ih20iw15oh17ow14kh4kw3ph0pw1,0,0.174561,0.0124512,0,0.0131037,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic32ih20iw15oh17ow14kh4kw3ph0pw1,0,0.171631,0.0168457,0,0.0179125,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic65ih20iw15oh17ow14kh4kw3ph0pw1,0,0.180908,0.0170898,0,0.0179457,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic65ih20iw15oh17ow14kh4kw3ph0pw1,0,0.167969,0.0234375,0,0.0242101,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic65ih20iw15oh17ow14kh4kw3ph0pw1,0,0.182861,0.0378418,0,0.0387408,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.18335,0.0102539,0,0.0109772,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.177246,0.012207,0,0.0129174,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.183594,0.0168457,0,0.0175238,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.180664,0.0136719,0,0.0144214,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.177979,0.0180664,0,0.0189588,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.173828,0.0270996,0,0.0275957,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.190674,0.0192871,0,0.0202284,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.177002,0.0273438,0,0.0282825,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.174072,0.0432129,0,0.0445523,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic16ih10oh6kh5sh5ph10,0,0.188965,0.00732422,0,0.00776166,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic16ih10oh6kh5sh5ph10,0,0.176514,0.00756836,0,0.00789937,0
125:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic16ih10oh6kh5sh5ph10
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic16ih10oh6kh5sh5ph10,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic20ih16oh3kh16sh16ph16,0,0.178467,0.0078125,0,0.00840697,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic20ih16oh3kh16sh16ph16,0,0.17749,0.00854492,0,0.00921711,0
128:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic20ih16oh3kh16sh16ph16
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic20ih16oh3kh16sh16ph16,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb3ic17ih13oh37kh17ph20,0,0.181152,0.131592,0,0.134214,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb3ic17ih13oh37kh17ph20,0,0.184326,0.206787,0,0.209346,0
131:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb3ic17ih13oh37kh17ph20
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb3ic17ih13oh37kh17ph20,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw13oh17ow14kh4kw3ph0pw3,0,0.170898,0.0131836,0,0.01371,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw13oh17ow14kh4kw3ph0pw3,0,0.185791,0.0168457,0,0.0173404,0
134:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw3ph0pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw3ph0pw3,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3,0,0.195801,0.0131836,0,0.0137451,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3,0,0.177246,0.0168457,0,0.0174517,0
137:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw13oh17ow14kh4kw6ph0pw6,0,0.184814,0.0153809,0,0.0161465,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw13oh17ow14kh4kw6ph0pw6,0,0.17749,0.0197754,0,0.0204701,0
140:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw6ph0pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw6ph0pw6,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6,0,0.177246,0.015625,0,0.0162833,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6,0,0.178955,0.0200195,0,0.0206805,0
143:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw16oh17ow14kh4kw3ph4pw0,0,0.180908,0.0136719,0,0.0144064,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw16oh17ow14kh4kw3ph4pw0,0,0.181641,0.0178223,0,0.0184183,0
146:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw16oh17ow14kh4kw3ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw16oh17ow14kh4kw3ph4pw0,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0,0,0.162842,0.0136719,0,0.0141961,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0,0,0.148438,0.0178223,0,0.0184261,0
149:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw19oh17ow14kh4kw6ph4pw0,0,0.142334,0.017334,0,0.0177986,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw19oh17ow14kh4kw6ph4pw0,0,0.139893,0.0224609,0,0.0232242,0
152:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw19oh17ow14kh4kw6ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw19oh17ow14kh4kw6ph4pw0,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0,0,0.143311,0.0178223,0,0.0186335,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0,0,0.138672,0.0231934,0,0.0241862,0
155:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw13oh17ow14kh4kw3ph4pw3,0,0.135498,0.0129395,0,0.013591,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw13oh17ow14kh4kw3ph4pw3,0,0.138672,0.0168457,0,0.0175024,0
158:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw3ph4pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw3ph4pw3,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3,0,0.13916,0.0129395,0,0.0134403,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3,0,0.138672,0.0166016,0,0.0170887,0
161:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw13oh17ow14kh4kw6ph4pw6,0,0.161621,0.0151367,0,0.0158049,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw13oh17ow14kh4kw6ph4pw6,0,0.136475,0.0197754,0,0.0203257,0
164:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw6ph4pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw6ph4pw6,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6,0,0.139404,0.0153809,0,0.0160766,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6,0,0.128906,0.0195312,0,0.0202146,0
167:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6,0,0,0,0,0,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0,0,0.140137,0.0134277,0,0.0140874,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0,0,0.133057,0.017334,0,0.0179751,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0,0,0.13208,0.0266113,0,0.0273026,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0,0,0.141602,0.0136719,0,0.0141514,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0,0,0.141113,0.017334,0,0.0178452,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0,0,0.133789,0.0268555,0,0.027432,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0,0,0.141602,0.017334,0,0.0179182,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0,0,0.139404,0.0222168,0,0.0227174,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0,0,0.13623,0.0356445,0,0.0365948,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0,0,0.143799,0.0175781,0,0.0179415,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0,0,0.140869,0.0222168,0,0.0229425,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0,0,0.136963,0.0356445,0,0.0363609,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0,0,0.142334,0.0134277,0,0.0139085,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0,0,0.141846,0.0175781,0,0.0180313,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0,0,0.131348,0.0268555,0,0.0274371,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0,0,0.136719,0.0134277,0,0.0139428,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0,0,0.143555,0.0175781,0,0.017957,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0,0,0.13208,0.0268555,0,0.0273869,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0,0,0.140869,0.017334,0,0.0181341,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0,0,0.13208,0.0229492,0,0.0236876,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0,0,0.139893,0.0356445,0,0.0366532,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0,0,0.129639,0.017334,0,0.0177566,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0,0,0.145264,0.0222168,0,0.0226993,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0,0,0.143799,0.0356445,0,0.0362648,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0,0,0.138672,0.013916,0,0.0146079,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0,0,0.139648,0.0180664,0,0.0187501,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0,0,0.141357,0.0268555,0,0.027724,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0,0,0.134033,0.0136719,0,0.0143161,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0,0,0.135254,0.0178223,0,0.0184311,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0,0,0.129883,0.0273438,0,0.0280898,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0,0,0.146484,0.017334,0,0.0179134,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0,0,0.139893,0.0224609,0,0.0229426,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0,0,0.134033,0.0358887,0,0.0365281,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0,0,0.13916,0.017334,0,0.0178914,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0,0,0.137451,0.0224609,0,0.023107,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0,0,0.13208,0.0356445,0,0.0364124,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih19oh10kh15sh2ph14,0,0.139404,0.00830078,0,0.0088493,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih19oh10kh15sh2ph14,0,0.137451,0.0090332,0,0.00959714,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih19oh10kh15sh2ph14,0,0.132324,0.00927734,0,0.00992803,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih19oh10kh14sh2ph13,0,0.143066,0.00805664,0,0.00866776,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih19oh10kh14sh2ph13,0,0.195801,0.00878906,0,0.00927303,0
perf,cpu,RISCV64GCV,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih19oh10kh14sh2ph13,0,0.132324,0.0090332,0,0.009598,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3oh3kh3ph1dh2,0,0.229492,0.00976562,0,0.0105678,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3oh3kh3ph1dh2,0,0.191162,0.00976562,0,0.0103604,0
212:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3oh3kh3ph1dh2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3oh3kh3ph1dh2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1,0,0.196045,7.74194,0,8.02333,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1,0,0.189697,6.64185,0,6.74362,0
215:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic17ih6oh7kh2ph1dh4,0,0.191406,0.0900879,0,0.0932948,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic17ih6oh7kh2ph1dh4,0,0.187744,0.0888672,0,0.0914113,0
218:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih6oh7kh2ph1dh4
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih6oh7kh2ph1dh4,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1,0,0.180908,0.00976562,0,0.0106872,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1,0,0.184814,0.00952148,0,0.0104181,0
221:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic1ih32oh6kh6sh6ph2dh2,0,0.186768,0.0161133,0,0.0166163,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic1ih32oh6kh6sh6ph2dh2,0,0.187256,0.0144043,0,0.0153449,0
224:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32oh6kh6sh6ph2dh2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32oh6kh6sh6ph2dh2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2,0,0.175049,1.15039,0,1.17002,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2,0,0.185059,0.997803,0,1.00769,0
227:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5,0,0.194092,1.18604,0,1.19746,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5,0,0.177246,1.021,0,1.03194,0
230:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2,0,0.190186,1.12476,0,1.1436,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2,0,0.184814,0.967529,0,0.978839,0
233:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw16oh17ow14kh4kw3ph1pw0dh1dw1,0,0.178467,1.3252,0,1.34988,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw16oh17ow14kh4kw3ph1pw0dh1dw1,0,0.179932,1.14307,0,1.15557,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw16oh17ow14kh4kw3ph1pw0dh1dw1,0,0.184814,1.1521,0,1.16499,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2,0,0.187744,0.202148,0,0.205179,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2,0,0.190674,0.175781,0,0.178572,0
239:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0,0,0.189209,0.529297,0,0.547434,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0,0,0.186768,0.456543,0,0.473053,0
242:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0,0,0,0,0,0,0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| RISCV64GCV : 195 (89%)                                   |
|    ref:any : 23 (11%)                                    |
============================================================
tests:243 passed:218 skipped:25 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):47.1128 avg(ms):50.0042
total: 673.40s; create_pd: 0.03s (0%); create_prim: 0.01s (0%); fill: 14.89s (2%); execute: 0.06s (0%);

```

</details>

### Benchmark Log Without this PR

<details>

```
OMP_NUM_THREADS=16 OMP_PROC_BIND=true OMP_PLACES=threads nohup taskset -c 48-63 ./benchdnn --pool --mode=P --dt=f16 --tag=nhwc --alg=max,avg_p,avg_np --dir=FWD_I --batch=inputs/pool/shapes_2d > bench_without_f16_nhwc_pool.log &
```

```Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3oh3kh3ph1,0,4.47021,0.00830078,0,0.00933394,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3oh3kh3ph1,0,0.210938,0.00854492,0,0.00945356,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3oh3kh3ph1,0,0.211914,0.00854492,0,0.00933379,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic128ih4oh2kh3ph0,0,0.205566,0.0134277,0,0.0143989,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic128ih4oh2kh3ph0,0,0.195801,0.0134277,0,0.0141507,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic128ih4oh2kh3ph0,0,0.188477,0.0134277,0,0.0143333,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic96ih4oh2kh3ph0,0,0.176025,0.012207,0,0.0129132,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic96ih4oh2kh3ph0,0,0.20166,0.0124512,0,0.0129942,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic96ih4oh2kh3ph0,0,0.194092,0.0124512,0,0.0130543,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic64ih1oh1kh3ph1,0,0.14917,0.012207,0,0.0131041,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic64ih1oh1kh3ph1,0,0.183105,0.0119629,0,0.0127355,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic64ih1oh1kh3ph1,0,0.181152,0.0119629,0,0.0125587,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic4ih4oh4kh3ph1,0,0.216553,0.0134277,0,0.0151483,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic4ih4oh4kh3ph1,0,0.206787,0.0112305,0,0.0127436,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic4ih4oh4kh3ph1,0,0.209229,0.0112305,0,0.0126126,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic32ih4oh4kh3ph1,0,0.212158,0.0124512,0,0.0141181,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic32ih4oh4kh3ph1,0,0.22876,0.0109863,0,0.0118651,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic32ih4oh4kh3ph1,0,0.21167,0.0109863,0,0.0120069,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic32ih13oh12kh3ph0,0,0.213623,0.072998,0,0.0779985,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic32ih13oh12kh3ph0,0,0.219238,0.0437012,0,0.0466777,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic32ih13oh12kh3ph0,0,0.218262,0.045166,0,0.048435,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb16ic64ih32oh16kh3sh2ph0,0,0.21875,0.918457,0,0.965677,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb16ic64ih32oh16kh3sh2ph0,0,0.228516,0.837402,0,0.850599,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb16ic64ih32oh16kh3sh2ph0,0,0.214111,0.839355,0,0.852079,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic16ih10oh10kh2ph1,0,0.219727,0.0327148,0,0.0357959,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic16ih10oh10kh2ph1,0,0.213135,0.0322266,0,0.035957,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic16ih10oh10kh2ph1,0,0.23291,0.0324707,0,0.0367659,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb64ic64ih56oh56kh3ph1,0,0.213867,39.0139,0,39.2502,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb64ic64ih56oh56kh3ph1,0,0.22876,41.157,0,41.373,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb64ic64ih56oh56kh3ph1,0,0.231934,41.3203,0,41.6608,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1,0,0.236816,1.14062,0,1.15963,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1,0,0.225342,1.04639,0,1.14813,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1,0,0.219727,1.05103,0,1.12371,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1,0,0.218994,8.76709,0,8.84453,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1,0,0.22583,5.47827,0,5.5404,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic32ih300iw500oh151ow251kh3kw3sh2sw2ph1pw1,0,0.243652,5.39185,0,5.43852,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic17ih6oh7kh2ph1,0,0.228271,0.0375977,0,0.0427099,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic17ih6oh7kh2ph1,0,0.216797,0.0322266,0,0.0367259,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih6oh7kh2ph1,0,0.219238,0.0371094,0,0.0424092,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1,0,0.224365,2.4939,0,2.54592,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1,0,0.212646,2.02026,0,2.14757,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1,0,0.226562,2.20752,0,2.28259,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1,0,0.21875,1.2356,0,1.28333,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1,0,0.206787,0.891602,0,0.941097,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1,0,0.233643,0.960449,0,1.02956,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1,0,0.217529,2.28955,0,2.33793,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1,0,0.218262,2.08374,0,2.15598,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1,0,0.209961,2.10376,0,2.16322,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1,0,0.215576,1.24243,0,1.31515,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1,0,0.22168,1.05469,0,1.12833,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1,0,0.208984,0.999756,0,1.0496,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1,0,0.220947,1.64209,0,1.69567,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1,0,0.214844,1.40015,0,1.42858,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1,0,0.217773,1.43896,0,1.54608,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1,0,0.224121,1.00073,0,1.01626,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1,0,0.22168,0.951416,0,0.966297,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1,0,0.219971,0.933594,0,0.959492,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1,0,0.217773,0.00805664,0,0.00858903,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1,0,0.216064,0.00805664,0,0.00870141,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1,0,0.211426,0.0078125,0,0.00867416,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1,0,0.204346,0.00854492,0,0.00950341,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1,0,0.227051,0.00878906,0,0.00972607,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw14oh1ow8kh3kw3sh1sw2ph0pw1,0,0.217285,0.00854492,0,0.00971806,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1,0,0.239014,0.0244141,0,0.0252306,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1,0,0.22168,0.0249023,0,0.0255855,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic96ih3iw100oh1ow51kh3kw3sh1sw2ph0pw1,0,0.195068,0.0249023,0,0.0257141,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0,0,0.194336,0.118164,0,0.121034,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0,0,0.209473,0.117676,0,0.119281,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic96ih103iw9oh52ow7kh3kw3sh2sw1ph1pw0,0,0.199463,0.11792,0,0.1203,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic1ih32oh6kh6sh6ph2,0,0.176025,0.012207,0,0.0128695,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic1ih32oh6kh6sh6ph2,0,0.168701,0.0119629,0,0.0126761,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32oh6kh6sh6ph2,0,0.193359,0.0119629,0,0.0124886,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0,0,0.179199,0.0112305,0,0.0117292,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0,0,0.200439,0.0112305,0,0.0122183,0
perf,cpu,simple_nchw:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32iw2oh6ow1kh6kw1sh6sw1ph2pw0,0,0.210693,0.0112305,0,0.0118736,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0,0,0.215332,0.303467,0,0.333394,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0,0,0.224854,0.303223,0,0.318439,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw42oh17ow14kh4kw3sh1sw3ph0pw0,0,0.217041,0.294189,0,0.310523,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0,0,0.213623,0.606201,0,0.640505,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0,0,0.212646,0.659912,0,0.692897,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw45oh17ow14kh4kw6sh1sw3ph0pw0,0,0.214355,0.596436,0,0.615345,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0,0,0.220459,0.292969,0,0.322317,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0,0,0.2229,0.322754,0,0.338273,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw16oh17ow14kh4kw3sh3sw1ph0pw0,0,0.227051,0.311523,0,0.3406,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0,0,0.227051,0.654297,0,0.67738,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0,0,0.220215,0.471924,0,0.486429,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw19oh17ow14kh4kw6sh3sw1ph0pw0,0,0.213867,0.544678,0,0.563192,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw15oh17ow14kh4kw3ph0pw1,0,0.238525,0.336426,0,0.359993,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw15oh17ow14kh4kw3ph0pw1,0,0.222656,0.256592,0,0.268933,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw15oh17ow14kh4kw3ph0pw1,0,0.222656,0.250977,0,0.26291,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw18oh17ow14kh4kw6ph0pw1,0,0.221191,0.682373,0,0.750564,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw18oh17ow14kh4kw6ph0pw1,0,0.218994,0.575439,0,0.615897,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw18oh17ow14kh4kw6ph0pw1,0,0.173828,0.500488,0,0.518315,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw16oh17ow14kh4kw3ph1pw0,0,0.185791,0.335205,0,0.362118,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw16oh17ow14kh4kw3ph1pw0,0,0.180908,0.248047,0,0.261238,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw16oh17ow14kh4kw3ph1pw0,0,0.178467,0.276367,0,0.287422,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw19oh17ow14kh4kw6ph1pw0,0,0.211914,0.525879,0,0.580199,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw19oh17ow14kh4kw6ph1pw0,0,0.179932,0.535645,0,0.55141,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw19oh17ow14kh4kw6ph1pw0,0,0.175781,0.456299,0,0.471364,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.187256,0.0463867,0,0.0543654,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.179932,0.043457,0,0.0482792,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.17749,0.0400391,0,0.043973,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0,0,0.187012,0.0100098,0,0.0115792,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0,0,0.18335,0.010498,0,0.0124101,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih9iw10oh3ow3kh2kw2sh4sw4ph1pw0,0,0.18457,0.0100098,0,0.0116455,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic16ih20iw15oh17ow14kh4kw3ph0pw1,0,0.186035,0.0895996,0,0.093854,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic16ih20iw15oh17ow14kh4kw3ph0pw1,0,0.175781,0.110352,0,0.115922,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic16ih20iw15oh17ow14kh4kw3ph0pw1,0,0.178223,0.100586,0,0.104987,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic32ih20iw15oh17ow14kh4kw3ph0pw1,0,0.185547,0.128174,0,0.134034,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic32ih20iw15oh17ow14kh4kw3ph0pw1,0,0.180664,0.0810547,0,0.085986,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic32ih20iw15oh17ow14kh4kw3ph0pw1,0,0.178223,0.079834,0,0.0838022,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic65ih20iw15oh17ow14kh4kw3ph0pw1,0,0.185547,0.265625,0,0.273154,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic65ih20iw15oh17ow14kh4kw3ph0pw1,0,0.17627,0.297607,0,0.305698,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic65ih20iw15oh17ow14kh4kw3ph0pw1,0,0.18042,0.310303,0,0.319744,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.180664,0.0656738,0,0.068367,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.177734,0.0710449,0,0.0743521,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic130ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.192627,0.0686035,0,0.071633,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.18042,0.106201,0,0.110839,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.170654,0.112549,0,0.118599,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.177734,0.115723,0,0.120946,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.186523,0.175293,0,0.179665,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.178711,0.178467,0,0.189383,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0,0,0.178711,0.173584,0,0.182865,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic16ih10oh6kh5sh5ph10,0,0.181641,0.0129395,0,0.0133859,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic16ih10oh6kh5sh5ph10,0,0.184082,0.012207,0,0.0129091,0
125:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic16ih10oh6kh5sh5ph10
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic16ih10oh6kh5sh5ph10,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic20ih16oh3kh16sh16ph16,0,0.176758,0.0395508,0,0.0402786,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic20ih16oh3kh16sh16ph16,0,0.177002,0.0351562,0,0.0364628,0
128:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic20ih16oh3kh16sh16ph16
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic20ih16oh3kh16sh16ph16,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb3ic17ih13oh37kh17ph20,0,0.17749,8.70801,0,9.28095,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb3ic17ih13oh37kh17ph20,0,0.167969,7.80835,0,8.51422,0
131:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb3ic17ih13oh37kh17ph20
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb3ic17ih13oh37kh17ph20,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw13oh17ow14kh4kw3ph0pw3,0,0.171631,0.259521,0,0.281391,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw13oh17ow14kh4kw3ph0pw3,0,0.181152,0.272217,0,0.294094,0
134:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw3ph0pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw3ph0pw3,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3,0,0.192627,0.29126,0,0.330555,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3,0,0.181641,0.232666,0,0.245707,0
137:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw3sh2sw1ph0pw3,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw13oh17ow14kh4kw6ph0pw6,0,0.186523,0.501465,0,0.525336,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw13oh17ow14kh4kw6ph0pw6,0,0.191162,0.41626,0,0.446707,0
140:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw6ph0pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw13oh17ow14kh4kw6ph0pw6,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6,0,0.185059,0.389893,0,0.403285,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6,0,0.177734,0.432129,0,0.478535,0
143:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw13oh17ow14kh4kw6sh2sw1ph0pw6,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw16oh17ow14kh4kw3ph4pw0,0,0.186523,0.283691,0,0.298412,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw16oh17ow14kh4kw3ph4pw0,0,0.175293,0.281982,0,0.308058,0
146:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw16oh17ow14kh4kw3ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw16oh17ow14kh4kw3ph4pw0,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0,0,0.174316,0.344727,0,0.379434,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0,0,0.180176,0.260254,0,0.274417,0
149:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw16oh17ow14kh4kw3sh2sw1ph4pw0,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw19oh17ow14kh4kw6ph4pw0,0,0.181641,0.493652,0,0.51922,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw19oh17ow14kh4kw6ph4pw0,0,0.184082,0.632568,0,0.680124,0
152:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw19oh17ow14kh4kw6ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw19oh17ow14kh4kw6ph4pw0,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0,0,0.179199,0.532715,0,0.572679,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0,0,0.185059,0.576172,0,0.609243,0
155:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw19oh17ow14kh4kw6sh2sw1ph4pw0,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw13oh17ow14kh4kw3ph4pw3,0,0.184814,0.232666,0,0.248127,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw13oh17ow14kh4kw3ph4pw3,0,0.17749,0.26416,0,0.276431,0
158:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw3ph4pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw3ph4pw3,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3,0,0.184326,0.264893,0,0.275942,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3,0,0.176025,0.267334,0,0.280519,0
161:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw3sh2sw1ph4pw3,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih16iw13oh17ow14kh4kw6ph4pw6,0,0.184814,0.407227,0,0.427127,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih16iw13oh17ow14kh4kw6ph4pw6,0,0.203613,0.368408,0,0.381463,0
164:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw6ph4pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih16iw13oh17ow14kh4kw6ph4pw6,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6,0,0.189697,0.418945,0,0.440155,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6,0,0.185303,0.406738,0,0.420518,0
167:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih32iw13oh17ow14kh4kw6sh2sw1ph4pw6,0,0,0,0,0,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0,0,0.182617,0.317627,0,0.335352,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0,0,0.185059,0.23999,0,0.250548,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw30oh17ow14kh4kw3sh1sw2ph0pw0,0,0.182861,0.258545,0,0.268758,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0,0,0.184814,0.285645,0,0.308753,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0,0,0.189209,0.269043,0,0.283802,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw30oh17ow14kh4kw3sh1sw2ph1pw0,0,0.182373,0.3125,0,0.324909,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0,0,0.20459,0.483154,0,0.502291,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0,0,0.181641,0.548584,0,0.570859,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw33oh17ow14kh4kw6sh1sw2ph0pw0,0,0.177979,0.479736,0,0.501321,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0,0,0.182129,0.705322,0,0.753453,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0,0,0.179199,0.570068,0,0.592998,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw33oh17ow14kh4kw6sh1sw2ph1pw0,0,0.177002,0.569092,0,0.605818,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0,0,0.182861,0.304932,0,0.319276,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0,0,0.185303,0.323975,0,0.338916,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw16oh17ow14kh4kw3sh2sw1ph0pw0,0,0.184326,0.294678,0,0.310092,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0,0,0.180176,0.331787,0,0.351513,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0,0,0.183594,0.311768,0,0.329366,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw16oh17ow14kh4kw3sh2sw1ph1pw0,0,0.180176,0.299805,0,0.319456,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0,0,0.190674,0.536377,0,0.561508,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0,0,0.180664,0.57373,0,0.620002,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw19oh17ow14kh4kw6sh2sw1ph0pw0,0,0.183594,0.501465,0,0.516206,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0,0,0.199219,0.645264,0,0.664,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0,0,0.172607,0.582275,0,0.647716,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw19oh17ow14kh4kw6sh2sw1ph1pw0,0,0.175537,0.51123,0,0.571294,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0,0,0.184082,0.345703,0,0.364109,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0,0,0.18457,0.307617,0,0.326642,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw30oh17ow14kh4kw3sh2sw2ph0pw0,0,0.184082,0.276367,0,0.298791,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0,0,0.181396,0.321045,0,0.340321,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0,0,0.195312,0.334229,0,0.351392,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw30oh17ow14kh4kw3sh2sw2ph1pw0,0,0.182861,0.298828,0,0.316506,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0,0,0.183838,0.540283,0,0.616471,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0,0,0.187988,0.62085,0,0.651903,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih37iw33oh17ow14kh4kw6sh2sw2ph0pw0,0,0.181885,0.429932,0,0.444549,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0,0,0.183838,0.658447,0,0.722548,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0,0,0.186279,0.508545,0,0.529907,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih36iw33oh17ow14kh4kw6sh2sw2ph1pw0,0,0.183838,0.685791,0,0.711856,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih19oh10kh15sh2ph14,0,0.179443,0.187012,0,0.192932,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih19oh10kh15sh2ph14,0,0.16626,0.190186,0,0.210931,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih19oh10kh15sh2ph14,0,0.181396,0.167969,0,0.185613,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih19oh10kh14sh2ph13,0,0.178223,0.174072,0,0.179655,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih19oh10kh14sh2ph13,0,0.247314,0.165283,0,0.180554,0
perf,cpu,simple_nhwc:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih19oh10kh14sh2ph13,0,0.170654,0.164551,0,0.176741,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3oh3kh3ph1dh2,0,0.194336,0.0102539,0,0.0109351,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3oh3kh3ph1dh2,0,0.181641,0.0102539,0,0.0109186,0
212:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3oh3kh3ph1dh2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3oh3kh3ph1dh2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1,0,0.183594,7.47681,0,7.63989,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1,0,0.18457,6.60229,0,6.76998,0
215:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb122ic32ih32iw2oh32ow2kh3kw3ph1pw1dh4dw1,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb4ic17ih6oh7kh2ph1dh4,0,0.184814,0.0854492,0,0.0880424,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb4ic17ih6oh7kh2ph1dh4,0,0.183105,0.0771484,0,0.0796529,0
218:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih6oh7kh2ph1dh4
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb4ic17ih6oh7kh2ph1dh4,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1,0,0.18457,0.0102539,0,0.0109608,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1,0,0.188721,0.00976562,0,0.0105541,0
221:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic8ih3iw4oh1ow5kh3kw3ph0pw1dh1dw1,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc mb1ic1ih32oh6kh6sh6ph2dh2,0,0.182861,0.0161133,0,0.0167254,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p mb1ic1ih32oh6kh6sh6ph2dh2,0,0.171631,0.0144043,0,0.0152244,0
224:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32oh6kh6sh6ph2dh2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np mb1ic1ih32oh6kh6sh6ph2dh2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2,0,0.176758,1.14746,0,1.16484,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2,0,0.196777,0.985107,0,1.00264,0
227:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw42oh17ow14kh4kw3sh1sw3ph7pw2dh5dw2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5,0,0.185303,1.19751,0,1.21261,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5,0,0.186768,1.01489,0,1.03167,0
230:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih52iw16oh17ow14kh4kw3sh3sw1ph4pw5dh3dw5,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2,0,0.184814,1.1731,0,1.21846,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2,0,0.176025,0.974609,0,0.985718,0
233:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih20iw15oh17ow14kh4kw3ph0pw1dh3dw2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw16oh17ow14kh4kw3ph1pw0dh1dw1,0,0.18042,1.32764,0,1.34726,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw16oh17ow14kh4kw3ph1pw0dh1dw1,0,0.176758,1.12402,0,1.14183,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw16oh17ow14kh4kw3ph1pw0dh1dw1,0,0.183105,1.17212,0,1.18306,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2,0,0.188232,0.202393,0,0.206724,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2,0,0.176758,0.174805,0,0.177948,0
239:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic35ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0dh2dw2,0,0,0,0,0,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0,0,0.179443,0.523926,0,0.54686,0
perf,cpu,ref:any,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_p ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0,0,0.177002,0.440674,0,0.463831,0
242:SKIPPED (Invalid case) (0 ms) __REPRO: --mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0
perf,cpu,,,--mode=P --pool --dir=FWD_I --dt=f16:f16 --tag=nhwc --alg=avg_np ic16ih20iw15oh17ow14kh4kw3ph0pw1dh3dw0,0,0,0,0,0,0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| simple_nhwc:any : 186 (85%)                              |
|         ref:any : 23 (11%)                               |
| simple_nchw:any : 9 (4%)                                 |
============================================================
tests:243 passed:218 skipped:25 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):255.919 avg(ms):262.424
total: 671.80s; create_pd: 0.04s (0%); create_prim: 0.01s (0%); fill: 15.38s (2%); execute: 0.27s (0%);

```

</details>

## Implementation Notes regarding C++ Standards
During the implementation, I considered using if constexpr (C++17) to unify the f32 and f16 logic into a single generic kernel. This would allow compile-time dispatching of intrinsics (e.g., vle32 vs vle16) based on the data type, resulting in more concise code.
However, considering oneDNN's generally conservative approach towards C++17 features in core kernels to maintain strict compiler compatibility and code clarity, I decided to use explicit template specialization instead.
* Separate compute functions (MaxPooling_f16, AvgPooling...f16) are defined.
* execute_forward is specialized for data_type::f16 to isolate the zvfh logic.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?