### PR TITLE
xe2: jit: gemm: use atomic loads for fused post-op readback

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
@@ -530,8 +530,11 @@ bool Generator<hw>::gemmFusedPostOpsFinalize(Label &labelLateExit, GEMMProblem &
     modState.ra.safeRelease(zero);
 
     status << "Load completed C tile" << status_stream::endl;
-    modStrategy.C.atomic = modStrategy.CO.atomic = false;
-    modState.Cext_strategy.atomic = false;
+    if (hw < HW::Xe2) {
+        /* Xe2 + later need atomic loads */
+        modStrategy.C.atomic = modStrategy.CO.atomic = false;
+        modState.Cext_strategy.atomic = false;
+    }
     gemmAccessC(COperation::Load, modProblem, modStrategy, modState);
 
     if (strategy.zeroTempC) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
@@ -104,7 +104,9 @@ void Generator<hw>::loadMatrixBlock(const Register &dest, const RegisterBlock &b
         case AccessType::Scattered:
         case AccessType::ChannelScattered: {
             auto spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Read);
-            if (block.descAssigned) {
+            if (astrategy.atomic && hw >= HW::Xe2)
+                atomic(AtomicOp::load, mod, dest, spec, astrategy.base, getAddress(addr, block, astrategy));
+            else if (block.descAssigned) {
                 MessageDescriptor desc;
                 ExtendedMessageDescriptor exdesc;
                 encodeLoadDescriptors(hw, desc, exdesc, block.simdSize, r0, spec, astrategy.base, null);


### PR DESCRIPTION
Backport of #4317 to `rls-v3.10`.