### PR TITLE
benchdnn: drop redundant warm-up run in performance mode

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -319,7 +319,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, {DST}, args, ref_args, setup_cmp, res, prb->dir);
     SAFE(check_bitwise(prim, {DST}, args, prb->attr, prb->inplace, res), WARN);

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -748,7 +748,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(v_prim[0], args, res), WARN);
+    SAFE(run_execution(v_prim[0], args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb, FLAG_FWD), args, ref_args,
             setup_cmp, res, FLAG_FWD);
@@ -769,7 +769,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
         args = args_t(mem_map);
         ref_args = args_t(ref_mem_map);
 
-        SAFE(execute_and_wait(v_prim[1], args, res), WARN);
+        SAFE(run_execution(v_prim[1], args, res), WARN);
 
         check_correctness(prb, get_kinds_to_check(prb, FLAG_BWD), args,
                 ref_args, setup_cmp, res, FLAG_BWD);

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -1351,27 +1351,27 @@ int doit(const prb_t *prb, res_t *res) {
 
     SAFE(init_hw_config(kernel_args), WARN);
 
+    if (has_bench_mode_bit(mode_bit_t::exec)
+            && !has_bench_mode_bit(mode_bit_t::perf)) {
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
-    if (prb->batch_kind == "addr") {
-        brgemm_kernel_execute_postops(brgemm_kernel, prb->batch_size,
-                v_batch_element.data(), acc_ptr, dst_ptr, post_ops_data,
-                scratchpad_ptr);
-    } else if (prb->batch_kind == "offs") {
-        brgemm_kernel_execute_postops(brgemm_kernel, prb->batch_size, src_ptr,
-                wei_ptr, v_batch_element.data(), acc_ptr, dst_ptr,
-                post_ops_data, scratchpad_ptr);
-    }
-#else // !defined(DNNL_EXPERIMENTAL_UKERNEL)
-    // `prb->use_dst_as_acc()=true` will make `dst_ptr=acc_ptr` and rest should
-    // be handled by API.
-    DNN_SAFE(dnnl_brgemm_execute_postops(brgemm, src_ptr, wei_packed_ptr,
-                     offsets.data(), acc_ptr, dst_ptr, scratchpad_ptr,
-                     attr_params),
-            WARN);
+        if (prb->batch_kind == "addr") {
+            brgemm_kernel_execute_postops(brgemm_kernel, prb->batch_size,
+                    v_batch_element.data(), acc_ptr, dst_ptr, post_ops_data,
+                    scratchpad_ptr);
+        } else if (prb->batch_kind == "offs") {
+            brgemm_kernel_execute_postops(brgemm_kernel, prb->batch_size,
+                    src_ptr, wei_ptr, v_batch_element.data(), acc_ptr, dst_ptr,
+                    post_ops_data, scratchpad_ptr);
+        }
+#else /* !defined(DNNL_EXPERIMENTAL_UKERNEL) */
+        // `prb->use_dst_as_acc()=true` will make `dst_ptr=acc_ptr` and rest should
+        // be handled by API.
+        DNN_SAFE(dnnl_brgemm_execute_postops(brgemm, src_ptr, wei_packed_ptr,
+                         offsets.data(), acc_ptr, dst_ptr, scratchpad_ptr,
+                         attr_params),
+                WARN);
 #endif
-    res->state = EXECUTED;
-
-    if (has_bench_mode_bit(mode_bit_t::corr)) {
+        res->state = EXECUTED;
         check_correctness(prb, {DST}, args, ref_args, setup_cmp, res, prb->dir);
     }
 

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -239,7 +239,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, {DST}, args, ref_args, setup_cmp, res, prb->dir);
     SAFE(check_bitwise(prim, {DST}, args, prb->attr, prb->inplace, res), WARN);

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -654,7 +654,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir, prim_ref);

