### PR TITLE
[GPU] xe: jit: eltwise_injector: fixup mx dst defaults

### DIFF
--- a/src/gpu/intel/jit/eltwise_injector.hpp
+++ b/src/gpu/intel/jit/eltwise_injector.hpp
@@ -70,9 +70,9 @@ struct eltwise_injector_f32_t {
 
     void prepare();
     void compute(const ngen::GRF &reg) { compute(ngen::GRFRange(reg, 1)); }
-    void compute(const ngen::GRFRange &regs, int seed = -1, int seed_off = -1,
+    void compute(const ngen::GRFRange &regs, int seed = -1, int seed_off = 0,
             ngen::DataType = ngen::DataType::invalid);
-    void compute(const int *grfs, int ngrf, int seed = -1, int seed_off = -1,
+    void compute(const int *grfs, int ngrf, int seed = -1, int seed_off = 0,
             ngen::DataType = ngen::DataType::invalid);
 
 private:


### PR DESCRIPTION
# Description

Fix default argument values to avoid underflow, fix ASAN error. 

Fixes # [MFDNN-14421](https://jira.devtools.intel.com/browse/MFDNN-14421)

[ASAN check](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f0c5b354-baa0-f171-b1c3-a4bf010d0e2d)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?

