### PR TITLE
graph: fixup unused variable warning

### DIFF
--- a/src/graph/utils/verbose.cpp
+++ b/src/graph/utils/verbose.cpp
@@ -241,7 +241,9 @@ void partition_info_t::init(const engine_t *engine,
     });
 }
 
+#ifndef DNNL_DISABLE_GRAPH_DUMP
 static setting_t<uint8_t> graph_dump_modes {0};
+#endif
 
 uint8_t parse_graph_dump_mode(const std::string &modes) {
     uint8_t m = 0;


### PR DESCRIPTION
Fixes a build warning related to the unused variable `graph_dump_mode` when `ONEDNN_DISABLE_GRAPH_DUMP` is set. When using `ONEDNN_BUILD_GRAPH=off`, this variable is also automatically set, which leads to the warning.

Example in [GPU performance CI](https://ecmd.jf.intel.com/commander/link/workspaceFile/workspaces/JF-COMMON-CI?jobStepId=f0c732d9-abc2-f1d3-9124-d4f5ef20c6a0&fileName=xe-hpg-atsm-compare.f0c732d9-abc2-f1d3-9124-d4f5ef20c6a0.log&jobName=PCm_Performance_GPU_oneDNN_2025-11-21-23%3A24%3A33-add_1dblock_xe2-cb2daf4&jobId=f0c7313c-8e02-f1ef-83e3-d4f5ef20c6a0&diagCharEncoding=&resourceName=sdpdnn4917&completed=1):
> [2025-11-21 15:41:06,208] WARNING: oneperf.build: /export/users/mkltest/ec/oneDNN-auto-f0c732d9-abc2-f1d3-9124-d4f5ef20c6a0/temp/0154e3ecd439683ba55ad05fd1b384531856e9ab/source/src/graph/utils/verbose.cpp:244:27: warning: unused variable 'graph_dump_modes' [-Wunused-variable]
[2025-11-21 15:41:06,208] WARNING: oneperf.build: 244 | static setting_t<uint8_t> graph_dump_modes {0};
[2025-11-21 15:41:06,208] WARNING: oneperf.build: |      