### PR TITLE
cpu: rv64: jit: integrate the third-party xbyak_riscv library

### DIFF
--- a/THIRD-PARTY-PROGRAMS
+++ b/THIRD-PARTY-PROGRAMS
@@ -562,6 +562,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+--------------------------------------------------------------------------------
 9. Sphinx (doc/sphinx/conf.py)
 Copyright (c) 2007-2021 by the Sphinx team (see AUTHORS file).
 All rights reserved.
@@ -590,6 +591,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 --------------------------------------------------------------------------------
 10. Intel(R) Metrics Discovery Application Programming Interface (third_party/mdapi/)
 MIT License
@@ -613,3 +615,33 @@ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+11. Xbyak_riscv (third_party/xbyak_riscv/)
+
+Copyright (c) 2007 MITSUNARI Shigeo
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+Neither the name of the copyright owner nor the names of its contributors may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/cpu/rv64/CMakeLists.txt
+++ b/src/cpu/rv64/CMakeLists.txt
@@ -39,3 +39,8 @@ add_library(${OBJ_LIB} OBJECT ${SOURCES})
 # Add compiled object files to oneDNN dependencies
 set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
              $<TARGET_OBJECTS:${OBJ_LIB}>)
+
+# Add xbyak_riscv include path for JIT code generation
+target_include_directories(${OBJ_LIB} PRIVATE
+    ${PROJECT_SOURCE_DIR}/third_party
+)