--- a/tests/benchdnn/conv/conv_dw_fusion.cpp
+++ b/tests/benchdnn/conv/conv_dw_fusion.cpp
@@ -368,7 +368,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     args_t args(mem_map), args0(mem_map0), args1(mem_map1);
 
     if (prb->dir & FLAG_FWD) {
-        SAFE(execute_and_wait(prim, args, res), WARN);
+        SAFE(run_execution(prim, args, res), WARN);
 
         if (has_bench_mode_bit(mode_bit_t::corr)) {
             SAFE(execute_and_wait(prim0, args0), WARN);

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -591,7 +591,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir, prim_ref);

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -440,6 +440,21 @@ int execute_and_wait(dnnl_primitive_t prim, const args_t &args, res_t *res) {
     return execute_and_wait(exec_func, engine, args, res);
 }
 
+int run_execution(dnnl_primitive_t prim, const args_t &args, res_t *res) {
+    if (!has_bench_mode_bit(mode_bit_t::exec)
+            || has_bench_mode_bit(mode_bit_t::perf))
+        return OK;
+    return execute_and_wait(prim, args, res);
+}
+
+int run_execution(perf_function_t &exec_func, const dnnl_engine_t &engine,
+        const args_t &args, res_t *res) {
+    if (!has_bench_mode_bit(mode_bit_t::exec)
+            || has_bench_mode_bit(mode_bit_t::perf))
+        return OK;
+    return execute_and_wait(exec_func, engine, args, res);
+}
+
 void reset_gpu_profiling(dnnl_stream_t stream) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL \
         || DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
@@ -656,7 +671,7 @@ int measure_perf(const thr_ctx_t &ctx, res_t *res, perf_function_t &perf_func,
                 ctx, measure_perf_aggregate, t, v_stream, perf_func, dnnl_args);
     }
 
-    if (ret != OK) res->state = FAILED;
+    res->state = (ret == OK ? EXECUTED : FAILED);
     execute_map_args(args);
     for (int j = 1; j < num_streams; j++) {
         execute_map_args(v_args[j]);

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -665,6 +665,10 @@ int execute_and_wait(perf_function_t &exec_func, const dnnl_engine_t &engine,
 int execute_and_wait(
         dnnl_primitive_t prim, const args_t &args, res_t *res = nullptr);
 
+int run_execution(perf_function_t &exec_func, const dnnl_engine_t &engine,
+        const args_t &args, res_t *res = nullptr);
+int run_execution(dnnl_primitive_t prim, const args_t &args, res_t *res);
+
 void reset_gpu_profiling(dnnl_stream_t stream);
 
 void finalize();

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -556,7 +556,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(v_prim[0], args, res), WARN);
+    SAFE(run_execution(v_prim[0], args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb, FLAG_FWD), args, ref_args,
             setup_cmp, res, FLAG_FWD);
@@ -575,7 +575,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
         args = args_t(mem_map);
         ref_args = args_t(ref_mem_map);
 
-        SAFE(execute_and_wait(v_prim[1], args, res), WARN);
+        SAFE(run_execution(v_prim[1], args, res), WARN);
 
         check_correctness(prb, get_kinds_to_check(prb, FLAG_BWD), args,
                 ref_args, setup_cmp, res, FLAG_BWD);

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -753,7 +753,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir);

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -450,7 +450,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir, prim_ref);

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -715,7 +715,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir);

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -245,7 +245,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(v_prim[0], args, res), WARN);
+    SAFE(run_execution(v_prim[0], args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb, FLAG_FWD), args, ref_args,
             setup_cmp, res, FLAG_FWD);
@@ -264,7 +264,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
         args = args_t(mem_map);
         ref_args = args_t(ref_mem_map);
 
-        SAFE(execute_and_wait(v_prim[1], args, res), WARN);
+        SAFE(run_execution(v_prim[1], args, res), WARN);
 
         check_correctness(prb, get_kinds_to_check(prb, FLAG_BWD), args,
                 ref_args, setup_cmp, res, FLAG_BWD);

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -1103,7 +1103,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir, prim_ref);

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -393,7 +393,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     args_t args(mem_map), ref_args(ref_mem_map);
 
     if (bench_mode != bench_mode_t::init)
-        SAFE(execute_and_wait(v_prim[0], args, res), WARN);
+        SAFE(run_execution(v_prim[0], args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb, FLAG_FWD), args, ref_args,
             setup_cmp, res, FLAG_FWD);
@@ -412,7 +412,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
         args = args_t(mem_map);
         ref_args = args_t(ref_mem_map);
 
