### PR TITLE
xe3: jit: gemm: workaround for HW DPAS read suppression bug

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -2128,6 +2128,17 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
         releaseLDMultiples(state.ldcMultiples[q], state);
     releaseIndexVec(state);
 
+    // Workaround for Xe3 HW bug: dpas with uninitialized src1/src2 can cause
+    //  data corruption in other threads.
+    if (hw == HW::Xe3 && strategy.systolic) {
+        if (state.A_layout.hasFlags() && state.Ar_regs.empty())
+            for (auto &A_regs: state.A_regs)
+                zeroMatrix(A_regs, strategy);
+        if (state.B_layout.hasFlags() && state.Br_regs.empty())
+            for (auto &B_regs: state.B_regs)
+                zeroMatrix(B_regs, strategy);
+    }
+
     // Release 64-bit emulation registers as they aren't needed in the inner loop.
     // Could also move r0 to acc here.
     if (state.emulate.temp[0].isValid()) {


### PR DESCRIPTION
Closes MFDNN-14292. Intermittent failures were seen for some Xe3 matmul layers, e.g.

```
--dt=bf16:bf16:f32 --stag=abc --wtag=acb --dtag=abc 1024x1x144:1024x144x1
```

This was root-caused to a complex HW bug in the DPAS read suppression logic when physical register allocations from different threads alias. The workaround here is to avoid dpas with uninitialized src1/src2 -- even though the kernel does not use the results of such dpas instructions.