### PR TITLE
oneDNN v3.10.2 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.10.1")
+set(PROJECT_VERSION "3.10.2")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.10.1:
* Fixed a memory leak in Graph API related to host scalars use (044124555fbf17c37196e4a565d61c10d8640bfc)
* Fixed `f16` matmul performance regression with `int4` weights on Intel Arc graphics for Intel Core Ultra processors (Series 3) (789711cc8dc1b1e163ce74f289849150464395e1, a1602472f5ee3d62dc0b3394604b98b4290ceeb7)
* Fixed `bf16` matmul performance regression on Intel Xeon processors with Intel AMX instruction set support (c29ec26019da8bcd80b4e28ba33e5d47d0439333)
* Changed register allocation in BRGEMM kernel to avoid register conflicts and improve code safety (95d651be16384dea97e140ca579a9c79e5e3862d)
* Fixed a crash related to incorrect caching of `int8` convolution primitive on Intel GPUs (28ccca41846882ef741d53c8adf20ed25406c0df, 0bc8060b68a27d5f9ee00b160a83ff9b7010a154)
* Fixed a bug preventing correct detection of Intel AVX 10.2 instruction set on Intel Xeon processors (568171cbe245a06ae68bcf676476c12805d2468e)