-        SAFE(execute_and_wait(v_prim[1], args, res), WARN);
+        SAFE(run_execution(v_prim[1], args, res), WARN);
 
         check_correctness(prb, get_kinds_to_check(prb, FLAG_BWD), args,
                 ref_args, setup_cmp, res, FLAG_BWD);

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -267,7 +267,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir);

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -360,7 +360,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, {DST}, args, ref_args, setup_cmp, res, prb->dir);
     SAFE(check_bitwise(prim, {DST}, args, prb->attr, prb->inplace, res), WARN);

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -607,7 +607,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     if (has_bench_mode_bit(mode_bit_t::corr)) {
         // Remove extra desc so that reorders with compensation could have

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -285,7 +285,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir);

--- a/tests/benchdnn/rnn/rnn.cpp
+++ b/tests/benchdnn/rnn/rnn.cpp
@@ -1330,7 +1330,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(v_prim[0], args, res), WARN);
+    SAFE(run_execution(v_prim[0], args, res), WARN);
 
     check_correctness(&prb, get_kinds_to_check(&prb, FLAG_FWD), args, ref_args,
             setup_cmp, res, FLAG_FWD);
@@ -1349,7 +1349,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
         args = args_t(mem_map);
         ref_args = args_t(ref_mem_map);
 
-        SAFE(execute_and_wait(v_prim[1], args, res), WARN);
+        SAFE(run_execution(v_prim[1], args, res), WARN);
 
         check_correctness(&prb, get_kinds_to_check(&prb, FLAG_BWD), args,
                 ref_args, setup_cmp, res, prb.dir);

--- a/tests/benchdnn/shuffle/shuffle.cpp
+++ b/tests/benchdnn/shuffle/shuffle.cpp
@@ -212,7 +212,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir);

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -486,7 +486,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, get_kinds_to_check(prb), args, ref_args, setup_cmp,
             res, prb->dir);

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -202,7 +202,7 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     args_t args(mem_map), ref_args(ref_mem_map);
 
-    SAFE(execute_and_wait(prim, args, res), WARN);
+    SAFE(run_execution(prim, args, res), WARN);
 
     check_correctness(prb, {DST}, args, ref_args, setup_cmp, res, prb->dir);
     SAFE(check_bitwise(prim, {DST}, args, prb->attr, prb->inplace, res), WARN);

--- a/tests/benchdnn/zeropad/zeropad.cpp
+++ b/tests/benchdnn/zeropad/zeropad.cpp
@@ -145,7 +145,7 @@ int doit(const prb_t *prb, res_t *res) {
     args.set(0, test_mem);
     perf_function_t perf_func_ = &perf_func;
 
-    execute_and_wait(perf_func_, test_engine, args, res);
+    SAFE(run_execution(perf_func_, test_engine, args, res), WARN);
 
     if (has_bench_mode_bit(mode_bit_t::corr)) {
         SAFE(compare(test_mem, res), WARN);
@@ -159,10 +159,7 @@ int doit(const prb_t *prb, res_t *res) {
         res->obytes = dnnl_memory_desc_get_size(data_md)
                 - dnnl_memory_desc_get_size(plain_data_md);
     }
-
-    measure_perf(default_thr_ctx, res, perf_func_, args);
-
-    return OK;
+    return measure_perf(default_thr_ctx, res, perf_func_, args);
 }
 
 } // namespace zeropad


### PR DESCRIPTION
Jira: [MFDNN-14340](https://jira.devtools.intel.com/browse/MFDNN-14340)

For example for matmul with `--mode=P --fix-times-per-prb=1` benchdnn executes the primitive three times:

- `execute_and_wait()` from [here](https://github.com/uxlfoundation/oneDNN/blob/4ad8a7d8e1d725993bfb9775c14b4cd8e8b9274b/tests/benchdnn/matmul/matmul.cpp#L1106)
- Warm-up run before measuring performance from [here](https://github.com/uxlfoundation/oneDNN/blob/4ad8a7d8e1d725993bfb9775c14b4cd8e8b9274b/tests/benchdnn/dnnl_common.cpp#L537)
- And finally the run to measure performance (single run as specified by `--fix-times-per-prb=1`)

PR introduces `run_execution()` which runs/skips primitive execution depending on the testing mode.