### PR TITLE
ci: aarch64: fix precommit performance tests

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -97,7 +97,7 @@ jobs:
           toolset: gcc
           build: ${{ matrix.config.build }}
           testset: ${{ matrix.config.testset }}
-          onednn_hash: ${{ matrix.config.name == 'onednn-perf-base' && fromJson(steps.get-versions.outputs.output).dependencies.onednn-base || '' }}
+          onednn_hash: ${{ matrix.config.name == 'onednn-perf-base' && github.base_ref || '' }}
           cache: ${{ matrix.config.name == 'onednn-perf-base' && 'true' || 'false'}}
 
   smoke-test:


### PR DESCRIPTION
The precommit perf tests are incorrectly comparing against v3.9 instead of the base branche for PRs, making every PR show a regression.
