### PR TITLE
aarch64: Enable Windows on Arm builds

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -299,10 +299,31 @@ jobs:
         if: ${{ steps.performance-test.outputs.pass != 'True' }}
         run: echo "::warning file=.github/workflows/ci-aarch64.yml,line=1,col=1::${{ steps.performance-test.outputs.message }}"
 
+  # TODO: Find an elegant way to integrate this build with the rest of the workflow.
+  windows:
+    name: build windows-msvc 
+    runs-on: windows-11-arm
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install Build Tools
+        run: choco install ninja --force --limit-output --no-progress
+        shell: cmd
+
+      # TODO: Find a way to persist VS dev environment across steps.
+      - name: Build and Test
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsarm64.bat"
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DONEDNN_TEST_SET=CI
+          cmake --build build --config Release
+          ctest --test-dir build -j%NUMBER_OF_PROCESSORS%
+        shell: cmd
+
   # This job adds a check named "CI AArch64" that represents overall
   # workflow status and can be used in branch rulesets
   status:
-    needs: [smoke-test, unit-test, perf-test]
+    needs: [smoke-test, unit-test, perf-test, windows]
     runs-on: ubuntu-latest
     name: "CI AArch64"
     steps:

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -432,7 +432,7 @@ void jit_uni_binary_kernel_t<isa>::compute_bcast(bool tail) {
 
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::push(const Xbyak_aarch64::XReg &reg) {
-    str(reg, pre_ptr(X_SP, -(reg.getBit() / 8)));
+    str(reg, pre_ptr(X_SP, -static_cast<int>(reg.getBit() / 8)));
 }
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::pop(const Xbyak_aarch64::XReg &reg) {

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -1608,7 +1608,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                     mov(reg_loop_cnt, tail_size);
                     // Put info that node is being processed with tail.
                     mov(X_TMP_0, with_tail_info_);
-                    str(X_TMP_0, pre_ptr(X_SP, -reg_bytes));
+                    str(X_TMP_0, pre_ptr(X_SP, -static_cast<int>(reg_bytes)));
                 } else {
                     ldr(X_TMP_0, ptr(data_chunk_addr(parent_node_id)));
                     check_if_this_is_last_chunk(X_TMP_0, parent_node_id);
@@ -1616,14 +1616,14 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                     mov(reg_loop_cnt, tail_size);
                     // Put info that node is being processed with tail.
                     mov(X_TMP_0, with_tail_info_);
-                    str(X_TMP_0, pre_ptr(X_SP, -reg_bytes));
+                    str(X_TMP_0, pre_ptr(X_SP, -static_cast<int>(reg_bytes)));
                     b(if_end);
 
                     L(if_no_tail);
                     mov(reg_loop_cnt, node_size);
                     // Put info that node is being processed without tail.
                     mov(X_TMP_0, without_tail_info_);
-                    str(X_TMP_0, pre_ptr(X_SP, -reg_bytes));
+                    str(X_TMP_0, pre_ptr(X_SP, -static_cast<int>(reg_bytes)));
                     L(if_end);
                 }
             }


### PR DESCRIPTION
- make necessary changes for building oneDNN with MSVC
- protect build with (basic) CI.

We do not build with ACL as ACL can not be built with MSVC (it requires Clang), and we have not yet fixed Clang builds for oneDNN.

Changes to make MSVC work are based on [this](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170) warning thrown at the modified sites.
