### PR TITLE
xe: move alg_kind_t out of kernel_ctx

### DIFF
--- a/src/gpu/intel/binary/common.h
+++ b/src/gpu/intel/binary/common.h
@@ -18,6 +18,7 @@
 #define GPU_INTEL_BINARY_COMMON_H
 
 #include "gpu/intel/include/dispatch.h"
+#include "gpu/intel/include/dnnl_interop.h"
 #include "gpu/intel/include/post_ops.h"
 #include "gpu/intel/include/types.h"
 #include "gpu/intel/include/utils.h"
@@ -371,28 +372,28 @@
 #define DEF_binary_op(dt, special_dt) \
     dt __attribute__((overloadable)) binary_op(int alg, dt src0, dt src1) { \
         switch (alg) { \
-            case (BINARY_ADD): return src0 + src1; \
-            case (BINARY_MUL): return src0 * src1; \
-            case (BINARY_MAX): return max(src0, src1); \
-            case (BINARY_MIN): return min(src0, src1); \
-            case (BINARY_DIV): return src0 / src1; \
-            case (BINARY_SUB): return src0 - src1; \
-            case (BINARY_GE): \
+            case binary_add: return src0 + src1; \
+            case binary_mul: return src0 * src1; \
+            case binary_max: return max(src0, src1); \
+            case binary_min: return min(src0, src1); \
+            case binary_div: return src0 / src1; \
+            case binary_sub: return src0 - src1; \
+            case binary_ge: \
                 return (src0 >= src1) ? SPECIAL(special_dt, one) \
                                       : SPECIAL(special_dt, zero); \
-            case (BINARY_GT): \
+            case binary_gt: \
                 return (src0 > src1) ? SPECIAL(special_dt, one) \
                                      : SPECIAL(special_dt, zero); \
-            case (BINARY_LE): \
+            case binary_le: \
                 return (src0 <= src1) ? SPECIAL(special_dt, one) \
                                       : SPECIAL(special_dt, zero); \
-            case (BINARY_LT): \
+            case binary_lt: \
                 return (src0 < src1) ? SPECIAL(special_dt, one) \
                                      : SPECIAL(special_dt, zero); \
-            case (BINARY_EQ): \
+            case binary_eq: \
                 return (src0 == src1) ? SPECIAL(special_dt, one) \
                                       : SPECIAL(special_dt, zero); \
-            case (BINARY_NE): \
+            case binary_ne: \
                 return (src0 != src1) ? SPECIAL(special_dt, one) \
                                       : SPECIAL(special_dt, zero); \
         } \

--- a/src/gpu/intel/binary/simple.cpp
+++ b/src/gpu/intel/binary/simple.cpp
@@ -125,7 +125,6 @@ status_t simple_t::pd_t::init_conf(impl::engine_t *engine) {
 
 status_t simple_t::pd_t::init_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
-    def_binary_alg_kinds(kernel_ctx);
     kernel_ctx.define_int("BINARY_ALG", conf.alg);
     kernel_ctx.define_int("IS_TERNARY", (conf.alg == alg_kind::binary_select));
 

--- a/src/gpu/intel/binary/xe.cpp
+++ b/src/gpu/intel/binary/xe.cpp
@@ -285,7 +285,6 @@ status_t xe_t::pd_t::init_conf(impl::engine_t *engine) {
 }
 
 status_t xe_t::pd_t::init_kernel_ctx(compute::kernel_ctx_t &kernel_ctx) const {
-    def_binary_alg_kinds(kernel_ctx);
     kernel_ctx.define_int("BINARY_ALG", conf.alg);
     kernel_ctx.define_int(
             "IS_TERNARY", (conf.alg == alg_kind::binary_select) ? 1 : 0);

--- a/src/gpu/intel/eltwise/ref.cpp
+++ b/src/gpu/intel/eltwise/ref.cpp
@@ -67,8 +67,6 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
         const memory_desc_t *dst_md) {
     kernel_ctx.set_data_type(conf.data_type);
 
-    def_eltwise_alg_kinds(kernel_ctx);
-
     kernel_ctx.define_int("ELTWISE_ALG", conf.alg);
     kernel_ctx.define_int("NDIMS", conf.ndims);
     kernel_ctx.define_int("GWS0", conf.dispatch.nd_range().global_range()[0]);

--- a/src/gpu/intel/eltwise/xe.cpp
+++ b/src/gpu/intel/eltwise/xe.cpp
@@ -67,7 +67,6 @@ compute::kernel_ctx_t xe_jit_params_t::get_kernel_ctx() const {
     compute::kernel_ctx_t kernel_ctx;
 
     kernel_ctx.set_data_type(data_type);
-    def_eltwise_alg_kinds(kernel_ctx);
 
     kernel_ctx.define_int("ELTWISE_ALG", alg_kind);
 

--- a/src/gpu/intel/gemm/ref.hpp
+++ b/src/gpu/intel/gemm/ref.hpp
@@ -55,8 +55,6 @@ struct ref_jit_params_t : public trivially_serializable_t<ref_jit_params_t> {
 
         kernel_ctx.define_int("WITH_POST_OP", with_post_ops);
         if (with_post_ops) {
-            def_binary_alg_kinds(kernel_ctx);
-            def_eltwise_alg_kinds(kernel_ctx);
             kernel_ctx.define_int("ELTWISE_ALG", eltwise_alg);
         }
         kernel_ctx.define_int("WITH_SUM", with_sum);

--- a/src/gpu/intel/include/dnnl_interop.h
+++ b/src/gpu/intel/include/dnnl_interop.h
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright 2025 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+#ifndef GPU_INTEL_INCLUDE_DNNL_INTEROP_H
+#define GPU_INTEL_INCLUDE_DNNL_INTEROP_H
+
+// Intended for use in both OpenCL C and C++ code. This is largely intended to
+// enable validation of the portion of the oneDNN C API that is required within
+// OpenCL kernels.
+
+#ifndef __OPENCL_VERSION__
+namespace {
+#endif
+
+enum dnnl_ocl_alg_kind_t {
+    // Eltwise algorithm kinds
+    eltwise_relu = 0x20,
+    eltwise_tanh = 0x21,
+    eltwise_elu = 0x22,
+    eltwise_square = 0x23,
+    eltwise_abs = 0x24,
+    eltwise_sqrt = 0x25,
+    eltwise_linear = 0x26,
+    eltwise_soft_relu = 0x27,
+    eltwise_hardsigmoid = 0x28,
+    eltwise_logistic = 0x29,
+    eltwise_exp = 0x2a,
+    eltwise_gelu_tanh = 0x2b,
+    eltwise_swish = 0x2c,
+    eltwise_log = 0x2d,
+    eltwise_clip = 0x2e,
+    eltwise_clip_v2 = 0x2f,
+    eltwise_pow = 0x30,
+    eltwise_gelu_erf = 0x31,
+    eltwise_round = 0x32,
+    eltwise_mish = 0x33,
+    eltwise_hardswish = 0x34,
+
+    eltwise_relu_dst = 0x100,
+    eltwise_tanh_dst = 0x101,
+    eltwise_elu_dst = 0x102,
+    eltwise_sqrt_dst = 0x103,
+    eltwise_logistic_dst = 0x104,
+    eltwise_exp_dst = 0x105,
+    eltwise_clip_v2_dst = 0x106,
+
+    // Binary alg kinds
+    binary_add = 0x1fff0,
+    binary_mul = 0x1fff1,
+    binary_max = 0x1fff2,
+    binary_min = 0x1fff3,
+    binary_div = 0x1fff4,
+    binary_sub = 0x1fff5,
+    binary_ge = 0x1fff6,
+    binary_gt = 0x1fff7,
+    binary_le = 0x1fff8,
+    binary_lt = 0x1fff9,
+    binary_eq = 0x1fffa,
+    binary_ne = 0x1fffb,
+    binary_select = 0x1fffc,
+};
+
+#ifndef __OPENCL_VERSION__
+#include "dnnl_types.h"
+
+// Eltwise algorithm kinds
+static_assert((int)eltwise_relu == dnnl_eltwise_relu, "dnnl API mismatch");
+static_assert((int)eltwise_tanh == dnnl_eltwise_tanh, "dnnl API mismatch");
+static_assert((int)eltwise_elu == dnnl_eltwise_elu, "dnnl API mismatch");
+static_assert((int)eltwise_square == dnnl_eltwise_square, "dnnl API mismatch");
+static_assert((int)eltwise_abs == dnnl_eltwise_abs, "dnnl API mismatch");
+static_assert((int)eltwise_sqrt == dnnl_eltwise_sqrt, "dnnl API mismatch");
+static_assert((int)eltwise_linear == dnnl_eltwise_linear, "dnnl API mismatch");
+static_assert(
+        (int)eltwise_soft_relu == dnnl_eltwise_soft_relu, "dnnl API mismatch");
+static_assert((int)eltwise_hardsigmoid == dnnl_eltwise_hardsigmoid,
+        "dnnl API mismatch");
+static_assert(
+        (int)eltwise_logistic == dnnl_eltwise_logistic, "dnnl API mismatch");
+static_assert((int)eltwise_exp == dnnl_eltwise_exp, "dnnl API mismatch");
+static_assert(
+        (int)eltwise_gelu_tanh == dnnl_eltwise_gelu_tanh, "dnnl API mismatch");
+static_assert((int)eltwise_swish == dnnl_eltwise_swish, "dnnl API mismatch");
+static_assert((int)eltwise_log == dnnl_eltwise_log, "dnnl API mismatch");
+static_assert((int)eltwise_clip == dnnl_eltwise_clip, "dnnl API mismatch");
+static_assert(
+        (int)eltwise_clip_v2 == dnnl_eltwise_clip_v2, "dnnl API mismatch");
+static_assert((int)eltwise_pow == dnnl_eltwise_pow, "dnnl API mismatch");
+static_assert(
+        (int)eltwise_gelu_erf == dnnl_eltwise_gelu_erf, "dnnl API mismatch");
+static_assert((int)eltwise_round == dnnl_eltwise_round, "dnnl API mismatch");
+static_assert((int)eltwise_mish == dnnl_eltwise_mish, "dnnl API mismatch");
+static_assert(
+        (int)eltwise_hardswish == dnnl_eltwise_hardswish, "dnnl API mismatch");
+
+static_assert((int)eltwise_relu_dst == dnnl_eltwise_relu_use_dst_for_bwd,
+        "dnnl API mismatch");
+static_assert((int)eltwise_tanh_dst == dnnl_eltwise_tanh_use_dst_for_bwd,
+        "dnnl API mismatch");
+static_assert((int)eltwise_elu_dst == dnnl_eltwise_elu_use_dst_for_bwd,
+        "dnnl API mismatch");
+static_assert((int)eltwise_sqrt_dst == dnnl_eltwise_sqrt_use_dst_for_bwd,
+        "dnnl API mismatch");
+static_assert(
+        (int)eltwise_logistic_dst == dnnl_eltwise_logistic_use_dst_for_bwd,
+        "dnnl API mismatch");
+static_assert((int)eltwise_exp_dst == dnnl_eltwise_exp_use_dst_for_bwd,
+        "dnnl API mismatch");
+static_assert((int)eltwise_clip_v2_dst == dnnl_eltwise_clip_v2_use_dst_for_bwd,
+        "dnnl API mismatch");
+
+// Binary algorithm kinds
+static_assert((int)binary_add == dnnl_binary_add, "dnnl API mismatch");
+static_assert((int)binary_mul == dnnl_binary_mul, "dnnl API mismatch");
+static_assert((int)binary_max == dnnl_binary_max, "dnnl API mismatch");
+static_assert((int)binary_min == dnnl_binary_min, "dnnl API mismatch");
+static_assert((int)binary_div == dnnl_binary_div, "dnnl API mismatch");
+static_assert((int)binary_sub == dnnl_binary_sub, "dnnl API mismatch");
+static_assert((int)binary_ge == dnnl_binary_ge, "dnnl API mismatch");
+static_assert((int)binary_gt == dnnl_binary_gt, "dnnl API mismatch");
+static_assert((int)binary_le == dnnl_binary_le, "dnnl API mismatch");
+static_assert((int)binary_lt == dnnl_binary_lt, "dnnl API mismatch");
+static_assert((int)binary_eq == dnnl_binary_eq, "dnnl API mismatch");
+static_assert((int)binary_ne == dnnl_binary_ne, "dnnl API mismatch");
+static_assert((int)binary_select == dnnl_binary_select, "dnnl API mismatch");
+
+#endif
+
+#ifndef __OPENCL_VERSION__
+}
+#endif
+
+#endif

--- a/src/gpu/intel/include/eltwise.h
+++ b/src/gpu/intel/include/eltwise.h
@@ -17,6 +17,7 @@
 #ifndef GPU_INTEL_INCLUDE_ELTWISE_H
 #define GPU_INTEL_INCLUDE_ELTWISE_H
 
+#include "gpu/intel/include/dnnl_interop.h"
 #include "gpu/intel/include/types.h"
 
 #if DT_F16 == 1
@@ -268,36 +269,44 @@ POST_OP_DATA_T hardswish_bwd(
 float fwd_eltwise_common(int eltwise_alg, POST_OP_DATA_T x, float alpha_,
         float beta_, float scale_) {
     switch (eltwise_alg) {
-        case RELU: return scale_ * relu_fwd(x, alpha_); break;
-        case LINEAR: return scale_ * linear_fwd(x, alpha_, beta_); break;
-        case SOFT_RELU: return scale_ * soft_relu_fwd(x, alpha_); break;
-        case MISH: return scale_ * mish_fwd(x); break;
-        case LOGISTIC: return scale_ * logistic_fwd(x); break;
-        case TANH: return scale_ * tanh_fwd(x); break;
-        case ELU: return scale_ * elu_fwd(x, alpha_); break;
-        case SQUARE: return scale_ * square_fwd(x); break;
-        case SQRT: return scale_ * sqrt_fwd(x); break;
-        case ABS: return scale_ * abs_fwd(x); break;
-        case EXP: return scale_ * exp_fwd(x); break;
-        case GELU_TANH: return scale_ * gelu_tanh_fwd(x); break;
-        case SWISH: return scale_ * swish_fwd(x, alpha_); break;
-        case LOG: return scale_ * log_fwd(x); break;
-        case CLIP: return scale_ * clip_fwd(x, alpha_, beta_); break;
-        case CLIP_V2: return scale_ * clip_v2_fwd(x, alpha_, beta_); break;
-        case POW: return scale_ * pow_fwd(x, alpha_, beta_); break;
-        case GELU_ERF: return scale_ * gelu_erf_fwd(x); break;
-        case ROUND: return scale_ * round_fwd(x); break;
-        case HARDSWISH: return scale_ * hardswish_fwd(x, alpha_, beta_); break;
-        case HARDSIGMOID:
+        case eltwise_relu: return scale_ * relu_fwd(x, alpha_); break;
+        case eltwise_linear:
+            return scale_ * linear_fwd(x, alpha_, beta_);
+            break;
+        case eltwise_soft_relu: return scale_ * soft_relu_fwd(x, alpha_); break;
+        case eltwise_mish: return scale_ * mish_fwd(x); break;
+        case eltwise_logistic: return scale_ * logistic_fwd(x); break;
+        case eltwise_tanh: return scale_ * tanh_fwd(x); break;
+        case eltwise_elu: return scale_ * elu_fwd(x, alpha_); break;
+        case eltwise_square: return scale_ * square_fwd(x); break;
+        case eltwise_sqrt: return scale_ * sqrt_fwd(x); break;
+        case eltwise_abs: return scale_ * abs_fwd(x); break;
+        case eltwise_exp: return scale_ * exp_fwd(x); break;
+        case eltwise_gelu_tanh: return scale_ * gelu_tanh_fwd(x); break;
+        case eltwise_swish: return scale_ * swish_fwd(x, alpha_); break;
+        case eltwise_log: return scale_ * log_fwd(x); break;
+        case eltwise_clip: return scale_ * clip_fwd(x, alpha_, beta_); break;
+        case eltwise_clip_v2:
+            return scale_ * clip_v2_fwd(x, alpha_, beta_);
+            break;
+        case eltwise_pow: return scale_ * pow_fwd(x, alpha_, beta_); break;
+        case eltwise_gelu_erf: return scale_ * gelu_erf_fwd(x); break;
+        case eltwise_round: return scale_ * round_fwd(x); break;
+        case eltwise_hardswish:
+            return scale_ * hardswish_fwd(x, alpha_, beta_);
+            break;
+        case eltwise_hardsigmoid:
             return scale_ * hardsigmoid_fwd(x, alpha_, beta_);
             break;
-        case RELU_DST: return scale_ * relu_fwd(x, alpha_); break;
-        case LOGISTIC_DST: return scale_ * logistic_fwd(x); break;
-        case TANH_DST: return scale_ * tanh_fwd(x); break;
-        case ELU_DST: return scale_ * elu_fwd(x, alpha_); break;
-        case SQRT_DST: return scale_ * sqrt_fwd(x); break;
-        case EXP_DST: return scale_ * exp_fwd(x); break;
-        case CLIP_V2_DST: return scale_ * clip_v2_fwd(x, alpha_, beta_); break;
+        case eltwise_relu_dst: return scale_ * relu_fwd(x, alpha_); break;
+        case eltwise_logistic_dst: return scale_ * logistic_fwd(x); break;
+        case eltwise_tanh_dst: return scale_ * tanh_fwd(x); break;
+        case eltwise_elu_dst: return scale_ * elu_fwd(x, alpha_); break;
+        case eltwise_sqrt_dst: return scale_ * sqrt_fwd(x); break;
+        case eltwise_exp_dst: return scale_ * exp_fwd(x); break;
+        case eltwise_clip_v2_dst:
+            return scale_ * clip_v2_fwd(x, alpha_, beta_);
+            break;
         default: return x; break;
     }
 }
@@ -314,33 +323,37 @@ float bwd_eltwise(
         POST_OP_DATA_T x, POST_OP_DATA_T y, float alpha_, float beta_) {
 #ifdef ELTWISE_ALG
     switch (ELTWISE_ALG) {
-        case RELU: return relu_bwd(x, y, alpha_); break;
-        case LINEAR: return linear_bwd(x, alpha_); break;
-        case SOFT_RELU: return soft_relu_bwd(x, y, alpha_); break;
-        case MISH: return mish_bwd(x, y); break;
-        case LOGISTIC: return logistic_bwd(x, y); break;
-        case TANH: return tanh_bwd(x, y); break;
-        case ELU: return elu_bwd(x, y, alpha_); break;
-        case SQUARE: return square_bwd(x, y); break;
-        case SQRT: return sqrt_bwd(x, y); break;
-        case ABS: return abs_bwd(x, y); break;
-        case EXP: return exp_bwd(x, y); break;
-        case GELU_TANH: return gelu_tanh_bwd(x, y); break;
-        case SWISH: return swish_bwd(x, y, alpha_); break;
-        case LOG: return log_bwd(x, y); break;
-        case CLIP: return clip_bwd(x, y, alpha_, beta_); break;
-        case CLIP_V2: return clip_v2_bwd(x, y, alpha_, beta_); break;
-        case POW: return pow_bwd(x, y, alpha_, beta_); break;
-        case GELU_ERF: return gelu_erf_bwd(x, y); break;
-        case HARDSWISH: return hardswish_bwd(x, y, alpha_, beta_); break;
-        case HARDSIGMOID: return hardsigmoid_bwd(x, y, alpha_, beta_); break;
-        case RELU_DST: return relu_bwd_use_dst(x, y, alpha_); break;
-        case LOGISTIC_DST: return logistic_bwd_use_dst(x, y); break;
-        case TANH_DST: return tanh_bwd_use_dst(x, y); break;
-        case ELU_DST: return elu_bwd_use_dst(x, y, alpha_); break;
-        case SQRT_DST: return sqrt_bwd_use_dst(x, y); break;
-        case EXP_DST: return exp_bwd_use_dst(x, y); break;
-        case CLIP_V2_DST:
+        case eltwise_relu: return relu_bwd(x, y, alpha_); break;
+        case eltwise_linear: return linear_bwd(x, alpha_); break;
+        case eltwise_soft_relu: return soft_relu_bwd(x, y, alpha_); break;
+        case eltwise_mish: return mish_bwd(x, y); break;
+        case eltwise_logistic: return logistic_bwd(x, y); break;
+        case eltwise_tanh: return tanh_bwd(x, y); break;
+        case eltwise_elu: return elu_bwd(x, y, alpha_); break;
+        case eltwise_square: return square_bwd(x, y); break;
+        case eltwise_sqrt: return sqrt_bwd(x, y); break;
+        case eltwise_abs: return abs_bwd(x, y); break;
+        case eltwise_exp: return exp_bwd(x, y); break;
+        case eltwise_gelu_tanh: return gelu_tanh_bwd(x, y); break;
+        case eltwise_swish: return swish_bwd(x, y, alpha_); break;
+        case eltwise_log: return log_bwd(x, y); break;
+        case eltwise_clip: return clip_bwd(x, y, alpha_, beta_); break;
+        case eltwise_clip_v2: return clip_v2_bwd(x, y, alpha_, beta_); break;
+        case eltwise_pow: return pow_bwd(x, y, alpha_, beta_); break;
+        case eltwise_gelu_erf: return gelu_erf_bwd(x, y); break;
+        case eltwise_hardswish:
+            return hardswish_bwd(x, y, alpha_, beta_);
+            break;
+        case eltwise_hardsigmoid:
+            return hardsigmoid_bwd(x, y, alpha_, beta_);
+            break;
+        case eltwise_relu_dst: return relu_bwd_use_dst(x, y, alpha_); break;
+        case eltwise_logistic_dst: return logistic_bwd_use_dst(x, y); break;
+        case eltwise_tanh_dst: return tanh_bwd_use_dst(x, y); break;
+        case eltwise_elu_dst: return elu_bwd_use_dst(x, y, alpha_); break;
+        case eltwise_sqrt_dst: return sqrt_bwd_use_dst(x, y); break;
+        case eltwise_exp_dst: return exp_bwd_use_dst(x, y); break;
+        case eltwise_clip_v2_dst:
             return clip_v2_bwd_use_dst(x, y, alpha_, beta_);
             break;
 

--- a/src/gpu/intel/include/post_ops.h
+++ b/src/gpu/intel/include/post_ops.h
@@ -32,20 +32,20 @@
 float fwd_binary(unsigned algorithm, POST_OP_DATA_T x, POST_OP_DATA_T y) {
     switch (algorithm) {
         // binary
-        case BINARY_ADD: return x + y; break;
-        case BINARY_MUL: return x * y; break;
-        case BINARY_MIN: return x < y ? x : y; break;
-        case BINARY_MAX: return x > y ? x : y; break;
-        case BINARY_DIV: return x / y; break;
-        case BINARY_SUB: return x - y; break;
-        case BINARY_GE: return x >= y; break;
-        case BINARY_GT: return x > y; break;
-        case BINARY_LE: return x <= y; break;
-        case BINARY_LT: return x < y; break;
-        case BINARY_EQ: return x == y; break;
-        case BINARY_NE: return x != y; break;
-        case RELU: // binary && relu = prelu
-            return fwd_eltwise_common(RELU, x, y, 0.0f, 1.0f);
+        case binary_add: return x + y; break;
+        case binary_mul: return x * y; break;
+        case binary_min: return x < y ? x : y; break;
+        case binary_max: return x > y ? x : y; break;
+        case binary_div: return x / y; break;
+        case binary_sub: return x - y; break;
+        case binary_ge: return x >= y; break;
+        case binary_gt: return x > y; break;
+        case binary_le: return x <= y; break;
+        case binary_lt: return x < y; break;
+        case binary_eq: return x == y; break;
+        case binary_ne: return x != y; break;
+        case eltwise_relu: // binary && relu = prelu
+            return fwd_eltwise_common(eltwise_relu, x, y, 0.0f, 1.0f);
             break;
         default: return 0.f;
     }

--- a/src/gpu/intel/ocl_kernel_list.cpp.in
+++ b/src/gpu/intel/ocl_kernel_list.cpp.in
@@ -92,6 +92,9 @@ const char *get_kernel_header(const std::string &name) {
             kernel_header_list
             = { @KER_HEADER_LIST_ENTRIES@ };
 
+    // Used for OpenCL interoperability validation in C++ code
+    if (name == "dnnl_types.h") return "";
+
     gpu_assert(kernel_header_list.count(name) == 1)
             << "Found " << kernel_header_list.count(name)
             << " headers with the name " << name << ". Expected 1";

--- a/src/gpu/intel/prelu/ref.cpp
+++ b/src/gpu/intel/prelu/ref.cpp
@@ -82,7 +82,6 @@ static status_t init_kernel_ctx_common(
         compute::kernel_ctx_t &kernel_ctx, const conf_t &conf) {
 
     kernel_ctx.set_data_type(conf.dst_md_info.data_type);
-    def_eltwise_alg_kinds(kernel_ctx);
 
     kernel_ctx.define_int("IS_FWD", conf.is_forward);
 

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -21,6 +21,9 @@
 
 #include "gpu/intel/primitive_conf.hpp"
 
+// Included to enable compatibility tests
+#include "gpu/intel/include/dnnl_interop.h"
+
 namespace dnnl {
 namespace impl {
 namespace gpu {
@@ -392,55 +395,6 @@ void def_memory_desc_info(compute::kernel_ctx_t &kernel_ctx,
     }
 }
 
-void def_binary_alg_kinds(compute::kernel_ctx_t &kernel_ctx) {
-    kernel_ctx.define_int("BINARY_ADD", alg_kind::binary_add);
-    kernel_ctx.define_int("BINARY_MUL", alg_kind::binary_mul);
-    kernel_ctx.define_int("BINARY_MIN", alg_kind::binary_min);
-    kernel_ctx.define_int("BINARY_MAX", alg_kind::binary_max);
-    kernel_ctx.define_int("BINARY_DIV", alg_kind::binary_div);
-    kernel_ctx.define_int("BINARY_SUB", alg_kind::binary_sub);
-    kernel_ctx.define_int("BINARY_GE", alg_kind::binary_ge);
-    kernel_ctx.define_int("BINARY_GT", alg_kind::binary_gt);
-    kernel_ctx.define_int("BINARY_LE", alg_kind::binary_le);
-    kernel_ctx.define_int("BINARY_LT", alg_kind::binary_lt);
-    kernel_ctx.define_int("BINARY_EQ", alg_kind::binary_eq);
-    kernel_ctx.define_int("BINARY_NE", alg_kind::binary_ne);
-}
-
-void def_eltwise_alg_kinds(compute::kernel_ctx_t &kernel_ctx) {
-    kernel_ctx.define_int("RELU", alg_kind::eltwise_relu);
-    kernel_ctx.define_int("LINEAR", alg_kind::eltwise_linear);
-    kernel_ctx.define_int("SOFT_RELU", alg_kind::eltwise_soft_relu);
-    kernel_ctx.define_int("MISH", alg_kind::eltwise_mish);
-    kernel_ctx.define_int("LOGISTIC", alg_kind::eltwise_logistic);
-    kernel_ctx.define_int("TANH", alg_kind::eltwise_tanh);
-    kernel_ctx.define_int("ELU", alg_kind::eltwise_elu);
-    kernel_ctx.define_int("SQUARE", alg_kind::eltwise_square);
-    kernel_ctx.define_int("SQRT", alg_kind::eltwise_sqrt);
-    kernel_ctx.define_int("ABS", alg_kind::eltwise_abs);
-    kernel_ctx.define_int("EXP", alg_kind::eltwise_exp);
-    kernel_ctx.define_int("GELU_TANH", alg_kind::eltwise_gelu_tanh);
-    kernel_ctx.define_int("SWISH", alg_kind::eltwise_swish);
-    kernel_ctx.define_int("LOG", alg_kind::eltwise_log);
-    kernel_ctx.define_int("CLIP", alg_kind::eltwise_clip);
-    kernel_ctx.define_int("CLIP_V2", alg_kind::eltwise_clip_v2);
-    kernel_ctx.define_int("POW", alg_kind::eltwise_pow);
-    kernel_ctx.define_int("GELU_ERF", alg_kind::eltwise_gelu_erf);
-    kernel_ctx.define_int("ROUND", alg_kind::eltwise_round);
-    kernel_ctx.define_int("HARDSWISH", alg_kind::eltwise_hardswish);
-    kernel_ctx.define_int("HARDSIGMOID", alg_kind::eltwise_hardsigmoid);
-
-    kernel_ctx.define_int("RELU_DST", alg_kind::eltwise_relu_use_dst_for_bwd);
-    kernel_ctx.define_int(
-            "LOGISTIC_DST", alg_kind::eltwise_logistic_use_dst_for_bwd);
-    kernel_ctx.define_int("TANH_DST", alg_kind::eltwise_tanh_use_dst_for_bwd);
-    kernel_ctx.define_int("ELU_DST", alg_kind::eltwise_elu_use_dst_for_bwd);
-    kernel_ctx.define_int("SQRT_DST", alg_kind::eltwise_sqrt_use_dst_for_bwd);
-    kernel_ctx.define_int("EXP_DST", alg_kind::eltwise_exp_use_dst_for_bwd);
-    kernel_ctx.define_int(
-            "CLIP_V2_DST", alg_kind::eltwise_clip_v2_use_dst_for_bwd);
-}
-
 bool post_ops_with_binary_ok(const primitive_attr_t *attr,
         const memory_desc_t &dst_md, const int max_ndims_supported) {
     const auto &p = attr->post_ops_;
@@ -754,9 +708,6 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("WITH_HOST_WEI_SCALE", attr_info.with_host_wei_scale);
     kernel_ctx.define_int("WITH_HOST_DST_SCALE", attr_info.with_host_dst_scale);
     kernel_ctx.define_int("WITH_MX_DST_SCALE", attr_info.with_mx_dst_scale);
-
-    def_binary_alg_kinds(kernel_ctx);
-    def_eltwise_alg_kinds(kernel_ctx);
 
     return def_post_ops_cfg(kernel_ctx, post_ops, dst_md);
 }

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -202,10 +202,6 @@ void def_memory_desc_info(compute::kernel_ctx_t &kernel_ctx,
         const memory_desc_info_t &md_info, const char *prefix,
         bool with_punning = true);
 
-void def_binary_alg_kinds(compute::kernel_ctx_t &kernel_ctx);
-
-void def_eltwise_alg_kinds(compute::kernel_ctx_t &kernel_ctx);
-
 bool post_ops_with_binary_ok(const primitive_attr_t *attr,
         const memory_desc_t &dst_md, const int max_ndims_supported = 2);
 


### PR DESCRIPTION
Replaces alg_kind_t defines with an interop header. This is intended to reduce the excessive noise this introduces when analyzing the OpenCL compilation defines.