### PR TITLE
build: stop linking to debug TBB version on Linux

### DIFF
--- a/cmake/TBB.cmake
+++ b/cmake/TBB.cmake
@@ -25,7 +25,17 @@ include("cmake/Threading.cmake")
 
 macro(handle_tbb_target)
     if(TBB_FOUND)
-        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "DEBUG")
+        if(WIN32)
+            # On Windows we must link to debug version of TBB library to ensure ABI compatibility
+            # with MSVC debug runtime.
+            set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "DEBUG")
+        else()
+            # On Linux TBB::tbb target may link to libtbb_debug.so which is not compatible with libtbb.so. Linking
+            # application to both may result in undefined behavior.
+            # See https://uxlfoundation.github.io/oneTBB/main/intro/limitations.html#debug-tbb-in-the-sycl-program
+            set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "RELEASE")
+            set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_DEBUG" "RELEASE")
+        endif()
         include_directories_with_host_compiler(${_tbb_include_dirs})
         list(APPEND EXTRA_SHARED_LIBS TBB::tbb)
 

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -39,6 +39,17 @@ if(DNNL_CPU_THREADING_RUNTIME STREQUAL "TBB")
         # Reverting the CMAKE_MODULE_PATH to its original state
         set(CMAKE_MODULE_PATH ${DNNL_ORIGINAL_CMAKE_MODULE_PATH})
     endif()
+    if(WIN32)
+        # On Windows we must link to debug version of TBB library to ensure ABI compatibility
+        # with MSVC debug runtime.
+        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "DEBUG")
+    else()
+        # On Linux TBB::tbb target may link to libtbb_debug.so which is not compatible with libtbb.so. Linking
+        # application to both may result in undefined behavior.
+        # See https://uxlfoundation.github.io/oneTBB/main/intro/limitations.html#debug-tbb-in-the-sycl-program
+        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "RELEASE")
+        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_DEBUG" "RELEASE")
+    endif()
 endif()
 
 # Use a custom find module for transitive dependencies


### PR DESCRIPTION
Default CMake behavior results in debug oneDNN builds linking to libtbb_debug.so, which is incompatible with libtbb.so. This results in undefined behavior when application is linked to libtbb.so as well. In our case the conflict happens with SYCL runtime (libsycl.so), but it may happen in other scenarios when release TBB is linked to an application.

This PR forces build system to use release version of TBB independently of `CMAKE_BUILD_TYPE` value on Linux.

Fixes MFDNN-14437.
