### PR TITLE
Add @mzhukova and @dzarukin as code owners for doc component.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,8 +43,8 @@
 /src/graph/ @uxlfoundation/onednn-graph
 
 # Documentation
-*.md  @uxlfoundation/onednn-doc @uxlfoundation/onednn-arch
-/doc/ @uxlfoundation/onednn-doc @uxlfoundation/onednn-arch
+*.md  @uxlfoundation/onednn-doc
+/doc/ @uxlfoundation/onednn-doc
 
 # Third party components
 /third-party/ @uxlfoundation/onednn-arch

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -236,6 +236,7 @@ Team: @uxlfoundation/onednn-doc
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
+| Dmitry Zarukin     | @dzarukin             | Intel Corporation | Code Owner |
 | Maria Zhukova      | @mzhukova             | Intel Corporation | Code Owner |
 | Ranu Kundu         | @ranukund             | Intel Corporation | Code Owner |
 | Tao Lv             | @TaoLv                | Intel Corporation | Code Owner |


### PR DESCRIPTION
I would like to nominate @mzhukova and @dzarukin as code owners for doc component. Both have a history of material contributions to oneDNN documentation:
* @mzhukova: [PR list](https://github.com/uxlfoundation/oneDNN/pulls?q=author%3Amzhukova+is%3Aclosed+label%3Adocumentation)
* @dzarukin: [PR list](https://github.com/uxlfoundation/oneDNN/pulls?q=author%3Adzarukin+is%3Aclosed+label%3Adocumentation)