--- a/src/cpu/rv64/cpu_isa_traits.hpp
+++ b/src/cpu/rv64/cpu_isa_traits.hpp
@@ -25,6 +25,7 @@
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 #include "dnnl_types.h"
+#include "xbyak_riscv/xbyak_riscv_util.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -80,8 +81,12 @@ private:
     }
 
     Riscv64Cpu() {
-        unsigned long hwcap = getauxval(AT_HWCAP);
-        has_v = (hwcap & (1UL << ('V' - 'A')));
+        // Use xbyak_riscv for V extension detection
+        const auto &xbyak_cpu = Xbyak_riscv::CPU::getInstance();
+        has_v = xbyak_cpu.hasExtension(Xbyak_riscv::RISCVExtension::V);
+
+        // Zvfh detection: xbyak_riscv doesn't support half-precision yet,
+        // so continue using procfs method
         if (has_v) {
             // TODO: Prioritize riscv_hwprobe when available (Linux 6.4+)
             has_zvfh = detect_zvfh_procfs();

--- a/third_party/xbyak_riscv/README.md
+++ b/third_party/xbyak_riscv/README.md
@@ -1,0 +1,3 @@
+This code is from [Xbyak_riscv](https://github.com/herumi/xbyak_riscv)
+
+tag: 1.01

--- a/third_party/xbyak_riscv/xbyak_riscv.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv.hpp
@@ -77,11 +77,17 @@
 
 #include "xbyak_riscv_csr.hpp"
 
+#if ((__cplusplus >= 201402L) && !(!defined(__clang__) && defined(__GNUC__) && (__GNUC__ <= 5))) || (defined(_MSC_VER) && _MSC_VER >= 1910)
+	#define XBYAK_RISCV_CONSTEXPR constexpr
+#else
+	#define XBYAK_RISCV_CONSTEXPR
+#endif
+
 namespace Xbyak_riscv {
 
 enum {
 	DEFAULT_MAX_CODE_SIZE = 4096,
-	VERSION = 0x1000 /* 0xABCD = A.BC.D */
+	VERSION = 0x1010 /* 0xABCD = A.BC.D */
 };
 
 inline uint32_t getVersion() { return VERSION; }
@@ -213,19 +219,19 @@ namespace local {
 
 static const size_t ALIGN_PAGE_SIZE = 4096;
 
-inline constexpr uint32_t mask(size_t n)
+inline XBYAK_RISCV_CONSTEXPR uint32_t mask(size_t n)
 {
 	XBYAK_RISCV_ASSERT(n <= 32);
 	return n == 32 ? 0xffffffff : (1u << n) - 1;
 }
 // is x <= mask(n) ?
-inline constexpr bool inBit(uint32_t x, size_t n)
+inline XBYAK_RISCV_CONSTEXPR bool inBit(uint32_t x, size_t n)
 {
 	return x <= mask(n);
 }
 
 // is x a signed n-bit integer?
-inline constexpr bool inSBit(int x, int n)
+inline XBYAK_RISCV_CONSTEXPR bool inSBit(int x, int n)
 {
 	return -(1 << (n-1)) <= x && x < (1 << (n-1));
 }
@@ -381,12 +387,12 @@ protected:
 	uint32_t idx_;
 	Kind kind_;
 public:
-	constexpr IReg(uint32_t idx = 0, Kind kind = GPR)
+	XBYAK_RISCV_CONSTEXPR IReg(uint32_t idx = 0, Kind kind = GPR)
 		: idx_(idx), kind_(kind)
 	{
 		XBYAK_RISCV_ASSERT(local::inBit(idx, 5));
 	}
-	constexpr int getIdx() const { return idx_; }
+	XBYAK_RISCV_CONSTEXPR int getIdx() const { return idx_; }
 	const char *toString() const
 	{
 		if (kind_ == GPR) {
@@ -428,55 +434,55 @@ public:
 
 // General Purpose Register
 struct Reg : public local::IReg {
-	explicit constexpr Reg(int idx = 0) : local::IReg(idx, IReg::Kind::GPR) { }
+	explicit XBYAK_RISCV_CONSTEXPR Reg(int idx = 0) : local::IReg(idx, IReg::Kind::GPR) { }
 };
 
-static constexpr Reg x0(0), x1(1), x2(2), x3(3), x4(4), x5(5), x6(6), x7(7);
-static constexpr Reg x8(8), x9(9), x10(10), x11(11), x12(12), x13(13), x14(14), x15(15);
-static constexpr Reg x16(16), x17(17), x18(18), x19(19), x20(20), x21(21), x22(22), x23(23);
-static constexpr Reg x24(24), x25(25), x26(26), x27(27), x28(28), x29(29), x30(30), x31(31);
+static XBYAK_RISCV_CONSTEXPR Reg x0(0), x1(1), x2(2), x3(3), x4(4), x5(5), x6(6), x7(7);
+static XBYAK_RISCV_CONSTEXPR Reg x8(8), x9(9), x10(10), x11(11), x12(12), x13(13), x14(14), x15(15);
+static XBYAK_RISCV_CONSTEXPR Reg x16(16), x17(17), x18(18), x19(19), x20(20), x21(21), x22(22), x23(23);
+static XBYAK_RISCV_CONSTEXPR Reg x24(24), x25(25), x26(26), x27(27), x28(28), x29(29), x30(30), x31(31);
 
-static constexpr Reg zero(x0);
-static constexpr Reg ra(x1);
-static constexpr Reg sp(x2);
-static constexpr Reg gp(x3);
-static constexpr Reg tp(x4);
-static constexpr Reg t0(x5);
-static constexpr Reg t1(x6);
-static constexpr Reg t2(x7);
-static constexpr Reg fp(x8);
-static constexpr Reg s0(x8);
-static constexpr Reg s1(x9);
-static constexpr Reg a0(x10), a1(x11), a2(x12), a3(x13), a4(x14), a5(x15), a6(x16), a7(x17);
-static constexpr Reg s2(x18), s3(x19), s4(x20), s5(x21), s6(x22), s7(x23), s8(x24), s9(x25);
-static constexpr Reg s10(x26), s11(x27);
-static constexpr Reg t3(x28), t4(x29), t5(x30), t6(x31);
+static XBYAK_RISCV_CONSTEXPR Reg zero(x0);
+static XBYAK_RISCV_CONSTEXPR Reg ra(x1);
+static XBYAK_RISCV_CONSTEXPR Reg sp(x2);
+static XBYAK_RISCV_CONSTEXPR Reg gp(x3);
+static XBYAK_RISCV_CONSTEXPR Reg tp(x4);
+static XBYAK_RISCV_CONSTEXPR Reg t0(x5);
+static XBYAK_RISCV_CONSTEXPR Reg t1(x6);
+static XBYAK_RISCV_CONSTEXPR Reg t2(x7);
+static XBYAK_RISCV_CONSTEXPR Reg fp(x8);
+static XBYAK_RISCV_CONSTEXPR Reg s0(x8);
+static XBYAK_RISCV_CONSTEXPR Reg s1(x9);
+static XBYAK_RISCV_CONSTEXPR Reg a0(x10), a1(x11), a2(x12), a3(x13), a4(x14), a5(x15), a6(x16), a7(x17);
+static XBYAK_RISCV_CONSTEXPR Reg s2(x18), s3(x19), s4(x20), s5(x21), s6(x22), s7(x23), s8(x24), s9(x25);
+static XBYAK_RISCV_CONSTEXPR Reg s10(x26), s11(x27);
+static XBYAK_RISCV_CONSTEXPR Reg t3(x28), t4(x29), t5(x30), t6(x31);
 
 // Floating Point Register
 struct FReg : public local::IReg {
-	explicit constexpr FReg(int idx = 0) : local::IReg(idx, IReg::Kind::FReg) { }
+	explicit XBYAK_RISCV_CONSTEXPR FReg(int idx = 0) : local::IReg(idx, IReg::Kind::FReg) { }
 };
 
-static constexpr FReg f0(0), f1(1), f2(2), f3(3), f4(4), f5(5), f6(6), f7(7);
-static constexpr FReg f8(8), f9(9), f10(10), f11(11), f12(12), f13(13), f14(14), f15(15);
-static constexpr FReg f16(16), f17(17), f18(18), f19(19), f20(20), f21(21), f22(22), f23(23);
-static constexpr FReg f24(24), f25(25), f26(26), f27(27), f28(28), f29(29), f30(30), f31(31);
+static XBYAK_RISCV_CONSTEXPR FReg f0(0), f1(1), f2(2), f3(3), f4(4), f5(5), f6(6), f7(7);
+static XBYAK_RISCV_CONSTEXPR FReg f8(8), f9(9), f10(10), f11(11), f12(12), f13(13), f14(14), f15(15);
+static XBYAK_RISCV_CONSTEXPR FReg f16(16), f17(17), f18(18), f19(19), f20(20), f21(21), f22(22), f23(23);
+static XBYAK_RISCV_CONSTEXPR FReg f24(24), f25(25), f26(26), f27(27), f28(28), f29(29), f30(30), f31(31);
 // ABI name
-static constexpr FReg ft0(0), ft1(1), ft2(2), ft3(3), ft4(4), ft5(5), ft6(6), ft7(7);
-static constexpr FReg fs0(8), fs1(9), fa0(10), fa1(11), fa2(12), fa3(13), fa4(14), fa5(15), fa6(16), fa7(f17);
-static constexpr FReg fs2(18), fs3(19), fs4(20), fs5(21), fs6(22), fs7(23), fs8(24), fs9(25), fs10(26), fs11(27);
-static constexpr FReg ft8(28), ft9(29), ft10(30), ft11(31);
+static XBYAK_RISCV_CONSTEXPR FReg ft0(0), ft1(1), ft2(2), ft3(3), ft4(4), ft5(5), ft6(6), ft7(7);
+static XBYAK_RISCV_CONSTEXPR FReg fs0(8), fs1(9), fa0(10), fa1(11), fa2(12), fa3(13), fa4(14), fa5(15), fa6(16), fa7(f17);
+static XBYAK_RISCV_CONSTEXPR FReg fs2(18), fs3(19), fs4(20), fs5(21), fs6(22), fs7(23), fs8(24), fs9(25), fs10(26), fs11(27);
+static XBYAK_RISCV_CONSTEXPR FReg ft8(28), ft9(29), ft10(30), ft11(31);
 
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
 // Vector Register
 struct VReg : public local::IReg {
-	explicit constexpr VReg(int idx = 0) : local::IReg(idx, IReg::Kind::VECTOR) { }
+	explicit XBYAK_RISCV_CONSTEXPR VReg(int idx = 0) : local::IReg(idx, IReg::Kind::VECTOR) { }
 };
 
-static constexpr VReg v0(0), v1(1), v2(2), v3(3), v4(4), v5(5), v6(6), v7(7);
-static constexpr VReg v8(8), v9(9), v10(10), v11(11), v12(12), v13(13), v14(14), v15(15);
-static constexpr VReg v16(16), v17(17), v18(18), v19(19), v20(20), v21(21), v22(22), v23(23);
-static constexpr VReg v24(24), v25(25), v26(26), v27(27), v28(28), v29(29), v30(30), v31(31);
+static XBYAK_RISCV_CONSTEXPR VReg v0(0), v1(1), v2(2), v3(3), v4(4), v5(5), v6(6), v7(7);
+static XBYAK_RISCV_CONSTEXPR VReg v8(8), v9(9), v10(10), v11(11), v12(12), v13(13), v14(14), v15(15);
+static XBYAK_RISCV_CONSTEXPR VReg v16(16), v17(17), v18(18), v19(19), v20(20), v21(21), v22(22), v23(23);
+static XBYAK_RISCV_CONSTEXPR VReg v24(24), v25(25), v26(26), v27(27), v28(28), v29(29), v30(30), v31(31);
 #endif
 
 // 2nd parameter for constructor of CodeArray(maxSize, userPtr, alloc)

--- a/third_party/xbyak_riscv/xbyak_riscv.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv.hpp
@@ -1,0 +1,1377 @@
+#pragma once
+/*!
+	@file xbyak_riscv.hpp
+	@brief Xbyak_riscv ; JIT assembler for RISC-V
+	@author herumi
+	@url https://github.com/herumi/xbyak_riscv
+	@note modified new BSD license
+	http://opensource.org/licenses/BSD-3-Clause
+*/
+
+// Copyright (C), 2023, KNS Group LLC (YADRO)
+
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+#include <list>
+#include <string>
+#include <algorithm>
+#include <unordered_set>
+#include <unordered_map>
+
+#ifdef _WIN32
+	#ifndef WIN32_LEAN_AND_MEAN
+		#define WIN32_LEAN_AND_MEAN
+	#endif
+	#include <windows.h>
+	#include <malloc.h>
+#elif defined(__GNUC__)
+	#include <unistd.h>
+	#include <sys/mman.h>
+	#include <stdlib.h>
+#endif
+#if defined(__APPLE__)
+	#define XBYAK_RISCV_USE_MAP_JIT
+	#include <sys/sysctl.h>
+	#ifndef MAP_JIT
+		#define MAP_JIT 0x800
+	#endif
+#endif
+
+#if defined(__GNUC__) && !defined(__MINGW32__)
+	#define XBYAK_RISCV_USE_MMAP_ALLOCATOR
+#endif
+
+#ifdef NDEBUG
+	#define XBYAK_RISCV_ASSERT(x)
+#else
+	#define XBYAK_RISCV_ASSERT(x) assert(x)
+#endif
+
+// MFD_CLOEXEC defined only linux 3.17 or later.
+// Android wraps the memfd_create syscall from API version 30.
+#if !defined(MFD_CLOEXEC) || (defined(__ANDROID__) && __ANDROID_API__ < 30)
+	#undef XBYAK_RISCV_USE_MEMFD
+#endif
+
+#if defined(_WIN64) || defined(__MINGW64__) || (defined(__CYGWIN__) && defined(__x86_64__))
+	#define XBYAK_RISCV64_WIN
+#elif defined(__x86_64__)
+	#define XBYAK_RISCV64_GCC
+#endif
+#if !defined(XBYAK_RISCV64) && !defined(XBYAK_RISCV32)
+	#if defined(XBYAK_RISCV64_GCC) || defined(XBYAK_RISCV64_WIN)
+		#define XBYAK_RISCV64
+	#else
+		#define XBYAK_RISCV32
+	#endif
+#endif
+
+#ifdef _MSC_VER
+	#pragma warning(push)
+	#pragma warning(disable : 4514) /* remove inline function */
+	#pragma warning(disable : 4786) /* identifier is too long */
+	#pragma warning(disable : 4503) /* name is too long */
+	#pragma warning(disable : 4127) /* constant expresison */
+#endif
+
+#include "xbyak_riscv_csr.hpp"
+
+namespace Xbyak_riscv {
+
+enum {
+	DEFAULT_MAX_CODE_SIZE = 4096,
+	VERSION = 0x1000 /* 0xABCD = A.BC.D */
+};
+
+inline uint32_t getVersion() { return VERSION; }
+
+enum {
+	ERR_NONE = 1,
+	ERR_OFFSET_IS_TOO_BIG,
+	ERR_CODE_IS_TOO_BIG,
+	ERR_IMM_IS_TOO_BIG,
+	ERR_INVALID_IMM_OF_JAL,
+	ERR_INVALID_IMM_OF_BTYPE,
+	ERR_LABEL_IS_NOT_FOUND,
+	ERR_LABEL_IS_REDEFINED,
+	ERR_LABEL_IS_TOO_FAR,
+	ERR_LABEL_IS_NOT_SET_BY_L,
+	ERR_LABEL_IS_ALREADY_SET_BY_L,
+	ERR_CANT_PROTECT,
+	ERR_CANT_ALLOC,
+	ERR_BAD_PARAMETER,
+	ERR_MUNMAP,
+	ERR_BAD_ALIGN,
+	ERR_INTERNAL // Put it at last.
+};
+
+inline const char *ConvertErrorToString(int err)
+{
+	static const char *errTbl[] = {
+		"none",
+		"offset is too big",
+		"code is too big",
+		"imm is too big",
+		"invalid imm of jal",
+		"invalid imm of Btype",
+		"label is not found",
+		"label is redefined",
+		"label is too far",
+		"label is not set by L",
+		"label is already set by L",
+		"can't protect",
+		"can't alloc",
+		"bad parameter",
+		"munmap",
+		"bad align",
+		"internal error"
+	};
+	assert(ERR_INTERNAL == sizeof(errTbl) / sizeof(*errTbl));
+	return err <= ERR_INTERNAL ? errTbl[err] : "unknown err";
+}
+
+#ifdef XBYAK_RISCV_NO_EXCEPTION
+namespace local {
+
+inline int& GetErrorRef() {
+	static thread_local int err = 0;
+	return err;
+}
+
+inline void SetError(int err) {
+	if (local::GetErrorRef()) return; // keep the first err code
+	local::GetErrorRef() = err;
+}
+
+} // local
+
+inline void ClearError() {
+	local::GetErrorRef() = 0;
+}
+inline int GetError() { return Xbyak::local::GetErrorRef(); }
+
+#define XBYAK_RISCV_THROW(err) { Xbyak::local::SetError(err); return; }
+#define XBYAK_RISCV_THROW_RET(err, r) { Xbyak::local::SetError(err); return r; }
+
+#else
+class Error : public std::exception {
+	int err_;
+public:
+	explicit Error(int err) : err_(err)
+	{
+		if (err_ < 0 || err_ > ERR_INTERNAL) {
+			err_ = ERR_INTERNAL;
+		}
+	}
+	operator int() const { return err_; }
+	const char *what() const noexcept override
+	{
+		return ConvertErrorToString(err_);
+	}
+};
+
+// dummy functions
+inline void ClearError() { }
+inline int GetError() { return 0; }
+
+inline const char *ConvertErrorToString(const Error& err)
+{
+	return err.what();
+}
+
+#define XBYAK_RISCV_THROW(err) { throw Error(err); }
+#define XBYAK_RISCV_THROW_RET(err, r) { throw Error(err); }
+
+#endif
+
+inline void *AlignedMalloc(size_t size, size_t alignment)
+{
+#ifdef __MINGW32__
+	return __mingw_aligned_malloc(size, alignment);
+#elif defined(_WIN32)
+	return _aligned_malloc(size, alignment);
+#else
+	void *p;
+	int ret = posix_memalign(&p, alignment, size);
+	return (ret == 0) ? p : 0;
+#endif
+}
+
+inline void AlignedFree(void *p)
+{
+#ifdef __MINGW32__
+	__mingw_aligned_free(p);
+#elif defined(_MSC_VER)
+	_aligned_free(p);
+#else
+	free(p);
+#endif
+}
+
+namespace local {
+
+static const size_t ALIGN_PAGE_SIZE = 4096;
+
+inline constexpr uint32_t mask(size_t n)
+{
+	XBYAK_RISCV_ASSERT(n <= 32);
+	return n == 32 ? 0xffffffff : (1u << n) - 1;
+}
+// is x <= mask(n) ?
+inline constexpr bool inBit(uint32_t x, size_t n)
+{
+	return x <= mask(n);
+}
+
+// is x a signed n-bit integer?
+inline constexpr bool inSBit(int x, int n)
+{
+	return -(1 << (n-1)) <= x && x < (1 << (n-1));
+}
+
+// split x to hi20bits and low12bits
+// return false if x in 12-bit signed integer
+inline bool split32bit(int *pH, int* pL, int x) {
+	if (inSBit(x, 12)) return false;
+	int H = (x >> 12) & mask(20);
+	int L = x & mask(12);
+	if (x & (1 << 11)) {
+		H++;
+		L = L | (mask(20) << 12);
+	}
+	*pH = H;
+	*pL = L;
+	return true;
+}
+
+// @@@ embedded by bit_pattern.py (DON'T DELETE THIS LINE)
+inline size_t get20_10to1_11_19to12_z12(size_t v) { return ((v & (1<<20)) << 11)| ((v & (1023<<1)) << 20)| ((v & (1<<11)) << 9)| (v & (255<<12)); }
+inline size_t get12_10to5_z13_4to1_11_z7(size_t v) { return ((v & (1<<12)) << 19)| ((v & (63<<5)) << 20)| ((v & (15<<1)) << 7)| ((v & (1<<11)) >> 4); }
+inline size_t get5to4_9to6_2_3_z5(size_t v) { return ((v & (3<<4)) << 7)| ((v & (15<<6)) << 1)| ((v & (1<<2)) << 4)| ((v & (1<<3)) << 2); }
+inline size_t get9_z5_4_6_8to7_5_z2(size_t v) { return ((v & (1<<9)) << 3)| ((v & (1<<4)) << 2)| ((v & (1<<6)) >> 1)| ((v & (3<<7)) >> 4)| ((v & (1<<5)) >> 3); }
+inline size_t get5to3_z3_2_6_z5(size_t v) { return ((v & (7<<3)) << 7)| ((v & (1<<2)) << 4)| ((v & (1<<6)) >> 1); }
+inline size_t get5to3_z3_7_6_z5(size_t v) { return ((v & (7<<3)) << 7)| ((v & (1<<7)) >> 1)| ((v & (1<<6)) >> 1); }
+inline size_t get5_z5_4to0_z2(size_t v) { return ((v & (1<<5)) << 7)| ((v & 31) << 2); }
+inline size_t get11_4_9to8_10_6_7_3to1_5_z2(size_t v) { return ((v & (1<<11)) << 1)| ((v & (1<<4)) << 7)| ((v & (3<<8)) << 1)| ((v & (1<<10)) >> 2)| ((v & (1<<6)) << 1)| ((v & (1<<7)) >> 1)| ((v & (7<<1)) << 2)| ((v & (1<<5)) >> 3); }
+inline size_t get17_z5_16to12_z2(size_t v) { return ((v & (1<<17)) >> 5)| ((v & (31<<12)) >> 10); }
+inline size_t get5_z5_4to2_7to6_z2(size_t v) { return ((v & (1<<5)) << 7)| ((v & (7<<2)) << 2)| ((v & (3<<6)) >> 4); }
+inline size_t get5_z5_4to3_8to6_z2(size_t v) { return ((v & (1<<5)) << 7)| ((v & (3<<3)) << 2)| ((v & (7<<6)) >> 4); }
+inline size_t get5to2_7to6_z7(size_t v) { return ((v & (15<<2)) << 7)| ((v & (3<<6)) << 1); }
+inline size_t get5to3_8to6_z7(size_t v) { return ((v & (7<<3)) << 7)| ((v & (7<<6)) << 1); }
+// @@@ embedded by bit_pattern.py (DON'T DELETE THIS LINE)
+
+} // local
+
+/*
+	custom allocator
+*/
+struct Allocator {
+	explicit Allocator(const std::string& = "") {} // same interface with MmapAllocator
+	virtual uint8_t *alloc(size_t size) { return reinterpret_cast<uint8_t*>(AlignedMalloc(size, local::ALIGN_PAGE_SIZE)); }
+	virtual void free(uint8_t *p) { AlignedFree(p); }
+	virtual ~Allocator() {}
+	/* override to return false if you call protect() manually */
+	virtual bool useProtect() const { return true; }
+};
+
+#ifdef XBYAK_RISCV_USE_MMAP_ALLOCATOR
+#ifdef XBYAK_RISCV_USE_MAP_JIT
+namespace local {
+
+inline int getMacOsVersionPure()
+{
+	char buf[64];
+	size_t size = sizeof(buf);
+	int err = sysctlbyname("kern.osrelease", buf, &size, NULL, 0);
+	if (err != 0) return 0;
+	char *endp;
+	int major = strtol(buf, &endp, 10);
+	if (*endp != '.') return 0;
+	return major;
+}
+
+inline int getMacOsVersion()
+{
+	static const int version = getMacOsVersionPure();
+	return version;
+}
+
+} // local
+#endif
+class MmapAllocator : public Allocator {
+	struct Allocation {
+		size_t size;
+#if defined(XBYAK_RISCV_USE_MEMFD)
+		// fd_ is only used with XBYAK_RISCV_USE_MEMFD. We keep the file open
+		// during the lifetime of each allocation in order to support
+		// checkpoint/restore by unprivileged users.
+		int fd;
+#endif
+	};
+	const std::string name_; // only used with XBYAK_RISCV_USE_MEMFD
+	typedef std::unordered_map<uintptr_t, Allocation> AllocationList;
+	AllocationList allocList_;
+public:
+	explicit MmapAllocator(const std::string& name = "xbyak") : name_(name) {}
+	uint8_t *alloc(size_t size) override
+	{
+		const size_t alignedSizeM1 = local::ALIGN_PAGE_SIZE - 1;
+		size = (size + alignedSizeM1) & ~alignedSizeM1;
+#if defined(MAP_ANONYMOUS)
+		int mode = MAP_PRIVATE | MAP_ANONYMOUS;
+#elif defined(MAP_ANON)
+		int mode = MAP_PRIVATE | MAP_ANON;
+#else
+		#error "not supported"
+#endif
+#if defined(XBYAK_RISCV_USE_MAP_JIT)
+		const int mojaveVersion = 18;
+		if (local::getMacOsVersion() >= mojaveVersion) mode |= MAP_JIT;
+#endif
+		int fd = -1;
+#if defined(XBYAK_RISCV_USE_MEMFD)
+		fd = memfd_create(name_.c_str(), MFD_CLOEXEC);
+		if (fd != -1) {
+			mode = MAP_SHARED;
+			if (ftruncate(fd, size) != 0) {
+				close(fd);
+				XBYAK_RISCV_THROW_RET(ERR_CANT_ALLOC, 0)
+			}
+		}
+#endif
+		void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, fd, 0);
+		if (p == MAP_FAILED) {
+			if (fd != -1) close(fd);
+			XBYAK_RISCV_THROW_RET(ERR_CANT_ALLOC, 0)
+		}
+		assert(p);
+		Allocation &alloc = allocList_[(uintptr_t)p];
+		alloc.size = size;
+#if defined(XBYAK_RISCV_USE_MEMFD)
+		alloc.fd = fd;
+#endif
+		return (uint8_t*)p;
+	}
+	void free(uint8_t *p) override
+	{
+		if (p == 0) return;
+		AllocationList::iterator i = allocList_.find((uintptr_t)p);
+		if (i == allocList_.end()) XBYAK_RISCV_THROW(ERR_BAD_PARAMETER)
+		if (munmap((void*)i->first, i->second.size) < 0) XBYAK_RISCV_THROW(ERR_MUNMAP)
+#if defined(XBYAK_RISCV_USE_MEMFD)
+		if (i->second.fd != -1) close(i->second.fd);
+#endif
+		allocList_.erase(i);
+	}
+};
+#endif
+
+namespace local {
+
+// Register Interface
+class IReg {
+public:
+	enum Kind {
+		GPR = 1,         // General purpose register
+		FReg = 1 << 1,   // Floating-point register
+		VECTOR = 1 << 2, // Vector register
+	};
+protected:
+	uint32_t idx_;
+	Kind kind_;
+public:
+	constexpr IReg(uint32_t idx = 0, Kind kind = GPR)
+		: idx_(idx), kind_(kind)
+	{
+		XBYAK_RISCV_ASSERT(local::inBit(idx, 5));
+	}
+	constexpr int getIdx() const { return idx_; }
+	const char *toString() const
+	{
+		if (kind_ == GPR) {
+			static const char tbl[][4] = {
+				"x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+				"x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15",
+				"x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23",
+				"x24", "x25", "x26", "x27", "x28", "x29", "x30", "x31",
+			};
+			return tbl[idx_];
+		} else if (kind_ == FReg) {
+			static const char tbl[][4] = {
+				"f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7",
+				"f8", "f9", "f10", "f11", "f12", "f13", "f14", "f15",
+				"f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+				"f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31",
+			};
+			return tbl[idx_];
+		} else if (kind_ == VECTOR) {
+			static const char tbl[][4] = {
+				"v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+				"v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+				"v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+				"v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31",
+			};
+			return tbl[idx_];
+		}
+		XBYAK_RISCV_THROW_RET(ERR_INTERNAL, 0);
+	}
+	bool operator==(const IReg& rhs) const
+	{
+		return idx_ == rhs.idx_ && kind_ == rhs.kind_;
+	}
+	bool operator!=(const IReg& rhs) const { return !operator==(rhs); }
+
+};
+
+} // local
+
+// General Purpose Register
+struct Reg : public local::IReg {
+	explicit constexpr Reg(int idx = 0) : local::IReg(idx, IReg::Kind::GPR) { }
+};
+
+static constexpr Reg x0(0), x1(1), x2(2), x3(3), x4(4), x5(5), x6(6), x7(7);
+static constexpr Reg x8(8), x9(9), x10(10), x11(11), x12(12), x13(13), x14(14), x15(15);
+static constexpr Reg x16(16), x17(17), x18(18), x19(19), x20(20), x21(21), x22(22), x23(23);
+static constexpr Reg x24(24), x25(25), x26(26), x27(27), x28(28), x29(29), x30(30), x31(31);
+
+static constexpr Reg zero(x0);
+static constexpr Reg ra(x1);
+static constexpr Reg sp(x2);
+static constexpr Reg gp(x3);
+static constexpr Reg tp(x4);
+static constexpr Reg t0(x5);
+static constexpr Reg t1(x6);
+static constexpr Reg t2(x7);
+static constexpr Reg fp(x8);
+static constexpr Reg s0(x8);
+static constexpr Reg s1(x9);
+static constexpr Reg a0(x10), a1(x11), a2(x12), a3(x13), a4(x14), a5(x15), a6(x16), a7(x17);
+static constexpr Reg s2(x18), s3(x19), s4(x20), s5(x21), s6(x22), s7(x23), s8(x24), s9(x25);
+static constexpr Reg s10(x26), s11(x27);
+static constexpr Reg t3(x28), t4(x29), t5(x30), t6(x31);
+
+// Floating Point Register
+struct FReg : public local::IReg {
+	explicit constexpr FReg(int idx = 0) : local::IReg(idx, IReg::Kind::FReg) { }
+};
+
+static constexpr FReg f0(0), f1(1), f2(2), f3(3), f4(4), f5(5), f6(6), f7(7);
+static constexpr FReg f8(8), f9(9), f10(10), f11(11), f12(12), f13(13), f14(14), f15(15);
+static constexpr FReg f16(16), f17(17), f18(18), f19(19), f20(20), f21(21), f22(22), f23(23);
+static constexpr FReg f24(24), f25(25), f26(26), f27(27), f28(28), f29(29), f30(30), f31(31);
+// ABI name
+static constexpr FReg ft0(0), ft1(1), ft2(2), ft3(3), ft4(4), ft5(5), ft6(6), ft7(7);
+static constexpr FReg fs0(8), fs1(9), fa0(10), fa1(11), fa2(12), fa3(13), fa4(14), fa5(15), fa6(16), fa7(f17);
+static constexpr FReg fs2(18), fs3(19), fs4(20), fs5(21), fs6(22), fs7(23), fs8(24), fs9(25), fs10(26), fs11(27);
+static constexpr FReg ft8(28), ft9(29), ft10(30), ft11(31);
+
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+// Vector Register
+struct VReg : public local::IReg {
+	explicit constexpr VReg(int idx = 0) : local::IReg(idx, IReg::Kind::VECTOR) { }
+};
+
+static constexpr VReg v0(0), v1(1), v2(2), v3(3), v4(4), v5(5), v6(6), v7(7);
+static constexpr VReg v8(8), v9(9), v10(10), v11(11), v12(12), v13(13), v14(14), v15(15);
+static constexpr VReg v16(16), v17(17), v18(18), v19(19), v20(20), v21(21), v22(22), v23(23);
+static constexpr VReg v24(24), v25(25), v26(26), v27(27), v28(28), v29(29), v30(30), v31(31);
+#endif
+
+// 2nd parameter for constructor of CodeArray(maxSize, userPtr, alloc)
+void *const DontSetProtectRWE = (void*)2; //-V566
+
+class CodeArray {
+	enum Type {
+		USER_BUF = 1, // use userPtr(non alignment, non protect)
+		ALLOC_BUF // use new(alignment, protect)
+	};
+	CodeArray(const CodeArray& rhs);
+	void operator=(const CodeArray&);
+	bool isAllocType() const { return type_ == ALLOC_BUF; }
+	const Type type_;
+#ifdef XBYAK_RISCV_USE_MMAP_ALLOCATOR
+	MmapAllocator defaultAllocator_;
+#else
+	Allocator defaultAllocator_;
+#endif
+	Allocator *alloc_;
+protected:
+	size_t maxSize_;
+	uint8_t *top_;
+	size_t size_;
+
+	bool useProtect() const { return alloc_->useProtect(); }
+public:
+	enum ProtectMode {
+		PROTECT_RW = 0, // read/write
+		PROTECT_RWE = 1, // read/write/exec
+		PROTECT_RE = 2 // read/exec
+	};
+	explicit CodeArray(size_t maxSize, void *userPtr = 0, Allocator *allocator = 0)
+		: type_((userPtr == 0 || userPtr == DontSetProtectRWE) ? ALLOC_BUF : USER_BUF)
+		, alloc_(allocator ? allocator : (Allocator*)&defaultAllocator_)
+		, maxSize_(maxSize)
+		, top_(type_ == USER_BUF ? reinterpret_cast<uint8_t*>(userPtr) : alloc_->alloc((std::max<size_t>)(maxSize, 1)))
+		, size_(0)
+	{
+		if (maxSize_ > 0 && top_ == 0) XBYAK_RISCV_THROW(ERR_CANT_ALLOC)
+		if ((type_ == ALLOC_BUF && userPtr != DontSetProtectRWE && useProtect()) && !setProtectMode(PROTECT_RWE, false)) {
+			alloc_->free(top_);
+			XBYAK_RISCV_THROW(ERR_CANT_PROTECT)
+		}
+	}
+	virtual ~CodeArray()
+	{
+		if (isAllocType()) {
+			if (useProtect()) setProtectModeRW(false);
+			alloc_->free(top_);
+		}
+	}
+	bool setProtectMode(ProtectMode mode, bool throwException = true)
+	{
+		bool isOK = protect(top_, maxSize_, mode);
+		if (isOK) return true;
+		if (throwException) XBYAK_RISCV_THROW_RET(ERR_CANT_PROTECT, false)
+		return false;
+	}
+	bool setProtectModeRE(bool throwException = true) { return setProtectMode(PROTECT_RE, throwException); }
+	bool setProtectModeRW(bool throwException = true) { return setProtectMode(PROTECT_RW, throwException); }
+	void resetSize()
+	{
+		size_ = 0;
+	}
+	void writeBytes(size_t offset, uint64_t v, size_t n)
+	{
+		if (n > 8) XBYAK_RISCV_THROW(ERR_BAD_PARAMETER)
+		if (offset + n > maxSize_) XBYAK_RISCV_THROW(ERR_CODE_IS_TOO_BIG)
+		uint8_t *const p = top_ + offset;
+		for (size_t i = 0; i < n; i++) {
+			p[i] = static_cast<uint8_t>(v >> (i * 8));
+		}
+	}
+	void writeBytes(const uint8_t *addr, uint64_t v, size_t n)
+	{
+		writeBytes(addr - top_, v, n);
+	}
+	void appendBytes(uint64_t v, size_t n)
+	{
+		writeBytes(size_, v, n);
+		size_ += n;
+	}
+	void append4B(uint32_t code) { appendBytes(code, 4); }
+	void append2B(uint32_t code) { appendBytes(code, 2); }
+	void append1B(uint32_t code) { appendBytes(code, 1); }
+	void write4B(size_t offset, uint32_t v) { writeBytes(offset, v, 4); }
+	void dump(bool separate = false) const
+	{
+		const uint8_t *p = getCode();
+		const size_t bufSize = getSize();
+		if (separate) {
+			size_t pos = 0;
+			while (pos < bufSize) {
+				uint32_t v = p[pos];
+				size_t n = (v & 3) == 3 ? 4 : 2;
+				if (pos + n <= bufSize) {
+					for (size_t i = 0; i < n; i++) {
+						printf("%02x", p[pos + n - 1 - i]);
+					}
+					printf("\n");
+					pos += n;
+				} else {
+					printf("%02x error\n", v);
+					return;
+				}
+			}
+			return;
+		}
+		size_t remain = bufSize;
+		for (int i = 0; i < 4; i++) {
+			size_t disp = 16;
+			if (remain < 16) {
+				disp = remain;
+			}
+			for (size_t j = 0; j < 16; j++) {
+				if (j < disp) {
+					printf("%02x", p[i * 16 + j]);
+				}
+			}
+			putchar('\n');
+			remain -= disp;
+			if (remain == 0) {
+				break;
+			}
+		}
+	}
+	const uint8_t *getCode() const { return top_; }
+	template<class F>
+	const F getCode() const { return reinterpret_cast<F>(top_); }
+	const uint8_t *getCurr() const { return &top_[size_]; }
+	template<class F>
+	const F getCurr() const { return reinterpret_cast<F>(&top_[size_]); }
+	size_t getSize() const { return size_; }
+	void setSize(size_t size)
+	{
+		if (size > maxSize_) XBYAK_RISCV_THROW(ERR_OFFSET_IS_TOO_BIG)
+		size_ = size;
+	}
+	/**
+		change exec permission of memory
+		@param addr [in] buffer address
+		@param size [in] buffer size
+		@param protectMode [in] mode(RW/RWE/RE)
+		@return true(success), false(failure)
+	*/
+	static inline bool protect(const void *addr, size_t size, int protectMode)
+	{
+#if defined(_WIN32)
+		const DWORD c_rw = PAGE_READWRITE;
+		const DWORD c_rwe = PAGE_EXECUTE_READWRITE;
+		const DWORD c_re = PAGE_EXECUTE_READ;
+		DWORD mode;
+#else
+		const int c_rw = PROT_READ | PROT_WRITE;
+		const int c_rwe = PROT_READ | PROT_WRITE | PROT_EXEC;
+		const int c_re = PROT_READ | PROT_EXEC;
+		int mode;
+#endif
+		switch (protectMode) {
+		case PROTECT_RW: mode = c_rw; break;
+		case PROTECT_RWE: mode = c_rwe; break;
+		case PROTECT_RE: mode = c_re; break;
+		default:
+			return false;
+		}
+#if defined(_WIN32)
+		DWORD oldProtect;
+		return VirtualProtect(const_cast<void*>(addr), size, mode, &oldProtect) != 0;
+#elif defined(__GNUC__)
+		size_t pageSize = sysconf(_SC_PAGESIZE);
+		size_t iaddr = reinterpret_cast<size_t>(addr);
+		size_t roundAddr = iaddr & ~(pageSize - static_cast<size_t>(1));
+		return mprotect(reinterpret_cast<void*>(roundAddr), size + (iaddr - roundAddr), mode) == 0;
+#else
+		return true;
+#endif
+	}
+	/**
+		get aligned memory pointer
+		@param addr [in] address
+		@param alignedSize [in] power of two
+		@return aligned addr by alingedSize
+	*/
+	static inline uint8_t *getAlignedAddress(uint8_t *addr, size_t alignedSize = 16)
+	{
+		return reinterpret_cast<uint8_t*>((reinterpret_cast<size_t>(addr) + alignedSize - 1) & ~(alignedSize - static_cast<size_t>(1)));
+	}
+};
+
+struct Jmp {
+	enum Type {
+		tJal,
+		tBtype,
+		tRawAddress,
+	} type;
+	const uint8_t* from; /* address of the jmp mnemonic */
+	uint32_t encoded;
+	size_t encSize() const
+	{
+		return (type == tRawAddress) ? sizeof(size_t) : 4;
+	}
+	// jal
+	Jmp(const uint8_t *from, uint32_t opcode, const Reg& rd)
+		: type(tJal)
+		, from(from)
+		, encoded((rd.getIdx() << 7) | opcode)
+	{
+	}
+	// B-type
+	Jmp(const uint8_t* from, uint32_t opcode, uint32_t funct3, const Reg& src1, const Reg& src2)
+		: type(tBtype)
+		, from(from)
+		, encoded((src2.getIdx() << 20) | (src1.getIdx() << 15) | (funct3 << 12) | opcode)
+	{
+	}
+	// raw address
+	explicit Jmp(const uint8_t* from)
+		: type(tRawAddress)
+		, from(from)
+		, encoded(0)
+	{
+	}
+	static inline bool isValidImm(size_t imm, size_t maskBit)
+	{
+		const size_t M = local::mask(maskBit);
+		return (imm < M || ~M <= imm) && (imm & 1) == 0;
+	}
+	size_t encode(const uint8_t* addr) const
+	{
+		if (addr == 0) return 0;
+		if (type == tRawAddress) return size_t(addr);
+		const size_t imm = addr - from;
+		if (type == tJal) {
+			if (!isValidImm(imm, 20)) XBYAK_RISCV_THROW(ERR_INVALID_IMM_OF_JAL)
+			return local::get20_10to1_11_19to12_z12(imm) | encoded;
+		} else {
+			if (!isValidImm(imm, 12)) XBYAK_RISCV_THROW(ERR_INVALID_IMM_OF_JAL)
+			return local::get12_10to5_z13_4to1_11_z7(imm) | encoded;
+		}
+	}
+	// update jmp address by base->getCurr()
+	void update(CodeArray *base) const
+	{
+		base->writeBytes(from, encode(base->getCurr()), encSize());
+	}
+	// append jmp opcode with addr
+	void appendCode(CodeArray *base, const uint8_t *addr) const
+	{
+		base->appendBytes(encode(addr), encSize());
+	}
+};
+
+class LabelManager;
+
+class Label {
+	mutable LabelManager *mgr;
+	mutable int id;
+	friend class LabelManager;
+public:
+	Label() : mgr(0), id(0) {}
+	Label(const Label& rhs);
+	Label& operator=(const Label& rhs);
+	~Label();
+	void clear() { mgr = 0; id = 0; }
+	int getId() const { return id; }
+	const uint8_t *getAddress() const;
+};
+
+class LabelManager {
+	// for Label class
+	struct ClabelVal {
+		ClabelVal(const uint8_t* addr = 0) : addr(addr), refCount(1) {}
+		const uint8_t* addr;
+		int refCount;
+	};
+	typedef std::unordered_map<int, ClabelVal> ClabelDefList;
+	typedef std::unordered_multimap<int, Jmp> ClabelUndefList;
+	typedef std::unordered_set<Label*> LabelPtrList;
+
+	CodeArray *base_;
+	mutable int labelId_;
+	ClabelDefList clabelDefList_;
+	ClabelUndefList clabelUndefList_;
+	LabelPtrList labelPtrList_;
+
+	int getId(const Label& label) const
+	{
+		if (label.id == 0) label.id = labelId_++;
+		return label.id;
+	}
+	void define_inner(ClabelDefList& defList, ClabelUndefList& undefList, int labelId, const uint8_t* addr)
+	{
+		// add label
+		ClabelDefList::value_type item(labelId, addr);
+		std::pair<ClabelDefList::iterator, bool> ret = defList.insert(item);
+		if (!ret.second) XBYAK_RISCV_THROW(ERR_LABEL_IS_REDEFINED)
+		// search undefined label
+		for (;;) {
+			ClabelUndefList::iterator itr = undefList.find(labelId);
+			if (itr == undefList.end()) break;
+			const Jmp& jmp = itr->second;
+			jmp.update(base_);
+			undefList.erase(itr);
+		}
+	}
+	friend class Label;
+	void incRefCount(int id, Label *label)
+	{
+		clabelDefList_[id].refCount++;
+		labelPtrList_.insert(label);
+	}
+	void decRefCount(int id, Label *label)
+	{
+		labelPtrList_.erase(label);
+		ClabelDefList::iterator i = clabelDefList_.find(id);
+		if (i == clabelDefList_.end()) return;
+		if (i->second.refCount == 1) {
+			clabelDefList_.erase(id);
+		} else {
+			--i->second.refCount;
+		}
+	}
+	template<class T>
+	bool hasUndefinedLabel_inner(const T& list) const
+	{
+		return !list.empty();
+	}
+	// detach all labels linked to LabelManager
+	void resetLabelPtrList()
+	{
+		for (LabelPtrList::iterator i = labelPtrList_.begin(), ie = labelPtrList_.end(); i != ie; ++i) {
+			(*i)->clear();
+		}
+		labelPtrList_.clear();
+	}
+public:
+	LabelManager()
+	{
+		reset();
+	}
+	~LabelManager()
+	{
+		resetLabelPtrList();
+	}
+	void reset()
+	{
+		base_ = 0;
+		labelId_ = 1;
+		clabelDefList_.clear();
+		clabelUndefList_.clear();
+		resetLabelPtrList();
+	}
+	void set(CodeArray *base) { base_ = base; }
+	void defineClabel(Label& label)
+	{
+		define_inner(clabelDefList_, clabelUndefList_, getId(label), base_->getCurr());
+		label.mgr = this;
+		labelPtrList_.insert(&label);
+	}
+	void assign(Label& dst, const Label& src)
+	{
+		ClabelDefList::const_iterator i = clabelDefList_.find(src.id);
+		if (i == clabelDefList_.end()) XBYAK_RISCV_THROW(ERR_LABEL_IS_NOT_SET_BY_L)
+		define_inner(clabelDefList_, clabelUndefList_, dst.id, i->second.addr);
+		dst.mgr = this;
+		labelPtrList_.insert(&dst);
+	}
+	// return 0 unless label exists
+	const uint8_t* getAddr(const Label& label) const
+	{
+		ClabelDefList::const_iterator i = clabelDefList_.find(getId(label));
+		if (i == clabelDefList_.end()) return 0;
+		return i->second.addr;
+	}
+	void addUndefinedLabel(const Label& label, const Jmp& jmp)
+	{
+		clabelUndefList_.insert(ClabelUndefList::value_type(label.id, jmp));
+	}
+	bool hasUndefClabel() const { return hasUndefinedLabel_inner(clabelUndefList_); }
+	const uint8_t *getCode() const { return base_->getCode(); }
+};
+
+inline Label::Label(const Label& rhs)
+{
+	id = rhs.id;
+	mgr = rhs.mgr;
+	if (mgr) mgr->incRefCount(id, this);
+}
+inline Label& Label::operator=(const Label& rhs)
+{
+	if (id) XBYAK_RISCV_THROW_RET(ERR_LABEL_IS_ALREADY_SET_BY_L, *this)
+	id = rhs.id;
+	mgr = rhs.mgr;
+	if (mgr) mgr->incRefCount(id, this);
+	return *this;
+}
+inline Label::~Label()
+{
+	if (id && mgr) mgr->decRefCount(id, this);
+}
+inline const uint8_t* Label::getAddress() const
+{
+	if (mgr == 0) return 0;
+	return mgr->getAddr(*this);
+}
+
+namespace local {
+
+template<size_t n>
+struct Bit {
+	uint32_t v;
+	Bit(uint32_t v)
+		: v(v)
+	{
+		XBYAK_RISCV_ASSERT(inBit(v, n));
+	}
+	Bit(const IReg& r)
+		: v(r.getIdx())
+	{
+	}
+	Bit(VM vm)
+		: v(static_cast<uint32_t>(vm))
+	{
+	}
+	Bit(CSR csr)
+		: v(static_cast<uint32_t>(csr))
+	{
+	}
+	Bit(RM rm)
+		: v(static_cast<uint32_t>(rm))
+	{
+	}
+};
+
+} // local
+
+class CodeGenerator : public CodeArray {
+public:
+	enum AqRlType {
+		T_aq = 2,
+		T_rl = 1,
+		T_aqrl = 3,
+	};
+	typedef local::Bit<1> Bit1;
+	typedef local::Bit<2> Bit2;
+	typedef local::Bit<3> Bit3;
+	typedef local::Bit<5> Bit5;
+	typedef local::Bit<6> Bit6;
+	typedef local::Bit<7> Bit7;
+	typedef local::Bit<12> Bit12;
+	typedef local::Bit<32> Bit32;
+private:
+	CodeGenerator operator=(const CodeGenerator&) = delete;
+	LabelManager labelMgr_;
+	int XLEN_;
+	bool isRV32_;
+	bool supportRVC_;
+	void opJmp(const Label& label, const Jmp& jmp)
+	{
+		const uint8_t* addr = labelMgr_.getAddr(label);
+		jmp.appendCode(this, addr);
+		if (addr) return;
+		labelMgr_.addUndefinedLabel(label, jmp);
+	}
+	uint32_t enc2(uint32_t a, uint32_t b) const { return (a<<7) | (b<<15); }
+	uint32_t enc3(uint32_t a, uint32_t b, uint32_t c) const { return enc2(a, b) | (c<<20); }
+	void Rtype(Bit7 opcode, Bit3 funct3, Bit7 funct7, Bit5 rd, Bit5 rs1, Bit5 rs2)
+	{
+		uint32_t v = (funct7.v<<25) | (funct3.v<<12) | opcode.v | enc3(rd.v, rs1.v, rs2.v);
+		append4B(v);
+	}
+	void Itype(Bit7 opcode, Bit3 funct3, Bit5 rd, Bit5 rs1, int imm)
+	{
+		if (!local::inSBit(imm, 12)) XBYAK_RISCV_THROW(ERR_IMM_IS_TOO_BIG)
+		uint32_t v = (imm<<20) | (funct3.v<<12) | opcode.v | enc2(rd.v, rs1.v);
+		append4B(v);
+	}
+	void Stype(Bit7 opcode, Bit3 funct3, Bit5 rs1, Bit5 rs2, int imm)
+	{
+		if (!local::inSBit(imm, 12)) XBYAK_RISCV_THROW(ERR_IMM_IS_TOO_BIG)
+		uint32_t v = ((imm>>5)<<25) | (funct3.v<<12) | opcode.v | enc3(imm & local::mask(5), rs1.v, rs2.v);
+		append4B(v);
+	}
+	void Utype(Bit7 opcode, Bit5 rd, uint32_t imm)
+	{
+		if (imm >= (1u << 20)) XBYAK_RISCV_THROW(ERR_IMM_IS_TOO_BIG)
+		uint32_t v = (imm<<12) | opcode.v | (rd.v<<7);
+		append4B(v);
+	}
+	void opShift(Bit7 pre, Bit3 funct3, Bit7 opcode, Bit5 rd, Bit5 rs1, uint32_t shamt, int range = 0)
+	{
+		if (range == 0) range = isRV32_ ? 5 : 6;
+		if (shamt >= (1u << range)) XBYAK_RISCV_THROW(ERR_IMM_IS_TOO_BIG)
+		uint32_t v = (pre.v<<25) | (funct3.v<<12) | opcode.v | enc3(rd.v, rs1.v, shamt);
+		append4B(v);
+	}
+	void opAtomic(Bit5 rd, Bit5 rs2, Bit5 addr, Bit5 funct5, Bit3 funct3, uint32_t flag)
+	{
+		assert(flag <= 3);
+		Rtype(0x2f, funct3.v, (funct5.v << 2) | flag, rd, addr, rs2);
+	}
+	void opIVV(Bit32 baseValue, Bit1 vm, Bit5 vs2, Bit5 vs1, Bit5 vd)
+	{
+		/*
+		    31 .. 26 | 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func6    vm      vs2       vs1        func3       vd     opcode
+
+			func6, func3, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (vs2.v<<20) | (vs1.v<<15) | (vd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opFVV(Bit32 baseValue, Bit1 vm, Bit5 vs2, Bit5 vs1, Bit5 d)
+	{
+		/*
+		    31 .. 26 | 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func6    vm      vs2       vs1        func3     vd/rd    opcode
+
+			func6, func3, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (vs2.v<<20) | (vs1.v<<15) | (d.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opMVV(Bit32 baseValue, Bit1 vm, Bit5 vs2, Bit5 vs1, Bit5 d)
+	{
+		/*
+		    31 .. 26 | 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func6    vm      vs2       vs1        func3     vd/rd    opcode
+
+			func6, func3, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (vs2.v<<20) | (vs1.v<<15) | (d.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opIVI(Bit32 baseValue, Bit1 vm, Bit5 vs2, uint32_t imm, Bit5 vd)
+	{
+		/*
+		    31 .. 26 | 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func6    vm      vs2       imm       func3       vd     opcode
+
+			func6, func3, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (vs2.v<<20) | ((imm & local::mask(5))<<15) | (vd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opIVX(Bit32 baseValue, Bit1 vm, Bit5 vs2, Bit5 rs1, Bit5 vd)
+	{
+		/*
+		    31 .. 26 | 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func6    vm      vs2       rs1        func3       vd     opcode
+
+			func6, func3, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (vs2.v<<20) | (rs1.v<<15) | (vd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opFVF(Bit32 baseValue, Bit1 vm, Bit5 vs2, Bit5 rs1, Bit5 vd)
+	{
+		/*
+		    31 .. 26 | 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func6    vm      vs2       rs1        func3       vd     opcode
+
+			func6, func3, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (vs2.v<<20) | (rs1.v<<15) | (vd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opMVX(Bit32 baseValue, Bit1 vm, Bit5 vs2, Bit5 rs1, Bit5 d)
+	{
+		/*
+		    31 .. 26 | 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func6    vm      vs2       rs1        func3     vd/rd    opcode
+
+			func6, func3, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (vs2.v<<20) | (rs1.v<<15) | (d.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opVectorLoad(Bit32 baseValue, Bit1 vm, Bit5 rs2_vs2, Bit5 rs1, Bit5 vd)
+	{
+		/*
+		    31 .. 29 | 28 | 27 .. 26 | 25 |     24 .. 20     | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			   nf      mew     mop     vm     lumop/rs2/vs2      rs1        width       vd     opcode
+
+			mew, mop, width, lumop, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (rs2_vs2.v<<20) | (rs1.v<<15) | (vd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opVectorStore(Bit32 baseValue, Bit1 vm, Bit5 rs2_vs2, Bit5 rs1, Bit5 vs3)
+	{
+		/*
+		    31 .. 29 | 28 | 27 .. 26 | 25 |     24 .. 20     | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			   nf      mew     mop     vm     sumop/rs2/vs2       rs1        width     vd      opcode
+
+			mew, mop, width, sumop, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (vm.v<<25) | (rs2_vs2.v<<20) | (rs1.v<<15) | (vs3.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opCSR(Bit32 baseValue, Bit12 csr, Bit5 rs1_uimm, Bit5 rd)
+	{
+		/*
+		    31 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			   csr     rs1_uimm     func3       rd     opcode
+
+			func3 and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (csr.v<<20) | (rs1_uimm.v<<15) | (rd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opLoadFP(Bit32 baseValue, int imm, Bit5 rs1, Bit5 rd)
+	{
+		if (!local::inSBit(imm, 12)) XBYAK_RISCV_THROW(ERR_IMM_IS_TOO_BIG)
+		/*
+			31 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			imm[11:0]     rs1       width       rd      opcode
+
+			width and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (imm<<20) | (rs1.v<<15) | (rd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opStoreFP(Bit32 baseValue, int imm, Bit5 rs2, Bit5 rs1)
+	{
+		if (!local::inSBit(imm, 12)) XBYAK_RISCV_THROW(ERR_IMM_IS_TOO_BIG)
+		/*
+			31 .. 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			imm[11:5]     rs2        rs1       width    imm[4:0]   opcode
+
+			width and opcode must be encoded in the baseValue
+		*/
+		uint32_t imm_11_5 = imm & (local::mask(7)<<5);
+		uint32_t imm_4_0 = imm & local::mask(5);
+		uint32_t v = (imm_11_5<<20) | (rs2.v<<20) | (rs1.v<<15) | (imm_4_0<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opFP(Bit32 baseValue, Bit5 rs2, Bit5 rs1, Bit3 rm, Bit5 rd)
+	{
+		/*
+			31 .. 27 | 26 .. 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func5       fmt        rs2        rs1        rm         rd      opcode
+
+			func5, fmt, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (rs2.v<<20) | (rs1.v<<15) | (rm.v<<12) | (rd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opR4(Bit32 baseValue, Bit5 rs3, Bit5 rs2, Bit5 rs1, Bit3 rm, Bit5 rd)
+	{
+		/*
+			31 .. 27 | 26 .. 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			   rs3        fmt        rs2        rs1        rm         rd      opcode
+
+			fmt and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (rs3.v<<27) | (rs2.v<<20) | (rs1.v<<15) | (rm.v<<12) | (rd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	bool isValiCidx(uint32_t idx) const { return 8 <= idx && idx < 16; }
+	// c_addi, c_addiw
+	bool c_addi_inner(const Reg& rd, const Reg& rs, uint32_t imm, uint32_t funct3)
+	{
+		uint32_t dIdx = rd.getIdx();
+		uint32_t sIdx = rs.getIdx();
+		if (sIdx == 0 && c_li(rd, imm, 2, 1)) return true;
+		if (dIdx == 0 || dIdx != sIdx || !local::inSBit(imm, 6)) return false;
+		uint32_t v = (funct3<<13) | ((imm & (1<<5))<<7) | (dIdx<<7) | ((imm & 31)<<2)| 1;
+		append2B(v);
+		return true;
+	}
+	bool c_addi16sp(const Reg& rd, const Reg& rs, uint32_t imm)
+	{
+		if (rd != sp || rs != sp || (imm % 16) != 0 || (496 < imm && imm < ~512u) || imm == 0) return false;
+		uint32_t v = (3<<13) | (2<<7) | 1 | local::get9_z5_4_6_8to7_5_z2(imm);
+		append2B(v);
+		return true;
+	}
+	// c_li, c_slli
+	bool c_li(const Reg& rd, uint32_t imm, uint32_t funct3, uint32_t op)
+	{
+		if (rd == x0 || !local::inSBit(imm, 6)) return false;
+		uint32_t v = (funct3<<13) | (rd.getIdx() << 7) | op | local::get5_z5_4to0_z2(imm);
+		append2B(v);
+		return true;
+	}
+	bool c_lui(const Reg& rd, uint32_t imm)
+	{
+		if (rd == x0 || rd == x2 || imm == 0 || (32 <= imm && imm < (1<<20)-32)) return false;
+		uint32_t v = (3<<13) | (rd.getIdx()<<7) | 1 | local::get5_z5_4to0_z2(imm);
+		append2B(v);
+		return true;
+	}
+	bool c_addi(const Reg& rd, const Reg& rs, uint32_t imm)
+	{
+		uint32_t dIdx = rd.getIdx();
+		if (imm == 0 && c_mv(rd, rs, 0)) return true;
+		if (c_addi_inner(rd, rs, imm, 0)) return true;
+		if (c_addi16sp(rd, rs, imm)) return true;
+		// c.addi4spn(rd, imm) = c.addi(rd, x2, imm)
+		if (rs != sp || !isValiCidx(dIdx) || imm == 0 || (imm % 4) != 0 || imm >= 1024) return false;
+		uint32_t v = ((dIdx-8)<<2) | local::get5to4_9to6_2_3_z5(imm);
+		append2B(v);
+		return true;
+	}
+	uint32_t creg2(uint32_t a, uint32_t b) { return ((a-8)<<7) | ((b-8)<<2); }
+	// c_lw, c_sw
+	bool c_lsw(const Reg& rd, const Reg& rs, int imm, uint32_t funct3)
+	{
+		uint32_t dIdx = rd.getIdx();
+		uint32_t sIdx = rs.getIdx();
+		if (!isValiCidx(dIdx) || !isValiCidx(sIdx) || (imm % 4) != 0 || imm < 0 || imm >= (1 << 7)) return false;
+		uint32_t v = (funct3<<13) | creg2(sIdx, dIdx) | local::get5to3_z3_2_6_z5(imm);
+		append2B(v);
+		return true;
+	}
+	// c_ld, c_sd
+	bool c_lsd(const Reg& rd, const Reg& rs, int imm, uint32_t funct3)
+	{
+		uint32_t dIdx = rd.getIdx();
+		uint32_t sIdx = rs.getIdx();
+		if (!isValiCidx(dIdx) || !isValiCidx(sIdx) || (imm % 8) != 0 || imm < 0 || imm >= (1 << 8)) return false;
+		uint32_t v = (funct3<<13) | creg2(sIdx, dIdx) | local::get5to3_z3_7_6_z5(imm);
+		append2B(v);
+		return true;
+	}
+	// c_srli, c_srai, c_andi
+	bool c_srli(const Reg& rd, const Reg& rs, int imm, uint32_t funct2, bool allowImm0 = false)
+	{
+		uint32_t dIdx = rd.getIdx();
+		uint32_t sIdx = rs.getIdx();
+		if (dIdx != sIdx || !isValiCidx(dIdx) || (!allowImm0 && imm == 0) || imm >= (1 << 6)) return false;
+		uint32_t v = (4<<13) | (funct2<<10) | ((dIdx-8)<<7) | local::get5_z5_4to0_z2(imm) | 1;
+		append2B(v);
+		return true;
+	}
+	// rd = rs1
+	// c_sub, c_xor, c_or, c_and, c_subw
+	bool c_noimm(const Reg& rd, const Reg& rs1, const Reg& rs2, uint32_t funct3, uint32_t funct2)
+	{
+		uint32_t dIdx = rd.getIdx();
+		uint32_t sIdx = rs2.getIdx();
+		if (rd.getIdx() != rs1.getIdx() || !isValiCidx(dIdx) || !isValiCidx(sIdx)) return false;
+		uint32_t v = (funct3<<10) | ((dIdx-8)<<7) | (funct2<<5) | ((sIdx-8)<<2) | 1;
+		append2B(v);
+		return true;
+	}
+	// c_lwsp, c_flwsp
+	bool c_lwsp(const Reg& rd, const Reg& addr, int imm, uint32_t funct3)
+	{
+		uint32_t idx = rd.getIdx();
+		if (addr != sp || (imm % 4) != 0 || (imm >> 8)) return false;
+		uint32_t v = (funct3<<13) | (idx<<7) | local::get5_z5_4to2_7to6_z2(imm) | 2;
+		append2B(v);
+		return true;
+	}
+	// c_ldsp
+	bool c_ldsp(const Reg& rd, const Reg& addr, int imm, uint32_t funct3)
+	{
+		uint32_t idx = rd.getIdx();
+		if (addr != sp || (imm % 8) != 0 || (imm >> 9)) return false;
+		uint32_t v = (funct3<<13) | (idx<<7) | local::get5_z5_4to3_8to6_z2(imm) | 2;
+		append2B(v);
+		return true;
+	}
+	// c.mv, c.add
+	bool c_mv(const Reg& rd, const Reg& rs, uint32_t funct1)
+	{
+		if (rd == x0 || rs == x0) return false;
+		uint32_t v = (4<<13) | (funct1<<12) | (rd.getIdx()<<7) | (rs.getIdx()<<2) | 2;
+		append2B(v);
+		return true;
+	}
+	bool c_swsp(const Reg& rs, const Reg& addr, int imm, uint32_t funct3)
+	{
+		if (addr != sp || (imm % 4) != 0 || (imm >> 8)) return false;
+		uint32_t v = (funct3<<13) | (rs.getIdx()<<2) | local::get5to2_7to6_z7(imm) | 2;
+		append2B(v);
+		return true;
+	}
+	bool c_sdsp(const Reg& rs, const Reg& addr, int imm, uint32_t funct3)
+	{
+		if (addr != sp || (imm % 8) != 0 || (imm >> 9)) return false;
+		uint32_t v = (funct3<<13) | (rs.getIdx()<<2) | local::get5to3_8to6_z7(imm) | 2;
+		append2B(v);
+		return true;
+	}
+public:
+	void L(Label& label) { labelMgr_.defineClabel(label); }
+	Label L() { Label label; L(label); return label; }
+	/*
+		assign src to dst
+		require
+		dst : does not used by L()
+		src : used by L()
+	*/
+	void assignL(Label& dst, const Label& src) { labelMgr_.assign(dst, src); }
+	/*
+		put the absolute address of label to buffer
+		@note the put size is 4(32-bit), 8(64-bit)
+	*/
+	void putL(const Label &label)
+	{
+		Jmp jmp(getCurr());
+		opJmp(label, jmp);
+	}
+
+	// constructor
+	CodeGenerator(size_t maxSize = DEFAULT_MAX_CODE_SIZE, void *userPtr = DontSetProtectRWE, Allocator *allocator = 0)
+		: CodeArray(maxSize, userPtr, allocator)
+		, XLEN_(64)
+		, isRV32_(false)
+		, supportRVC_(false)
+	{
+		labelMgr_.set(this);
+	}
+	void reset()
+	{
+		ClearError();
+		resetSize();
+		labelMgr_.reset();
+		labelMgr_.set(this);
+		XLEN_ = 64;
+		isRV32_ = false;
+		supportRVC_ = false;
+	}
+	void setRV32(bool on = true)
+	{
+		isRV32_ = on;
+		XLEN_ = on ? 32 : 64;
+	}
+	void supportRVC(bool on = true)
+	{
+		supportRVC_ = on;
+	}
+	bool hasUndefinedLabel() const { return labelMgr_.hasUndefClabel(); }
+	static inline void clearCache(void *p, size_t n)
+	{
+#ifdef _WIN32
+		FlushInstructionCache(GetCurrentProcess(), begin, n);
+#elif defined(__APPLE__)
+		sys_icache_invalidate(begin, n);
+#else
+		__builtin___clear_cache((char *)p, (char *)p + n);
+#endif
+	}
+	/*
+		MUST call ready() to complete generating code if you use AutoGrow mode.
+		It is not necessary for the other mode if hasUndefinedLabel() is true.
+	*/
+	void ready(ProtectMode mode = PROTECT_RWE)
+	{
+		if (hasUndefinedLabel()) XBYAK_RISCV_THROW(ERR_LABEL_IS_NOT_FOUND)
+		if (useProtect()) setProtectMode(mode);
+		clearCache(top_, size_);
+	}
+	// set read/exec
+	void readyRE() { return ready(PROTECT_RE); }
+
+	void align(size_t x)
+	{
+		if (x == 1) return;
+		if (x < 4 || (x & (x - 1))) XBYAK_RISCV_THROW(ERR_BAD_ALIGN)
+		size_t remain = size_t(getCurr()) % x;
+		if (remain % 4) XBYAK_RISCV_THROW(ERR_INTERNAL)
+		if (remain) {
+			for (size_t i = 0; i < (x - remain) / 4; i++) {
+				nop();
+			}
+		}
+	}
+
+#include "xbyak_riscv_mnemonic.hpp"
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+#include "xbyak_riscv_v.hpp"
+#endif
+};
+
+#ifdef _MSC_VER
+	#pragma warning(pop)
+#endif
+} // Xbyak_riscv
+

--- a/third_party/xbyak_riscv/xbyak_riscv_csr.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv_csr.hpp
@@ -1,0 +1,112 @@
+/******************************************************************************
+* Copyright (C), 2023, KNS Group LLC (YADRO)
+*
+* Licensed under the 3-Clause BSD License
+* You may obtain a copy of the License at https://opensource.org/license/bsd-3-clause/
+*******************************************************************************/
+
+#pragma once
+namespace Xbyak_riscv {
+
+// Control and Status Register
+enum class CSR : uint32_t {
+    // FP CSRs
+    fflags = 0x001, // Floating-Point Accrued Exceptions
+    frm    = 0x002, // Floating-Point Dynamic Rounding Mode
+    fcsr   = 0x003, // Floating-Point Control and Status register
+    // vector CSRs
+    vstart = 0x008, // Vector start position
+    vxsat  = 0x009, // Fixed-Point Saturate Flag
+    vxrm   = 0x00A, // Fixed-Point Rounding Mode
+    vcsr   = 0x00F, // Vector control and status register
+    vl     = 0xC20, // Vector length
+    vtype  = 0xC21, // Vector data type register
+    vlenb  = 0xC22, // VLEN/8 (vector register length in bytes)
+};
+
+
+// Selected Element Width
+enum class SEW : uint32_t {
+    e8  = 0x0,
+    e16 = 0x1,
+    e32 = 0x2,
+    e64 = 0x3
+};
+
+// Vector Length Multiplier
+enum class LMUL : uint32_t {
+    mf8 = 0x5,
+    mf4 = 0x6,
+    mf2 = 0x7,
+    m1  = 0x0,
+    m2  = 0x1,
+    m4  = 0x2,
+    m8  = 0x3
+};
+
+// Vector Mask Agnostic
+enum class VMA : uint32_t {
+    mu = 0, // undisturbed
+    ma = 1, // agnostic
+};
+
+// Vector Tail Agnostic
+enum class VTA : uint32_t {
+    tu = 0, // undisturbed
+    ta = 1, // agnostic
+};
+
+enum class VectorAddressingMode : uint32_t {
+    unitStride       = 0x0,
+    indexedUnordered = 0x1,
+    strided          = 0x2,
+    indexedOrdered   = 0x3
+    // other encodings are reserved
+};
+
+enum class UnitStrideVectorAddressingModeLoad : uint32_t {
+    load              = 0x0, // unit-stride load
+    wholeRegisterLoad = 0x8, // unit-stride, whole register load
+    maskLoad          = 0xb, // unit-stride, mask load, EEW=8
+    faultOnlyFirst    = 0x10  // unit-stride fault-only-first
+    // other encodings are reserved
+};
+
+enum class UnitStrideVectorAddressingModeStore : uint32_t {
+    store              = 0x0, // unit-stride store
+    wholeRegisterStore = 0x8, // unit-stride, whole register store
+    maskStore          = 0xb  // unit-stride, mask store, EEW=8
+    // other encodings are reserved
+};
+
+enum class WidthEncoding : uint32_t {
+    e8  = 0x0, // Vector 8-bit  element
+    e16 = 0x5, // Vector 16-bit element
+    e32 = 0x6, // Vector 32-bit element
+    e64 = 0x7, // Vector 64-bit element
+};
+
+enum class VM : uint32_t {
+    unmasked = 1,
+    masked = 0
+};
+
+enum class RM : uint32_t {
+    rne = 0x0, // Round to Nearest, ties to Even
+    rtz = 0x1, // Round towards Zero
+    rdn = 0x2, // Round Down (towards -infinity)
+    rup = 0x3, // Round Up (towards + infinity)
+    rmm = 0x4, // Round to Nearest, ties to Max Magnitude
+    dyn = 0x7  // In instruction’s rm field, selects dynamic rounding mode;
+               // In Rounding Mode register, reserved.
+};
+
+enum class FFlags : uint32_t {
+    NV = 0x01, // Invalid Operation
+    DZ = 0x02, // Divide by Zero
+    OF = 0x04, // Overflow
+    UF = 0x08, // Underflow
+    NX = 0x10  // Inexact
+};
+
+} // Xbyak_riscv

--- a/third_party/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -1,4 +1,4 @@
-const char *getVersionString() const { return "1.00"; }
+const char *getVersionString() const { return "1.01"; }
 void add(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && rd == rs1 && c_mv(rd, rs2, 1)) return; Rtype(0x33, 0, 0x0, rd, rs1, rs2); }
 void sub(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x23, 0)) return; Rtype(0x33, 0, 0x20, rd, rs1, rs2); }
 void sll(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x0, rd, rs1, rs2); }

--- a/third_party/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -1,0 +1,231 @@
+const char *getVersionString() const { return "1.00"; }
+void add(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && rd == rs1 && c_mv(rd, rs2, 1)) return; Rtype(0x33, 0, 0x0, rd, rs1, rs2); }
+void sub(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x23, 0)) return; Rtype(0x33, 0, 0x20, rd, rs1, rs2); }
+void sll(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x0, rd, rs1, rs2); }
+void slt(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 2, 0x0, rd, rs1, rs2); }
+void sltu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 3, 0x0, rd, rs1, rs2); }
+void xor_(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x23, 1)) return; Rtype(0x33, 4, 0x0, rd, rs1, rs2); }
+void srl(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x0, rd, rs1, rs2); }
+void sra(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x20, rd, rs1, rs2); }
+void or_(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x23, 2)) return; Rtype(0x33, 6, 0x0, rd, rs1, rs2); }
+void and_(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x23, 3)) return; Rtype(0x33, 7, 0x0, rd, rs1, rs2); }
+void addw(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x27, 1)) return; Rtype(0x3b, 0, 0x0, rd, rs1, rs2); }
+void subw(const Reg& rd, const Reg& rs1, const Reg& rs2) { if (supportRVC_ && c_noimm(rd, rs1, rs2, 0x27, 0)) return; Rtype(0x3b, 0, 0x20, rd, rs1, rs2); }
+void sllw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 1, 0x0, rd, rs1, rs2); }
+void srlw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 5, 0x0, rd, rs1, rs2); }
+void sraw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 5, 0x20, rd, rs1, rs2); }
+void mul(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 0, 0x1, rd, rs1, rs2); }
+void mulh(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x1, rd, rs1, rs2); }
+void mulhsu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 2, 0x1, rd, rs1, rs2); }
+void mulhu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 3, 0x1, rd, rs1, rs2); }
+void div(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 4, 0x1, rd, rs1, rs2); }
+void divu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x1, rd, rs1, rs2); }
+void rem(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 6, 0x1, rd, rs1, rs2); }
+void remu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 7, 0x1, rd, rs1, rs2); }
+void mulw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 0, 0x1, rd, rs1, rs2); }
+void divw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 4, 0x1, rd, rs1, rs2); }
+void remw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 6, 0x1, rd, rs1, rs2); }
+void remuw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 7, 0x1, rd, rs1, rs2); }
+void addi(const Reg& rd, const Reg& rs1, int imm) { if (supportRVC_ && c_addi(rd, rs1, imm)) return; Itype(0x13, 0, rd, rs1, imm); }
+void slti(const Reg& rd, const Reg& rs1, int imm) { Itype(0x13, 2, rd, rs1, imm); }
+void sltiu(const Reg& rd, const Reg& rs1, int imm) { Itype(0x13, 3, rd, rs1, imm); }
+void xori(const Reg& rd, const Reg& rs1, int imm) { Itype(0x13, 4, rd, rs1, imm); }
+void ori(const Reg& rd, const Reg& rs1, int imm) { Itype(0x13, 6, rd, rs1, imm); }
+void andi(const Reg& rd, const Reg& rs1, int imm) { if (supportRVC_ && c_srli(rd, rs1, imm, 2, true)) return; Itype(0x13, 7, rd, rs1, imm); }
+void addiw(const Reg& rd, const Reg& rs1, int imm) { if (supportRVC_ && c_addi_inner(rd, rs1, imm, 1)) return; Itype(0x1b, 0, rd, rs1, imm); }
+// load-op rd, imm(addr); rd = addr[imm];
+void jalr(const Reg& rd, const Reg& addr, int imm = 0) { Itype(0x67, 0, rd, addr, imm); }
+void lb(const Reg& rd, const Reg& addr, int imm = 0) { Itype(0x3, 0, rd, addr, imm); }
+void lh(const Reg& rd, const Reg& addr, int imm = 0) { Itype(0x3, 1, rd, addr, imm); }
+void lw(const Reg& rd, const Reg& addr, int imm = 0) { if (supportRVC_ && (c_lwsp(rd, addr, imm, 2) || c_lsw(rd, addr, imm, 2))) return; Itype(0x3, 2, rd, addr, imm); }
+void lbu(const Reg& rd, const Reg& addr, int imm = 0) { Itype(0x3, 4, rd, addr, imm); }
+void lhu(const Reg& rd, const Reg& addr, int imm = 0) { Itype(0x3, 5, rd, addr, imm); }
+void lwu(const Reg& rd, const Reg& addr, int imm = 0) { Itype(0x3, 6, rd, addr, imm); }
+void ld(const Reg& rd, const Reg& addr, int imm = 0) { if (supportRVC_ && (c_ldsp(rd, addr, imm, 3) || c_lsd(rd, addr, imm, 3))) return; Itype(0x3, 3, rd, addr, imm); }
+void auipc(const Reg& rd, uint32_t imm) { Utype(0x17, rd, imm); }
+void lui(const Reg& rd, uint32_t imm) { if (supportRVC_ && c_lui(rd, imm)) return; Utype(0x37, rd, imm); }
+void slli(const Reg& rd, const Reg& rs1, uint32_t shamt) { if (supportRVC_ && rd == rs1 && shamt != 0 && c_li(rd, shamt, 0, 2)) return; opShift(0x0, 1, 0x13, rd, rs1, shamt); }
+void srli(const Reg& rd, const Reg& rs1, uint32_t shamt) { if (supportRVC_ && c_srli(rd, rs1, shamt, 0)) return; opShift(0x0, 5, 0x13, rd, rs1, shamt); }
+void srai(const Reg& rd, const Reg& rs1, uint32_t shamt) { if (supportRVC_ && c_srli(rd, rs1, shamt, 1)) return; opShift(0x20, 5, 0x13, rd, rs1, shamt); }
+void slliw(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x0, 1, 0x1b, rd, rs1, shamt, 5); }
+void srliw(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x0, 5, 0x1b, rd, rs1, shamt, 5); }
+void sraiw(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x20, 5, 0x1b, rd, rs1, shamt, 5); }
+void fence_rw_rw() { append4B(0x330000f); }
+void fence_tso() { append4B(0x8330000f); }
+void fence_rw_w() { append4B(0x310000f); }
+void fence_r_rw() { append4B(0x230000f); }
+void fence_r_r() { append4B(0x220000f); }
+void fence_w_w() { append4B(0x110000f); }
+void fence_i() { append4B(0x100f); }
+void ecall() { append4B(0x73); }
+void ebreak() { if (supportRVC_) append2B(0x9002); else append4B(0x00100073); }
+// store-op rs, imm(addr) ; addr[imm] = rs;
+void sb(const Reg& rs, const Reg& addr, int imm = 0) { Stype(0x23, 0, addr, rs, imm); }
+void sh(const Reg& rs, const Reg& addr, int imm = 0) { Stype(0x23, 1, addr, rs, imm); }
+void sw(const Reg& rs, const Reg& addr, int imm = 0) { if (supportRVC_ && (c_swsp(rs, addr, imm, 6) || c_lsw(rs, addr, imm, 6))) return; Stype(0x23, 2, addr, rs, imm); }
+void sd(const Reg& rs, const Reg& addr, int imm = 0) { if (supportRVC_ && (c_sdsp(rs, addr, imm, 7) || c_lsd(rs, addr, imm, 7))) return; Stype(0x23, 3, addr, rs, imm); }
+void beq(const Reg& rs1, const Reg& rs2, const Label& label) { Jmp jmp(getCurr(), 0x63, 0, rs1, rs2); opJmp(label, jmp); }
+void bne(const Reg& rs1, const Reg& rs2, const Label& label) { Jmp jmp(getCurr(), 0x63, 1, rs1, rs2); opJmp(label, jmp); }
+void blt(const Reg& rs1, const Reg& rs2, const Label& label) { Jmp jmp(getCurr(), 0x63, 4, rs1, rs2); opJmp(label, jmp); }
+void bge(const Reg& rs1, const Reg& rs2, const Label& label) { Jmp jmp(getCurr(), 0x63, 5, rs1, rs2); opJmp(label, jmp); }
+void bltu(const Reg& rs1, const Reg& rs2, const Label& label) { Jmp jmp(getCurr(), 0x63, 6, rs1, rs2); opJmp(label, jmp); }
+void bgeu(const Reg& rs1, const Reg& rs2, const Label& label) { Jmp jmp(getCurr(), 0x63, 7, rs1, rs2); opJmp(label, jmp); }
+void beqz(const Reg& rs, const Label& label) { beq(rs, x0, label); }
+void bnez(const Reg& rs, const Label& label) { bne(rs, x0, label); }
+void blez(const Reg& rs, const Label& label) { bge(x0, rs, label); }
+void bgez(const Reg& rs, const Label& label) { bge(rs, x0, label); }
+void bltz(const Reg& rs, const Label& label) { blt(rs, x0, label); }
+void bgtz(const Reg& rs, const Label& label) { blt(x0, rs, label); }
+void bgt(const Reg& rs, const Reg& rt, const Label& label) { blt(rt, rs, label); }
+void ble(const Reg& rs, const Reg& rt, const Label& label) { bge(rt, rs, label); }
+void bgtu(const Reg& rs, const Reg& rt, const Label& label) { bltu(rt, rs, label); }
+void bleu(const Reg& rs, const Reg& rt, const Label& label) { bgeu(rt, rs, label); }
+// amos**, rd, rs2, (addr)
+void sc_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x3, 2, flag); }
+void sc_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x3, 3, flag); }
+void amoswap_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x1, 2, flag); }
+void amoswap_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x1, 3, flag); }
+void amoadd_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x0, 2, flag); }
+void amoadd_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x0, 3, flag); }
+void amoxor_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x4, 2, flag); }
+void amoxor_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x4, 3, flag); }
+void amoand_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0xc, 2, flag); }
+void amoand_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0xc, 3, flag); }
+void amoor_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x8, 2, flag); }
+void amoor_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x8, 3, flag); }
+void amomin_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x10, 2, flag); }
+void amomin_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x10, 3, flag); }
+void amomax_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x14, 2, flag); }
+void amomax_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x14, 3, flag); }
+void amominu_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x18, 2, flag); }
+void amominu_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x18, 3, flag); }
+void amomaxu_w(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x1c, 2, flag); }
+void amomaxu_d(const Reg& rd, const Reg& rs2, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, rs2, addr, 0x1c, 3, flag); }
+void csrrw(const Reg& rd, CSR csr, const Reg& rs1) { opCSR(0x1073, csr, rs1, rd); }
+void csrrs(const Reg& rd, CSR csr, const Reg& rs1) { opCSR(0x2073, csr, rs1, rd); }
+void csrrc(const Reg& rd, CSR csr, const Reg& rs1) { opCSR(0x3073, csr, rs1, rd); }
+void csrrwi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x5073, csr, imm, rd); }
+void csrrsi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x6073, csr, imm, rd); }
+void csrrci(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x7073, csr, imm, rd); }
+void fadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x53, rs2, rs1, rm, rd); }
+void fclass_s(const Reg& rd, const FReg& rs1) { opFP(0xe0001053, 0, rs1, 0, rd); }
+void fcvt_s_w(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0000053, 0, rs1, rm, rd); }
+void fcvt_s_wu(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0100053, 0, rs1, rm, rd); }
+void fcvt_w_s(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc0000053, 0, rs1, rm, rd); }
+void fcvt_wu_s(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc0100053, 0, rs1, rm, rd); }
+void fdiv_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x18000053, rs2, rs1, rm, rd); }
+void feq_s(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa0002053, rs2, rs1, 0, rd); }
+void fle_s(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa0000053, rs2, rs1, 0, rd); }
+void flt_s(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa0001053, rs2, rs1, 0, rd); }
+void fmax_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x28001053, rs2, rs1, 0, rd); }
+void fmin_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x28000053, rs2, rs1, 0, rd); }
+void fmul_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x10000053, rs2, rs1, rm, rd); }
+void fmv_w_x(const FReg& rd, const Reg& rs1) { opFP(0xf0000053, 0, rs1, 0, rd); }
+void fmv_x_w(const Reg& rd, const FReg& rs1) { opFP(0xe0000053, 0, rs1, 0, rd); }
+void fsgnj_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x20000053, rs2, rs1, 0, rd); }
+void fsgnjn_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x20001053, rs2, rs1, 0, rd); }
+void fsgnjx_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x20002053, rs2, rs1, 0, rd); }
+void fsqrt_s(const FReg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0x58000053, 0, rs1, rm, rd); }
+void fsub_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x8000053, rs2, rs1, rm, rd); }
+void fcvt_l_s(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc0200053, 0, rs1, rm, rd); }
+void fcvt_lu_s(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc0300053, 0, rs1, rm, rd); }
+void fcvt_s_l(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0200053, 0, rs1, rm, rd); }
+void fcvt_s_lu(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0300053, 0, rs1, rm, rd); }
+void fadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x4000053, rs2, rs1, rm, rd); }
+void fclass_h(const Reg& rd, const FReg& rs1) { opFP(0xe4001053, 0, rs1, 0, rd); }
+void fcvt_h_s(const Reg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0x44000053, 0, rs1, rm, rd); }
+void fcvt_h_w(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd4000053, 0, rs1, rm, rd); }
+void fcvt_h_wu(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd4100053, 0, rs1, rm, rd); }
+void fcvt_s_h(const Reg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0x40200053, 0, rs1, rm, rd); }
+void fcvt_w_h(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc4000053, 0, rs1, rm, rd); }
+void fcvt_wu_h(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc4100053, 0, rs1, rm, rd); }
+void fdiv_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x1c000053, rs2, rs1, rm, rd); }
+void feq_h(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa4002053, rs2, rs1, 0, rd); }
+void fle_h(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa4000053, rs2, rs1, 0, rd); }
+void flt_h(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa4001053, rs2, rs1, 0, rd); }
+void fmax_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x2c001053, rs2, rs1, 0, rd); }
+void fmin_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x2c000053, rs2, rs1, 0, rd); }
+void fmul_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x14000053, rs2, rs1, rm, rd); }
+void fmv_h_x(const FReg& rd, const Reg& rs1) { opFP(0xf4000053, 0, rs1, 0, rd); }
+void fmv_x_h(const Reg& rd, const FReg& rs1) { opFP(0xe4000053, 0, rs1, 0, rd); }
+void fsgnj_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x24000053, rs2, rs1, 0, rd); }
+void fsgnjn_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x24001053, rs2, rs1, 0, rd); }
+void fsgnjx_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x24002053, rs2, rs1, 0, rd); }
+void fsqrt_h(const FReg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0x5c000053, 0, rs1, rm, rd); }
+void fsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0xc000053, rs2, rs1, rm, rd); }
+void fcvt_h_l(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd4200053, 0, rs1, rm, rd); }
+void fcvt_h_lu(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd4300053, 0, rs1, rm, rd); }
+void fcvt_l_h(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc4200053, 0, rs1, rm, rd); }
+void fcvt_lu_h(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc4300053, 0, rs1, rm, rd); }
+
+void fmadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x43, rs3, rs2, rs1, rm, rd); }
+void fmsub_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x47, rs3, rs2, rs1, rm, rd); }
+void fnmsub_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x4b, rs3, rs2, rs1, rm, rd); }
+void fnmadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x4f, rs3, rs2, rs1, rm, rd); }
+
+void fmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x4000043, rs3, rs2, rs1, rm, rd); }
+void fmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x4000047, rs3, rs2, rs1, rm, rd); }
+void fnmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x400004b, rs3, rs2, rs1, rm, rd); }
+void fnmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x400004f, rs3, rs2, rs1, rm, rd); }
+
+
+void flq(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x4007, imm12, rs1, rd); }
+void fsq(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x4027, imm12, rs2, rs1); }
+void fld(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x3007, imm12, rs1, rd); }
+void fsd(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x3027, imm12, rs2, rs1); }
+void flw(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x2007, imm12, rs1, rd); }
+void fsw(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x2027, imm12, rs2, rs1); }
+void flh(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x1007, imm12, rs1, rd); }
+void fsh(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x1027, imm12, rs2, rs1); }
+
+
+void nop() { if (supportRVC_) { append2B(0x0001); return; } addi(x0, x0, 0); }
+void li(const Reg& rd, uint32_t imm)
+{
+	if (imm && (imm & local::mask(12)) == 0) { // lower 12 bits of imm are zero
+		lui(rd, uint32_t(imm >> 12));
+		return;
+	}
+	int H, L;
+	if (!local::split32bit(&H, &L, imm)) {
+		addi(rd, zero, imm);
+		return;
+	}
+	lui(rd, H);
+	if (isRV32_) {
+		addi(rd, rd, L);
+	} else {
+		addiw(rd, rd, L);
+	}
+}
+void mv(const Reg& rd, const Reg& rs) { addi(rd, rs, 0); }
+void not_(const Reg& rd, const Reg& rs) { xori(rd, rs, -1); }
+void neg(const Reg& rd, const Reg& rs) { sub(rd, x0, rs); }
+void negw(const Reg& rd, const Reg& rs) { subw(rd, x0, rs); }
+void sext_b(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 8); srai(rd, rd, XLEN_ - 8); }
+void sext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srai(rd, rd, XLEN_ - 16); }
+void sext_w(const Reg& rd, const Reg& rs) { addiw(rd, rs, 0); }
+void zext_b(const Reg& rd, const Reg& rs) { andi(rd, rs, 255); }
+void zext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srli(rd, rd, XLEN_ - 16); }
+void zext_w(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 32); srli(rd, rd, XLEN_ - 32); }
+void seqz(const Reg& rd, const Reg& rs) { sltiu(rd, rs, 1); }
+void snez(const Reg& rd, const Reg& rs) { sltu(rd, x0, rs); }
+void sltz(const Reg& rd, const Reg& rs) { slt(rd, rs, x0); }
+void sgtz(const Reg& rd, const Reg& rs) { slt(rd, x0, rs); }
+void fence() { append4B(0x0ff0000f); }
+void j_(const Label& label) { jal(x0, label); }
+void jal(const Reg& rd, const Label& label) { Jmp jmp(getCurr(), 0x6f, rd); opJmp(label, jmp); }
+void jr(const Reg& rs) { jalr(x0, rs, 0); }
+void jalr(const Reg& rs) { jalr(x1, rs, 0); }
+void ret() { jalr(x0, x1); }
+// lr rd, (addr)
+void lr_w(const Reg& rd, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, 0, addr, 2, 2, flag); }
+void lr_d(const Reg& rd, const Reg& addr, uint32_t flag = 0) { opAtomic(rd, 0, addr, 2, 3, flag); }
+void csrr(const Reg& rd, CSR csr) { csrrs(rd, csr, x0); }
+void csrw(CSR csr, const Reg& rs) { csrrw(x0, csr, rs); }
+void csrs(CSR csr, const Reg& rs) { csrrs(x0, csr, rs); }
+void csrc(CSR csr, const Reg& rs) { csrrc(x0, csr, rs); }
+void csrwi(CSR csr, uint32_t imm) { csrrwi(x0, csr, imm); }
+void csrsi(CSR csr, uint32_t imm) { csrrsi(x0, csr, imm); }
+void csrci(CSR csr, uint32_t imm) { csrrci(x0, csr, imm); }
+

