### PR TITLE
fixup: build: stop linking to debug TBB version on Linux

### DIFF
--- a/cmake/TBB.cmake
+++ b/cmake/TBB.cmake
@@ -33,8 +33,8 @@ macro(handle_tbb_target)
             # On Linux TBB::tbb target may link to libtbb_debug.so which is not compatible with libtbb.so. Linking
             # application to both may result in undefined behavior.
             # See https://uxlfoundation.github.io/oneTBB/main/intro/limitations.html#debug-tbb-in-the-sycl-program
-            set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "RELEASE")
-            set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_DEBUG" "RELEASE")
+            set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "RELEASE" "NONE")
+            set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_DEBUG" "RELEASE" "NONE")
         endif()
         include_directories_with_host_compiler(${_tbb_include_dirs})
         list(APPEND EXTRA_SHARED_LIBS TBB::tbb)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -47,8 +47,8 @@ if(DNNL_CPU_THREADING_RUNTIME STREQUAL "TBB")
         # On Linux TBB::tbb target may link to libtbb_debug.so which is not compatible with libtbb.so. Linking
         # application to both may result in undefined behavior.
         # See https://uxlfoundation.github.io/oneTBB/main/intro/limitations.html#debug-tbb-in-the-sycl-program
-        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "RELEASE")
-        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_DEBUG" "RELEASE")
+        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_RELWITHMDD" "RELEASE" "NONE")
+        set_property(TARGET TBB::tbb PROPERTY "MAP_IMPORTED_CONFIG_DEBUG" "RELEASE" "NONE")
     endif()
 endif()
 


### PR DESCRIPTION
TBB native packages on Ubuntu define only CMake configuration 'NONE'. This leads to configuration step failure with changes from #4407:
```
CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION or IMPORTED_IMPLIB not set for imported target "TBB::tbb"
  configuration "Debug".
```

Fixup for #4407.
Fixes MFDNN-14453.
