### PR TITLE
gpu: intel: ocl: allow unlimited allocations

### DIFF
--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -216,6 +216,7 @@ public:
     static int max_slm_size_per_tg(gpu_arch_t gpu_arch);
     static int max_slm_size_per_tg(
             gpu_arch_t gpu_arch, int tg_size, bool large_grf_mode = false);
+    size_t memory_size() const { return memory_size_; }
     size_t l3_cache_size() const { return l3_cache_size_; }
     size_t icache_size() const;
     size_t max_kernel_param_size() const { return max_kernel_param_size_; }
@@ -288,10 +289,11 @@ protected:
     int32_t max_subgroup_size_ = 16;
     int max_exec_size_ = 0;
     size_t max_wg_size_ = 0;
+    size_t memory_size_ = 0;
     size_t l3_cache_size_ = 0;
     size_t max_kernel_param_size_ = 1024;
     uint32_t device_address_bits_ = 64;
-    uint64_t max_allocation_size_ = 0;
+    uint64_t max_allocation_size_ = UINT32_MAX;
 
     // extensions_ and gpu_arch_ describe effective extensions and GPU architecture.
     uint64_t extensions_ = 0;

--- a/src/gpu/intel/compute/dispatch_reusable.cpp
+++ b/src/gpu/intel/compute/dispatch_reusable.cpp
@@ -456,7 +456,6 @@ void dispatch_compile_params_t::def_kernel_macros(
         kernel_ctx_t &kernel_ctx, const char *suffix) const {
     kernel_ctx.define_int("GWS_WITH_RUNTIME_PARAMS", 1);
     kernel_ctx.use_int32_offset(use_int32_offset);
-    kernel_ctx.require_large_buffers(require_large_buffers);
 
     // Find a unique prefix (in case there are many kernels in a file).
     std::string gws_prefix;

--- a/src/gpu/intel/compute/dispatch_reusable.hpp
+++ b/src/gpu/intel/compute/dispatch_reusable.hpp
@@ -245,8 +245,7 @@ struct dispatch_compile_params_t {
     subgroup_data_t subgroup;
     int32_t num_terms = 0;
     bool use_int32_offset = false;
-    bool require_large_buffers = true;
-    uint8_t padding[2] = {0};
+    uint8_t padding[3] = {0};
     gws_indexing_term_t::compile_params_t terms[MAX_INDEXING_TERMS]
             = {{gws_op_t::SOLO, 0}};
 
@@ -532,7 +531,6 @@ public:
 
         // Save buffer information
         dim_t max_buffer_size = 0;
-        uint64_t max_buffer_size_bytes = 0;
         compile_params.num_buffers = buffers.size();
         for (size_t buf_idx = 0; buf_idx < buffers.size(); buf_idx++) {
             const named_buffer_t &buffer = buffers[buf_idx];
@@ -553,15 +551,10 @@ public:
             compile_params.buffer_types[buf_idx] = buffer.data_type;
 
             // Check buffer sizes to see if we can use int32_t offsets
-            // or do we need to use stateless addressing model
             max_buffer_size = std::max(max_buffer_size, buffer.nelems(true));
-            max_buffer_size_bytes = std::max(
-                    max_buffer_size_bytes, buffer.size(0, true, true));
         }
 
         compile_params.use_int32_offset = max_buffer_size <= INT32_MAX;
-        compile_params.require_large_buffers
-                = max_buffer_size_bytes > UINT32_MAX;
         compile_params.subgroup = subgroup;
 
         // Set runtime params

--- a/src/gpu/intel/compute/kernel_ctx.cpp
+++ b/src/gpu/intel/compute/kernel_ctx.cpp
@@ -24,13 +24,12 @@ namespace intel {
 namespace compute {
 
 void kernel_ctx_t::register_buffer_size(const memory_desc_wrapper &mdw) {
-    register_buffer_size(mdw.nelems(true), mdw.size(0, true, true));
+    register_buffer_size(mdw.nelems(true));
 }
 
 void kernel_ctx_t::register_buffer_size(const memory_desc_info_t &mdi) {
     register_buffer_size(
-            (mdi.size / types::data_type_size(mdi.data_type)) + mdi.offset0,
-            mdi.size + (mdi.offset0 * types::data_type_size(mdi.data_type)));
+            (mdi.size / types::data_type_size(mdi.data_type)) + mdi.offset0);
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -85,9 +85,6 @@ public:
     // operations when native 64-bit operations are unsupported.
     void use_int32_offset(bool value) { use_int32_offset_ = value; }
 
-    void require_large_buffers(bool value) { require_large_buffers_ = value; }
-    bool has_large_buffers() const { return require_large_buffers_; }
-
     void define_int(const char *variable, int64_t value) {
         set_macro(variable, value, int_var_map_);
     }
@@ -160,9 +157,8 @@ public:
     bool has_custom_headers() const { return !custom_headers_.empty(); }
 
 private:
-    void register_buffer_size(dim_t nelems, size_t size) {
+    void register_buffer_size(dim_t nelems) {
         if (nelems > INT_MAX) use_int32_offset(false);
-        if (size > UINT32_MAX) require_large_buffers(true);
     }
 
     void set_default_options(const primitive_attr_t *attr) {
@@ -212,7 +208,6 @@ private:
     std::set<std::string> option_set_;
     std::unordered_map<std::string, std::string> custom_headers_;
     bool use_int32_offset_ = true;
-    bool require_large_buffers_ = false;
 };
 
 } // namespace compute

--- a/src/gpu/intel/concat/xe.cpp
+++ b/src/gpu/intel/concat/xe.cpp
@@ -122,12 +122,12 @@ status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
     conf.n = pd->n_inputs();
     conf.concat_axis = pd->concat_dim();
 
-    dim_t max_bytes = dst_mdw.size();
+    dim_t max_elems = dst_mdw.nelems();
     int concat_axis_end = 0;
     conf.scales_mask = 0;
     for (int i = 0; i < conf.n; ++i) {
         const memory_desc_wrapper src_mdw(pd->src_md(i));
-        max_bytes = std::max(max_bytes, into<dim_t>(src_mdw.size()));
+        max_elems = std::max(max_elems, into<dim_t>(src_mdw.nelems()));
         concat_axis_end += src_mdw.dims()[conf.concat_axis];
         conf.offset[i] = concat_axis_end;
         conf.src_md_infos[i] = memory_desc_info_t::create(pd->src_md(i));
@@ -136,7 +136,7 @@ status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
         conf.scales_mask |= ((!conf.scale_src[i].has_default_values()) << i);
     }
 
-    conf.use_large_index = (max_bytes > std::numeric_limits<int>::max());
+    conf.use_large_index = (max_elems > std::numeric_limits<int>::max());
 
     conf.sub_group_size = calculate_sub_group_size(intel_engine);
     std::tie(conf.iter_dim_idx, conf.iter_dim_chunk)

--- a/src/gpu/intel/ocl/device_info.cpp
+++ b/src/gpu/intel/ocl/device_info.cpp
@@ -134,6 +134,12 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
     OCL_CHECK(err);
     max_wg_size_ = max_wg_size;
 
+    cl_ulong mem_size;
+    err = clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(mem_size),
+            &mem_size, nullptr);
+    OCL_CHECK(err);
+    memory_size_ = mem_size;
+
     cl_ulong mem_cache_size;
     err = clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE,
             sizeof(mem_cache_size), &mem_cache_size, nullptr);

--- a/src/gpu/intel/ocl/engine.cpp
+++ b/src/gpu/intel/ocl/engine.cpp
@@ -245,7 +245,7 @@ status_t engine_t::build_program_from_source(
 
     // Compile kernel in a stateless addressing model allowing usage of
     // allocations of any size. Not needed if allowed allocation is already > 4GB.
-    if (kernel_ctx.has_large_buffers()
+    if (dev_info->device_address_bits() >= 64
             && dev_info->max_allocation_size() <= UINT32_MAX)
         options += " -cl-intel-greater-than-4GB-buffer-required";
 

--- a/src/gpu/intel/sycl/device_info.cpp
+++ b/src/gpu/intel/sycl/device_info.cpp
@@ -138,10 +138,13 @@ status_t device_info_t::init_attributes(impl::engine_t *engine) {
         eu_count_ = device.get_info<::sycl::info::device::max_compute_units>();
     }
     max_wg_size_ = device.get_info<::sycl::info::device::max_work_group_size>();
+    memory_size_ = device.get_info<::sycl::info::device::global_mem_size>();
     l3_cache_size_
             = device.get_info<::sycl::info::device::global_mem_cache_size>();
     mayiuse_system_memory_allocators_
             = device.has(::sycl::aspect::usm_system_allocations);
+    device_address_bits_
+            = device.get_info<::sycl::info::device::address_bits>();
     max_allocation_size_
             = device.get_info<::sycl::info::device::max_mem_alloc_size>();
     return status::success;

--- a/src/xpu/ocl/utils.hpp
+++ b/src/xpu/ocl/utils.hpp
@@ -28,6 +28,11 @@
 
 #include "xpu/utils.hpp"
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+#define CL_MEM_FLAGS_INTEL 0x10001
+#define CL_MEM_ALLOW_UNRESTRICTED_SIZE_INTEL (1 << 23)
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace xpu {

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1028,9 +1028,9 @@ size_t get_cpu_ram_size() {
 }
 #endif
 
-int get_gpu_ram_sizes(size_t &ram_size, size_t &max_alloc_size) {
+int get_gpu_ram_size(size_t &ram_size) {
     if (!is_gpu()) return OK;
-    if (ram_size > 0 && max_alloc_size > 0) return OK;
+    if (ram_size > 0) return OK;
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     auto eng = dnnl::engine(get_test_engine(), true);
@@ -1042,26 +1042,16 @@ int get_gpu_ram_sizes(size_t &ram_size, size_t &max_alloc_size) {
             sizeof(cl_ulong), &ram_sz, nullptr);
     if (status != CL_SUCCESS) return FAIL;
 
-    cl_ulong max_alloc_sz = 0;
-    status = clGetDeviceInfo(ocl_device, CL_DEVICE_MAX_MEM_ALLOC_SIZE,
-            sizeof(cl_ulong), &max_alloc_sz, nullptr);
-    if (status != CL_SUCCESS) return FAIL;
-
     ram_size = (size_t)ram_sz;
-    max_alloc_size = (size_t)max_alloc_sz;
     return OK;
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_DPCPP
     auto eng = dnnl::engine(get_test_engine(), true);
     auto sycl_dev = dnnl::sycl_interop::get_device(eng);
     ram_size = (size_t)sycl_dev
                        .get_info<::sycl::info::device::global_mem_size>();
-    max_alloc_size
-            = (size_t)sycl_dev
-                      .get_info<::sycl::info::device::max_mem_alloc_size>();
     return OK;
 #endif
     ram_size = 0;
-    max_alloc_size = 0;
     return OK;
 }
 
@@ -1132,8 +1122,7 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
 
     static size_t cpu_device_capacity = get_cpu_ram_size();
     static size_t gpu_device_capacity = 0;
-    static size_t gpu_max_alloc_capacity = 0;
-    SAFE(get_gpu_ram_sizes(gpu_device_capacity, gpu_max_alloc_capacity), WARN);
+    SAFE(get_gpu_ram_size(gpu_device_capacity), WARN);
 
     const size_t device_max_capacity
             = is_cpu() ? cpu_device_capacity : gpu_device_capacity;
@@ -1171,32 +1160,13 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
             res->reason = skip_reason::not_enough_ram;
         }
 
-        const bool all_allocation_fit_limit = std::all_of(
-                check_mem_size_args.sizes.cbegin(),
-                check_mem_size_args.sizes.cend(), [&](size_t s) {
-                    const bool fit = s < gpu_max_alloc_capacity;
-                    if (!fit) {
-                        BENCHDNN_PRINT(1,
-                                "[CHECK_MEM][%s]: Allocation of size %s "
-                                "doesn't fit allocation limit of %s.\n",
-                                dir_c_str(), smart_bytes(s).c_str(),
-                                smart_bytes(gpu_max_alloc_capacity).c_str());
-                    }
-                    return fit;
-                });
-        if (!all_allocation_fit_limit) {
-            res->state = SKIPPED;
-            res->reason = skip_reason::not_enough_ram;
-        }
-
         BENCHDNN_PRINT((!fits_device_ram ? 1 : 6),
                 "[CHECK_MEM][%s]: Requested: %s; benchdnn_device_limit: %s; "
-                "device_RAM_capacity: %s; gpu_max_alloc: %s;\n",
+                "device_RAM_capacity: %s;\n",
                 dir_c_str(),
                 smart_bytes(check_mem_size_args.total_size_device).c_str(),
                 smart_bytes(benchdnn_device_limit).c_str(),
-                smart_bytes(gpu_device_capacity).c_str(),
-                smart_bytes(gpu_max_alloc_capacity).c_str());
+                smart_bytes(gpu_device_capacity).c_str());
     }
 
     // Note: in theory, `total_size_ref` itself can be smaller for a `prim_ref`

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -231,7 +231,7 @@ struct cpu_cache_args_t {
 };
 
 size_t get_cpu_ram_size();
-int get_gpu_ram_sizes(size_t &ram_size, size_t &max_alloc_size);
+int get_gpu_ram_size(size_t &ram_size);
 int get_cpu_cache_size(cpu_cache_args_t &cache_args);
 int get_gpu_cache_size(size_t &cache_size);
 
@@ -424,31 +424,6 @@ int create_primitive(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &primw,
     SAFE(collect_mem_size(res->mem_size_args, pdw, dir,
                  /* need_skip = */ !is_graph_ref),
             WARN);
-
-    // The library scratchpad is allocated at create_primitive stage. The memory
-    // check is moved after the creation stage. It's necessary to check the
-    // library scratchpad size against gpu_max_alloc, otherwise, out_of_memory
-    // would be issued by the library.
-    if (res->mem_size_args.scratchpad_size > 0 && is_gpu()
-            && query_scratchpad_mode(query_attr(pdw))
-                    == dnnl_scratchpad_mode_library) {
-        static size_t gpu_device_capacity = 0;
-        static size_t gpu_max_alloc_capacity = 0;
-        SAFE(get_gpu_ram_sizes(gpu_device_capacity, gpu_max_alloc_capacity),
-                WARN);
-        const bool fit
-                = res->mem_size_args.scratchpad_size < gpu_max_alloc_capacity;
-        if (!fit) {
-            BENCHDNN_PRINT(1,
-                    "[CHECK_MEM]: Size of the scratchpad %s "
-                    "doesn't fit the allocation limit of %s.\n",
-                    smart_bytes(res->mem_size_args.scratchpad_size).c_str(),
-                    smart_bytes(gpu_max_alloc_capacity).c_str());
-            res->state = SKIPPED;
-            res->reason = skip_reason::not_enough_ram;
-            return OK;
-        }
-    }
 
     TIME_C_PRIM(DNN_SAFE(dnnl_primitive_create(&prim, pdw), WARN));
     primw.reset(prim);

--- a/tests/benchdnn/graph/graph_memory.cpp
+++ b/tests/benchdnn/graph/graph_memory.cpp
@@ -34,8 +34,7 @@ size_t get_benchdnn_cpu_limit() {
 size_t get_benchdnn_device_limit() {
     if (is_cpu()) return 0;
     static size_t gpu_device_capacity = 0;
-    static size_t gpu_max_alloc_capacity = 0;
-    SAFE(get_gpu_ram_sizes(gpu_device_capacity, gpu_max_alloc_capacity), WARN);
+    SAFE(get_gpu_ram_size(gpu_device_capacity), WARN);
 
     const double benchdnn_device_limit = capacity_factor * gpu_device_capacity;
     assert(benchdnn_device_limit > 0);


### PR DESCRIPTION
Allow allocation of buffers bigger than `CL_DEVICE_MAX_MEM_ALLOC_SIZE` limited by `CL_DEVICE_GLOBAL_MEM_SIZE`.