--- a/third_party/xbyak_riscv/xbyak_riscv_util.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv_util.hpp
@@ -1,0 +1,194 @@
+/******************************************************************************
+* Copyright (C), 2023, KNS Group LLC (YADRO)
+*
+* Licensed under the 3-Clause BSD License
+* You may obtain a copy of the License at https://opensource.org/license/bsd-3-clause/
+*******************************************************************************/
+
+#pragma once
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include "xbyak_riscv_csr.hpp"
+#include "xbyak_riscv.hpp"
+
+#if defined(__linux__) && defined(__riscv)
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+#include <sys/utsname.h>
+#include <asm/hwcap.h>
+#include <unistd.h>
+#endif
+
+namespace Xbyak_riscv {
+
+#ifndef COMPAT_HWCAP_ISA_I
+#define COMPAT_HWCAP_ISA_I  (1U << ('I' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_M
+#define COMPAT_HWCAP_ISA_M  (1U << ('M' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_A
+#define COMPAT_HWCAP_ISA_A  (1U << ('A' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_F
+#define COMPAT_HWCAP_ISA_F  (1U << ('F' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_D
+#define COMPAT_HWCAP_ISA_D  (1U << ('D' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_C
+#define COMPAT_HWCAP_ISA_C  (1U << ('C' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_V
+#define COMPAT_HWCAP_ISA_V  (1U << ('V' - 'A'))
+#endif
+
+enum class RISCVExtension : uint64_t {
+    I = COMPAT_HWCAP_ISA_I,
+    M = COMPAT_HWCAP_ISA_M,
+    A = COMPAT_HWCAP_ISA_A,
+    F = COMPAT_HWCAP_ISA_F,
+    D = COMPAT_HWCAP_ISA_D,
+    C = COMPAT_HWCAP_ISA_C,
+    V = COMPAT_HWCAP_ISA_V
+};
+
+template <CSR csr>
+struct CSRReader : public CodeGenerator {
+    // Buffer capacity exactly for 2 instructions.
+    static constexpr size_t capacity = 8;
+
+    CSRReader() : CodeGenerator(capacity) {
+        csrrs(a0, csr, x0);
+        ret();
+    }
+};
+
+/**
+ * Class that detects information about a RISC-V CPU.
+ */
+class CPU final {
+public:
+    static const CPU& getInstance() {
+        static const CPU cpu;
+        return cpu;
+    }
+
+    CPU() {
+#if defined(__linux__) && defined(__riscv)
+        // Set hwcapFeatures with AT_HWCAP value from
+        // the Linux auxiliary vector to check for base extensions support.
+        hwcapFeatures = getauxval(AT_HWCAP) & (
+            COMPAT_HWCAP_ISA_I |
+            COMPAT_HWCAP_ISA_M |
+            COMPAT_HWCAP_ISA_A |
+            COMPAT_HWCAP_ISA_F |
+            COMPAT_HWCAP_ISA_D |
+            COMPAT_HWCAP_ISA_C |
+            COMPAT_HWCAP_ISA_V
+        );
+
+        // Set xlen, number of cores, cache info
+        xlen = sysconf(_SC_LONG_BIT);
+        numCores = sysconf(_SC_NPROCESSORS_ONLN);
+        numCores = sysconf(_SC_NPROCESSORS_ONLN);
+
+        dataCacheSize_[0] = sysconf(_SC_LEVEL1_DCACHE_SIZE);
+        dataCacheSize_[1] = sysconf(_SC_LEVEL2_CACHE_SIZE);
+        dataCacheSize_[2] = sysconf(_SC_LEVEL3_CACHE_SIZE);
+        dataCacheSize_[3] = sysconf(_SC_LEVEL4_CACHE_SIZE);
+
+        dataCacheLineSize_[0] = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+        dataCacheLineSize_[1] = sysconf(_SC_LEVEL2_CACHE_LINESIZE);
+        dataCacheLineSize_[2] = sysconf(_SC_LEVEL3_CACHE_LINESIZE);
+        dataCacheLineSize_[3] = sysconf(_SC_LEVEL4_CACHE_LINESIZE);
+#endif
+
+        // Set vlen
+        if(hasExtension(RISCVExtension::V)) {
+            CSRReader<CSR::vlenb> csrReaderGenerator;
+            csrReaderGenerator.ready();
+            const auto csrReader = csrReaderGenerator.getCode<uint32_t (*)()>();
+            vlen = csrReader() * 8 /* bit */;
+        }
+
+        // Set flen (bit)
+        if (hasExtension(RISCVExtension::D)) {
+            flen = 64;
+        } else if (hasExtension(RISCVExtension::F)) {
+            flen = 32;
+        }
+    }
+
+    /**
+     * Checks if a particular RISC-V extension is available.
+     *
+     * @param extension The extension to check.
+     */
+    bool hasExtension(RISCVExtension extension) const {
+        return (hwcapFeatures & static_cast<uint64_t>(extension)) != 0;
+    }
+
+    /**
+     * Get vector register width in bits
+    */
+    uint32_t getVlen() const {
+        return vlen;
+    }
+
+    /**
+     * Get general purpose register width in bits
+    */
+    uint32_t getXlen() const {
+        return xlen;
+    };
+
+    /**
+     * Get floating-point register width in bits
+    */
+    uint32_t getFlen() const {
+        return flen;
+    }
+
+    uint32_t getNumCores() const {
+        return numCores;
+    }
+
+    /**
+     * Get data cache size in bytes
+     * @param lvl Cache level 1..4
+    */
+    uint32_t getDataCacheSize(uint32_t lvl) const {
+        if (lvl == 0 || lvl > maxNumberCacheLevels) XBYAK_RISCV_THROW(ERR_BAD_PARAMETER);
+        return dataCacheSize_[lvl - 1];
+    }
+
+    /**
+     * Get data cache line size in bytes
+     * @param lvl Cache level 1..4
+    */
+    uint32_t getDataCacheLineSize(uint32_t lvl) const {
+        if (lvl == 0 || lvl > maxNumberCacheLevels) XBYAK_RISCV_THROW(ERR_BAD_PARAMETER);
+        return dataCacheLineSize_[lvl - 1];
+    }
+
+private:
+    uint64_t hwcapFeatures = 0;
+    static constexpr size_t maxNumberCacheLevels = 4;
+    uint32_t dataCacheSize_[maxNumberCacheLevels] = {0, 0, 0, 0};
+    uint32_t dataCacheLineSize_[maxNumberCacheLevels] = {0, 0, 0, 0};
+    uint32_t numCores = 0;
+    uint32_t xlen = 0;
+    uint32_t vlen = 0;
+    uint32_t flen = 0;
+};
+
+} // Xbyak_riscv

