### PR TITLE
cpu: pool: enable different dt on src and dst in ref

### DIFF
--- a/doc/primitives/pooling.md
+++ b/doc/primitives/pooling.md
@@ -154,11 +154,7 @@ of any preceding compute-intensive primitive.
 1. Refer to @ref dev_guide_data_types for limitations related to data types
    support.
 
-2. **CPU**
-    - Different data types of source and destination in forward inference
-      are not supported.
-
-3. **GPU**
+2. **GPU**
     - #dnnl_pooling_max for f64 data type will return `-FLT_MAX` as an output
       value instead of `-DBL_MAX` in scenarios when pooling kernel is applied
       to a completely padded area.

--- a/src/cpu/cpu_pooling_list.cpp
+++ b/src/cpu/cpu_pooling_list.cpp
@@ -79,19 +79,12 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE(nhwc_pooling_fwd_t<f16>)
             CPU_INSTANCE(nhwc_pooling_fwd_t<f8_e5m2>)
             CPU_INSTANCE(nhwc_pooling_fwd_t<f8_e4m3>)
-            CPU_INSTANCE(ref_pooling_fwd_t<f32>)
-            CPU_INSTANCE(ref_pooling_fwd_t<bf16, f32>)
-            CPU_INSTANCE(ref_pooling_fwd_t<f16, f32>)
-            CPU_INSTANCE(ref_pooling_fwd_t<f8_e5m2, f32>)
-            CPU_INSTANCE(ref_pooling_fwd_t<f8_e4m3, f32>)
             /* int */
             CPU_INSTANCE_X64(jit_uni_i8i8_pooling_fwd_t<avx512_core>)
             CPU_INSTANCE_X64(jit_uni_i8i8_pooling_fwd_t<avx2>)
             CPU_INSTANCE_X64(jit_uni_i8i8_pooling_fwd_t<sse41>)
             CPU_INSTANCE_AARCH64(jit_uni_i8i8_pooling_fwd_t<sve_512>)
