### PR TITLE
Introducing code owners for RISC-V implementation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 
 # CPU Engine
 /src/cpu/aarch64/ @uxlfoundation/onednn-cpu-aarch64
+/src/cpu/rv64/ @uxlfoundation/onednn-cpu-rv64
 /src/cpu/x64/ @uxlfoundation/onednn-cpu-x64
 /src/cpu/rnn/ @uxlfoundation/onednn-cpu-x64
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -180,9 +180,14 @@ Vacant. Maintained by Core team.
 
 Vacant. Maintained by Core team.
 
-### RISC-V
+### RISC-V (RV64)
 
-Vacant. Maintained by Core team.
+Team: @uxlfoundation/onednn-cpu-rv64
+
+| Name               | Github ID             | Affiliation       | Role       |
+| ------------------ | --------------------- | ----------------- | ---------- |
+| Fei Zhang          | @zhangfeiv0           | ISCAS             | Code Owner |
+| Jian Zhang         | @zhangjian29          | ZTE Corporation   | Code Owner |
 
 ### Loongarch64
 


### PR DESCRIPTION
I would like to nominate @zhangfeiv0 and @zhangjian29 as code owners for RISC-V implementation of oneDNN. These contributors did extensive work on RISC-V optimizations in the project:
* @zhangfeiv0: [PR list](https://github.com/uxlfoundation/oneDNN/issues?q=is%3Apr+author%3Azhangfeiv0)
* @zhangjian29: [PR list](https://github.com/uxlfoundation/oneDNN/issues?q=is%3Apr+author%3Azhangjian29)
