### PR TITLE
src: common: disable groups with common scale at API

### DIFF
--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -610,6 +610,8 @@ status_t dnnl_primitive_attr_set_scales_v3(primitive_attr_t *attr, int arg,
         VCHECK_ATTR(mask >= 0, VERBOSE_BAD_PARAM, "mask");
         VCHECK_ATTR(group_ndims >= 0, VERBOSE_BAD_PARAM, "group_ndims");
     }
+    VCHECK_ATTR(IMPLICATION(group_ndims > 0, mask > 0), VERBOSE_BAD_PARAM,
+            "mask incompatible with group_dims");
     return attr->scales_.set(
             arg, mask, data_type, group_ndims, group_dims, is_on_host, qmode);
 }


### PR DESCRIPTION
# Description

Issue [MFDNN-14456](https://jira.devtools.intel.com/browse/MFDNN-14456) shows group dims being used with common scales. This behavior is disabled in benchdnn but not explicitly via API. 

This commit adds an explicit check to prevent this.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
