### PR TITLE
all: update clang-format to v18 and apply changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,10 +24,11 @@ AlignEscapedNewlines: DontAlign
 AlignOperands:   false
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true
+AllowBreakBeforeNoexceptSpecifier : Never
+AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -47,6 +48,8 @@ BraceWrapping:
   AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
@@ -93,6 +96,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
+ReferenceAlignment: Pointer
 ReflowComments:  false
 SortIncludes:    true
 SortUsingDeclarations: true

--- a/.github/automation/clang-format.sh
+++ b/.github/automation/clang-format.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #===============================================================================
 
-CLANG_FORMAT=clang-format-11
+CLANG_FORMAT=clang-format-18
 
 echo "Checking ${CLANG_FORMAT}"
 if ! ${CLANG_FORMAT} --version; then

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -55,14 +55,14 @@ jobs:
 
   pr-clang-format:
     name: Clang-Format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
       - name: Install clang-format
-        run: sudo apt update && sudo apt install -y "clang-format-11"
+        run: sudo apt update && sudo apt install -y "clang-format-18"
       - name: Check code formatting
         run: .github/automation/clang-format.sh ${{ github.event.pull_request.base.sha }}
 

--- a/examples/graph/sycl_getting_started.cpp
+++ b/examples/graph/sycl_getting_started.cpp
@@ -254,9 +254,9 @@ void sycl_getting_started_tutorial(dnnl::engine::kind ekind) {
     //[Define sycl queue]
     sycl::queue q = (ekind == engine::kind::gpu)
             ? sycl::queue(
-                    sycl::gpu_selector_v, sycl::property::queue::in_order {})
+                      sycl::gpu_selector_v, sycl::property::queue::in_order {})
             : sycl::queue(
-                    sycl::cpu_selector_v, sycl::property::queue::in_order {});
+                      sycl::cpu_selector_v, sycl::property::queue::in_order {});
     //[Define sycl queue]
 
     /// Create a #dnnl::engine based on SYCL device and context. Also,

--- a/examples/primitives/convolution.cpp
+++ b/examples/primitives/convolution.cpp
@@ -127,7 +127,7 @@ void convolution_example(dnnl::engine::kind engine_kind) {
     auto user_bias_md = bias_dims.empty()
             ? memory::desc()
             : memory::desc(
-                    bias_dims, memory::data_type::f32, memory::format_tag::a);
+                      bias_dims, memory::data_type::f32, memory::format_tag::a);
     auto user_bias_mem = memory(user_bias_md, engine);
 
     // Write data to memory object's handle.

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -3261,7 +3261,7 @@ struct memory : public handle<dnnl_memory_t> {
                     get(), dnnl_query_sparse_encoding, 0, &sparse_encoding);
             return status == dnnl_success
                     ? static_cast<dnnl::memory::sparse_encoding>(
-                            sparse_encoding)
+                              sparse_encoding)
                     : dnnl::memory::sparse_encoding::undef;
         }
 
@@ -5663,8 +5663,8 @@ struct convolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, &bias_desc, dst_desc, strides, nullptr,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, &bias_desc, dst_desc, strides, nullptr,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution forward
         ///     propagation primitive without bias.
@@ -5709,8 +5709,8 @@ struct convolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, nullptr, dst_desc, strides, nullptr,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, nullptr, dst_desc, strides, nullptr,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution forward
         ///     propagation primitive with bias.
@@ -5760,8 +5760,8 @@ struct convolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, &bias_desc, dst_desc, strides, &dilates,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, &bias_desc, dst_desc, strides, &dilates,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution forward
         ///     propagation primitive without bias.
@@ -5808,8 +5808,8 @@ struct convolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, nullptr, dst_desc, strides, &dilates,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, nullptr, dst_desc, strides, &dilates,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution forward
         /// propagation primitive from a C API primitive descriptor that must
@@ -5819,8 +5819,8 @@ struct convolution_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::convolution,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -5958,8 +5958,8 @@ struct convolution_backward_data : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, diff_src_desc, weights_desc,
-                    diff_dst_desc, strides, nullptr, padding_l, padding_r,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      diff_dst_desc, strides, nullptr, padding_l, padding_r,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution backward
         ///     propagation primitive.
@@ -6008,8 +6008,8 @@ struct convolution_backward_data : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, diff_src_desc, weights_desc,
-                    diff_dst_desc, strides, &dilates, padding_l, padding_r,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      diff_dst_desc, strides, &dilates, padding_l, padding_r,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution backward
         /// propagation primitive from a C API primitive descriptor that must
@@ -6019,7 +6019,7 @@ struct convolution_backward_data : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::convolution,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
@@ -6155,8 +6155,8 @@ struct convolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    &diff_bias_desc, diff_dst_desc, strides, nullptr, padding_l,
-                    padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      &diff_bias_desc, diff_dst_desc, strides, nullptr,
+                      padding_l, padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution weights gradient
         ///     primitive without bias.
@@ -6202,8 +6202,8 @@ struct convolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    nullptr, diff_dst_desc, strides, nullptr, padding_l,
-                    padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      nullptr, diff_dst_desc, strides, nullptr, padding_l,
+                      padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution weights
         ///     gradient primitive with bias.
@@ -6255,8 +6255,8 @@ struct convolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    &diff_bias_desc, diff_dst_desc, strides, &dilates,
-                    padding_l, padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      &diff_bias_desc, diff_dst_desc, strides, &dilates,
+                      padding_l, padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution weights
         ///     gradient primitive without bias.
@@ -6305,8 +6305,8 @@ struct convolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    nullptr, diff_dst_desc, strides, &dilates, padding_l,
-                    padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      nullptr, diff_dst_desc, strides, &dilates, padding_l,
+                      padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a convolution weights gradient
         /// primitive from a C API primitive descriptor that must have a
@@ -6316,7 +6316,7 @@ struct convolution_backward_weights : public primitive {
         ///     gradient primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::convolution,
-                    dnnl::prop_kind::backward_weights) {}
+                      dnnl::prop_kind::backward_weights) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -6469,8 +6469,8 @@ struct deconvolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, &bias_desc, dst_desc, strides, nullptr,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, &bias_desc, dst_desc, strides, nullptr,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution forward
         ///     propagation primitive without bias.
@@ -6514,8 +6514,8 @@ struct deconvolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, nullptr, dst_desc, strides, nullptr,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, nullptr, dst_desc, strides, nullptr,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution forward
         ///     propagation primitive with bias.
@@ -6564,8 +6564,8 @@ struct deconvolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, &bias_desc, dst_desc, strides, &dilates,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, &bias_desc, dst_desc, strides, &dilates,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution forward
         ///     propagation primitive without bias.
@@ -6611,8 +6611,8 @@ struct deconvolution_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    weights_desc, nullptr, dst_desc, strides, &dilates,
-                    padding_l, padding_r, attr, allow_empty) {}
+                      weights_desc, nullptr, dst_desc, strides, &dilates,
+                      padding_l, padding_r, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution forward
         /// propagation primitive from a C API primitive descriptor that must
@@ -6622,8 +6622,8 @@ struct deconvolution_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::deconvolution,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -6757,8 +6757,8 @@ struct deconvolution_backward_data : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, diff_src_desc, weights_desc,
-                    diff_dst_desc, strides, nullptr, padding_l, padding_r,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      diff_dst_desc, strides, nullptr, padding_l, padding_r,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution backward
         ///     propagation primitive.
@@ -6806,8 +6806,8 @@ struct deconvolution_backward_data : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, diff_src_desc, weights_desc,
-                    diff_dst_desc, strides, &dilates, padding_l, padding_r,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      diff_dst_desc, strides, &dilates, padding_l, padding_r,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution backward
         /// propagation primitive from a C API primitive descriptor that must
@@ -6817,7 +6817,7 @@ struct deconvolution_backward_data : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::deconvolution,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
@@ -6952,8 +6952,8 @@ struct deconvolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    &diff_bias_desc, diff_dst_desc, strides, nullptr, padding_l,
-                    padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      &diff_bias_desc, diff_dst_desc, strides, nullptr,
+                      padding_l, padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution weights
         ///     gradient primitive without bias.
@@ -6998,8 +6998,8 @@ struct deconvolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    nullptr, diff_dst_desc, strides, nullptr, padding_l,
-                    padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      nullptr, diff_dst_desc, strides, nullptr, padding_l,
+                      padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution weights
         ///     gradient primitive with bias.
@@ -7050,8 +7050,8 @@ struct deconvolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    &diff_bias_desc, diff_dst_desc, strides, &dilates,
-                    padding_l, padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      &diff_bias_desc, diff_dst_desc, strides, &dilates,
+                      padding_l, padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution weights
         ///     gradient primitive without bias.
@@ -7099,8 +7099,8 @@ struct deconvolution_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
-                    nullptr, diff_dst_desc, strides, &dilates, padding_l,
-                    padding_r, hint_fwd_pd, attr, allow_empty) {}
+                      nullptr, diff_dst_desc, strides, &dilates, padding_l,
+                      padding_r, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a deconvolution weights
         /// gradient primitive from a C API primitive descriptor that must
@@ -7110,7 +7110,7 @@ struct deconvolution_backward_weights : public primitive {
         ///     gradient primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::deconvolution,
-                    dnnl::prop_kind::backward_weights) {}
+                      dnnl::prop_kind::backward_weights) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -7270,8 +7270,8 @@ struct lrn_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::lrn,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -7379,7 +7379,7 @@ struct lrn_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::lrn,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
@@ -7478,7 +7478,7 @@ struct eltwise_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    dst_desc, nullptr, nullptr, attr, allow_empty) {}
+                      dst_desc, nullptr, nullptr, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an elementwise forward
         ///     propagation primitive with an alpha parameter.
@@ -7504,7 +7504,7 @@ struct eltwise_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    dst_desc, &alpha, nullptr, attr, allow_empty) {}
+                      dst_desc, &alpha, nullptr, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an elementwise forward
         ///     propagation primitive with an alpha and beta parameters.
@@ -7532,7 +7532,7 @@ struct eltwise_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, src_desc,
-                    dst_desc, &alpha, &beta, attr, allow_empty) {}
+                      dst_desc, &alpha, &beta, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an eltwise forward
         /// propagation primitive from a C API primitive descriptor that must
@@ -7542,8 +7542,8 @@ struct eltwise_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::eltwise,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -7639,8 +7639,8 @@ struct eltwise_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, diff_src_desc, diff_dst_desc,
-                    data_desc, nullptr, nullptr, hint_fwd_pd, attr,
-                    allow_empty) {}
+                      data_desc, nullptr, nullptr, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an elementwise backward
         ///     propagation primitive with an alpha parameter.
@@ -7672,8 +7672,8 @@ struct eltwise_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, diff_src_desc, diff_dst_desc,
-                    data_desc, &alpha, nullptr, hint_fwd_pd, attr,
-                    allow_empty) {}
+                      data_desc, &alpha, nullptr, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an elementwise backward
         ///     propagation primitive with an alpha and beta parameters.
@@ -7707,7 +7707,8 @@ struct eltwise_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, diff_src_desc, diff_dst_desc,
-                    data_desc, &alpha, &beta, hint_fwd_pd, attr, allow_empty) {}
+                      data_desc, &alpha, &beta, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an eltwise backward
         /// propagation primitive from a C API primitive descriptor that must
@@ -7717,7 +7718,7 @@ struct eltwise_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::eltwise,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -7848,8 +7849,8 @@ struct softmax_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::softmax,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -7941,7 +7942,7 @@ struct softmax_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::softmax,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::dst_desc()const
         memory::desc dst_desc() const { return base::dst_desc(0); }
@@ -8062,9 +8063,9 @@ struct batch_normalization_forward : public primitive {
         ///     forward propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd,
-                    dnnl::primitive::kind::batch_normalization,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::primitive::kind::batch_normalization,
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -8193,9 +8194,9 @@ struct batch_normalization_backward : public primitive {
         ///     backward propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd,
-                    dnnl::primitive::kind::batch_normalization,
-                    dnnl::prop_kind::backward, dnnl::prop_kind::backward_data) {
-        }
+                      dnnl::primitive::kind::batch_normalization,
+                      dnnl::prop_kind::backward,
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -8341,9 +8342,9 @@ struct group_normalization_forward : public primitive {
         ///     forward propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd,
-                    dnnl::primitive::kind::group_normalization,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::primitive::kind::group_normalization,
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -8476,9 +8477,9 @@ struct group_normalization_backward : public primitive {
         ///     backward propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd,
-                    dnnl::primitive::kind::group_normalization,
-                    dnnl::prop_kind::backward, dnnl::prop_kind::backward_data) {
-        }
+                      dnnl::primitive::kind::group_normalization,
+                      dnnl::prop_kind::backward,
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -8601,8 +8602,8 @@ struct layer_normalization_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, src_desc, dst_desc,
-                    &stat_desc, memory::data_type::f32, epsilon, flags, attr,
-                    allow_empty) {}
+                      &stat_desc, memory::data_type::f32, epsilon, flags, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization forward
         /// propagation primitive.
@@ -8628,8 +8629,8 @@ struct layer_normalization_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, src_desc, dst_desc, nullptr,
-                    memory::data_type::f32, epsilon, flags, attr, allow_empty) {
-        }
+                      memory::data_type::f32, epsilon, flags, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization forward
         /// propagation primitive with a user-provided data type for the scale
@@ -8662,8 +8663,8 @@ struct layer_normalization_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, src_desc, dst_desc,
-                    &stat_desc, scale_shift_data_type, epsilon, flags, attr,
-                    allow_empty) {}
+                      &stat_desc, scale_shift_data_type, epsilon, flags, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization forward
         /// propagation primitive with a user-provided data type for the scale
@@ -8694,7 +8695,8 @@ struct layer_normalization_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, src_desc, dst_desc, nullptr,
-                    scale_shift_data_type, epsilon, flags, attr, allow_empty) {}
+                      scale_shift_data_type, epsilon, flags, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization
         /// forward propagation primitive from a C API primitive descriptor
@@ -8704,9 +8706,9 @@ struct layer_normalization_forward : public primitive {
         ///     forward propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd,
-                    dnnl::primitive::kind::layer_normalization,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::primitive::kind::layer_normalization,
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -8836,9 +8838,9 @@ struct layer_normalization_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, diff_src_desc, diff_dst_desc,
-                    src_desc, &stat_desc, memory::data_type::f32,
-                    memory::data_type::f32, epsilon, flags, hint_fwd_pd, attr,
-                    allow_empty) {}
+                      src_desc, &stat_desc, memory::data_type::f32,
+                      memory::data_type::f32, epsilon, flags, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization backward
         /// propagation primitive.
@@ -8870,9 +8872,9 @@ struct layer_normalization_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, diff_src_desc, diff_dst_desc,
-                    src_desc, nullptr, memory::data_type::f32,
-                    memory::data_type::f32, epsilon, flags, hint_fwd_pd, attr,
-                    allow_empty) {}
+                      src_desc, nullptr, memory::data_type::f32,
+                      memory::data_type::f32, epsilon, flags, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization backward
         /// propagation primitive with a user-provided data type for the scale
@@ -8915,9 +8917,9 @@ struct layer_normalization_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, diff_src_desc, diff_dst_desc,
-                    src_desc, &stat_desc, diff_scale_shift_data_type,
-                    scale_shift_data_type, epsilon, flags, hint_fwd_pd, attr,
-                    allow_empty) {}
+                      src_desc, &stat_desc, diff_scale_shift_data_type,
+                      scale_shift_data_type, epsilon, flags, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization backward
         /// propagation primitive with a user-provided data type for the scale
@@ -8958,9 +8960,9 @@ struct layer_normalization_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, diff_src_desc, diff_dst_desc,
-                    src_desc, nullptr, diff_scale_shift_data_type,
-                    scale_shift_data_type, epsilon, flags, hint_fwd_pd, attr,
-                    allow_empty) {}
+                      src_desc, nullptr, diff_scale_shift_data_type,
+                      scale_shift_data_type, epsilon, flags, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for a layer normalization
         /// backward propagation primitive from a C API primitive descriptor
@@ -8970,9 +8972,9 @@ struct layer_normalization_backward : public primitive {
         ///     backward propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd,
-                    dnnl::primitive::kind::layer_normalization,
-                    dnnl::prop_kind::backward, dnnl::prop_kind::backward_data) {
-        }
+                      dnnl::primitive::kind::layer_normalization,
+                      dnnl::prop_kind::backward,
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -9112,7 +9114,7 @@ struct inner_product_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, src_desc, weights_desc,
-                    &bias_desc, dst_desc, attr, allow_empty) {}
+                      &bias_desc, dst_desc, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an inner product forward
         /// propagation primitive.
@@ -9140,7 +9142,7 @@ struct inner_product_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, src_desc, weights_desc,
-                    nullptr, dst_desc, attr, allow_empty) {}
+                      nullptr, dst_desc, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an inner product forward
         /// propagation primitive from a C API primitive descriptor that must
@@ -9150,8 +9152,8 @@ struct inner_product_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::inner_product,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -9268,7 +9270,7 @@ struct inner_product_backward_data : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::inner_product,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
@@ -9337,8 +9339,8 @@ struct inner_product_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, src_desc, diff_weights_desc,
-                    &diff_bias_desc, diff_dst_desc, hint_fwd_pd, attr,
-                    allow_empty) {}
+                      &diff_bias_desc, diff_dst_desc, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an inner product weights
         /// update primitive.
@@ -9367,7 +9369,7 @@ struct inner_product_backward_weights : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, src_desc, diff_weights_desc, nullptr,
-                    diff_dst_desc, hint_fwd_pd, attr, allow_empty) {}
+                      diff_dst_desc, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an inner product weights
         /// update primitive from a C API primitive descriptor that must
@@ -9377,7 +9379,7 @@ struct inner_product_backward_weights : public primitive {
         ///     gradient primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::inner_product,
-                    dnnl::prop_kind::backward_weights) {}
+                      dnnl::prop_kind::backward_weights) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -10020,11 +10022,11 @@ struct vanilla_rnn_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_rnn,
-                    aprop_kind, activation, direction, src_layer_desc,
-                    src_iter_desc, nullptr, nullptr, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
-                    0.0f, 0.0f, attr, allow_empty) {}
+                      aprop_kind, activation, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
+                      0.0f, 0.0f, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a vanilla RNN forward
         ///     propagation primitive with alpha parameter.
@@ -10083,11 +10085,11 @@ struct vanilla_rnn_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_rnn,
-                    aprop_kind, activation, direction, src_layer_desc,
-                    src_iter_desc, nullptr, nullptr, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
-                    alpha, 0.0f, attr, allow_empty) {}
+                      aprop_kind, activation, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
+                      alpha, 0.0f, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a vanilla RNN forward
         /// propagation primitive from a C API primitive descriptor that must
@@ -10097,8 +10099,8 @@ struct vanilla_rnn_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference,
-                    dnnl::algorithm::vanilla_rnn) {}
+                      dnnl::prop_kind::forward_inference,
+                      dnnl::algorithm::vanilla_rnn) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -10258,15 +10260,15 @@ struct vanilla_rnn_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_rnn,
-                    aprop_kind, activation, direction, src_layer_desc,
-                    src_iter_desc, nullptr, nullptr, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, diff_src_layer_desc,
-                    diff_src_iter_desc, nullptr, nullptr,
-                    diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
-                    nullptr, diff_bias_desc, diff_dst_layer_desc,
-                    diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      aprop_kind, activation, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr,
+                      diff_src_layer_desc, diff_src_iter_desc, nullptr, nullptr,
+                      diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
+                      nullptr, diff_bias_desc, diff_dst_layer_desc,
+                      diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a vanilla RNN backward
         ///     propagation primitive with an alpha parameter.
@@ -10348,15 +10350,15 @@ struct vanilla_rnn_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_rnn,
-                    aprop_kind, activation, direction, src_layer_desc,
-                    src_iter_desc, nullptr, nullptr, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, diff_src_layer_desc,
-                    diff_src_iter_desc, nullptr, nullptr,
-                    diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
-                    nullptr, diff_bias_desc, diff_dst_layer_desc,
-                    diff_dst_iter_desc, nullptr, rnn_flags::undef, alpha, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      aprop_kind, activation, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr,
+                      diff_src_layer_desc, diff_src_iter_desc, nullptr, nullptr,
+                      diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
+                      nullptr, diff_bias_desc, diff_dst_layer_desc,
+                      diff_dst_iter_desc, nullptr, rnn_flags::undef, alpha,
+                      0.0f, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a vanilla RNN backward
         /// propagation primitive from a C API primitive descriptor that must
@@ -10366,7 +10368,7 @@ struct vanilla_rnn_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
-                    dnnl::algorithm::vanilla_rnn) {}
+                      dnnl::algorithm::vanilla_rnn) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -10553,12 +10555,13 @@ struct lstm_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_lstm,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, &src_iter_c_desc, nullptr,
-                    weights_layer_desc, weights_iter_desc,
-                    &weights_peephole_desc, &weights_projection_desc, bias_desc,
-                    dst_layer_desc, dst_iter_desc, &dst_iter_c_desc,
-                    rnn_flags::undef, 0.0f, 0.0f, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, &src_iter_c_desc, nullptr,
+                      weights_layer_desc, weights_iter_desc,
+                      &weights_peephole_desc, &weights_projection_desc,
+                      bias_desc, dst_layer_desc, dst_iter_desc,
+                      &dst_iter_c_desc, rnn_flags::undef, 0.0f, 0.0f, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an LSTM (with or without
         ///     peephole) forward propagation primitive.
@@ -10621,12 +10624,12 @@ struct lstm_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_lstm,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, &src_iter_c_desc, nullptr,
-                    weights_layer_desc, weights_iter_desc,
-                    &weights_peephole_desc, nullptr, bias_desc, dst_layer_desc,
-                    dst_iter_desc, &dst_iter_c_desc, rnn_flags::undef, 0.0f,
-                    0.0f, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, &src_iter_c_desc, nullptr,
+                      weights_layer_desc, weights_iter_desc,
+                      &weights_peephole_desc, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, &dst_iter_c_desc,
+                      rnn_flags::undef, 0.0f, 0.0f, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an LSTM forward propagation
         ///     primitive.
@@ -10684,11 +10687,12 @@ struct lstm_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_lstm,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, &src_iter_c_desc, nullptr,
-                    weights_layer_desc, weights_iter_desc, nullptr, nullptr,
-                    bias_desc, dst_layer_desc, dst_iter_desc, &dst_iter_c_desc,
-                    rnn_flags::undef, 0.0f, 0.0f, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, &src_iter_c_desc, nullptr,
+                      weights_layer_desc, weights_iter_desc, nullptr, nullptr,
+                      bias_desc, dst_layer_desc, dst_iter_desc,
+                      &dst_iter_c_desc, rnn_flags::undef, 0.0f, 0.0f, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an LSTM forward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -10698,8 +10702,8 @@ struct lstm_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference,
-                    dnnl::algorithm::vanilla_lstm) {}
+                      dnnl::prop_kind::forward_inference,
+                      dnnl::algorithm::vanilla_lstm) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -10900,18 +10904,18 @@ struct lstm_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_lstm,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, &src_iter_c_desc, nullptr,
-                    weights_layer_desc, weights_iter_desc,
-                    &weights_peephole_desc, &weights_projection_desc, bias_desc,
-                    dst_layer_desc, dst_iter_desc, &dst_iter_c_desc,
-                    diff_src_layer_desc, diff_src_iter_desc,
-                    &diff_src_iter_c_desc, nullptr, diff_weights_layer_desc,
-                    diff_weights_iter_desc, &diff_weights_peephole_desc,
-                    &diff_weights_projection_desc, diff_bias_desc,
-                    diff_dst_layer_desc, diff_dst_iter_desc,
-                    &diff_dst_iter_c_desc, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, &src_iter_c_desc, nullptr,
+                      weights_layer_desc, weights_iter_desc,
+                      &weights_peephole_desc, &weights_projection_desc,
+                      bias_desc, dst_layer_desc, dst_iter_desc,
+                      &dst_iter_c_desc, diff_src_layer_desc, diff_src_iter_desc,
+                      &diff_src_iter_c_desc, nullptr, diff_weights_layer_desc,
+                      diff_weights_iter_desc, &diff_weights_peephole_desc,
+                      &diff_weights_projection_desc, diff_bias_desc,
+                      diff_dst_layer_desc, diff_dst_iter_desc,
+                      &diff_dst_iter_c_desc, rnn_flags::undef, 0.0f, 0.0f,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs an LSTM (with or without peephole) primitive descriptor
         ///     for backward propagation using @p prop_kind, @p direction,
@@ -11011,17 +11015,18 @@ struct lstm_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_lstm,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, &src_iter_c_desc, nullptr,
-                    weights_layer_desc, weights_iter_desc,
-                    &weights_peephole_desc, nullptr, bias_desc, dst_layer_desc,
-                    dst_iter_desc, &dst_iter_c_desc, diff_src_layer_desc,
-                    diff_src_iter_desc, &diff_src_iter_c_desc, nullptr,
-                    diff_weights_layer_desc, diff_weights_iter_desc,
-                    &diff_weights_peephole_desc, nullptr, diff_bias_desc,
-                    diff_dst_layer_desc, diff_dst_iter_desc,
-                    &diff_dst_iter_c_desc, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, &src_iter_c_desc, nullptr,
+                      weights_layer_desc, weights_iter_desc,
+                      &weights_peephole_desc, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, &dst_iter_c_desc,
+                      diff_src_layer_desc, diff_src_iter_desc,
+                      &diff_src_iter_c_desc, nullptr, diff_weights_layer_desc,
+                      diff_weights_iter_desc, &diff_weights_peephole_desc,
+                      nullptr, diff_bias_desc, diff_dst_layer_desc,
+                      diff_dst_iter_desc, &diff_dst_iter_c_desc,
+                      rnn_flags::undef, 0.0f, 0.0f, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs an LSTM primitive descriptor for backward propagation
         ///     using @p prop_kind, @p direction, and memory descriptors.
@@ -11110,16 +11115,16 @@ struct lstm_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_lstm,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, &src_iter_c_desc, nullptr,
-                    weights_layer_desc, weights_iter_desc, nullptr, nullptr,
-                    bias_desc, dst_layer_desc, dst_iter_desc, &dst_iter_c_desc,
-                    diff_src_layer_desc, diff_src_iter_desc,
-                    &diff_src_iter_c_desc, nullptr, diff_weights_layer_desc,
-                    diff_weights_iter_desc, nullptr, nullptr, diff_bias_desc,
-                    diff_dst_layer_desc, diff_dst_iter_desc,
-                    &diff_dst_iter_c_desc, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, &src_iter_c_desc, nullptr,
+                      weights_layer_desc, weights_iter_desc, nullptr, nullptr,
+                      bias_desc, dst_layer_desc, dst_iter_desc,
+                      &dst_iter_c_desc, diff_src_layer_desc, diff_src_iter_desc,
+                      &diff_src_iter_c_desc, nullptr, diff_weights_layer_desc,
+                      diff_weights_iter_desc, nullptr, nullptr, diff_bias_desc,
+                      diff_dst_layer_desc, diff_dst_iter_desc,
+                      &diff_dst_iter_c_desc, rnn_flags::undef, 0.0f, 0.0f,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an LSTM backward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -11129,7 +11134,7 @@ struct lstm_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
-                    dnnl::algorithm::vanilla_lstm) {}
+                      dnnl::algorithm::vanilla_lstm) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -11324,11 +11329,11 @@ struct gru_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_gru,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, nullptr, nullptr, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
-                    0.0f, 0.0f, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
+                      0.0f, 0.0f, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a GRU forward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -11338,8 +11343,8 @@ struct gru_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference,
-                    dnnl::algorithm::vanilla_gru) {}
+                      dnnl::prop_kind::forward_inference,
+                      dnnl::algorithm::vanilla_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -11482,15 +11487,15 @@ struct gru_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_gru,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, nullptr, nullptr, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, diff_src_layer_desc,
-                    diff_src_iter_desc, nullptr, nullptr,
-                    diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
-                    nullptr, diff_bias_desc, diff_dst_layer_desc,
-                    diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr,
+                      diff_src_layer_desc, diff_src_iter_desc, nullptr, nullptr,
+                      diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
+                      nullptr, diff_bias_desc, diff_dst_layer_desc,
+                      diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a GRU backward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -11500,7 +11505,7 @@ struct gru_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
-                    dnnl::algorithm::vanilla_gru) {}
+                      dnnl::algorithm::vanilla_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -11656,10 +11661,11 @@ struct lbr_gru_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::lbr_gru, aprop_kind,
-                    algorithm::undef, direction, src_layer_desc, src_iter_desc,
-                    nullptr, nullptr, weights_layer_desc, weights_iter_desc,
-                    nullptr, nullptr, bias_desc, dst_layer_desc, dst_iter_desc,
-                    nullptr, rnn_flags::undef, 0.0f, 0.0f, attr, allow_empty) {}
+                      algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
+                      0.0f, 0.0f, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a LBR GRU forward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -11669,8 +11675,8 @@ struct lbr_gru_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference,
-                    dnnl::algorithm::lbr_gru) {}
+                      dnnl::prop_kind::forward_inference,
+                      dnnl::algorithm::lbr_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -11813,14 +11819,15 @@ struct lbr_gru_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::lbr_gru, aprop_kind,
-                    algorithm::undef, direction, src_layer_desc, src_iter_desc,
-                    nullptr, nullptr, weights_layer_desc, weights_iter_desc,
-                    nullptr, nullptr, bias_desc, dst_layer_desc, dst_iter_desc,
-                    nullptr, diff_src_layer_desc, diff_src_iter_desc, nullptr,
-                    nullptr, diff_weights_layer_desc, diff_weights_iter_desc,
-                    nullptr, nullptr, diff_bias_desc, diff_dst_layer_desc,
-                    diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, nullptr, weights_layer_desc,
+                      weights_iter_desc, nullptr, nullptr, bias_desc,
+                      dst_layer_desc, dst_iter_desc, nullptr,
+                      diff_src_layer_desc, diff_src_iter_desc, nullptr, nullptr,
+                      diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
+                      nullptr, diff_bias_desc, diff_dst_layer_desc,
+                      diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
+                      hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a LBR GRU backward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -11829,8 +11836,8 @@ struct lbr_gru_backward : public primitive {
         /// @param pd C API primitive descriptor for a LBR GRU backward
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
-            : rnn_primitive_desc_base(
-                    pd, dnnl::prop_kind::backward, dnnl::algorithm::lbr_gru) {}
+            : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
+                      dnnl::algorithm::lbr_gru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -11988,11 +11995,11 @@ struct augru_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_augru,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, nullptr, &attention_desc, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
-                    0.0f, 0.0f, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, &attention_desc,
+                      weights_layer_desc, weights_iter_desc, nullptr, nullptr,
+                      bias_desc, dst_layer_desc, dst_iter_desc, nullptr,
+                      rnn_flags::undef, 0.0f, 0.0f, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an AUGRU forward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -12002,8 +12009,8 @@ struct augru_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference,
-                    dnnl::algorithm::vanilla_augru) {}
+                      dnnl::prop_kind::forward_inference,
+                      dnnl::algorithm::vanilla_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -12157,15 +12164,16 @@ struct augru_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::vanilla_augru,
-                    aprop_kind, algorithm::undef, direction, src_layer_desc,
-                    src_iter_desc, nullptr, &attention_desc, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, diff_src_layer_desc,
-                    diff_src_iter_desc, nullptr, &diff_attention_desc,
-                    diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
-                    nullptr, diff_bias_desc, diff_dst_layer_desc,
-                    diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      aprop_kind, algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, &attention_desc,
+                      weights_layer_desc, weights_iter_desc, nullptr, nullptr,
+                      bias_desc, dst_layer_desc, dst_iter_desc, nullptr,
+                      diff_src_layer_desc, diff_src_iter_desc, nullptr,
+                      &diff_attention_desc, diff_weights_layer_desc,
+                      diff_weights_iter_desc, nullptr, nullptr, diff_bias_desc,
+                      diff_dst_layer_desc, diff_dst_iter_desc, nullptr,
+                      rnn_flags::undef, 0.0f, 0.0f, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an AUGRU backward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -12175,7 +12183,7 @@ struct augru_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
-                    dnnl::algorithm::vanilla_augru) {}
+                      dnnl::algorithm::vanilla_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -12345,11 +12353,11 @@ struct lbr_augru_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::lbr_augru, aprop_kind,
-                    algorithm::undef, direction, src_layer_desc, src_iter_desc,
-                    nullptr, &attention_desc, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, rnn_flags::undef,
-                    0.0f, 0.0f, attr, allow_empty) {}
+                      algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, &attention_desc,
+                      weights_layer_desc, weights_iter_desc, nullptr, nullptr,
+                      bias_desc, dst_layer_desc, dst_iter_desc, nullptr,
+                      rnn_flags::undef, 0.0f, 0.0f, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for an LBR AUGRU forward propagation
         /// primitive from a C API primitive descriptor that must have a
@@ -12359,8 +12367,8 @@ struct lbr_augru_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference,
-                    dnnl::algorithm::lbr_augru) {}
+                      dnnl::prop_kind::forward_inference,
+                      dnnl::algorithm::lbr_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -12513,15 +12521,16 @@ struct lbr_augru_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : rnn_primitive_desc_base(aengine, algorithm::lbr_augru, aprop_kind,
-                    algorithm::undef, direction, src_layer_desc, src_iter_desc,
-                    nullptr, &attention_desc, weights_layer_desc,
-                    weights_iter_desc, nullptr, nullptr, bias_desc,
-                    dst_layer_desc, dst_iter_desc, nullptr, diff_src_layer_desc,
-                    diff_src_iter_desc, nullptr, &diff_attention_desc,
-                    diff_weights_layer_desc, diff_weights_iter_desc, nullptr,
-                    nullptr, diff_bias_desc, diff_dst_layer_desc,
-                    diff_dst_iter_desc, nullptr, rnn_flags::undef, 0.0f, 0.0f,
-                    hint_fwd_pd, attr, allow_empty) {}
+                      algorithm::undef, direction, src_layer_desc,
+                      src_iter_desc, nullptr, &attention_desc,
+                      weights_layer_desc, weights_iter_desc, nullptr, nullptr,
+                      bias_desc, dst_layer_desc, dst_iter_desc, nullptr,
+                      diff_src_layer_desc, diff_src_iter_desc, nullptr,
+                      &diff_attention_desc, diff_weights_layer_desc,
+                      diff_weights_iter_desc, nullptr, nullptr, diff_bias_desc,
+                      diff_dst_layer_desc, diff_dst_iter_desc, nullptr,
+                      rnn_flags::undef, 0.0f, 0.0f, hint_fwd_pd, attr,
+                      allow_empty) {}
 
         /// Constructs a primitive descriptor for an LBR AUGRU backward
         /// propagation primitive from a C API primitive descriptor that must
@@ -12531,7 +12540,7 @@ struct lbr_augru_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : rnn_primitive_desc_base(pd, dnnl::prop_kind::backward,
-                    dnnl::algorithm::lbr_augru) {}
+                      dnnl::algorithm::lbr_augru) {}
 
         /// @copydoc dnnl::rnn_primitive_desc_base::src_layer_desc()const
         memory::desc src_layer_desc() const {
@@ -12702,8 +12711,8 @@ struct shuffle_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::shuffle,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -12791,7 +12800,7 @@ struct shuffle_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::shuffle,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
@@ -12992,7 +13001,7 @@ struct matmul : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, src_desc, weights_desc, nullptr, dst_desc,
-                    attr, allow_empty) {}
+                      attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a matmul primitive with bias.
         ///
@@ -13013,7 +13022,7 @@ struct matmul : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, src_desc, weights_desc, &bias_desc,
-                    dst_desc, attr, allow_empty) {}
+                      dst_desc, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a matmul primitive from a C
         /// API primitive descriptor that must have a matching kind.
@@ -13121,7 +13130,7 @@ struct resampling_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, nullptr, src_desc,
-                    &dst_desc, attr, allow_empty) {}
+                      &dst_desc, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a resampling forward
         ///     propagation primitive using source memory descriptor and
@@ -13148,7 +13157,7 @@ struct resampling_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, &factors,
-                    src_desc, nullptr, attr, allow_empty) {}
+                      src_desc, nullptr, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a resampling forward
         ///     propagation primitive.
@@ -13179,7 +13188,7 @@ struct resampling_forward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aprop_kind, aalgorithm, &factors,
-                    src_desc, &dst_desc, attr, allow_empty) {}
+                      src_desc, &dst_desc, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a resampling forward
         /// propagation primitive from a C API primitive descriptor that must
@@ -13189,8 +13198,8 @@ struct resampling_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::resampling,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -13275,7 +13284,7 @@ struct resampling_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, nullptr, diff_src_desc,
-                    diff_dst_desc, hint_fwd_pd, attr, allow_empty) {}
+                      diff_dst_desc, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for resampling backward
         ///     propagation primitive.
@@ -13304,7 +13313,7 @@ struct resampling_backward : public primitive {
                 const primitive_attr &attr = default_attr(),
                 bool allow_empty = false)
             : primitive_desc(aengine, aalgorithm, &factors, diff_src_desc,
-                    diff_dst_desc, hint_fwd_pd, attr, allow_empty) {}
+                      diff_dst_desc, hint_fwd_pd, attr, allow_empty) {}
 
         /// Constructs a primitive descriptor for a resampling backward
         /// propagation primitive from a C API primitive descriptor that must
@@ -13314,7 +13323,7 @@ struct resampling_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::resampling,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::diff_src_desc()const
         memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
@@ -13453,8 +13462,8 @@ struct pooling_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::pooling,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -13581,7 +13590,7 @@ struct pooling_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::pooling,
-                    dnnl::prop_kind::backward_data) {}
+                      dnnl::prop_kind::backward_data) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc diff_src_desc() const { return base::diff_src_desc(0); }
@@ -13696,8 +13705,8 @@ struct prelu_forward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::prelu,
-                    dnnl::prop_kind::forward_training,
-                    dnnl::prop_kind::forward_inference) {}
+                      dnnl::prop_kind::forward_training,
+                      dnnl::prop_kind::forward_inference) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }
@@ -13783,7 +13792,7 @@ struct prelu_backward : public primitive {
         ///     propagation primitive.
         primitive_desc(dnnl_primitive_desc_t pd)
             : dnnl::primitive_desc(pd, dnnl::primitive::kind::prelu,
-                    dnnl::prop_kind::backward) {}
+                      dnnl::prop_kind::backward) {}
 
         /// @copydoc dnnl::primitive_desc_base::src_desc()const
         memory::desc src_desc() const { return base::src_desc(0); }

--- a/include/oneapi/dnnl/dnnl_common_types.h
+++ b/include/oneapi/dnnl/dnnl_common_types.h
@@ -250,7 +250,7 @@ typedef struct {
 
 /// Special pointer value that indicates that the library needs to allocate an
 /// underlying buffer for a memory object.
-#define DNNL_MEMORY_ALLOCATE ((void *)(size_t)-1)
+#define DNNL_MEMORY_ALLOCATE ((void *)(size_t) - 1)
 
 /// @} dnnl_api_memory
 

--- a/src/common/bfloat16.hpp
+++ b/src/common/bfloat16.hpp
@@ -48,7 +48,7 @@ struct bfloat16_t {
                     std::is_integral<IntegerType>::value>::type>
     bfloat16_t(const IntegerType i)
         : raw_bits_ {convert_bits_of_normal_or_zero(
-                utils::bit_cast<uint32_t>(static_cast<float>(i)))} {}
+                  utils::bit_cast<uint32_t>(static_cast<float>(i)))} {}
 
     bfloat16_t DNNL_API &operator=(float f);
 

--- a/src/common/concat_pd.hpp
+++ b/src/common/concat_pd.hpp
@@ -298,7 +298,9 @@ private:
         if (!new_pd->is_initialized()) return nullptr; \
         return new_pd.release(); \
     } \
-    const char *name() const override { return impl_name; }
+    const char *name() const override { \
+        return impl_name; \
+    }
 
 #define DECLARE_CONCAT_PD_T(impl_name, ...) \
     DECLARE_CONCAT_PD_t(impl_name, __VA_ARGS__)

--- a/src/common/engine.hpp
+++ b/src/common/engine.hpp
@@ -113,23 +113,27 @@ struct dnnl_engine : public dnnl::impl::c_compatible {
      * a NULL-terminated list */
     virtual const dnnl::impl::impl_list_item_t *get_reorder_implementation_list(
             const dnnl::impl::memory_desc_t *src_md,
-            const dnnl::impl::memory_desc_t *dst_md) const = 0;
+            const dnnl::impl::memory_desc_t *dst_md) const
+            = 0;
 
     /** return the list of concat implementations. engine guarantees to return
      * a NULL-terminated list */
     virtual const dnnl::impl::impl_list_item_t *
-    get_concat_implementation_list() const = 0;
+    get_concat_implementation_list() const
+            = 0;
 
     /** return the list of sum implementations. engine guarantees to return
      * a NULL-terminated list */
     virtual const dnnl::impl::impl_list_item_t *
-    get_sum_implementation_list() const = 0;
+    get_sum_implementation_list() const
+            = 0;
 
     /** return the list of implementations for a given descriptor.
      * engine guarantees to return a NULL-terminated list */
 
     virtual const dnnl::impl::impl_list_item_t *get_implementation_list(
-            const dnnl::impl::op_desc_t *desc) const = 0;
+            const dnnl::impl::op_desc_t *desc) const
+            = 0;
 
     virtual dnnl::impl::status_t serialize_device(
             dnnl::impl::serialization_stream_t &sstream) const {

--- a/src/common/impl_list_item.hpp
+++ b/src/common/impl_list_item.hpp
@@ -96,7 +96,7 @@ struct impl_list_item_t {
     template <typename pd_t>
     constexpr impl_list_item_t(concat_type_deduction_helper_t<pd_t>)
         : create_concat_pd_func_(
-                concat_type_deduction_helper_t<pd_t>::type::create) {}
+                  concat_type_deduction_helper_t<pd_t>::type::create) {}
 
     template <typename pd_t>
     constexpr impl_list_item_t(sum_type_deduction_helper_t<pd_t>)
@@ -106,7 +106,7 @@ struct impl_list_item_t {
     template <typename pd_t>
     constexpr impl_list_item_t(reorder_type_deduction_helper_t<pd_t>)
         : create_reorder_pd_func_(
-                reorder_type_deduction_helper_t<pd_t>::type::create) {}
+                  reorder_type_deduction_helper_t<pd_t>::type::create) {}
 
     explicit operator bool() const {
         return !utils::everyone_is(nullptr, create_pd_func_,

--- a/src/common/memory.hpp
+++ b/src/common/memory.hpp
@@ -51,7 +51,7 @@ struct dnnl_memory : public dnnl::impl::c_compatible {
     dnnl_memory(dnnl::impl::engine_t *engine,
             const dnnl::impl::memory_desc_t *md, unsigned flags, void *handle)
         : dnnl_memory(engine, md, std::vector<unsigned> {flags},
-                std::vector<void *> {handle}) {}
+                  std::vector<void *> {handle}) {}
     dnnl_memory(dnnl::impl::engine_t *engine,
             const dnnl::impl::memory_desc_t *md,
             std::unique_ptr<dnnl::impl::memory_storage_t> &&memory_storage);

--- a/src/common/memory_storage.hpp
+++ b/src/common/memory_storage.hpp
@@ -59,7 +59,8 @@ struct memory_storage_t : public c_compatible {
     virtual size_t base_offset() const { return 0; }
 
     virtual status_t map_data(
-            void **mapped_ptr, stream_t *stream, size_t size) const = 0;
+            void **mapped_ptr, stream_t *stream, size_t size) const
+            = 0;
 
     virtual status_t unmap_data(void *mapped_ptr, stream_t *stream) const = 0;
 
@@ -72,7 +73,8 @@ struct memory_storage_t : public c_compatible {
      * @note: sub-storage lifetime shall not exceed one of the base memory storage
      * @note: (offset + size) shall not be greater than base memory storage size */
     virtual std::unique_ptr<memory_storage_t> get_sub_storage(
-            size_t offset, size_t size) const = 0;
+            size_t offset, size_t size) const
+            = 0;
 
     /** returns shallow copy */
     virtual std::unique_ptr<memory_storage_t> clone() const = 0;

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -431,12 +431,12 @@ constexpr std::array<typename std::remove_cv<T>::type, N> to_array(T (&a)[N]) {
 
 template <class T, std::size_t N, std::size_t... I>
 constexpr std::array<typename std::remove_cv<T>::type, N> to_array_impl(
-        T(&&a)[N], index_sequence<I...>) {
+        T (&&a)[N], index_sequence<I...>) {
     return {{std::move(a[I])...}};
 }
 
 template <class T, std::size_t N>
-constexpr std::array<typename std::remove_cv<T>::type, N> to_array(T(&&a)[N]) {
+constexpr std::array<typename std::remove_cv<T>::type, N> to_array(T (&&a)[N]) {
     return to_array_impl(std::move(a), make_index_sequence<N> {});
 }
 

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -416,7 +416,8 @@ struct primitive_desc_t : public c_compatible {
     virtual status_t create_primitive(
             std::pair<std::shared_ptr<primitive_t>, cache_state_t> &primitive,
             engine_t *engine, const cache_blob_t &cache_blob,
-            bool force_create_from_blob) const = 0;
+            bool force_create_from_blob) const
+            = 0;
 
     // This is a proxy interface that is used for creating nested primitives.
     // It ignores the cache_state_t value that indicates whether the requested primitive
@@ -550,7 +551,9 @@ protected:
                 primitive, this, engine, use_global_scratchpad, cache_blob, \
                 force_create_from_blob); \
     } \
-    const char *name() const override { return impl_name; } \
+    const char *name() const override { \
+        return impl_name; \
+    } \
     template <typename pd_t> \
     friend status_t primitive_desc_t::create(primitive_desc_t **pd, \
             const op_desc_t *adesc, const primitive_attr_t *attr, \

--- a/src/common/primitive_exec_types.cpp
+++ b/src/common/primitive_exec_types.cpp
@@ -149,7 +149,7 @@ exec_ctx_t::exec_ctx_t(stream_t *stream, exec_args_t &&args)
 
 exec_ctx_t::exec_ctx_t(const exec_ctx_t &other, exec_args_t &&args)
     : impl_(new exec_ctx_impl_t(other.stream(), std::move(args),
-            other.get_memory_mapping(), other.get_resource_mapper())) {}
+              other.get_memory_mapping(), other.get_resource_mapper())) {}
 
 void exec_ctx_t::set_memory_mapping(void *handle, void *host_ptr) {
     impl_->set_memory_mapping(handle, host_ptr);

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -43,7 +43,7 @@ key_t::key_t(const engine_t *engine, const op_desc_t *op_desc,
 
 key_t::key_t(const primitive_desc_t *pd, const engine_t *engine)
     : key_t(engine, pd->op_desc(), pd->attr(), pd->pd_iterator_offset(),
-            pd->hint_mds(false /* is_hint */), pd->skip_idx()) {}
+              pd->hint_mds(false /* is_hint */), pd->skip_idx()) {}
 
 bool key_t::operator==(const key_t &rhs) const {
     DNNL_SHORT_CIRCUIT_SELF_COMPARISON(rhs);

--- a/src/common/serialization.hpp
+++ b/src/common/serialization.hpp
@@ -97,7 +97,8 @@ struct serialization_stream_t {
     template <typename T,
             utils::enable_if_t<is_trivially_serialized<T>::value
                             && !has_serialize_t<T>::value,
-                    bool> = true>
+                    bool>
+            = true>
     void append(const T &t) {
         std::array<uint8_t, sizeof(T)> type_data;
         std::memcpy(type_data.data(), &t, sizeof(T));
@@ -220,7 +221,8 @@ struct deserializer_t {
             utils::enable_if_t<
                     serialization_stream_t::is_trivially_serialized<T>::value
                             && !has_deserialize_t<T>::value,
-                    bool> = true>
+                    bool>
+            = true>
     void pop(T &t) {
         t = sstream_.get<T>(idx_);
         idx_ += sizeof(T);
@@ -230,7 +232,8 @@ struct deserializer_t {
             utils::enable_if_t<
                     serialization_stream_t::is_trivially_serialized<T>::value
                             && !has_deserialize_t<T>::value,
-                    bool> = true>
+                    bool>
+            = true>
     T pop() {
         auto idx_start = idx_;
         idx_ += sizeof(T);
@@ -255,7 +258,8 @@ struct deserializer_t {
     template <typename T,
             utils::enable_if_t<
                     serialization_stream_t::is_trivially_serialized<T>::value,
-                    bool> = true>
+                    bool>
+            = true>
     void pop_array(size_t &size, T *ptr) {
         pop(size);
         sstream_.get(idx_, sizeof(T) * size, reinterpret_cast<uint8_t *>(ptr));

--- a/src/common/sum_pd.hpp
+++ b/src/common/sum_pd.hpp
@@ -223,7 +223,9 @@ private:
         if (!new_pd->is_initialized()) return nullptr; \
         return new_pd.release(); \
     } \
-    const char *name() const override { return impl_name; }
+    const char *name() const override { \
+        return impl_name; \
+    }
 
 #define DECLARE_SUM_PD_T(impl_name, ...) \
     DECLARE_SUM_PD_t(impl_name, __VA_ARGS__)

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -800,8 +800,7 @@ std::ostream &operator<<(std::ostream &ss, const primitive_attr_t *attr) {
                 } break;
                 case primitive_kind::prelu: {
                     const auto &ep = e.prelu;
-                    ss << delim << "prelu"
-                       << ":" << ep.mask;
+                    ss << delim << "prelu" << ":" << ep.mask;
                 } break;
                 default: assert(!"unsupported post op primitive kind!"); break;
             }
@@ -978,8 +977,8 @@ std::string init_info_convolution(const engine_t *e, const pd_t *pd) {
     ss << "alg:" << pd->desc()->alg_kind << ",";
 
     if (pd->with_groups()) ss << "g" << pd->G();
-    ss << "mb" << pd->MB() << "_"
-       << "ic" << pd->IC() << "oc" << pd->OC() << "_";
+    ss << "mb" << pd->MB() << "_" << "ic" << pd->IC() << "oc" << pd->OC()
+       << "_";
     if (pd->ndims() >= 5)
         ss << "id" << pd->ID() << "od" << (has_fused_dw ? pd->ID() : pd->OD())
            << "kd" << pd->KD() << "sd" << pd->KSD() << "dd" << pd->KDD() << "pd"

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -29,7 +29,7 @@ namespace aarch64 {
 struct acl_wino_resource_t : public resource_t {
     acl_wino_resource_t()
         : acl_wino_obj_(utils::make_unique<
-                acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>()) {}
+                  acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>()) {}
 
     status_t configure(const acl_conv_conf_t &acp) {
         if (!acl_wino_obj_) return status::out_of_memory;

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -35,7 +35,7 @@
 #define LDR_IMM(reg, addr, off) \
     do { \
         const uint64_t IMM12_MASK = ~uint64_t(0xfff); \
-        if (((off)&IMM12_MASK) == 0) { \
+        if (((off) & IMM12_MASK) == 0) { \
             ldr(reg, ptr(addr, off)); \
         } else { \
             add_imm(X_DEFAULT_ADDR, addr, off, X_TMP_0); \
@@ -45,7 +45,7 @@
 #define STR_IMM(reg, addr, off) \
     do { \
         const uint64_t IMM12_MASK = ~uint64_t(0xfff); \
-        if (((off)&IMM12_MASK) == 0) { \
+        if (((off) & IMM12_MASK) == 0) { \
             str(reg, ptr(addr, off)); \
         } else { \
             add_imm(X_DEFAULT_ADDR, addr, off, X_TMP_0); \

--- a/src/cpu/aarch64/cpu_reducer.cpp
+++ b/src/cpu/aarch64/cpu_reducer.cpp
@@ -154,7 +154,7 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type, isa> {
     reducer_2d_driver_f_s_32_t(int n_src, size_t src_ld, size_t src_step,
             size_t dst_step, bool nullify_dst)
         : reducer_2d_driver_t<data_type, isa>(
-                n_src, src_ld, src_step, dst_step, nullify_dst) {}
+                  n_src, src_ld, src_step, dst_step, nullify_dst) {}
 
     void uni_load(const Vmm &z1, const XReg &src, size_t off, int load_len) {
         auto src_ptr = (off == 0) ? src : reg_tmp_ptr;

--- a/src/cpu/aarch64/injectors/injector_utils.cpp
+++ b/src/cpu/aarch64/injectors/injector_utils.cpp
@@ -132,9 +132,9 @@ conditional_register_preserve_guard_t<
         std::initializer_list<Xbyak_aarch64::XReg> reg64_to_preserve,
         std::initializer_list<Xbyak_aarch64::VReg> vmm_to_preserve)
     : register_preserve_guard_t<isa> {condition_to_be_met
-                    ? register_preserve_guard_t<isa> {host, reg64_to_preserve,
-                            vmm_to_preserve}
-                    : register_preserve_guard_t<isa> {nullptr, {}, {}}} {};
+                      ? register_preserve_guard_t<isa> {host, reg64_to_preserve,
+                                vmm_to_preserve}
+                      : register_preserve_guard_t<isa> {nullptr, {}, {}}} {};
 
 template class register_preserve_guard_t<sve_512>;
 template class register_preserve_guard_t<sve_256>;

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -190,7 +190,7 @@ static_params_t::static_params_t(const Xbyak_aarch64::XReg &param1,
 static_params_t::static_params_t(const Xbyak_aarch64::XReg &param1,
         const rhs_arg_static_params_t &rhs_arg_static_params)
     : static_params_t(param1, get_all_strategies_supported_by_injector(),
-            rhs_arg_static_params) {}
+              rhs_arg_static_params) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
@@ -201,10 +201,11 @@ rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
         std::size_t tail_size, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
-            Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast, rhs_helper_reg,
-            false /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+              Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast,
+              rhs_helper_reg, false /*is_opmask_set*/,
+              false /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
@@ -216,75 +217,77 @@ rhs_arg_static_params_t::rhs_arg_static_params_t(
         const memory_desc_wrapper &dst_d, std::size_t tail_size,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
-            tail_size, Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast,
-            rhs_helper_reg, false /*is_opmask_set*/, true /*is_dst_orig_set*/) {
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+              tail_size, Xbyak_aarch64::PReg(2), use_exact_tail_scalar_bcast,
+              rhs_helper_reg, false /*is_opmask_set*/,
+              true /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+              tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
+              true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        const Xbyak_aarch64::PReg &tail_opmask,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+              tail_size, tail_opmask, use_exact_tail_scalar_bcast,
+              rhs_helper_reg, true /*is_opmask_set*/,
+              true /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &reg_tail_size,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
+              tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
+              true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx,
+        const Xbyak_aarch64::XReg &rhs_addr_reg,
+        const Xbyak_aarch64::XReg &rhs_helper_reg,
+        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
+        bool preserve_gpr_helpers, bool preserve_vmm_helper,
+        std::size_t abi_param_offset, std::size_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, std::size_t tail_size,
+        const Xbyak_aarch64::PReg &tail_opmask,
+        const Xbyak_aarch64::XReg &reg_tail_size,
+        bool use_exact_tail_scalar_bcast)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+              tail_size, tail_opmask, use_exact_tail_scalar_bcast,
+              reg_tail_size, true /*is_opmask_set*/, true /*is_dst_orig_set*/) {
 }
-
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx,
-        const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg,
-        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
-        bool preserve_gpr_helpers, bool preserve_vmm_helper,
-        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
-        bool use_exact_tail_scalar_bcast)
-    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
-            tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
-            true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
-
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx,
-        const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg,
-        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
-        bool preserve_gpr_helpers, bool preserve_vmm_helper,
-        std::size_t abi_param_offset, std::size_t dst_orig_offset,
-        const memory_desc_wrapper &dst_d, std::size_t tail_size,
-        const Xbyak_aarch64::PReg &tail_opmask,
-        bool use_exact_tail_scalar_bcast)
-    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
-            tail_size, tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
-            true /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
-
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx,
-        const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg,
-        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
-        bool preserve_gpr_helpers, bool preserve_vmm_helper,
-        std::size_t abi_param_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak_aarch64::PReg &tail_opmask,
-        const Xbyak_aarch64::XReg &reg_tail_size,
-        bool use_exact_tail_scalar_bcast)
-    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, 0, dst_d, tail_size,
-            tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
-            true /*is_opmask_set*/, false /*is_dst_orig_set*/) {}
-
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx,
-        const Xbyak_aarch64::XReg &rhs_addr_reg,
-        const Xbyak_aarch64::XReg &rhs_helper_reg,
-        const Xbyak_aarch64::XReg &rhs_addr_cache_reg,
-        bool preserve_gpr_helpers, bool preserve_vmm_helper,
-        std::size_t abi_param_offset, std::size_t dst_orig_offset,
-        const memory_desc_wrapper &dst_d, std::size_t tail_size,
-        const Xbyak_aarch64::PReg &tail_opmask,
-        const Xbyak_aarch64::XReg &reg_tail_size,
-        bool use_exact_tail_scalar_bcast)
-    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
-            tail_size, tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
-            true /*is_opmask_set*/, true /*is_dst_orig_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx,
@@ -502,13 +505,13 @@ void jit_uni_binary_injector_t<isa>::compute_vector_range(
     const injector_utils::register_preserve_guard_t<isa> register_guard {host_,
             (rhs_arg_static_params_.preserve_gpr_helpers
                             ? std::initializer_list<Xbyak_aarch64::XReg>(
-                                    {rhs_arg_static_params_.rhs_addr_reg,
-                                            rhs_arg_static_params_
-                                                    .rhs_helper_reg})
+                                      {rhs_arg_static_params_.rhs_addr_reg,
+                                              rhs_arg_static_params_
+                                                      .rhs_helper_reg})
                             : std::initializer_list<Xbyak_aarch64::XReg>()),
             (rhs_arg_static_params_.preserve_vmm_helper && dt_helper_vmm_needed
                             ? std::initializer_list<Xbyak_aarch64::VReg>(
-                                    {Xbyak_aarch64::VReg(vmm_hint)})
+                                      {Xbyak_aarch64::VReg(vmm_hint)})
                             : std::initializer_list<Xbyak_aarch64::VReg>())};
 
     bool vmm0_was_preserved = false;

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -135,9 +135,9 @@ struct jit_uni_eltwise_injector_t {
             bool is_fwd = true, bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true, data_type_t d_type = data_type::f32)
         : jit_uni_eltwise_injector_t(host, eltwise.alg, eltwise.alpha,
-                eltwise.beta, eltwise.scale, save_state, x_table, p_mask,
-                p_tmp0, is_fwd, use_dst, preserve_vmm, preserve_p_table,
-                d_type) {}
+                  eltwise.beta, eltwise.scale, save_state, x_table, p_mask,
+                  p_tmp0, is_fwd, use_dst, preserve_vmm, preserve_p_table,
+                  d_type) {}
 
     void compute_vector_range(size_t start_idx, size_t end_idx);
     void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs);

--- a/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_postops_injector.cpp
@@ -93,7 +93,7 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-            eltwise_injector::static_params_t(), lambda_jit_injectors_t()) {}
+              eltwise_injector::static_params_t(), lambda_jit_injectors_t()) {}
 
 template <cpu_isa_t isa>
 jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
@@ -101,7 +101,7 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
         const binary_injector::static_params_t &binary_static_params,
         const lambda_jit_injectors_t &lambda_jit_injectors)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-            eltwise_injector::static_params_t(), lambda_jit_injectors) {}
+              eltwise_injector::static_params_t(), lambda_jit_injectors) {}
 
 template <cpu_isa_t isa>
 jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
@@ -109,7 +109,7 @@ jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-            eltwise_static_params, lambda_jit_injectors_t()) {}
+              eltwise_static_params, lambda_jit_injectors_t()) {}
 
 template <cpu_isa_t isa>
 void jit_uni_postops_injector_t<isa>::compute_vector_range(size_t start_idx,

--- a/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
@@ -333,14 +333,14 @@ void brdgmm_dw_convolution_fwd_t<isa>::pd_t::init_batch_elements() {
         const int oh = ohb < h_blk_info.n_lpad_blks
                 ? ohb
                 : (h_blk_info.rpad_blk_start_idx
-                        + (ohb - h_blk_info.n_lpad_blks));
+                          + (ohb - h_blk_info.n_lpad_blks));
         const int bpad = oh * h_shift + jcp.kh - (jcp.ih + jcp.t_pad);
 
         const int fpad = jcp.f_pad - odb * d_shift;
         const int od = odb < d_blk_info.n_lpad_blks
                 ? odb
                 : (d_blk_info.rpad_blk_start_idx
-                        + (odb - d_blk_info.n_lpad_blks));
+                          + (odb - d_blk_info.n_lpad_blks));
         const int backpad = od * d_shift + jcp.kd - (jcp.id + jcp.f_pad);
 
         gen_batch_elements(fpad, backpad, tpad, bpad, lpad, rpad, bs_[bi],
@@ -418,9 +418,7 @@ status_t brdgmm_dw_convolution_fwd_t<isa>::pd_t::init_brdgmm_conf() {
 
                 if (ow_tail_block && (jcp.ow % ow_tail_block == 0))
                     jcp.ow_block = ow_tail_block;
-                else {
-                    jcp.ow_block = jcp.ow;
-                }
+                else { jcp.ow_block = jcp.ow; }
             } else {
                 const int max_ow_block = is_superset(jcp.isa, sve_512)
                         ? 6

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -466,7 +466,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::execute_forward_all(
     brgemm_batch_element_t *const brg_batch_global
             = (jcp.brg_type != brgemm_strd)
             ? scratchpad.template get<brgemm_batch_element_t>(
-                    key_brgemm_primitive_batch)
+                      key_brgemm_primitive_batch)
             : nullptr;
     char *const c_buffer_global = (jcp.use_buffer)
             ? scratchpad.template get<char>(key_brgemm_primitive_buffer)

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -1152,7 +1152,7 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
             = brgemm_convolution_utils::uses_batch_elements(
                       jcp.brg_type, jcp.exec_type)
             ? scratchpad.template get<brgemm_batch_element_t>(
-                    key_brgemm_primitive_batch)
+                      key_brgemm_primitive_batch)
             : nullptr;
     char *const __restrict c_buffer_global = (jcp.use_buffer)
             ? scratchpad.template get<char>(key_brgemm_primitive_buffer)
@@ -1166,12 +1166,12 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
             : nullptr;
     int32_t *src_zp_comp_base = jcp.src_zero_point
             ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
-                       key_brgemm_primitive_zp_comp_a)
+                                              key_brgemm_primitive_zp_comp_a)
                                     : zp_compensation)
             : nullptr;
     int32_t *s8s8_comp_base = jcp.s8s8_compensation_required
             ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
-                       key_brgemm_primitive_buffer_comp)
+                                              key_brgemm_primitive_buffer_comp)
                                     : s8s8_compensation)
             : nullptr;
 
@@ -1412,10 +1412,10 @@ void brgemm_convolution_fwd_t<isa>::perform_outwork(
                     + dst_dsz
                             * (btc.od * dst_h_sz + btc.oh * dst_w_sz
                                     + ow_pw_s * jcp.oc_without_padding);
-            p.ptr_in = static_cast<void *>(
-                    jcp.use_buffer ? (
-                            btc.c_buffer + acc_dsz * (ow_pw_s - ow) * jcp.LDC)
-                                   : p.ptr_out);
+            p.ptr_in = static_cast<void *>(jcp.use_buffer
+                            ? (btc.c_buffer
+                                      + acc_dsz * (ow_pw_s - ow) * jcp.LDC)
+                            : p.ptr_out);
         } else {
             p.apply_comp = has_postcomp;
             char *const ptr_Cz = jcp.use_buffer
@@ -1505,7 +1505,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(int ithr,
     const auto icb = icc * jcp.nb_ic_blocking;
 
 #define bmask(icb, odb, ohb, owb) \
-    inp_buffer_mask[(((icb)*jcp.nb_od + (odb)) * jcp.nb_oh + (ohb)) \
+    inp_buffer_mask[(((icb) * jcp.nb_od + (odb)) * jcp.nb_oh + (ohb)) \
                     * jcp.nb_ow \
             + (owb)]
 
@@ -1881,7 +1881,7 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(
                 + src_dsz
                         * ((jcp.copy_block_only ? 0
                                                 : ((icb + ic_block_s)
-                                                        * _pd->pbuf_d_sz)));
+                                                          * _pd->pbuf_d_sz)));
         const void *ptrA {nullptr}, *ptrB {nullptr};
 
         if (jcp.brg_type == brgemm_static_offs) {

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -1527,9 +1527,9 @@ void brg_blocking_t::calc_blocks_1x1() {
         const auto max_os_block_thr
                 = (src_dsz * ic >= 1024 && src_dsz * ic < 4096)
                 ? nstl::max(nstl::min(16, os),
-                        div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
+                          div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
                 : nstl::max(div_up(2048, oc_block),
-                        static_cast<int>(div_up(mb * ngroups * os, nthr)));
+                          static_cast<int>(div_up(mb * ngroups * os, nthr)));
         const auto max_os_block_L2 = max_sp_block_L2;
 
         auto max_os_block_aliasing = 1000000 / nthr;
@@ -1950,12 +1950,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         dim_t ds = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.idp, jcp.od_block, jcp.kd,
                            jcp.stride_d, jcp.dilate_d)
-                        + nstl::max(0, jcp.f_pad) + nstl::max(0, jcp.back_pad))
+                          + nstl::max(0, jcp.f_pad)
+                          + nstl::max(0, jcp.back_pad))
                 : jcp.idp;
         dim_t hs = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.ihp, jcp.oh_block, jcp.kh,
                            jcp.stride_h, jcp.dilate_h)
-                        + nstl::max(0, jcp.t_pad) + nstl::max(0, jcp.b_pad))
+                          + nstl::max(0, jcp.t_pad) + nstl::max(0, jcp.b_pad))
                 : jcp.ihp;
         if (jcp.is_os_blocking)
             hs = div_up(rnd_up(hs * jcp.iwp, jcp.brgM), jcp.iwp);
@@ -2164,7 +2165,7 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = jcp.is_rtus ? rnd_up(jcp.LDA * jcp.os, align_size) : 0;
     jcp.inp_buffer_mask_size = jcp.is_rtus
             ? rnd_up(div_up(jcp.nb_ic, jcp.nb_ic_blocking) * jcp.nb_os,
-                    align_size)
+                      align_size)
             : 0;
     jcp.buffer_size = jcp.LDC * jcp.M;
 

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -36,8 +36,12 @@
 #endif
 
 #define DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_name) \
-    const char *name() const override { return STRINGIFY(jit_name); } \
-    const char *source_file() const override { return __FILE__; }
+    const char *name() const override { \
+        return STRINGIFY(jit_name); \
+    } \
+    const char *source_file() const override { \
+        return __FILE__; \
+    }
 
 #define LD_MUL_VL(mn, op, mask, addr, off, size) \
     do { \
@@ -709,8 +713,9 @@ public:
     jit_generator_t(void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE,
             bool use_autogrow = true, cpu_isa_t max_cpu_isa = isa_all)
         : Xbyak_aarch64::CodeGenerator(code_size,
-                (code_ptr == nullptr && use_autogrow) ? Xbyak_aarch64::AutoGrow
-                                                      : code_ptr)
+                  (code_ptr == nullptr && use_autogrow)
+                          ? Xbyak_aarch64::AutoGrow
+                          : code_ptr)
         , max_cpu_isa_(max_cpu_isa) {}
     ~jit_generator_t() override = default;
 

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
@@ -266,7 +266,7 @@ void jit_sve_1x1_conv_kernel_t<isa_>::reduce_loop(
         int lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
-                                           jcp.reduce_dim, jcp.reduce_block));
+                                             jcp.reduce_dim, jcp.reduce_block));
         int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(addr, tmp, aux_reg_load_data,
@@ -527,8 +527,8 @@ void jit_sve_1x1_conv_kernel_t<isa_>::generate() {
                                 * (is_out_layout_nxc(jcp)
                                                 ? 1
                                                 : (jcp.with_dw_conv
-                                                                ? jcp.ow
-                                                                : jcp.bcast_dim)),
+                                                                  ? jcp.ow
+                                                                  : jcp.bcast_dim)),
                         reg_tmp_imm);
                 if (jcp.with_binary) {
                     const auto oc_off_oprnd = aux_reg_load_data;
@@ -802,27 +802,27 @@ status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
             case sve_512: {
                 wei_tag = with_groups
                         ? pick(2 * ndims - 6 + is_bwd_d, gOIw16i16o, gIOw16o16i,
-                                gOIhw16i16o, gIOhw16o16i, gOIdhw16i16o,
-                                gIOdhw16o16i)
+                                  gOIhw16i16o, gIOhw16o16i, gOIdhw16i16o,
+                                  gIOdhw16o16i)
                         : pick(2 * ndims - 6 + is_bwd_d, OIw16i16o, IOw16o16i,
-                                OIhw16i16o, IOhw16o16i, OIdhw16i16o,
-                                IOdhw16o16i);
+                                  OIhw16i16o, IOhw16o16i, OIdhw16i16o,
+                                  IOdhw16o16i);
                 break;
             }
             case sve_256: {
                 wei_tag = with_groups
                         ? pick(2 * ndims - 6 + is_bwd_d, gOIw8i8o, gIOw8o8i,
-                                gOIhw8i8o, gIOhw8o8i, gOIdhw8i8o, gIOdhw8o8i)
+                                  gOIhw8i8o, gIOhw8o8i, gOIdhw8i8o, gIOdhw8o8i)
                         : pick(2 * ndims - 6 + is_bwd_d, OIw8i8o, IOw8o8i,
-                                OIhw8i8o, IOhw8o8i, OIdhw8i8o, IOdhw8o8i);
+                                  OIhw8i8o, IOhw8o8i, OIdhw8i8o, IOdhw8o8i);
                 break;
             }
             case sve_128: {
                 wei_tag = with_groups
                         ? pick(2 * ndims - 6 + is_bwd_d, gOIw4i4o, gIOw4o4i,
-                                gOIhw4i4o, gIOhw4o4i, gOIdhw4i4o, gIOdhw4o4i)
+                                  gOIhw4i4o, gIOhw4o4i, gOIdhw4i4o, gIOdhw4o4i)
                         : pick(2 * ndims - 6 + is_bwd_d, OIw4i4o, IOw4o4i,
-                                OIhw4i4o, IOhw4o4i, OIdhw4i4o, IOdhw4o4i);
+                                  OIhw4i4o, IOhw4o4i, OIdhw4i4o, IOdhw4o4i);
                 break;
             }
             default: return status::unimplemented;
@@ -1232,8 +1232,8 @@ status_t jit_sve_1x1_conv_kernel_t<isa_>::init_conf(jit_1x1_conv_conf_t &jcp,
                 = jcp.oc_block * jcp.ur * jcp.typesize_out;
         jcp.bcast_loop_bcast_step = jcp.ic_block
                 * (is_data_layout_nxc ? 1
-                                      : utils::rnd_up(
-                                              jcp.reduce_dim, jcp.reduce_block))
+                                      : utils::rnd_up(jcp.reduce_dim,
+                                                jcp.reduce_block))
                 * jcp.typesize_in;
         jcp.bcast_loop_bcast_substep = jcp.ur * jcp.typesize_in;
 

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
@@ -57,8 +57,8 @@ void jit_sve_1x1_convolution_fwd_t<src_type, wei_type, dst_type,
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_
             ? binary_injector::prepare_binary_args(
-                    pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                    pd()->jcp_.post_ops.entry_.size() + 1)
+                      pd()->dw_conv_pd_->jcp_.post_ops, ctx,
+                      pd()->jcp_.post_ops.entry_.size() + 1)
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -463,7 +463,7 @@ void jit_sve_1x1_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
     const auto &jcp = kernel_->jcp;
     auto rtus_space = pd()->rtus_.reduce_src_
             ? ctx.get_scratchpad_grantor().template get<diff_src_data_t>(
-                    key_conv_rtus_space)
+                      key_conv_rtus_space)
             : nullptr;
 
     const int ndims = diff_src_d.ndims();

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
@@ -517,9 +517,11 @@ void jit_sve_512_core_x8s8s32x_deconv_fwd_kernel_t<isa>::compute_ker(int ur_w,
                                          : jcp.ic_without_padding % 4;
         int n_ic_blocks = jcp.is_depthwise
                 ? 1
-                : (last_ic_block_flag & ~no_last_block ? div_up(
-                           jcp.ic_without_padding % jcp.ic_block, 4)
-                                                       : jcp.ic_block / 4);
+                : (last_ic_block_flag & ~no_last_block
+                                  ? div_up(jcp.ic_without_padding
+                                                    % jcp.ic_block,
+                                            4)
+                                  : jcp.ic_block / 4);
 
         for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded == true) {
@@ -1404,8 +1406,8 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             ? reinterpret_cast<int32_t *>(&w[offset])
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
-            ? get_src_zp_comp_from_wei(
-                    weights, weights_d, !jcp.signed_input, jcp.ngroups, jcp.oc)
+            ? get_src_zp_comp_from_wei(weights, weights_d, !jcp.signed_input,
+                      jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1505,8 +1507,8 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             ? reinterpret_cast<int32_t *>(&w[offset])
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
-            ? get_src_zp_comp_from_wei(
-                    weights, weights_d, !jcp.signed_input, jcp.ngroups, jcp.oc)
+            ? get_src_zp_comp_from_wei(weights, weights_d, !jcp.signed_input,
+                      jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1589,11 +1591,11 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
                         : max(0,
-                                jcp.kh
-                                        - (kh_lo
-                                                + max(0, kh_len - 1)
-                                                        * jcp.stride_h
-                                                + 1));
+                                  jcp.kh
+                                          - (kh_lo
+                                                  + max(0, kh_len - 1)
+                                                          * jcp.stride_h
+                                                  + 1));
                 p.b_overflow = kh_lo;
                 p.kh_padding = kh_len;
                 p.scales = scales;
@@ -1669,8 +1671,8 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             ? reinterpret_cast<int32_t *>(&w[offset])
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
-            ? get_src_zp_comp_from_wei(
-                    weights, weights_d, !jcp.signed_input, jcp.ngroups, jcp.oc)
+            ? get_src_zp_comp_from_wei(weights, weights_d, !jcp.signed_input,
+                      jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1795,20 +1797,20 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
                         : max(0,
-                                jcp.kh
-                                        - (kh_lo
-                                                + max(0, kh_len - 1)
-                                                        * jcp.stride_h
-                                                + 1));
+                                  jcp.kh
+                                          - (kh_lo
+                                                  + max(0, kh_len - 1)
+                                                          * jcp.stride_h
+                                                  + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
                         : max(0,
-                                jcp.kd
-                                        - (kd_lo
-                                                + max(0, kd_len - 1)
-                                                        * jcp.stride_d
-                                                + 1));
+                                  jcp.kd
+                                          - (kd_lo
+                                                  + max(0, kd_len - 1)
+                                                          * jcp.stride_d
+                                                  + 1));
                 p.back_overflow = kd_lo;
                 p.kh_padding = kh_len;
                 p.kd_padding = kd_len;

--- a/src/cpu/aarch64/jit_sve_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.cpp
@@ -574,9 +574,7 @@ void jit_sve_conv_fwd_kernel_t<isa>::compute_loop(
         else if (jcp.kernel_kind == embd_bcast && jcp.nb_oc_blocking == 1)
             assert(!"STOP:jcp.kernel_kind == embd_bcast && jcp.nb_oc_blocking "
                     "== 1");
-        else {
-            compute_loop_fma_core(ur_w, pad_l, pad_r);
-        }
+        else { compute_loop_fma_core(ur_w, pad_l, pad_r); }
     else
         assert(!"unknown convolution version");
 
@@ -2551,9 +2549,9 @@ void jit_sve_conv_bwd_weights_kernel_f32_t<isa>::compute_ic_block_step(int ur_w,
     int num_zregs4out = 4;
     num_zregs4out = (28 - num_zregs4ker) / num_zregs4ker
             ? nstl::max(num_zregs4out
-                            + ((32 - num_zregs4out - num_zregs4ker)
-                                    % (num_zregs4ker)),
-                    4)
+                              + ((32 - num_zregs4out - num_zregs4ker)
+                                      % (num_zregs4ker)),
+                      4)
             : nstl::max(32 - (num_zregs4ker + ic_block_step), 4);
     int idata_reg_offset = num_zregs4ker + num_zregs4out;
     int num_zregs4idata = 32 - idata_reg_offset;

--- a/src/cpu/aarch64/jit_sve_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_convolution.cpp
@@ -1228,7 +1228,7 @@ struct jit_sve_convolution_bwd_weights_t<src_type, diff_dst_type,
                 && jcp.oc_without_padding % jcp.oc_block != 0;
         diff_bias = is_bias_padded
                 ? scratchpad.template get<diff_weights_data_t>(
-                        key_conv_padded_bias)
+                          key_conv_padded_bias)
                 : CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
 
         /* reduction dimension */

--- a/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
@@ -67,9 +67,10 @@ inline void rtus_prepare(conv_pd_t *self, const convolution_desc_t *&conv_d,
 
     const auto dat_tag = ndims == 3
             ? memory_desc_wrapper(src_d).matches_one_of_tag(format_tag::nCw4c,
-                    format_tag::nCw8c, format_tag::nCw16c, format_tag::nwc)
+                      format_tag::nCw8c, format_tag::nCw16c, format_tag::nwc)
             : memory_desc_wrapper(src_d).matches_one_of_tag(format_tag::nChw4c,
-                    format_tag::nChw8c, format_tag::nChw16c, format_tag::nhwc);
+                      format_tag::nChw8c, format_tag::nChw16c,
+                      format_tag::nhwc);
     if (dat_tag == format_tag::undef) return;
 
     const bool is_nspc

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -1179,9 +1179,7 @@ struct jit_bnorm_t : public jit_generator_t {
                 }
                 if (isa == sve_256 || isa == sve_512)
                     fdiv(ZRegS(1), P_ALL_ONE / T_m, ZRegS(vchan_size.getIdx()));
-                else {
-                    fdiv(VReg4S(1), VReg4S(1), VReg4S(IDX(vchan_size)));
-                }
+                else { fdiv(VReg4S(1), VReg4S(1), VReg4S(IDX(vchan_size))); }
                 uni_store_maybe_tail(var_ptr(), TReg(1));
                 if (isa == sve_256 || isa == sve_512)
                     add_imm(reg_coff, reg_coff, vlen, X_TMP_0);
@@ -2366,12 +2364,13 @@ status_t jit_uni_batch_normalization_fwd_t<isa>::execute(
     auto scale = CTX_IN_MEM(const acc_data_t *, DNNL_ARG_SCALE);
     auto shift = CTX_IN_MEM(const acc_data_t *, DNNL_ARG_SHIFT);
 
-    auto mean = pd()->stats_is_src() ? const_cast<acc_data_t *>(
-                        CTX_IN_MEM(const acc_data_t *, DNNL_ARG_MEAN))
-                                     : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_MEAN);
+    auto mean = pd()->stats_is_src()
+            ? const_cast<acc_data_t *>(
+                      CTX_IN_MEM(const acc_data_t *, DNNL_ARG_MEAN))
+            : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_MEAN);
     auto var = pd()->stats_is_src()
             ? const_cast<acc_data_t *>(
-                    CTX_IN_MEM(const acc_data_t *, DNNL_ARG_VARIANCE))
+                      CTX_IN_MEM(const acc_data_t *, DNNL_ARG_VARIANCE))
             : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_VARIANCE);
     auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
     auto ws = CTX_OUT_MEM(uint8_t *, DNNL_ARG_WORKSPACE);

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -773,9 +773,10 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
             = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
     const dim_t nelems_slice_src1 = bcast_type == bcast_t::none
             ? nelems_slice_src0
-            : ((bcast_dims[0] == 0) ? utils::array_product(
-                       src1_d.padded_dims() + 1, ndims - 1)
-                                    : 0);
+            : ((bcast_dims[0] == 0)
+                              ? utils::array_product(
+                                        src1_d.padded_dims() + 1, ndims - 1)
+                              : 0);
 
     if (op_type == op_t::c_blocked) {
         const dim_t C_blocks = std::ceil(
@@ -894,7 +895,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
     // array product of outer dimensions that are not broadcast
     const dim_t SP_no_bcast = ndims >= 3
             ? utils::array_product(
-                    dims + (ndims - not_bcasted_sp_dims), not_bcasted_sp_dims)
+                      dims + (ndims - not_bcasted_sp_dims), not_bcasted_sp_dims)
             : 1;
     const dim_t C = ndims >= 2 ? dims[1] : 1;
     const dim_t SP = ndims >= 3 ? utils::array_product(dims + 2, ndims - 2) : 1;

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -72,8 +72,8 @@ size_t binary_kernel_t::get_tail_size() const {
         else if (conf_.op_type == op_t::n_c_spatial && ndims >= 3)
             nelems = conf_.bcast_type == bcast_t::per_w
                     ? utils::array_product(
-                            dims + (ndims - conf_.not_bcasted_sp_dims),
-                            conf_.not_bcasted_sp_dims)
+                              dims + (ndims - conf_.not_bcasted_sp_dims),
+                              conf_.not_bcasted_sp_dims)
                     : utils::array_product(dims + 2, ndims - 2);
     }
     // it's float due to for bfloat16 we still load 16 elements, not 32.

--- a/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -64,9 +64,11 @@ void jit_uni_deconv_zp_pad_str_kernel_base_t::compute() {
 
         const int n_inner_ic_blk = jcp_.is_depthwise
                 ? 1
-                : (is_last_icb && ic_tail_exists ? utils::div_up(
-                           jcp_.ic_without_padding % jcp_.ic_block, 4)
-                                                 : (jcp_.ic_block / 4));
+                : (is_last_icb && ic_tail_exists
+                                  ? utils::div_up(jcp_.ic_without_padding
+                                                    % jcp_.ic_block,
+                                            4)
+                                  : (jcp_.ic_block / 4));
 
         const dim_t outer_wei_offset = icb * outer_icb_step;
 

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -43,7 +43,7 @@ struct jit_uni_dw_conv_fwd_kernel_t {
 
     jit_uni_dw_conv_fwd_kernel_t(jit_conv_conf_t ajcp)
         : ker_(utils::make_unique<jit_uni_dw_conv_fwd_kernel_f32_t<isa>>(
-                ajcp)) {}
+                  ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
     ~jit_uni_dw_conv_fwd_kernel_t() = default;
@@ -325,7 +325,7 @@ struct jit_uni_dw_conv_bwd_data_kernel_t {
 
     jit_uni_dw_conv_bwd_data_kernel_t(jit_conv_conf_t ajcp)
         : ker_(utils::make_unique<jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>>(
-                ajcp)) {}
+                  ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
     ~jit_uni_dw_conv_bwd_data_kernel_t() = default;
@@ -457,7 +457,7 @@ struct jit_uni_dw_conv_bwd_weights_kernel_t {
 
     jit_uni_dw_conv_bwd_weights_kernel_t(jit_conv_conf_t ajcp)
         : ker_(utils::make_unique<
-                jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>>(ajcp)) {}
+                  jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>>(ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
     ~jit_uni_dw_conv_bwd_weights_kernel_t() = default;

--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -376,7 +376,7 @@ public:
             const data_t *src, data_t *dst, char *indices,
             const exec_ctx_t &ctx)
         : transpose_facade_base_t<wsp_data_t, d_type>(
-                jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx) {
+                  jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx) {
 
         if (this->should_transpose_src()) {
             this->execute_transpose_input_
@@ -423,7 +423,7 @@ public:
             data_t *src, const data_t *dst, const char *indices,
             const exec_ctx_t &ctx)
         : transpose_facade_base_t<wsp_data_t, d_type>(
-                jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx)
+                  jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx)
         , c_tail_(jpp.c_without_padding % jpp.c_block) {
 
         if (this->should_transpose_src())

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -333,15 +333,17 @@ status_t acl_lowp_matmul_t::execute(const exec_ctx_t &ctx) const {
         bia_tensor.allocator()->import_memory(const_cast<float *>(bias));
     }
 
-    auto dst = pd()->almc_.use_dst_acc ? scratchpad.get<void>(
-                       memory_tracking::names::key_matmul_dst_in_acc_dt)
-                                       : CTX_OUT_MEM(float *, DNNL_ARG_DST);
+    auto dst = pd()->almc_.use_dst_acc
+            ? scratchpad.get<void>(
+                      memory_tracking::names::key_matmul_dst_in_acc_dt)
+            : CTX_OUT_MEM(float *, DNNL_ARG_DST);
     dst_tensor.allocator()->init(alcm.dst_tensor_info);
     dst_tensor.allocator()->import_memory(dst);
 
-    auto dst_cast = pd()->almc_.use_cast_acc ? scratchpad.get<void>(
-                            memory_tracking::names::key_matmul_dst_cast_acc)
-                                             : nullptr;
+    auto dst_cast = pd()->almc_.use_cast_acc
+            ? scratchpad.get<void>(
+                      memory_tracking::names::key_matmul_dst_cast_acc)
+            : nullptr;
     if (dst_cast) {
         dst_cast_tensor.allocator()->init(alcm.dst_cast_tensor_info);
         dst_cast_tensor.allocator()->import_memory(dst_cast);

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -229,9 +229,10 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
 
     // If we have an unfused sum post op, put the result in a scratchpad tensor.
     // Result will be summed to the dst during acl_post_ops.execute
-    auto dst_base = use_dst_acc_for_sum ? scratchpad.get<void>(
-                            memory_tracking::names::key_matmul_dst_in_acc_dt)
-                                        : CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+    auto dst_base = use_dst_acc_for_sum
+            ? scratchpad.get<void>(
+                      memory_tracking::names::key_matmul_dst_in_acc_dt)
+            : CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
     dst_tensor.allocator()->import_memory(dst_base);
 
     // Run transpose kernel

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -746,20 +746,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         zero_point_a_negative_val_ = src_zero_points
                 ? -cpu::io::load_int_value(
-                        pd->attr()->zero_points_.get_data_type(DNNL_ARG_SRC),
-                        src_zero_points, 0)
+                          pd->attr()->zero_points_.get_data_type(DNNL_ARG_SRC),
+                          src_zero_points, 0)
                 : 0;
         const int zero_point_b_val = wei_zero_points
                 ? cpu::io::load_int_value(
-                        pd->attr()->zero_points_.get_data_type(
-                                DNNL_ARG_WEIGHTS),
-                        wei_zero_points, 0)
+                          pd->attr()->zero_points_.get_data_type(
+                                  DNNL_ARG_WEIGHTS),
+                          wei_zero_points, 0)
                 : 0;
         zero_point_b_negative_val_ = -zero_point_b_val;
         zero_point_c_val_ = dst_zero_points
                 ? cpu::io::load_int_value(
-                        pd->attr()->zero_points_.get_data_type(DNNL_ARG_DST),
-                        dst_zero_points, 0)
+                          pd->attr()->zero_points_.get_data_type(DNNL_ARG_DST),
+                          dst_zero_points, 0)
                 : 0;
 
         const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -791,22 +791,22 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 * (weights_d.size() - weights_d.additional_buffer_size());
         s8s8_compensation_ptr_ = (bgmmc.s8s8_compensation_required)
                 ? ((bgmmc.use_buffer_b)
-                                ? scratchpad.template get<int32_t>(
-                                        key_brgemm_primitive_buffer_comp)
-                                : const_cast<int32_t *>(
-                                        reinterpret_cast<const int32_t *>(
-                                                &data_B_ptr_[comp_offset])))
+                                  ? scratchpad.template get<int32_t>(
+                                            key_brgemm_primitive_buffer_comp)
+                                  : const_cast<int32_t *>(
+                                            reinterpret_cast<const int32_t *>(
+                                                    &data_B_ptr_[comp_offset])))
                 : nullptr;
         assert(IMPLICATION(bgmmc.s8s8_compensation_required,
                 bgmmc_.b_dt_sz == bgmmc_.tr_b_dt_sz));
 
         zero_point_a_compensations_ptr_ = bgmmc.has_zero_point_a
                 ? scratchpad.template get<int32_t>(
-                        key_brgemm_primitive_zp_comp_a)
+                          key_brgemm_primitive_zp_comp_a)
                 : nullptr;
         zero_point_b_compensations_ptr_ = bgmmc.has_zero_point_b
                 ? scratchpad.template get<int32_t>(
-                        key_brgemm_primitive_zp_comp_b)
+                          key_brgemm_primitive_zp_comp_b)
                 : nullptr;
 
         zero_point_mixed_ab_compensation_component_

--- a/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
@@ -39,7 +39,7 @@ using namespace Xbyak_aarch64;
 #define LDR_IMM(reg, addr, off) \
     { \
         const uint64_t IMM12_MASK = ~uint64_t(0xfff); \
-        if (((off)&IMM12_MASK) == 0) { \
+        if (((off) & IMM12_MASK) == 0) { \
             ldr(reg, ptr(addr, off)); \
         } else { \
             add_imm(X_DEFAULT_ADDR, addr, off, X_TMP_0); \
@@ -50,7 +50,7 @@ using namespace Xbyak_aarch64;
 #define STR_IMM(reg, addr, off) \
     { \
         const uint64_t IMM12_MASK = ~uint64_t(0xfff); \
-        if (((off)&IMM12_MASK) == 0) { \
+        if (((off) & IMM12_MASK) == 0) { \
             str(reg, ptr(addr, off)); \
         } else { \
             add_imm(X_DEFAULT_ADDR, addr, off, X_TMP_0); \

--- a/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
@@ -165,7 +165,7 @@ status_t brgemm_matmul_copy_reorder_t::execute_body(
             = dst_d.size() - dst_d.additional_buffer_size();
     const size_t s8s8_comp_size_bytes = kernel_conf.s8s8_compensation_required
             ? dst_d.additional_buffer_size(
-                    memory_extra_flags::compensation_conv_s8s8)
+                      memory_extra_flags::compensation_conv_s8s8)
             : 0;
     const size_t zp_comp_offset_bytes
             = comp_offset_bytes + s8s8_comp_size_bytes;

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -213,11 +213,11 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(
     } else {
         bgmmc.wei_tag = blocked_B_layouts_allowed
                 ? memory_desc_matches_one_of_tag(B_md, plain_tensor_layout_tag,
-                        transposed_tensor_layout_tag, blocked_64n_B_layout_tag,
-                        blocked_48n_B_layout_tag, blocked_32n_B_layout_tag,
-                        blocked_16n_B_layout_tag)
+                          transposed_tensor_layout_tag,
+                          blocked_64n_B_layout_tag, blocked_48n_B_layout_tag,
+                          blocked_32n_B_layout_tag, blocked_16n_B_layout_tag)
                 : memory_desc_matches_one_of_tag(B_md, plain_tensor_layout_tag,
-                        transposed_tensor_layout_tag, acbd, adbc);
+                          transposed_tensor_layout_tag, acbd, adbc);
 
         // If the B memory descriptor matches both the transposed and plain
         // version that means that for dims = [P, Q, K, N] in the weight matrix,
@@ -260,16 +260,16 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_tags(memory_desc_t &A_md,
         bgmmc.src_tag = (this->is_bf16() || this->is_f32() || this->is_bf32()
                                 || this->is_f16())
                 ? memory_desc_matches_one_of_tag(A_md, plain_tensor_layout_tag,
-                        transposed_tensor_layout_tag, acbd, adbc)
+                          transposed_tensor_layout_tag, acbd, adbc)
                 // Enable support of int8 problems with formally transposed A
                 // layout which can be treated as plain.
                 // TODO: remove this extra code path after transposed A is
                 // supported for int8
                 : (this->is_int8() && can_treat_transposed_A_as_plain)
                 ? memory_desc_matches_one_of_tag(A_md, plain_tensor_layout_tag,
-                        transposed_tensor_layout_tag, acbd)
+                          transposed_tensor_layout_tag, acbd)
                 : memory_desc_matches_one_of_tag(
-                        A_md, plain_tensor_layout_tag, acbd);
+                          A_md, plain_tensor_layout_tag, acbd);
     }
 
     if (C_any_layout) {

--- a/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
@@ -46,7 +46,7 @@
 #define LDR_IMM(reg, addr, off) \
     { \
         const uint64_t IMM12_MASK = ~uint64_t(0xfff); \
-        if (((off)&IMM12_MASK) == 0) { \
+        if (((off) & IMM12_MASK) == 0) { \
             ldr(reg, ptr(addr, off)); \
         } else { \
             add_imm(X_DEFAULT_ADDR, addr, off, X_TMP_0); \

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -54,7 +54,7 @@
 #define LDR_IMM(reg, addr, off) \
     { \
         const uint64_t IMM12_MASK = ~uint64_t(0xfff); \
-        if (((off)&IMM12_MASK) == 0) { \
+        if (((off) & IMM12_MASK) == 0) { \
             ldr(reg, ptr(addr, off)); \
         } else { \
             add_imm(X_DEFAULT_ADDR, addr, off, X_TMP_0); \

--- a/src/cpu/aarch64/matmul/jit_int8_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul_utils.cpp
@@ -26,7 +26,7 @@
 #define LDR_IMM(reg, addr, off) \
     { \
         const uint64_t IMM12_MASK = ~uint64_t(0xfff); \
-        if (((off)&IMM12_MASK) == 0) { \
+        if (((off) & IMM12_MASK) == 0) { \
             ldr(reg, ptr(addr, off)); \
         } else { \
             add_imm(X_DEFAULT_ADDR, addr, off, X_TMP_0); \

--- a/src/cpu/aarch64/utils/jit_io_helper.cpp
+++ b/src/cpu/aarch64/utils/jit_io_helper.cpp
@@ -774,10 +774,11 @@ jit_io_multi_dt_helper_t<Vmm>::jit_io_multi_dt_helper_t(jit_generator_t *host,
             storage_.emplace(dt,
                     std::make_shared<jit_io_helper_t<Vmm>>(host, isa, dt,
                             io_conf, tail_conf,
-                            store_saturation_needed ? utils::optional_t<
-                                    io_saturation_conf_t> {saturation_conf
-                                                                   ->second}
-                                                    : utils::nullopt,
+                            store_saturation_needed
+                                    ? utils::optional_t<
+                                              io_saturation_conf_t> {saturation_conf
+                                                                             ->second}
+                                    : utils::nullopt,
                             gather_conf));
         }
     }

--- a/src/cpu/cpu_engine.hpp
+++ b/src/cpu/cpu_engine.hpp
@@ -87,7 +87,7 @@ public:
             const op_desc_t *desc) {
         static const impl_list_item_t empty_list[] = {nullptr};
 
-// clang-format off
+        // clang-format off
 #define CASE(kind) \
     case primitive_kind::kind: \
         return get_##kind##_impl_list((const kind##_desc_t *)desc);

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -1149,9 +1149,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
     auto default_dat_tag = is_int8_conv
             ? utils::pick(ndims - 3, format_tag::nwc, format_tag::nhwc,
-                    format_tag::ndhwc)
+                      format_tag::ndhwc)
             : utils::pick(ndims - 3, format_tag::ncw, format_tag::nchw,
-                    format_tag::ncdhw);
+                      format_tag::ncdhw);
     const status_t check_tag_status = set_or_check_tags(default_dat_tag,
             default_dat_tag, src_md.data_type == data_type::s8);
     VDISPATCH_CONV_IC(check_tag_status == status::success,
@@ -1231,11 +1231,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
     // to the number of threads and multiplied by a heuristic coefficient (15)
     const size_t zp_src_pad_comp_size = zp_src_with_padding
             ? (jcp.oc * jcp.ngroups * jcp.zp.src_pad_comp.d
-                    * jcp.zp.src_pad_comp.h * jcp.zp.src_pad_comp.w)
+                      * jcp.zp.src_pad_comp.h * jcp.zp.src_pad_comp.w)
             : 0u;
     const size_t zp_src_comp_size = jcp.zp.src_is_common
             ? utils::rnd_up(jcp.oc * jcp.ngroups,
-                    platform::get_cache_line_size() / sizeof(int))
+                      platform::get_cache_line_size() / sizeof(int))
             : 0u;
 
     const size_t weights_size = weights_d.size()

--- a/src/cpu/gemm_inner_product_utils.cpp
+++ b/src/cpu/gemm_inner_product_utils.cpp
@@ -39,8 +39,8 @@ struct ref_pp_kernel_t : public pp_kernel_t {
     ref_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
             const primitive_attr_t *attr, data_type_t bias_dt,
             data_type_t acc_dt, const memory_desc_t *dst_md, bool skip_sum)
-        : pp_kernel_t(
-                OC, MB, dst_mb_stride, attr, bias_dt, acc_dt, dst_md, skip_sum)
+        : pp_kernel_t(OC, MB, dst_mb_stride, attr, bias_dt, acc_dt, dst_md,
+                  skip_sum)
         , dst_md_(dst_md)
         , skip_sum_(skip_sum)
         , do_postops_(this->do_sum_ || this->do_eltwise_ || this->do_binary_

--- a/src/cpu/gemm_inner_product_utils.hpp
+++ b/src/cpu/gemm_inner_product_utils.hpp
@@ -53,7 +53,8 @@ struct pp_kernel_t {
             const float *dst_zero_points,
             const void *post_ops_binary_rhs_arg_vec, const void *dst_orig,
             size_t first_mb_matrix_addr_off, const exec_ctx_t &ctx,
-            const memory_desc_t &dst_md) const = 0;
+            const memory_desc_t &dst_md) const
+            = 0;
 
     virtual status_t create_kernel() { return status::success; }
 

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -300,7 +300,7 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
             const single_gemm_conv_chunk_desc_t chunk_desc
                     = should_apply_zp_src_comp_pad_jit_pp
                     ? single_gemm_conv_chunk_desc_t {od, 1, oh, h_step, ow,
-                            w_step}
+                              w_step}
                     : single_gemm_conv_chunk_desc_t {};
 
             parallel(0, [&](int ithr, int nthr) {

--- a/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
@@ -41,7 +41,8 @@ struct pp_ker_t {
             const zero_point_call_params_t &zp,
             const void *post_ops_binary_rhs_arg_vec, const void *dst_orig,
             const exec_ctx_t &ctx, const memory_desc_t &dst_md,
-            const single_gemm_conv_chunk_desc_t &chunk_desc) const = 0;
+            const single_gemm_conv_chunk_desc_t &chunk_desc) const
+            = 0;
 
     virtual status_t create_kernel() { return status::success; }
 

--- a/src/cpu/gemm_x8s8s32x_inner_product.cpp
+++ b/src/cpu/gemm_x8s8s32x_inner_product.cpp
@@ -71,7 +71,7 @@ status_t gemm_x8s8s32x_inner_product_fwd_t::execute_forward(
     int32_t *acc = pd()->dst_is_acc_
             ? (int32_t *)dst
             : ctx.get_scratchpad_grantor().template get<int32_t>(
-                    key_iprod_int_dat_in_acc_dt);
+                      key_iprod_int_dat_in_acc_dt);
 
     const float onef = 1.0, zerof = 0.0;
 

--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -256,7 +256,7 @@ status_t gemm_bf16_matmul_t<dst_type>::execute_ref(
     acc_data_t *acc = dst_is_acc
             ? (acc_data_t *)dst
             : ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    memory_tracking::names::key_matmul_dst_in_acc_dt);
+                      memory_tracking::names::key_matmul_dst_in_acc_dt);
     // case: dynamic sizes
     bool need_free_acc = false;
     if (acc == nullptr) {
@@ -357,7 +357,7 @@ status_t gemm_bf16_matmul_t<dst_type>::execute_ref(
                     const size_t dst_logical_off = i_work;
                     const size_t dim1_off = helper.ndims() > 3
                             ? ((cur_b % batch_without_dim0)
-                                    / batch_without_dim01)
+                                      / batch_without_dim01)
                             : cur_m;
                     // offset for case with post-op broadcast_channel
                     const size_t matrix_per_first_batch_off = helper.ndims() > 3

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -241,7 +241,7 @@ status_t gemm_f32_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
     acc_data_t *acc = dst_is_acc
             ? (acc_data_t *)dst
             : ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    memory_tracking::names::key_matmul_dst_in_acc_dt);
+                      memory_tracking::names::key_matmul_dst_in_acc_dt);
     // case: dynamic sizes
     bool need_free_acc = false;
     if (acc == nullptr) {
@@ -342,7 +342,7 @@ status_t gemm_f32_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                     const size_t dst_logical_off = i_work;
                     const size_t dim1_off = helper.ndims() > 3
                             ? ((cur_b % batch_without_dim0)
-                                    / batch_without_dim01)
+                                      / batch_without_dim01)
                             : cur_m;
 
                     // offset for case with post-op broadcast_channel

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -275,12 +275,12 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
     const bool use_single_gemm_call = pd()->has_runtime_dims_or_strides()
             ? helper.use_single_gemm_call_optimization(po)
             : ((platform::is_ppc64() && ndims == 2)
-                    || params.use_single_gemm_call_optimization_);
+                      || params.use_single_gemm_call_optimization_);
     bool dst_is_acc = params.dst_is_acc_;
     int32_t *acc = dst_is_acc
             ? reinterpret_cast<int32_t *>(dst)
             : ctx.get_scratchpad_grantor().template get<int32_t>(
-                    memory_tracking::names::key_matmul_dst_in_acc_dt);
+                      memory_tracking::names::key_matmul_dst_in_acc_dt);
     // case: dynamic sizes
     bool need_free_acc = false;
     if (acc == nullptr) {
@@ -442,7 +442,7 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                     const size_t dst_logical_off = i_work;
                     const size_t dim1_off = helper.ndims() > 3
                             ? ((cur_b % batch_without_dim0)
-                                    / batch_without_dim01)
+                                      / batch_without_dim01)
                             : cur_m;
                     // offset for case with post-op broadcast_channel
                     const size_t matrix_per_first_batch_off = helper.ndims() > 3

--- a/src/cpu/ppc64/gemm/gemm_driver.cpp
+++ b/src/cpu/ppc64/gemm/gemm_driver.cpp
@@ -1365,7 +1365,7 @@ static dnnl_status_t gemm_threading_driver(
 
                 auto m_padd = (thread_info.copy == copy_type::shared_a)
                         ? get_m_padd_parallel_a(
-                                ithr, m, arg, thread_info.nthrs())
+                                  ithr, m, arg, thread_info.nthrs())
                         : get_m_padd(ithr, m, arg);
                 auto n_padd = get_n_padd(ithr, n, k, arg);
                 auto k_padd = get_k_padd(ithr, k, arg);

--- a/src/cpu/ppc64/gemm/gemm_pack_storage.hpp
+++ b/src/cpu/ppc64/gemm/gemm_pack_storage.hpp
@@ -224,7 +224,7 @@ protected:
         size_t off_matrix, off_sums;
         size_t size;
         gemm_threading_t threading; /* if packed */
-    } * header;
+    } *header;
 
     struct slice_header_t {
         bool packed;
@@ -327,7 +327,7 @@ protected:
                 slice[id].finalize<data_type>(cur_off);
 #endif
         }
-    } * matrix_header, *sums_header;
+    } *matrix_header, *sums_header;
 
     size_t total_header_size = 0;
 

--- a/src/cpu/primitive_attr_postops.cpp
+++ b/src/cpu/primitive_attr_postops.cpp
@@ -181,7 +181,7 @@ ref_eltwise_scalar_fwd_t::ref_eltwise_scalar_fwd_t(
 ref_eltwise_scalar_fwd_t::ref_eltwise_scalar_fwd_t(
         const post_ops_t::entry_t::eltwise_t &eltwise)
     : ref_eltwise_scalar_fwd_t(
-            eltwise.alg, eltwise.alpha, eltwise.beta, eltwise.scale) {}
+              eltwise.alg, eltwise.alpha, eltwise.beta, eltwise.scale) {}
 
 float ref_eltwise_scalar_fwd_t::compute_scalar(float s) const {
     return compute_eltwise_scalar_fwd(alg_, s, alpha_, beta_) * scale_;

--- a/src/cpu/ref_batch_normalization.cpp
+++ b/src/cpu/ref_batch_normalization.cpp
@@ -76,7 +76,7 @@ status_t ref_batch_normalization_fwd_t<d_type>::execute_forward(
     CHECK(status);
     auto variance = pd()->stats_is_src()
             ? const_cast<acc_data_t *>(
-                    CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE))
+                      CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE))
             : CTX_OUT_CLEAN_MEM(float *, DNNL_ARG_VARIANCE, status);
     CHECK(status);
 

--- a/src/cpu/ref_convolution_int8.cpp
+++ b/src/cpu/ref_convolution_int8.cpp
@@ -137,7 +137,7 @@ status_t ref_convolution_int8_fwd_t::execute_forward(
             const int s = io::load_int_value(src_d.data_type(), src, src_off);
             const int src_zp = src_zero_points
                     ? io::load_int_value(data_type::s32, src_zero_points,
-                            src_zp_idx_mult * (g * IC + ic))
+                              src_zp_idx_mult * (g * IC + ic))
                     : 0;
             const int w = io::load_int_value(
                     weights_d.data_type(), weights, wei_off);
@@ -194,10 +194,11 @@ status_t ref_convolution_int8_fwd_t::execute_forward(
                             + kw;
                     const int s = io::load_int_value(
                             src_d.data_type(), src_loc, src_off + src_loc_off);
-                    const int src_zp = src_zero_points ? io::load_int_value(
-                                               data_type::s32, src_zero_points,
-                                               src_zp_idx_mult * (g * IC + ic))
-                                                       : 0;
+                    const int src_zp = src_zero_points
+                            ? io::load_int_value(data_type::s32,
+                                      src_zero_points,
+                                      src_zp_idx_mult * (g * IC + ic))
+                            : 0;
                     const int w = io::load_int_value(weights_d.data_type(),
                             weights_loc, weights_off + weights_loc_off);
                     d += (s - src_zp) * w;
@@ -223,7 +224,7 @@ status_t ref_convolution_int8_fwd_t::execute_forward(
                         src_d.data_type(), src_loc, src_off + src_loc_off);
                 const int src_zp = src_zero_points
                         ? io::load_int_value(data_type::s32, src_zero_points,
-                                src_zp_idx_mult * (g * IC + ic))
+                                  src_zp_idx_mult * (g * IC + ic))
                         : 0;
                 const int w = io::load_int_value(weights_d.data_type(),
                         weights_loc, weights_off + weights_loc_off);

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -124,8 +124,8 @@ void ref_deconvolution_fwd_t::compute_fwd_bias_nCdhwXc(const exec_ctx_t &ctx,
 
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < blk_size; ++i) {
-                    float b = i < blk ? io::load_float_value(
-                                      bias_d.data_type(), bias, oc + i)
+                    float b = i < blk ? io::load_float_value(bias_d.data_type(),
+                                                bias, oc + i)
                                       : 0;
                     float d = conv_output[off + i];
                     // Use f32 if attributes happen after bias to get precise

--- a/src/cpu/ref_eltwise.cpp
+++ b/src/cpu/ref_eltwise.cpp
@@ -34,10 +34,10 @@ namespace cpu {
             ? (f).off(n) \
             : ((ndims == 2) ? (f).off(n, c) \
                             : ((ndims == 3) ? (f).off(n, c, w) \
-                                            : ((ndims == 4) ? (f).off( \
-                                                       n, c, h, w) \
+                                            : ((ndims == 4) ? (f).off(n, c, h, \
+                                                                      w) \
                                                             : (f).off(n, c, d, \
-                                                                    h, w))))
+                                                                      h, w))))
 
 status_t ref_eltwise_fwd_t::execute_forward_generic(
         const exec_ctx_t &ctx) const {

--- a/src/cpu/ref_layer_normalization.cpp
+++ b/src/cpu/ref_layer_normalization.cpp
@@ -229,7 +229,7 @@ status_t ref_layer_normalization_bwd_t::execute_backward(
             for (dim_t c = 0; c < C; ++c) {
                 const float gamma = scale
                         ? io::load_float_value(
-                                sc_d.data_type(), scale, sc_d.off(c))
+                                  sc_d.data_type(), scale, sc_d.off(c))
                         : 1.f;
                 const auto src_off = src_d.off_l(n * C + c);
                 const auto diff_dst_off = diff_dst_d.off_l(n * C + c);

--- a/src/cpu/ref_sum.hpp
+++ b/src/cpu/ref_sum.hpp
@@ -114,7 +114,7 @@ struct ref_sum_t : public primitive_t {
 
         auto sum_reduce = pd()->need_output_reorder()
                 ? ctx.get_scratchpad_grantor().get_memory_storage(
-                        key_sum_reduction)
+                          key_sum_reduction)
                 : nullptr;
         const auto &dst = ctx.args().at(DNNL_ARG_DST);
 

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -323,7 +323,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                         ? input[input_d.blk_off<!w_groups>(g, oc, ic, h, w)]
                         : input[input_d.blk_off<!w_groups>(g, oc, ic, w)];
                 auto &o = w_depth ? output[output_d.blk_off<!w_groups>(
-                                  g, oc, ic, d, h, w)]
+                                            g, oc, ic, d, h, w)]
                         : w_height
                         ? output[output_d.blk_off<!w_groups>(g, oc, ic, h, w)]
                         : output[output_d.blk_off<!w_groups>(g, oc, ic, w)];
@@ -2046,7 +2046,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                     : ndims >= 4 + with_g \
                     ? (md).blk_off<!with_g>(g, h0, h1, m1, m2) \
                     : /* ndims >= 3 + with_g ? */ (md).blk_off<!with_g>( \
-                            g, h0, h1, m2))
+                              g, h0, h1, m2))
 
         parallel_nd(G, NB_H0, NB_H1, M0, M1, M2,
                 [=](dim_t g, dim_t nb_h0, dim_t nb_h1, dim_t m0, dim_t m1,
@@ -2416,7 +2416,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 src_scale = src_scales_d.nelems() == 1
                         ? src_scales[0]
                         : io::load_float_value(src_scales_d.data_type(),
-                                src_scales, src_scales_off);
+                                  src_scales, src_scales_off);
             }
 
             int src_zp_val = 0; // Avoid clashing with the one defined for rest.
@@ -2647,7 +2647,7 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 src_scale = src_scales_d.nelems() == 1
                         ? src_scales[0]
                         : io::load_float_value(src_scales_d.data_type(),
-                                src_scales, src_scales_off);
+                                  src_scales, src_scales_off);
             }
 
             float dst_scale = 1.f;

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -605,22 +605,14 @@ void ref_rnn_common_t<aprop, src_type, weights_type,
     // them run simulataneously. So, we can re-use the same scratchpad across
     // all primitives. Iterate through them to find the largest scratchpad
     // required.
-    const auto nested_pds
-            = { matmul_layer_1_pd_,
-                  matmul_layer_2_pd_,
-                  matmul_layer_3_pd_,
-                  matmul_iter_1_pd_,
-                  matmul_iter_2_pd_,
-                  matmul_iter_3_pd_,
-                  matmul_part2_1_pd_,
-                  matmul_part2_2_pd_,
-                  matmul_part2_3_pd_,
-                  matmul_part2_4_pd_,
+    const auto nested_pds = {matmul_layer_1_pd_, matmul_layer_2_pd_,
+            matmul_layer_3_pd_, matmul_iter_1_pd_, matmul_iter_2_pd_,
+            matmul_iter_3_pd_, matmul_part2_1_pd_, matmul_part2_2_pd_,
+            matmul_part2_3_pd_, matmul_part2_4_pd_,
 #if DNNL_X64
-                  bf32_wei_layer_reorder_pd_,
-                  bf32_wei_iter_reorder_pd_
+            bf32_wei_layer_reorder_pd_, bf32_wei_iter_reorder_pd_
 #endif
-              };
+    };
 
     size_t max_nested_scratchpad_size = 0;
     for (const auto &n_pd : nested_pds) {
@@ -2066,7 +2058,7 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
     if (rnn.use_workspace)
         ws_ptr = rnn.is_fwd ? CTX_OUT_MEM(char *, DNNL_ARG_WORKSPACE)
                             : const_cast<char *>(CTX_IN_MEM(
-                                    const char *, DNNL_ARG_WORKSPACE));
+                                      const char *, DNNL_ARG_WORKSPACE));
 
     char *base_ptr = rnn.use_workspace ? ws_ptr : scratch_ptr;
     // ws_gates is only used to pass data from FWD to BWD.

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -451,11 +451,11 @@ private:
 
         /* Quantize src & compute compensation */
         auto scratch_quantized
-                = (int8_t * __restrict) ctx.get_scratchpad_grantor()
+                = (int8_t *__restrict)ctx.get_scratchpad_grantor()
                           .template get<void>(memory_tracking::names::
                                           key_reorder_rnn_weights_quantization);
         auto scratch_compensation
-                = (int32_t * __restrict) ctx.get_scratchpad_grantor()
+                = (int32_t *__restrict)ctx.get_scratchpad_grantor()
                           .template get<void>(memory_tracking::names::
                                           key_reorder_rnn_weights_reduction);
         float *comp = reinterpret_cast<float *>(
@@ -486,7 +486,7 @@ private:
                 default: assert(!"Unsupported reorder");
             }
         } else
-            scratch_quantized = (int8_t * __restrict) src;
+            scratch_quantized = (int8_t *__restrict)src;
 
         /* Step 2: we pre-compute the compensation */
         switch (pd()->itag_) {
@@ -873,11 +873,11 @@ private:
 
         /* Quantize src & compute compensation */
         auto scratch_quantized
-                = (int8_t * __restrict) ctx.get_scratchpad_grantor()
+                = (int8_t *__restrict)ctx.get_scratchpad_grantor()
                           .template get<void>(memory_tracking::names::
                                           key_reorder_rnn_weights_quantization);
         auto scratch_compensation
-                = (int32_t * __restrict) ctx.get_scratchpad_grantor()
+                = (int32_t *__restrict)ctx.get_scratchpad_grantor()
                           .template get<void>(memory_tracking::names::
                                           key_reorder_rnn_weights_reduction);
         float *comp = reinterpret_cast<float *>(dst + compensation_offset);
@@ -902,7 +902,7 @@ private:
             quantize_igo<type_i>(
                     scratch_quantized, src_d, (float *)src, mask, scales);
         } else
-            scratch_quantized = (int8_t * __restrict) src;
+            scratch_quantized = (int8_t *__restrict)src;
 
         if (req_s8s8_comp && mask_ok(dst_d.extra().compensation_mask))
             compensate_igo(comp, src_d, scratch_quantized, scratch_compensation,

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -512,9 +512,9 @@ struct rnn_conf_t {
         return (cell_position & first_iter) && skip_src_iter_copy()
                 ? src_iter_ld_
                 : ((cell_position & last_layer) && skip_dst_layer_copy()
-                                        && !(cell_position & first_iter)
-                                ? dst_layer_ld_
-                                : ws_states_iter_ld);
+                                          && !(cell_position & first_iter)
+                                  ? dst_layer_ld_
+                                  : ws_states_iter_ld);
     }
 
     inline dim_t layer_brgemm_desc(cell_position_t cell_position) const {
@@ -1400,7 +1400,7 @@ template <typename T>
 struct ws_diff_states_layer_aoc_t {
     ws_diff_states_layer_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_layer_(data, rnn.ws_diff_states_layer_nld,
-                rnn.ws_diff_states_layer_ld) {}
+                  rnn.ws_diff_states_layer_ld) {}
     T &operator()(int batch, int dhc) const {
         return diff_states_layer_(batch, dhc);
     }
@@ -1413,7 +1413,7 @@ template <typename T>
 struct ws_diff_states_iter_aoc_t {
     ws_diff_states_iter_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_(data, rnn.ws_diff_states_iter_nld,
-                rnn.ws_diff_states_iter_ld) {}
+                  rnn.ws_diff_states_iter_ld) {}
     T &operator()(int batch, int dhc) const {
         return diff_states_iter_(batch, dhc);
     }
@@ -1426,7 +1426,7 @@ template <typename T>
 struct ws_diff_states_iter_c_aoc_t {
     ws_diff_states_iter_c_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_c_(data, rnn.ws_diff_states_iter_c_nld,
-                rnn.ws_diff_states_iter_c_ld) {}
+                  rnn.ws_diff_states_iter_c_ld) {}
     T &operator()(int batch, int dhc) const {
         return diff_states_iter_c_(batch, dhc);
     }
@@ -1438,7 +1438,7 @@ private:
 struct ws_diff_w_iter_aoc_t {
     ws_diff_w_iter_aoc_t(const rnn_conf_t &rnn, float *data)
         : diff_weights_iter_(
-                data, rnn.diff_weights_iter_nld, rnn.diff_weights_iter_ld)
+                  data, rnn.diff_weights_iter_nld, rnn.diff_weights_iter_ld)
         , DHC_(rnn.dhc) {}
     float &operator()(int sic, int gate, int dhc) const {
         return diff_weights_iter_(sic, gate * DHC_ + dhc);

--- a/src/cpu/rv64/rvv_gemm_convolution_utils.cpp
+++ b/src/cpu/rv64/rvv_gemm_convolution_utils.cpp
@@ -1141,9 +1141,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
     auto default_dat_tag = is_int8_conv
             ? utils::pick(ndims - 3, format_tag::nwc, format_tag::nhwc,
-                    format_tag::ndhwc)
+                      format_tag::ndhwc)
             : utils::pick(ndims - 3, format_tag::ncw, format_tag::nchw,
-                    format_tag::ncdhw);
+                      format_tag::ncdhw);
     const status_t check_tag_status = set_or_check_tags(default_dat_tag,
             default_dat_tag, src_md.data_type == data_type::s8);
     VDISPATCH_CONV_IC(check_tag_status == status::success,
@@ -1206,11 +1206,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
     // to the number of threads and multiplied by a heuristic coefficient (15)
     const size_t zp_src_pad_comp_size = zp_src_with_padding
             ? (jcp.oc * jcp.ngroups * jcp.zp.src_pad_comp.d
-                    * jcp.zp.src_pad_comp.h * jcp.zp.src_pad_comp.w)
+                      * jcp.zp.src_pad_comp.h * jcp.zp.src_pad_comp.w)
             : 0u;
     const size_t zp_src_comp_size = jcp.zp.src_is_common
             ? utils::rnd_up(jcp.oc * jcp.ngroups,
-                    platform::get_cache_line_size() / sizeof(int))
+                      platform::get_cache_line_size() / sizeof(int))
             : 0u;
 
     const size_t weights_size = weights_d.size()

--- a/src/cpu/s390x/helpers.h
+++ b/src/cpu/s390x/helpers.h
@@ -25,9 +25,9 @@ namespace s390x {
 
 constexpr int VLEN_BYTES = 16;
 constexpr bool ISLASTINDEX_FAST = false;
-#define aPtr(i, j) A[(j)*ldA + (i)] // map aPtr( i,j ) to array A
-#define bPtr(i, j) B[(j)*ldB + (i)] // map bPtr( i,j ) to array B
-#define gPtr(i, j) C[(j)*ldC + (i)] // map gPtr( i,j ) to array C
+#define aPtr(i, j) A[(j) * ldA + (i)] // map aPtr( i,j ) to array A
+#define bPtr(i, j) B[(j) * ldB + (i)] // map bPtr( i,j ) to array B
+#define gPtr(i, j) C[(j) * ldC + (i)] // map gPtr( i,j ) to array C
 
 template <typename T>
 struct vec_inner_type_t {

--- a/src/cpu/s390x/pack.hpp
+++ b/src/cpu/s390x/pack.hpp
@@ -82,9 +82,9 @@ typename utils::enable_if<(N < G), void>::type pack_KK_TAILS(const int k,
 }
 
 template <typename T, typename DT, int G, int KK = 4, bool trans>
-void __attribute__((noinline))
-pack_K(const int k, const int n, const T *__restrict src, int srcLD,
-        DT *__restrict dst, DT add_val = 0) {
+void __attribute__((noinline)) pack_K(const int k, const int n,
+        const T *__restrict src, int srcLD, DT *__restrict dst,
+        DT add_val = 0) {
 
     // if k is not divisible by 4 , the rest will be 0-ed
     constexpr bool accessSide = trans ? (!ISLASTINDEX_FAST) : ISLASTINDEX_FAST;

--- a/src/cpu/simple_layer_normalization.cpp
+++ b/src/cpu/simple_layer_normalization.cpp
@@ -105,7 +105,7 @@ status_t simple_layer_normalization_fwd_t::execute_forward(
                 : CTX_OUT_MEM(float *, DNNL_ARG_MEAN);
         variance = pd()->stats_are_src()
                 ? const_cast<float *>(
-                        CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE))
+                          CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE))
                 : CTX_OUT_MEM(float *, DNNL_ARG_VARIANCE);
     }
 

--- a/src/cpu/sycl/engine.hpp
+++ b/src/cpu/sycl/engine.hpp
@@ -38,7 +38,7 @@ public:
     engine_t(
             const ::sycl::device &dev, const ::sycl::context &ctx, size_t index)
         : cpu::cpu_engine_t(new xpu::sycl::engine_impl_t(
-                engine_kind::cpu, dev, ctx, index)) {}
+                  engine_kind::cpu, dev, ctx, index)) {}
 
     status_t init() { return init_impl(); }
 

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -271,7 +271,7 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
 
     const int postops_regs = brg->attr()
             ? injector::aux_vec_count(
-                    brg->attr()->post_ops_, brg->isa_impl, true)
+                      brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;
 
     // Emulators: fp8 emulation are supported for amx only
@@ -915,7 +915,7 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
     const int bf16_emu_vregs = brg->is_bf16_emu * 4;
     const int postops_regs = brg->attr()
             ? injector::aux_vec_count(
-                    brg->attr()->post_ops_, brg->isa_impl, true)
+                      brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;
 
     const int max_acc_vmms = max_vregs

--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -161,7 +161,7 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
     reducer_2d_driver_f_s_32_t(int n_src, size_t src_ld, size_t src_step,
             size_t dst_step, bool nullify_dst)
         : reducer_2d_driver_t<data_type>(
-                n_src, src_ld, src_step, dst_step, nullify_dst, jit_name()) {}
+                  n_src, src_ld, src_step, dst_step, nullify_dst, jit_name()) {}
 
     void nullify_dst(int nloads, int load_len) {
         UNUSED(load_len);

--- a/src/cpu/x64/gemm/gemm_driver.cpp
+++ b/src/cpu/x64/gemm/gemm_driver.cpp
@@ -1821,7 +1821,7 @@ static dnnl_status_t gemm_threading_driver(
 
                 auto m_padd = (thread_info.copy == copy_type::shared_a)
                         ? get_m_padd_parallel_a(
-                                ithr, m, arg, thread_info.nthrs())
+                                  ithr, m, arg, thread_info.nthrs())
                         : get_m_padd(ithr, m, arg);
                 auto n_padd = get_n_padd(ithr, n, k, arg);
                 auto k_padd = get_k_padd(ithr, k, arg);

--- a/src/cpu/x64/gemm/gemm_pack_storage.hpp
+++ b/src/cpu/x64/gemm/gemm_pack_storage.hpp
@@ -224,7 +224,7 @@ protected:
         size_t off_matrix, off_sums;
         size_t size;
         gemm_threading_t threading; /* if packed */
-    } * header;
+    } *header;
 
     struct slice_header_t {
         bool packed;
@@ -327,7 +327,7 @@ protected:
                 slice[id].finalize<data_type>(cur_off);
 #endif
         }
-    } * matrix_header, *sums_header;
+    } *matrix_header, *sums_header;
 
     size_t total_header_size = 0;
 

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_gemm_s8u8s32_kern.cpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_gemm_s8u8s32_kern.cpp
@@ -488,7 +488,7 @@ void jit_avx512_core_gemm_s8u8s32_kern_t::generate() {
 jit_avx512_core_gemm_s8u8s32_kern_t::jit_avx512_core_gemm_s8u8s32_kern_t(
         bool beta_zero, bool enable_offset_c, bool enable_offset_r)
     : jit_generator_t(jit_name(),
-            mayiuse(avx512_core_vnni) ? avx512_core_vnni : avx512_core)
+              mayiuse(avx512_core_vnni) ? avx512_core_vnni : avx512_core)
     , beta_zero_(beta_zero)
     , enable_offset_c_(enable_offset_c)
     , enable_offset_r_(enable_offset_r)

--- a/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_kernel_gemv_s8x8s32_kern.hpp
+++ b/src/cpu/x64/gemm/s8x8s32/jit_avx512_core_kernel_gemv_s8x8s32_kern.hpp
@@ -80,7 +80,7 @@ class jit_avx512_core_gemv_s8x8s32_kern_t : public jit_generator_t {
 public:
     jit_avx512_core_gemv_s8x8s32_kern_t(ver_t ver)
         : jit_generator_t(jit_name(),
-                mayiuse(avx512_core_vnni) ? avx512_core_vnni : avx512_core)
+                  mayiuse(avx512_core_vnni) ? avx512_core_vnni : avx512_core)
         , ver(ver) {}
 };
 

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -501,7 +501,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
                                     acc_needed ? acc_arr : (float *)dst_arr,
                                     bia_arr, sum_scale, jcp.oc,
                                     post_ops_binary_rhs_arg_vec, dst_base,
-                                    g * jcp.oc);
+                                    g *jcp.oc);
                         });
             }
         }
@@ -526,7 +526,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
             key_conv_gemm_col);
     acc_data_t *acc_base = is_bf16_dst
             ? ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_conv_int_dat_in_acc_dt)
+                      key_conv_int_dat_in_acc_dt)
             : nullptr;
 
     const conv_gemm_conf_t &jcp = this->pd()->jcp_;
@@ -609,7 +609,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
             float *bias_ptr = bias ? bias + groups * jcp.oc + oc : nullptr;
             (*pp_ker_)(dst_local, acc, bias_ptr, sum_scale, dst_str, acc_str, m,
                     oc_block, post_ops_binary_rhs_arg_vec.data(), dst,
-                    groups * jcp.oc + oc);
+                    groups *jcp.oc + oc);
         }
     };
 
@@ -789,7 +789,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
             key_conv_gemm_col);
     acc_data_t *acc_base = diff_src_data_type == data_type::bf16
             ? ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_conv_int_dat_in_acc_dt)
+                      key_conv_int_dat_in_acc_dt)
             : nullptr;
 
     const conv_gemm_conf_t &jcp = this->pd()->jcp_;
@@ -964,7 +964,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
     acc_data_t *acc_base = diff_wei_data_type == data_type::bf16
             ? ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_conv_int_dat_in_acc_dt)
+                      key_conv_int_dat_in_acc_dt)
             : (acc_data_t *)diff_weights;
 
     float *diff_bias = nullptr;
@@ -1171,7 +1171,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
     acc_data_t *acc_base = diff_wei_data_type == data_type::bf16
             ? ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_conv_int_dat_in_acc_dt)
+                      key_conv_int_dat_in_acc_dt)
             : (acc_data_t *)diff_weights;
 
     float *diff_bias = nullptr;

--- a/src/cpu/x64/gemm_bf16_inner_product.cpp
+++ b/src/cpu/x64/gemm_bf16_inner_product.cpp
@@ -64,7 +64,7 @@ status_t gemm_bf16_inner_product_fwd_t<dst_data_type>::execute_forward(
     acc_data_t *acc = pd()->dst_is_acc_
             ? (acc_data_t *)dst
             : ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_iprod_int_dat_in_acc_dt);
+                      key_iprod_int_dat_in_acc_dt);
 
     float alpha = 1.0;
     status_t st = gemm_bf16bf16f32(wei_tr ? "T" : "N", src_tr ? "T" : "N", &M,
@@ -111,7 +111,7 @@ gemm_bf16_inner_product_bwd_data_t<diff_src_data_type>::execute_backward_data(
     acc_data_t *acc = pd()->diff_src_is_acc_
             ? (acc_data_t *)diff_src
             : ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_iprod_int_dat_in_acc_dt);
+                      key_iprod_int_dat_in_acc_dt);
 
     float alpha = 1.0, beta = 0.0;
     status_t st = status::success;
@@ -160,7 +160,7 @@ status_t gemm_bf16_inner_product_bwd_weights_t<diff_wei_data_type>::
     acc_data_t *acc = pd()->diff_wei_is_acc_
             ? (acc_data_t *)diff_weights
             : ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_iprod_int_dat_in_acc_dt);
+                      key_iprod_int_dat_in_acc_dt);
 
     float alpha = 1.0, beta = 0.0;
     status_t st = status::success;
@@ -223,7 +223,7 @@ void gemm_bf16_inner_product_bwd_weights_t<diff_wei_data_type>::
     float *diff_bias_acc = diff_bias_is_acc
             ? (float *)diff_bias
             : (float *)ctx.get_scratchpad_grantor().template get<acc_data_t>(
-                    key_iprod_bias_bf16_convert_wsp);
+                      key_iprod_bias_bf16_convert_wsp);
 
     parallel(pd()->bias_reduction_nthr_, [&](int ithr, int nthr) {
         if (ithr < nthr_OCB * nthr_MB) {

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -112,9 +112,9 @@ conditional_register_preserve_guard_t::conditional_register_preserve_guard_t(
         std::initializer_list<Xbyak::Reg64> reg64_to_preserve,
         std::initializer_list<Xbyak::Xmm> vmm_to_preserve)
     : register_preserve_guard_t {condition_to_be_met
-                    ? register_preserve_guard_t {host, reg64_to_preserve,
-                            vmm_to_preserve}
-                    : register_preserve_guard_t {nullptr, {}, {}}} {};
+                      ? register_preserve_guard_t {host, reg64_to_preserve,
+                                vmm_to_preserve}
+                      : register_preserve_guard_t {nullptr, {}, {}}} {};
 
 /*
 * Registry scratchpad code
@@ -164,12 +164,12 @@ reg64_savable_t::reg64_savable_t(registry_scratchpad_t &regscratchpad,
         const Xbyak::Reg64 &reg, const Xbyak::Reg64 &alternative_reg,
         bool use_alternative)
     : reg64_savable_t(regscratchpad, use_alternative ? alternative_reg : reg,
-            !use_alternative) {}
+              !use_alternative) {}
 
 reg64_savable_t::reg64_savable_t(registry_scratchpad_t &regscratchpad,
         const Xbyak::Reg64 &reg, const Xbyak::Reg64 &ext_reg)
     : reg64_savable_t(
-            regscratchpad, reg, ext_reg, regscratchpad.ExtendedRegisters()) {
+              regscratchpad, reg, ext_reg, regscratchpad.ExtendedRegisters()) {
     // We expect ext_reg from extended registers set
     assert(16 <= ext_reg.getIdx() && ext_reg.getIdx() <= 31);
 }

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -172,7 +172,7 @@ public:
     reg64_savable_backup_t(
             const reg64_savable_t &other, const Xbyak::Reg64 &ext_reg)
         : reg64_savable_t(other.regscratchpad_,
-                other.regscratchpad_.ExtendedRegisters() ? ext_reg : other)
+                  other.regscratchpad_.ExtendedRegisters() ? ext_reg : other)
         , other_(other) {}
 
     void save() const override { other_.saveTo(*this); }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -218,12 +218,12 @@ static_params_t::static_params_t(const Xbyak::Reg64 &param1,
         const bcast_set_t &supported_strategy_set,
         const rhs_arg_static_params_t &rhs_arg_static_params)
     : static_params_t(param1, supported_strategy_set, rhs_arg_static_params,
-            nullptr, nullptr) {}
+              nullptr, nullptr) {}
 
 static_params_t::static_params_t(const Xbyak::Reg64 &param1,
         const rhs_arg_static_params_t &rhs_arg_static_params)
     : static_params_t(param1, get_all_strategies_supported_by_injector(),
-            rhs_arg_static_params) {}
+              rhs_arg_static_params) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
@@ -233,10 +233,10 @@ rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
         std::size_t tail_size, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
-            tail_size, Xbyak::Opmask(2), use_exact_tail_scalar_bcast,
-            rhs_helper_reg, false /*is_opmask_set*/) {}
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+              tail_size, Xbyak::Opmask(2), use_exact_tail_scalar_bcast,
+              rhs_helper_reg, false /*is_opmask_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
@@ -247,10 +247,10 @@ rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
         bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
-            tail_size, tail_opmask, use_exact_tail_scalar_bcast, rhs_helper_reg,
-            true /*is_opmask_set*/) {}
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+              tail_size, tail_opmask, use_exact_tail_scalar_bcast,
+              rhs_helper_reg, true /*is_opmask_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
@@ -261,10 +261,10 @@ rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
         const Xbyak::Reg64 &reg_tail_size, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
-            rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
-            preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
-            tail_size, tail_opmask, use_exact_tail_scalar_bcast, reg_tail_size,
-            true /*is_opmask_set*/) {}
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+              tail_size, tail_opmask, use_exact_tail_scalar_bcast,
+              reg_tail_size, true /*is_opmask_set*/) {}
 
 rhs_arg_static_params_t::rhs_arg_static_params_t(
         std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
@@ -485,48 +485,52 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const injector_utils::register_preserve_guard_t register_guard {host_,
             (rhs_arg_static_params_.preserve_gpr_helpers
                                     && should_preserve_w_or_oc_offset_conversion_regs
-                            ? std::initializer_list<Xbyak::Reg64>(
-                                    {rhs_arg_static_params_.rhs_addr_reg,
-                                            rhs_arg_static_params_
-                                                    .rhs_helper_reg,
-                                            rhs_arg_static_params_
-                                                    .rhs_addr_cache_reg,
-                                            host_->rax, host_->rdx, host_->r8})
+                            ? std::initializer_list<
+                                      Xbyak::Reg64>({rhs_arg_static_params_
+                                                             .rhs_addr_reg,
+                                      rhs_arg_static_params_.rhs_helper_reg,
+                                      rhs_arg_static_params_.rhs_addr_cache_reg,
+                                      host_->rax, host_->rdx, host_->r8})
                             : rhs_arg_static_params_.preserve_gpr_helpers
                                     && should_preserve_mb_sp_offset_conversion_regs
                             ? std::initializer_list<Xbyak::Reg64>(
-                                    {rhs_arg_static_params_.rhs_addr_reg,
-                                            rhs_arg_static_params_
-                                                    .rhs_helper_reg,
-                                            rhs_arg_static_params_
-                                                    .rhs_addr_cache_reg,
-                                            host_->rax, host_->rdx, host_->r8,
-                                            host_->r9})
+                                      {rhs_arg_static_params_.rhs_addr_reg,
+                                              rhs_arg_static_params_
+                                                      .rhs_helper_reg,
+                                              rhs_arg_static_params_
+                                                      .rhs_addr_cache_reg,
+                                              host_->rax, host_->rdx, host_->r8,
+                                              host_->r9})
                             : rhs_arg_static_params_.preserve_gpr_helpers
                             ? std::initializer_list<Xbyak::Reg64>(
-                                    {rhs_arg_static_params_.rhs_addr_reg,
-                                            rhs_arg_static_params_
-                                                    .rhs_helper_reg,
-                                            rhs_arg_static_params_
-                                                    .rhs_addr_cache_reg,
-                                            host_->rax, host_->rdx})
+                                      {rhs_arg_static_params_.rhs_addr_reg,
+                                              rhs_arg_static_params_
+                                                      .rhs_helper_reg,
+                                              rhs_arg_static_params_
+                                                      .rhs_addr_cache_reg,
+                                              host_->rax, host_->rdx})
                             : should_preserve_w_or_oc_offset_conversion_regs
                             ? std::initializer_list<Xbyak::Reg64>(
-                                    {rhs_arg_static_params_.rhs_addr_cache_reg,
-                                            host_->rax, host_->rdx, host_->r8})
+                                      {rhs_arg_static_params_
+                                                      .rhs_addr_cache_reg,
+                                              host_->rax, host_->rdx,
+                                              host_->r8})
                             : shoud_preserve_oc_d_offset_conversion_regs
                             ? std::initializer_list<Xbyak::Reg64>(
-                                    {rhs_arg_static_params_.rhs_addr_cache_reg,
-                                            host_->rax, host_->rdx})
+                                      {rhs_arg_static_params_
+                                                      .rhs_addr_cache_reg,
+                                              host_->rax, host_->rdx})
                             : should_preserve_mb_sp_offset_conversion_regs
                             ? std::initializer_list<Xbyak::Reg64>(
-                                    {rhs_arg_static_params_.rhs_addr_cache_reg,
-                                            host_->rax, host_->rdx, host_->r8,
-                                            host_->r9})
+                                      {rhs_arg_static_params_
+                                                      .rhs_addr_cache_reg,
+                                              host_->rax, host_->rdx, host_->r8,
+                                              host_->r9})
                             : use_offset_conversions
                             ? std::initializer_list<Xbyak::Reg64>(
-                                    {rhs_arg_static_params_.rhs_addr_cache_reg,
-                                            host_->rax, host_->rdx})
+                                      {rhs_arg_static_params_
+                                                      .rhs_addr_cache_reg,
+                                              host_->rax, host_->rdx})
                             : std::initializer_list<Xbyak::Reg64>()),
             (rhs_arg_static_params_.preserve_vmm_helper && dt_helper_vmm_needed
                             ? std::initializer_list<Xbyak::Xmm>({Vmm(vmm_hint)})
@@ -839,9 +843,10 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
             const auto r8 = host_->r8;
 
             const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg ? utils::one_of(
-                                            it_out_reg->second, rax, rdx, r8)
-                                               : false,
+                    register_guard {is_out_reg
+                                    ? utils::one_of(
+                                              it_out_reg->second, rax, rdx, r8)
+                                    : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
 
@@ -1067,9 +1072,10 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
             const auto rdx = host_->rdx;
 
             const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg ? utils::one_of(
-                                            it_out_reg->second, rax, rdx)
-                                               : false,
+                    register_guard {is_out_reg
+                                    ? utils::one_of(
+                                              it_out_reg->second, rax, rdx)
+                                    : false,
                             host_, {it_out_reg->second}};
 
             switch (layout) {
@@ -1190,7 +1196,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
             const injector_utils::conditional_register_preserve_guard_t
                     register_guard {is_out_reg
                                     ? utils::one_of(it_out_reg->second, rax,
-                                            rdx, r8, r9)
+                                              rdx, r8, r9)
                                     : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
@@ -1472,7 +1478,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
             const injector_utils::conditional_register_preserve_guard_t
                     register_guard {is_out_reg
                                     ? utils::one_of(it_out_reg->second, rax,
-                                            rdx, r8, r9)
+                                              rdx, r8, r9)
                                     : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
@@ -1780,9 +1786,10 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
             const auto r8 = host_->r8;
 
             const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg ? utils::one_of(
-                                            it_out_reg->second, rax, rdx, r8)
-                                               : false,
+                    register_guard {is_out_reg
+                                    ? utils::one_of(
+                                              it_out_reg->second, rax, rdx, r8)
+                                    : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
 
@@ -1913,9 +1920,10 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
             const auto r8 = host_->r8;
 
             const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg ? utils::one_of(
-                                            it_out_reg->second, rax, rdx, r8)
-                                               : false,
+                    register_guard {is_out_reg
+                                    ? utils::one_of(
+                                              it_out_reg->second, rax, rdx, r8)
+                                    : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
 
@@ -2122,9 +2130,10 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
             const auto r8 = host_->r8;
 
             const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg ? utils::one_of(
-                                            it_out_reg->second, rax, rdx, r8)
-                                               : false,
+                    register_guard {is_out_reg
+                                    ? utils::one_of(
+                                              it_out_reg->second, rax, rdx, r8)
+                                    : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
 
@@ -2298,9 +2307,10 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
             const auto r8 = host_->r8;
 
             const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg ? utils::one_of(
-                                            it_out_reg->second, rax, rdx, r8)
-                                               : false,
+                    register_guard {is_out_reg
+                                    ? utils::one_of(
+                                              it_out_reg->second, rax, rdx, r8)
+                                    : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
 
@@ -2468,9 +2478,10 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
             const auto r8 = host_->r8;
 
             const injector_utils::conditional_register_preserve_guard_t
-                    register_guard {is_out_reg ? utils::one_of(
-                                            it_out_reg->second, rax, rdx, r8)
-                                               : false,
+                    register_guard {is_out_reg
+                                    ? utils::one_of(
+                                              it_out_reg->second, rax, rdx, r8)
+                                    : false,
                             host_,
                             {is_out_reg ? it_out_reg->second : Xbyak::Reg64()}};
 

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -125,8 +125,8 @@ struct jit_uni_eltwise_injector_t {
             bool use_dst = false, bool preserve_vmm = true,
             bool preserve_p_table = true)
         : jit_uni_eltwise_injector_t(host, eltwise.alg, eltwise.alpha,
-                eltwise.beta, eltwise.scale, dt, save_state, p_table, k_mask,
-                is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
+                  eltwise.beta, eltwise.scale, dt, save_state, p_table, k_mask,
+                  is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
 
     void compute_vector_range(size_t start_compute_idx, size_t end_compute_idx,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {});

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -103,7 +103,7 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-            eltwise_injector::static_params_t(), lambda_jit_injectors_t()) {}
+              eltwise_injector::static_params_t(), lambda_jit_injectors_t()) {}
 
 template <cpu_isa_t isa, typename Vmm>
 jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
@@ -111,7 +111,7 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
         const binary_injector::static_params_t &binary_static_params,
         const lambda_jit_injectors_t &lambda_jit_injectors)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-            eltwise_injector::static_params_t(), lambda_jit_injectors) {}
+              eltwise_injector::static_params_t(), lambda_jit_injectors) {}
 
 template <cpu_isa_t isa, typename Vmm>
 jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
@@ -119,7 +119,7 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-            eltwise_static_params, lambda_jit_injectors_t()) {}
+              eltwise_static_params, lambda_jit_injectors_t()) {}
 
 // Specialization instantiations are needed to avoid instantiating ISA with
 // Vmm that don't make any sense like sse41 + Zmm.

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -778,9 +778,9 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     const int is_bwd_d = jcp.prop_kind == backward_data;
     format_tag_t wei_tag = with_groups
             ? utils::pick(2 * ndims - 6 + is_bwd_d, gOIw8i8o, gOIw8o8i,
-                    gOIhw8i8o, gOIdhw8o8i, gOIhw8i8o, gOIdhw8o8i)
+                      gOIhw8i8o, gOIdhw8o8i, gOIhw8i8o, gOIdhw8o8i)
             : utils::pick(2 * ndims - 6 + is_bwd_d, OIw8i8o, OIw8o8i, OIhw8i8o,
-                    OIhw8o8i, OIdhw8i8o, OIdhw8o8i);
+                      OIhw8o8i, OIdhw8i8o, OIdhw8o8i);
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
 
     const int simd_w = 8;

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -52,7 +52,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                    pd()->jcp_.post_ops.entry_.size() + 1)
+                      pd()->jcp_.post_ops.entry_.size() + 1)
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -99,9 +99,9 @@ struct jit_avx2_convolution_fwd_t : public primitive_t {
             auto dst_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_nCx8c;
             auto wei_tag = with_groups()
                     ? utils::pick(2 * ndims() - 6 + flat, gOIw8i8o, gOwi8o,
-                            gOIhw8i8o, gOhwi8o, gOIdhw8i8o, gOdhwi8o)
+                              gOIhw8i8o, gOhwi8o, gOIdhw8i8o, gOdhwi8o)
                     : utils::pick(2 * ndims() - 6 + flat, OIw8i8o, Owi8o,
-                            OIhw8i8o, Ohwi8o, OIdhw8i8o, Odhwi8o);
+                              OIhw8i8o, Ohwi8o, OIdhw8i8o, Odhwi8o);
 
             return set_default_formats_common(src_tag, wei_tag, dst_tag);
         }
@@ -293,9 +293,9 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
             auto dst_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_nCx8c;
             auto wei_tag = with_groups()
                     ? utils::pick(2 * ndims() - 6 + flat, gOIw8i8o, gOwi8o,
-                            gOIhw8i8o, gOhwi8o, gOIdhw8i8o, gOdhwi8o)
+                              gOIhw8i8o, gOhwi8o, gOIdhw8i8o, gOdhwi8o)
                     : utils::pick(2 * ndims() - 6 + flat, OIw8i8o, Owi8o,
-                            OIhw8i8o, Ohwi8o, OIdhw8i8o, Odhwi8o);
+                              OIhw8i8o, Ohwi8o, OIdhw8i8o, Odhwi8o);
 
             return set_default_formats_common(src_tag, wei_tag, dst_tag);
         }

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -257,7 +257,7 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
         int lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
-                                           jcp.reduce_dim, jcp.reduce_block));
+                                             jcp.reduce_dim, jcp.reduce_block));
         int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
@@ -697,9 +697,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     const int is_bwd_d = jcp.prop_kind == backward_data;
     format_tag_t wei_tag = with_groups
             ? pick(2 * ndims - 6 + is_bwd_d, gOIw16i16o, gIOw16o16i,
-                    gOIhw16i16o, gIOhw16o16i, gOIdhw16i16o, gIOdhw16o16i)
+                      gOIhw16i16o, gIOhw16o16i, gOIdhw16i16o, gIOdhw16o16i)
             : pick(2 * ndims - 6 + is_bwd_d, OIw16i16o, IOw16o16i, OIhw16i16o,
-                    IOhw16o16i, OIdhw16i16o, IOdhw16o16i);
+                      IOhw16o16i, OIdhw16i16o, IOdhw16o16i);
 
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
     VDISPATCH_CONV_IC(jcp.wei_tag == wei_tag, VERBOSE_UNSUPPORTED_TAG_S, "wei");
@@ -1073,8 +1073,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 = jcp.oc_block * jcp.ur * jcp.typesize_out;
         jcp.bcast_loop_bcast_step = jcp.ic_block
                 * (is_data_layout_nxc ? 1
-                                      : utils::rnd_up(
-                                              jcp.reduce_dim, jcp.reduce_block))
+                                      : utils::rnd_up(jcp.reduce_dim,
+                                                jcp.reduce_block))
                 * jcp.typesize_in;
         jcp.bcast_loop_bcast_substep = jcp.ur * jcp.typesize_in;
 

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -54,8 +54,8 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_
             ? binary_injector::prepare_binary_args(
-                    pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                    pd()->jcp_.post_ops.entry_.size() + 1)
+                      pd()->dw_conv_pd_->jcp_.post_ops, ctx,
+                      pd()->jcp_.post_ops.entry_.size() + 1)
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -457,7 +457,7 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = kernel_->jcp;
     auto rtus_space = pd()->rtus_.reduce_src_
             ? ctx.get_scratchpad_grantor().template get<diff_src_data_t>(
-                    key_conv_rtus_space)
+                      key_conv_rtus_space)
             : nullptr;
 
     const int ndims = diff_src_d.ndims();

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -924,8 +924,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     if (jcp.is_1stconv) {
         wei_tag = with_groups
                 ? ((jcp.simd_w == 4)
-                                ? pick(ndims - 3, gOwi4o, gOhwi4o, gOdhwi4o)
-                                : pick(ndims - 3, gOwi16o, gOhwi16o, gOdhwi16o))
+                                  ? pick(ndims - 3, gOwi4o, gOhwi4o, gOdhwi4o)
+                                  : pick(ndims - 3, gOwi16o, gOhwi16o,
+                                            gOdhwi16o))
                 : pick(ndims - 3, Owi16o, Ohwi16o, Odhwi16o);
     }
 

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -1205,7 +1205,7 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 && jcp.oc_without_padding % jcp.oc_block != 0;
         diff_bias = is_bias_padded
                 ? scratchpad.template get<diff_weights_data_t>(
-                        key_conv_padded_bias)
+                          key_conv_padded_bias)
                 : CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
 
         wei_bia_reduction_bctx = scratchpad.template get<simple_barrier::ctx_t>(

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -1114,11 +1114,11 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         format_tag_t wei_tag;
         wei_tag = (is_bf16_convolution)
                 ? pick(with_groups + 2 * (ndims - 3), OIw16i16o2i, gOIw16i16o2i,
-                        OIhw16i16o2i, gOIhw16i16o2i, OIdhw16i16o2i,
-                        gOIdhw16i16o2i)
+                          OIhw16i16o2i, gOIhw16i16o2i, OIdhw16i16o2i,
+                          gOIdhw16i16o2i)
                 : pick(with_groups + 2 * (ndims - 3), OIw16i16o4i, gOIw16i16o4i,
-                        OIhw16i16o4i, gOIhw16i16o4i, OIdhw16i16o4i,
-                        gOIdhw16i16o4i);
+                          OIhw16i16o4i, gOIhw16i16o4i, OIdhw16i16o4i,
+                          gOIdhw16i16o4i);
         memory_desc_t want_wei_md = weights_md;
         CHECK_BOOL(memory_desc_init_by_tag(want_wei_md, wei_tag));
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
@@ -42,9 +42,9 @@ using namespace nstl;
 #define md_blk_off(md, n, c, d, h, w) \
     (pd()->ndims() == 3 \
                     ? (md).blk_off((n), (c), (w)) \
-                    : (pd()->ndims() == 4 \
-                                    ? (md).blk_off((n), (c), (h), (w)) \
-                                    : (md).blk_off((n), (c), (d), (h), (w))))
+                    : (pd()->ndims() == 4 ? (md).blk_off((n), (c), (h), (w)) \
+                                          : (md).blk_off( \
+                                                    (n), (c), (d), (h), (w))))
 
 void jit_avx512_core_amx_1x1_convolution_fwd_t::prepare_padded_bias(
         const char *&bias, const memory_tracking::grantor_t &scratchpad) const {
@@ -112,7 +112,7 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             key_conv_amx_wsp_buffer);
     int32_t *wsp_tile = (is_ic_tail)
             ? ctx.get_scratchpad_grantor().template get<int32_t>(
-                    key_conv_amx_tile_buffer)
+                      key_conv_amx_tile_buffer)
             : nullptr;
     auto global_tcfg = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_tilecfg);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -91,8 +91,8 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
     /* Skip the last loads of input
             if (ic%16)/ic_sub_step < ic_block/ic_sub_step */
     const int icb = (last_ic_block_flag == ic_block_t::last_ic_block)
-            ? div_up(
-                    (jcp.ic_without_padding % jcp.ic_block_int), ic_inner_block)
+            ? div_up((jcp.ic_without_padding % jcp.ic_block_int),
+                      ic_inner_block)
             : ic_block / ic_inner_block;
 
     auto get_filter_offset = [this, oc_block](int ocb, int ic, int ki) {
@@ -2547,17 +2547,19 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         using namespace format_tag;
         using namespace memory_extra_flags;
         format_tag_t wei_tag;
-        wei_tag = jcp.is_relo ? pick(with_groups + 2 * (ndims - 3), Owi16o,
-                          gOwi16o, Owhi16o, gOwhi16o, Odwhi16o, gOdwhi16o)
-                : is_bf16_convolution ? pick(with_groups + 2 * (ndims - 3),
-                          OIw16i16o2i, gOIw16i16o2i, OIhw16i16o2i,
-                          gOIhw16i16o2i, OIdhw16i16o2i, gOIdhw16i16o2i)
+        wei_tag = jcp.is_relo
+                ? pick(with_groups + 2 * (ndims - 3), Owi16o, gOwi16o, Owhi16o,
+                          gOwhi16o, Odwhi16o, gOdwhi16o)
+                : is_bf16_convolution
+                ? pick(with_groups + 2 * (ndims - 3), OIw16i16o2i, gOIw16i16o2i,
+                          OIhw16i16o2i, gOIhw16i16o2i, OIdhw16i16o2i,
+                          gOIdhw16i16o2i)
                 : is_small_ic
                 ? pick(with_groups + 2 * (ndims - 3), OwI16o4i, gOwI16o4i,
-                        OhwI16o4i, gOhwI16o4i, OdhwI16o4i, gOdhwI16o4i)
+                          OhwI16o4i, gOhwI16o4i, OdhwI16o4i, gOdhwI16o4i)
                 : pick(with_groups + 2 * (ndims - 3), OIw16i16o4i, gOIw16i16o4i,
-                        OIhw16i16o4i, gOIhw16i16o4i, OIdhw16i16o4i,
-                        gOIdhw16i16o4i);
+                          OIhw16i16o4i, gOIhw16i16o4i, OIdhw16i16o4i,
+                          gOIdhw16i16o4i);
 
         memory_desc_t want_wei_md = weights_md;
         CHECK_BOOL(memory_desc_init_by_tag(want_wei_md, wei_tag));
@@ -5442,9 +5444,9 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
 
     jcp.harness = ndims == 5
             ? harness_3d_reduction
-            : (use_full_spat_loop          ? harness_compute_full_spatial
-                            : (ndims == 4) ? harness_2d_reduction
-                                           : harness_mb_reduction);
+            : (use_full_spat_loop            ? harness_compute_full_spatial
+                              : (ndims == 4) ? harness_2d_reduction
+                                             : harness_mb_reduction);
     switch (jcp.harness) {
         case harness_2d_reduction: jcp.nthr_mb_work = jcp.mb * jcp.oh; break;
         case harness_3d_reduction: jcp.nthr_mb_work = jcp.mb * jcp.od; break;

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -42,9 +42,9 @@ using namespace nstl;
 #define mem_blk_off(mdw, n, c, d, h, w) \
     (pd()->ndims() == 3 \
                     ? (mdw).blk_off((n), (c), (w)) \
-                    : (pd()->ndims() == 4 \
-                                    ? (mdw).blk_off((n), (c), (h), (w)) \
-                                    : (mdw).blk_off((n), (c), (d), (h), (w))))
+                    : (pd()->ndims() == 4 ? (mdw).blk_off((n), (c), (h), (w)) \
+                                          : (mdw).blk_off( \
+                                                    (n), (c), (d), (h), (w))))
 
 template <typename T>
 static inline T accum_with_upper_bound(T ub, T lv, T uv) {
@@ -200,8 +200,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
         balance211(work_amount, nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
-                                ? zero_point_pbuff
-                                : &zero_point_pbuff[ithr * zp_pbuff_size])
+                                  ? zero_point_pbuff
+                                  : &zero_point_pbuff[ithr * zp_pbuff_size])
                 : nullptr;
         bool *zp_flags = zp_pbuff_parallel_block
                 ? &zp_flags_[ithr * oc_chunks * ngroups]
@@ -584,8 +584,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
         balance211(work_amount, nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
-                                ? zero_point_pbuff
-                                : &zero_point_pbuff[ithr * zp_pbuff_size])
+                                  ? zero_point_pbuff
+                                  : &zero_point_pbuff[ithr * zp_pbuff_size])
                 : nullptr;
         bool *zp_flags = zp_pbuff_parallel_block
                 ? &zp_flags_[ithr * oc_chunks * ngroups]
@@ -1854,9 +1854,9 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
             if (need_local_gwork) oc = gg * jcp.oc + oc_b * jcp.oc_block;
             diff_dst_data_t *tr_diff_dst = (jcp.ndims == 5)
                     ? &ti->tr_diff_dst[tr_diff_dst_off_3d(
-                            gg, oc_b, nb_oc_block, d, j)]
+                              gg, oc_b, nb_oc_block, d, j)]
                     : &ti->tr_diff_dst[tr_diff_dst_off(
-                            gg, oc_b, nb_oc_block, j)];
+                              gg, oc_b, nb_oc_block, j)];
             auto ddst_offset = diff_dst_d.blk_off(img, oc);
             const diff_dst_data_t *diff_dst = &ti->diff_dst[ddst_offset];
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -307,7 +307,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
         int lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
-                                           jcp.reduce_dim, jcp.reduce_block));
+                                             jcp.reduce_dim, jcp.reduce_block));
         int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         int offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
@@ -1244,7 +1244,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
     jcp.bia_dt = jcp.with_bias
             ? pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.data_type,
-                    data_type::undef, cd.diff_bias_desc.data_type)
+                      data_type::undef, cd.diff_bias_desc.data_type)
             : data_type::undef;
     jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
 
@@ -1827,7 +1827,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_scratchpad(
         const size_t max_load_per_thread = is_out_layout_nxc
                 ? utils::rnd_up(jcp.load_dim, jcp.load_block)
                 : rnd_up((utils::div_up(jcp.load_dim, grp_count)),
-                        jcp.load_block);
+                          jcp.load_block);
         const size_t store_buffer_size = (size_t)jcp.nthr
                 * utils::rnd_up(jcp.bcast_dim, jcp.bcast_block)
                 * max_load_per_thread;

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -77,7 +77,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_ != nullptr
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                    pd()->jcp_.post_ops.entry_.size() + 1)
+                      pd()->jcp_.post_ops.entry_.size() + 1)
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -962,8 +962,8 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                         p.bias_data = diff_bia
                                 ? &diff_bia[oc_off_idx
-                                        * (is_ddst_layout_nxc ? 1
-                                                              : jcp.oc_block)]
+                                          * (is_ddst_layout_nxc ? 1
+                                                                : jcp.oc_block)]
                                 : nullptr;
                         (*kernel_)(&p);
                     }

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -4289,9 +4289,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     auto dst_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_nCx16c;
     auto wei_tag = jcp.is_1stconv
             ? pick(2 * ndims - 6 + with_groups, Owi16o, gOwi16o, Ohwi16o,
-                    gOhwi16o, Odhwi16o, gOdhwi16o)
+                      gOhwi16o, Odhwi16o, gOdhwi16o)
             : pick(2 * ndims - 6 + with_groups, OIw16i16o, gOIw16i16o,
-                    OIhw16i16o, gOIhw16i16o, OIdhw16i16o, gOIdhw16i16o);
+                      OIhw16i16o, gOIhw16i16o, OIdhw16i16o, gOIdhw16i16o);
 
     if (src_md.format_kind == format_kind::any) {
         CHECK(memory_desc_init_by_tag(src_md, src_tag));
@@ -4526,9 +4526,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
 
     jcp.harness = ndims == 5
             ? harness_3d_reduction
-            : (use_full_spat_loop          ? harness_compute_full_spatial
-                            : (ndims == 4) ? harness_2d_reduction
-                                           : harness_mb_reduction);
+            : (use_full_spat_loop            ? harness_compute_full_spatial
+                              : (ndims == 4) ? harness_2d_reduction
+                                             : harness_mb_reduction);
 
     switch (jcp.harness) {
         case harness_2d_reduction: jcp.nthr_mb_work = jcp.mb * jcp.oh; break;

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -672,8 +672,8 @@ private:
         dim_t iw_str = jcp.is_1stconv || jcp.transpose_src
                 ? 1
                 : (is_src_layout_nxc()
-                                ? static_cast<dim_t>(jcp.ngroups) * jcp.ic
-                                : jcp.ic_block);
+                                  ? static_cast<dim_t>(jcp.ngroups) * jcp.ic
+                                  : jcp.ic_block);
         dim_t ihid_str = static_cast<dim_t>(jcp.tr_iw)
                 * (jcp.transpose_src ? jcp.ic_block : iw_str);
         // jcp.transpose_src w_idx might be greater than jcp.tr_iw as right zero

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -49,7 +49,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                    pd()->jcp_.post_ops.entry_.size() + 1)
+                      pd()->jcp_.post_ops.entry_.size() + 1)
             : std::vector<const void *> {};
 
     const void *src_scales

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -596,9 +596,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
         int n_ic_blocks = jcp.is_depthwise
                 ? 1
                 : (last_ic_block_flag & ~ker_block_t::no_last_block
-                                ? div_up(jcp.ic_without_padding % jcp.ic_block,
-                                        4)
-                                : jcp.ic_block / 4);
+                                  ? div_up(jcp.ic_without_padding
+                                                    % jcp.ic_block,
+                                            4)
+                                  : jcp.ic_block / 4);
 
         for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded == true) {
@@ -1463,7 +1464,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
             ? get_src_zp_comp_from_wei(
-                    weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
+                      weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1573,7 +1574,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
             ? get_src_zp_comp_from_wei(
-                    weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
+                      weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1656,11 +1657,11 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
                         : max(0,
-                                jcp.kh
-                                        - (kh_lo
-                                                + max(0, kh_len - 1)
-                                                        * jcp.stride_h
-                                                + 1));
+                                  jcp.kh
+                                          - (kh_lo
+                                                  + max(0, kh_len - 1)
+                                                          * jcp.stride_h
+                                                  + 1));
                 p.b_overflow = kh_lo;
                 p.kh_padding = kh_len;
                 p.scales = scales;
@@ -1747,7 +1748,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
             ? get_src_zp_comp_from_wei(
-                    weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
+                      weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1872,20 +1873,20 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
                         : max(0,
-                                jcp.kh
-                                        - (kh_lo
-                                                + max(0, kh_len - 1)
-                                                        * jcp.stride_h
-                                                + 1));
+                                  jcp.kh
+                                          - (kh_lo
+                                                  + max(0, kh_len - 1)
+                                                          * jcp.stride_h
+                                                  + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
                         : max(0,
-                                jcp.kd
-                                        - (kd_lo
-                                                + max(0, kd_len - 1)
-                                                        * jcp.stride_d
-                                                + 1));
+                                  jcp.kd
+                                          - (kd_lo
+                                                  + max(0, kd_len - 1)
+                                                          * jcp.stride_d
+                                                  + 1));
                 p.back_overflow = kd_lo;
                 p.kh_padding = kh_len;
                 p.kd_padding = kd_len;

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -376,14 +376,14 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
         const int oh = ohb < h_blk_info.n_lpad_blks
                 ? ohb
                 : (h_blk_info.rpad_blk_start_idx
-                        + (ohb - h_blk_info.n_lpad_blks));
+                          + (ohb - h_blk_info.n_lpad_blks));
         const int bpad = oh * h_shift + jcp.kh - (jcp.ih + jcp.t_pad);
 
         const int fpad = jcp.f_pad - odb * d_shift;
         const int od = odb < d_blk_info.n_lpad_blks
                 ? odb
                 : (d_blk_info.rpad_blk_start_idx
-                        + (odb - d_blk_info.n_lpad_blks));
+                          + (odb - d_blk_info.n_lpad_blks));
         const int backpad = od * d_shift + jcp.kd - (jcp.id + jcp.f_pad);
 
         gen_batch_elements(fpad, backpad, tpad, bpad, lpad, rpad, bs_[bi],
@@ -476,9 +476,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                         = (work_per_thr / jcp.nb_ch) % jcp.ow;
                 if (ow_tail_block && (jcp.ow % ow_tail_block == 0))
                     jcp.ow_block = ow_tail_block;
-                else {
-                    jcp.ow_block = jcp.ow;
-                }
+                else { jcp.ow_block = jcp.ow; }
             } else {
                 const int max_ow_block = is_superset(jcp.isa, avx512_core)
                         ? 6
@@ -602,11 +600,11 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
             : 0;
     int32_t *s8s8_comp_ptr = jcp.s8s8_compensation_required
             ? reinterpret_cast<int32_t *>(
-                    const_cast<char *>(weights) + extra_data_offset)
+                      const_cast<char *>(weights) + extra_data_offset)
             : nullptr;
     int32_t *zp_compensation = jcp.src_zero_point
-            ? reinterpret_cast<int32_t *>(
-                    const_cast<char *>(weights) + extra_data_offset + s8_offset)
+            ? reinterpret_cast<int32_t *>(const_cast<char *>(weights)
+                      + extra_data_offset + s8_offset)
             : nullptr;
 
     const int chb_step = jcp.nb_ch_blocking;

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -441,7 +441,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
     const bool is_ic_tail = jcp.is_reduced_rtus
             ? is_last_os
             : (icc == pd()->ic_chunks_ - 1
-                    && ((jcp.ic - ic) % jcp.ic_block != 0));
+                      && ((jcp.ic - ic) % jcp.ic_block != 0));
 
     // Using blk_off to offset batch is motivated input\output striding aligment
     // See `blk_off` definition.
@@ -498,9 +498,9 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
 
         for (int k = 0; k < n_ic_blocks; k++) {
             const size_t ic_off = jcp.is_reduced_rtus
-                    ? (brgemm_is_ic_tail
-                                    ? jcp.ic_without_padding - jcp.rtus_ic_size
-                                    : 0)
+                    ? (brgemm_is_ic_tail ? jcp.ic_without_padding
+                                              - jcp.rtus_ic_size
+                                         : 0)
                     : (ic_block_s + k) * jcp.ic_block;
             const size_t src_ic = ic_off;
             const auto wei_ic = ic + ic_off;
@@ -763,7 +763,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::execute_forward_all(
     brgemm_batch_element_t *const brg_batch_global
             = (jcp.brg_type != brgemm_strd)
             ? scratchpad.template get<brgemm_batch_element_t>(
-                    key_brgemm_primitive_batch)
+                      key_brgemm_primitive_batch)
             : nullptr;
     char *const c_buffer_global = (jcp.use_buffer)
             ? scratchpad.template get<char>(key_brgemm_primitive_buffer)

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -47,9 +47,9 @@ int brgemm_convolution_fwd_t<isa>::pd_t::get_brg_idx(int m,
         int kd_e, int kh_b, int kh_e) const {
     const auto brg_idx = jcp_.use_uker
             ? brg_indices.find({m, is_N_tail, is_K_tail, do_initialization,
-                    kd_b, kd_e, kh_b, kh_e})
+                      kd_b, kd_e, kh_b, kh_e})
             : brg_indices.find({m, is_N_tail, is_K_tail, do_initialization, 0,
-                    jcp_.kd, 0, jcp_.kh});
+                      jcp_.kd, 0, jcp_.kh});
     if (brg_idx == brg_indices.end()) return -1;
     return brg_idx->second;
 }
@@ -1359,7 +1359,7 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
             = brgemm_convolution_utils::uses_batch_elements(
                       jcp.brg_type, jcp.exec_type)
             ? scratchpad.template get<brgemm_batch_element_t>(
-                    key_brgemm_primitive_batch)
+                      key_brgemm_primitive_batch)
             : nullptr;
     char *const __restrict c_buffer_global = (jcp.use_buffer)
             ? scratchpad.template get<char>(key_brgemm_primitive_buffer)
@@ -1373,12 +1373,12 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
             : nullptr;
     int32_t *src_zp_comp_base = jcp.src_zero_point
             ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
-                       key_brgemm_primitive_zp_comp_a)
+                                              key_brgemm_primitive_zp_comp_a)
                                     : zp_compensation)
             : nullptr;
     int32_t *s8s8_comp_base = jcp.s8s8_compensation_required
             ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
-                       key_brgemm_primitive_buffer_comp)
+                                              key_brgemm_primitive_buffer_comp)
                                     : s8s8_compensation)
             : nullptr;
 
@@ -1586,13 +1586,13 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
                     ? div_up(jcp.oc_block, inp_oc_block)
                     : jcp.nb_oc;
             const auto wei_offs = is_relo_with_relo_weights
-                    ? (jcp.is_relo_wi()
-                                    ? ((((g * nb_oc + wei_ocb) * KD) + kd_b)
-                                                      * KH
-                                              + kh_b)
-                                            * KW * jcp.ic * inp_oc_block
-                                    : (((g * nb_oc + wei_ocb) * KH * KW) + kh_b)
-                                            * jcp.ic * inp_oc_block)
+                    ? (jcp.is_relo_wi() ? ((((g * nb_oc + wei_ocb) * KD) + kd_b)
+                                                          * KH
+                                                  + kh_b)
+                                              * KW * jcp.ic * inp_oc_block
+                                        : (((g * nb_oc + wei_ocb) * KH * KW)
+                                                  + kh_b)
+                                              * jcp.ic * inp_oc_block)
                     : g * _pd->wei_g_stride + wei_ocb * _pd->wei_ocb_stride
                             + kd_b * _pd->wei_kd_stride
                             + kh_b * _pd->wei_kh_stride
@@ -1676,21 +1676,21 @@ void brgemm_convolution_fwd_t<isa>::perform_outwork(
             p.apply_comp = has_postcomp;
             p.a_zp_compensation = has_postcomp && jcp.src_zero_point
                     ? &btc.src_zp_comp_ptr[comp_ker_offs
-                            + (ow_pw_s - ow) * comp_ow_sz]
+                              + (ow_pw_s - ow) * comp_ow_sz]
                     : btc.src_zp_comp_ptr;
             p.s8s8_compensation = has_postcomp && jcp.s8s8_compensation_required
                     ? &btc.s8s8_comp_ptr[comp_ker_offs
-                            + (ow_pw_s - ow) * comp_ow_sz]
+                              + (ow_pw_s - ow) * comp_ow_sz]
                     : btc.s8s8_comp_ptr;
 
             p.ptr_out = dst_base
                     + dst_dsz
                             * (btc.od * dst_h_sz + btc.oh * dst_w_sz
                                     + ow_pw_s * jcp.oc_without_padding);
-            p.ptr_in = static_cast<void *>(
-                    jcp.use_buffer ? (
-                            btc.c_buffer + acc_dsz * (ow_pw_s - ow) * jcp.LDC)
-                                   : p.ptr_out);
+            p.ptr_in = static_cast<void *>(jcp.use_buffer
+                            ? (btc.c_buffer
+                                      + acc_dsz * (ow_pw_s - ow) * jcp.LDC)
+                            : p.ptr_out);
         } else {
             p.apply_comp = has_postcomp;
             char *const ptr_Cz = jcp.use_buffer
@@ -1840,7 +1840,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
     const auto icb = btc.icc * jcp.nb_ic_blocking;
 
 #define bmask(icb, odb, ohb, owb) \
-    btc.inp_buffer_mask[(((icb)*jcp.nb_od + (odb)) * jcp.nb_oh + (ohb)) \
+    btc.inp_buffer_mask[(((icb) * jcp.nb_od + (odb)) * jcp.nb_oh + (ohb)) \
                     * jcp.nb_ow \
             + (owb)]
 
@@ -2170,7 +2170,7 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         if (ow_l > 0) {
             const size_t comp_ker_offs = do_postwork
                     ? get_comp_offset(btc.g, btc.ocb, 0, ow_b, kd_s, kd_f, kh_s,
-                            kh_f, 0, KW)
+                              kh_f, 0, KW)
                     : 0;
 
             if (nb_ic_b > 0) {
@@ -2314,7 +2314,7 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
                 + src_dsz
                         * ((jcp.copy_block_only ? 0
                                                 : ((icb + ic_block_s)
-                                                        * _pd->pbuf_d_sz)))
+                                                          * _pd->pbuf_d_sz)))
                 + (jcp.is_relo_whi() ? src_dsz * btc.ohb
                                         * ((jcp.oh_block - 1) * _pd->pbuf_w_sz
                                                 + jcp.stride_h
@@ -2347,7 +2347,7 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
 
         const auto comp_ker_offs = do_postwork
                 ? get_comp_offset(btc.g, btc.ocb, btc.oh, ow_b, kd_s, kd_f,
-                        comp_kh_s, comp_kh_f, 0, KW)
+                          comp_kh_s, comp_kh_f, 0, KW)
                 : 0;
 
         if (nb_ic_b > 0) {

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -727,7 +727,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
             = (jcp.brg_type == brgemm_strd && jcp.exec_type != exec_vpad)
             ? nullptr
             : scratchpad.template get<brgemm_batch_element_t>(
-                    key_brgemm_primitive_batch);
+                      key_brgemm_primitive_batch);
     char *const __restrict c_buffer_global = (jcp.use_buffer)
             ? scratchpad.template get<char>(key_brgemm_primitive_buffer)
             : nullptr;
@@ -745,12 +745,12 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
 
     int32_t *src_zp_comp_base = jcp.src_zero_point
             ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
-                       key_brgemm_primitive_zp_comp_a)
+                                              key_brgemm_primitive_zp_comp_a)
                                     : zp_compensation)
             : nullptr;
     int32_t *s8s8_comp_base = jcp.s8s8_compensation_required
             ? (jcp.req_cal_comp_pad ? scratchpad.template get<int32_t>(
-                       key_brgemm_primitive_buffer_comp)
+                                              key_brgemm_primitive_buffer_comp)
                                     : s8s8_compensation)
             : nullptr;
 
@@ -1047,10 +1047,11 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
                     + dst_dsz
                             * (id * dst_h_sz + ih * dst_w_sz
                                     + iw_pw_s * jcp.ic_without_padding);
-            p.ptr_in = static_cast<void *>(
-                    jcp.use_buffer ? (c_buffer
-                            + acc_dsz * div_up(iw_pw_s - iw, SW) * jcp.LDC)
-                                   : p.ptr_out);
+            p.ptr_in = static_cast<void *>(jcp.use_buffer
+                            ? (c_buffer
+                                      + acc_dsz * div_up(iw_pw_s - iw, SW)
+                                              * jcp.LDC)
+                            : p.ptr_out);
         } else {
             p.apply_comp = has_postcomp;
             char *const ptr_Cz = jcp.use_buffer
@@ -1518,7 +1519,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                     * (need_out_buffer
                                     ? btc.sw * jcp.ic_without_padding
                                     : (id * dst_h_sz + ih * dst_w_sz
-                                            + iw_b * jcp.ic_without_padding));
+                                              + iw_b * jcp.ic_without_padding));
 
     ptr_C = (jcp.use_buffer) ? btc.c_buffer : static_cast<char *>(ptr_D);
 
@@ -1612,7 +1613,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
 
         const auto comp_ker_offs = kd_l * kh_l > 0
                 ? get_comp_offset(
-                        btc.g, btc.icb, iw, kd_s, kd_f, kh_s, kh_f, 0, KW)
+                          btc.g, btc.icb, iw, kd_s, kd_f, kh_s, kh_f, 0, KW)
                 : get_comp_offset(btc.g, btc.icb, iw, 0, 0, 0, 0, 0, 0);
 
         if (nb_oc_b > 0) {

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1183,7 +1183,7 @@ float brg_blocking_t::est_eff_1x1() {
     const auto amx_fac = maskrcnn_cond
             ? (div_up(M + M_tail, 16) / (M_n_sp_blks + M_tail_n_sp_blks))
             : (static_cast<float>(div_up(M + M_tail, 16))
-                    / (M_n_sp_blks + M_tail_n_sp_blks));
+                      / (M_n_sp_blks + M_tail_n_sp_blks));
 
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(icb_ave) * spb_ave)

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -439,7 +439,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 = (jcp.brg_type == brgemm_strd)
                 ? nullptr
                 : scratchpad.template get<brgemm_batch_element_t>(
-                        key_brgemm_primitive_batch);
+                          key_brgemm_primitive_batch);
         brg_batch = brg_batch_global
                 + static_cast<size_t>(ithr) * jcp.adjusted_batch_size;
 
@@ -797,10 +797,10 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 auto wei_offs_ext = pd()->ndims() == 3
                         ? wht_blk_off(diff_weights_d, g, oc_b, ic_b_start, 0)
                         : (pd()->ndims() == 4
-                                        ? wht_blk_off(diff_weights_d, g, oc_b,
-                                                ic_b_start, 0, 0)
-                                        : wht_blk_off(diff_weights_d, g, oc_b,
-                                                ic_b_start, 0, 0, 0));
+                                          ? wht_blk_off(diff_weights_d, g, oc_b,
+                                                    ic_b_start, 0, 0)
+                                          : wht_blk_off(diff_weights_d, g, oc_b,
+                                                    ic_b_start, 0, 0, 0));
                 void *ptr_C = (jcp.transform_to_vnni) ? diff_wei
                                 + self->wei_offset_int(
                                         g, oc_b, ic_b_start, 0, 0, 0)
@@ -822,10 +822,10 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 auto wei_offs_ext = pd()->ndims() == 3
                         ? wht_blk_off(diff_weights_d, g, oc_b, ic_b_start, 0)
                         : (pd()->ndims() == 4
-                                        ? wht_blk_off(diff_weights_d, g, oc_b,
-                                                ic_b_start, 0, 0)
-                                        : wht_blk_off(diff_weights_d, g, oc_b,
-                                                ic_b_start, 0, 0, 0));
+                                          ? wht_blk_off(diff_weights_d, g, oc_b,
+                                                    ic_b_start, 0, 0)
+                                          : wht_blk_off(diff_weights_d, g, oc_b,
+                                                    ic_b_start, 0, 0, 0));
                 void *ptr_C = (jcp.transform_to_vnni) ? diff_wei
                                 + self->wei_offset_int(
                                         g, oc_b, ic_b_start, 0, 0, 0)
@@ -914,10 +914,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
         void *ptr_C = (jcp.transform_to_vnni)
                 ? diff_wei + wei_offset_int(g, oc_b, ic_b, 0, kh, kw)
                 : diff_wei
-                        + (pd()->ndims() == 3 ? wht_blk_off(
-                                   diff_weights_d, g, oc_b, ic_b, kw)
+                        + (pd()->ndims() == 3 ? wht_blk_off(diff_weights_d, g,
+                                                        oc_b, ic_b, kw)
                                               : wht_blk_off(diff_weights_d, g,
-                                                      oc_b, ic_b, kh, kw));
+                                                        oc_b, ic_b, kh, kw));
         bool M_tail = (icb_end < ic_b + jcp.nb_ic_blocking);
         bool N_tail = (ocb_end < oc_b + jcp.nb_oc_blocking);
 

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -895,7 +895,7 @@ float brg_blocking_t::est_eff() {
     const dim_t max_job = (loop_order == loop_ndhwgc)
             ? grid_coverage(thread_job, oc, ngroups, oc_block, sp, sp_block)
             : grid_coverage(thread_job, sp, static_cast<dim_t>(nb_od) * nb_oh,
-                    sp_block, oc, oc_block);
+                      sp_block, oc, oc_block);
     const dim_t sum_job = static_cast<dim_t>(mb) * od * oh * ow * ngroups * oc;
 
     const float job_eff = max_job == 0
@@ -1320,7 +1320,7 @@ float brg_blocking_t::est_eff_1x1() {
     const auto amx_fac = maskrcnn_cond
             ? (div_up(M + M_tail, 16) / (M_n_sp_blks + M_tail_n_sp_blks))
             : (static_cast<float>(div_up(M + M_tail, 16))
-                    / (M_n_sp_blks + M_tail_n_sp_blks));
+                      / (M_n_sp_blks + M_tail_n_sp_blks));
 
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(ocb_ave) * spb_ave)
@@ -1377,15 +1377,15 @@ float brg_blocking_t::est_eff_1x1() {
     if (is_os_blocking) {
         max_job = (loop_order == loop_ndhwgc)
                 ? grid_coverage(thread_job, oc, ngroups, oc_block, os,
-                        static_cast<dim_t>(nb_os_blocking) * sp_block)
+                          static_cast<dim_t>(nb_os_blocking) * sp_block)
                 : grid_coverage(thread_job, os, 1,
-                        static_cast<dim_t>(nb_os_blocking) * sp_block, oc,
-                        oc_block);
+                          static_cast<dim_t>(nb_os_blocking) * sp_block, oc,
+                          oc_block);
     } else {
         max_job = (loop_order == loop_ndhwgc)
                 ? grid_coverage(thread_job, oc, ngroups, oc_block, sp, sp_block)
                 : grid_coverage(thread_job, sp, static_cast<dim_t>(od) * oh,
-                        sp_block, oc, oc_block);
+                          sp_block, oc, oc_block);
     }
 
     const dim_t sum_job = static_cast<dim_t>(mb) * od * oh * ow * ngroups * oc;
@@ -1564,9 +1564,9 @@ void brg_blocking_t::calc_blocks_1x1() {
         const auto max_os_block_thr
                 = (src_dsz * ic >= 1024 && src_dsz * ic < 4096)
                 ? nstl::max(nstl::min(16, os),
-                        div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
+                          div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
                 : nstl::max(div_up(2048, oc_block),
-                        static_cast<int>(div_up(mb * ngroups * os, nthr)));
+                          static_cast<int>(div_up(mb * ngroups * os, nthr)));
         const auto max_os_block_L2 = max_sp_block_L2;
 
         auto max_os_block_aliasing = 1000000 / nthr;
@@ -2370,12 +2370,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         dim_t ds = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.idp, jcp.od_block, jcp.kd,
                            jcp.stride_d, jcp.dilate_d)
-                        + nstl::max(0, jcp.f_pad) + nstl::max(0, jcp.back_pad))
+                          + nstl::max(0, jcp.f_pad)
+                          + nstl::max(0, jcp.back_pad))
                 : jcp.idp;
         dim_t hs = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.ihp, jcp.oh_block, jcp.kh,
                            jcp.stride_h, jcp.dilate_h)
-                        + nstl::max(0, jcp.t_pad) + nstl::max(0, jcp.b_pad))
+                          + nstl::max(0, jcp.t_pad) + nstl::max(0, jcp.b_pad))
                 : jcp.ihp;
         if (jcp.is_os_blocking)
             hs = div_up(rnd_up(hs * jcp.iwp, jcp.brgM), jcp.iwp)

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -114,7 +114,7 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
     const bool is_amx = jbgp.is_amx;
     auto wsp_tile_base = is_amx
             ? ctx.get_scratchpad_grantor().template get<char>(
-                    key_conv_amx_tile_buffer)
+                      key_conv_amx_tile_buffer)
             : nullptr;
 
     const int ic_chunks = div_up(jbgp.nb_ic, jbgp.nb_ic_blocking);
@@ -258,8 +258,8 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
                 auto A_ptr = jbgp.use_buffer_a
                         ? (a_buffer + src_dt_size * b * jbgp.K)
                         : (src
-                                + blk_off(
-                                        src_d, n, ic + b * jbgp.K, kd, kh, kw));
+                                  + blk_off(src_d, n, ic + b * jbgp.K, kd, kh,
+                                          kw));
                 addr_batch[b].ptr.A = A_ptr;
                 const dim_t wei_offset = wei_cur_ocb
                         + wei_ic_stride * (icb + b * ic_blocks_per_batch);
@@ -273,9 +273,11 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
                     && is_last_ic_chunk && !is_ic_tail && last_spatial_slice) {
                 void *scratch = is_amx
                         ? static_cast<void *>(wsp_tile)
-                        : (jbgp.req_s8s8_compensation ? static_cast<void *>(
-                                   const_cast<int *>(&compensation[oc]))
-                                                      : nullptr);
+                        : (jbgp.req_s8s8_compensation
+                                          ? static_cast<void *>(
+                                                    const_cast<int *>(
+                                                            &compensation[oc]))
+                                          : nullptr);
                 auto ptr_bias
                         = jbgp.with_bias ? bias + bia_dt_size * oc : nullptr;
                 const brgemm_post_ops_data_t post_ops_data {
@@ -322,9 +324,11 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
                     && last_spatial_slice) {
                 void *scratch = is_amx
                         ? static_cast<void *>(wsp_tile)
-                        : (jbgp.req_s8s8_compensation ? static_cast<void *>(
-                                   const_cast<int *>(&compensation[oc]))
-                                                      : nullptr);
+                        : (jbgp.req_s8s8_compensation
+                                          ? static_cast<void *>(
+                                                    const_cast<int *>(
+                                                            &compensation[oc]))
+                                          : nullptr);
                 auto ptr_bias
                         = jbgp.with_bias ? bias + bia_dt_size * oc : nullptr;
                 const brgemm_post_ops_data_t post_ops_data {
@@ -610,10 +614,13 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
 
                             void *scratch = is_amx
                                     ? static_cast<void *>(wsp_tile)
-                                    : (jbgp.req_s8s8_compensation ? static_cast<
-                                                    void *>(const_cast<int *>(
-                                               &compensation[oc]))
-                                                                  : nullptr);
+                                    : (jbgp.req_s8s8_compensation
+                                                      ? static_cast<
+                                                                void *>(const_cast<
+                                                                int *>(
+                                                                &compensation
+                                                                        [oc]))
+                                                      : nullptr);
 
                             const brgemm_post_ops_data_t post_ops_data {
                                     static_cast<const void *>(ptr_bias),
@@ -698,7 +705,7 @@ void brgemm_inner_product_bwd_data_t<isa>::execute_backward_data(
             : nullptr;
     auto wsp_tile_base = is_amx
             ? ctx.get_scratchpad_grantor().template get<char>(
-                    key_conv_amx_tile_buffer)
+                      key_conv_amx_tile_buffer)
             : nullptr;
 
     const dim_t acc_dt_sz = types::data_type_size(jbgp.acc_dt);
@@ -1153,7 +1160,7 @@ struct brgemm_inner_product_bwd_weights_t<isa>::thread_info_t {
 
         wsp_tile_base = is_amx
                 ? ctx.get_scratchpad_grantor().template get<char>(
-                        key_conv_amx_tile_buffer)
+                          key_conv_amx_tile_buffer)
                 : nullptr;
 
         nthr = jbgp.nthr;

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -351,10 +351,11 @@ struct brgemm_inner_product_bwd_data_t : public primitive_t {
             auto adj_oc = jbgp_.use_buffer_a
                     ? utils::rnd_up(jbgp_.oc, jbgp_.oc_block)
                     : jbgp_.oc;
-            auto bs = (is_K_tail) ? 1
-                                  : ((is_bs_tail) ? (adj_oc / jbgp_.oc_block)
-                                                          % jbgp_.nb_oc_blocking
-                                                  : jbgp_.nb_oc_blocking);
+            auto bs = (is_K_tail)
+                    ? 1
+                    : ((is_bs_tail) ? (adj_oc / jbgp_.oc_block)
+                                              % jbgp_.nb_oc_blocking
+                                    : jbgp_.nb_oc_blocking);
 
             return bs;
         }
@@ -537,10 +538,11 @@ struct brgemm_inner_product_bwd_weights_t : public primitive_t {
         }
 
         int get_brg_batchsize(bool is_bs_tail, bool is_K_tail) const {
-            auto bs = (is_K_tail) ? 1
-                                  : ((is_bs_tail) ? (jbgp_.os / jbgp_.os_block)
-                                                          % jbgp_.nb_os_blocking
-                                                  : jbgp_.nb_os_blocking);
+            auto bs = (is_K_tail)
+                    ? 1
+                    : ((is_bs_tail) ? (jbgp_.os / jbgp_.os_block)
+                                              % jbgp_.nb_os_blocking
+                                    : jbgp_.nb_os_blocking);
             return bs;
         }
 

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -1319,7 +1319,7 @@ status_t jit_brgemm_ip_conf_t::init_conf_base(cpu_isa_t isa,
     jbgp.wei_dt = weights_d.data_type();
     jbgp.bia_dt = jbgp.with_bias
             ? pick_by_prop_kind(jbgp.prop_kind, ipd.bias_desc.data_type,
-                    data_type::undef, ipd.diff_bias_desc.data_type)
+                      data_type::undef, ipd.diff_bias_desc.data_type)
             : data_type::undef;
     jbgp.req_s8s8_compensation
             = one_of(isa, avx512_core, avx512_core_vnni, avx2_vnni)

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -271,7 +271,7 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
         const primitive_attr_t *attr, data_type_t bias_dt, data_type_t acc_dt,
         const memory_desc_t *dst_md, bool skip_sum)
     : pp_kernel_t(
-            OC, MB, dst_mb_stride, attr, bias_dt, acc_dt, dst_md, skip_sum)
+              OC, MB, dst_mb_stride, attr, bias_dt, acc_dt, dst_md, skip_sum)
     , jit_generator_t(jit_name(), isa) {
     assert(IMPLICATION(this->dst_data_type_ == bf16, mayiuse(avx512_core)));
 

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -168,10 +168,10 @@ jit_pp_ker_t::jit_pp_ker_t(
     , zp_pad_comp_helper_(jit_gemm_convolution_utils::padding_exists(jcp)
                               && jcp.zp.src_exists
                       ? utils::make_unique<
-                              jit_gemm_x8s8s32x_zp_pad_comp_helper_t>(this,
-                              jcp_, reg_zp_pad_comp_, reg_zp_pad_comp_temp_,
-                              reg_should_apply_src_pad_comp_,
-                              pd->src_md()->ndims)
+                                jit_gemm_x8s8s32x_zp_pad_comp_helper_t>(this,
+                                jcp_, reg_zp_pad_comp_, reg_zp_pad_comp_temp_,
+                                reg_should_apply_src_pad_comp_,
+                                pd->src_md()->ndims)
                       : nullptr)
 
 {

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -40,8 +40,12 @@
 #endif
 
 #define DECLARE_CPU_JIT_AUX_FUNCTIONS(gen_name) \
-    const char *name() const override { return STRINGIFY(gen_name); } \
-    const char *source_file() const override { return __FILE__; } \
+    const char *name() const override { \
+        return STRINGIFY(gen_name); \
+    } \
+    const char *source_file() const override { \
+        return __FILE__; \
+    } \
     static const char *jit_name() { \
         static constexpr char ret[] = "/oneDNN:" STRINGIFY(gen_name); \
         return ret; \
@@ -660,9 +664,7 @@ public:
             const Xbyak::Xmm &x1, const Xbyak::Operand &op, Xbyak::uint8 imm) {
         if (is_valid_isa(avx))
             vpshufd(x1, op, imm);
-        else {
-            pshufd(x1, op, imm);
-        }
+        else { pshufd(x1, op, imm); }
     }
 
     void uni_vrcpss(const Xbyak::Xmm &x, const Xbyak::Operand &op) {

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -647,9 +647,9 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     const int is_bwd_d = jcp.prop_kind == backward_data;
     format_tag_t wei_tag = with_groups
             ? utils::pick(2 * ndims - 6 + is_bwd_d, gOIw8i8o, gOIw8o8i,
-                    gOIhw8i8o, gOIhw8o8i)
+                      gOIhw8i8o, gOIhw8o8i)
             : utils::pick(2 * ndims - 6 + is_bwd_d, OIw8i8o, OIw8o8i, OIhw8i8o,
-                    OIhw8o8i);
+                      OIhw8o8i);
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
 
     bool args_ok = true && jcp.ngroups == 1 && jcp.src_tag == dat_tag

--- a/src/cpu/x64/jit_sse41_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.cpp
@@ -47,8 +47,8 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_ != nullptr
             ? binary_injector::prepare_binary_args(
-                    pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                    pd()->jcp_.post_ops.entry_.size() + 1)
+                      pd()->dw_conv_pd_->jcp_.post_ops, ctx,
+                      pd()->jcp_.post_ops.entry_.size() + 1)
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();

--- a/src/cpu/x64/jit_sse41_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_convolution.hpp
@@ -94,9 +94,9 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
             auto dst_tag = is_data_layout_nxc ? dat_tag_nxc : dat_tag_nCx8c;
             auto wei_tag = with_groups()
                     ? utils::pick(2 * ndims() - 6 + flat, gOIw8i8o, gOwi8o,
-                            gOIhw8i8o, gOhwi8o, gOIdhw8i8o, gOdhwi8o)
+                              gOIhw8i8o, gOhwi8o, gOIdhw8i8o, gOdhwi8o)
                     : utils::pick(2 * ndims() - 6 + flat, OIw8i8o, Owi8o,
-                            OIhw8i8o, Ohwi8o, OIdhw8i8o, Odhwi8o);
+                              OIhw8i8o, Ohwi8o, OIdhw8i8o, Odhwi8o);
 
             return set_default_formats_common(src_tag, wei_tag, dst_tag);
         }

--- a/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
@@ -71,9 +71,9 @@ inline void rtus_prepare(conv_pd_t *self, const convolution_desc_t *&conv_d,
 
     const auto dat_tag = ndims == 3
             ? memory_desc_wrapper(src_d).matches_one_of_tag(
-                    format_tag::nCw8c, format_tag::nCw16c, format_tag::nwc)
-            : memory_desc_wrapper(src_d).matches_one_of_tag(
-                    format_tag::nChw8c, format_tag::nChw16c, format_tag::nhwc);
+                      format_tag::nCw8c, format_tag::nCw16c, format_tag::nwc)
+            : memory_desc_wrapper(src_d).matches_one_of_tag(format_tag::nChw8c,
+                      format_tag::nChw16c, format_tag::nhwc);
     if (dat_tag == format_tag::undef) return;
 
     const bool is_nspc

--- a/src/cpu/x64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.cpp
@@ -930,7 +930,7 @@ struct jit_bnorm_t : public jit_generator_t {
                 compute_mean
                         ? mean_compute_avx2_ne_xf16(num_ch_blks, num_spat_pts)
                         : variance_compute_avx2_ne_xf16(
-                                num_ch_blks, num_spat_pts);
+                                  num_ch_blks, num_spat_pts);
             else
                 compute_mean ? mean_compute(num_ch_blks, num_spat_pts)
                              : variance_compute(num_ch_blks, num_spat_pts);
@@ -2455,12 +2455,13 @@ status_t jit_uni_batch_normalization_fwd_t<isa>::execute(
     auto scale = CTX_IN_MEM(const acc_data_t *, DNNL_ARG_SCALE);
     auto shift = CTX_IN_MEM(const acc_data_t *, DNNL_ARG_SHIFT);
 
-    auto mean = pd()->stats_is_src() ? const_cast<acc_data_t *>(
-                        CTX_IN_MEM(const acc_data_t *, DNNL_ARG_MEAN))
-                                     : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_MEAN);
+    auto mean = pd()->stats_is_src()
+            ? const_cast<acc_data_t *>(
+                      CTX_IN_MEM(const acc_data_t *, DNNL_ARG_MEAN))
+            : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_MEAN);
     auto var = pd()->stats_is_src()
             ? const_cast<acc_data_t *>(
-                    CTX_IN_MEM(const acc_data_t *, DNNL_ARG_VARIANCE))
+                      CTX_IN_MEM(const acc_data_t *, DNNL_ARG_VARIANCE))
             : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_VARIANCE);
     auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
     auto ws = CTX_OUT_MEM(uint8_t *, DNNL_ARG_WORKSPACE);

--- a/src/cpu/x64/jit_uni_batch_normalization.hpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.hpp
@@ -48,9 +48,9 @@ struct jit_uni_batch_normalization_fwd_t : public primitive_t {
                 JIT_IMPL_NAME_HELPER("bnorm_jit:",
                         (src_md()->data_type == data_type::bf16)
                                 ? (mayiuse(avx512_core_bf16) ? avx512_core_bf16
-                                                : mayiuse(avx512_core)
-                                                ? bf16_emulation_t::get_isa()
-                                                : avx2_vnni_2)
+                                                  : mayiuse(avx512_core)
+                                                  ? bf16_emulation_t::get_isa()
+                                                  : avx2_vnni_2)
                                 : (src_md()->data_type == data_type::f16)
                                 ? (mayiuse(avx512_core_fp16) ? avx512_core_fp16
                                                              : avx2_vnni_2)
@@ -86,8 +86,8 @@ struct jit_uni_batch_normalization_bwd_t : public primitive_t {
                 JIT_IMPL_NAME_HELPER("bnorm_jit:",
                         (src_md()->data_type == data_type::bf16)
                                 ? (mayiuse(avx512_core_bf16)
-                                                ? avx512_core_bf16
-                                                : bf16_emulation_t::get_isa())
+                                                  ? avx512_core_bf16
+                                                  : bf16_emulation_t::get_isa())
                                 : (src_md()->data_type == data_type::f16)
                                 ? avx512_core_fp16
                                 : isa,

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -928,9 +928,10 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
             = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
     const dim_t nelems_slice_src1 = bcast_type == bcast_t::none
             ? nelems_slice_src0
-            : ((bcast_dims[0] == 0) ? utils::array_product(
-                       src1_d.padded_dims() + 1, ndims - 1)
-                                    : 0);
+            : ((bcast_dims[0] == 0)
+                              ? utils::array_product(
+                                        src1_d.padded_dims() + 1, ndims - 1)
+                              : 0);
 
     if (op_type == op_t::c_blocked) {
         const dim_t C_blocks = std::ceil(
@@ -1058,7 +1059,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
     // array product of outer dimensions that are not broadcast
     const dim_t SP_no_bcast = ndims >= 3
             ? utils::array_product(
-                    dims + (ndims - not_bcasted_sp_dims), not_bcasted_sp_dims)
+                      dims + (ndims - not_bcasted_sp_dims), not_bcasted_sp_dims)
             : 1;
     const dim_t C = ndims >= 2 ? dims[1] : 1;
     const dim_t SP = ndims >= 3 ? utils::array_product(dims + 2, ndims - 2) : 1;

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -79,8 +79,8 @@ size_t binary_kernel_t::get_tail_size() const {
         else if (conf_.op_type == op_t::n_c_spatial && ndims >= 3)
             nelems = conf_.bcast_type == bcast_t::per_w
                     ? utils::array_product(
-                            dims + (ndims - conf_.not_bcasted_sp_dims),
-                            conf_.not_bcasted_sp_dims)
+                              dims + (ndims - conf_.not_bcasted_sp_dims),
+                              conf_.not_bcasted_sp_dims)
                     : utils::array_product(dims + 2, ndims - 2);
     }
     // it's float due to for bfloat16 we still load 16 elements, not 32.
@@ -91,7 +91,7 @@ template <cpu_isa_t isa, typename Vmm>
 jit_uni_binary_kernel_t<isa, Vmm>::jit_uni_binary_kernel_t(
         const binary_pd_t *pd, const jit_binary_conf_t conf, bool tail_kernel)
     : binary_kernel_t(
-            vreg_traits_t<Vmm>::vlen, pd, conf, jit_name(), tail_kernel)
+              vreg_traits_t<Vmm>::vlen, pd, conf, jit_name(), tail_kernel)
     , offt_src0_(vlen_ / ((conf_.is_bf16 || conf_.is_f16) ? 2 : 1))
     , offt_src1_(conf_.use_stride_src1 ? offt_src0_ : 0)
     , offt_src2_(offt_src0_) {

--- a/src/cpu/x64/jit_uni_convert_xf16.hpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.hpp
@@ -108,8 +108,8 @@ struct jit_avx512_core_cvt_ps_to_bf16_t
         : jit_uni_cvt_ps_to_xf16_t<avx512_core>(dt, nelems)
         , use_bf16_emu_(!mayiuse(avx512_core_bf16))
         , bf16_emu_(use_bf16_emu_ ? utils::make_unique<bf16_emulation_t>(this,
-                            vmm_one, vmm_even, vmm_selector, reg_scratch,
-                            vmm_fp32_tmp)
+                                            vmm_one, vmm_even, vmm_selector,
+                                            reg_scratch, vmm_fp32_tmp)
                                   : nullptr) {
         assert(dt == data_type::bf16);
     }

--- a/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -61,9 +61,11 @@ void jit_uni_deconv_zp_pad_str_kernel_base_t::compute() {
 
         const int n_inner_ic_blk = jcp_.is_depthwise
                 ? 1
-                : (is_last_icb && ic_tail_exists ? utils::div_up(
-                           jcp_.ic_without_padding % jcp_.ic_block, 4)
-                                                 : (jcp_.ic_block / 4));
+                : (is_last_icb && ic_tail_exists
+                                  ? utils::div_up(jcp_.ic_without_padding
+                                                    % jcp_.ic_block,
+                                            4)
+                                  : (jcp_.ic_block / 4));
 
         const dim_t outer_wei_offset = icb * outer_icb_step;
 

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -43,10 +43,11 @@ cpu_isa_t get_io_isa(cpu_isa_t isa, bool has_f16, bool has_bf16) {
     // re-using avx512_core instantiation for xf16
     // re-using avx2 instantiation for xf16
     if (has_f16 || has_bf16)
-        return is_superset(isa, avx512_core) ? (has_f16    ? avx512_core_fp16
-                               : mayiuse(avx512_core_bf16) ? avx512_core_bf16
-                                                           : avx512_core)
-                                             : avx2_vnni_2;
+        return is_superset(isa, avx512_core)
+                ? (has_f16                                    ? avx512_core_fp16
+                                  : mayiuse(avx512_core_bf16) ? avx512_core_bf16
+                                                              : avx512_core)
+                : avx2_vnni_2;
     else
         return isa;
 }

--- a/src/cpu/x64/jit_uni_group_normalization.hpp
+++ b/src/cpu/x64/jit_uni_group_normalization.hpp
@@ -62,7 +62,8 @@ struct jit_uni_group_normalization_fwd_t : public primitive_t {
                 const float *shift, const float *mean, const float *var,
                 const float *src_scales, const float *dst_scales,
                 const void *post_ops_binary_rhs_arg_vec,
-                const size_t block_size) const = 0;
+                const size_t block_size) const
+                = 0;
         static kernel_base_t *create(const group_normalization_pd_t *pd);
         virtual status_t create_kernel() = 0;
         virtual ~kernel_base_t() = default;
@@ -77,9 +78,11 @@ struct jit_uni_group_normalization_fwd_t : public primitive_t {
 
     struct kernel_stat_base_t {
         virtual void operator()(
-                const void *src, float *mean, size_t block_size) const = 0;
+                const void *src, float *mean, size_t block_size) const
+                = 0;
         virtual void operator()(const void *src, const float *mean, float *var,
-                size_t block_size) const = 0;
+                size_t block_size) const
+                = 0;
         static kernel_stat_base_t *create(
                 const group_normalization_pd_t *pd, bool compute_var = false);
         virtual status_t create_kernel() = 0;

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -43,10 +43,11 @@ cpu_isa_t get_io_isa(cpu_isa_t isa, bool has_f16, bool has_bf16) {
     // re-using avx512_core instantiation for xf16
     // re-using avx2 instantiation for xf16
     if (has_f16 || has_bf16)
-        return is_superset(isa, avx512_core) ? (has_f16    ? avx512_core_fp16
-                               : mayiuse(avx512_core_bf16) ? avx512_core_bf16
-                                                           : avx512_core)
-                                             : avx2_vnni_2;
+        return is_superset(isa, avx512_core)
+                ? (has_f16                                    ? avx512_core_fp16
+                                  : mayiuse(avx512_core_bf16) ? avx512_core_bf16
+                                                              : avx512_core)
+                : avx2_vnni_2;
     else
         return isa;
 }

--- a/src/cpu/x64/jit_uni_instance_normalization.hpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.hpp
@@ -63,7 +63,8 @@ struct jit_uni_instance_normalization_fwd_t : public primitive_t {
                 const float *shift, const float *mean, const float *var,
                 const float *src_scales, const float *dst_scales,
                 const void *post_ops_binary_rhs_arg_vec,
-                const size_t block_size) const = 0;
+                const size_t block_size) const
+                = 0;
         static kernel_base_t *create(const group_normalization_pd_t *pd);
         virtual status_t create_kernel() = 0;
         virtual ~kernel_base_t() = default;
@@ -78,9 +79,11 @@ struct jit_uni_instance_normalization_fwd_t : public primitive_t {
 
     struct kernel_stat_base_t {
         virtual void operator()(
-                const void *src, float *mean, size_t block_size) const = 0;
+                const void *src, float *mean, size_t block_size) const
+                = 0;
         virtual void operator()(const void *src, const float *mean, float *var,
-                size_t block_size) const = 0;
+                size_t block_size) const
+                = 0;
         static kernel_stat_base_t *create(
                 const group_normalization_pd_t *pd, bool compute_var = false);
         virtual status_t create_kernel() = 0;

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -49,10 +49,11 @@ cpu_isa_t get_io_isa(cpu_isa_t isa, bool has_f16, bool has_bf16) {
     // re-using avx512_core instantiation for xf16
     // re-using avx2 instantiation for xf16
     if (has_f16 || has_bf16)
-        return is_superset(isa, avx512_core) ? (has_f16    ? avx512_core_fp16
-                               : mayiuse(avx512_core_bf16) ? avx512_core_bf16
-                                                           : avx512_core)
-                                             : avx2_vnni_2;
+        return is_superset(isa, avx512_core)
+                ? (has_f16                                    ? avx512_core_fp16
+                                  : mayiuse(avx512_core_bf16) ? avx512_core_bf16
+                                                              : avx512_core)
+                : avx2_vnni_2;
     else
         return isa;
 }
@@ -1302,7 +1303,7 @@ status_t jit_uni_layer_normalization_fwd_t::execute_forward(
                 : CTX_OUT_MEM(float *, DNNL_ARG_MEAN);
         variance = pd()->stats_are_src()
                 ? const_cast<float *>(
-                        CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE))
+                          CTX_IN_MEM(const float *, DNNL_ARG_VARIANCE))
                 : CTX_OUT_MEM(float *, DNNL_ARG_VARIANCE);
     }
 

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -375,7 +375,7 @@ public:
             const data_t *src, data_t *dst, char *indices,
             const exec_ctx_t &ctx)
         : transpose_facade_base_t<wsp_data_t, d_type>(
-                jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx) {
+                  jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx) {
 
         if (this->should_transpose_src()) {
             this->execute_transpose_input_
@@ -422,7 +422,7 @@ public:
             data_t *src, const data_t *dst, const char *indices,
             const exec_ctx_t &ctx)
         : transpose_facade_base_t<wsp_data_t, d_type>(
-                jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx)
+                  jpp, src_d, dst_d, indices_d, indices, wsp_dt, ctx)
         , c_tail_(jpp.c_without_padding % jpp.c_block) {
 
         if (this->should_transpose_src())

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -121,7 +121,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
 #define PARAM(x) \
     prb_.is_tail_present \
             ? ptr[abi_param1 + offsetof(tail_call_param_t, base_params) \
-                    + offsetof(call_param_t, x)] \
+                      + offsetof(call_param_t, x)] \
             : ptr[abi_param1 + offsetof(call_param_t, x)]
 #define TAIL_PARAM(x) ptr[abi_param1 + offsetof(tail_call_param_t, x)]
 

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
@@ -55,7 +55,8 @@ struct jit_uni_reorder_direct_copy_t : public primitive_t {
 
     struct kernel_base_t {
         virtual void operator()(
-                const void *src, void *dst, size_t work_amount) const = 0;
+                const void *src, void *dst, size_t work_amount) const
+                = 0;
         static kernel_base_t *create(const reorder_pd_t *pd, cpu_isa_t isa);
         virtual status_t create_kernel() = 0;
         virtual int get_max_unroll() const = 0;

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -228,7 +228,7 @@ struct jit_bnorm_process_relu_t {
             jit_generator_t *host, Reg64 reg_off_dat, Reg64 reg_tmp,
             Reg64 reg_ptr_ws, Vmm vzero, Vmm vstore_mask, Opmask kstore_mask)
         : jit_bnorm_process_relu_t(pd, host, reg_off_dat, reg_tmp, reg_ptr_ws,
-                vzero, vstore_mask, kstore_mask, Vmm(), Vmm(), Reg64()) {}
+                  vzero, vstore_mask, kstore_mask, Vmm(), Vmm(), Reg64()) {}
 
     jit_generator_t *const h_;
     const Reg64 reg_off_dat_;
@@ -703,7 +703,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
                 {
                     is_avx2_ne_xf16_
                             ? compute_stat_avx2_ne_xf16(
-                                    compute_mean, c_blks_to_unroll)
+                                      compute_mean, c_blks_to_unroll)
                             : compute_stat(compute_mean, c_blks_to_unroll);
 
                     add(reg_off_dat_, stride_S_ * data_type_size_);
@@ -2551,12 +2551,13 @@ status_t jit_uni_tbb_batch_normalization_fwd_t<isa>::execute(
     auto scale = CTX_IN_MEM(const acc_data_t *, DNNL_ARG_SCALE);
     auto shift = CTX_IN_MEM(const acc_data_t *, DNNL_ARG_SHIFT);
 
-    auto mean = pd()->stats_is_src() ? const_cast<acc_data_t *>(
-                        CTX_IN_MEM(const acc_data_t *, DNNL_ARG_MEAN))
-                                     : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_MEAN);
+    auto mean = pd()->stats_is_src()
+            ? const_cast<acc_data_t *>(
+                      CTX_IN_MEM(const acc_data_t *, DNNL_ARG_MEAN))
+            : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_MEAN);
     auto var = pd()->stats_is_src()
             ? const_cast<acc_data_t *>(
-                    CTX_IN_MEM(const acc_data_t *, DNNL_ARG_VARIANCE))
+                      CTX_IN_MEM(const acc_data_t *, DNNL_ARG_VARIANCE))
             : CTX_OUT_MEM(acc_data_t *, DNNL_ARG_VARIANCE);
 
     auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.hpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.hpp
@@ -46,9 +46,9 @@ struct jit_uni_tbb_batch_normalization_fwd_t : public primitive_t {
                 JIT_IMPL_NAME_HELPER("bnorm_tbb_jit:",
                         (src_md()->data_type == data_type::bf16)
                                 ? (mayiuse(avx512_core_bf16) ? avx512_core_bf16
-                                                : mayiuse(avx512_core)
-                                                ? bf16_emulation_t::get_isa()
-                                                : avx2_vnni_2)
+                                                  : mayiuse(avx512_core)
+                                                  ? bf16_emulation_t::get_isa()
+                                                  : avx2_vnni_2)
                                 : (src_md()->data_type == data_type::f16)
                                 ? (mayiuse(avx512_core_fp16) ? avx512_core_fp16
                                                              : avx2_vnni_2)
@@ -85,8 +85,8 @@ struct jit_uni_tbb_batch_normalization_bwd_t : public primitive_t {
                 JIT_IMPL_NAME_HELPER("bnorm_tbb_jit:",
                         (src_md()->data_type == data_type::bf16)
                                 ? (mayiuse(avx512_core_bf16)
-                                                ? avx512_core_bf16
-                                                : bf16_emulation_t::get_isa())
+                                                  ? avx512_core_bf16
+                                                  : bf16_emulation_t::get_isa())
                                 : (src_md()->data_type == data_type::f16)
                                 ? avx512_core_fp16
                                 : isa,

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -54,7 +54,7 @@ status_t jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                    pd()->jcp_.post_ops.entry_.size() + 1)
+                      pd()->jcp_.post_ops.entry_.size() + 1)
             : std::vector<const void *> {};
 
     const int32_t *src_zero_points = CTX_IN_MEM(

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -197,15 +197,15 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                 case avx2:
                     wei_tag = with_groups()
                             ? utils::pick(ndims() - 3, gOIw2i8o4i, gOIhw2i8o4i,
-                                    gOIdhw2i8o4i)
+                                      gOIdhw2i8o4i)
                             : utils::pick(ndims() - 3, OIw2i8o4i, OIhw2i8o4i,
-                                    OIdhw2i8o4i);
+                                      OIdhw2i8o4i);
                     break;
                 case sse41:
                     wei_tag = with_groups() ? utils::pick(ndims() - 3, gOIw4o4i,
-                                      gOIhw4o4i, gOIdhw4o4i)
+                                                      gOIhw4o4i, gOIdhw4o4i)
                                             : utils::pick(ndims() - 3, OIw4o4i,
-                                                    OIhw4o4i, OIdhw4o4i);
+                                                      OIhw4o4i, OIdhw4o4i);
                     break;
                 default: assert(!"Current ISA is not supported!"); break;
             }

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -699,9 +699,11 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                                 : jcp_.ic_without_padding % 4;
         const int n_ic_blocks = jcp_.is_depthwise
                 ? 1
-                : (last_ic_block_flag != no_last_block ? div_up(
-                           jcp_.ic_without_padding % jcp_.ic_block, 4)
-                                                       : jcp_.ic_block / 4);
+                : (last_ic_block_flag != no_last_block
+                                  ? div_up(jcp_.ic_without_padding
+                                                    % jcp_.ic_block,
+                                            4)
+                                  : jcp_.ic_block / 4);
 
         for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded) {
@@ -1541,7 +1543,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
             ? get_src_zp_comp_from_wei(
-                    weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
+                      weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1655,7 +1657,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
             ? get_src_zp_comp_from_wei(
-                    weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
+                      weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1741,11 +1743,11 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
                         : max(0,
-                                jcp.kh
-                                        - (kh_lo
-                                                + max(0, kh_len - 1)
-                                                        * jcp.stride_h
-                                                + 1));
+                                  jcp.kh
+                                          - (kh_lo
+                                                  + max(0, kh_len - 1)
+                                                          * jcp.stride_h
+                                                  + 1));
                 p.b_overflow = kh_lo;
                 p.kh_padding = kh_len;
                 p.scales = scales;
@@ -1833,7 +1835,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             : nullptr;
     const int32_t *zp_compensation = jcp.src_zero_point
             ? get_src_zp_comp_from_wei(
-                    weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
+                      weights, weights_d, jcp.signed_input, jcp.ngroups, jcp.oc)
             : nullptr;
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
@@ -1961,20 +1963,20 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
                         : max(0,
-                                jcp.kh
-                                        - (kh_lo
-                                                + max(0, kh_len - 1)
-                                                        * jcp.stride_h
-                                                + 1));
+                                  jcp.kh
+                                          - (kh_lo
+                                                  + max(0, kh_len - 1)
+                                                          * jcp.stride_h
+                                                  + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
                         : max(0,
-                                jcp.kd
-                                        - (kd_lo
-                                                + max(0, kd_len - 1)
-                                                        * jcp.stride_d
-                                                + 1));
+                                  jcp.kd
+                                          - (kd_lo
+                                                  + max(0, kd_len - 1)
+                                                          * jcp.stride_d
+                                                  + 1));
                 p.back_overflow = kd_lo;
                 p.kh_padding = kh_len;
                 p.kd_padding = kd_len;

--- a/src/cpu/x64/jit_uni_xf16_sum.hpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.hpp
@@ -102,7 +102,7 @@ struct jit_avx512_core_bf16_sum_kernel_t
     : jit_uni_xf16_sum_kernel_t<Xbyak::Zmm> {
     jit_avx512_core_bf16_sum_kernel_t(jit_sum_conf_t ajsp)
         : jit_uni_xf16_sum_kernel_t<Xbyak::Zmm>(
-                ajsp, utils::div_up(ajsp.num_srcs, 2))
+                  ajsp, utils::div_up(ajsp.num_srcs, 2))
         , max_vregs_available(cpu_isa_traits_t<avx512_core>::n_vregs
                   - (isa_has_bf16(jsp.isa) ? 1 : 6))
         , bf16_emu_(nullptr) {
@@ -298,9 +298,9 @@ struct jit_xf16_sum_t : public primitive_t {
 
             return is_superset(isa, avx512_core)
                     ? jit_avx512_core_bf16_sum_kernel_t::init_conf(
-                            jsp_, src_mds_.size(), dst_md_)
+                              jsp_, src_mds_.size(), dst_md_)
                     : jit_avx2_vnni_2_xf16_sum_kernel_t::init_conf(
-                            jsp_, src_mds_.size(), src_mds_, dst_md_);
+                              jsp_, src_mds_.size(), src_mds_, dst_md_);
         }
         jit_sum_conf_t jsp_;
     };

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_blocked.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_blocked.cpp
@@ -29,7 +29,7 @@ jit_avx512_common_lrn_kernel_bwd_blocked_t<d_type>::
                 const struct nChw16c_across_t &J, float alpha, float beta,
                 int local_size, int use_h_parallel)
     : jit_avx512_common_lrn_kernel_bwd_t<d_type>(
-            alpha, beta, local_size, jit_name())
+              alpha, beta, local_size, jit_name())
     , xmm_size_ {4 * sizeof(acc_data_t)}
     , zmm_size_ {64}
     , buffer_block_ {xmm_size_ + zmm_size_ + xmm_size_}

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
@@ -30,7 +30,7 @@ jit_avx512_common_lrn_kernel_bwd_nhwc_t<
         d_type>::jit_avx512_common_lrn_kernel_bwd_nhwc_t(unsigned C,
         float alpha, float beta, int local_size)
     : jit_avx512_common_lrn_kernel_bwd_t<d_type>(
-            alpha, beta, local_size, jit_name())
+              alpha, beta, local_size, jit_name())
     , tmp_mask_prev_ {[this]() {
         std::vector<int> v(this->local_size_ / 2);
         std::iota(v.begin(), v.end(), this->zdiffsrc_ + 2);

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_blocked.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_blocked.cpp
@@ -28,7 +28,7 @@ jit_avx512_common_lrn_kernel_fwd_blocked_t<d_type>::
                 int use_h_parallel, float alpha, float beta, float k,
                 int local_size)
     : jit_avx512_common_lrn_kernel_fwd_t<d_type>(
-            prop_kind, alpha, beta, k, local_size, jit_name())
+              prop_kind, alpha, beta, k, local_size, jit_name())
     // some registers needed for conversion from bf16 to f32
     , xmm_size_(4 * sizeof(acc_data_t))
     , zmm_size_(64)

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
@@ -28,7 +28,7 @@ jit_avx512_common_lrn_kernel_fwd_nhwc_t<
         d_type>::jit_avx512_common_lrn_kernel_fwd_nhwc_t(unsigned C,
         prop_kind_t prop_kind, float alpha, float beta, float k, int local_size)
     : jit_avx512_common_lrn_kernel_fwd_t<d_type>(
-            prop_kind, alpha, beta, k, local_size, jit_name())
+              prop_kind, alpha, beta, k, local_size, jit_name())
     , tmp_mask_prev_ {[this]() {
         std::vector<int> v(this->local_size_ / 2);
         std::iota(v.begin(), v.end(), this->zc_ + 2);

--- a/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
@@ -53,11 +53,12 @@ jit_uni_lrn_kernel_t<Derived<isa, d_type>>::jit_uni_lrn_kernel_t(
     : jit_generator_t(name, isa)
     , emulate_bfloat_(d_type == data_type::bf16 && !mayiuse(avx512_core_bf16)
               && is_superset(isa, avx512_core))
-    , bf16_emu_(
-              emulate_bfloat_ ? utils::make_unique<bf16_emulation_t>(this,
-                      bf16_emu_reserv_1_, bf16_emu_reserv_2_,
-                      bf16_emu_reserv_3_, bf16_emu_scratch_, bf16_emu_reserv_4_)
-                              : nullptr)
+    , bf16_emu_(emulate_bfloat_
+                      ? utils::make_unique<bf16_emulation_t>(this,
+                                bf16_emu_reserv_1_, bf16_emu_reserv_2_,
+                                bf16_emu_reserv_3_, bf16_emu_scratch_,
+                                bf16_emu_reserv_4_)
+                      : nullptr)
     , io_(this, get_io_isa(isa, d_type), {d_type}, {},
               io::io_tail_conf_t {simd_w_, 0, this->k1, 0, this->reg_tmp_},
               io::io_emu_bf16_conf_t {bf16_emu_reserv_1_, bf16_emu_reserv_2_,

--- a/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
@@ -32,11 +32,11 @@ class lrn_avx512_nhwc_executor_fwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_fwd_t(const PD_T *pd)
         : ker_(utils::make_unique<
-                lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(pd->C(),
-                pd->desc()->prop_kind,
-                pd->desc()->lrn_alpha / pd->desc()->local_size,
-                pd->desc()->lrn_beta, pd->desc()->lrn_k,
-                pd->desc()->local_size))
+                  lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(pd->C(),
+                  pd->desc()->prop_kind,
+                  pd->desc()->lrn_alpha / pd->desc()->local_size,
+                  pd->desc()->lrn_beta, pd->desc()->lrn_k,
+                  pd->desc()->local_size))
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())
@@ -87,9 +87,9 @@ class lrn_avx512_nhwc_executor_bwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_bwd_t(const PD_T *pd)
         : ker_ {utils::make_unique<
-                lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(pd->C(),
-                pd->desc()->lrn_alpha / pd->desc()->local_size,
-                pd->desc()->lrn_beta, pd->desc()->local_size)}
+                  lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(pd->C(),
+                  pd->desc()->lrn_alpha / pd->desc()->local_size,
+                  pd->desc()->lrn_beta, pd->desc()->local_size)}
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -344,11 +344,11 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     // processing for tail kernel
     const auto backup_isa = is_amx && bgmmc_.is_runtime_M && !is_s8s8
             ? (is_f16 || is_f32_f16 || is_f16_with_int_wei
-                            ? avx512_core_fp16
-                            : (is_bf16 || is_f32_bf16 || is_bf16_with_int_wei
-                                            ? avx512_core_bf16
-                                            : (is_int8 ? avx512_core_vnni
-                                                       : avx512_core)))
+                              ? avx512_core_fp16
+                              : (is_bf16 || is_f32_bf16 || is_bf16_with_int_wei
+                                                ? avx512_core_bf16
+                                                : (is_int8 ? avx512_core_vnni
+                                                           : avx512_core)))
             : isa;
 
     const int i_bs_end = bgmmc_.brgemm_batch_tail_size ? 2 : 1;
@@ -779,7 +779,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
             void *scratch = is_amx
                     ? static_cast<void *>(wsp_tile)
                     : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                            ithr, b_idx, n_blk_idx));
+                              ithr, b_idx, n_blk_idx));
 
             const size_t dst_row_logical_off
                     = brgmm_ctx.get_M_idx(m_blk_idx, true);
@@ -835,7 +835,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
             void *scratch = is_amx
                     ? static_cast<void *>(wsp_tile)
                     : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
-                            ithr, b_idx, n_blk_idx));
+                              ithr, b_idx, n_blk_idx));
 
             const size_t dst_row_logical_off
                     = brgmm_ctx.get_M_idx(m_blk_idx, true);
@@ -1442,35 +1442,35 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         buf_reduce_ptr_ = bgmmc.use_buffer_reduce
                 ? scratchpad.template get<char>(
-                        key_brgemm_primitive_buffer_reduce)
+                          key_brgemm_primitive_buffer_reduce)
                 : nullptr;
 
         is_amx_ = is_superset(isa, avx512_core_amx);
         wsp_tile_ptr_ = is_amx_
                 ? ctx.get_scratchpad_grantor().template get<char>(
-                        key_conv_amx_tile_buffer)
+                          key_conv_amx_tile_buffer)
                 : nullptr;
 
         const dim_t comp_offset = bgmmc_.b_dt_sz
                 * (weights_d.size() - weights_d.additional_buffer_size());
         s8s8_compensation_ptr_ = (bgmmc.s8s8_compensation_required)
                 ? ((bgmmc.use_buffer_b)
-                                ? scratchpad.template get<int32_t>(
-                                        key_brgemm_primitive_buffer_comp)
-                                : const_cast<int32_t *>(
-                                        reinterpret_cast<const int32_t *>(
-                                                &data_B_ptr_[comp_offset])))
+                                  ? scratchpad.template get<int32_t>(
+                                            key_brgemm_primitive_buffer_comp)
+                                  : const_cast<int32_t *>(
+                                            reinterpret_cast<const int32_t *>(
+                                                    &data_B_ptr_[comp_offset])))
                 : nullptr;
         assert(IMPLICATION(bgmmc.s8s8_compensation_required,
                 bgmmc_.b_dt_sz == bgmmc_.tr_b_dt_sz));
 
         zero_point_a_compensations_ptr_ = bgmmc.has_zero_point_a
                 ? scratchpad.template get<int32_t>(
-                        key_brgemm_primitive_zp_comp_a)
+                          key_brgemm_primitive_zp_comp_a)
                 : nullptr;
         zero_point_b_compensations_ptr_ = bgmmc.has_zero_point_b
                 ? scratchpad.template get<int32_t>(
-                        key_brgemm_primitive_zp_comp_b)
+                          key_brgemm_primitive_zp_comp_b)
                 : nullptr;
 
         post_ops_binary_rhs_arg_vec_ = binary_injector::prepare_binary_args(

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -3348,7 +3348,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
                     const int idx_offset = i + out_ur * n_iters;
                     const auto addr = !is_ymm_
                             ? EVEX_compress_addr(
-                                    reg_comp_ptr, idx_offset * simd_w_)
+                                      reg_comp_ptr, idx_offset * simd_w_)
                             : ptr[reg_comp_ptr + idx_offset * simd_w_];
                     uni_vmovups(addr, vmm_res);
                 }
@@ -4234,10 +4234,10 @@ struct jit_brgemm_matmul_copy_b_transposed_t
         , max_tmp_idx(16
                   - (avx512_core_dot_product_
                                   ? 8
-                                  : (do_compute_compensation_       ? 6
-                                                  : is_src_int4_    ? 2
-                                                  : req_zp_b_shift_ ? 1
-                                                                    : 0)))
+                                  : (do_compute_compensation_         ? 6
+                                                    : is_src_int4_    ? 2
+                                                    : req_zp_b_shift_ ? 1
+                                                                      : 0)))
         , src_stride_(conf_->copy_B_wei_stride)
         , tr_src_stride_(conf_->LDB * vnni_granularity_ * tr_typesize_)
         , src_elems_per_byte_(is_src_int4_ ? 2 : 1)

--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -388,7 +388,7 @@ status_t brgemm_matmul_copy_reorder_t::execute_body(
             = dst_d.size() - dst_d.additional_buffer_size();
     const size_t s8s8_comp_size_bytes = kernel_conf.s8s8_compensation_required
             ? dst_d.additional_buffer_size(
-                    memory_extra_flags::compensation_conv_s8s8)
+                      memory_extra_flags::compensation_conv_s8s8)
             : 0;
     const size_t zp_comp_offset_bytes
             = comp_offset_bytes + s8s8_comp_size_bytes;
@@ -471,7 +471,7 @@ status_t brgemm_matmul_copy_reorder_t::execute_body(
                         const auto src_offset = !kernel_conf.blocked_B
                                 ? get_blk_off(src_d, sdt_sz, batch, k, n)
                                 : get_blk_off(src_d, sdt_sz, batch, k_blk_idx,
-                                        n_blk_idx);
+                                          n_blk_idx);
                         ker_exec_ctx.src
                                 = (void *)&src[src_offset / src_typesz_scale];
                         ker_exec_ctx.tr_src = (void *)&dst[get_blk_off(
@@ -485,7 +485,7 @@ status_t brgemm_matmul_copy_reorder_t::execute_body(
                         const auto src_offset = !kernel_conf.blocked_B
                                 ? get_blk_off(src_d, sdt_sz, batch, k, n)
                                 : get_blk_off(src_d, sdt_sz, batch, k_blk_idx,
-                                        n_blk_idx);
+                                          n_blk_idx);
                         ker_exec_ctx.src
                                 = (void *)&src[src_offset / src_typesz_scale];
                         const auto dst_offset = get_blk_off(

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -376,8 +376,8 @@ format_tag_t brgemm_matmul_conf_utils_t::get_gemv_A_tag(
     if (A_any_layout) return plain_tensor_layout_tag;
 
     return is_m1
-            ? memory_desc_matches_one_of_tag(
-                    A_md, plain_tensor_layout_tag, transposed_tensor_layout_tag)
+            ? memory_desc_matches_one_of_tag(A_md, plain_tensor_layout_tag,
+                      transposed_tensor_layout_tag)
             : memory_desc_matches_one_of_tag(A_md, plain_tensor_layout_tag);
 }
 
@@ -413,10 +413,11 @@ format_tag_t brgemm_matmul_conf_utils_t::get_gemv_B_tag(
         // - allow both plain and transposed formats for the N=1 case
         // - allow only the transposed format for the M=1 case
         // Consider removing the need to infer wei_tag in the future.
-        return is_n1 ? memory_desc_matches_one_of_tag(B_md,
-                       plain_tensor_layout_tag, transposed_tensor_layout_tag)
-                     : memory_desc_matches_one_of_tag(
-                             B_md, transposed_tensor_layout_tag);
+        return is_n1
+                ? memory_desc_matches_one_of_tag(B_md, plain_tensor_layout_tag,
+                          transposed_tensor_layout_tag)
+                : memory_desc_matches_one_of_tag(
+                          B_md, transposed_tensor_layout_tag);
     }
 }
 
@@ -491,13 +492,15 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
             bgmmc.wei_tag = blocked_B_layouts_allowed && !bgmmc.is_runtime_N
                             && !bgmmc.is_int4_weights
                     ? memory_desc_matches_one_of_tag(B_md,
-                            plain_tensor_layout_tag,
-                            transposed_tensor_layout_tag,
-                            blocked_64n_B_layout_tag, blocked_48n_B_layout_tag,
-                            blocked_32n_B_layout_tag, blocked_16n_B_layout_tag)
+                              plain_tensor_layout_tag,
+                              transposed_tensor_layout_tag,
+                              blocked_64n_B_layout_tag,
+                              blocked_48n_B_layout_tag,
+                              blocked_32n_B_layout_tag,
+                              blocked_16n_B_layout_tag)
                     : memory_desc_matches_one_of_tag(B_md,
-                            plain_tensor_layout_tag,
-                            transposed_tensor_layout_tag, acbd, adbc);
+                              plain_tensor_layout_tag,
+                              transposed_tensor_layout_tag, acbd, adbc);
             const bool plain_transposed_matched
                     = memory_desc_matches_tag(B_md, plain_tensor_layout_tag)
                     && memory_desc_matches_tag(
@@ -569,15 +572,16 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_tags(memory_desc_t &A_md,
                               || this->is_f16_with_int_wei() || this->is_tf32()
                               || this->is_f32_with_int_wei())
                     && !xf16_avx2_vnni_2;
-            bgmmc.src_tag = is_adbc_allowed ? memory_desc_matches_one_of_tag(
-                                    A_md, plain_tensor_layout_tag,
-                                    transposed_tensor_layout_tag, acbd, adbc)
+            bgmmc.src_tag = is_adbc_allowed
+                    ? memory_desc_matches_one_of_tag(A_md,
+                              plain_tensor_layout_tag,
+                              transposed_tensor_layout_tag, acbd, adbc)
                     : is_int8_avx512_core
                     ? memory_desc_matches_one_of_tag(A_md,
-                            plain_tensor_layout_tag,
-                            transposed_tensor_layout_tag, acbd)
+                              plain_tensor_layout_tag,
+                              transposed_tensor_layout_tag, acbd)
                     : memory_desc_matches_one_of_tag(
-                            A_md, plain_tensor_layout_tag, acbd);
+                              A_md, plain_tensor_layout_tag, acbd);
             if (bgmmc.src_tag == format_tag::undef
                     || (memory_desc_matches_tag(
                                 A_md, transposed_tensor_layout_tag)
@@ -1087,7 +1091,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     const bool swap_m_n_blks = bgmmc.is_gemv && bgmmc.gemv_swap_a_b;
     const auto &matmul = swap_m_n_blks
             ? matmul_avx512_blocking_params_t::matmul_params_t(
-                    matmul_.N, matmul_.M, matmul_.K, matmul_.batch)
+                      matmul_.N, matmul_.M, matmul_.K, matmul_.batch)
             : matmul_;
 
     const int nthr = bgmmc.nthr;
@@ -1304,9 +1308,9 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
 
         const float best_imbalance = is_f32
                 ? compute_blocking_heuristic_avx2_f32(
-                        bgmmc, bm_conf_utils, matmul, best_blocking)
+                          bgmmc, bm_conf_utils, matmul, best_blocking)
                 : compute_blocking_heuristic_avx2(
-                        bgmmc, bm_conf_utils, matmul, best_blocking);
+                          bgmmc, bm_conf_utils, matmul, best_blocking);
 
         VCONDCHECK_BG(best_imbalance != 1.f, VERBOSE_BLOCKING_FAIL, "")
 
@@ -1804,9 +1808,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.N_tail = bgmmc.is_runtime_N ? 0 : bgmmc.N % bgmmc.N_blk;
     bgmmc.K_tail = bgmmc.K > bgmmc.K_blk
             ? ((bgmmc.extendable_k || bgmmc.use_fused_copy_a)
-                            ? bgmmc.K % bgmmc.K_blk
-                            : rnd_up(bgmmc.K % bgmmc.K_blk,
-                                    bgmmc.required_k_granularity))
+                              ? bgmmc.K % bgmmc.K_blk
+                              : rnd_up(bgmmc.K % bgmmc.K_blk,
+                                        bgmmc.required_k_granularity))
             : 0;
 
     bgmmc.LDB = bm_conf_utils.get_actual_LDB();

--- a/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
@@ -26,10 +26,10 @@ jit_prelu_backward_kernel_t::jit_prelu_backward_kernel_t(
         const cpu_prelu_bwd_pd_t *pd, const cpu_isa_t &isa, const int vlen,
         const size_t number_vmm_single_compute)
     : jit_prelu_base_kernel_t(isa, vlen,
-            prelu::get_bcast_type(memory_desc_wrapper(pd->diff_src_md(0)),
-                    memory_desc_wrapper(pd->diff_weights_md(0))),
-            memory_desc_wrapper(pd->diff_src_md(0)), number_vmm_single_compute,
-            jit_name())
+              prelu::get_bcast_type(memory_desc_wrapper(pd->diff_src_md(0)),
+                      memory_desc_wrapper(pd->diff_weights_md(0))),
+              memory_desc_wrapper(pd->diff_src_md(0)),
+              number_vmm_single_compute, jit_name())
     , pd_(pd)
     , src_dt_(pd->src_md(0)->data_type)
     , wei_dt_(pd->weights_md(0)->data_type)
@@ -84,7 +84,7 @@ template <typename Vmm>
 jit_uni_prelu_backward_kernel_t<Vmm>::jit_uni_prelu_backward_kernel_t(
         const cpu_prelu_bwd_pd_t *pd, const cpu_isa_t &isa)
     : jit_prelu_backward_kernel_t(pd, isa, vreg_traits_t<Vmm>::vlen,
-            std::is_same<Vmm, Xbyak::Zmm>::value ? 4u : 6u)
+              std::is_same<Vmm, Xbyak::Zmm>::value ? 4u : 6u)
     , saturation_needed_diff_src_(utils::one_of(
               diff_src_dt_, data_type::u8, data_type::s8, data_type::s32))
     , saturation_needed_diff_weights_(utils::one_of(
@@ -95,8 +95,8 @@ jit_uni_prelu_backward_kernel_t<Vmm>::jit_uni_prelu_backward_kernel_t(
               saturation_needed_diff_src_ ? reserve_vmm() : 0)
     , saturation_ubound_diff_weights_(saturation_needed_diff_weights_
                       ? (diff_wei_dt_ == diff_src_dt_
-                                      ? saturation_ubound_diff_src_.getIdx()
-                                      : reserve_vmm())
+                                        ? saturation_ubound_diff_src_.getIdx()
+                                        : reserve_vmm())
                       : 0)
     , vmm_ones_(reserve_vmm())
     , weights_const_vmm_(utils::one_of(bcast_, prelu::bcast::per_oc_n_c_spatial,

--- a/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
@@ -26,10 +26,10 @@ jit_prelu_forward_kernel_t::jit_prelu_forward_kernel_t(
         const cpu_prelu_fwd_pd_t *pd, const cpu_isa_t &isa, const int vlen,
         const size_t number_vmm_single_compute)
     : jit_prelu_base_kernel_t(isa, vlen,
-            prelu::get_bcast_type(memory_desc_wrapper(pd->src_md(0)),
-                    memory_desc_wrapper(pd->weights_md(0))),
-            memory_desc_wrapper(pd->src_md(0)), number_vmm_single_compute,
-            jit_name())
+              prelu::get_bcast_type(memory_desc_wrapper(pd->src_md(0)),
+                      memory_desc_wrapper(pd->weights_md(0))),
+              memory_desc_wrapper(pd->src_md(0)), number_vmm_single_compute,
+              jit_name())
     , src_dt_(pd->src_md(0)->data_type)
     , wei_dt_(pd->weights_md(0)->data_type)
     , dst_dt_(pd->dst_md(0)->data_type)
@@ -72,10 +72,10 @@ template <typename Vmm>
 jit_uni_prelu_forward_kernel_t<Vmm>::jit_uni_prelu_forward_kernel_t(
         const cpu_prelu_fwd_pd_t *pd, const cpu_isa_t &isa)
     : jit_prelu_forward_kernel_t(pd, isa, vreg_traits_t<Vmm>::vlen,
-            (utils::one_of(isa, sse41, avx)
-                    || pd->src_md(0)->data_type != data_type::f32)
-                    ? 4u
-                    : 3u)
+              (utils::one_of(isa, sse41, avx)
+                      || pd->src_md(0)->data_type != data_type::f32)
+                      ? 4u
+                      : 3u)
     , saturation_needed_(utils::one_of(
               dst_dt_, data_type::u8, data_type::s8, data_type::s32))
     , tail_vmm_mask_(

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
@@ -530,7 +530,7 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
     scratch_t *const A_iter_transposed_ithr = global_transpose
             ? A_iter_transposed_scratch_
             : (A_iter_transposed_scratch_
-                    + ithr * rnn_.diff_wei_brgemm.Kpadded * m_iter_block_);
+                      + ithr * rnn_.diff_wei_brgemm.Kpadded * m_iter_block_);
 
     scratch_t *const A_layer_transposed_ithr = global_transpose
             ? A_layer_transposed_scratch_
@@ -695,7 +695,7 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
     scratch_t *const A_iter_transposed_ithr = global_transpose
             ? A_iter_transposed_scratch_
             : (A_iter_transposed_scratch_
-                    + ithr * rnn_.diff_wei_brgemm.Kpadded * m_iter_block_);
+                      + ithr * rnn_.diff_wei_brgemm.Kpadded * m_iter_block_);
     scratch_t *const A_layer_transposed_ithr = global_transpose
             ? A_layer_transposed_scratch_
             : A_layer_transposed_scratch_

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -250,7 +250,7 @@ dim_t brgemm_calc_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks, bool is_f32,
     const bool adj_by_l2 = is_f32
             ? true
             : (static_cast<float>(As + Cs)
-                    < 0.6 * static_cast<float>(l2_cache_size));
+                      < 0.6 * static_cast<float>(l2_cache_size));
 
     if (work_by_N > 2.0 || (work_by_N > 1.0 && adj_by_l2))
         return M;

--- a/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -84,8 +84,8 @@ void jit_uni_shuffle_kernel_t<avx512_core>::emu_gather_data(
 
     for (unsigned i = 0; i < number_of_xmms; i++) {
         const unsigned number_of_xmm_halfs = is_tail && i == number_of_xmms - 1
-                ? utils::div_up(
-                        conf_.simd_tail, xmm_size_elem_half + i * xmm_size_elem)
+                ? utils::div_up(conf_.simd_tail,
+                          xmm_size_elem_half + i * xmm_size_elem)
                 : 2;
 
         for (unsigned j = 0; j < number_of_xmm_halfs; j++) {

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -1051,10 +1051,11 @@ jit_io_multi_dt_helper_t<Vmm>::jit_io_multi_dt_helper_t(jit_generator_t *host,
                     std::make_shared<jit_io_helper_t<Vmm>>(host, isa, dt,
                             io_conf, tail_conf,
                             dt == data_type::bf16 ? bf16_conf : utils::nullopt,
-                            store_saturation_needed ? utils::optional_t<
-                                    io_saturation_conf_t> {saturation_conf
-                                                                   ->second}
-                                                    : utils::nullopt,
+                            store_saturation_needed
+                                    ? utils::optional_t<
+                                              io_saturation_conf_t> {saturation_conf
+                                                                             ->second}
+                                    : utils::nullopt,
                             gather_conf,
                             utils::one_of(
                                     dt, data_type::f8_e4m3, data_type::f8_e5m2)

--- a/src/gpu/amd/engine.cpp
+++ b/src/gpu/amd/engine.cpp
@@ -43,7 +43,7 @@ status_t engine_create(impl::engine_t **engine, engine_kind_t engine_kind,
 engine_t::engine_t(
         const ::sycl::device &dev, const ::sycl::context &ctx, size_t index)
     : impl::gpu::engine_t(
-            new xpu::sycl::engine_impl_t(engine_kind::gpu, dev, ctx, index)) {
+              new xpu::sycl::engine_impl_t(engine_kind::gpu, dev, ctx, index)) {
     assert(xpu::sycl::is_amd_gpu(dev));
     set_miopen_handle();
     set_rocblas_handle();

--- a/src/gpu/amd/miopen_batch_normalization_executor.hpp
+++ b/src/gpu/amd/miopen_batch_normalization_executor.hpp
@@ -39,7 +39,8 @@ namespace amd {
 struct bnorm_exec_base_t {
     virtual status_t execute(const exec_ctx_t &ctx, impl::engine_t *engine,
             const std::shared_ptr<miopen_batch_normalization_impl_base_t>
-                    bnorm_impl) const = 0;
+                    bnorm_impl) const
+            = 0;
     virtual ~bnorm_exec_base_t() = default;
 
 protected:
@@ -89,15 +90,15 @@ protected:
 
                     auto *scale = use_scale
                             ? static_cast<uint8_t *>(
-                                    arg_scale.get_native_pointer(ih))
+                                      arg_scale.get_native_pointer(ih))
                             : static_cast<uint8_t *>(
-                                    arg_scale_buf.get_native_pointer(ih));
+                                      arg_scale_buf.get_native_pointer(ih));
 
                     uint8_t *shift = use_shift
                             ? static_cast<uint8_t *>(
-                                    arg_shift.get_native_pointer(ih))
+                                      arg_shift.get_native_pointer(ih))
                             : static_cast<uint8_t *>(
-                                    arg_shift_buf.get_native_pointer(ih));
+                                      arg_shift_buf.get_native_pointer(ih));
                     uint8_t *y_prime = nullptr, *save_mean = nullptr,
                             *save_var = nullptr;
 
@@ -165,19 +166,21 @@ protected:
 
                     auto *scale = use_scale
                             ? static_cast<uint8_t *>(
-                                    arg_scale.get_native_pointer(ih))
+                                      arg_scale.get_native_pointer(ih))
                             : static_cast<uint8_t *>(
-                                    arg_scale_buf.get_native_pointer(ih));
+                                      arg_scale_buf.get_native_pointer(ih));
                     auto *diff_scale = use_scale
                             ? static_cast<uint8_t *>(
-                                    arg_diff_scale.get_native_pointer(ih))
+                                      arg_diff_scale.get_native_pointer(ih))
                             : static_cast<uint8_t *>(
-                                    arg_diff_scale_buf.get_native_pointer(ih));
+                                      arg_diff_scale_buf.get_native_pointer(
+                                              ih));
                     uint8_t *diff_shift = use_shift
                             ? static_cast<uint8_t *>(
-                                    arg_diff_shift.get_native_pointer(ih))
+                                      arg_diff_shift.get_native_pointer(ih))
                             : static_cast<uint8_t *>(
-                                    arg_diff_shift_buf.get_native_pointer(ih));
+                                      arg_diff_shift_buf.get_native_pointer(
+                                              ih));
 
                     auto *save_mean = static_cast<uint8_t *>(
                             arg_wkspace.get_native_pointer(ih));
@@ -269,7 +272,7 @@ struct bnorm_exec_fwd_t : public bnorm_exec_base_t {
             auto arg_wkspace = bnorm_impl->is_training()
                     ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::write>();
+                              ::sycl::access::mode::write>();
 
             if (!use_global_stats) {
                 const bool init_global_stats = bnorm_impl->is_training();

--- a/src/gpu/amd/miopen_batch_normalization_impl.hpp
+++ b/src/gpu/amd/miopen_batch_normalization_impl.hpp
@@ -79,8 +79,9 @@ struct miopen_batch_normalization_impl_base_t {
 
     virtual status_t init(batch_normalization_pd_t *pd) = 0;
 
-    virtual void execute(miopenHandle_t handle,
-            std::shared_ptr<bnorm_args_t> args) const = 0;
+    virtual void execute(
+            miopenHandle_t handle, std::shared_ptr<bnorm_args_t> args) const
+            = 0;
 
     bool is_bwd_d() const { return is_bwd_data_; }
     bool is_training() const { return is_training_; }

--- a/src/gpu/amd/miopen_convolution_impl.hpp
+++ b/src/gpu/amd/miopen_convolution_impl.hpp
@@ -303,7 +303,8 @@ public:
     }
 
     virtual void execute(
-            miopenHandle_t handle, const std::vector<void *> &args) const = 0;
+            miopenHandle_t handle, const std::vector<void *> &args) const
+            = 0;
 
     void execute_sum(miopenHandle_t handle, void *x, void *y, float alpha_,
             float beta_) const {

--- a/src/gpu/amd/miopen_inner_product_impl.hpp
+++ b/src/gpu/amd/miopen_inner_product_impl.hpp
@@ -150,7 +150,8 @@ struct miopen_inner_product_impl_base_t {
 
     virtual void execute(miopenHandle_t /*handle*/,
             rocblas_handle /*rocblas_handle*/,
-            const std::vector<void *> & /*args*/) const = 0;
+            const std::vector<void *> & /*args*/) const
+            = 0;
 };
 
 struct miopen_inner_product_fwd_base_t

--- a/src/gpu/amd/miopen_lrn_impl.hpp
+++ b/src/gpu/amd/miopen_lrn_impl.hpp
@@ -42,7 +42,8 @@ struct miopen_lrn_impl_base_t {
 
     virtual status_t init(lrn_pd_t *pd) = 0;
     virtual void execute(
-            miopenHandle_t handle, const std::vector<void *> &args) const = 0;
+            miopenHandle_t handle, const std::vector<void *> &args) const
+            = 0;
 
     size_t get_workspace_size() const { return workspace_size; }
 

--- a/src/gpu/amd/miopen_pooling_impl.hpp
+++ b/src/gpu/amd/miopen_pooling_impl.hpp
@@ -43,7 +43,8 @@ struct miopen_pooling_impl_base_t {
     }
 
     virtual void execute(
-            miopenHandle_t handle, void *x, void *y, void *ws) const = 0;
+            miopenHandle_t handle, void *x, void *y, void *ws) const
+            = 0;
 
     size_t get_ws_size_miopen() const { return ws_size_miopen_; }
 

--- a/src/gpu/amd/miopen_reorder_impl.hpp
+++ b/src/gpu/amd/miopen_reorder_impl.hpp
@@ -31,7 +31,8 @@ public:
     virtual status_t init(const reorder_pd_t *pd) = 0;
 
     virtual void execute(miopenHandle_t handle, void *src, void *dst,
-            void *src_scale, void *dst_scale) const = 0;
+            void *src_scale, void *dst_scale) const
+            = 0;
 
     virtual ~miopen_reorder_generic_t() {
         MIOPEN_EXECUTE_FUNC_V(miopenDestroyTensorDescriptor, src_desc_);

--- a/src/gpu/amd/sycl_hip_utils.hpp
+++ b/src/gpu/amd/sycl_hip_utils.hpp
@@ -226,7 +226,7 @@ protected:
 public:
     explicit rocblas_error(const std::string &message, rocblas_status result)
         : std::runtime_error(
-                (message + std::string(rocblas_error_map(result)))) {
+                  (message + std::string(rocblas_error_map(result)))) {
         error_number_ = static_cast<int>(result);
     }
 
@@ -415,7 +415,7 @@ protected:
 public:
     explicit miopen_error(const std::string &message, miopenStatus_t result)
         : std::runtime_error(
-                (message + std::string(miopen_get_error_string(result)))) {
+                  (message + std::string(miopen_get_error_string(result)))) {
         error_number_ = static_cast<int>(result);
     }
 

--- a/src/gpu/generic/sycl/convolution_kernels.hpp
+++ b/src/gpu/generic/sycl/convolution_kernels.hpp
@@ -85,7 +85,7 @@ struct convolution_kernel_fwd_t {
 
         float sm_weights = (conf_.do_scale_weights && conf_.single_weight_scale
                         ? load_float_value(
-                                scales_weights_dt_, weights_scale_ptr(), 0)
+                                  scales_weights_dt_, weights_scale_ptr(), 0)
                         : 1.f);
 
         const float sm_dst = (conf_.do_scale_dst
@@ -339,7 +339,7 @@ struct convolution_kernel_bwd_data_t {
 
         float sm_weights = (conf_.do_scale_weights && conf_.single_weight_scale
                         ? load_float_value(
-                                scales_weights_dt_, weights_scale_ptr(), 0)
+                                  scales_weights_dt_, weights_scale_ptr(), 0)
                         : 1.f);
 
         const float sm_dst = (conf_.do_scale_dst

--- a/src/gpu/generic/sycl/engine.cpp
+++ b/src/gpu/generic/sycl/engine.cpp
@@ -40,7 +40,8 @@ status_t engine_create(impl::engine_t **engine, engine_kind_t engine_kind,
 engine_t::engine_t(
         const ::sycl::device &dev, const ::sycl::context &ctx, size_t index)
     : impl::gpu::engine_t(
-            new xpu::sycl::engine_impl_t(engine_kind::gpu, dev, ctx, index)) {}
+              new xpu::sycl::engine_impl_t(engine_kind::gpu, dev, ctx, index)) {
+}
 
 status_t engine_t::create_stream(
         impl::stream_t **stream, impl::stream_impl_t *stream_impl) {

--- a/src/gpu/generic/sycl/group_normalization_kernel.hpp
+++ b/src/gpu/generic/sycl/group_normalization_kernel.hpp
@@ -254,9 +254,10 @@ struct group_norm_bwd_t {
 
         dims_t logical_index;
         logical_index[1] = channel_num;
-        float gamma = conf_.scale_diff_required ? load_float_value(
-                              data_type::f32, scales.get_pointer(), channel_num)
-                                                : 1.0f;
+        float gamma = conf_.scale_diff_required
+                ? load_float_value(
+                          data_type::f32, scales.get_pointer(), channel_num)
+                : 1.0f;
         float diff_gamma = 0;
         float diff_beta = 0;
         for (dim_t batch = 0; batch < dims[0]; batch++) {

--- a/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
+++ b/src/gpu/generic/sycl/layer_normalizations_kernels.hpp
@@ -434,7 +434,7 @@ private:
 
                     float gamma = (conf_.use_scale)
                             ? load_float_value(data_scaleshift_md().data_type(),
-                                    scale_ptr(), data_scaleshift_md().off(c))
+                                      scale_ptr(), data_scaleshift_md().off(c))
                             : 1.f;
                     const size_t src_off = data_md().off_l(n * conf_.C + c),
                                  diff_dst_off
@@ -454,7 +454,7 @@ private:
             for (dim_t c = 0; c < C; ++c) {
                 float gamma = (conf_.use_scale)
                         ? load_float_value(data_scaleshift_md().data_type(),
-                                scale_ptr(), data_scaleshift_md().off(c))
+                                  scale_ptr(), data_scaleshift_md().off(c))
                         : 1.f;
                 const size_t src_off
                         = data_md().off_l(n * conf_.C + c),

--- a/src/gpu/generic/sycl/prelu_kernels.hpp
+++ b/src/gpu/generic/sycl/prelu_kernels.hpp
@@ -157,11 +157,11 @@ struct prelu_bwd_kernel_vec_t {
         , diff_dst_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_DIFF_DST))
         , scratchpad_(reduce_diff_weights
                           ? utils::downcast<
-                                  const xpu::sycl::memory_storage_base_t *>(
-                                  scratch_mem->memory_storage())
+                                    const xpu::sycl::memory_storage_base_t *>(
+                                    scratch_mem->memory_storage())
                                     ->get_out_memory_arg(ctx.stream(), cgh)
                           : xpu::sycl::memory_storage_base_t::
-                                  empty_out_memory_arg(ctx.stream(), cgh)) {}
+                                    empty_out_memory_arg(ctx.stream(), cgh)) {}
 
     void operator()(::sycl::nd_item<1> item) const {
         memory_tensor_t data_mem(data_, conf_.data_md);

--- a/src/gpu/generic/sycl/rnn/ref_rnn.cpp
+++ b/src/gpu/generic/sycl/rnn/ref_rnn.cpp
@@ -818,10 +818,10 @@ status_t ref_rnn_common_base_t::launch_copy(bool fwd, const exec_ctx_t &ctx,
     parallel_for(ctx, cpy_kernel, [&](::sycl::handler &cgh) {
         auto src_mem_arg = input
                 ? utils::downcast<const xpu::sycl::memory_storage_base_t *>(
-                        &input)
+                          &input)
                           ->get_in_memory_arg(ctx.stream(), cgh)
                 : xpu::sycl::memory_storage_base_t::empty_in_memory_arg(
-                        ctx.stream(), cgh);
+                          ctx.stream(), cgh);
         auto dst_mem_arg
                 = utils::downcast<const xpu::sycl::memory_storage_base_t *>(
                         &output)

--- a/src/gpu/generic/sycl/rnn/ref_rnn.hpp
+++ b/src/gpu/generic/sycl/rnn/ref_rnn.hpp
@@ -110,7 +110,8 @@ protected:
             const exec_ctx_t &ctx, std::unique_ptr<memory_storage_t> &a,
             std::unique_ptr<memory_storage_t> &b,
             std::unique_ptr<memory_storage_t> &c,
-            matmul_kind_t matmul_kind) const = 0;
+            matmul_kind_t matmul_kind) const
+            = 0;
 
     status_t launch_copy(bool fwd, const exec_ctx_t &ctx,
             const kernel_t &cpy_kernel, const sycl_rnn_copy_conf_t &copy_conf,
@@ -127,19 +128,23 @@ protected:
     virtual status_t copy_init_layer(const exec_ctx_t &ctx, dim_t batch,
             dim_t dhc, dim_t sic, dim_t slc, dim_t n_iter, dim_t n_layer,
             dim_t n_dir, dim_t states_ws_ld, const memory_storage_t &input,
-            const memory_storage_t &output) const = 0;
+            const memory_storage_t &output) const
+            = 0;
     virtual status_t copy_init_iter(const exec_ctx_t &ctx, dim_t batch,
             dim_t dhc, dim_t sic, dim_t slc, dim_t n_iter, dim_t n_layer,
             dim_t n_dir, dim_t states_ws_ld, const memory_storage_t &input,
-            const memory_storage_t &output) const = 0;
+            const memory_storage_t &output) const
+            = 0;
     virtual status_t copy_res_layer(const exec_ctx_t &ctx, dim_t batch,
             dim_t dhc, dim_t sic, dim_t slc, dim_t n_iter, dim_t n_layer,
             dim_t n_dir, dim_t states_ws_ld, const memory_storage_t &input,
-            const memory_storage_t &output) const = 0;
+            const memory_storage_t &output) const
+            = 0;
     virtual status_t copy_res_iter(const exec_ctx_t &ctx, dim_t batch,
             dim_t dhc, dim_t sic, dim_t slc, dim_t n_iter, dim_t n_layer,
             dim_t n_dir, dim_t states_ws_ld, const memory_storage_t &input,
-            const memory_storage_t &output) const = 0;
+            const memory_storage_t &output) const
+            = 0;
 
     status_t execution_loop(const grid_ctx_t &grid_struct);
 

--- a/src/gpu/generic/sycl/sycl_post_ops.hpp
+++ b/src/gpu/generic/sycl/sycl_post_ops.hpp
@@ -52,7 +52,7 @@ struct ref_eltwise_fwd_t {
 
     ref_eltwise_fwd_t(const post_ops_t::entry_t::eltwise_t &eltwise)
         : ref_eltwise_fwd_t(
-                eltwise.alg, eltwise.alpha, eltwise.beta, eltwise.scale) {}
+                  eltwise.alg, eltwise.alpha, eltwise.beta, eltwise.scale) {}
 
     float compute(float s) const {
         return compute(alg_, s, alpha_, beta_) * scale_;
@@ -361,10 +361,10 @@ struct post_op_input_args {
                             ? DNNL_ARG_WEIGHTS \
                             : DNNL_ARG_SRC_1))
         : args_ {CTX_IN_SYCL_KERNEL_MEMORY_PO(0),
-                CTX_IN_SYCL_KERNEL_MEMORY_PO(1),
-                CTX_IN_SYCL_KERNEL_MEMORY_PO(2),
-                CTX_IN_SYCL_KERNEL_MEMORY_PO(3),
-                CTX_IN_SYCL_KERNEL_MEMORY_PO(4)} {
+                  CTX_IN_SYCL_KERNEL_MEMORY_PO(1),
+                  CTX_IN_SYCL_KERNEL_MEMORY_PO(2),
+                  CTX_IN_SYCL_KERNEL_MEMORY_PO(3),
+                  CTX_IN_SYCL_KERNEL_MEMORY_PO(4)} {
     }
 #undef CTX_IN_SYCL_KERNEL_MEMORY_PO
 

--- a/src/gpu/intel/binary/common.h
+++ b/src/gpu/intel/binary/common.h
@@ -407,8 +407,8 @@ DEF_binary_op(float8, float);
 #undef DEF_binary_op
 
 #define DEF_ternary_op(dt, special_dt) \
-    dt __attribute__((overloadable)) \
-            ternary_op(int alg, dt src0, dt src1, char src2) { \
+    dt __attribute__((overloadable)) ternary_op( \
+            int alg, dt src0, dt src1, char src2) { \
         return (src2 != 0) ? src0 : src1; \
     }
 

--- a/src/gpu/intel/binary/simple.cpp
+++ b/src/gpu/intel/binary/simple.cpp
@@ -58,7 +58,7 @@ status_t simple_t::pd_t::init_conf(impl::engine_t *engine) {
         if (is_ternary_op()) {
             conf.src2_bcast_dims[i] = i < ndims
                     ? (src2_d.dims()[i] == 1
-                            && src2_d.dims()[i] != dst_d.dims()[i])
+                              && src2_d.dims()[i] != dst_d.dims()[i])
                     : 0;
         }
     }

--- a/src/gpu/intel/bnorm/nhwc_reusable.cpp
+++ b/src/gpu/intel/bnorm/nhwc_reusable.cpp
@@ -263,9 +263,10 @@ static dim_t get_calc_slm_size(const nhwc_reusable_compile_params_t &cmpl_conf,
         const nhwc_reusable_runtime_params_t &rt_conf) {
     return rt_conf.use_fused_atomics_reduction
             ? (rt_conf.use_buffers_calc ? sizeof(float) * rt_conf.ic_block
-                                    * rt_conf.calc_adj_lws[1]
+                                      * rt_conf.calc_adj_lws[1]
                                         : sizeof(float) * cmpl_conf.vect_size
-                                    * rt_conf.sg_size * rt_conf.calc_adj_lws[1])
+                                      * rt_conf.sg_size
+                                      * rt_conf.calc_adj_lws[1])
             : 0;
 }
 

--- a/src/gpu/intel/bnorm/xe.h
+++ b/src/gpu/intel/bnorm/xe.h
@@ -113,7 +113,7 @@
 #define MAYBE_LAST_IC_LOAD_FLOAT_1x16(ptr, idx) \
     (is_last_ic_block ? (simd_id < 8 ? ptr[(idx) + simd_id] : 0.0f) \
                       : as_float(intel_sub_group_block_read( \
-                              (const __global uint *)(&ptr[(idx)]))))
+                                (const __global uint *)(&ptr[(idx)]))))
 #else
 #define MAYBE_LAST_IC_LOAD_FLOAT_1x16(ptr, idx) LOAD_FLOAT_1x16(&ptr[(idx)])
 #endif

--- a/src/gpu/intel/compute/dispatch.cpp
+++ b/src/gpu/intel/compute/dispatch.cpp
@@ -89,7 +89,7 @@ compute::range_t get_optimal_lws(compute::range_t &gws,
         auto lws_i = (static_cast<size_t>(mapped_vec_dim_idx) == i
                              && gpu_arch >= gpu_arch_t::xe_hp)
                 ? match(optimal_vect_values, gws[i], rest_lws,
-                        utils::rnd_up_pow2(lws_min[i]))
+                          utils::rnd_up_pow2(lws_min[i]))
                 : match(optimal_lws_values, gws[i], rest_lws, lws_min[i]);
 
         lws_nd[i] *= lws_i;
@@ -141,8 +141,7 @@ std::string dispatch_t::str() const {
     ostringstream_t oss;
     for (dim_idx_t i = 0; i < ndims_; ++i) {
         auto &d = dims_[i];
-        oss << "    "
-            << "dim #" << i << " name: " << std::setw(10) << d.name
+        oss << "    " << "dim #" << i << " name: " << std::setw(10) << d.name
             << " size: " << std::setw(6) << d.size << " block: " << std::setw(4)
             << d.block << " nesting_level: " << std::setw(4) << d.nesting_level
             << " vsize: " << std::setw(4) << d.vector_size

--- a/src/gpu/intel/compute/dispatch_reusable.hpp
+++ b/src/gpu/intel/compute/dispatch_reusable.hpp
@@ -316,7 +316,8 @@ struct lws_strategy_t {
     virtual ~lws_strategy_t() = default;
 
     virtual range_t create_lws(
-            range_t &gws, const gws_bin_mapping_t &mapper) const = 0;
+            range_t &gws, const gws_bin_mapping_t &mapper) const
+            = 0;
 
     // Determine if a given block (mapped to each buffer) should be in the lws.
     // Gets called for each block dispatched to the GWS.

--- a/src/gpu/intel/compute/kernel.hpp
+++ b/src/gpu/intel/compute/kernel.hpp
@@ -184,8 +184,8 @@ public:
         return status::success;
     }
 
-    virtual status_t check_alignment(
-            const kernel_arg_list_t &arg_list) const = 0;
+    virtual status_t check_alignment(const kernel_arg_list_t &arg_list) const
+            = 0;
 
     status_t check_alignment(const void *ptr, int arg_idx) const {
         const int min_alignment = 64;

--- a/src/gpu/intel/concat/common.h
+++ b/src/gpu/intel/concat/common.h
@@ -91,7 +91,7 @@
 
 #define INTERNAL_CAT(a, b) a##b
 #define CAT(a, b) INTERNAL_CAT(a, b)
-#define DIV_UP(a, b) (((a) + ((b)-1)) / (b))
+#define DIV_UP(a, b) (((a) + ((b) - 1)) / (b))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 

--- a/src/gpu/intel/concat/simple.cl
+++ b/src/gpu/intel/concat/simple.cl
@@ -636,7 +636,7 @@ internal_padding_block_concat2(__global DATA_T *dst,
 
             COMPUTE_T trailmask = (ntrail < NPERSG)
                     ? SHIFTR(SHIFTL(FULLMASK, ntrail * DATA_TYPE_SIZE * 8),
-                            ntrail * DATA_TYPE_SIZE * 8)
+                              ntrail * DATA_TYPE_SIZE * 8)
                     : zero;
 
             if (cutoff > 0 && (ic % B0) >= cutoff) {

--- a/src/gpu/intel/conv/jit/ir_builder.cpp
+++ b/src/gpu/intel/conv/jit/ir_builder.cpp
@@ -469,10 +469,11 @@ private:
             int buf_size, stmt_t &g2r_load_stmt, stmt_t &s2r_load_stmt) {
         if (subtile_idx > 0 && x2r_load.split_factor() == 1) return;
         auto reg_buf = buf_mgr_.get(prefix, buf_size);
-        auto load_buf = x2r_reorder ? buf_mgr_.get("x2r_tmp",
-                                std::max(x2r_load.reg_buf_size(),
-                                        into<int>(x2r_reorder.src_buf_size())))
-                                    : reg_buf;
+        auto load_buf = x2r_reorder
+                ? buf_mgr_.get("x2r_tmp",
+                          std::max(x2r_load.reg_buf_size(),
+                                  into<int>(x2r_reorder.src_buf_size())))
+                : reg_buf;
         if (load_buf.is_same(reg_buf)) {
             reg_buf = buf_mgr_.get(prefix, x2r_load.reg_buf_size());
         }

--- a/src/gpu/intel/conv/jit/kernel.hpp
+++ b/src/gpu/intel/conv/jit/kernel.hpp
@@ -36,7 +36,7 @@ public:
     conv_kernel_t(const config_t &cfg, const kernel_info_t &kernel_info,
             const compute::range_t &local_range, const layout_t &zp_dst)
         : ir_kernel_t(kernel_info.iface("gen_conv"), cfg.options(), local_range,
-                {GENERATOR_NAME, GENERATOR_LINE})
+                  {GENERATOR_NAME, GENERATOR_LINE})
         , prb_(cfg.prb())
         , cfg_(cfg) {
 

--- a/src/gpu/intel/conv/jit/key.cpp
+++ b/src/gpu/intel/conv/jit/key.cpp
@@ -483,8 +483,7 @@ public:
         oss << "," << prop_;
         oss << "," << type_info_;
         if (csv) {
-            oss << ","
-                << "mb" << mb_.value << desc_;
+            oss << "," << "mb" << mb_.value << desc_;
         } else {
             oss << "," << mb_;
             oss << "," << desc_;

--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -1149,13 +1149,13 @@ grf_usage_t plan_t::grf_usage() const {
     int a_g2r_buf_regs = use_a_slm
             ? 0
             : x2r.a_load.estimate_regs(/*with_buffer=*/true,
-                    /*with_headers=*/false,
-                    /*reuse_headers=*/false);
+                      /*with_headers=*/false,
+                      /*reuse_headers=*/false);
     int b_g2r_buf_regs = use_b_slm
             ? 0
             : x2r.b_load.estimate_regs(/*with_buffer=*/true,
-                    /*with_headers=*/false,
-                    /*reuse_headers=*/false);
+                      /*with_headers=*/false,
+                      /*reuse_headers=*/false);
     if (x2r.a_reorder && x2r.b_reorder) {
         gpu_assert(!use_a_slm && !use_b_slm);
         // Reuse load buffer when both reorders are enabled.

--- a/src/gpu/intel/conv/jit/tiler.cpp
+++ b/src/gpu/intel/conv/jit/tiler.cpp
@@ -599,8 +599,8 @@ private:
     struct context_t {
         context_t(const blocking_t &blk, const config_t &cfg)
             : context_t(blk, cfg, to_gemm(blk.iter(), cfg.prb()),
-                    to_gemm(blk.loop(), cfg.prb()),
-                    to_gemm(blk.thread_group(), cfg.prb())) {}
+                      to_gemm(blk.loop(), cfg.prb()),
+                      to_gemm(blk.thread_group(), cfg.prb())) {}
 
         context_t(const blocking_t &blk, const config_t &cfg,
                 const tile_t &iter, const tile_t &loop, const tile_t &tg)

--- a/src/gpu/intel/conv/jit/v2/plan.hpp
+++ b/src/gpu/intel/conv/jit/v2/plan.hpp
@@ -54,7 +54,7 @@ public:
             }
             e.loop_idx = e.loop_size.is(1) ? expr_t(0)
                                            : var_t::make(dsl::type_t::s32(),
-                                                   e.dim.str() + "_loop_idx");
+                                                     e.dim.str() + "_loop_idx");
         }
         e.tg_idx = expr_t(0);
         e.thr_idx = (tg_tile == 1 ? expr_t(0) : thr_idx);

--- a/src/gpu/intel/conv/jit/zero_out.hpp
+++ b/src/gpu/intel/conv/jit/zero_out.hpp
@@ -81,12 +81,12 @@ public:
             const kernel_info_t &kernel_info, const impl::engine_t *engine)
         : zero_out_kernel_t(zero_out_kernel_desc_t(options.regs(),
                                     options.simd(), options.require_dpas()),
-                engine) {}
+                  engine) {}
 
     zero_out_kernel_t(
             const kernel_desc_base_t &_desc, const impl::engine_t *engine)
         : base_type(get_kernel_iface(_desc), _desc.options(engine),
-                debug_config_t {GENERATOR_NAME, GENERATOR_LINE}) {
+                  debug_config_t {GENERATOR_NAME, GENERATOR_LINE}) {
         requireLocalID(3);
         requireLocalSize();
         requireGRF(options().regs());

--- a/src/gpu/intel/conv/xe_wino_fwd_data_fused.cl
+++ b/src/gpu/intel/conv/xe_wino_fwd_data_fused.cl
@@ -457,7 +457,7 @@ xe_wino_conv_fwd(__global DATA_T *dst, const __global DATA_T *src,
                 bool y_in = 0 <= (src_ih + index) && (src_ih + index) < IH
                         && x_in;
                 src[index] = y_in ? *((const __global VTRANS_DATA_T *)(src_load
-                                     + src_off(0, 0, 0, index, 0)))
+                                            + src_off(0, 0, 0, index, 0)))
                                   : 0;
 
                 //Scale input to prevent intermediate computations overflow in
@@ -571,7 +571,9 @@ xe_wino_conv_fwd(__global DATA_T *dst, const __global DATA_T *src,
 
         unroll_for(int i = 0; i < COMP_OC_COUNT; i++) {
             wino_m_transform(C[i], M[i]);
-            unroll_for(int j = 0; j < WINO_M; j++) { C[i][j] = C[i][j] * scl; }
+            unroll_for(int j = 0; j < WINO_M; j++) {
+                C[i][j] = C[i][j] * scl;
+            }
         }
 
         // Write data
@@ -606,8 +608,9 @@ xe_wino_conv_fwd(__global DATA_T *dst, const __global DATA_T *src,
                                 = OW % OW_BLOCK == 0 || ow + ow_block < OW;
                         S[oc_block][oh_block][ow_block] = valid_oh && valid_ow
                                 ? dst[dst_idx
-                                        + dst_off(0, oc_block * COMP_OC_STRIDE,
-                                                0, oh_block, ow_block)]
+                                          + dst_off(0,
+                                                  oc_block * COMP_OC_STRIDE, 0,
+                                                  oh_block, ow_block)]
                                 : 0;
                     }
                 }

--- a/src/gpu/intel/engine.hpp
+++ b/src/gpu/intel/engine.hpp
@@ -68,14 +68,17 @@ public:
     }
 
     virtual status_t create_kernel(
-            compute::kernel_t *kernel, jit::generator_base_t *jitter) const = 0;
+            compute::kernel_t *kernel, jit::generator_base_t *jitter) const
+            = 0;
 
     virtual status_t create_kernel(compute::kernel_t &kernel,
-            const jit::dsl::kernel_t &kernel_ir) const = 0;
+            const jit::dsl::kernel_t &kernel_ir) const
+            = 0;
 
     virtual status_t create_kernels(std::vector<compute::kernel_t> *kernels,
             const std::vector<const char *> &kernel_names,
-            const compute::kernel_ctx_t &kernel_ctx) const = 0;
+            const compute::kernel_ctx_t &kernel_ctx) const
+            = 0;
 
     status_t create_kernel_bundle(compute::kernel_bundle_t &bundle,
             const std::vector<const char *> &kernel_names,
@@ -88,12 +91,14 @@ public:
 
     virtual status_t create_kernel_from_binary(compute::kernel_t &kernel,
             const xpu::binary_t &binary, const char *kernel_name,
-            const compute::program_src_t &src) const = 0;
+            const compute::program_src_t &src) const
+            = 0;
 
     virtual status_t create_kernels_from_cache_blob(
             const cache_blob_t &cache_blob,
             std::vector<compute::kernel_t> &kernels,
-            const std::vector<const char *> &kernel_names) const = 0;
+            const std::vector<const char *> &kernel_names) const
+            = 0;
 
     status_t create_kernel_from_cache_blob(const cache_blob_t &cache_blob,
             compute::kernel_t &kernel, const char *kernel_name) const {

--- a/src/gpu/intel/gemm/jit/dsl/ir/core.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/core.cpp
@@ -295,7 +295,9 @@ stmt_t stmt_seq_t::make(const std::vector<stmt_t> &_vec) {
 }
 
 #define DECL_TRAVERSE_LEAF(name) \
-    object_t ir_mutator_t::_mutate(const name &obj) { return obj; } \
+    object_t ir_mutator_t::_mutate(const name &obj) { \
+        return obj; \
+    } \
     void ir_visitor_t::_visit(const name &obj) {}
 
 DECL_TRAVERSE_LEAF(bool_imm_t)

--- a/src/gpu/intel/gemm/jit/dsl/ir/object.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/object.cpp
@@ -129,7 +129,7 @@ DEFINE_BINARY_OPERATOR(^, op_kind_t::_xor)
 #undef DEFINE_BINARY_OPERATOR
 
 #define DEFINE_BINARY_ASSIGN_OPERATOR(op) \
-    expr_t &expr_t::operator op##=(const expr_t &rhs) { \
+    expr_t &expr_t::operator op##=(const expr_t & rhs) { \
         auto tmp = (*this)op rhs; \
         *this = std::move(tmp); \
         return *this; \

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
@@ -403,11 +403,11 @@ expr_t simplify_rewrite_and(const expr_t &_e) {
         auto _true = (e.type().is_scalar()
                         ? expr_t(true)
                         : shuffle_t::make_broadcast(
-                                expr_t(true), e.type().elems()));
+                                  expr_t(true), e.type().elems()));
         auto _false = (e.type().is_scalar()
                         ? expr_t(false)
                         : shuffle_t::make_broadcast(
-                                expr_t(false), e.type().elems()));
+                                  expr_t(false), e.type().elems()));
         REWRITE_BINARY_NO_STATIC(_true & x, x);
         REWRITE_BINARY_NO_STATIC(x & _true, x);
         REWRITE_BINARY_NO_STATIC(_false & x, _false);
@@ -430,11 +430,11 @@ expr_t simplify_rewrite_or(const expr_t &_e) {
         auto _true = (e.type().is_scalar()
                         ? expr_t(true)
                         : shuffle_t::make_broadcast(
-                                expr_t(true), e.type().elems()));
+                                  expr_t(true), e.type().elems()));
         auto _false = (e.type().is_scalar()
                         ? expr_t(false)
                         : shuffle_t::make_broadcast(
-                                expr_t(false), e.type().elems()));
+                                  expr_t(false), e.type().elems()));
         REWRITE_BINARY_NO_STATIC(_true | x, _true);
         REWRITE_BINARY_NO_STATIC(x | _true, _true);
         REWRITE_BINARY_NO_STATIC(_false | x, x);
@@ -1152,7 +1152,7 @@ public:
 private:
     factored_expr_t(const expr_t &e)
         : expr_iface_t(
-                e.type().with_attr(e.type().attr() & ~type::attr_t::mut)) {
+                  e.type().with_attr(e.type().attr() & ~type::attr_t::mut)) {
         init_factors(e);
     }
 
@@ -1971,8 +1971,8 @@ struct voider_t {
 
 template <op_kind_t op_kind, typename T>
 struct compute_helper_t<op_kind, T,
-        typename voider_t<decltype(
-                op_traits_t<op_kind>::compute(T(), T()))>::type> {
+        typename voider_t<decltype(op_traits_t<op_kind>::compute(
+                T(), T()))>::type> {
     static expr_t call(T a, T b) {
         return to_expr(op_traits_t<op_kind>::compute(a, b));
     }

--- a/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
+++ b/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
@@ -551,16 +551,18 @@ struct generator_dsl_t {
         tensor_config_t B_load(
                 kloop_it.B_load(), B_load_transform, strategy.B_copies);
 
-        auto prefetchA = strategy.prefetchA ? dnnl::impl::utils::rnd_dn(
-                                 strategy.prefetchA, strategy.ka_prefetch)
-                                            : 0;
+        auto prefetchA = strategy.prefetchA
+                ? dnnl::impl::utils::rnd_dn(
+                          strategy.prefetchA, strategy.ka_prefetch)
+                : 0;
         if (prefetchA != strategy.prefetchA)
             gpu_warning() << "Unimplemented partial A tile prefetch, modifying "
                              "prefetch distance "
                           << strategy.prefetchA << " -> " << prefetchA;
-        auto prefetchB = strategy.prefetchB ? dnnl::impl::utils::rnd_dn(
-                                 strategy.prefetchB, strategy.kb_prefetch)
-                                            : 0;
+        auto prefetchB = strategy.prefetchB
+                ? dnnl::impl::utils::rnd_dn(
+                          strategy.prefetchB, strategy.kb_prefetch)
+                : 0;
         if (prefetchB != strategy.prefetchB)
             gpu_warning() << "Unimplemented partial B tile prefetch, modifying "
                              "prefetch distance "

--- a/src/gpu/intel/gemm/jit/include/gemmstone/dsl/ir/object.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/dsl/ir/object.hpp
@@ -297,7 +297,7 @@ public:
     const type_t &type() const;
 
 #define DECLARE_BINARY_ASSIGN_OPERATOR(op) \
-    expr_t &operator op##=(const expr_t &rhs);
+    expr_t &operator op##=(const expr_t & rhs);
 
     DECLARE_BINARY_ASSIGN_OPERATOR(+)
     DECLARE_BINARY_ASSIGN_OPERATOR(-)

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.hpp
@@ -52,8 +52,8 @@ struct xe_hp_systolic_t : public gemm::primitive_t {
             using namespace data_type;
             return with_bias() ? desc()->bias_type()
                                : (utils::one_of(desc()->a_type(), s8, u8)
-                                               ? s32
-                                               : desc()->c_type());
+                                                 ? s32
+                                                 : desc()->c_type());
         }
 
         data_type_t impl_acc_type() const {

--- a/src/gpu/intel/include/conversion.h
+++ b/src/gpu/intel/include/conversion.h
@@ -29,7 +29,9 @@
 
 // Identity conversions
 #define def_identity_into(dt) \
-    dt __attribute__((overloadable)) CONCAT2(into_, dt)(dt val) { return val; }
+    dt __attribute__((overloadable)) CONCAT2(into_, dt)(dt val) { \
+        return val; \
+    }
 
 def_identity_into(float);
 def_identity_into(char);
@@ -51,13 +53,13 @@ def_identity_into(f8_e4m3);
 
 // Standard-standard conversions, utilizing convert_* builtins
 #define def_std_into(out_type, in_type) \
-    out_type __attribute__((overloadable)) \
-            CONCAT2(into_, out_type)(in_type val) { \
+    out_type __attribute__((overloadable)) CONCAT2(into_, out_type)( \
+            in_type val) { \
         return CONCAT2(convert_, out_type)(val); \
     }
 #define def_std_into_sat(out_type, in_type) \
-    out_type __attribute__((overloadable)) \
-            CONCAT2(into_, out_type)(in_type val) { \
+    out_type __attribute__((overloadable)) CONCAT2(into_, out_type)( \
+            in_type val) { \
         return CONCAT3(convert_, out_type, _sat_rte)(val); \
     }
 
@@ -94,8 +96,8 @@ IF_DOUBLE_SUPPORTED(def_std_into(double, int));
 IF_DOUBLE_SUPPORTED(IF_HALF_SUPPORTED(def_std_into(double, half)));
 
 #define def_undef_into(out_type) \
-    out_type __attribute__((overloadable)) \
-            CONCAT2(into_, out_type)(undef_data val) { \
+    out_type __attribute__((overloadable)) CONCAT2(into_, out_type)( \
+            undef_data val) { \
         DEBUG_PRINT("Error: unexpected conversion from undefined data"); \
         return 0xbadbad; \
     }
@@ -113,8 +115,8 @@ IF_DOUBLE_SUPPORTED(def_undef_into(double));
 // - mid_type into_<mid_type>(in_type)
 // - out_type into_<out_type>(mid_type)
 #define def_two_step_conversion(out_type, in_type, mid_type) \
-    out_type __attribute__((overloadable)) \
-            CONCAT2(into_, out_type)(in_type val) { \
+    out_type __attribute__((overloadable)) CONCAT2(into_, out_type)( \
+            in_type val) { \
         return CONCAT2(into_, out_type)(CONCAT2(into_, mid_type)(val)); \
     }
 

--- a/src/gpu/intel/include/io.h
+++ b/src/gpu/intel/include/io.h
@@ -97,28 +97,28 @@ DECLARE_AS_BLOCK(double)
 #undef DECLARE_AS_STRUCT_BLOCK
 
 #define DEF_load(dst_dt, src_dt) \
-    void __attribute__((overloadable)) \
-            load(__private dst_dt *dst, __global const src_dt *val) { \
+    void __attribute__((overloadable)) load( \
+            __private dst_dt *dst, __global const src_dt *val) { \
         *dst = CONCAT2(into_, dst_dt)(*val); \
     } \
-    dst_dt __attribute__((overloadable, warn_unused_result)) \
-            load(dst_dt dst, __global const src_dt *val) { \
+    dst_dt __attribute__((overloadable, warn_unused_result)) load( \
+            dst_dt dst, __global const src_dt *val) { \
         return CONCAT2(into_, dst_dt)(*val); \
     } \
     void __attribute__((overloadable)) load( \
             __private dst_dt *dst, __global const src_dt *val, off_t off) { \
         *dst = CONCAT2(into_, dst_dt)(val[off]); \
     } \
-    dst_dt __attribute__((overloadable, warn_unused_result)) \
-            load(dst_dt dst, __global const src_dt *val, off_t off) { \
+    dst_dt __attribute__((overloadable, warn_unused_result)) load( \
+            dst_dt dst, __global const src_dt *val, off_t off) { \
         return CONCAT2(into_, dst_dt)(val[off]); \
     } \
-    void __attribute__((overloadable)) \
-            load(__private dst_dt *dst, __private const src_dt *val) { \
+    void __attribute__((overloadable)) load( \
+            __private dst_dt *dst, __private const src_dt *val) { \
         *dst = CONCAT2(into_, dst_dt)(*val); \
     } \
-    dst_dt __attribute__((overloadable, warn_unused_result)) \
-            load(dst_dt dst, __private const src_dt *val) { \
+    dst_dt __attribute__((overloadable, warn_unused_result)) load( \
+            dst_dt dst, __private const src_dt *val) { \
         return CONCAT2(into_, dst_dt)(*val); \
     } \
     __attribute__((overloadable)) void block_load( \
@@ -180,8 +180,8 @@ DECLARE_AS_BLOCK(double)
     }
 
 #define DEF_load_half_byte(dst_dt, src_dt) \
-    dst_dt __attribute__((overloadable, warn_unused_result)) \
-            load(dst_dt dst, __global const src_dt *val, off_t off) { \
+    dst_dt __attribute__((overloadable, warn_unused_result)) load( \
+            dst_dt dst, __global const src_dt *val, off_t off) { \
         src_dt data = CONCAT2(as_, src_dt)( \
                 get_half_byte((__global const uchar *)val, off)); \
         return CONCAT2(into_, dst_dt)(data); \
@@ -192,20 +192,20 @@ DECLARE_AS_BLOCK(double)
     }
 
 #define DEF_write(dst_dt, src_dt) \
-    void __attribute__((overloadable)) \
-            write(__global dst_dt *dst, __private const src_dt *val) { \
+    void __attribute__((overloadable)) write( \
+            __global dst_dt *dst, __private const src_dt *val) { \
         *dst = CONCAT2(into_, dst_dt)(*val); \
     } \
-    void __attribute__((overloadable)) \
-            write(__global dst_dt *dst, __private src_dt val) { \
+    void __attribute__((overloadable)) write( \
+            __global dst_dt *dst, __private src_dt val) { \
         *dst = CONCAT2(into_, dst_dt)(val); \
     } \
-    void __attribute__((overloadable)) \
-            write(__private dst_dt *dst, __private const src_dt *val) { \
+    void __attribute__((overloadable)) write( \
+            __private dst_dt *dst, __private const src_dt *val) { \
         *dst = CONCAT2(into_, dst_dt)(*val); \
     } \
-    void __attribute__((overloadable)) \
-            write(__private dst_dt *dst, __private src_dt val) { \
+    void __attribute__((overloadable)) write( \
+            __private dst_dt *dst, __private src_dt val) { \
         *dst = CONCAT2(into_, dst_dt)(val); \
     } \
     __attribute__((overloadable)) void block_write( \

--- a/src/gpu/intel/include/math_utils.h
+++ b/src/gpu/intel/include/math_utils.h
@@ -536,14 +536,14 @@ double16 __attribute__((overloadable)) cvt_bf16_to_f64(ushort16 b) {
 #endif
 
 #define DECLARE_BLOCK_READ(suffix, func, data_type, addr_space, p_type) \
-    data_type __attribute__((overloadable)) \
-            block_read##suffix(const addr_space p_type *p) { \
+    data_type __attribute__((overloadable)) block_read##suffix( \
+            const addr_space p_type *p) { \
         return func(p); \
     }
 
 #define DECLARE_BLOCK_READ_EMU(suffix, data_type, addr_space, p_type) \
-    data_type __attribute__((overloadable)) \
-            block_read##suffix##_emu(const addr_space p_type *p) { \
+    data_type __attribute__((overloadable)) block_read##suffix##_emu( \
+            const addr_space p_type *p) { \
         data_type ret; \
         uint idx = get_sub_group_local_id(); \
         for (int i = 0; i < sizeof(data_type) / sizeof(p_type); i++) { \
@@ -554,14 +554,14 @@ double16 __attribute__((overloadable)) cvt_bf16_to_f64(ushort16 b) {
     }
 
 #define DECLARE_BLOCK_WRITE(suffix, func, data_type, addr_space, p_type) \
-    void __attribute__((overloadable)) \
-            block_write##suffix(addr_space p_type *p, data_type data) { \
+    void __attribute__((overloadable)) block_write##suffix( \
+            addr_space p_type *p, data_type data) { \
         func(p, data); \
     }
 
 #define DECLARE_BLOCK_WRITE_EMU(suffix, data_type, addr_space, p_type) \
-    void __attribute__((overloadable)) \
-            block_write##suffix##_emu(addr_space p_type *p, data_type data) { \
+    void __attribute__((overloadable)) block_write##suffix##_emu( \
+            addr_space p_type *p, data_type data) { \
         uint idx = get_sub_group_local_id(); \
         for (int i = 0; i < sizeof(data_type) / sizeof(p_type); i++) { \
             p[idx] = ((p_type *)&data)[i]; \
@@ -580,11 +580,11 @@ DECLARE_BLOCK_WRITE(4, intel_sub_group_block_write4, uint4, __global, uint)
 DECLARE_BLOCK_WRITE(8, intel_sub_group_block_write8, uint8, __global, uint)
 
 #ifdef cl_intel_subgroups_char
-void __attribute__((overloadable))
-intel_sub_group_block_write_uc16(__global uchar *p, uchar16 data);
+void __attribute__((overloadable)) intel_sub_group_block_write_uc16(
+        __global uchar *p, uchar16 data);
 
-uchar16 __attribute__((overloadable))
-intel_sub_group_block_read_uc16(const __global uchar *p);
+uchar16 __attribute__((overloadable)) intel_sub_group_block_read_uc16(
+        const __global uchar *p);
 #endif
 
 // Emulation for cl_intel_subgroup_local_block_io. These functions are not
@@ -803,8 +803,8 @@ float __attribute__((overloadable)) cvt_f4_e3m0_to_f32(uchar a) {
         || MATH_UTILS_DECLARE_F4_E2M1 || MATH_UTILS_DECLARE_F4_E3M0
 #define GET_HALF_BYTE(x, y) get_half_byte(x, y)
 
-uchar __attribute__((overloadable))
-get_half_byte(const __global uchar *x, off_t y) {
+uchar __attribute__((overloadable)) get_half_byte(
+        const __global uchar *x, off_t y) {
     uchar ret = 0;
     if (y % 2) {
         ret = (uchar)((uchar)(x[y / 2] & 0xf0) >> 4);
@@ -814,8 +814,8 @@ get_half_byte(const __global uchar *x, off_t y) {
     return ret;
 }
 
-char __attribute__((overloadable))
-get_half_byte(const __global char *x, off_t y) {
+char __attribute__((overloadable)) get_half_byte(
+        const __global char *x, off_t y) {
     if (y % 2) {
         return (x[y / 2] & 0xf0) >> 4;
     } else {
@@ -823,13 +823,13 @@ get_half_byte(const __global char *x, off_t y) {
     }
 }
 
-void __attribute__((overloadable))
-set_double_half_byte(__global uchar *x, off_t y, uchar z) {
+void __attribute__((overloadable)) set_double_half_byte(
+        __global uchar *x, off_t y, uchar z) {
     x[y / 2] = z;
 }
 
-void __attribute__((overloadable))
-set_double_half_byte(__global char *x, off_t y, uchar z) {
+void __attribute__((overloadable)) set_double_half_byte(
+        __global char *x, off_t y, uchar z) {
     x[y / 2] = z;
 }
 

--- a/src/gpu/intel/include/tile_ops.h
+++ b/src/gpu/intel/include/tile_ops.h
@@ -62,9 +62,9 @@ __attribute__((overloadable)) int local_atomic_max(local int *p, int v) {
     }
 
 #define DEF_BLOCK_LOAD_STORE1(type, itype, suffix) \
-    __attribute__((overloadable)) \
-            type##1 block_load(const global type *p, int vlen) __attribute__( \
-                    (enable_if(vlen == 1, "wrong vector length"))) { \
+    __attribute__((overloadable)) type##1 block_load( \
+            const global type *p, int vlen) \
+            __attribute__((enable_if(vlen == 1, "wrong vector length"))) { \
         type##1 x; \
         x[0] = as_##type( \
                 intel_sub_group_block_read##suffix((global void *)p)); \
@@ -81,9 +81,9 @@ __attribute__((overloadable)) int local_atomic_max(local int *p, int v) {
     }
 
 #define DEF_BLOCK_LOAD_STORE16(type, itype, suffix) \
-    __attribute__((overloadable)) \
-            type##16 block_load(const global type *p, int vlen) __attribute__( \
-                    (enable_if(vlen == 16, "wrong vector length"))) { \
+    __attribute__((overloadable)) type##16 block_load( \
+            const global type *p, int vlen) \
+            __attribute__((enable_if(vlen == 16, "wrong vector length"))) { \
         type##16 x; \
         x.s01234567 = as_##type##8( \
                 intel_sub_group_block_read##suffix##8((global void *)p)); \
@@ -109,9 +109,9 @@ __attribute__((overloadable)) int local_atomic_max(local int *p, int v) {
     }
 
 #define DEF_BLOCK_LOAD_STORE32(type, itype, suffix) \
-    __attribute__((overloadable)) \
-            type##32 block_load(const global type *p, int vlen) __attribute__( \
-                    (enable_if(vlen == 32, "wrong vector length"))) { \
+    __attribute__((overloadable)) type##32 block_load( \
+            const global type *p, int vlen) \
+            __attribute__((enable_if(vlen == 32, "wrong vector length"))) { \
         type##32 x; \
         x = (type##32)(as_##type##8(intel_sub_group_block_read##suffix##8( \
                                (global void *)p)), \
@@ -197,11 +197,10 @@ DEF_BLOCK_LOAD_STORE32(float, uint, )
     void __builtin_IB_subgroup_block_write_flat_##suffix( \
             long, int, int, int, int2, itype##vl); \
     __attribute__((overloadable)) type##vl block2d_load(const global type *p, \
-            int w, int h, int ld, int x, int y, int br, int bc, \
-            int sg) __attribute__((enable_if(br == BR, "wrong #rows"))) \
+            int w, int h, int ld, int x, int y, int br, int bc, int sg) \
+            __attribute__((enable_if(br == BR, "wrong #rows"))) \
             __attribute__((enable_if(bc == BC, "wrong #columns"))) \
-                    __attribute__( \
-                            (enable_if(sg == SG, "wrong subgroup size"))) { \
+            __attribute__((enable_if(sg == SG, "wrong subgroup size"))) { \
         ulong pp = as_long(p); \
         ulong prem = pp & 0x3F; \
         pp &= ~0x3F; \
@@ -213,11 +212,10 @@ DEF_BLOCK_LOAD_STORE32(float, uint, )
     } \
     __attribute__((overloadable)) void block2d_store(type##vl v, \
             const global type *p, int w, int h, int ld, int x, int y, int br, \
-            int bc, \
-            int sg) __attribute__((enable_if(br == BR, "wrong #rows"))) \
+            int bc, int sg) \
+            __attribute__((enable_if(br == BR, "wrong #rows"))) \
             __attribute__((enable_if(bc == BC, "wrong #columns"))) \
-                    __attribute__( \
-                            (enable_if(sg == SG, "wrong subgroup size"))) { \
+            __attribute__((enable_if(sg == SG, "wrong subgroup size"))) { \
         ulong pp = as_long(p); \
         ulong prem = pp & 0x3F; \
         pp &= ~0x3F; \
@@ -643,8 +641,8 @@ DEF_BLOCK2D_LOAD_STORE(float, uint, 16, 16, u32_m8k32v1, 32, 8)
     }
 
 #define DECLARE_2D_TILE(tile_type, element_type, sg, br, bc, nbr, nbc) \
-    typedef element_type __attribute__((ext_vector_type(br * bc / sg))) \
-            _e_##tile_type; \
+    typedef element_type \
+            __attribute__((ext_vector_type(br * bc / sg))) _e_##tile_type; \
     typedef struct { \
         _e_##tile_type x[nbr * nbc]; \
     } tile_type; \

--- a/src/gpu/intel/include/utils.h
+++ b/src/gpu/intel/include/utils.h
@@ -60,10 +60,18 @@
 // Defines (for example) float_zero, float_one, float_min, and float_max
 // Can be used in a data-type agnostic way with the SPECIAL macro below
 #define DEF_special_vals(dt, zero_val, one_val, min_val, max_val) \
-    dt CONCAT2(dt, _zero)() { return zero_val; } \
-    dt CONCAT2(dt, _one)() { return one_val; } \
-    dt CONCAT2(dt, _min)() { return min_val; } \
-    dt CONCAT2(dt, _max)() { return max_val; }
+    dt CONCAT2(dt, _zero)() { \
+        return zero_val; \
+    } \
+    dt CONCAT2(dt, _one)() { \
+        return one_val; \
+    } \
+    dt CONCAT2(dt, _min)() { \
+        return min_val; \
+    } \
+    dt CONCAT2(dt, _max)() { \
+        return max_val; \
+    }
 
 DEF_special_vals(float, 0.0f, 1.0f, -FLT_MAX, FLT_MAX);
 DEF_special_vals(int, 0, 1, INT_MIN, INT_MAX);

--- a/src/gpu/intel/jit/codegen/reg_buf.hpp
+++ b/src/gpu/intel/jit/codegen/reg_buf.hpp
@@ -142,7 +142,7 @@ public:
 
     reg_buf_data_t(ngen::HW hw, const ngen::Subregister &sub)
         : reg_buf_(std::make_shared<reg_buf_t>(
-                hw, ngen::GRFRange(sub.getBase(), 1)))
+                  hw, ngen::GRFRange(sub.getBase(), 1)))
         , rd_(sub) {}
 
     const reg_buf_t &reg_buf() const { return *reg_buf_; }

--- a/src/gpu/intel/jit/codegen/reorder.cpp
+++ b/src/gpu/intel/jit/codegen/reorder.cpp
@@ -261,8 +261,8 @@ void reorder_2d_impl_t::tile_to_2d_dims(
 }
 
 auto reorder_2d_impl_t::find_min_cost_path(ngen::HW hw, const layout_t &src,
-        const layout_t &dst, dim_t tile_a, dim_t tile_b)
-        -> std::vector<reorder_step_t> {
+        const layout_t &dst, dim_t tile_a,
+        dim_t tile_b) -> std::vector<reorder_step_t> {
     // Create all possible edges - 2D reorders.
     std::vector<edge_t> edges;
     for (int a = 1; a <= tile_a; a *= 2) {

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -66,7 +66,7 @@ public:
     operator expr_t() const { return var; }
 
 #define DEFINE_BINARY_ASSIGN_OPERATOR(op) \
-    lval_t &operator op##=(const expr_t &rhs) { \
+    lval_t &operator op##=(const expr_t & rhs) { \
         (*this) = (*this)op rhs; \
         return *this; \
     }

--- a/src/gpu/intel/jit/ir/kernel_desc.hpp
+++ b/src/gpu/intel/jit/ir/kernel_desc.hpp
@@ -49,16 +49,18 @@ class kernel_desc_base_t {
 public:
     virtual ~kernel_desc_base_t() = default;
     virtual std::string kernel_name() const = 0;
-    virtual dsl::kernel::options_t options(
-            const impl::engine_t *engine) const = 0;
+    virtual dsl::kernel::options_t options(const impl::engine_t *engine) const
+            = 0;
     virtual compute::range_t local_range() const = 0;
-    virtual void init_kernel_iface(
-            dsl::kernel::iface_t &kernel_iface) const = 0;
+    virtual void init_kernel_iface(dsl::kernel::iface_t &kernel_iface) const
+            = 0;
     virtual void init_kernel_info(kernel_info_t &kernel_info,
             const kernel_params_base_t &params,
-            const impl::engine_t *engine) const = 0;
+            const impl::engine_t *engine) const
+            = 0;
     virtual status_t create_kernel(compute::kernel_t &kernel,
-            primitive_t *primitive, impl::engine_t *engine) const = 0;
+            primitive_t *primitive, impl::engine_t *engine) const
+            = 0;
     virtual serialization_stream_t serialize() const = 0;
 };
 

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -55,7 +55,7 @@ public:
 
     zero_points_config_t(const primitive_desc_t *pd = nullptr)
         : do_src_compensation(pd
-                && !pd->attr()->zero_points_.has_default_values(DNNL_ARG_SRC))
+                  && !pd->attr()->zero_points_.has_default_values(DNNL_ARG_SRC))
         , do_wei_compensation(pd
                   && !pd->attr()->zero_points_.has_default_values(
                           DNNL_ARG_WEIGHTS))

--- a/src/gpu/intel/jit/ir/send_patterns.hpp
+++ b/src/gpu/intel/jit/ir/send_patterns.hpp
@@ -313,9 +313,10 @@ struct uniform_send_idiom_t final {
                 && hint.block_rem() > 1)
             valid_block = false;
 
-        auto width_stride = hint.width_rem() > 1 ? std::max(layout.type_size,
-                                    hint_t::block_width / hint.width_rem())
-                                                 : hint_t::block_width;
+        auto width_stride = hint.width_rem() > 1
+                ? std::max(layout.type_size,
+                          hint_t::block_width / hint.width_rem())
+                : hint_t::block_width;
 
         // Check hint is potentially valid
         if (valid_2d && width_stride < i_stride_bytes && hint.width_rem() > 8) {

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -46,7 +46,8 @@ public:
     virtual void set_split(int factor) = 0;
     virtual int split_factor() const = 0;
     virtual int estimate_regs(
-            bool with_buffer, bool with_headers, bool reuse_headers) const = 0;
+            bool with_buffer, bool with_headers, bool reuse_headers) const
+            = 0;
     virtual std::string str(const std::string &tag) const = 0;
 
     int estimate_regs(bool with_buffer, bool with_headers) const {
@@ -103,7 +104,8 @@ protected:
 private:
     virtual const layout_t &message_layout() const { return reg_layout(); }
     virtual stmt_t do_create_stmt(const expr_t &mem_buf, const expr_t &reg_buf,
-            int subtile_idx, const expr_t &pattern) const = 0;
+            int subtile_idx, const expr_t &pattern) const
+            = 0;
 };
 
 send_op_t to_2d(send_op_t op) {
@@ -578,18 +580,13 @@ public:
     std::string str(const std::string &indent = {}) const {
         ostringstream_t oss;
         oss << indent << "mask#" << tidx() << std::endl;
-        oss << indent << "  "
-            << "base = " << base_ << std::endl;
-        oss << indent << "  "
-            << "block = " << tdim_.block() << std::endl;
+        oss << indent << "  " << "base = " << base_ << std::endl;
+        oss << indent << "  " << "block = " << tdim_.block() << std::endl;
         switch (kind_) {
             case mask_kind_t::ab:
                 oss << indent << "  " << a_ << " <= x < " << b_;
                 break;
-            case mask_kind_t::b:
-                oss << indent << "  "
-                    << "x < " << b_;
-                break;
+            case mask_kind_t::b: oss << indent << "  " << "x < " << b_; break;
             default: gpu_error_not_expected();
         }
         return oss.str();
@@ -2155,7 +2152,7 @@ private:
             auto g = (split_factor_ == 1)
                     ? _g
                     : _g.split(split_bounds_t(message_layout_, split_factor_),
-                            subtile_idx, is_g1b1);
+                              subtile_idx, is_g1b1);
             gpu_assert(!g.is_empty());
             bool try_legacy = send_params().try_legacy
                     && (g.hw < ngen::HW::XeHPC) && g.is_block();

--- a/src/gpu/intel/jit/pass/cse.cpp
+++ b/src/gpu/intel/jit/pass/cse.cpp
@@ -604,9 +604,11 @@ private:
             auto ret = seen_vars_.insert(var);
             if (ret.second)
                 lets_.push_back(let_t::make(var,
-                        obj.type.is_bool() ? cast(obj,
-                                bool_imm_t::get_packed_type(obj.type.elems()))
-                                           : obj));
+                        obj.type.is_bool()
+                                ? cast(obj,
+                                          bool_imm_t::get_packed_type(
+                                                  obj.type.elems()))
+                                : obj));
         }
     }
 

--- a/src/gpu/intel/jit/pass/dpas.cpp
+++ b/src/gpu/intel/jit/pass/dpas.cpp
@@ -61,8 +61,8 @@ public:
         return mutate_mul_impl(entries);
     }
 
-    virtual stmt_t mutate_mul_impl(
-            const std::vector<entry_t> &entries) const = 0;
+    virtual stmt_t mutate_mul_impl(const std::vector<entry_t> &entries) const
+            = 0;
 };
 
 class dpas_atomic_mutator_t : public mul_mutator_t {

--- a/src/gpu/intel/jit/utils/range.hpp
+++ b/src/gpu/intel/jit/utils/range.hpp
@@ -44,8 +44,8 @@ filter_range_t<Fn> filter(Fn fn) {
 }
 
 template <typename IterT, typename Fn>
-auto operator|(const IterT &iter, const filter_range_t<Fn> &fn)
-        -> decltype(filter(iter, fn.fn)) {
+auto operator|(const IterT &iter,
+        const filter_range_t<Fn> &fn) -> decltype(filter(iter, fn.fn)) {
     return filter(iter, fn.fn);
 }
 
@@ -67,8 +67,8 @@ transform_range_t<Fn> transform(Fn fn) {
 }
 
 template <typename IterT, typename Fn>
-auto operator|(const IterT &iter, const transform_range_t<Fn> &fn)
-        -> decltype(transform(iter, fn.fn)) {
+auto operator|(const IterT &iter,
+        const transform_range_t<Fn> &fn) -> decltype(transform(iter, fn.fn)) {
     return transform(iter, fn.fn);
 }
 

--- a/src/gpu/intel/jit/utils/utils.hpp
+++ b/src/gpu/intel/jit/utils/utils.hpp
@@ -1217,7 +1217,9 @@ void deserialize_from_hex(T &t, const std::string &s_hex) {
         using backing_t = typename std::underlying_type<E>::type; \
         return static_cast<E>(~static_cast<backing_t>(a)); \
     } \
-    constexpr bool any(E a) { return a != static_cast<E>(0); }
+    constexpr bool any(E a) { \
+        return a != static_cast<E>(0); \
+    }
 // NOLINTEND(bugprone-macro-parentheses)
 
 #define GPU_HW_CASE_(hw) \

--- a/src/gpu/intel/kernel_cache.hpp
+++ b/src/gpu/intel/kernel_cache.hpp
@@ -49,8 +49,8 @@ struct trivial_key_validator_t {
     };
 
     template <typename U,
-            utils::enable_if_t<is_trivially_validatable_t<U>::value,
-                    bool> = true>
+            utils::enable_if_t<is_trivially_validatable_t<U>::value, bool>
+            = true>
     static bool is_valid(const U &t) {
         static_assert(std::is_same<T, U>::value,
                 "key validation is not intended for comparing different types");
@@ -58,8 +58,8 @@ struct trivial_key_validator_t {
     }
 
     template <typename U,
-            utils::enable_if_t<!is_trivially_validatable_t<U>::value,
-                    bool> = true>
+            utils::enable_if_t<!is_trivially_validatable_t<U>::value, bool>
+            = true>
     static bool is_valid(const U &t) {
         // Runtime validation only occurs in C++20 as default comparisons
         // significantly improves the reliability of this check.
@@ -95,8 +95,8 @@ struct trivial_key_t : public T {
     };
 
     using value_type =
-            typename std::remove_reference<typename create_signature_t<decltype(
-                    &T::create_generator)>::arg2_type>::type;
+            typename std::remove_reference<typename create_signature_t<
+                    decltype(&T::create_generator)>::arg2_type>::type;
 
     trivial_key_t() = delete;
     trivial_key_t(const T &t, const engine_id_t &id)
@@ -148,7 +148,8 @@ private:
 // GPU specific abstract interface for kernel_cache::key_impl_t
 struct gpu_kernel_key_impl_t : public kernel_cache::key_impl_t {
     virtual status_t create_generator(
-            impl::engine_t *engine, gpu_kernel_value_t &generator) const = 0;
+            impl::engine_t *engine, gpu_kernel_value_t &generator) const
+            = 0;
 };
 
 // Templated key container which implements the necessary virtual interfaces

--- a/src/gpu/intel/lnorm/vectorized_fused.cl
+++ b/src/gpu/intel/lnorm/vectorized_fused.cl
@@ -72,7 +72,7 @@
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
-#define DIV_UP(a, b) ((a) + ((b)-1)) / (b)
+#define DIV_UP(a, b) ((a) + ((b) - 1)) / (b)
 
 #define MAX_CHUNKS MAX(NUM_ACROSS_BLOCKS, NUM_NORM_BLOCKS_FUSED)
 
@@ -129,12 +129,14 @@ __kernel void vectorized_lnorm_bwd_fused(__global DATA_T *src,
                 const int src_off = SRC_PLAIN_OFF(n_idx, c_idx);
                 const int dst_off = DST_PLAIN_OFF(n_idx, c_idx);
 
-                const VECT_FLOAT_T src_vect = CONVERT_VECT_FLOAT_T(
-                        AS_VECT_DATA_T(VECT_BLOCK_READ((const __global
-                                        BLOCK_DATA_T *)(&src[src_off]))));
-                const VECT_FLOAT_T diff_dst_vect = CONVERT_VECT_FLOAT_T(
-                        AS_VECT_DATA_T(VECT_BLOCK_READ((const __global
-                                        BLOCK_DATA_T *)(&diff_dst[dst_off]))));
+                const VECT_FLOAT_T src_vect
+                        = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                                VECT_BLOCK_READ((const __global BLOCK_DATA_T
+                                                *)(&src[src_off]))));
+                const VECT_FLOAT_T diff_dst_vect
+                        = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                                VECT_BLOCK_READ((const __global BLOCK_DATA_T
+                                                *)(&diff_dst[dst_off]))));
 
                 diff_gamma_vect += (src_vect - mean_vect) * diff_dst_vect
                         * inv_sqrt_variance;

--- a/src/gpu/intel/ocl/engine.hpp
+++ b/src/gpu/intel/ocl/engine.hpp
@@ -41,7 +41,7 @@ class engine_t : public intel::engine_t {
 public:
     engine_t(cl_device_id adevice, cl_context acontext, size_t index)
         : intel::engine_t(
-                new xpu::ocl::engine_impl_t(adevice, acontext, index)) {}
+                  new xpu::ocl::engine_impl_t(adevice, acontext, index)) {}
 
     status_t init() override;
     status_t init(const std::vector<uint8_t> &cache_blob);

--- a/src/gpu/intel/pool/jit/kernel.hpp
+++ b/src/gpu/intel/pool/jit/kernel.hpp
@@ -32,8 +32,8 @@ public:
     kernel_t(config_t &cfg, const std::string &kernel_name,
             const kernel_info_t &kernel_info, const primitive_desc_t &pd)
         : ir_kernel_t(kernel_info.iface(kernel_name), cfg.options(),
-                kernel_info.nd_range().local_range(),
-                {GENERATOR_NAME, GENERATOR_LINE}) {
+                  kernel_info.nd_range().local_range(),
+                  {GENERATOR_NAME, GENERATOR_LINE}) {
         builder_t builder(cfg, kernel_info, pd);
         const stmt_t &body = builder.stmt();
         generate_from_ir(body);

--- a/src/gpu/intel/pool/xe.cl
+++ b/src/gpu/intel/pool/xe.cl
@@ -435,7 +435,9 @@ __kernel void xe_pooling_bwd(__global DATA_T *diff_src, __global int *ws,
     S0 /= KD * KH * KW;
     S1 /= KD * KH * KW;
 #if UNROLL_MB_COUNT > 1
-    unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) { S[i] /= KD * KH * KW; }
+    unroll_for(int i = 0; i < UNROLL_MB_COUNT; i++) {
+        S[i] /= KD * KH * KW;
+    }
 #endif
 #endif
 

--- a/src/gpu/intel/pool/xe_global.hpp
+++ b/src/gpu/intel/pool/xe_global.hpp
@@ -96,9 +96,7 @@ struct xe_global_fwd_t : public primitive_t {
             reduction_pd_ = *(++it);
             if (reduction_pd_)
                 return status::success;
-            else {
-                return status::invalid_arguments;
-            }
+            else { return status::invalid_arguments; }
         }
 
         std::shared_ptr<primitive_desc_t> reduction_pd_;

--- a/src/gpu/intel/prelu/ref.cpp
+++ b/src/gpu/intel/prelu/ref.cpp
@@ -66,7 +66,7 @@ static status_t init_conf_common(
             const dnnl_dim_t diff_wei_dim = conf.is_forward
                     ? 1
                     : static_cast<dnnl_dim_t>(
-                            conf.diff_wei_md_info.padded_dims[i]);
+                              conf.diff_wei_md_info.padded_dims[i]);
             dnnl_dim_t dim2dispatch
                     = nstl::max(dst_mdw.padded_dims()[i], diff_wei_dim);
             conf.dispatch.define_dim(utils::format("D%d", i), i, dim2dispatch);

--- a/src/gpu/intel/prelu/ref.hpp
+++ b/src/gpu/intel/prelu/ref.hpp
@@ -136,9 +136,7 @@ struct ref_bwd_t : public primitive_t {
             reduction_pd_ = *(++it);
             if (reduction_pd_)
                 return status::success;
-            else {
-                return status::invalid_arguments;
-            }
+            else { return status::invalid_arguments; }
         }
 
         conf_t conf;

--- a/src/gpu/intel/reduction/combined.cl
+++ b/src/gpu/intel/reduction/combined.cl
@@ -105,7 +105,7 @@ dim_t dst_off_w_zero_padding(dim_t outer, dim_t inner) {
 }
 
 #define _SRC_OFF(outer, reduction, inner) \
-    ((outer)*REDUCTION_SIZE * INNER_DIM_SIZE + (reduction)*INNER_DIM_SIZE \
+    ((outer) * REDUCTION_SIZE * INNER_DIM_SIZE + (reduction) * INNER_DIM_SIZE \
             + (inner))
 
 #define _DST_OFF(outer, inner) dst_off_w_zero_padding(outer, inner)

--- a/src/gpu/intel/reduction/common.h
+++ b/src/gpu/intel/reduction/common.h
@@ -31,7 +31,9 @@
     dt __attribute__((overloadable)) max(dt lhs, dt rhs) { \
         return fmax(lhs, rhs); \
     } \
-    dt __attribute__((overloadable)) abs(dt val) { return fabs(val); }
+    dt __attribute__((overloadable)) abs(dt val) { \
+        return fabs(val); \
+    }
 
 DEF_fp_minmax_abs(float);
 IF_HALF_SUPPORTED(DEF_fp_minmax_abs(half));
@@ -42,8 +44,8 @@ IF_DOUBLE_SUPPORTED(DEF_fp_minmax_abs(double));
 // *********** Generic reduction functions ************* //
 
 #define DEF_reduce(dt) \
-    dt __attribute__((overloadable)) \
-            reduce(int alg, dt lhs, dt rhs, float power) { \
+    dt __attribute__((overloadable)) reduce( \
+            int alg, dt lhs, dt rhs, float power) { \
         switch (alg) { \
             case (REDUCTION_MAX): return max(lhs, rhs); \
             case (REDUCTION_MIN): return min(lhs, rhs); \

--- a/src/gpu/intel/reduction/jit/generator.hpp
+++ b/src/gpu/intel/reduction/jit/generator.hpp
@@ -45,7 +45,7 @@ public:
     generator_t(const compute::device_info_t &device_info, impl::alg_kind_t alg,
             dim_t stride, dim_t iters, int nregs)
         : emulated_generator_t<hw>(
-                device_info, {GENERATOR_NAME, GENERATOR_LINE}) {
+                  device_info, {GENERATOR_NAME, GENERATOR_LINE}) {
         constexpr auto GlobalPtr = ngen::ExternalArgumentType::GlobalPtr;
 
         // Number of dst elements computed per thread

--- a/src/gpu/intel/reorder/jit/kernel.hpp
+++ b/src/gpu/intel/reorder/jit/kernel.hpp
@@ -33,8 +33,8 @@ public:
             const kernel_info_t &kernel_info,
             const primitive_desc_t *pd = nullptr)
         : ir_kernel_t(kernel_info.iface(kernel_name), cfg.options(),
-                kernel_info.nd_range().local_range(),
-                {GENERATOR_NAME, GENERATOR_LINE}) {
+                  kernel_info.nd_range().local_range(),
+                  {GENERATOR_NAME, GENERATOR_LINE}) {
         const primitive_attr_t *attr = (pd) ? pd->attr() : nullptr;
         const memory_desc_t *dst_md = (pd) ? pd->dst_md() : nullptr;
         ir_builder_t builder(cfg, kernel_info, attr, dst_md);

--- a/src/gpu/intel/reorder/jit/tiler.cpp
+++ b/src/gpu/intel/reorder/jit/tiler.cpp
@@ -100,7 +100,7 @@ struct message_info_t {
         return kind == message_kind_t::block
                 ? count_block_messages(hw, inner_bytes, iterations)
                 : count_scattered_messages(
-                        hw, inner_bytes, iterations, item_size);
+                          hw, inner_bytes, iterations, item_size);
     }
 };
 

--- a/src/gpu/intel/rnn/cell_compute.h
+++ b/src/gpu/intel/rnn/cell_compute.h
@@ -156,19 +156,19 @@ inline int checkCopyScratchMemory(
     return copy_none;
 }
 
-inline void __attribute__((overloadable))
-load(float *s, const __global float *data, bool is_valid) {
+inline void __attribute__((overloadable)) load(
+        float *s, const __global float *data, bool is_valid) {
     *s = is_valid ? data[get_sub_group_local_id()] : 0;
 }
 
-inline void __attribute__((overloadable))
-load(float *s, const __global half *data, bool is_valid) {
+inline void __attribute__((overloadable)) load(
+        float *s, const __global half *data, bool is_valid) {
     *s = is_valid ? into_float(data[get_sub_group_local_id()]) : 0;
 }
 
 // Bfloat 16
-inline void __attribute__((overloadable))
-load(float *s, const __global ushort *data, bool is_valid) {
+inline void __attribute__((overloadable)) load(
+        float *s, const __global ushort *data, bool is_valid) {
     *s = is_valid ? into_float(as_bf16(data[get_sub_group_local_id()])) : 0;
 }
 
@@ -176,8 +176,8 @@ inline float __attribute__((overloadable)) sg_get(float s, int offset) {
     return intel_sub_group_shuffle(s, offset);
 }
 
-inline bool __attribute__((overloadable))
-sg_get(bool s[gemm_k_block / SUBGROUP_SIZE], int offset) {
+inline bool __attribute__((overloadable)) sg_get(
+        bool s[gemm_k_block / SUBGROUP_SIZE], int offset) {
     return intel_sub_group_shuffle(
             s[offset / SUBGROUP_SIZE], offset % SUBGROUP_SIZE);
 }

--- a/src/gpu/intel/rnn/grid.cl
+++ b/src/gpu/intel/rnn/grid.cl
@@ -162,7 +162,7 @@ __kernel void simple_rnn_copy_init_iter(__global WS_STATE_DATA_T *dst_base,
         dst[off_scratch_diff_states(n_layer, n_dir, n_states, n_iter, batch,
                 scratch_diff_states_ld, lay, dir, 1, n_iter, b, s)]
                 = src_c_base ? src_c[diff_dst_i_c_off(
-                          diff_dst_iter_c_strides, lay, dir, b, s)]
+                                       diff_dst_iter_c_strides, lay, dir, b, s)]
                              : 0.0f;
     }
 #endif
@@ -196,9 +196,9 @@ simple_rnn_copy_res_layer(
                 ? TO_DST(((float)src[off_ws_state(n_layer, n_dir, n_iter, batch,
                                   states_ws_ld, n_layer - 1, dir, it, b, s)]
                                  - shift)
-                        / scale)
+                          / scale)
                 : src[off_ws_state(n_layer, n_dir, n_iter, batch, states_ws_ld,
-                        n_layer - 1, dir, it, b, s)];
+                          n_layer - 1, dir, it, b, s)];
         dir = 1;
     }
     if (rl) {
@@ -232,9 +232,9 @@ simple_rnn_copy_res_layer(
                                   states_ws_ld, n_layer - 1, dir,
                                   n_iter - it - 1, b, s)]
                                  - shift)
-                        / scale)
+                          / scale)
                 : src[off_ws_state(n_layer, n_dir, n_iter, batch, states_ws_ld,
-                        n_layer - 1, dir, n_iter - it - 1, b, s)];
+                          n_layer - 1, dir, n_iter - it - 1, b, s)];
 #endif
     }
 #else // BWD
@@ -287,13 +287,13 @@ __kernel void simple_rnn_copy_res_iter(
 
     if (dst_base && s < dhc) {
         dst[dst_i_off(strides, lay, dir, b, s)] = dequantize
-                ? TO_OUTPUT(
-                        ((float)src[off_ws_state(n_layer, n_dir, n_iter, batch,
-                                 states_ws_ld, lay, dir, n_iter - 1, b, s)]
-                                - shift)
-                        / scale)
+                ? TO_OUTPUT(((float)src[off_ws_state(n_layer, n_dir, n_iter,
+                                     batch, states_ws_ld, lay, dir, n_iter - 1,
+                                     b, s)]
+                                    - shift)
+                          / scale)
                 : TO_OUTPUT(src[off_ws_state(n_layer, n_dir, n_iter, batch,
-                        states_ws_ld, lay, dir, n_iter - 1, b, s)]);
+                          states_ws_ld, lay, dir, n_iter - 1, b, s)]);
     }
 #if WITH_DST_ITER_C
     __global AUX_DATA_T *src_c = src_c_base;

--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -206,9 +206,9 @@ static status_t init_ocl_conf(ocl_conf_t &ocl_conf, const pd_t *pd,
             into<int>(ocl_conf.deterministic
                             ? conf.mb
                             : std::min(into<dim_t>(8),
-                                    utils::rnd_up_pow2(
-                                            max_elemwise_threads_per_eu
-                                            / preferred_threads_per_eu))));
+                                      utils::rnd_up_pow2(
+                                              max_elemwise_threads_per_eu
+                                              / preferred_threads_per_eu))));
     ocl_conf.need_bias_atomic_reduce
             = !ocl_conf.is_fwd && ocl_conf.elemwise_bwd_batch_block < conf.mb;
 
@@ -965,14 +965,15 @@ status_t simple_common_t<aprop>::init(impl::engine_t *engine) {
     CHECK(create_kernels(engine, kernels_, kernel_names, pd()->ocl_conf));
 
     bool gemm_ok = utils::everyone_is(status::success,
-            pd()->gemm_layer_fwd_pd_ ? create_nested_primitive(
-                    gemm_layer_fwd_, pd()->gemm_layer_fwd_pd_, engine)
+            pd()->gemm_layer_fwd_pd_ ? create_nested_primitive(gemm_layer_fwd_,
+                                               pd()->gemm_layer_fwd_pd_, engine)
                                      : status::success,
-            pd()->gemm_layer_fwd_src_pd_ ? create_nested_primitive(
-                    gemm_layer_fwd_src_, pd()->gemm_layer_fwd_src_pd_, engine)
-                                         : status::success,
-            pd()->gemm_iter_fwd_pd_ ? create_nested_primitive(
-                    gemm_iter_fwd_, pd()->gemm_iter_fwd_pd_, engine)
+            pd()->gemm_layer_fwd_src_pd_
+                    ? create_nested_primitive(gemm_layer_fwd_src_,
+                              pd()->gemm_layer_fwd_src_pd_, engine)
+                    : status::success,
+            pd()->gemm_iter_fwd_pd_ ? create_nested_primitive(gemm_iter_fwd_,
+                                              pd()->gemm_iter_fwd_pd_, engine)
                                     : status::success);
     switch (aprop) {
         case prop_kind::forward:
@@ -980,7 +981,7 @@ status_t simple_common_t<aprop>::init(impl::engine_t *engine) {
                     && utils::everyone_is(status::success,
                             conf.is_vanilla_gru
                                     ? create_nested_primitive(gemm_iter_fwd_2_,
-                                            pd()->gemm_iter_fwd_2_pd_, engine)
+                                              pd()->gemm_iter_fwd_2_pd_, engine)
                                     : status::success);
             break;
         case prop_kind::backward:
@@ -990,9 +991,9 @@ status_t simple_common_t<aprop>::init(impl::engine_t *engine) {
                                     pd()->gemm_layer_bwd_pd_, engine),
                             (pd()->gemm_layer_bwd_src_pd_
                                             ? create_nested_primitive(
-                                                    gemm_layer_bwd_src_,
-                                                    pd()->gemm_layer_bwd_src_pd_,
-                                                    engine)
+                                                      gemm_layer_bwd_src_,
+                                                      pd()->gemm_layer_bwd_src_pd_,
+                                                      engine)
                                             : status::success),
                             create_nested_primitive(gemm_iter_bwd_,
                                     pd()->gemm_iter_bwd_pd_, engine),
@@ -1000,20 +1001,22 @@ status_t simple_common_t<aprop>::init(impl::engine_t *engine) {
                                     pd()->gemm_diff_wei_layer_pd_, engine),
                             (pd()->gemm_diff_wei_layer_src_pd_
                                             ? create_nested_primitive(
-                                                    gemm_diff_wei_layer_src_,
-                                                    pd()->gemm_diff_wei_layer_src_pd_,
-                                                    engine)
+                                                      gemm_diff_wei_layer_src_,
+                                                      pd()->gemm_diff_wei_layer_src_pd_,
+                                                      engine)
                                             : status::success),
                             create_nested_primitive(gemm_diff_wei_iter_,
                                     pd()->gemm_diff_wei_iter_pd_, engine),
                             conf.is_vanilla_gru
                                     ? create_nested_primitive(gemm_iter_bwd_2_,
-                                            pd()->gemm_iter_bwd_2_pd_, engine)
+                                              pd()->gemm_iter_bwd_2_pd_, engine)
                                     : status::success,
-                            conf.is_vanilla_gru ? create_nested_primitive(
-                                    gemm_diff_wei_iter_2_,
-                                    pd()->gemm_diff_wei_iter_2_pd_, engine)
-                                                : status::success);
+                            conf.is_vanilla_gru
+                                    ? create_nested_primitive(
+                                              gemm_diff_wei_iter_2_,
+                                              pd()->gemm_diff_wei_iter_2_pd_,
+                                              engine)
+                                    : status::success);
             break;
         default: assert(!"unknown prop_kind"); return status::invalid_arguments;
     }
@@ -1188,7 +1191,7 @@ grid_execution_sig((simple_common_t<aprop>::linear_execution)) {
                 auto grid_layer = (!conf.copy_src_layer && lay == 0)
                         ? user_data.src_layer(dir, 0, true)
                         : workspace.states_range(
-                                lay - 1, lay - 1, dir, dir, 0, n_iter);
+                                  lay - 1, lay - 1, dir, dir, 0, n_iter);
 
                 auto gemm_grid_layer_fwd = (!conf.copy_src_layer && lay == 0)
                         ? gemm_layer_fwd_src

--- a/src/gpu/intel/rnn/utils.cpp
+++ b/src/gpu/intel/rnn/utils.cpp
@@ -306,7 +306,7 @@ void set_conf(conf_t &conf, const desc_t &rd,
             = get_good_ld(conf.arch_ld, conf.gates_ld, conf.scratch_gates_elsz);
     conf.scratch_diff_gates_ld = is_bwd
             ? get_good_ld(
-                    conf.arch_ld, conf.gates_ld, conf.scratch_diff_gates_elsz)
+                      conf.arch_ld, conf.gates_ld, conf.scratch_diff_gates_elsz)
             : 0;
 
     bool is_lstm = rd.cell_kind == dnnl_vanilla_lstm;
@@ -447,9 +447,10 @@ void set_conf(conf_t &conf, const desc_t &rd,
             * conf.scratch_diff_states_ld * aux_elsz;
 
     conf.ws_gates_cell_size = conf.mb * conf.gates_ws_ld * aux_elsz;
-    conf.ws_gates_size = conf.is_training ? (conf.n_layer * conf.n_dir
-                                 * conf.n_iter * conf.ws_gates_cell_size)
-                                          : 0;
+    conf.ws_gates_size = conf.is_training
+            ? (conf.n_layer * conf.n_dir * conf.n_iter
+                      * conf.ws_gates_cell_size)
+            : 0;
 
     // Reduce workspace memory by recomputing gates for bwd
     // TODO: Extend this optimization to other alg_kind.

--- a/src/gpu/intel/rnn/utils.hpp
+++ b/src/gpu/intel/rnn/utils.hpp
@@ -412,23 +412,27 @@ struct workspace_t : public data_helper_t {
     workspace_t(const mst &ws, const conf_t &conf)
         : ws_(ws)
         , conf_(conf)
-        , gates_(conf.ws_gates_size > 0 ? ws.get_sub_storage(
-                         conf.ws_gates_offset, conf.ws_gates_size)
-                                        : nullptr)
+        , gates_(conf.ws_gates_size > 0
+                          ? ws.get_sub_storage(
+                                    conf.ws_gates_offset, conf.ws_gates_size)
+                          : nullptr)
         , gates_strides_ {0}
-        , states_(conf.ws_states_size > 0 ? ws.get_sub_storage(
-                          conf.ws_states_offset, conf.ws_states_size)
-                                          : nullptr)
+        , states_(conf.ws_states_size > 0
+                          ? ws.get_sub_storage(
+                                    conf.ws_states_offset, conf.ws_states_size)
+                          : nullptr)
         , states_strides_ {0}
-        , c_states_(conf.ws_c_states_size > 0 ? ws.get_sub_storage(
-                            conf.ws_c_state_offset, conf.ws_c_states_size)
-                                              : nullptr)
-        , bias_(conf.ws_bias_size > 0 ? ws.get_sub_storage(
-                        conf.ws_bias_offset, conf.ws_bias_size)
+        , c_states_(conf.ws_c_states_size > 0
+                          ? ws.get_sub_storage(conf.ws_c_state_offset,
+                                    conf.ws_c_states_size)
+                          : nullptr)
+        , bias_(conf.ws_bias_size > 0 ? ws.get_sub_storage(conf.ws_bias_offset,
+                                                conf.ws_bias_size)
                                       : nullptr)
-        , grid_comp_(conf.ws_grid_comp_size > 0 ? ws.get_sub_storage(
-                             conf.ws_grid_comp_offset, conf.ws_grid_comp_size)
-                                                : nullptr) {
+        , grid_comp_(conf.ws_grid_comp_size > 0
+                          ? ws.get_sub_storage(conf.ws_grid_comp_offset,
+                                    conf.ws_grid_comp_size)
+                          : nullptr) {
         if (gates_) {
             const dim_t n_b = conf_.mb;
             const dim_t n_tb = conf_.n_iter * n_b;

--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -30,7 +30,7 @@
 #define QUANTIZE_COMMON 3
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
-#define DIV_UP(x, y) (((x) + (y)-1) / (y))
+#define DIV_UP(x, y) (((x) + (y) - 1) / (y))
 
 #define sg_per_wg (ugemm_kq_sg_per_wg_m * ugemm_kq_sg_per_wg_n)
 #define q_tile_sg_n DIV_UP(ugemm_kq_wg_tile_n, sg_per_wg)
@@ -689,13 +689,13 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
 
 #if KEY_SCALES == QUANTIZE_COMMON
-#define k_scale_op(x) ((x)*k_scale)
+#define k_scale_op(x) ((x) * k_scale)
         tile_elementwise(S_tile, k_scale_op);
 #endif
 
         /* Apply attention mask */
 #if WITH_ATTN_MASK
-#define unscale(x) ((x)*iscale)
+#define unscale(x) ((x) * iscale)
         mask_tile_type_float mask_tile_float;
         tile_copy_reblock(mask_tile, &mask_tile_float);
 #if WITH_ATTN_SCALE
@@ -1008,7 +1008,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             tile_binary(A_scale_tile, A_scale_tile_load, binary_add);
         }
 #if VAL_SCALES == QUANTIZE_COMMON
-#define v_scale_op(x) ((x)*v_scale)
+#define v_scale_op(x) ((x) * v_scale)
         tile_elementwise(A_tile, v_scale_op);
 #endif
 

--- a/src/gpu/intel/sdpa/utils.h
+++ b/src/gpu/intel/sdpa/utils.h
@@ -28,7 +28,8 @@
 #define VAL_OFF(x0, x1, x2, x3) _4D_OFF(VAL, x0, x1, x2, x3)
 #define MSK_OFF(x0, x1, x2, x3) _4D_OFF(MSK, x0, x1, x2, x3)
 
-#define _BATCH_OFF(tag, x0, x1) ((x0)*tag##_S.array[0] + (x1)*tag##_S.array[1])
+#define _BATCH_OFF(tag, x0, x1) \
+    ((x0) * tag##_S.array[0] + (x1) * tag##_S.array[1])
 
 #define QRY_BATCH(x0, x1) _BATCH_OFF(QRY, x0, x1)
 #define KEY_BATCH(x0, x1) _BATCH_OFF(KEY, x0, x1)

--- a/src/gpu/intel/softmax/simple.cl
+++ b/src/gpu/intel/softmax/simple.cl
@@ -150,7 +150,7 @@ simple_softmax_fwd_generic(__global SRC_DATA_T *src, __global DATA_T *dst,
 
 #define GET_DATA_IDX(dim_idx) \
     (SOFTMAX_AXIS_IDX > (dim_idx))           ? dim[(dim_idx)] \
-            : (SOFTMAX_AXIS_IDX < (dim_idx)) ? dim[(dim_idx)-1] \
+            : (SOFTMAX_AXIS_IDX < (dim_idx)) ? dim[(dim_idx) - 1] \
                                              : i
         const unsigned po_d0 = SOFTMAX_AXIS_IDX > 0 ? dim[0] : i;
         const unsigned po_d1 = GET_DATA_IDX(1);

--- a/src/gpu/intel/sycl/engine.hpp
+++ b/src/gpu/intel/sycl/engine.hpp
@@ -51,7 +51,7 @@ public:
     engine_t(
             const ::sycl::device &dev, const ::sycl::context &ctx, size_t index)
         : gpu::intel::engine_t(new xpu::sycl::engine_impl_t(
-                engine_kind::gpu, dev, ctx, index)) {}
+                  engine_kind::gpu, dev, ctx, index)) {}
 
     status_t init() override {
         CHECK(init_impl());

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -53,13 +53,13 @@ status_t stream_t::init() {
             props = (flags() & stream_flags::in_order)
                     ? ::sycl::property_list {::sycl::property::queue::
                                                      in_order {},
-                            ::sycl::property::queue::enable_profiling {}}
+                              ::sycl::property::queue::enable_profiling {}}
                     : ::sycl::property_list {
-                            ::sycl::property::queue::enable_profiling {}};
+                              ::sycl::property::queue::enable_profiling {}};
         } else {
             props = (flags() & stream_flags::in_order)
-                    ? ::sycl::
-                            property_list {::sycl::property::queue::in_order {}}
+                    ? ::sycl::property_list {::sycl::property::queue::
+                                      in_order {}}
                     : ::sycl::property_list {};
         }
         impl()->set_queue(::sycl::queue(sycl_ctx, sycl_dev, props));
@@ -100,8 +100,8 @@ void stream_t::after_exec_hook() {
 //  not be defined. Some SFINAE is needed to avoid compile errors in this case.
 namespace syclex = ::sycl::ext::oneapi::experimental;
 template <typename Q>
-static auto get_graph_internal(const Q &q, bool &success, int)
-        -> decltype(q.ext_oneapi_get_graph()) {
+static auto get_graph_internal(
+        const Q &q, bool &success, int) -> decltype(q.ext_oneapi_get_graph()) {
     success = true;
     return q.ext_oneapi_get_graph();
 }

--- a/src/gpu/nvidia/cudnn_batch_normalization_executor.hpp
+++ b/src/gpu/nvidia/cudnn_batch_normalization_executor.hpp
@@ -38,7 +38,8 @@ namespace nvidia {
 struct bnorm_exec_base_t {
     virtual status_t execute(const exec_ctx_t &ctx, impl::engine_t *engine,
             const std::shared_ptr<cudnn_batch_normalization_impl_base_t>
-                    bnorm_impl) const = 0;
+                    bnorm_impl) const
+            = 0;
     virtual ~bnorm_exec_base_t() = default;
 
 protected:
@@ -87,11 +88,11 @@ protected:
             auto *scale = use_scale
                     ? static_cast<uint8_t *>(arg_scale.get_native_pointer(ih))
                     : static_cast<uint8_t *>(
-                            arg_scale_buf.get_native_pointer(ih));
+                              arg_scale_buf.get_native_pointer(ih));
             uint8_t *shift = use_shift
                     ? static_cast<uint8_t *>(arg_shift.get_native_pointer(ih))
                     : static_cast<uint8_t *>(
-                            arg_shift_buf.get_native_pointer(ih));
+                              arg_shift_buf.get_native_pointer(ih));
             uint8_t *y_prime = nullptr, *save_mean = nullptr,
                     *save_var = nullptr;
 
@@ -156,17 +157,17 @@ protected:
             auto *scale = use_scale
                     ? static_cast<uint8_t *>(arg_scale.get_native_pointer(ih))
                     : static_cast<uint8_t *>(
-                            arg_scale_buf.get_native_pointer(ih));
+                              arg_scale_buf.get_native_pointer(ih));
             auto *diff_scale = use_scale
                     ? static_cast<uint8_t *>(
-                            arg_diff_scale.get_native_pointer(ih))
+                              arg_diff_scale.get_native_pointer(ih))
                     : static_cast<uint8_t *>(
-                            arg_diff_scale_buf.get_native_pointer(ih));
+                              arg_diff_scale_buf.get_native_pointer(ih));
             uint8_t *diff_shift = use_shift
                     ? static_cast<uint8_t *>(
-                            arg_diff_shift.get_native_pointer(ih))
+                              arg_diff_shift.get_native_pointer(ih))
                     : static_cast<uint8_t *>(
-                            arg_diff_shift_buf.get_native_pointer(ih));
+                              arg_diff_shift_buf.get_native_pointer(ih));
 
             auto *save_mean = static_cast<uint8_t *>(
                     arg_wkspace.get_native_pointer(ih));
@@ -251,7 +252,7 @@ struct bnorm_exec_fwd_t : public bnorm_exec_base_t {
             auto arg_wkspace = bnorm_impl->is_training()
                     ? CTX_OUT_SYCL_MEMORY(DNNL_ARG_WORKSPACE)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::write>();
+                              ::sycl::access::mode::write>();
 
             if (!use_global_stats) {
                 const bool init_global_stats = bnorm_impl->is_training();

--- a/src/gpu/nvidia/cudnn_batch_normalization_impl.hpp
+++ b/src/gpu/nvidia/cudnn_batch_normalization_impl.hpp
@@ -79,7 +79,8 @@ struct cudnn_batch_normalization_impl_base_t {
     virtual status_t init(batch_normalization_pd_t *pd) = 0;
 
     virtual void execute(
-            cudnnHandle_t handle, std::shared_ptr<bnorm_args_t> args) const = 0;
+            cudnnHandle_t handle, std::shared_ptr<bnorm_args_t> args) const
+            = 0;
 
     bool is_bwd_d() const { return is_bwd_data_; }
     bool is_training() const { return is_training_; }

--- a/src/gpu/nvidia/cudnn_conv_inner_product_impl.hpp
+++ b/src/gpu/nvidia/cudnn_conv_inner_product_impl.hpp
@@ -92,7 +92,8 @@ struct cudnn_conv_inner_product_impl_base_t
     }
 
     virtual void execute(cudnnHandle_t handle, cublasHandle_t,
-            const std::vector<void *> &args) const = 0;
+            const std::vector<void *> &args) const
+            = 0;
 };
 
 struct cudnn_conv_inner_product_fwd_impl_t

--- a/src/gpu/nvidia/cudnn_convolution_impl.hpp
+++ b/src/gpu/nvidia/cudnn_convolution_impl.hpp
@@ -95,11 +95,11 @@ public:
         return (mem_wrapper.matches_one_of_tag(format_tag::ab, format_tag::abc,
                         format_tag::abcd, format_tag::abcde, format_tag::abcdef)
                 || (with_groups ? mem_wrapper.matches_one_of_tag(
-                            format_tag::gowi, format_tag::gohwi,
-                            format_tag::godhwi)
+                                          format_tag::gowi, format_tag::gohwi,
+                                          format_tag::godhwi)
                                 : mem_wrapper.matches_one_of_tag(
-                                        format_tag::owi, format_tag::ohwi,
-                                        format_tag::odhwi)));
+                                          format_tag::owi, format_tag::ohwi,
+                                          format_tag::odhwi)));
     }
 
     bool using_transformed_filter() const { return filter_needs_transform; }
@@ -299,7 +299,8 @@ public:
     }
 
     virtual void execute(
-            cudnnHandle_t handle, const std::vector<void *> &args) const = 0;
+            cudnnHandle_t handle, const std::vector<void *> &args) const
+            = 0;
 
     void execute_sum(cudnnHandle_t handle, void *x, void *y, float alpha_,
             float beta_) const {

--- a/src/gpu/nvidia/cudnn_inner_product_impl.hpp
+++ b/src/gpu/nvidia/cudnn_inner_product_impl.hpp
@@ -154,7 +154,8 @@ struct cudnn_inner_product_impl_base_t {
 
     virtual void execute(cudnnHandle_t /*handle*/,
             cublasHandle_t /*cublas_handle*/,
-            const std::vector<void *> & /*args*/) const = 0;
+            const std::vector<void *> & /*args*/) const
+            = 0;
 
     virtual ~cudnn_inner_product_impl_base_t() {
         for (int i = 0; i < NUM_IO; ++i) {

--- a/src/gpu/nvidia/cudnn_lrn_impl.hpp
+++ b/src/gpu/nvidia/cudnn_lrn_impl.hpp
@@ -42,7 +42,8 @@ struct cudnn_lrn_impl_base_t {
     }
     virtual status_t init(const lrn_pd_t *pd) = 0;
     virtual void execute(
-            cudnnHandle_t handle, const std::vector<void *> &args) const = 0;
+            cudnnHandle_t handle, const std::vector<void *> &args) const
+            = 0;
 
 protected:
     enum io { src_idx = 0, dst_idx, d_src_idx, d_dst_idx, NUM_IO };

--- a/src/gpu/nvidia/cudnn_matmul_executor.hpp
+++ b/src/gpu/nvidia/cudnn_matmul_executor.hpp
@@ -144,9 +144,9 @@ struct cudnn_matmul_exec_t final : cudnn_matmul_base_exec_t {
 
             auto arg_bias_scratch = params->reorder_scratch_size_ != 0
                     ? CTX_SCRATCH_SYCL_MEMORY(
-                            memory_tracking::names::key_matmul_dst_in_acc_dt)
+                              memory_tracking::names::key_matmul_dst_in_acc_dt)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::read_write>();
+                              ::sycl::access::mode::read_write>();
 
             auto arg_src_scale
                     = CTX_IN_SYCL_MEMORY(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
@@ -357,30 +357,30 @@ struct cudnn_matmul_lt_exec_t final : public cudnn_matmul_lt_base_exec_t {
             auto arg_dst_scale
                     = CTX_IN_SYCL_MEMORY(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
             auto arg_algo_scratch = params->algo_scratch_size_ != 0
-                    ? CTX_SCRATCH_SYCL_MEMORY(
-                            memory_tracking::names::key_matmul_lt_algo_scratch)
+                    ? CTX_SCRATCH_SYCL_MEMORY(memory_tracking::names::
+                                      key_matmul_lt_algo_scratch)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::read_write>();
+                              ::sycl::access::mode::read_write>();
             auto arg_bias_scratch = params->reorder_scratch_size_ != 0
                     ? CTX_SCRATCH_SYCL_MEMORY(
-                            memory_tracking::names::key_matmul_dst_in_acc_dt)
+                              memory_tracking::names::key_matmul_dst_in_acc_dt)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::read_write>();
+                              ::sycl::access::mode::read_write>();
             auto arg_block_a_scratch = params->weight_size_ != 0
                     ? CTX_SCRATCH_SYCL_MEMORY(
-                            memory_tracking::names::key_gemm_blocked_a)
+                              memory_tracking::names::key_gemm_blocked_a)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::read_write>();
+                              ::sycl::access::mode::read_write>();
             auto arg_block_b_scratch = params->source_size_ != 0
                     ? CTX_SCRATCH_SYCL_MEMORY(
-                            memory_tracking::names::key_gemm_blocked_b)
+                              memory_tracking::names::key_gemm_blocked_b)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::read_write>();
+                              ::sycl::access::mode::read_write>();
             auto arg_block_c_scratch = params->dest_size_ != 0
                     ? CTX_SCRATCH_SYCL_MEMORY(
-                            memory_tracking::names::key_matmul_lt_block_c)
+                              memory_tracking::names::key_matmul_lt_block_c)
                     : xpu::sycl::interop_memory_arg_t<
-                            ::sycl::access::mode::read_write>();
+                              ::sycl::access::mode::read_write>();
 
             interop_task(matmul_impl_, params, engine, cgh, cuda_stream, arg_wt,
                     arg_src, arg_dst, arg_bias, arg_algo_scratch,

--- a/src/gpu/nvidia/cudnn_pooling_impl.hpp
+++ b/src/gpu/nvidia/cudnn_pooling_impl.hpp
@@ -44,7 +44,8 @@ struct cudnn_pooling_impl_base_t {
     }
 
     virtual void execute(cudnnHandle_t handle, void *x, void *y, void *ws_x,
-            void *ws_y) const = 0;
+            void *ws_y) const
+            = 0;
 
 protected:
     status_t init_common(const pooling_pd_t *pd) {

--- a/src/gpu/nvidia/cudnn_reorder_impl.hpp
+++ b/src/gpu/nvidia/cudnn_reorder_impl.hpp
@@ -48,7 +48,8 @@ public:
     virtual status_t init(const reorder_pd_t *pd) = 0;
 
     virtual void execute(cudnnHandle_t handle, void *src, void *dst,
-            void *src_scale, void *dst_scale) const = 0;
+            void *src_scale, void *dst_scale) const
+            = 0;
 
     virtual ~cudnn_reorder_generic_t() {
         CUDNN_EXECUTE_FUNC_V(cudnnDestroyTensorDescriptor, src_desc_);

--- a/src/gpu/nvidia/engine.cpp
+++ b/src/gpu/nvidia/engine.cpp
@@ -43,7 +43,7 @@ status_t engine_create(impl::engine_t **engine, engine_kind_t engine_kind,
 engine_t::engine_t(
         const ::sycl::device &dev, const ::sycl::context &ctx, size_t index)
     : impl::gpu::engine_t(
-            new xpu::sycl::engine_impl_t(engine_kind::gpu, dev, ctx, index)) {
+              new xpu::sycl::engine_impl_t(engine_kind::gpu, dev, ctx, index)) {
     assert(xpu::sycl::is_nvidia_gpu(dev));
     set_cudnn_handle();
     set_cublas_handle();

--- a/src/gpu/nvidia/sycl_cuda_utils.hpp
+++ b/src/gpu/nvidia/sycl_cuda_utils.hpp
@@ -284,7 +284,7 @@ protected:
 public:
     explicit cublas_error(const std::string &message, cublasStatus_t result)
         : std::runtime_error(
-                (message + std::string(cublas_error_map(result)))) {
+                  (message + std::string(cublas_error_map(result)))) {
         error_number_ = static_cast<int>(result);
     }
 
@@ -320,7 +320,7 @@ public:
 
     explicit cuda_error(const std::string &message, cudaError_t result)
         : std::runtime_error(
-                (message + std::to_string(static_cast<int>(result)))) {
+                  (message + std::to_string(static_cast<int>(result)))) {
         error_number_ = static_cast<int>(result);
     }
     virtual ~cuda_error() throw() {}
@@ -364,7 +364,7 @@ protected:
 public:
     explicit cudnn_error(const std::string &message, cudnnStatus_t result)
         : std::runtime_error(
-                (message + std::string(cudnn_get_error_string(result)))) {
+                  (message + std::string(cudnn_get_error_string(result)))) {
         error_number_ = static_cast<int>(result);
     }
 

--- a/src/graph/backend/dnnl/dnnl_backend.hpp
+++ b/src/graph/backend/dnnl/dnnl_backend.hpp
@@ -81,12 +81,12 @@ public:
         static const std::unordered_set<engine_kind_t, enum_hash_t>
                 supported_kind = {
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
-                    engine_kind::cpu,
+                        engine_kind::cpu,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL \
         || DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-                    engine_kind::gpu,
+                        engine_kind::gpu,
 #endif
                 };
         return supported_kind.count(kind);

--- a/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
+++ b/src/graph/backend/dnnl/dnnl_constant_tensor_cache.hpp
@@ -32,7 +32,7 @@ struct dnnl_constant_buffer_t : public graph::constant_buffer_t {
     dnnl_constant_buffer_t(
             size_t size, dnnl::engine &engine, graph::allocator_t *alc)
         : graph::constant_buffer_t(
-                size, engine.get(), alc, malloc_func, free_func) {}
+                  size, engine.get(), alc, malloc_func, free_func) {}
 
     static void *malloc_func(
             size_t size, impl::engine_t *eng, graph::allocator_t *alc) {

--- a/src/graph/backend/dnnl/dnnl_partition_impl.hpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.hpp
@@ -45,7 +45,7 @@ public:
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs, kernel_ptr &kernel)
         : compiled_partition_impl_t(
-                engine, inputs, outputs, kernel->get_inplace_pairs())
+                  engine, inputs, outputs, kernel->get_inplace_pairs())
         , kernel_(kernel) {}
 
     // Current implementation uses const_cast to reset `engine_` to point to a

--- a/src/graph/backend/dnnl/executables/base.hpp
+++ b/src/graph/backend/dnnl/executables/base.hpp
@@ -123,18 +123,21 @@ inline arg_indices_t dummy_arg_indices_getter(const op_t *op) {
 struct op_executable_t {
     virtual ~op_executable_t() = default;
     virtual void execute(const stream &stream,
-            const std::unordered_map<int, memory> &args) const = 0;
+            const std::unordered_map<int, memory> &args) const
+            = 0;
     virtual status_t reset_engine(const dnnl::engine &engine) = 0;
 #ifdef DNNL_WITH_SYCL
     virtual ::sycl::event execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<::sycl::event> &deps) const = 0;
+            const std::vector<::sycl::event> &deps) const
+            = 0;
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     virtual cl_event execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const = 0;
+            const std::vector<cl_event> &deps) const
+            = 0;
 #endif
 };
 
@@ -177,7 +180,9 @@ inline std::shared_ptr<op_executable_t> executable_creator(
     public: \
         desc_t(const type &pd, bool from_cache) \
             : type(pd), from_cache_(from_cache) {} \
-        bool is_from_cache() const { return from_cache_; } \
+        bool is_from_cache() const { \
+            return from_cache_; \
+        } \
     }; \
     static desc_t create_desc(std::shared_ptr<op_t> &op, \
             const dnnl::engine &p_engine, pd_cache_t &pd_cache, \

--- a/src/graph/backend/dnnl/executables/conv.cpp
+++ b/src/graph/backend/dnnl/executables/conv.cpp
@@ -149,13 +149,13 @@ cl_event conv_fwd_executable_t::execute_ocl(const stream &stream,
                         = dnnl::ocl_interop::get_memory_kind(dst_mem)
                                 == dnnl::ocl_interop::memory_kind::usm
                         ? dnnl::ocl_interop::make_memory(new_to_desc,
-                                psrc_mem.get_engine(),
-                                dnnl::ocl_interop::memory_kind::usm,
-                                dst_mem.get_data_handle())
+                                  psrc_mem.get_engine(),
+                                  dnnl::ocl_interop::memory_kind::usm,
+                                  dst_mem.get_data_handle())
                         : dnnl::ocl_interop::make_memory(new_to_desc,
-                                psrc_mem.get_engine(),
-                                reinterpret_cast<cl_mem>(
-                                        dst_mem.get_data_handle()));
+                                  psrc_mem.get_engine(),
+                                  reinterpret_cast<cl_mem>(
+                                          dst_mem.get_data_handle()));
 
                 auto prim = dnnl::reorder(psrc_mem, to_mem);
                 auto e = dnnl::ocl_interop::execute(prim, stream,

--- a/src/graph/backend/dnnl/executables/pool.cpp
+++ b/src/graph/backend/dnnl/executables/pool.cpp
@@ -139,7 +139,7 @@ pool_bwd_executable_t::desc_t pool_bwd_executable_t::create_desc(
     auto src = op->get_attr<std::string>(op_attr::kind) == "maxpool"
             ? make_dnnl_memory_desc(op->get_input_logical_tensor(2))
             : dnnl::memory::desc(diff_src.get_dims(), diff_src.get_data_type(),
-                    get_ncx_format(diff_src.get_dims()));
+                      get_ncx_format(diff_src.get_dims()));
 
     // infer dnnl explicit pad
     bool adj_pad = false;

--- a/src/graph/backend/dnnl/executables/softmax.cpp
+++ b/src/graph/backend/dnnl/executables/softmax.cpp
@@ -48,9 +48,10 @@ softmax_executable_t::desc_t softmax_executable_t::create_desc(
     dnnl::algorithm algo = dnnl::algorithm::undef;
     if (op->get_kind() == dnnl_impl::op_kind::dnnl_softmax) {
         const auto mode = op->get_attr<std::string>(op_attr::mode);
-        algo = mode == "inf_as_zero" ? static_cast<dnnl::algorithm>(
-                       dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)
-                                     : dnnl::algorithm::softmax_accurate;
+        algo = mode == "inf_as_zero"
+                ? static_cast<dnnl::algorithm>(
+                          dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)
+                : dnnl::algorithm::softmax_accurate;
     } else if (op->get_kind() == dnnl_impl::op_kind::dnnl_logsoftmax) {
         algo = dnnl::algorithm::softmax_log;
     } else {

--- a/src/graph/backend/dnnl/kernels/kernel_base.hpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.hpp
@@ -125,7 +125,9 @@ using kernel_ptr = std::shared_ptr<kernel_base_t>;
 using FCreateKernel = std::function<kernel_ptr(void)>;
 
 #define DEF_KERNEL_METHOD_STR(name) \
-    std::string str() const override { return #name; }
+    std::string str() const override { \
+        return #name; \
+    }
 
 } // namespace dnnl_impl
 } // namespace graph

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -98,7 +98,7 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
     memory::data_type dt_inter = quantized
             ? dt
             : static_cast<memory::data_type>(
-                    ltw(mqa_op[1]->get_output_logical_tensor(0)).data_type());
+                      ltw(mqa_op[1]->get_output_logical_tensor(0)).data_type());
 
     ////////////////////////////////////////////////////////////////////////
     ////////////// Start Creating primitives ///////////////////////////////
@@ -186,7 +186,7 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
     const auto mode = mqa_op[2]->get_attr<std::string>(op_attr::mode);
     const dnnl::algorithm algo = mode == "inf_as_zero"
             ? static_cast<dnnl::algorithm>(
-                    dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)
+                      dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)
             : dnnl::algorithm::softmax_accurate;
     auto sub_softmax_pd = softmax_forward::primitive_desc(p_engine,
             prop_kind::forward_inference, algo, sub_mm1_dst_md,

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -141,7 +141,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
     memory::data_type dt_inter = quantized
             ? dt
             : static_cast<memory::data_type>(
-                    ltw(sdp_op[1]->get_output_logical_tensor(0)).data_type());
+                      ltw(sdp_op[1]->get_output_logical_tensor(0)).data_type());
 
     ////////////////////////////////////////////////////////////////////////
     ////////////// Start Creating primitives ///////////////////////////////
@@ -308,7 +308,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
     const auto mode = sdp_op[2]->get_attr<std::string>(op_attr::mode);
     const dnnl::algorithm algo = mode == "inf_as_zero"
             ? static_cast<dnnl::algorithm>(
-                    dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)
+                      dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)
             : dnnl::algorithm::softmax_accurate;
     auto sub_softmax_pd = softmax_forward::primitive_desc(p_engine,
             prop_kind::forward_inference, algo, sub_mm1_dst_md,

--- a/src/graph/backend/dnnl/passes/lower.cpp
+++ b/src/graph/backend/dnnl/passes/lower.cpp
@@ -917,7 +917,9 @@ static status_t gen_index_handler(
 
 #define ITEM(kind, func) \
     { \
-        graph::op_kind::kind, handler_func { (func) } \
+        graph::op_kind::kind, handler_func { \
+            (func) \
+        } \
     }
 
 static const std::unordered_map<graph::op_kind_t, handler_func> handler_table {

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -1709,7 +1709,7 @@ status_t conv_bwd_data_canonicalization(std::shared_ptr<subgraph_t> &sg) {
                 : false;
         bool need_permute_1 = cur_op->has_attr(op_attr::weights_format)
                 ? (cur_op->get_attr<std::string>(op_attr::weights_format)
-                        == "XIO")
+                          == "XIO")
                 : false;
 
         if (need_permute_0) {
@@ -1790,7 +1790,7 @@ status_t conv_bwd_weights_canonicalization(std::shared_ptr<subgraph_t> &sg) {
                 : false;
         bool need_permute_1 = cur_op->has_attr(op_attr::weights_format)
                 ? (cur_op->get_attr<std::string>(op_attr::weights_format)
-                        != "OIX")
+                          != "OIX")
                 : false;
 
         if (need_permute_0) {

--- a/src/graph/backend/dnnl/patterns/utils.hpp
+++ b/src/graph/backend/dnnl/patterns/utils.hpp
@@ -362,7 +362,7 @@ inline graph::utils::pm::pb_node_t *optional_smooth_quant(
     auto opt = optional_qout
             ? p_curr_graph->append_optional(optional_graph)
             : p_curr_graph->append_optional(optional_graph,
-                    graph::utils::pm::in_edges_t {in_edge(0, input, 0)});
+                      graph::utils::pm::in_edges_t {in_edge(0, input, 0)});
     graph::utils::pm::pb_op_t *quant_out
             = p_curr_graph->append_op(graph::op_kind::Quantize,
                     graph::utils::pm::in_edges_t {in_edge(0, opt, 0)});

--- a/src/graph/interface/partition_hashing.cpp
+++ b/src/graph/interface/partition_hashing.cpp
@@ -52,7 +52,7 @@ key_t::key_t(const partition_t *partition, const impl::engine_t *engine,
         const std::vector<const logical_tensor_t *> &ins,
         const std::vector<const logical_tensor_t *> &outs)
     : key_t(engine, partition->get_ops(), ins, outs,
-            partition->get_fpmath_mode()) {}
+              partition->get_fpmath_mode()) {}
 
 bool key_t::operator==(const key_t &rhs) const {
     if (this == &rhs) return true;

--- a/src/graph/interface/partition_impl.hpp
+++ b/src/graph/interface/partition_impl.hpp
@@ -126,7 +126,8 @@ public:
     ///     with the in/outputs_. Backend should do the reorder inside this
     ///     function's implementation.
     virtual status_t infer_shape(std::vector<const logical_tensor_t *> &inputs,
-            std::vector<logical_tensor_t *> &outputs) const = 0;
+            std::vector<logical_tensor_t *> &outputs) const
+            = 0;
 
     /// Compile the partition with specific inputs and outputs logical tensors
     /// and engine. A partition can be compiled multiple times with different
@@ -173,7 +174,8 @@ public:
     virtual status_t compile(compiled_partition_t *compiled_partition,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs,
-            const engine_t *aengine) const = 0;
+            const engine_t *aengine) const
+            = 0;
 
     /// get partition_impl id
     size_t id() const { return id_; }

--- a/src/graph/utils/any.hpp
+++ b/src/graph/utils/any.hpp
@@ -49,8 +49,8 @@ template <typename F>
 decltype(first_argument_helper(&F::operator())) first_argument_helper(F);
 
 template <typename T>
-using first_argument = typename std::decay<decltype(
-        first_argument_helper(std::declval<T>()))>::type;
+using first_argument = typename std::decay<decltype(first_argument_helper(
+        std::declval<T>()))>::type;
 
 // any structure
 // now we only use this any struct for the project.

--- a/src/xpu/ocl/engine_impl.hpp
+++ b/src/xpu/ocl/engine_impl.hpp
@@ -144,9 +144,15 @@ private:
 };
 
 #define DECLARE_COMMON_OCL_ENGINE_FUNCTIONS() \
-    cl_device_id device() const { return impl()->device(); } \
-    cl_context context() const { return impl()->context(); } \
-    cl_platform_id platform() const { return impl()->platform(); }
+    cl_device_id device() const { \
+        return impl()->device(); \
+    } \
+    cl_context context() const { \
+        return impl()->context(); \
+    } \
+    cl_platform_id platform() const { \
+        return impl()->platform(); \
+    }
 
 } // namespace ocl
 } // namespace xpu

--- a/src/xpu/stream_profiler.hpp
+++ b/src/xpu/stream_profiler.hpp
@@ -55,7 +55,8 @@ struct stream_profiler_t {
     };
 
     virtual status_t get_info(profiling_data_kind_t data_kind, int *num_entries,
-            uint64_t *data) const = 0;
+            uint64_t *data) const
+            = 0;
 
     uint64_t stamp() const { return stamp_; }
 

--- a/src/xpu/sycl/buffer_memory_storage.cpp
+++ b/src/xpu/sycl/buffer_memory_storage.cpp
@@ -108,7 +108,7 @@ std::unique_ptr<memory_storage_t> buffer_memory_storage_t::get_sub_storage(
                 offset % sycl_engine_impl->get_buffer_alignment() == 0));
         xpu::sycl::buffer_u8_t *sub_buffer = buffer_
                 ? new xpu::sycl::buffer_u8_t(
-                        parent_buffer(), base_offset_ + offset, size)
+                          parent_buffer(), base_offset_ + offset, size)
                 : nullptr;
         storage->buffer_.reset(sub_buffer);
         storage->base_offset_ = base_offset_ + offset;

--- a/src/xpu/sycl/compat.hpp
+++ b/src/xpu/sycl/compat.hpp
@@ -44,8 +44,8 @@ inline auto host_task_impl(H &cgh, F &&f, int) -> decltype(cgh.host_task(f)) {
 }
 
 template <typename H, typename F>
-inline auto host_task_impl(H &cgh, F &&f, long)
-        -> decltype(cgh.codeplay_host_task(f)) {
+inline auto host_task_impl(
+        H &cgh, F &&f, long) -> decltype(cgh.codeplay_host_task(f)) {
     cgh.codeplay_host_task(f);
 }
 

--- a/src/xpu/sycl/engine_impl.hpp
+++ b/src/xpu/sycl/engine_impl.hpp
@@ -113,9 +113,15 @@ private:
 };
 
 #define DECLARE_COMMON_SYCL_ENGINE_FUNCTIONS() \
-    const ::sycl::device &device() const { return impl()->device(); } \
-    const ::sycl::context &context() const { return impl()->context(); } \
-    xpu::sycl::backend_t backend() const { return impl()->backend(); }
+    const ::sycl::device &device() const { \
+        return impl()->device(); \
+    } \
+    const ::sycl::context &context() const { \
+        return impl()->context(); \
+    } \
+    xpu::sycl::backend_t backend() const { \
+        return impl()->backend(); \
+    }
 
 } // namespace sycl
 } // namespace xpu

--- a/src/xpu/sycl/memory_storage_base.hpp
+++ b/src/xpu/sycl/memory_storage_base.hpp
@@ -33,11 +33,14 @@ public:
     virtual memory_kind_t memory_kind() const = 0;
 
     virtual in_memory_arg_t get_in_memory_arg(
-            stream_t *stream, ::sycl::handler &cgh) const = 0;
+            stream_t *stream, ::sycl::handler &cgh) const
+            = 0;
     virtual out_memory_arg_t get_out_memory_arg(
-            stream_t *stream, ::sycl::handler &cgh) const = 0;
+            stream_t *stream, ::sycl::handler &cgh) const
+            = 0;
     virtual inout_memory_arg_t get_inout_memory_arg(
-            stream_t *stream, ::sycl::handler &cgh) const = 0;
+            stream_t *stream, ::sycl::handler &cgh) const
+            = 0;
 
     static in_memory_arg_t empty_in_memory_arg(
             stream_t *stream, ::sycl::handler &cgh);

--- a/src/xpu/sycl/types.hpp
+++ b/src/xpu/sycl/types.hpp
@@ -35,25 +35,25 @@ namespace sycl {
 #define CTX_IN_SYCL_KERNEL_MEMORY(arg) \
     CTX_IN_STORAGE(arg).is_null() \
             ? xpu::sycl::memory_storage_base_t::empty_in_memory_arg( \
-                    ctx.stream(), cgh) \
+                      ctx.stream(), cgh) \
             : utils::downcast<const xpu::sycl::memory_storage_base_t *>( \
-                    &CTX_IN_STORAGE(arg)) \
+                      &CTX_IN_STORAGE(arg)) \
                       ->get_in_memory_arg(ctx.stream(), cgh)
 
 #define CTX_OUT_SYCL_KERNEL_MEMORY(arg) \
     CTX_OUT_STORAGE(arg).is_null() \
             ? xpu::sycl::memory_storage_base_t::empty_out_memory_arg( \
-                    ctx.stream(), cgh) \
+                      ctx.stream(), cgh) \
             : utils::downcast<const xpu::sycl::memory_storage_base_t *>( \
-                    &CTX_OUT_STORAGE(arg)) \
+                      &CTX_OUT_STORAGE(arg)) \
                       ->get_out_memory_arg(ctx.stream(), cgh)
 
 #define CTX_INOUT_SYCL_KERNEL_MEMORY(arg) \
     CTX_OUT_STORAGE(arg).is_null() \
             ? xpu::sycl::memory_storage_base_t::empty_inout_memory_arg( \
-                    ctx.stream(), cgh) \
+                      ctx.stream(), cgh) \
             : utils::downcast<const xpu::sycl::memory_storage_base_t *>( \
-                    &CTX_OUT_STORAGE(arg)) \
+                      &CTX_OUT_STORAGE(arg)) \
                       ->get_inout_memory_arg(ctx.stream(), cgh)
 
 #define CTX_IN_SCRATCH_KERNEL_MEMORY(KEY) \
@@ -61,11 +61,11 @@ namespace sycl {
                     .get_memory_storage(memory_tracking::names::KEY) \
                     ->is_null() \
             ? xpu::sycl::memory_storage_base_t::empty_in_memory_arg( \
-                    ctx.stream(), cgh) \
+                      ctx.stream(), cgh) \
             : utils::downcast<const xpu::sycl::memory_storage_base_t *>( \
-                    ctx.get_scratchpad_grantor() \
-                            .get_memory_storage(memory_tracking::names::KEY) \
-                            .get()) \
+                      ctx.get_scratchpad_grantor() \
+                              .get_memory_storage(memory_tracking::names::KEY) \
+                              .get()) \
                       ->get_in_memory_arg(ctx.stream(), cgh);
 
 #define CTX_OUT_SCRATCH_KERNEL_MEMORY(KEY) \
@@ -73,11 +73,11 @@ namespace sycl {
                     .get_memory_storage(memory_tracking::names::KEY) \
                     ->is_null() \
             ? xpu::sycl::memory_storage_base_t::empty_out_memory_arg( \
-                    ctx.stream(), cgh) \
+                      ctx.stream(), cgh) \
             : utils::downcast<const xpu::sycl::memory_storage_base_t *>( \
-                    ctx.get_scratchpad_grantor() \
-                            .get_memory_storage(memory_tracking::names::KEY) \
-                            .get()) \
+                      ctx.get_scratchpad_grantor() \
+                              .get_memory_storage(memory_tracking::names::KEY) \
+                              .get()) \
                       ->get_out_memory_arg(ctx.stream(), cgh);
 
 #define CHECK_SYCL_KERNEL_ARG_TYPE(type) \

--- a/src/xpu/sycl/verbose.hpp
+++ b/src/xpu/sycl/verbose.hpp
@@ -51,7 +51,7 @@ inline void print_verbose_header(engine_kind_t kind) {
 
             const xpu::sycl::engine_impl_t *engine_impl = eng
                     ? utils::downcast<const xpu::sycl::engine_impl_t *>(
-                            eng->impl())
+                              eng->impl())
                     : nullptr;
 
             const auto &s_backend = engine_impl

--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -123,9 +123,10 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
     // creating the primitive descriptor.
     auto src2_d = prb->is_ternary_op()
             ? dnn_mem_t::init_md(prb->ndims,
-                    prb->vdims.size() > 2 ? prb->vdims[2].data()
-                                          : prb->vdims[0].data(),
-                    dnnl_s8, prb->stag.size() > 2 ? prb->stag[2] : prb->stag[0])
+                      prb->vdims.size() > 2 ? prb->vdims[2].data()
+                                            : prb->vdims[0].data(),
+                      dnnl_s8,
+                      prb->stag.size() > 2 ? prb->stag[2] : prb->stag[0])
             : nullptr;
 
     TIME_C_PD(DNN_SAFE_STATUS(dnnl_binary_primitive_desc_create_v2(

--- a/tests/benchdnn/binary/binary.hpp
+++ b/tests/benchdnn/binary/binary.hpp
@@ -60,8 +60,8 @@ struct prb_t : public prb_vdims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0], s.alg[0],
-                s.inplace[0], s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.inplace[0], s.attributes.front(), s.ctx_init[0],
+                  s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/bnorm/bnorm.hpp
+++ b/tests/benchdnn/bnorm/bnorm.hpp
@@ -94,9 +94,9 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.strides[0], s.flags[0],
-                s.check_alg, s.debug_check_ws, s.mb[0], s.inplace[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.check_alg, s.debug_check_ws, s.mb[0], s.inplace[0],
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -1240,11 +1240,11 @@ int doit(const prb_t *prb, res_t *res) {
     const int32_t *dst_zp_ptr
             = mem_map.count(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST)
             ? (const int32_t *)mem_map.at(
-                    DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST)
+                      DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST)
             : nullptr;
     int32_t zp_a_val = mem_map.count(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC)
             ? *(const int32_t *)mem_map.at(
-                    DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC)
+                      DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC)
             : 0;
     const char *bia_dt_ptr = mem_map.count(DNNL_ARG_BIAS)
             ? (const char *)mem_map.at(DNNL_ARG_BIAS)

--- a/tests/benchdnn/brgemm/ref_brgemm.cpp
+++ b/tests/benchdnn/brgemm/ref_brgemm.cpp
@@ -109,9 +109,9 @@ void compute_ref_brgemm(const prb_t *prb, const args_t &args) {
                 int src_zp = has_src_zp
                         ? src_zps.get_elem(src_zp_mask > 0 ? k : 0)
                         : 0;
-                int wei_zp = has_wei_zp ? wei_zps.get_elem(
-                                     wei_zp_stride_k * (k / wei_zp_group_k)
-                                     + wei_zp_stride_n * n)
+                int wei_zp = has_wei_zp ? wei_zps.get_elem(wei_zp_stride_k
+                                                          * (k / wei_zp_group_k)
+                                                  + wei_zp_stride_n * n)
                                         : 0;
 
                 auto s = src[src_off_f(prb, bs, m, k)] - src_zp;

--- a/tests/benchdnn/concat/concat.hpp
+++ b/tests/benchdnn/concat/concat.hpp
@@ -57,8 +57,8 @@ struct prb_t : public prb_vdims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
-                s.axis[0], s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.axis[0], s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -120,9 +120,9 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.bia_dt[0], s.stag[0], s.wtag[0],
-                s.dtag[0], s.strides[0], s.alg[0], s.mb[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.dtag[0], s.strides[0], s.alg[0], s.mb[0],
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/conv/ref_conv.cpp
+++ b/tests/benchdnn/conv/ref_conv.cpp
@@ -49,15 +49,15 @@ void compute_ref_direct_fwd(const prb_t *prb, const args_t &args) {
             = has_dst_scale ? 1.f / dst_scales.get_f32_elem(0) : 1.f;
     const int src_scale_mask = has_src_scale
             ? prb->attr.scales.get_mask(DNNL_ARG_SRC, dnnl_convolution,
-                    src_m.ndims(), prb->has_groups)
+                      src_m.ndims(), prb->has_groups)
             : 0;
     const int wei_scale_mask = has_wei_scale
             ? prb->attr.scales.get_mask(DNNL_ARG_WEIGHTS, dnnl_convolution,
-                    wei_m.ndims(), prb->has_groups)
+                      wei_m.ndims(), prb->has_groups)
             : 0;
     const int dst_scale_mask = has_dst_scale
             ? prb->attr.scales.get_mask(DNNL_ARG_DST, dnnl_convolution,
-                    dst_m.ndims(), prb->has_groups)
+                      dst_m.ndims(), prb->has_groups)
             : 0;
 
     assert(IMPLICATION(
@@ -71,18 +71,18 @@ void compute_ref_direct_fwd(const prb_t *prb, const args_t &args) {
     const bool has_dst_zp = !prb->attr.zero_points.get(DNNL_ARG_DST).is_def();
     const int src_zp_mask = has_src_zp
             ? attr_t::get_default_mask(
-                    prb->attr.zero_points.get(DNNL_ARG_SRC).policy,
-                    src_m.ndims())
+                      prb->attr.zero_points.get(DNNL_ARG_SRC).policy,
+                      src_m.ndims())
             : 0;
     const int wei_zp_mask = has_wei_zp
             ? attr_t::get_default_mask(
-                    prb->attr.zero_points.get(DNNL_ARG_WEIGHTS).policy,
-                    wei_m.ndims())
+                      prb->attr.zero_points.get(DNNL_ARG_WEIGHTS).policy,
+                      wei_m.ndims())
             : 0;
     const int dst_zp_mask = has_dst_zp
             ? attr_t::get_default_mask(
-                    prb->attr.zero_points.get(DNNL_ARG_DST).policy,
-                    dst_m.ndims())
+                      prb->attr.zero_points.get(DNNL_ARG_DST).policy,
+                      dst_m.ndims())
             : 0;
 
     /* help compiler optimize the code */
@@ -311,9 +311,10 @@ void compute_ref_direct_bwd_d(const prb_t *prb, const args_t &args) {
                                 = ((oc * OD + od) * OH + oh) * OW + ow;
                         const int64_t wei_off
                                 = ((oc * ICG * KD + kd) * KH + kh) * KW + kw;
-                        int src_zp = has_src_zp ? src_zps.get_elem(
-                                             src_zp_mask > 0 ? g * OCG + oc : 0)
-                                                : 0;
+                        int src_zp = has_src_zp
+                                ? src_zps.get_elem(
+                                          src_zp_mask > 0 ? g * OCG + oc : 0)
+                                : 0;
                         float diff_dst_val
                                 = (diff_dst_loc[diff_dst_off] - src_zp)
                                 * src_scale;

--- a/tests/benchdnn/deconv/deconv.hpp
+++ b/tests/benchdnn/deconv/deconv.hpp
@@ -121,8 +121,8 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.bia_dt[0], s.stag[0], s.wtag[0],
-                s.dtag[0], s.alg[0], s.mb[0], s.attributes.front(),
-                s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
+                  s.dtag[0], s.alg[0], s.mb[0], s.attributes.front(),
+                  s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/deconv/ref_deconv.cpp
+++ b/tests/benchdnn/deconv/ref_deconv.cpp
@@ -87,9 +87,10 @@ void compute_ref_direct_fwd(const prb_t *prb, const args_t &args) {
                     for (int64_t ic = 0; ic < ICG; ++ic) {
                         int64_t src_off = ((ic * ID + id) * IH + ih) * IW + iw;
                         int64_t wei_off = ((ic * KD + kd) * KH + kh) * KW + kw;
-                        int src_zp = has_src_zp ? src_zps.get_f32_elem(
-                                             src_zp_mask > 0 ? g * ICG + ic : 0)
-                                                : 0;
+                        int src_zp = has_src_zp
+                                ? src_zps.get_f32_elem(
+                                          src_zp_mask > 0 ? g * ICG + ic : 0)
+                                : 0;
                         float s = (src_loc[src_off] - src_zp) * src_scale;
                         float wei_scale = 1.f;
                         if (has_wei_scale)
@@ -123,9 +124,10 @@ void compute_ref_direct_fwd(const prb_t *prb, const args_t &args) {
 
                 maybe_post_ops(prb->attr, conv_res, dst, v_po_vals);
 
-                int dst_zp = has_dst_zp ? dst_zps.get_f32_elem(
-                                     dst_zp_mask > 0 ? g * OCG + oc : 0)
-                                        : 0;
+                int dst_zp = has_dst_zp
+                        ? dst_zps.get_f32_elem(
+                                  dst_zp_mask > 0 ? g * OCG + oc : 0)
+                        : 0;
                 dst = conv_res * dst_scale + dst_zp;
             });
 }
@@ -256,9 +258,10 @@ void compute_ref_direct_bwd_d(const prb_t *prb, const args_t &args) {
                                 = ((oc * OD + od) * OH + oh) * OW + ow;
                         const int64_t wei_off
                                 = ((oc * ICG * KD + kd) * KH + kh) * KW + kw;
-                        int src_zp = has_src_zp ? src_zps.get_f32_elem(
-                                             src_zp_mask > 0 ? g * OCG + oc : 0)
-                                                : 0;
+                        int src_zp = has_src_zp
+                                ? src_zps.get_f32_elem(
+                                          src_zp_mask > 0 ? g * OCG + oc : 0)
+                                : 0;
                         float diff_dst_val
                                 = (diff_dst_loc[diff_dst_off] - src_zp)
                                 * src_scale;
@@ -297,9 +300,10 @@ void compute_ref_direct_bwd_d(const prb_t *prb, const args_t &args) {
 
                 maybe_post_ops(prb->attr, conv_res, ds, v_po_vals);
 
-                int dst_zp = has_dst_zp ? dst_zps.get_f32_elem(
-                                     dst_zp_mask > 0 ? g * ICG + ic : 0)
-                                        : 0;
+                int dst_zp = has_dst_zp
+                        ? dst_zps.get_f32_elem(
+                                  dst_zp_mask > 0 ? g * ICG + ic : 0)
+                        : 0;
                 ds = conv_res * dst_scale + dst_zp;
             });
 }

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -703,8 +703,8 @@ std::vector<std::pair<int, int>> attr_t::post_ops_t::get_po_masks(
             auto mask_input = e.binary.mask_input;
             mask = mask_input == mask_input_t::mask
                     ? e.binary.mask
-                    : policy2mask(
-                            DNNL_ARG_SRC_1, e.binary.policy, ndims, prim_kind);
+                    : policy2mask(DNNL_ARG_SRC_1, e.binary.policy, ndims,
+                              prim_kind);
             arg = DNNL_ARG_SRC_1;
         } else if (e.is_prelu_kind()) {
             mask = attr_t::get_default_mask(e.prelu.policy, ndims);

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -704,8 +704,8 @@ inline int measure_perf_aggregate(timer::timer_t &t,
             int batch_times_heuristic = (ms_min == 0.0)
                     ? INT_MAX
                     : MAX2(1,
-                            (int)((max_ms_per_prb - t.total_ms()) / ms_min
-                                    / 5));
+                              (int)((max_ms_per_prb - t.total_ms()) / ms_min
+                                      / 5));
             cur_batch_times = MIN2(max_batch_times, batch_times_heuristic);
             is_first_loop = false;
         }

--- a/tests/benchdnn/eltwise/eltwise.hpp
+++ b/tests/benchdnn/eltwise/eltwise.hpp
@@ -60,8 +60,8 @@ struct prb_t : public prb_dims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.dir[0], s.dt[0], s.tag[0], s.alg[0], s.alpha[0],
-                s.beta[0], s.mb[0], s.inplace[0], s.attributes.front(),
-                s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
+                  s.beta[0], s.mb[0], s.inplace[0], s.attributes.front(),
+                  s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/gnorm/gnorm.hpp
+++ b/tests/benchdnn/gnorm/gnorm.hpp
@@ -79,8 +79,8 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.flags[0], s.check_alg,
-                s.mb[0], s.inplace[0], s.attributes.front(), s.ctx_init[0],
-                s.ctx_exe[0], s.impl_filter) {
+                  s.mb[0], s.inplace[0], s.attributes.front(), s.ctx_init[0],
+                  s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 
@@ -175,10 +175,10 @@ struct cfg_t {
         , want_flex_bits_(MIN2(6, exact_bits_ / 2))
         , check_alg_(prb->check_alg == bnorm::ALG_AUTO
                           ? (free_bits_ >= min_flex_bits_
-                                          ? bnorm::ALG_1
-                                          : (want_flex_bits_ == exact_bits_ / 2
-                                                          ? bnorm::ALG_2
-                                                          : bnorm::ALG_0))
+                                            ? bnorm::ALG_1
+                                            : (want_flex_bits_ == exact_bits_ / 2
+                                                              ? bnorm::ALG_2
+                                                              : bnorm::ALG_0))
                           : prb->check_alg)
         , flex_bits_(check_alg_ == bnorm::ALG_1 ? MIN2(exact_bits_, free_bits_)
                                                 : want_flex_bits_)

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -184,8 +184,8 @@ inline int measure_perf_aggregate(timer::timer_t &t,
             int batch_times_heuristic = (ms_min == 0.0)
                     ? INT_MAX
                     : MAX2(1,
-                            (int)((max_ms_per_prb - t.total_ms()) / ms_min
-                                    / 5));
+                              (int)((max_ms_per_prb - t.total_ms()) / ms_min
+                                      / 5));
             cur_batch_times = MIN2(max_batch_times, batch_times_heuristic);
             is_first_loop = false;
         }

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -97,7 +97,7 @@ enum { CRIT = 0x001, WARN = 0x002, NEED_CLEANUP = 0x004 };
         try { \
             (f); \
         } catch (const dnnl::error &e) { \
-            if (((s)&CRIT) || ((s)&WARN)) { \
+            if (((s) & CRIT) || ((s) & WARN)) { \
                 bdnn_state_t bs = convert_state(e.status); \
                 (ss)->state = bs.state; \
                 if ((ss)->state == res_state_t::SKIPPED) { \
@@ -117,9 +117,9 @@ enum { CRIT = 0x001, WARN = 0x002, NEED_CLEANUP = 0x004 };
                             __FUNCTION__, __FILE__, __LINE__, e.what()); \
                 } \
                 fflush(0); \
-                if ((s)&CRIT) exit(2); \
+                if ((s) & CRIT) exit(2); \
             } \
-            if (!((s)&NEED_CLEANUP)) return FAIL; \
+            if (!((s) & NEED_CLEANUP)) return FAIL; \
         } \
     } while (0)
 

--- a/tests/benchdnn/ip/ip.hpp
+++ b/tests/benchdnn/ip/ip.hpp
@@ -71,8 +71,8 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.bia_dt[0], s.stag[0], s.wtag[0],
-                s.dtag[0], s.mb[0], s.attributes.front(), s.ctx_init[0],
-                s.ctx_exe[0], s.impl_filter) {
+                  s.dtag[0], s.mb[0], s.attributes.front(), s.ctx_init[0],
+                  s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/lnorm/lnorm.hpp
+++ b/tests/benchdnn/lnorm/lnorm.hpp
@@ -76,9 +76,9 @@ struct prb_t : public prb_dims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.tag[0], s.stat_tag[0], s.ss_dt[0], s.dir[0],
-                s.dt[0], s.flags[0], s.check_alg, s.inplace[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.dt[0], s.flags[0], s.check_alg, s.inplace[0],
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 
@@ -179,10 +179,10 @@ struct cfg_t {
         , want_flex_bits_(MIN2(6, exact_bits_ / 2))
         , check_alg_(prb->check_alg == bnorm::ALG_AUTO
                           ? (free_bits_ >= min_flex_bits_
-                                          ? bnorm::ALG_1
-                                          : (want_flex_bits_ == exact_bits_ / 2
-                                                          ? bnorm::ALG_2
-                                                          : bnorm::ALG_0))
+                                            ? bnorm::ALG_1
+                                            : (want_flex_bits_ == exact_bits_ / 2
+                                                              ? bnorm::ALG_2
+                                                              : bnorm::ALG_0))
                           : prb->check_alg)
         , flex_bits_(check_alg_ == bnorm::ALG_1 ? MIN2(exact_bits_, free_bits_)
                                                 : want_flex_bits_)

--- a/tests/benchdnn/lrn/lrn.hpp
+++ b/tests/benchdnn/lrn/lrn.hpp
@@ -74,8 +74,8 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.alg[0], s.mb[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -68,9 +68,9 @@ struct prb_t : public prb_vdims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.dt[0], s.stag[0], s.wtag[0], s.dtag[0],
-                s.strides[0], s.bia_dt[0], s.bia_mask[0], s.rt_dims_masks[0],
-                s.sparse_options[0], s.attributes.front(), s.ctx_init[0],
-                s.ctx_exe[0], s.impl_filter) {
+                  s.strides[0], s.bia_dt[0], s.bia_mask[0], s.rt_dims_masks[0],
+                  s.sparse_options[0], s.attributes.front(), s.ctx_init[0],
+                  s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/pool/pool.hpp
+++ b/tests/benchdnn/pool/pool.hpp
@@ -111,8 +111,8 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.dt[0], s.tag[0], s.alg[0], s.mb[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/prelu/prelu.hpp
+++ b/tests/benchdnn/prelu/prelu.hpp
@@ -53,8 +53,8 @@ struct prb_t : public prb_vdims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.dir[0], s.sdt[0], s.stag[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/reduction/reduction.hpp
+++ b/tests/benchdnn/reduction/reduction.hpp
@@ -82,8 +82,8 @@ struct prb_t : public prb_vdims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0], s.alg[0],
-                s.p[0], s.eps[0], s.attributes.front(), s.ctx_init[0],
-                s.ctx_exe[0], s.impl_filter) {
+                  s.p[0], s.eps[0], s.attributes.front(), s.ctx_init[0],
+                  s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/reorder/reorder.hpp
+++ b/tests/benchdnn/reorder/reorder.hpp
@@ -83,9 +83,9 @@ struct prb_t : public prb_dims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
-                s.strides[0], s.oflag[0], s.cross_engine[0],
-                s.runtime_dim_mask[0], s.attributes.front(), s.ctx_init[0],
-                s.ctx_exe[0], s.impl_filter) {
+                  s.strides[0], s.oflag[0], s.cross_engine[0],
+                  s.runtime_dim_mask[0], s.attributes.front(), s.ctx_init[0],
+                  s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/resampling/resampling.hpp
+++ b/tests/benchdnn/resampling/resampling.hpp
@@ -85,8 +85,8 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, s.dir[0], s.sdt[0], s.ddt[0], s.tag[0], s.alg[0],
-                s.mb[0], s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.mb[0], s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -280,12 +280,12 @@ struct prb_t : public desc_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.desc, dt_conf_t::create(s.cfg[0], s.attributes.front()),
-                s.tag[0], s.prop[0], s.alg[0], s.with_peephole[0],
-                s.with_projection[0], s.direction[0], s.scale_policy[0],
-                s.scale_proj_policy[0], s.flags[0], s.activation[0], s.alpha,
-                s.beta, s.skip_nonlinear[0], s.trivial_strides[0], s.n_layer[0],
-                s.n_iter[0], s.mb[0], s.attributes.front(), s.ctx_init[0],
-                s.ctx_exe[0], s.impl_filter) {
+                  s.tag[0], s.prop[0], s.alg[0], s.with_peephole[0],
+                  s.with_projection[0], s.direction[0], s.scale_policy[0],
+                  s.scale_proj_policy[0], s.flags[0], s.activation[0], s.alpha,
+                  s.beta, s.skip_nonlinear[0], s.trivial_strides[0],
+                  s.n_layer[0], s.n_iter[0], s.mb[0], s.attributes.front(),
+                  s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 
@@ -412,9 +412,9 @@ struct prb_t : public desc_t {
         return is_lstm()
                 ? 4
                 : (alg == VANILLA_GRU || alg == LBR_GRU || alg == VANILLA_AUGRU
-                                        || alg == LBR_AUGRU
-                                ? 3
-                                : 1);
+                                          || alg == LBR_AUGRU
+                                  ? 3
+                                  : 1);
     }
     int64_t n_bias() const {
         return alg == LBR_GRU || alg == LBR_AUGRU ? n_gates() + 1 : n_gates();

--- a/tests/benchdnn/rnn/rnn_aux.cpp
+++ b/tests/benchdnn/rnn/rnn_aux.cpp
@@ -117,9 +117,7 @@ flags_t str2flags(const char *str) {
     while (str && *str) {
         if (*str == 'O')
             flags |= DIFF_WEIGHTS_OVERWRITE;
-        else {
-            BENCHDNN_PRINT(0, "%s\n", "Error: unsupported flags value.");
-        }
+        else { BENCHDNN_PRINT(0, "%s\n", "Error: unsupported flags value."); }
         str++;
     }
     return flags;

--- a/tests/benchdnn/shuffle/shuffle.hpp
+++ b/tests/benchdnn/shuffle/shuffle.hpp
@@ -61,8 +61,8 @@ struct prb_t : public prb_dims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.dir[0], s.dt[0], s.tag[0], s.axis[0], s.group[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/softmax/softmax.hpp
+++ b/tests/benchdnn/softmax/softmax.hpp
@@ -74,9 +74,9 @@ struct prb_t : public prb_dims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.dir[0], s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
-                s.alg[0], s.axis[0], s.has_stats[0], s.mb[0], s.inplace[0],
-                s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+                  s.alg[0], s.axis[0], s.has_stats[0], s.mb[0], s.inplace[0],
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/sum/sum.hpp
+++ b/tests/benchdnn/sum/sum.hpp
@@ -58,8 +58,8 @@ struct prb_t : public prb_dims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
         : prb_t(s.prb_dims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
-                s.input_scales[0], s.inplace[0], s.attributes.front(),
-                s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
+                  s.input_scales[0], s.inplace[0], s.attributes.front(),
+                  s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -390,9 +390,7 @@ std::ostream &operator<<(std::ostream &s, cold_cache_mode_t cold_cache_mode) {
         s << "all";
     else if (cold_cache_mode == cold_cache_mode_t::custom)
         s << "custom";
-    else {
-        assert(!"unsupported cold cache mode");
-    }
+    else { assert(!"unsupported cold cache mode"); }
     return s;
 }
 

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -407,7 +407,7 @@ static inline data_t set_value(
         const memory::dim in_group = index % group_size;
         const bool fill = in_group == ((group % 1637) % group_size);
         return fill ? static_cast<data_t>(
-                       mean + deviation * sinf(float(index % 37)))
+                              mean + deviation * sinf(float(index % 37)))
                     : data_t {0};
     } else if (data_traits_t<data_t>::data_type == memory::data_type::s32
             || data_traits_t<data_t>::data_type == memory::data_type::s8) {
@@ -684,8 +684,8 @@ bool catch_expected_failures(const F &f, bool expect_to_fail,
             if (ignore_unimplemented && (e.status == dnnl_unimplemented)) {
                 // Print unimplemented but do not treat as error
                 std::cout << "(" << filename << ":" << line_num << ") "
-                          << "[  UNIMPL  ] "
-                          << "Implementation not found" << std::endl;
+                          << "[  UNIMPL  ] " << "Implementation not found"
+                          << std::endl;
                 reset_failed_malloc_counter();
                 return true;
             } else if (test_out_of_memory()

--- a/tests/gtests/dnnl_test_macros.hpp
+++ b/tests/gtests/dnnl_test_macros.hpp
@@ -151,7 +151,9 @@
         void TestBody() override {} \
 \
     public: \
-        DERIVED_TEST_CLASS(test_fixture, test_name)() { SetUp(); } \
+        DERIVED_TEST_CLASS(test_fixture, test_name)() { \
+            SetUp(); \
+        } \
         void Test_failures(); \
     }; \
     TEST_F(test_fixture, test_name) { \
@@ -171,7 +173,9 @@
         void TestBody() override {} \
 \
     public: \
-        DERIVED_TEST_CLASS(test_fixture, test_name)() { SetUp(); } \
+        DERIVED_TEST_CLASS(test_fixture, test_name)() { \
+            SetUp(); \
+        } \
         void Test_failures(); \
     }; \
     TEST_P(test_fixture, test_name) { \

--- a/tests/gtests/graph/api/sycl/test_cpp_api_compiled_partition.cpp
+++ b/tests/gtests/graph/api/sycl/test_cpp_api_compiled_partition.cpp
@@ -75,9 +75,9 @@ TEST(SYCLApi, CompiledPartitionExecute) {
 
     sycl::queue q = (ekind == dnnl::engine::kind::gpu)
             ? sycl::queue(dnnl::impl::xpu::sycl::compat::gpu_selector_v,
-                    sycl::property::queue::in_order {})
+                      sycl::property::queue::in_order {})
             : sycl::queue(dnnl::impl::xpu::sycl::compat::cpu_selector_v,
-                    sycl::property::queue::in_order {});
+                      sycl::property::queue::in_order {});
 
     dnnl::engine eng = sycl_interop::make_engine_with_allocator(
             q.get_device(), q.get_context(), alloc);
@@ -138,9 +138,9 @@ TEST(SYCLApi, CompiledPartitionInteropExecute) {
 
     sycl::queue q = (ekind == dnnl::engine::kind::gpu)
             ? sycl::queue(dnnl::impl::xpu::sycl::compat::gpu_selector_v,
-                    sycl::property::queue::in_order {})
+                      sycl::property::queue::in_order {})
             : sycl::queue(dnnl::impl::xpu::sycl::compat::cpu_selector_v,
-                    sycl::property::queue::in_order {});
+                      sycl::property::queue::in_order {});
 
     dnnl::engine eng = sycl_interop::make_engine_with_allocator(
             q.get_device(), q.get_context(), alloc);

--- a/tests/gtests/graph/api/sycl/test_cpp_api_engine.cpp
+++ b/tests/gtests/graph/api/sycl/test_cpp_api_engine.cpp
@@ -37,9 +37,9 @@ TEST(SYCLApi, Engine) {
 
     queue q = (ekind == dnnl::engine::kind::gpu)
             ? queue(dnnl::impl::xpu::sycl::compat::gpu_selector_v,
-                    property::queue::in_order {})
+                      property::queue::in_order {})
             : queue(dnnl::impl::xpu::sycl::compat::cpu_selector_v,
-                    property::queue::in_order {});
+                      property::queue::in_order {});
 
     allocator alloc = dnnl::graph::sycl_interop::make_allocator(
             dnnl::graph::testing::sycl_malloc_wrapper,

--- a/tests/gtests/graph/api/test_api_common.hpp
+++ b/tests/gtests/graph/api/test_api_common.hpp
@@ -167,7 +167,7 @@ dnnl::engine &cpp_api_test_dnnl_engine_create(dnnl::engine::kind engine_kind);
 inline dnnl_dim_t product(const std::vector<int64_t> &dims) {
     return dims.empty() ? 0
                         : std::accumulate(dims.begin(), dims.end(),
-                                (dnnl_dim_t)1, std::multiplies<dnnl_dim_t>());
+                                  (dnnl_dim_t)1, std::multiplies<dnnl_dim_t>());
 }
 
 #endif

--- a/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
@@ -2827,11 +2827,11 @@ TEST(test_convolution_execute_subgraph_int8, Conv1dConv2dConv3d) {
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {out_channel, in_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {out_channel, in_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {out_channel, in_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 10}
@@ -3862,11 +3862,11 @@ TEST(test_convolution_execute_subgraph_int8, Conv1d2d3dX8s8f32) {
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {out_channel, in_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {out_channel, in_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {out_channel, in_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 10}

--- a/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
@@ -768,9 +768,9 @@ TEST(test_convtranspose_operator_kernel, convtranspose_relu) {
         std::vector<float> bias_data = {2.0};
         std::vector<float> ref_dst_data = with_bias
                 ? std::vector<float> {1.0, 4.5, 1.0, 4.5, 7.0, 2.5, 9.5, 3.5,
-                        1.0, 9.5, 2.5, 4.5, 7.0, 3.5, 7.0, 3.5}
+                          1.0, 9.5, 2.5, 4.5, 7.0, 3.5, 7.0, 3.5}
                 : std::vector<float> {0.0, 2.5, 0.0, 2.5, 5.0, 0.5, 7.5, 1.5,
-                        0.0, 7.5, 0.5, 2.5, 5.0, 1.5, 5.0, 1.5};
+                          0.0, 7.5, 0.5, 2.5, 5.0, 1.5, 5.0, 1.5};
         std::vector<float> dst_data(ref_dst_data.size(), 0.0);
 
         graph::op_t convtranspose_op(
@@ -1253,11 +1253,11 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3d) {
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {in_channel, out_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {in_channel, out_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {in_channel, out_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 14}
@@ -1473,11 +1473,11 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose2dEltwise_CPU) {
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {in_channel, out_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {in_channel, out_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {in_channel, out_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 14}
@@ -1714,11 +1714,11 @@ TEST(test_convtranspose_execute_subgraph_int8,
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {in_channel, out_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {in_channel, out_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {in_channel, out_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 14}
@@ -2079,11 +2079,11 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3dAdd) {
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {in_channel, out_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {in_channel, out_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {in_channel, out_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 14}
@@ -2329,11 +2329,11 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3dBinary) {
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {in_channel, out_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {in_channel, out_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {in_channel, out_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 14}
@@ -2531,11 +2531,11 @@ TEST(test_convtranspose_execute_subgraph_int8,
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {in_channel, out_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {in_channel, out_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {in_channel, out_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 14}
@@ -2788,11 +2788,11 @@ TEST(test_convtranspose_execute_subgraph_fp32, Convtranspose3Postops) {
                           : std::vector<int64_t> {1, in_channel, 12, 12, 12};
         std::vector<int64_t> weight_shape = nd == 1
                 ? std::vector<int64_t> {in_channel, out_channel / g,
-                        kernel_size}
+                          kernel_size}
                 : nd == 2 ? std::vector<int64_t> {in_channel, out_channel / g,
-                          kernel_size, kernel_size}
+                                    kernel_size, kernel_size}
                           : std::vector<int64_t> {in_channel, out_channel / g,
-                                  kernel_size, kernel_size, kernel_size};
+                                    kernel_size, kernel_size, kernel_size};
         std::vector<int64_t> bias_shape {out_channel};
         std::vector<int64_t> dst_shape = nd == 1
                 ? std::vector<int64_t> {1, out_channel, 14}

--- a/tests/gtests/graph/unit/backend/dnnl/test_pass.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_pass.cpp
@@ -5124,9 +5124,7 @@ TEST(test_pass, InputJsonIsInvalidWithIncompleteHash) {
             + std::to_string(dnnl_version()->patch);
     invalid_stream << "{\n"
                    << "\"version\": \"" << version << "\",\n"
-                   << "\"hash\": \""
-                   << "aninvalidcommitid"
-                   << "\",\n"
+                   << "\"hash\": \"" << "aninvalidcommitid" << "\",\n"
                    << "\"passes\": [\n"
                    << "  {\n"
                    << "  \"pass_name\": \"conv_pass\",\n"

--- a/tests/gtests/graph/unit/interface/sycl/test_allocator.cpp
+++ b/tests/gtests/graph/unit/interface/sycl/test_allocator.cpp
@@ -34,9 +34,9 @@ TEST(test_interface_allocator, DefaultSyclAllocator) {
     graph::allocator_t *alloc = new graph::allocator_t();
     sycl::queue q = kind == graph::engine_kind::gpu
             ? sycl::queue {dnnl::impl::xpu::sycl::compat::gpu_selector_v,
-                    sycl::property::queue::in_order {}}
+                      sycl::property::queue::in_order {}}
             : sycl::queue {dnnl::impl::xpu::sycl::compat::cpu_selector_v,
-                    sycl::property::queue::in_order {}};
+                      sycl::property::queue::in_order {}};
 
     graph::allocator_t::mem_attr_t attr {
             graph::allocator_t::mem_type_t::persistent, 64};

--- a/tests/gtests/graph/unit/utils.hpp
+++ b/tests/gtests/graph/unit/utils.hpp
@@ -707,7 +707,7 @@ static inline void verify_two_ins_identity_shape_infer(
 inline dnnl_dim_t product(const std::vector<int64_t> &dims) {
     return dims.empty() ? 0
                         : std::accumulate(dims.begin(), dims.end(),
-                                (dnnl_dim_t)1, std::multiplies<dnnl_dim_t>());
+                                  (dnnl_dim_t)1, std::multiplies<dnnl_dim_t>());
 }
 
 inline void construct_f32_MHA(dnnl::impl::graph::graph_t *agraph,

--- a/tests/gtests/in/layer_normalization.h
+++ b/tests/gtests/in/layer_normalization.h
@@ -52,10 +52,14 @@
     }
 
 #define PARAMS_EF(...) \
-    test_lnorm_params_t { EXPAND_FORMATS(abc, ab, abc), __VA_ARGS__ }
+    test_lnorm_params_t { \
+        EXPAND_FORMATS(abc, ab, abc), __VA_ARGS__ \
+    }
 
 #define PARAMS_ANY_EF(...) \
-    test_lnorm_params_t { EXPAND_FORMATS(any, ab, abc), __VA_ARGS__ }
+    test_lnorm_params_t { \
+        EXPAND_FORMATS(any, ab, abc), __VA_ARGS__ \
+    }
 
 #define CPU_INST_TEST_CASE(str, ...) \
     CPU_INSTANTIATE_TEST_SUITE_P( \

--- a/tests/gtests/internals/test_sdpa.cpp
+++ b/tests/gtests/internals/test_sdpa.cpp
@@ -1153,9 +1153,9 @@ void prim_sdpa_quant(const sdpa_dims_t &p, const sdpa_tensors_t &t,
     }
     auto bmm1_pd = is_kq_acc_f16
             ? matmul::primitive_desc(eng, grouped_query_md,
-                    key_dequantized.get_desc(), score_f16_md, bmm1_attr)
+                      key_dequantized.get_desc(), score_f16_md, bmm1_attr)
             : matmul::primitive_desc(eng, grouped_query_md,
-                    key_dequantized.get_desc(), score_md, bmm1_attr);
+                      key_dequantized.get_desc(), score_md, bmm1_attr);
     auto bmm1_prim = matmul(bmm1_pd);
 
     // reorder primitive to convert f16 to f32 after bmm1
@@ -1214,9 +1214,9 @@ void prim_sdpa_quant(const sdpa_dims_t &p, const sdpa_tensors_t &t,
     // matmul primitive for VS
     auto bmm2_pd = is_vs_acc_f16
             ? matmul::primitive_desc(eng, score_f16_md, grouped_value_md,
-                    grouped_output_f16_md, bmm2_attr)
+                      grouped_output_f16_md, bmm2_attr)
             : matmul::primitive_desc(eng, score_md, grouped_value_md,
-                    grouped_query_md, bmm2_attr);
+                      grouped_query_md, bmm2_attr);
     auto bmm2_prim = matmul(bmm2_pd);
 
     // reorder primitive to convert f16 to f32 after bmm2
@@ -1432,7 +1432,7 @@ public:
 
     byte_t(memory::data_type dt)
         : value(dnnl_data_type_size((dnnl_data_type_t)dt)
-                / ((dt == mdt::s4 || dt == mdt::u4) ? 2.f : 1.f)) {}
+                  / ((dt == mdt::s4 || dt == mdt::u4) ? 2.f : 1.f)) {}
 
     template <typename OR>
     byte_t(byte_t<OR> o) : value(magnitude_cast<Unit>(o).value) {}

--- a/tests/gtests/internals/test_utils.cpp
+++ b/tests/gtests/internals/test_utils.cpp
@@ -19,9 +19,10 @@ using dnnl::memory;
 using mdt = memory::data_type;
 
 memory::dim product(const std::vector<int64_t> &dims) {
-    return dims.empty() ? 0
-                        : std::accumulate(dims.begin(), dims.end(),
-                                (memory::dim)1, std::multiplies<memory::dim>());
+    return dims.empty()
+            ? 0
+            : std::accumulate(dims.begin(), dims.end(), (memory::dim)1,
+                      std::multiplies<memory::dim>());
 }
 
 std::random_device &get_random_device() {

--- a/tests/gtests/test_convolution_backward_data_common.hpp
+++ b/tests/gtests/test_convolution_backward_data_common.hpp
@@ -70,9 +70,9 @@ void compute_ref_conv_bwd_data(const test_convolution_sizes_t &c,
                                         + oc * padded_ic / c.ng * c.kh * c.kw
                                         + ic * c.kh * c.kw + kh * c.kw + kw;
 
-                                a += (data_t_acc)(
-                                        diff_dst_data[diff_dst_mdw.off_l(
-                                                didx, true)]
+                                a += (data_t_acc)(diff_dst_data
+                                                          [diff_dst_mdw.off_l(
+                                                                  didx, true)]
                                         * weights_data[weights_mdw.off_l(
                                                 widx, true)]);
                             }
@@ -231,9 +231,9 @@ protected:
                 data_type_diff_src, p.formats.src_format);
         auto c_weights_desc = cd.ng > 1
                 ? create_md({cd.ng, cd.oc / cd.ng, cd.ic / cd.ng, cd.kh, cd.kw},
-                        data_type_wei, p.formats.weights_format)
+                          data_type_wei, p.formats.weights_format)
                 : create_md({cd.oc, cd.ic, cd.kh, cd.kw}, data_type_wei,
-                        p.formats.weights_format);
+                          p.formats.weights_format);
         auto c_dst_desc = create_md({cd.mb, cd.oc, cd.oh, cd.ow},
                 data_type_diff_dst, p.formats.dst_format);
         auto c_src_desc_f = create_md({cd.mb, cd.ic, cd.ih, cd.iw},

--- a/tests/gtests/test_convolution_backward_weights_common.hpp
+++ b/tests/gtests/test_convolution_backward_weights_common.hpp
@@ -275,18 +275,18 @@ protected:
                 p.formats.src_format);
         auto c_diff_weights_desc = cd.ng > 1
                 ? create_md({cd.ng, cd.oc / cd.ng, cd.ic / cd.ng, cd.kh, cd.kw},
-                        data_type_diff_weights, p.formats.weights_format)
+                          data_type_diff_weights, p.formats.weights_format)
                 : create_md({cd.oc, cd.ic, cd.kh, cd.kw},
-                        data_type_diff_weights, p.formats.weights_format);
+                          data_type_diff_weights, p.formats.weights_format);
         auto c_diff_bias_desc = create_md(
                 {cd.oc}, data_type_diff_bias, p.formats.bias_format);
         auto c_diff_dst_desc = create_md({cd.mb, cd.oc, cd.oh, cd.ow},
                 data_type_diff_dst, p.formats.dst_format);
         auto c_weights_desc_f = cd.ng > 1
                 ? create_md({cd.ng, cd.oc / cd.ng, cd.ic / cd.ng, cd.kh, cd.kw},
-                        data_type_diff_dst, p.formats.weights_format)
+                          data_type_diff_dst, p.formats.weights_format)
                 : create_md({cd.oc, cd.ic, cd.kh, cd.kw}, data_type_diff_dst,
-                        p.formats.weights_format);
+                          p.formats.weights_format);
         auto c_dst_desc_f = create_md({cd.mb, cd.oc, cd.oh, cd.ow},
                 data_type_diff_weights, p.formats.dst_format);
         auto c_src = test_memory(c_src_desc, eng);

--- a/tests/gtests/test_convolution_eltwise_forward_common.hpp
+++ b/tests/gtests/test_convolution_eltwise_forward_common.hpp
@@ -257,9 +257,9 @@ protected:
                 p.formats.src_format);
         auto c_weights_desc = cd.ng > 1
                 ? create_md({cd.ng, cd.oc / cd.ng, cd.ic / cd.ng, cd.kh, cd.kw},
-                        data_type_wei, p.formats.weights_format)
+                          data_type_wei, p.formats.weights_format)
                 : create_md({cd.oc, cd.ic, cd.kh, cd.kw}, data_type_wei,
-                        p.formats.weights_format);
+                          p.formats.weights_format);
         auto c_dst_desc = create_md({cd.mb, cd.oc, cd.oh, cd.ow}, data_type_dst,
                 p.formats.dst_format);
 
@@ -317,13 +317,13 @@ protected:
 
         auto conv_primitive_desc = with_bias
                 ? convolution_forward::primitive_desc(eng,
-                        prop_kind::forward_inference, p.aalgorithm, c_src_desc,
-                        c_weights_desc, c_bias_desc, c_dst_desc, strides,
-                        dilations, padL, padR, attr)
+                          prop_kind::forward_inference, p.aalgorithm,
+                          c_src_desc, c_weights_desc, c_bias_desc, c_dst_desc,
+                          strides, dilations, padL, padR, attr)
                 : convolution_forward::primitive_desc(eng,
-                        prop_kind::forward_inference, p.aalgorithm, c_src_desc,
-                        c_weights_desc, c_dst_desc, strides, dilations, padL,
-                        padR, attr);
+                          prop_kind::forward_inference, p.aalgorithm,
+                          c_src_desc, c_weights_desc, c_dst_desc, strides,
+                          dilations, padL, padR, attr);
 
         ASSERT_EQ(conv_primitive_desc.get_algorithm(), p.aalgorithm);
         ASSERT_EQ(conv_primitive_desc.get_prop_kind(),

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -74,7 +74,7 @@ protected:
                 = create_md({cd.mb, cd.ic, cd.ih, cd.iw}, data_type, tag::any);
         auto c_weights_desc = cd.ng > 1
                 ? create_md({cd.ng, cd.oc / cd.ng, cd.ic / cd.ng, cd.kh, cd.kw},
-                        data_type, tag::any)
+                          data_type, tag::any)
                 : create_md({cd.oc, cd.ic, cd.kh, cd.kw}, data_type, tag::any);
         auto c_dst_desc
                 = create_md({cd.mb, cd.oc, cd.oh, cd.ow}, data_type, tag::any);

--- a/tests/gtests/test_convolution_forward_common.hpp
+++ b/tests/gtests/test_convolution_forward_common.hpp
@@ -92,7 +92,7 @@ void compute_ref_conv_fwd(const test_convolution_sizes_t &c,
                 }
 
                 a_fp += (float)(bias_data ? bias_data[bias_mdw.off_l(
-                                        g * c.oc / c.ng + oc, true)]
+                                                    g * c.oc / c.ng + oc, true)]
                                           : 0);
 
                 if (attr.dst_scale.is_def()) {
@@ -239,9 +239,9 @@ protected:
                 p.formats.src_format);
         auto c_weights_desc = cd.ng > 1
                 ? create_md({cd.ng, cd.oc / cd.ng, cd.ic / cd.ng, cd.kh, cd.kw},
-                        data_type_wei, p.formats.weights_format)
+                          data_type_wei, p.formats.weights_format)
                 : create_md({cd.oc, cd.ic, cd.kh, cd.kw}, data_type_wei,
-                        p.formats.weights_format);
+                          p.formats.weights_format);
         auto c_dst_desc = create_md({cd.mb, cd.oc, cd.oh, cd.ow}, data_type_dst,
                 p.formats.dst_format);
         auto c_bias_desc = with_bias
@@ -302,12 +302,12 @@ protected:
 
         auto conv_primitive_desc = with_bias
                 ? convolution_forward::primitive_desc(eng, aprop_kind,
-                        p.aalgorithm, c_src_desc, c_weights_desc, c_bias_desc,
-                        c_dst_desc, strides, dilations, padL, padR,
-                        attr.dnnl_attr)
+                          p.aalgorithm, c_src_desc, c_weights_desc, c_bias_desc,
+                          c_dst_desc, strides, dilations, padL, padR,
+                          attr.dnnl_attr)
                 : convolution_forward::primitive_desc(eng, aprop_kind,
-                        p.aalgorithm, c_src_desc, c_weights_desc, c_dst_desc,
-                        strides, dilations, padL, padR, attr.dnnl_attr);
+                          p.aalgorithm, c_src_desc, c_weights_desc, c_dst_desc,
+                          strides, dilations, padL, padR, attr.dnnl_attr);
 
         conv_primitive_desc = convolution_forward::primitive_desc(
                 conv_primitive_desc.get()); // test construction from a C pd

--- a/tests/gtests/test_deconvolution.cpp
+++ b/tests/gtests/test_deconvolution.cpp
@@ -303,11 +303,11 @@ protected:
         transpose_wei<data_t>(dd, weights->get(), weights_tr);
         auto deconv_primitive_desc = with_bias
                 ? pd_t(eng, aprop_kind, algorithm::deconvolution_direct,
-                        *dec_src_desc, *dec_weights_desc, *dec_bias_desc,
-                        *dec_dst_desc, strides, padL, padR)
+                          *dec_src_desc, *dec_weights_desc, *dec_bias_desc,
+                          *dec_dst_desc, strides, padL, padR)
                 : pd_t(eng, aprop_kind, algorithm::deconvolution_direct,
-                        *dec_src_desc, *dec_weights_desc, *dec_dst_desc,
-                        strides, padL, padR);
+                          *dec_src_desc, *dec_weights_desc, *dec_dst_desc,
+                          strides, padL, padR);
 
         allows_attr_t aa {};
 

--- a/tests/gtests/test_inner_product_backward_data.cpp
+++ b/tests/gtests/test_inner_product_backward_data.cpp
@@ -235,11 +235,17 @@ using inner_product_test_float = inner_product_test_bwd_data_t<float>;
 using inprod_test_params_float = inprod_test_params_t;
 
 #define EXPAND_SIZES_3D(...) \
-    5, { __VA_ARGS__ }
+    5, { \
+        __VA_ARGS__ \
+    }
 #define EXPAND_SIZES_2D(mb, ic, oc, kh, kw) \
-    4, { mb, ic, oc, 1, kh, kw }
+    4, { \
+        mb, ic, oc, 1, kh, kw \
+    }
 #define EXPAND_SIZES_1D(mb, ic, oc, kw) \
-    3, { mb, ic, oc, 1, 1, kw }
+    3, { \
+        mb, ic, oc, 1, 1, kw \
+    }
 
 TEST_P(inner_product_test_float, TestsInnerProduct) {}
 

--- a/tests/gtests/test_inner_product_backward_weights.cpp
+++ b/tests/gtests/test_inner_product_backward_weights.cpp
@@ -222,11 +222,11 @@ protected:
         // Create inner product backward
         auto ip_primitive_desc = with_bias
                 ? inner_product_backward_weights::primitive_desc(eng,
-                        ip_src_desc, ip_diff_weights_desc, ip_diff_bias_desc,
-                        ip_diff_dst_desc, ip_fwd_pdesc)
+                          ip_src_desc, ip_diff_weights_desc, ip_diff_bias_desc,
+                          ip_diff_dst_desc, ip_fwd_pdesc)
                 : inner_product_backward_weights::primitive_desc(eng,
-                        ip_src_desc, ip_diff_weights_desc, ip_diff_dst_desc,
-                        ip_fwd_pdesc);
+                          ip_src_desc, ip_diff_weights_desc, ip_diff_dst_desc,
+                          ip_fwd_pdesc);
 
         allows_attr_t aa {}; // doesn't support anything
         test_bwd_pd_constructors<pd_t, hint_pd_t>(ip_primitive_desc,
@@ -297,11 +297,17 @@ using inner_product_test_float = inner_product_test_bwd_weights_t<float>;
 using inprod_test_params_float = inprod_test_params_t;
 
 #define EXPAND_SIZES_3D(...) \
-    5, { __VA_ARGS__ }
+    5, { \
+        __VA_ARGS__ \
+    }
 #define EXPAND_SIZES_2D(mb, ic, oc, kh, kw) \
-    4, { mb, ic, oc, 1, kh, kw }
+    4, { \
+        mb, ic, oc, 1, kh, kw \
+    }
 #define EXPAND_SIZES_1D(mb, ic, oc, kw) \
-    3, { mb, ic, oc, 1, 1, kw }
+    3, { \
+        mb, ic, oc, 1, 1, kw \
+    }
 
 TEST_P(inner_product_test_float, TestsInnerProduct) {}
 

--- a/tests/gtests/test_inner_product_forward.cpp
+++ b/tests/gtests/test_inner_product_forward.cpp
@@ -173,9 +173,9 @@ protected:
 
         auto ip_primitive_desc = with_bias
                 ? pd_t(eng, p.aprop_kind, ip_src_desc, ip_weights_desc,
-                        ip_bias_desc, ip_dst_desc)
+                          ip_bias_desc, ip_dst_desc)
                 : pd_t(eng, p.aprop_kind, ip_src_desc, ip_weights_desc,
-                        ip_dst_desc);
+                          ip_dst_desc);
 
         allows_attr_t aa {};
         aa.po_eltwise = true;
@@ -242,11 +242,17 @@ using inner_product_test_float = inner_product_test_t<float>;
 using inprod_test_params_float = inprod_test_params_t;
 
 #define EXPAND_SIZES_3D(...) \
-    5, { __VA_ARGS__ }
+    5, { \
+        __VA_ARGS__ \
+    }
 #define EXPAND_SIZES_2D(mb, ic, oc, kh, kw) \
-    4, { mb, ic, oc, 1, kh, kw }
+    4, { \
+        mb, ic, oc, 1, kh, kw \
+    }
 #define EXPAND_SIZES_1D(mb, ic, oc, kw) \
-    3, { mb, ic, oc, 1, 1, kw }
+    3, { \
+        mb, ic, oc, 1, 1, kw \
+    }
 
 TEST_P(inner_product_test_float, TestsInnerProduct) {}
 

--- a/tests/gtests/test_layer_normalization.cpp
+++ b/tests/gtests/test_layer_normalization.cpp
@@ -460,7 +460,9 @@ private:
 #define TAGS_cLDSNC EXPAND_FORMATS(abcde, acdb, abcde)
 
 #define LNORM_TEST_CASE(...) \
-    test_lnorm_params_t { __VA_ARGS__, false, dnnl_success }
+    test_lnorm_params_t { \
+        __VA_ARGS__, false, dnnl_success \
+    }
 
 static auto expected_failure_cases = []() {
     // clang-format off

--- a/tests/gtests/test_pooling_backward.cpp
+++ b/tests/gtests/test_pooling_backward.cpp
@@ -254,7 +254,9 @@ using pooling_bwd_test_float = pooling_bwd_test_t<float>;
 using pool_bwd_test_params_float = pool_bwd_test_params_t;
 
 #define EXPAND_SIZES_3D(...) \
-    5, { __VA_ARGS__ }
+    5, { \
+        __VA_ARGS__ \
+    }
 #define EXPAND_SIZES_2D( \
         mb, ic, ih, iw, oh, ow, kh, kw, dh, dw, padt, padl, strh, strw) \
     4, { \

--- a/tests/gtests/test_pooling_forward.cpp
+++ b/tests/gtests/test_pooling_forward.cpp
@@ -282,14 +282,14 @@ protected:
         test_pool_desc_t pd = p.test_pd;
         auto p_src_desc = (p.ndims == 5)
                 ? create_md({pd.mb, pd.c, pd.id, pd.ih, pd.iw}, data_type,
-                        p.src_format)
+                          p.src_format)
                 : create_md(
-                        {pd.mb, pd.c, pd.ih, pd.iw}, data_type, p.src_format);
+                          {pd.mb, pd.c, pd.ih, pd.iw}, data_type, p.src_format);
         auto p_dst_desc = (p.ndims == 5)
                 ? create_md({pd.mb, pd.c, pd.od, pd.oh, pd.ow}, data_type,
-                        p.dst_format)
+                          p.dst_format)
                 : create_md(
-                        {pd.mb, pd.c, pd.oh, pd.ow}, data_type, p.dst_format);
+                          {pd.mb, pd.c, pd.oh, pd.ow}, data_type, p.dst_format);
 
         if (p.ndims == 5) {
             strides = memory::dims({pd.strd, pd.strh, pd.strw});
@@ -374,7 +374,9 @@ using pool_test_params_float = pool_test_params_t;
 
 // sizes with explicit opposite side paddings
 #define EXPAND_SIZES_3D_XPADD(...) \
-    5, { __VA_ARGS__ }
+    5, { \
+        __VA_ARGS__ \
+    }
 
 #define EXPAND_SIZES_3D(mb, ic, id, ih, iw, od, oh, ow, kd, kh, kw, dd, dh, \
         dw, padf, padt, padl, strd, strh, strw) \

--- a/tests/gtests/test_resampling.cpp
+++ b/tests/gtests/test_resampling.cpp
@@ -388,11 +388,17 @@ protected:
 using resampling_test_float = resampling_test_t<float>;
 
 #define EXPAND_SIZES_3D(...) \
-    5, { __VA_ARGS__ }
+    5, { \
+        __VA_ARGS__ \
+    }
 #define EXPAND_SIZES_2D(mb, c, ih, iw, oh, ow, fh, fw) \
-    4, { mb, c, 1, ih, iw, 1, oh, ow, 1.f, fh, fw }
+    4, { \
+        mb, c, 1, ih, iw, 1, oh, ow, 1.f, fh, fw \
+    }
 #define EXPAND_SIZES_1D(mb, c, iw, ow, fw) \
-    3, { mb, c, 1, 1, iw, 1, 1, ow, 1.f, 1.f, fw }
+    3, { \
+        mb, c, 1, 1, iw, 1, 1, ow, 1.f, 1.f, fw \
+    }
 
 TEST_P(resampling_test_float, TestsResampleF32) {}
 

--- a/tests/gtests/test_rnn_forward.cpp
+++ b/tests/gtests/test_rnn_forward.cpp
@@ -257,11 +257,11 @@ protected:
                 {weights_iter_dims}, prec, p.fmts.weights_iter_fmt);
         auto weights_peephole_md_tgt = is_lstm_peephole
                 ? memory::desc({weights_peephole_dims}, prec,
-                        p.fmts.weights_peephole_fmt)
+                          p.fmts.weights_peephole_fmt)
                 : memory::desc();
         auto weights_projection_md_tgt = is_lstm_projection
                 ? memory::desc({weights_projection_dims}, prec,
-                        p.fmts.weights_projection_fmt)
+                          p.fmts.weights_projection_fmt)
                 : memory::desc();
         auto bias_md_tgt = memory::desc({bias_dims}, prec, p.fmts.bias_fmt);
         auto src_layer_md_tgt

--- a/tests/test_thread.hpp
+++ b/tests/test_thread.hpp
@@ -184,8 +184,8 @@ struct scoped_tp_deactivation_t {
 
 #define RUN_IN_THR_CTX(name) \
     template <typename F, typename... Args_t> \
-    auto name(const thr_ctx_t &ctx, F &&f, Args_t &...args) \
-            ->decltype(f(args...)) { \
+    auto name(const thr_ctx_t &ctx, F &&f, \
+            Args_t &...args) -> decltype(f(args...)) { \
 \
         THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type \
                         && ctx.max_concurrency \
@@ -206,8 +206,8 @@ RUN_IN_THR_CTX(execute_in_thr_ctx)
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
 #define RUN_IN_THR_CTX(name) \
     template <typename F, typename... Args_t> \
-    auto name(const thr_ctx_t &ctx, F &&f, Args_t &...args) \
-            ->decltype(f(args...)) { \
+    auto name(const thr_ctx_t &ctx, F &&f, \
+            Args_t &...args) -> decltype(f(args...)) { \
 \
         THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type, \
                 "core type %d is not supported for OMP runtime\n", \
@@ -264,8 +264,8 @@ struct params_pack_helper_t<0, R> {
 #include "oneapi/tbb/info.h"
 #define RUN_IN_THR_CTX(name) \
     template <typename F, typename... Args_t> \
-    auto name(const thr_ctx_t &ctx, F &&f, Args_t &...args) \
-            ->decltype(f(args...)) { \
+    auto name(const thr_ctx_t &ctx, F &&f, \
+            Args_t &...args) -> decltype(f(args...)) { \
         static auto core_types = tbb::info:: \
                 core_types(); /* sorted by the relative strength       */ \
 \
@@ -298,8 +298,8 @@ RUN_IN_THR_CTX(execute_in_thr_ctx)
 
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 template <typename F, typename... Args_t>
-auto create_in_thr_ctx(const thr_ctx_t &ctx, F &&f, Args_t &...args)
-        -> decltype(f(args...)) {
+auto create_in_thr_ctx(
+        const thr_ctx_t &ctx, F &&f, Args_t &...args) -> decltype(f(args...)) {
     THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type,
             "core type %d is not supported for TP runtime\n", ctx.core_type);
 
@@ -310,8 +310,8 @@ auto create_in_thr_ctx(const thr_ctx_t &ctx, F &&f, Args_t &...args)
 
 // The function f shall take an interop obj as last argument
 template <typename F, typename... Args_t>
-auto execute_in_thr_ctx(const thr_ctx_t &ctx, F &&f, Args_t &...args)
-        -> decltype(f(args...)) {
+auto execute_in_thr_ctx(
+        const thr_ctx_t &ctx, F &&f, Args_t &...args) -> decltype(f(args...)) {
     THR_CTX_ASSERT(ctx.core_type == default_thr_ctx.core_type,
             "core type %d is not supported for TP runtime\n", ctx.core_type);
     return f(args...);


### PR DESCRIPTION
PR updates a clang-format binary in automation checks from v11 to v18 and applies all the changes it invokes.

Two motivation points:
1) Decrease the pressure on the community by searching for an obsolete clang-format binary (as they are not entirely compatible starting from clang-format-14).
2) Introduce `LambdaBodyIndentation : OuterScope` to align lambda code on a fixed number of spaces and not move it every time a lambda declaration changes (like number of argument increases, etc.). This introduction will happen in a separate PR.

Couple notes on changes that might be considered as "bad":
1) It updated the way to count indentation in conditions. Used to start counting from `?` and `:`, now it from the following statement, or just adds two more spaces.
2) there are some updates to pure virtual functions and default template values, it's because they addressed the issue with `BreakBeforeBinaryOperators` which didn't consider those cases as relevant, now it does. It's possible to update it back by setting a value of `BreakBeforeBinaryOperators` from `All` to `NonAssignment`, meaning that all `=` changes will stop breaking on a new line, but that to be discussed and applied as a separate change if agreed on.
3) There're some changes to the macro bodies which declare/define functions/methods when the type is not considered as `const T &obj`  but instead as a binary operator `const T & obj`. I was not able to fight it back. If somebody has some time and expertise to do that, be my guest.
4) Some
```
if (c) statement
else {
    statement
}
```
were converted into
```
if (c) statement
else { statement }
```
which might be addressed in the future version with the current config values, or can be adjusted by changing the code (adding braces for `if`) or by changing settings (no short statements) but the latter has a big impact on the codebase.