### PR TITLE
xe: gemm: ignore type signing in kernel selection

### DIFF
--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -615,6 +615,7 @@ gen_nocopy_desc_t::select_kernel(compute::gpu_arch_t arch, int stepping,
     base.sizes.k = k;
     base.sizes.batch = batch;
     base.stepping = stepping;
+    base.ignoreCase = true;
 
     bool can_2d_a = (lda * problem_.Ta_ext <= 16777216);
     bool can_2d_b = (ldb * problem_.Tb_ext <= 16777216);


### PR DESCRIPTION
All kernels stored in the catalog use uppercase data types, which corresponds to signed data types. For problems with unsigned data types, we search the catalog and find nothing, then (as a fallback mechanic) enable `ignoreCase` which allows us to use catalog entries for signed data types despite the unsigned dt given to the selector.

The issue comes when mixing this behaviour with overrides like replacing `f` -> `[FO]` for some matches. Since this creates a match pattern with an uppercase data type, the first pass no longer returns nothing, searching instead for only `[FO]` kernels and ignoring `f` kernels. When we continue and enable `ignoreCase`, all kernels found are sorted after those found in the first pass, so they will essentially never be selected.

The fix is to just ignore the case from the start, and reduce the number of passes across the catalog.