-            CPU_INSTANCE(ref_pooling_fwd_t<s32>)
-            CPU_INSTANCE(ref_pooling_fwd_t<s8, s32>)
-            CPU_INSTANCE(ref_pooling_fwd_t<u8, s32>)
+            CPU_INSTANCE(ref_pooling_fwd_t)
             nullptr,
         }},
         {{backward}, REG_BWD_PK({

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -43,13 +43,11 @@ static inline dim_t get_offset(const memory_desc_wrapper &mdw, dim_t n, dim_t c,
 
 using namespace nstl;
 
-template <data_type_t data_type, data_type_t acc_type>
-status_t ref_pooling_fwd_t<data_type, acc_type>::execute_forward(
-        const exec_ctx_t &ctx) const {
+status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
     status_t status = status::success;
-    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
-    auto dst = CTX_OUT_CLEAN_MEM(data_t *, DNNL_ARG_DST, status);
+    auto src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_CLEAN_MEM(void *, DNNL_ARG_DST, status);
     CHECK(status);
     auto ws = CTX_OUT_CLEAN_MEM(unsigned char *, DNNL_ARG_WORKSPACE, status);
     CHECK(status);
@@ -111,7 +109,7 @@ status_t ref_pooling_fwd_t<data_type, acc_type>::execute_forward(
                     if (iw < 0 || iw >= IW) continue;
 
                     const auto off = get_offset(src_d, mb, oc, id, ih, iw);
-                    auto s = src[off];
+                    float s = io::load_float_value(src_d.data_type(), src, off);
                     if (s > d) {
                         d = s;
                         set_ws(mb, oc, od, oh, ow, (kd * KH + kh) * KW + kw);
@@ -134,7 +132,7 @@ status_t ref_pooling_fwd_t<data_type, acc_type>::execute_forward(
                     if (iw < 0 || iw >= IW) continue;
 
                     const auto off = get_offset(src_d, mb, oc, id, ih, iw);
-                    d += src[off];
+                    d += io::load_float_value(src_d.data_type(), src, off);
                 }
             }
         }
@@ -172,7 +170,8 @@ status_t ref_pooling_fwd_t<data_type, acc_type>::execute_forward(
     const bool is_max_pool = alg == alg_kind::pooling_max;
 
     float base_res
-            = is_max_pool ? (float)numeric_limits<data_t>::lowest() : 0.f;
+            = is_max_pool ? types::lowest_value<float>(dst_d.data_type()) : 0.f;
+
     using ker_t
             = std::function<void(float &, dim_t, dim_t, dim_t, dim_t, dim_t)>;
     ker_t kernel = is_max_pool ? (ker_t)ker_max : (ker_t)ker_avg;
@@ -190,7 +189,7 @@ status_t ref_pooling_fwd_t<data_type, acc_type>::execute_forward(
         args.dst_md = pd()->dst_md();
         ref_post_ops->execute(res, args);
 
-        dst[data_p_off] = cpu::q10n::saturate_and_round<data_t>(res);
+        io::store_float_value(dst_d.data_type(), res, dst, data_p_off);
     });
 
     return status::success;
@@ -369,15 +368,6 @@ status_t ref_pooling_bwd_t::execute(const exec_ctx_t &ctx) const {
 
     return status::success;
 }
-
-template struct ref_pooling_fwd_t<data_type::f32>;
-template struct ref_pooling_fwd_t<data_type::s32>;
-template struct ref_pooling_fwd_t<data_type::bf16, data_type::f32>;
-template struct ref_pooling_fwd_t<data_type::f16, data_type::f32>;
-template struct ref_pooling_fwd_t<data_type::f8_e5m2, data_type::f32>;
-template struct ref_pooling_fwd_t<data_type::f8_e4m3, data_type::f32>;
-template struct ref_pooling_fwd_t<data_type::s8, data_type::s32>;
-template struct ref_pooling_fwd_t<data_type::u8, data_type::s32>;
 
 } // namespace cpu
 } // namespace impl

--- a/tests/benchdnn/doc/driver_pool.md
+++ b/tests/benchdnn/doc/driver_pool.md
@@ -42,33 +42,6 @@ Refer to [descriptor](knobs_desc.md) for details. Input shape and kernel size
 are mandatory inputs. Output shape and padding may be deduced based on the
 values provided.
 
-## Precision Configurations
-
-`--cfg` option specifies what [data types](knobs_dt.md) will be used for a
-problem. It is implicit for the integer type saturation. This option also
-defines the threshold for computation errors.
-
-The table below shows supported name configurations for this driver:
-
-| src   | dst   | cfg   | notes
-|:---   |:---   |:---   |:---
-| f32   | f32   | f32   | TBA.
-| s32   | s32   | s32   |
-| f16   | f16   | f16   |
-| bf16  | bf16  | bf16  |
-| s8    | s8    | s8    |
-| u8    | u8    | u8    |
-| s8    | u8    | s8u8  | Only on GPU engine
-| u8    | s8    | u8s8  | Only on GPU engine
-| s8    | f16   | s8f16 | Only on GPU engine
-| f16   | s8    | f16s8 | Only on GPU engine
-| u8    | f16   | u8f16 | Only on GPU engine
-| f16   | u8    | f16u8 | Only on GPU engine
-| s8    | f32   | s8f32 | Only on GPU engine
-| f32   | s8    | f32s8 | Only on GPU engine
-| u8    | f32   | u8f32 | Only on GPU engine
-| f32   | u8    | f32u8 | Only on GPU engine
-
 
 ## Essence of Testing
 `max` algorithm: Fill input data with integers and expect an integer answer.


### PR DESCRIPTION
Addresses MFDNN-7685.

This PR adds support for different data types on source and destination in ref pooling. 
Support in JIT implementation is WIP and will be provided in separate PR.