### PR TITLE
[backport] graph: backend: dnnl: fix host_scalar_executable_t::execute_ocl leaks cl_event memory

### DIFF
--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -525,8 +525,9 @@ struct host_scalar_executable_t : public op_executable_t {
                     dst_mem.get_data_handle(), static_cast<const void *>(&val),
                     size, num, empty ? nullptr : deps.data(), &e));
             clWaitForEvents(1, &e);
+            clReleaseEvent(e);
         });
-        return e;
+        return nullptr;
     }
 #endif
 


### PR DESCRIPTION
# Description

backport memory leak fix from https://github.com/uxlfoundation/oneDNN/pull/4319 to v3.10.