--- a/third_party/xbyak_riscv/xbyak_riscv_v.hpp
+++ b/third_party/xbyak_riscv/xbyak_riscv_v.hpp
@@ -1,0 +1,776 @@
+/*
+	Copyright (C), 2023, MITSUNARI Shigeo
+	Copyright (C), 2023, KNS Group LLC (YADRO)
+	Licensed under the 3-Clause BSD License
+	You may obtain a copy of the License at https://opensource.org/license/bsd-3-clause/
+*/
+void vaadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x24002057, vm, vs2, vs1, vd); }
+void vaadd_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x24006057, vm, vs2, rs1, vd); }
+void vaaddu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x20002057, vm, vs2, vs1, vd); }
+void vaaddu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x20006057, vm, vs2, rs1, vd); }
+void vadc_vim(const VReg& vd, const VReg& vs2, int32_t simm5) { opIVI(0x40003057, 0, vs2, simm5, vd); }
+void vadc_vvm(const VReg& vd, const VReg& vs2, const VReg& vs1) { opIVV(0x40000057, 0, vs2, vs1, vd); }
+void vadc_vxm(const VReg& vd, const VReg& vs2, const Reg& rs1) { opIVX(0x40004057, 0, vs2, rs1, vd); }
+void vadd_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x3057, vm, vs2, simm5, vd); }
+void vadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x57, vm, vs2, vs1, vd); }
+void vadd_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x4057, vm, vs2, rs1, vd); }
+void vand_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x24003057, vm, vs2, simm5, vd); }
+void vand_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x24000057, vm, vs2, vs1, vd); }
+void vand_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x24004057, vm, vs2, rs1, vd); }
+void vasub_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x2c002057, vm, vs2, vs1, vd); }
+void vasub_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x2c006057, vm, vs2, rs1, vd); }
+void vasubu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x28002057, vm, vs2, vs1, vd); }
+void vasubu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x28006057, vm, vs2, rs1, vd); }
+void vcompress_vm(const VReg& vd, const VReg& vs2, const VReg& vs1) { opMVV(0x5e002057, 0, vs2, vs1, vd); }
+void vcpop_m(const Reg& rd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x40082057, vm, vs2, 0, rd); }
+void vdiv_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x84002057, vm, vs2, vs1, vd); }
+void vdiv_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x84006057, vm, vs2, rs1, vd); }
+void vdivu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x80002057, vm, vs2, vs1, vd); }
+void vdivu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x80006057, vm, vs2, rs1, vd); }
+void vfadd_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x5057, vm, vs2, rs1, vd); }
+void vfadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x1057, vm, vs2, vs1, vd); }
+void vfclass_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x4c081057, vm, vs2, 0, vd); }
+void vfcvt_f_x_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48019057, vm, vs2, 0, vd); }
+void vfcvt_f_xu_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48011057, vm, vs2, 0, vd); }
+void vfcvt_rtz_x_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48039057, vm, vs2, 0, vd); }
+void vfcvt_rtz_xu_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48031057, vm, vs2, 0, vd); }
+void vfcvt_x_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48009057, vm, vs2, 0, vd); }
+void vfcvt_xu_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48001057, vm, vs2, 0, vd); }
+void vfdiv_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x80005057, vm, vs2, rs1, vd); }
+void vfdiv_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x80001057, vm, vs2, vs1, vd); }
+void vfirst_m(const Reg& rd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x4008a057, vm, vs2, 0, rd); }
+void vfmacc_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xb0005057, vm, vs2, rs1, vd); }
+void vfmacc_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xb0001057, vm, vs2, vs1, vd); }
+void vfmadd_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xa0005057, vm, vs2, rs1, vd); }
+void vfmadd_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xa0001057, vm, vs2, vs1, vd); }
+void vfmax_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x18005057, vm, vs2, rs1, vd); }
+void vfmax_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x18001057, vm, vs2, vs1, vd); }
+void vfmerge_vfm(const VReg& vd, const VReg& vs2, const FReg& rs1) { opFVF(0x5c005057, 0, vs2, rs1, vd); }
+void vfmin_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x10005057, vm, vs2, rs1, vd); }
+void vfmin_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x10001057, vm, vs2, vs1, vd); }
+void vfmsac_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xb8005057, vm, vs2, rs1, vd); }
+void vfmsac_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xb8001057, vm, vs2, vs1, vd); }
+void vfmsub_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xa8005057, vm, vs2, rs1, vd); }
+void vfmsub_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xa8001057, vm, vs2, vs1, vd); }
+void vfmul_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x90005057, vm, vs2, rs1, vd); }
+void vfmul_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x90001057, vm, vs2, vs1, vd); }
+void vfmv_f_s(const FReg& rd, const VReg& vs2) { opFVV(0x42001057, 0, vs2, 0, rd); }
+void vfmv_s_f(const VReg& vd, const FReg& rs1) { opFVF(0x42005057, 0, 0, rs1, vd); }
+void vfmv_v_f(const VReg& vd, const FReg& rs1) { opFVF(0x5e005057, 0, 0, rs1, vd); }
+void vfncvt_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480a1057, vm, vs2, 0, vd); }
+void vfncvt_f_x_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48099057, vm, vs2, 0, vd); }
+void vfncvt_f_xu_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48091057, vm, vs2, 0, vd); }
+void vfncvt_rod_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480a9057, vm, vs2, 0, vd); }
+void vfncvt_rtz_x_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480b9057, vm, vs2, 0, vd); }
+void vfncvt_rtz_xu_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480b1057, vm, vs2, 0, vd); }
+void vfncvt_x_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48089057, vm, vs2, 0, vd); }
+void vfncvt_xu_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48081057, vm, vs2, 0, vd); }
+void vfnmacc_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xb4005057, vm, vs2, rs1, vd); }
+void vfnmacc_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xb4001057, vm, vs2, vs1, vd); }
+void vfnmadd_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xa4005057, vm, vs2, rs1, vd); }
+void vfnmadd_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xa4001057, vm, vs2, vs1, vd); }
+void vfnmsac_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xbc005057, vm, vs2, rs1, vd); }
+void vfnmsac_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xbc001057, vm, vs2, vs1, vd); }
+void vfnmsub_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xac005057, vm, vs2, rs1, vd); }
+void vfnmsub_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xac001057, vm, vs2, vs1, vd); }
+void vfrdiv_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x84005057, vm, vs2, rs1, vd); }
+void vfrec7_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x4c029057, vm, vs2, 0, vd); }
+void vfredmax_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x1c001057, vm, vs2, vs1, vd); }
+void vfredmin_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x14001057, vm, vs2, vs1, vd); }
+void vfredosum_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xc001057, vm, vs2, vs1, vd); }
+void vfredusum_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x4001057, vm, vs2, vs1, vd); }
+void vfrsqrt7_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x4c021057, vm, vs2, 0, vd); }
+void vfrsub_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x9c005057, vm, vs2, rs1, vd); }
+void vfsgnj_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x20005057, vm, vs2, rs1, vd); }
+void vfsgnj_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x20001057, vm, vs2, vs1, vd); }
+void vfsgnjn_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x24005057, vm, vs2, rs1, vd); }
+void vfsgnjn_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x24001057, vm, vs2, vs1, vd); }
+void vfsgnjx_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x28005057, vm, vs2, rs1, vd); }
+void vfsgnjx_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x28001057, vm, vs2, vs1, vd); }
+void vfslide1down_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x3c005057, vm, vs2, rs1, vd); }
+void vfslide1up_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x38005057, vm, vs2, rs1, vd); }
+void vfsqrt_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x4c001057, vm, vs2, 0, vd); }
+void vfsub_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x8005057, vm, vs2, rs1, vd); }
+void vfsub_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x8001057, vm, vs2, vs1, vd); }
+void vfwadd_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0xc0005057, vm, vs2, rs1, vd); }
+void vfwadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xc0001057, vm, vs2, vs1, vd); }
+void vfwadd_wf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0xd0005057, vm, vs2, rs1, vd); }
+void vfwadd_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xd0001057, vm, vs2, vs1, vd); }
+void vfwcvt_f_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48061057, vm, vs2, 0, vd); }
+void vfwcvt_f_x_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48059057, vm, vs2, 0, vd); }
+void vfwcvt_f_xu_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48051057, vm, vs2, 0, vd); }
+void vfwcvt_rtz_x_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48079057, vm, vs2, 0, vd); }
+void vfwcvt_rtz_xu_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48071057, vm, vs2, 0, vd); }
+void vfwcvt_x_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48049057, vm, vs2, 0, vd); }
+void vfwcvt_xu_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48041057, vm, vs2, 0, vd); }
+void vfwmacc_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xf0005057, vm, vs2, rs1, vd); }
+void vfwmacc_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xf0001057, vm, vs2, vs1, vd); }
+void vfwmsac_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xf8005057, vm, vs2, rs1, vd); }
+void vfwmsac_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xf8001057, vm, vs2, vs1, vd); }
+void vfwmul_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0xe0005057, vm, vs2, rs1, vd); }
+void vfwmul_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xe0001057, vm, vs2, vs1, vd); }
+void vfwnmacc_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xf4005057, vm, vs2, rs1, vd); }
+void vfwnmacc_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xf4001057, vm, vs2, vs1, vd); }
+void vfwnmsac_vf(const VReg& vd, const FReg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opFVF(0xfc005057, vm, vs2, rs1, vd); }
+void vfwnmsac_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0xfc001057, vm, vs2, vs1, vd); }
+void vfwredosum_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xcc001057, vm, vs2, vs1, vd); }
+void vfwredusum_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xc4001057, vm, vs2, vs1, vd); }
+void vfwsub_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0xc8005057, vm, vs2, rs1, vd); }
+void vfwsub_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xc8001057, vm, vs2, vs1, vd); }
+void vfwsub_wf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0xd8005057, vm, vs2, rs1, vd); }
+void vfwsub_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xd8001057, vm, vs2, vs1, vd); }
+void vid_v(const VReg& vd, VM vm=VM::unmasked) { opMVV(0x5008a057, vm, 0, 0, vd); }
+void viota_m(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x50082057, vm, vs2, 0, vd); }
+void vl1re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, rs1, vd); }
+void vl1re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
+void vl1re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
+void vl1re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
+void vl2re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, rs1, vd); }
+void vl2re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
+void vl2re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
+void vl2re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
+void vl4re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, rs1, vd); }
+void vl4re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
+void vl4re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
+void vl4re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
+void vl8re16_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2805007, 0, 0, rs1, vd); }
+void vl8re32_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2806007, 0, 0, rs1, vd); }
+void vl8re64_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2807007, 0, 0, rs1, vd); }
+void vl8re8_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2800007, 0, 0, rs1, vd); }
+void vlseg1e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10007007, vm, 0, rs1, vd); }
+void vlseg2e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x30007007, vm, 0, rs1, vd); }
+void vlseg3e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x50007007, vm, 0, rs1, vd); }
+void vlseg4e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x70007007, vm, 0, rs1, vd); }
+void vlseg5e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x90007007, vm, 0, rs1, vd); }
+void vlseg6e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb0007007, vm, 0, rs1, vd); }
+void vlseg7e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd0007007, vm, 0, rs1, vd); }
+void vlseg8e1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf0007007, vm, 0, rs1, vd); }
+void vle1024_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10007007, vm, 0, rs1, vd); }
+void vlseg1e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11007007, vm, 0, rs1, vd); }
+void vlseg2e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x31007007, vm, 0, rs1, vd); }
+void vlseg3e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x51007007, vm, 0, rs1, vd); }
+void vlseg4e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x71007007, vm, 0, rs1, vd); }
+void vlseg5e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x91007007, vm, 0, rs1, vd); }
+void vlseg6e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb1007007, vm, 0, rs1, vd); }
+void vlseg7e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd1007007, vm, 0, rs1, vd); }
+void vlseg8e1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf1007007, vm, 0, rs1, vd); }
+void vle1024ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11007007, vm, 0, rs1, vd); }
+void vlseg1e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10000007, vm, 0, rs1, vd); }
+void vlseg2e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x30000007, vm, 0, rs1, vd); }
+void vlseg3e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x50000007, vm, 0, rs1, vd); }
+void vlseg4e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x70000007, vm, 0, rs1, vd); }
+void vlseg5e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x90000007, vm, 0, rs1, vd); }
+void vlseg6e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb0000007, vm, 0, rs1, vd); }
+void vlseg7e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd0000007, vm, 0, rs1, vd); }
+void vlseg8e128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf0000007, vm, 0, rs1, vd); }
+void vle128_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10000007, vm, 0, rs1, vd); }
+void vlseg1e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11000007, vm, 0, rs1, vd); }
+void vlseg2e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x31000007, vm, 0, rs1, vd); }
+void vlseg3e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x51000007, vm, 0, rs1, vd); }
+void vlseg4e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x71000007, vm, 0, rs1, vd); }
+void vlseg5e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x91000007, vm, 0, rs1, vd); }
+void vlseg6e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb1000007, vm, 0, rs1, vd); }
+void vlseg7e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd1000007, vm, 0, rs1, vd); }
+void vlseg8e128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf1000007, vm, 0, rs1, vd); }
+void vle128ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11000007, vm, 0, rs1, vd); }
+void vlseg1e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x5007, vm, 0, rs1, vd); }
+void vlseg2e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x20005007, vm, 0, rs1, vd); }
+void vlseg3e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x40005007, vm, 0, rs1, vd); }
+void vlseg4e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x60005007, vm, 0, rs1, vd); }
+void vlseg5e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x80005007, vm, 0, rs1, vd); }
+void vlseg6e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa0005007, vm, 0, rs1, vd); }
+void vlseg7e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc0005007, vm, 0, rs1, vd); }
+void vlseg8e16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe0005007, vm, 0, rs1, vd); }
+void vle16_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x5007, vm, 0, rs1, vd); }
+void vlseg1e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1005007, vm, 0, rs1, vd); }
+void vlseg2e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x21005007, vm, 0, rs1, vd); }
+void vlseg3e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x41005007, vm, 0, rs1, vd); }
+void vlseg4e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x61005007, vm, 0, rs1, vd); }
+void vlseg5e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x81005007, vm, 0, rs1, vd); }
+void vlseg6e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa1005007, vm, 0, rs1, vd); }
+void vlseg7e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc1005007, vm, 0, rs1, vd); }
+void vlseg8e16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe1005007, vm, 0, rs1, vd); }
+void vle16ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1005007, vm, 0, rs1, vd); }
+void vlseg1e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10005007, vm, 0, rs1, vd); }
+void vlseg2e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x30005007, vm, 0, rs1, vd); }
+void vlseg3e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x50005007, vm, 0, rs1, vd); }
+void vlseg4e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x70005007, vm, 0, rs1, vd); }
+void vlseg5e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x90005007, vm, 0, rs1, vd); }
+void vlseg6e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb0005007, vm, 0, rs1, vd); }
+void vlseg7e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd0005007, vm, 0, rs1, vd); }
+void vlseg8e256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf0005007, vm, 0, rs1, vd); }
+void vle256_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10005007, vm, 0, rs1, vd); }
+void vlseg1e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11005007, vm, 0, rs1, vd); }
+void vlseg2e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x31005007, vm, 0, rs1, vd); }
+void vlseg3e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x51005007, vm, 0, rs1, vd); }
+void vlseg4e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x71005007, vm, 0, rs1, vd); }
+void vlseg5e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x91005007, vm, 0, rs1, vd); }
+void vlseg6e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb1005007, vm, 0, rs1, vd); }
+void vlseg7e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd1005007, vm, 0, rs1, vd); }
+void vlseg8e256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf1005007, vm, 0, rs1, vd); }
+void vle256ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11005007, vm, 0, rs1, vd); }
+void vlseg1e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x6007, vm, 0, rs1, vd); }
+void vlseg2e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x20006007, vm, 0, rs1, vd); }
+void vlseg3e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x40006007, vm, 0, rs1, vd); }
+void vlseg4e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x60006007, vm, 0, rs1, vd); }
+void vlseg5e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x80006007, vm, 0, rs1, vd); }
+void vlseg6e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa0006007, vm, 0, rs1, vd); }
+void vlseg7e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc0006007, vm, 0, rs1, vd); }
+void vlseg8e32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe0006007, vm, 0, rs1, vd); }
+void vle32_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x6007, vm, 0, rs1, vd); }
+void vlseg1e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1006007, vm, 0, rs1, vd); }
+void vlseg2e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x21006007, vm, 0, rs1, vd); }
+void vlseg3e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x41006007, vm, 0, rs1, vd); }
+void vlseg4e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x61006007, vm, 0, rs1, vd); }
+void vlseg5e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x81006007, vm, 0, rs1, vd); }
+void vlseg6e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa1006007, vm, 0, rs1, vd); }
+void vlseg7e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc1006007, vm, 0, rs1, vd); }
+void vlseg8e32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe1006007, vm, 0, rs1, vd); }
+void vle32ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1006007, vm, 0, rs1, vd); }
+void vlseg1e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10006007, vm, 0, rs1, vd); }
+void vlseg2e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x30006007, vm, 0, rs1, vd); }
+void vlseg3e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x50006007, vm, 0, rs1, vd); }
+void vlseg4e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x70006007, vm, 0, rs1, vd); }
+void vlseg5e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x90006007, vm, 0, rs1, vd); }
+void vlseg6e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb0006007, vm, 0, rs1, vd); }
+void vlseg7e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd0006007, vm, 0, rs1, vd); }
+void vlseg8e512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf0006007, vm, 0, rs1, vd); }
+void vle512_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x10006007, vm, 0, rs1, vd); }
+void vlseg1e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11006007, vm, 0, rs1, vd); }
+void vlseg2e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x31006007, vm, 0, rs1, vd); }
+void vlseg3e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x51006007, vm, 0, rs1, vd); }
+void vlseg4e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x71006007, vm, 0, rs1, vd); }
+void vlseg5e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x91006007, vm, 0, rs1, vd); }
+void vlseg6e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xb1006007, vm, 0, rs1, vd); }
+void vlseg7e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xd1006007, vm, 0, rs1, vd); }
+void vlseg8e512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xf1006007, vm, 0, rs1, vd); }
+void vle512ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x11006007, vm, 0, rs1, vd); }
+void vlseg1e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x7007, vm, 0, rs1, vd); }
+void vlseg2e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x20007007, vm, 0, rs1, vd); }
+void vlseg3e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x40007007, vm, 0, rs1, vd); }
+void vlseg4e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x60007007, vm, 0, rs1, vd); }
+void vlseg5e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x80007007, vm, 0, rs1, vd); }
+void vlseg6e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa0007007, vm, 0, rs1, vd); }
+void vlseg7e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc0007007, vm, 0, rs1, vd); }
+void vlseg8e64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe0007007, vm, 0, rs1, vd); }
+void vle64_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x7007, vm, 0, rs1, vd); }
+void vlseg1e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1007007, vm, 0, rs1, vd); }
+void vlseg2e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x21007007, vm, 0, rs1, vd); }
+void vlseg3e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x41007007, vm, 0, rs1, vd); }
+void vlseg4e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x61007007, vm, 0, rs1, vd); }
+void vlseg5e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x81007007, vm, 0, rs1, vd); }
+void vlseg6e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa1007007, vm, 0, rs1, vd); }
+void vlseg7e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc1007007, vm, 0, rs1, vd); }
+void vlseg8e64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe1007007, vm, 0, rs1, vd); }
+void vle64ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1007007, vm, 0, rs1, vd); }
+void vlseg1e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x7, vm, 0, rs1, vd); }
+void vlseg2e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x20000007, vm, 0, rs1, vd); }
+void vlseg3e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x40000007, vm, 0, rs1, vd); }
+void vlseg4e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x60000007, vm, 0, rs1, vd); }
+void vlseg5e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x80000007, vm, 0, rs1, vd); }
+void vlseg6e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa0000007, vm, 0, rs1, vd); }
+void vlseg7e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc0000007, vm, 0, rs1, vd); }
+void vlseg8e8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe0000007, vm, 0, rs1, vd); }
+void vle8_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x7, vm, 0, rs1, vd); }
+void vlseg1e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1000007, vm, 0, rs1, vd); }
+void vlseg2e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x21000007, vm, 0, rs1, vd); }
+void vlseg3e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x41000007, vm, 0, rs1, vd); }
+void vlseg4e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x61000007, vm, 0, rs1, vd); }
+void vlseg5e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x81000007, vm, 0, rs1, vd); }
+void vlseg6e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xa1000007, vm, 0, rs1, vd); }
+void vlseg7e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xc1000007, vm, 0, rs1, vd); }
+void vlseg8e8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0xe1000007, vm, 0, rs1, vd); }
+void vle8ff_v(const VReg& vd, const Reg& rs1, VM vm=VM::unmasked) { opVectorLoad(0x1000007, vm, 0, rs1, vd); }
+void vlm_v(const VReg& vd, const Reg& rs1) { opVectorLoad(0x2b00007, 0, 0, rs1, vd); }
+void vloxei1024_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x1c007007, vm, vs2, rs1, vd); }
+void vloxei128_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x1c000007, vm, vs2, rs1, vd); }
+void vloxei16_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0xc005007, vm, vs2, rs1, vd); }
+void vloxei256_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x1c005007, vm, vs2, rs1, vd); }
+void vloxei32_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0xc006007, vm, vs2, rs1, vd); }
+void vloxei512_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x1c006007, vm, vs2, rs1, vd); }
+void vloxei64_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0xc007007, vm, vs2, rs1, vd); }
+void vloxei8_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0xc000007, vm, vs2, rs1, vd); }
+void vlsseg1e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18007007, vm, rs2, rs1, vd); }
+void vlsseg2e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x38007007, vm, rs2, rs1, vd); }
+void vlsseg3e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x58007007, vm, rs2, rs1, vd); }
+void vlsseg4e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x78007007, vm, rs2, rs1, vd); }
+void vlsseg5e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x98007007, vm, rs2, rs1, vd); }
+void vlsseg6e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xb8007007, vm, rs2, rs1, vd); }
+void vlsseg7e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xd8007007, vm, rs2, rs1, vd); }
+void vlsseg8e1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xf8007007, vm, rs2, rs1, vd); }
+void vlse1024_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18007007, vm, rs2, rs1, vd); }
+void vlsseg1e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18000007, vm, rs2, rs1, vd); }
+void vlsseg2e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x38000007, vm, rs2, rs1, vd); }
+void vlsseg3e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x58000007, vm, rs2, rs1, vd); }
+void vlsseg4e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x78000007, vm, rs2, rs1, vd); }
+void vlsseg5e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x98000007, vm, rs2, rs1, vd); }
+void vlsseg6e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xb8000007, vm, rs2, rs1, vd); }
+void vlsseg7e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xd8000007, vm, rs2, rs1, vd); }
+void vlsseg8e128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xf8000007, vm, rs2, rs1, vd); }
+void vlse128_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18000007, vm, rs2, rs1, vd); }
+void vlsseg1e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8005007, vm, rs2, rs1, vd); }
+void vlsseg2e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x28005007, vm, rs2, rs1, vd); }
+void vlsseg3e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x48005007, vm, rs2, rs1, vd); }
+void vlsseg4e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x68005007, vm, rs2, rs1, vd); }
+void vlsseg5e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x88005007, vm, rs2, rs1, vd); }
+void vlsseg6e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xa8005007, vm, rs2, rs1, vd); }
+void vlsseg7e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xc8005007, vm, rs2, rs1, vd); }
+void vlsseg8e16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xe8005007, vm, rs2, rs1, vd); }
+void vlse16_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8005007, vm, rs2, rs1, vd); }
+void vlsseg1e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18005007, vm, rs2, rs1, vd); }
+void vlsseg2e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x38005007, vm, rs2, rs1, vd); }
+void vlsseg3e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x58005007, vm, rs2, rs1, vd); }
+void vlsseg4e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x78005007, vm, rs2, rs1, vd); }
+void vlsseg5e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x98005007, vm, rs2, rs1, vd); }
+void vlsseg6e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xb8005007, vm, rs2, rs1, vd); }
+void vlsseg7e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xd8005007, vm, rs2, rs1, vd); }
+void vlsseg8e256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xf8005007, vm, rs2, rs1, vd); }
+void vlse256_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18005007, vm, rs2, rs1, vd); }
+void vlsseg1e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8006007, vm, rs2, rs1, vd); }
+void vlsseg2e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x28006007, vm, rs2, rs1, vd); }
+void vlsseg3e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x48006007, vm, rs2, rs1, vd); }
+void vlsseg4e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x68006007, vm, rs2, rs1, vd); }
+void vlsseg5e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x88006007, vm, rs2, rs1, vd); }
+void vlsseg6e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xa8006007, vm, rs2, rs1, vd); }
+void vlsseg7e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xc8006007, vm, rs2, rs1, vd); }
+void vlsseg8e32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xe8006007, vm, rs2, rs1, vd); }
+void vlse32_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8006007, vm, rs2, rs1, vd); }
+void vlsseg1e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18006007, vm, rs2, rs1, vd); }
+void vlsseg2e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x38006007, vm, rs2, rs1, vd); }
+void vlsseg3e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x58006007, vm, rs2, rs1, vd); }
+void vlsseg4e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x78006007, vm, rs2, rs1, vd); }
+void vlsseg5e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x98006007, vm, rs2, rs1, vd); }
+void vlsseg6e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xb8006007, vm, rs2, rs1, vd); }
+void vlsseg7e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xd8006007, vm, rs2, rs1, vd); }
+void vlsseg8e512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xf8006007, vm, rs2, rs1, vd); }
+void vlse512_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x18006007, vm, rs2, rs1, vd); }
+void vlsseg1e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8007007, vm, rs2, rs1, vd); }
+void vlsseg2e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x28007007, vm, rs2, rs1, vd); }
+void vlsseg3e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x48007007, vm, rs2, rs1, vd); }
+void vlsseg4e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x68007007, vm, rs2, rs1, vd); }
+void vlsseg5e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x88007007, vm, rs2, rs1, vd); }
+void vlsseg6e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xa8007007, vm, rs2, rs1, vd); }
+void vlsseg7e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xc8007007, vm, rs2, rs1, vd); }
+void vlsseg8e64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xe8007007, vm, rs2, rs1, vd); }
+void vlse64_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8007007, vm, rs2, rs1, vd); }
+void vlsseg1e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8000007, vm, rs2, rs1, vd); }
+void vlsseg2e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x28000007, vm, rs2, rs1, vd); }
+void vlsseg3e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x48000007, vm, rs2, rs1, vd); }
+void vlsseg4e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x68000007, vm, rs2, rs1, vd); }
+void vlsseg5e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x88000007, vm, rs2, rs1, vd); }
+void vlsseg6e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xa8000007, vm, rs2, rs1, vd); }
+void vlsseg7e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xc8000007, vm, rs2, rs1, vd); }
+void vlsseg8e8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0xe8000007, vm, rs2, rs1, vd); }
+void vlse8_v(const VReg& vd, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorLoad(0x8000007, vm, rs2, rs1, vd); }
+void vluxei1024_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x14007007, vm, vs2, rs1, vd); }
+void vluxei128_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x14000007, vm, vs2, rs1, vd); }
+void vluxei16_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x4005007, vm, vs2, rs1, vd); }
+void vluxei256_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x14005007, vm, vs2, rs1, vd); }
+void vluxei32_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x4006007, vm, vs2, rs1, vd); }
+void vluxei512_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x14006007, vm, vs2, rs1, vd); }
+void vluxei64_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x4007007, vm, vs2, rs1, vd); }
+void vluxei8_v(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorLoad(0x4000007, vm, vs2, rs1, vd); }
+void vmacc_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0xb4002057, vm, vs2, vs1, vd); }
+void vmacc_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xb4006057, vm, vs2, rs1, vd); }
+void vmadc_vi(const VReg& vd, const VReg& vs2, int32_t simm5) { opIVI(0x46003057, 0, vs2, simm5, vd); }
+void vmadc_vim(const VReg& vd, const VReg& vs2, int32_t simm5) { opIVI(0x44003057, 0, vs2, simm5, vd); }
+void vmadc_vv(const VReg& vd, const VReg& vs2, const VReg& vs1) { opIVV(0x46000057, 0, vs2, vs1, vd); }
+void vmadc_vvm(const VReg& vd, const VReg& vs2, const VReg& vs1) { opIVV(0x44000057, 0, vs2, vs1, vd); }
+void vmadc_vx(const VReg& vd, const VReg& vs2, const Reg& rs1) { opIVX(0x46004057, 0, vs2, rs1, vd); }
+void vmadc_vxm(const VReg& vd, const VReg& vs2, const Reg& rs1) { opIVX(0x44004057, 0, vs2, rs1, vd); }
+void vmadd_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0xa4002057, vm, vs2, vs1, vd); }
+void vmadd_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xa4006057, vm, vs2, rs1, vd); }
+void vmand_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x64002057, vm, vs2, vs1, vd); }
+void vmandn_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x60002057, vm, vs2, vs1, vd); }
+void vmax_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x1c000057, vm, vs2, vs1, vd); }
+void vmax_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x1c004057, vm, vs2, rs1, vd); }
+void vmaxu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x18000057, vm, vs2, vs1, vd); }
+void vmaxu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x18004057, vm, vs2, rs1, vd); }
+void vmerge_vim(const VReg& vd, const VReg& vs2, int32_t simm5) { opIVI(0x5c003057, 0, vs2, simm5, vd); }
+void vmerge_vvm(const VReg& vd, const VReg& vs2, const VReg& vs1) { opIVV(0x5c000057, 0, vs2, vs1, vd); }
+void vmerge_vxm(const VReg& vd, const VReg& vs2, const Reg& rs1) { opIVX(0x5c004057, 0, vs2, rs1, vd); }
+void vmfeq_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x60005057, vm, vs2, rs1, vd); }
+void vmfeq_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x60001057, vm, vs2, vs1, vd); }
+void vmfge_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x7c005057, vm, vs2, rs1, vd); }
+void vmfgt_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x74005057, vm, vs2, rs1, vd); }
+void vmfle_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x64005057, vm, vs2, rs1, vd); }
+void vmfle_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x64001057, vm, vs2, vs1, vd); }
+void vmflt_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x6c005057, vm, vs2, rs1, vd); }
+void vmflt_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x6c001057, vm, vs2, vs1, vd); }
+void vmfne_vf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0x70005057, vm, vs2, rs1, vd); }
+void vmfne_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0x70001057, vm, vs2, vs1, vd); }
+void vmin_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x14000057, vm, vs2, vs1, vd); }
+void vmin_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x14004057, vm, vs2, rs1, vd); }
+void vminu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x10000057, vm, vs2, vs1, vd); }
+void vminu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x10004057, vm, vs2, rs1, vd); }
+void vmnand_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x74002057, vm, vs2, vs1, vd); }
+void vmnor_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x78002057, vm, vs2, vs1, vd); }
+void vmor_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x68002057, vm, vs2, vs1, vd); }
+void vmorn_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x70002057, vm, vs2, vs1, vd); }
+void vmsbc_vv(const VReg& vd, const VReg& vs2, const VReg& vs1) { opIVV(0x4e000057, 0, vs2, vs1, vd); }
+void vmsbc_vvm(const VReg& vd, const VReg& vs2, const VReg& vs1) { opIVV(0x4c000057, 0, vs2, vs1, vd); }
+void vmsbc_vx(const VReg& vd, const VReg& vs2, const Reg& rs1) { opIVX(0x4e004057, 0, vs2, rs1, vd); }
+void vmsbc_vxm(const VReg& vd, const VReg& vs2, const Reg& rs1) { opIVX(0x4c004057, 0, vs2, rs1, vd); }
+void vmsbf_m(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x5000a057, vm, vs2, 0, vd); }
+void vmseq_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x60003057, vm, vs2, simm5, vd); }
+void vmseq_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x60000057, vm, vs2, vs1, vd); }
+void vmseq_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x60004057, vm, vs2, rs1, vd); }
+void vmsgt_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x7c003057, vm, vs2, simm5, vd); }
+void vmsgt_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x7c004057, vm, vs2, rs1, vd); }
+void vmsgtu_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x78003057, vm, vs2, simm5, vd); }
+void vmsgtu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x78004057, vm, vs2, rs1, vd); }
+void vmsif_m(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x5001a057, vm, vs2, 0, vd); }
+void vmsle_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x74003057, vm, vs2, simm5, vd); }
+void vmsle_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x74000057, vm, vs2, vs1, vd); }
+void vmsle_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x74004057, vm, vs2, rs1, vd); }
+void vmsleu_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x70003057, vm, vs2, simm5, vd); }
+void vmsleu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x70000057, vm, vs2, vs1, vd); }
+void vmsleu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x70004057, vm, vs2, rs1, vd); }
+void vmslt_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x6c000057, vm, vs2, vs1, vd); }
+void vmslt_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x6c004057, vm, vs2, rs1, vd); }
+void vmsltu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x68000057, vm, vs2, vs1, vd); }
+void vmsltu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x68004057, vm, vs2, rs1, vd); }
+void vmsne_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x64003057, vm, vs2, simm5, vd); }
+void vmsne_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x64000057, vm, vs2, vs1, vd); }
+void vmsne_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x64004057, vm, vs2, rs1, vd); }
+void vmsof_m(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x50012057, vm, vs2, 0, vd); }
+void vmul_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x94002057, vm, vs2, vs1, vd); }
+void vmul_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x94006057, vm, vs2, rs1, vd); }
+void vmulh_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x9c002057, vm, vs2, vs1, vd); }
+void vmulh_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x9c006057, vm, vs2, rs1, vd); }
+void vmulhsu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x98002057, vm, vs2, vs1, vd); }
+void vmulhsu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x98006057, vm, vs2, rs1, vd); }
+void vmulhu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x90002057, vm, vs2, vs1, vd); }
+void vmulhu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x90006057, vm, vs2, rs1, vd); }
+void vmv1r_v(const VReg& vd, const VReg& vs2) { opIVI(0x9e003057, 0, vs2, 0, vd); }
+void vmv2r_v(const VReg& vd, const VReg& vs2) { opIVI(0x9e00b057, 0, vs2, 0, vd); }
+void vmv4r_v(const VReg& vd, const VReg& vs2) { opIVI(0x9e01b057, 0, vs2, 0, vd); }
+void vmv8r_v(const VReg& vd, const VReg& vs2) { opIVI(0x9e03b057, 0, vs2, 0, vd); }
+void vmv_s_x(const VReg& vd, const Reg& rs1) { opMVX(0x42006057, 0, 0, rs1, vd); }
+void vmv_v_i(const VReg& vd, int32_t simm5) { opIVI(0x5e003057, 0, 0, simm5, vd); }
+void vmv_v_v(const VReg& vd, const VReg& vs1) { opIVV(0x5e000057, 0, 0, vs1, vd); }
+void vmv_v_x(const VReg& vd, const Reg& rs1) { opIVX(0x5e004057, 0, 0, rs1, vd); }
+void vmv_x_s(const Reg& rd, const VReg& vs2) { opMVV(0x42002057, 0, vs2, 0, rd); }
+void vmxnor_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x7c002057, vm, vs2, vs1, vd); }
+void vmxor_mm(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x6c002057, vm, vs2, vs1, vd); }
+void vnclip_wi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xbc003057, vm, vs2, simm5, vd); }
+void vnclip_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xbc000057, vm, vs2, vs1, vd); }
+void vnclip_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xbc004057, vm, vs2, rs1, vd); }
+void vnclipu_wi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xb8003057, vm, vs2, simm5, vd); }
+void vnclipu_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xb8000057, vm, vs2, vs1, vd); }
+void vnclipu_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xb8004057, vm, vs2, rs1, vd); }
+void vnmsac_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0xbc002057, vm, vs2, vs1, vd); }
+void vnmsac_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xbc006057, vm, vs2, rs1, vd); }
+void vnmsub_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0xac002057, vm, vs2, vs1, vd); }
+void vnmsub_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xac006057, vm, vs2, rs1, vd); }
+void vnsra_wi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xb4003057, vm, vs2, simm5, vd); }
+void vnsra_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xb4000057, vm, vs2, vs1, vd); }
+void vnsra_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xb4004057, vm, vs2, rs1, vd); }
+void vnsrl_wi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xb0003057, vm, vs2, simm5, vd); }
+void vnsrl_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xb0000057, vm, vs2, vs1, vd); }
+void vnsrl_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xb0004057, vm, vs2, rs1, vd); }
+void vor_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x28003057, vm, vs2, simm5, vd); }
+void vor_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x28000057, vm, vs2, vs1, vd); }
+void vor_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x28004057, vm, vs2, rs1, vd); }
+void vredand_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x4002057, vm, vs2, vs1, vd); }
+void vredmax_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x1c002057, vm, vs2, vs1, vd); }
+void vredmaxu_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x18002057, vm, vs2, vs1, vd); }
+void vredmin_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x14002057, vm, vs2, vs1, vd); }
+void vredminu_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x10002057, vm, vs2, vs1, vd); }
+void vredor_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x8002057, vm, vs2, vs1, vd); }
+void vredsum_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x2057, vm, vs2, vs1, vd); }
+void vredxor_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xc002057, vm, vs2, vs1, vd); }
+void vrem_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x8c002057, vm, vs2, vs1, vd); }
+void vrem_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x8c006057, vm, vs2, rs1, vd); }
+void vremu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0x88002057, vm, vs2, vs1, vd); }
+void vremu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x88006057, vm, vs2, rs1, vd); }
+void vrgather_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x30003057, vm, vs2, simm5, vd); }
+void vrgather_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x30000057, vm, vs2, vs1, vd); }
+void vrgather_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x30004057, vm, vs2, rs1, vd); }
+void vrgatherei16_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x38000057, vm, vs2, vs1, vd); }
+void vrsub_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xc003057, vm, vs2, simm5, vd); }
+void vrsub_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xc004057, vm, vs2, rs1, vd); }
+void vs1r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
+void vs2r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
+void vs4r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
+void vs8r_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2800027, 0, 0, rs1, vs3); }
+void vsadd_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x84003057, vm, vs2, simm5, vd); }
+void vsadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x84000057, vm, vs2, vs1, vd); }
+void vsadd_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x84004057, vm, vs2, rs1, vd); }
+void vsaddu_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x80003057, vm, vs2, simm5, vd); }
+void vsaddu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x80000057, vm, vs2, vs1, vd); }
+void vsaddu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x80004057, vm, vs2, rs1, vd); }
+void vsbc_vvm(const VReg& vd, const VReg& vs2, const VReg& vs1) { opIVV(0x48000057, 0, vs2, vs1, vd); }
+void vsbc_vxm(const VReg& vd, const VReg& vs2, const Reg& rs1) { opIVX(0x48004057, 0, vs2, rs1, vd); }
+void vsseg1e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10007027, vm, 0, rs1, vs3); }
+void vsseg2e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x30007027, vm, 0, rs1, vs3); }
+void vsseg3e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x50007027, vm, 0, rs1, vs3); }
+void vsseg4e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x70007027, vm, 0, rs1, vs3); }
+void vsseg5e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x90007027, vm, 0, rs1, vs3); }
+void vsseg6e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xb0007027, vm, 0, rs1, vs3); }
+void vsseg7e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xd0007027, vm, 0, rs1, vs3); }
+void vsseg8e1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xf0007027, vm, 0, rs1, vs3); }
+void vse1024_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10007027, vm, 0, rs1, vs3); }
+void vsseg1e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10000027, vm, 0, rs1, vs3); }
+void vsseg2e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x30000027, vm, 0, rs1, vs3); }
+void vsseg3e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x50000027, vm, 0, rs1, vs3); }
+void vsseg4e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x70000027, vm, 0, rs1, vs3); }
+void vsseg5e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x90000027, vm, 0, rs1, vs3); }
+void vsseg6e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xb0000027, vm, 0, rs1, vs3); }
+void vsseg7e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xd0000027, vm, 0, rs1, vs3); }
+void vsseg8e128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xf0000027, vm, 0, rs1, vs3); }
+void vse128_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10000027, vm, 0, rs1, vs3); }
+void vsseg1e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x5027, vm, 0, rs1, vs3); }
+void vsseg2e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x20005027, vm, 0, rs1, vs3); }
+void vsseg3e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x40005027, vm, 0, rs1, vs3); }
+void vsseg4e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x60005027, vm, 0, rs1, vs3); }
+void vsseg5e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x80005027, vm, 0, rs1, vs3); }
+void vsseg6e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xa0005027, vm, 0, rs1, vs3); }
+void vsseg7e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xc0005027, vm, 0, rs1, vs3); }
+void vsseg8e16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xe0005027, vm, 0, rs1, vs3); }
+void vse16_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x5027, vm, 0, rs1, vs3); }
+void vsseg1e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10005027, vm, 0, rs1, vs3); }
+void vsseg2e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x30005027, vm, 0, rs1, vs3); }
+void vsseg3e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x50005027, vm, 0, rs1, vs3); }
+void vsseg4e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x70005027, vm, 0, rs1, vs3); }
+void vsseg5e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x90005027, vm, 0, rs1, vs3); }
+void vsseg6e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xb0005027, vm, 0, rs1, vs3); }
+void vsseg7e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xd0005027, vm, 0, rs1, vs3); }
+void vsseg8e256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xf0005027, vm, 0, rs1, vs3); }
+void vse256_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10005027, vm, 0, rs1, vs3); }
+void vsseg1e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x6027, vm, 0, rs1, vs3); }
+void vsseg2e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x20006027, vm, 0, rs1, vs3); }
+void vsseg3e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x40006027, vm, 0, rs1, vs3); }
+void vsseg4e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x60006027, vm, 0, rs1, vs3); }
+void vsseg5e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x80006027, vm, 0, rs1, vs3); }
+void vsseg6e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xa0006027, vm, 0, rs1, vs3); }
+void vsseg7e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xc0006027, vm, 0, rs1, vs3); }
+void vsseg8e32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xe0006027, vm, 0, rs1, vs3); }
+void vse32_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x6027, vm, 0, rs1, vs3); }
+void vsseg1e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10006027, vm, 0, rs1, vs3); }
+void vsseg2e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x30006027, vm, 0, rs1, vs3); }
+void vsseg3e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x50006027, vm, 0, rs1, vs3); }
+void vsseg4e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x70006027, vm, 0, rs1, vs3); }
+void vsseg5e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x90006027, vm, 0, rs1, vs3); }
+void vsseg6e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xb0006027, vm, 0, rs1, vs3); }
+void vsseg7e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xd0006027, vm, 0, rs1, vs3); }
+void vsseg8e512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xf0006027, vm, 0, rs1, vs3); }
+void vse512_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x10006027, vm, 0, rs1, vs3); }
+void vsseg1e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x7027, vm, 0, rs1, vs3); }
+void vsseg2e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x20007027, vm, 0, rs1, vs3); }
+void vsseg3e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x40007027, vm, 0, rs1, vs3); }
+void vsseg4e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x60007027, vm, 0, rs1, vs3); }
+void vsseg5e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x80007027, vm, 0, rs1, vs3); }
+void vsseg6e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xa0007027, vm, 0, rs1, vs3); }
+void vsseg7e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xc0007027, vm, 0, rs1, vs3); }
+void vsseg8e64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xe0007027, vm, 0, rs1, vs3); }
+void vse64_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x7027, vm, 0, rs1, vs3); }
+void vsseg1e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x27, vm, 0, rs1, vs3); }
+void vsseg2e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x20000027, vm, 0, rs1, vs3); }
+void vsseg3e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x40000027, vm, 0, rs1, vs3); }
+void vsseg4e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x60000027, vm, 0, rs1, vs3); }
+void vsseg5e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x80000027, vm, 0, rs1, vs3); }
+void vsseg6e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xa0000027, vm, 0, rs1, vs3); }
+void vsseg7e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xc0000027, vm, 0, rs1, vs3); }
+void vsseg8e8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0xe0000027, vm, 0, rs1, vs3); }
+void vse8_v(VReg vs3, const Reg& rs1, VM vm=VM::unmasked) { opVectorStore(0x27, vm, 0, rs1, vs3); }
+void vsext_vf2(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x4803a057, vm, vs2, 0, vd); }
+void vsext_vf4(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x4802a057, vm, vs2, 0, vd); }
+void vsext_vf8(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x4801a057, vm, vs2, 0, vd); }
+void vslide1down_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x3c006057, vm, vs2, rs1, vd); }
+void vslide1up_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0x38006057, vm, vs2, rs1, vd); }
+void vslidedown_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x3c003057, vm, vs2, simm5, vd); }
+void vslidedown_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x3c004057, vm, vs2, rs1, vd); }
+void vslideup_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x38003057, vm, vs2, simm5, vd); }
+void vslideup_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x38004057, vm, vs2, rs1, vd); }
+void vsll_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x94003057, vm, vs2, simm5, vd); }
+void vsll_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x94000057, vm, vs2, vs1, vd); }
+void vsll_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x94004057, vm, vs2, rs1, vd); }
+void vsm_v(VReg vs3, const Reg& rs1) { opVectorStore(0x2b00027, 0, 0, rs1, vs3); }
+void vsmul_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x9c000057, vm, vs2, vs1, vd); }
+void vsmul_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x9c004057, vm, vs2, rs1, vd); }
+void vsoxei1024_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x1c007027, vm, vs2, rs1, vs3); }
+void vsoxei128_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x1c000027, vm, vs2, rs1, vs3); }
+void vsoxei16_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0xc005027, vm, vs2, rs1, vs3); }
+void vsoxei256_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x1c005027, vm, vs2, rs1, vs3); }
+void vsoxei32_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0xc006027, vm, vs2, rs1, vs3); }
+void vsoxei512_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x1c006027, vm, vs2, rs1, vs3); }
+void vsoxei64_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0xc007027, vm, vs2, rs1, vs3); }
+void vsoxei8_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0xc000027, vm, vs2, rs1, vs3); }
+void vsra_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xa4003057, vm, vs2, simm5, vd); }
+void vsra_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xa4000057, vm, vs2, vs1, vd); }
+void vsra_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xa4004057, vm, vs2, rs1, vd); }
+void vsrl_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xa0003057, vm, vs2, simm5, vd); }
+void vsrl_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xa0000057, vm, vs2, vs1, vd); }
+void vsrl_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xa0004057, vm, vs2, rs1, vd); }
+void vssseg1e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18007027, vm, rs2, rs1, vs3); }
+void vssseg2e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x38007027, vm, rs2, rs1, vs3); }
+void vssseg3e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x58007027, vm, rs2, rs1, vs3); }
+void vssseg4e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x78007027, vm, rs2, rs1, vs3); }
+void vssseg5e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x98007027, vm, rs2, rs1, vs3); }
+void vssseg6e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xb8007027, vm, rs2, rs1, vs3); }
+void vssseg7e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xd8007027, vm, rs2, rs1, vs3); }
+void vssseg8e1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xf8007027, vm, rs2, rs1, vs3); }
+void vsse1024_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18007027, vm, rs2, rs1, vs3); }
+void vssseg1e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18000027, vm, rs2, rs1, vs3); }
+void vssseg2e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x38000027, vm, rs2, rs1, vs3); }
+void vssseg3e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x58000027, vm, rs2, rs1, vs3); }
+void vssseg4e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x78000027, vm, rs2, rs1, vs3); }
+void vssseg5e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x98000027, vm, rs2, rs1, vs3); }
+void vssseg6e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xb8000027, vm, rs2, rs1, vs3); }
+void vssseg7e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xd8000027, vm, rs2, rs1, vs3); }
+void vssseg8e128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xf8000027, vm, rs2, rs1, vs3); }
+void vsse128_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18000027, vm, rs2, rs1, vs3); }
+void vssseg1e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8005027, vm, rs2, rs1, vs3); }
+void vssseg2e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x28005027, vm, rs2, rs1, vs3); }
+void vssseg3e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x48005027, vm, rs2, rs1, vs3); }
+void vssseg4e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x68005027, vm, rs2, rs1, vs3); }
+void vssseg5e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x88005027, vm, rs2, rs1, vs3); }
+void vssseg6e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xa8005027, vm, rs2, rs1, vs3); }
+void vssseg7e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xc8005027, vm, rs2, rs1, vs3); }
+void vssseg8e16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xe8005027, vm, rs2, rs1, vs3); }
+void vsse16_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8005027, vm, rs2, rs1, vs3); }
+void vssseg1e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18005027, vm, rs2, rs1, vs3); }
+void vssseg2e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x38005027, vm, rs2, rs1, vs3); }
+void vssseg3e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x58005027, vm, rs2, rs1, vs3); }
+void vssseg4e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x78005027, vm, rs2, rs1, vs3); }
+void vssseg5e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x98005027, vm, rs2, rs1, vs3); }
+void vssseg6e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xb8005027, vm, rs2, rs1, vs3); }
+void vssseg7e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xd8005027, vm, rs2, rs1, vs3); }
+void vssseg8e256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xf8005027, vm, rs2, rs1, vs3); }
+void vsse256_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18005027, vm, rs2, rs1, vs3); }
+void vssseg1e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8006027, vm, rs2, rs1, vs3); }
+void vssseg2e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x28006027, vm, rs2, rs1, vs3); }
+void vssseg3e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x48006027, vm, rs2, rs1, vs3); }
+void vssseg4e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x68006027, vm, rs2, rs1, vs3); }
+void vssseg5e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x88006027, vm, rs2, rs1, vs3); }
+void vssseg6e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xa8006027, vm, rs2, rs1, vs3); }
+void vssseg7e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xc8006027, vm, rs2, rs1, vs3); }
+void vssseg8e32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xe8006027, vm, rs2, rs1, vs3); }
+void vsse32_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8006027, vm, rs2, rs1, vs3); }
+void vssseg1e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18006027, vm, rs2, rs1, vs3); }
+void vssseg2e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x38006027, vm, rs2, rs1, vs3); }
+void vssseg3e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x58006027, vm, rs2, rs1, vs3); }
+void vssseg4e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x78006027, vm, rs2, rs1, vs3); }
+void vssseg5e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x98006027, vm, rs2, rs1, vs3); }
+void vssseg6e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xb8006027, vm, rs2, rs1, vs3); }
+void vssseg7e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xd8006027, vm, rs2, rs1, vs3); }
+void vssseg8e512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xf8006027, vm, rs2, rs1, vs3); }
+void vsse512_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x18006027, vm, rs2, rs1, vs3); }
+void vssseg1e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8007027, vm, rs2, rs1, vs3); }
+void vssseg2e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x28007027, vm, rs2, rs1, vs3); }
+void vssseg3e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x48007027, vm, rs2, rs1, vs3); }
+void vssseg4e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x68007027, vm, rs2, rs1, vs3); }
+void vssseg5e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x88007027, vm, rs2, rs1, vs3); }
+void vssseg6e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xa8007027, vm, rs2, rs1, vs3); }
+void vssseg7e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xc8007027, vm, rs2, rs1, vs3); }
+void vssseg8e64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xe8007027, vm, rs2, rs1, vs3); }
+void vsse64_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8007027, vm, rs2, rs1, vs3); }
+void vssseg1e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8000027, vm, rs2, rs1, vs3); }
+void vssseg2e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x28000027, vm, rs2, rs1, vs3); }
+void vssseg3e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x48000027, vm, rs2, rs1, vs3); }
+void vssseg4e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x68000027, vm, rs2, rs1, vs3); }
+void vssseg5e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x88000027, vm, rs2, rs1, vs3); }
+void vssseg6e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xa8000027, vm, rs2, rs1, vs3); }
+void vssseg7e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xc8000027, vm, rs2, rs1, vs3); }
+void vssseg8e8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0xe8000027, vm, rs2, rs1, vs3); }
+void vsse8_v(VReg vs3, const Reg& rs1, const Reg& rs2, VM vm=VM::unmasked) { opVectorStore(0x8000027, vm, rs2, rs1, vs3); }
+void vssra_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xac003057, vm, vs2, simm5, vd); }
+void vssra_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xac000057, vm, vs2, vs1, vd); }
+void vssra_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xac004057, vm, vs2, rs1, vd); }
+void vssrl_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0xa8003057, vm, vs2, simm5, vd); }
+void vssrl_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xa8000057, vm, vs2, vs1, vd); }
+void vssrl_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0xa8004057, vm, vs2, rs1, vd); }
+void vssub_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x8c000057, vm, vs2, vs1, vd); }
+void vssub_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x8c004057, vm, vs2, rs1, vd); }
+void vssubu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x88000057, vm, vs2, vs1, vd); }
+void vssubu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x88004057, vm, vs2, rs1, vd); }
+void vsub_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x8000057, vm, vs2, vs1, vd); }
+void vsub_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x8004057, vm, vs2, rs1, vd); }
+void vsuxei1024_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x14007027, vm, vs2, rs1, vs3); }
+void vsuxei128_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x14000027, vm, vs2, rs1, vs3); }
+void vsuxei16_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x4005027, vm, vs2, rs1, vs3); }
+void vsuxei256_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x14005027, vm, vs2, rs1, vs3); }
+void vsuxei32_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x4006027, vm, vs2, rs1, vs3); }
+void vsuxei512_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x14006027, vm, vs2, rs1, vs3); }
+void vsuxei64_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x4007027, vm, vs2, rs1, vs3); }
+void vsuxei8_v(VReg vs3, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opVectorStore(0x4000027, vm, vs2, rs1, vs3); }
+void vwadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xc4002057, vm, vs2, vs1, vd); }
+void vwadd_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xc4006057, vm, vs2, rs1, vd); }
+void vwadd_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xd4002057, vm, vs2, vs1, vd); }
+void vwadd_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xd4006057, vm, vs2, rs1, vd); }
+void vwaddu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xc0002057, vm, vs2, vs1, vd); }
+void vwaddu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xc0006057, vm, vs2, rs1, vd); }
+void vwaddu_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xd0002057, vm, vs2, vs1, vd); }
+void vwaddu_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xd0006057, vm, vs2, rs1, vd); }
+void vwmacc_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0xf4002057, vm, vs2, vs1, vd); }
+void vwmacc_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xf4006057, vm, vs2, rs1, vd); }
+void vwmaccsu_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0xfc002057, vm, vs2, vs1, vd); }
+void vwmaccsu_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xfc006057, vm, vs2, rs1, vd); }
+void vwmaccu_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0xf0002057, vm, vs2, vs1, vd); }
+void vwmaccu_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xf0006057, vm, vs2, rs1, vd); }
+void vwmaccus_vx(const VReg& vd, const Reg& rs1, const VReg& vs2, VM vm=VM::unmasked) { opMVX(0xf8006057, vm, vs2, rs1, vd); }
+void vwmul_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xec002057, vm, vs2, vs1, vd); }
+void vwmul_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xec006057, vm, vs2, rs1, vd); }
+void vwmulsu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xe8002057, vm, vs2, vs1, vd); }
+void vwmulsu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xe8006057, vm, vs2, rs1, vd); }
+void vwmulu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xe0002057, vm, vs2, vs1, vd); }
+void vwmulu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xe0006057, vm, vs2, rs1, vd); }
+void vwredsum_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xc4000057, vm, vs2, vs1, vd); }
+void vwredsumu_vs(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0xc0000057, vm, vs2, vs1, vd); }
+void vwsub_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xcc002057, vm, vs2, vs1, vd); }
+void vwsub_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xcc006057, vm, vs2, rs1, vd); }
+void vwsub_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xdc002057, vm, vs2, vs1, vd); }
+void vwsub_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xdc006057, vm, vs2, rs1, vd); }
+void vwsubu_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xc8002057, vm, vs2, vs1, vd); }
+void vwsubu_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xc8006057, vm, vs2, rs1, vd); }
+void vwsubu_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opMVV(0xd8002057, vm, vs2, vs1, vd); }
+void vwsubu_wx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opMVX(0xd8006057, vm, vs2, rs1, vd); }
+void vxor_vi(const VReg& vd, const VReg& vs2, int32_t simm5, VM vm=VM::unmasked) { opIVI(0x2c003057, vm, vs2, simm5, vd); }
+void vxor_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opIVV(0x2c000057, vm, vs2, vs1, vd); }
+void vxor_vx(const VReg& vd, const VReg& vs2, const Reg& rs1, VM vm=VM::unmasked) { opIVX(0x2c004057, vm, vs2, rs1, vd); }
+void vzext_vf2(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x48032057, vm, vs2, 0, vd); }
+void vzext_vf4(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x48022057, vm, vs2, 0, vd); }
+void vzext_vf8(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opMVV(0x48012057, vm, vs2, 0, vd); }
+
+void vsetivli(const Reg& rd, uint32_t uimm, SEW sew, LMUL lmul=LMUL::m1, VTA vta=VTA::tu, VMA vma=VMA::mu) {
+    uint32_t zimm = (static_cast<uint32_t>(vma)<<7) |
+                    (static_cast<uint32_t>(vta)<<6) |
+                    (static_cast<uint32_t>(sew)<<3) |
+                    (static_cast<uint32_t>(lmul));
+    uint32_t v = (0x3<<30) | (zimm<<20) | (uimm<<15) | (0x7<<12) | (rd.getIdx()<<7) | (0x57);
+    append4B(v);
+}
+
+void vsetvli(const Reg& rd, const Reg& rs1, SEW sew, LMUL lmul=LMUL::m1, VTA vta=VTA::tu, VMA vma=VMA::mu) {
+    uint32_t zimm = (static_cast<uint32_t>(vma)<<7) |
+                    (static_cast<uint32_t>(vta)<<6) |
+                    (static_cast<uint32_t>(sew)<<3) |
+                    (static_cast<uint32_t>(lmul));
+    uint32_t v = (0x0<<31) | (zimm<<20) | (rs1.getIdx()<<15) | (0x7<<12) | (rd.getIdx()<<7) | (0x57);
+    append4B(v);
+}
+
+void vsetvl(const Reg& rd, const Reg& rs1, const Reg& rs2) {
+    uint32_t v = (0x40<<25) | (rs2.getIdx()<<20) | (rs1.getIdx()<<15) | (0x7<<12) | (rd.getIdx()<<7) | (0x57);
+    append4B(v);
+}
+
+
+// Copy mask register
+void vmmv_m(const VReg& vd, const VReg& vs) { vmand_mm(vd, vs, vs); }
+// Clear mask register
+void vmclr_m(const VReg& vd) { vmxor_mm(vd, vd, vd); }
+// Set mask register
+void vmset_m(const VReg& vd) { vmxnor_mm(vd, vd, vd); }
+// Invert bits
+void vmnot_m(const VReg& vd, const VReg& vs) { vmnand_mm(vd, vs, vs); }
+
+
+// vector compare pseudoinstructions
+void vmfgt_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { vmflt_vv(vd, vs2, vs1, vm); }
+void vmfge_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { vmfle_vv(vd, vs2, vs1, vm); }
+
+// sign-related pseudoinstructions
+void vfabs_v(const VReg& vd, const VReg& vs, VM vm=VM::unmasked) { vfsgnjx_vv(vd, vs, vs, vm); }
+void vfneg_v(const VReg& vd, const VReg& vs, VM vm=VM::unmasked) { vfsgnjn_vv(vd, vs, vs, vm); }


### PR DESCRIPTION
# Description

According to @vpirogov's [comment](https://github.com/uxlfoundation/oneDNN/pull/4322#issuecomment-3582234666), we will first introduce `xbyak_riscv` and use it for detecting the `v` extension. For other extensions such as `zvfh`, since `xbyak_riscv` does not yet support them, we will retain the current detection approach.  

The modifications to `xbyak_riscv` have been merged upstream in [xbyak_riscv/pull/20](https://github.com/herumi/xbyak_riscv/pull/20).

I will subsequently optimize the detection mechanism in `xbyak_riscv` and synchronize the updates into oneDNN.