### PR TITLE
cpu: x64: remove check for AMX_TRANSPOSE for DMR

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -455,9 +455,9 @@ inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
                     && mayiuse(amx_fp16, soft));
         case avx10_2_512_amx_2:
             REG_AMX_ISA(return mayiuse(avx10_2_512, soft)
-                    && mayiuse(amx_tile, soft) && cpu().has(Cpu::tAMX_TRANSPOSE)
-                    && cpu().has(Cpu::tAMX_TF32) && cpu().has(Cpu::tAMX_AVX512)
-                    && cpu().has(Cpu::tAMX_MOVRS) && cpu().has(Cpu::tAMX_FP8));
+                    && mayiuse(amx_tile, soft) && cpu().has(Cpu::tAMX_TF32)
+                    && cpu().has(Cpu::tAMX_AVX512) && cpu().has(Cpu::tAMX_MOVRS)
+                    && cpu().has(Cpu::tAMX_FP8));
         case isa_all: return false;
         case isa_undef: return true;
     }


### PR DESCRIPTION
Backport of #4358 