### PR TITLE
third_party: ngen: restore PVC WAR bug workaround

### DIFF
--- a/third_party/ngen/ngen_auto_swsb.hpp
+++ b/third_party/ngen/ngen_auto_swsb.hpp
@@ -2229,7 +2229,7 @@ inline void analyze(HW hw, int tokens, Program &program, BasicBlock &bb, int pha
                     // Alter SWSB with any workarounds for PVC WAR dependencies.
                     // Note these alterations do not affect the dependency tables.
                     auto inumSync = (inumChain >= 0) ? inumChain : inum;
-                    if ((tokenMaskDst & pww.dep.tokenMaskDst) == pww.dep.tokenMaskDst)
+                    if ((tokenMaskDst & pww.dep.tokenMaskSrc) == pww.dep.tokenMaskSrc)
                         pww.strategy = PVCWARWA::None;
                     auto depTokenMask = pww.dep.tokenMaskSrc | pww.dep.tokenMaskDst;
                     switch (pww.strategy) {


### PR DESCRIPTION
Jira: [MFDNN-14449](https://jira.devtools.intel.com/browse/MFDNN-14449)
Introduced with nGEN update in https://github.com/uxlfoundation/oneDNN/pull/3770.
Thanks to @petercad for help with investigation.