### PR TITLE
cpu: aarch64: Enable 1xK and Kx1 gemv.

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -175,8 +175,9 @@ status_t brgemm_desc_init(brgemm_t *brg, cpu_isa_t isa,
             alpha, beta, LDA, LDB, LDC, M, N, K, strides));
 
     if (M <= 0 || N <= 0 || K <= 0) return status::invalid_arguments;
-    bool ldx_check = (brg->is_row_major()) ? (LDA < K)
-                                           : (LDA < M || LDB < K || LDC < M);
+    bool ldx_check = (brg->is_gemv || brg->is_row_major())
+            ? (LDA < K)
+            : (LDA < M || LDB < K || LDC < M);
     if (ldx_check) return status::invalid_arguments;
 
     if (utils::everyone_is(

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -224,6 +224,7 @@ struct brgemm_t {
     bool with_eltwise = false;
     bool with_binary = false;
     bool with_scales = false;
+    bool is_gemv = false; // (M == 1 && is_col_major()) || (N == 1 && LDB == 1)
 
     brgemm_broadcast_t zp_type_a = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;
@@ -283,6 +284,11 @@ struct brgemm_t {
     bool is_row_major() const {
         assert(layout != brgemm_layout_undef);
         return layout == brgemm_row_major;
+    }
+
+    bool is_col_major() const {
+        assert(layout != brgemm_layout_undef);
+        return layout == brgemm_col_major;
     }
 
     int get_wsp_buffer_size() const noexcept {


### PR DESCRIPTION
# Description

This PR improves the GEMV 1xK:KxN and MxK:Kx1 matmul paths for BRGeMM. It is an extension of the work initially developed by @karmeh01 on the PR #3786. The novelty of this PR is enabling the 1xK:KxN path into BRGeMM.

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

All the NIGHTLY tests are passing when the command below is executed: 

`ctest -j$(nproc) -E $(../.github/automation/aarch64/skipped-tests.sh)`

- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

Here is the benchmark for VLLM with the relative (gemv / acl) comparison between GEMV and ACL. A value less than 1 indicates that GEMV is better than ACL. This PR provides significant performance improvements compared to ACL.

```
threads               1     8     16    32    64
DESC                                            
1x64:64x197         0.50  0.56  0.60  0.43  0.50
1x128:128x128       0.48  0.56  0.62  0.58  0.47
1x197:197x64        0.55  0.47  0.38  0.28  0.08
1x256:256x256       0.46  0.57  0.65  0.47  0.51
1x576:576x64        0.51  0.50  0.46  0.30  0.09
1x768:768x768       0.72  0.69  0.52  0.40  0.48
1x768:768x3072      0.86  0.82  0.66  0.50  0.51
1x768:768x2304      0.82  0.76  0.61  0.49  0.73
1x1152:1152x128     0.57  0.62  0.59  0.46  0.81
1x2304:2304x256     0.65  0.65  0.63  0.44  0.48
1x3072:3072x768     0.83  0.78  0.65  0.43  0.49
1x3584:3584x14336   0.89  0.85  0.84  0.85  0.87
1x3584:3584x3584    1.02  0.81  0.79  0.59  0.26
1x3584:3584x8192    0.90  0.85  0.88  0.74  0.59
1x4096:4096x8       0.71  0.59  0.59  0.36  0.12
1x4096:4096x6144    0.90  0.89  1.02  0.73  0.59
1x4096:4096x4096    0.94  0.93  0.73  0.70  0.53
1x4096:4096x14336   0.87  0.80  0.88  0.86  0.61
1x4096:4096x512     0.86  0.71  0.66  0.44  0.55
1x6144:6144x18432   0.89  0.79  0.89  0.89  0.86
1x6144:6144x24576   0.88  0.76  0.89  0.92  0.88
1x6144:6144x6144    0.89  0.84  0.88  0.85  0.92
1x8192:8192x28672   0.88  0.91  0.93  0.90  1.02
1x8192:8192x10240   0.87  0.80  0.92  0.91  0.82
1x8192:8192x8192    0.89  0.97  0.89  0.90  0.66
1x14336:14336x4096  0.88  0.87  0.89  0.90  0.77
1x14336:14336x3584  0.87  0.96  0.90  0.90  0.69
1x24576:24576x6144  0.87  0.98  0.94  0.92  0.90
1x28672:28672x8192  0.85  0.91  0.94  0.93  0.92
```

Also, the absolute numbers:

```
version                acl                               gemv                        
threads                  1     8     16    32    64        1     8     16    32    64
DESC                                                                                 
1x64:64x197            0.03  0.04  0.05  0.11  0.38      0.02  0.02  0.03  0.05  0.19
1x128:128x128          0.03  0.04  0.05  0.10  0.40      0.01  0.02  0.03  0.06  0.19
1x197:197x64           0.03  0.04  0.04  0.06  0.19      0.02  0.02  0.02  0.02  0.02
1x256:256x256          0.04  0.04  0.05  0.11  0.39      0.02  0.02  0.03  0.05  0.20
1x576:576x64           0.03  0.04  0.05  0.07  0.18      0.02  0.02  0.02  0.02  0.02
1x768:768x768          0.09  0.05  0.06  0.10  0.38      0.07  0.03  0.03  0.04  0.18
1x768:768x3072         0.24  0.07  0.07  0.11  0.37      0.21  0.06  0.05  0.06  0.19
1x768:768x2304         0.20  0.07  0.06  0.11  0.40      0.17  0.05  0.04  0.05  0.29
1x1152:1152x128        0.05  0.04  0.05  0.11  0.38      0.03  0.03  0.03  0.05  0.31
1x2304:2304x256        0.10  0.05  0.05  0.11  0.40      0.07  0.03  0.03  0.05  0.20
1x3072:3072x768        0.25  0.07  0.07  0.11  0.38      0.20  0.06  0.05  0.05  0.19
1x3584:3584x14336      7.53  1.50  1.07  0.86  0.89      6.73  1.28  0.90  0.73  0.77
1x3584:3584x3584       1.56  0.41  0.37  0.23  0.67      1.58  0.33  0.29  0.13  0.17
1x3584:3584x8192       4.12  0.93  0.56  0.48  0.52      3.69  0.79  0.50  0.36  0.31
1x4096:4096x8          0.04  0.04  0.05  0.07  0.19      0.02  0.02  0.03  0.02  0.02
1x4096:4096x6144       3.50  0.69  0.49  0.40  0.47      3.16  0.62  0.51  0.30  0.28
1x4096:4096x4096       2.21  0.47  0.40  0.33  0.39      2.09  0.43  0.29  0.23  0.21
1x4096:4096x14336      8.68  1.66  1.17  1.00  1.18      7.58  1.33  1.03  0.86  0.72
1x4096:4096x512        0.23  0.07  0.07  0.10  0.38      0.20  0.05  0.04  0.04  0.21
1x6144:6144x18432     16.92  3.37  2.30  1.91  1.73     15.00  2.67  2.04  1.70  1.49
1x6144:6144x24576     22.58  4.39  3.10  2.56  2.33     19.82  3.34  2.75  2.35  2.04
1x6144:6144x6144       5.44  1.16  0.74  0.60  0.67      4.83  0.98  0.65  0.51  0.61
1x8192:8192x28672     35.85  6.09  4.68  4.07  3.56     31.38  5.54  4.34  3.68  3.64
1x8192:8192x10240     12.55  2.36  1.68  1.39  1.32     10.95  1.90  1.55  1.26  1.08
1x8192:8192x8192       9.88  1.70  1.36  1.10  1.27      8.82  1.65  1.21  0.99  0.83
1x14336:14336x4096     8.80  1.53  1.18  0.95  0.95      7.74  1.34  1.05  0.85  0.73
1x14336:14336x3584     7.64  1.23  1.03  0.85  0.86      6.63  1.18  0.93  0.76  0.59
1x24576:24576x6144    22.63  3.47  3.00  2.56  2.31     19.66  3.42  2.83  2.36  2.07
1x28672:28672x8192    36.02  5.79  4.60  4.00  3.58     30.74  5.26  4.33  3.71  3.28
```