### PR TITLE
governance: Add Marek Michalowski to onednn-devops

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -250,6 +250,7 @@ Team: @uxlfoundation/onednn-devops
 | Hamza Butt         | @theComputeKid        | Arm Ltd           | Code Owner |
 | Ryo Suzuki         | @Ryo-not-rio          | Arm Ltd           | Code Owner |
 | Siddhartha Menon   | @Sqvid                | Arm Ltd           | Code Owner |
+| Marek Michalowski  | @michalowski-arm      | Arm Ltd           | Code Owner |
 
 ### Release management
 


### PR DESCRIPTION
Marek has been a contributor to onednn for a year and a half and will be taking over the role of onednn ci maintainer moving forward. https://github.com/uxlfoundation/oneDNN/pulls?q=is%3Apr+author%3Amichalowski-arm
