### PR TITLE
cpu: aarch64: reorder: add 4x4 blk kernel for SVE-128

### DIFF
--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
@@ -320,9 +320,16 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
     // Register allocation xmm0~11
     void gen_transpose_8x8();
 
+    void gen_transpose_4x4();
+
     // keep order nchw -> nChw()C
     // or nChw()C -> nchw
     void gen_setmask(int mask);
+
+    void gen_tr4x4(int i_off, int o_off, int input_stride, int output_stride,
+            int in_tail, int out_tail);
+    void gen_ker4x4(int i_off, int o_off, int input_stride, int output_stride,
+            int in_tail, int out_tail);
 
     // TODO: Mark parameter with type information
     // XXX: !


### PR DESCRIPTION
# Description

Adds a 4x4 transpose kernel for SVE-128.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

|threads|old impl|new impl|shape|old min|new min|old avg|new avg|speedup ratio (old avg / new avg)|
|---------|---------|---------|---------|---------|---------|---------|---------|---------|
|1|jit:uni|jit:blk|128x128|0.00585938|0.00610352|0.00585938|0.00610352|0.9600x|
|2|jit:uni|jit:blk|128x128|0.00366211|0.00366211|0.00366211|0.00366211|1.0000x|
|4|jit:uni|jit:blk|128x128|0.00219727|0.00219727|0.00219727|0.00219727|1.0000x|
|8|jit:uni|jit:blk|128x128|0.00195312|0.00195312|0.00195312|0.00195312|1.0000x|
|16|jit:uni|jit:blk|128x128|0.00219727|0.00219727|0.00219727|0.00219727|1.0000x|
|32|jit:uni|jit:blk|128x128|0.00317383|0.00317383|0.00317383|0.00317383|1.0000x|
|64|jit:uni|jit:blk|128x128|0.00537109|0.00537109|0.00537109|0.00537109|1.0000x|
|1|jit:uni|jit:blk|256x256|0.0234375|0.0217285|0.0234375|0.0217285|1.0787x|
|2|jit:uni|jit:blk|256x256|0.0124512|0.0117188|0.0124512|0.0117188|1.0625x|
|4|jit:uni|jit:blk|256x256|0.00683594|0.00634766|0.00683594|0.00634766|1.0769x|
|8|jit:uni|jit:blk|256x256|0.00390625|0.00415039|0.00390625|0.00415039|0.9412x|
|16|jit:uni|jit:blk|256x256|0.00317383|0.00317383|0.00317383|0.00317383|1.0000x|
|32|jit:uni|jit:blk|256x256|0.00341797|0.00366211|0.00341797|0.00366211|0.9333x|
|64|jit:uni|jit:blk|256x256|0.00537109|0.00634766|0.00537109|0.00634766|0.8462x|
|1|jit:uni|jit:blk|1024x1024|0.37915|0.349609|0.37915|0.349609|1.0845x|
|2|jit:uni|jit:blk|1024x1024|0.193115|0.17749|0.193115|0.17749|1.0880x|
|4|jit:uni|jit:blk|1024x1024|0.0952148|0.0874023|0.0952148|0.0874023|1.0894x|
|8|jit:uni|jit:blk|1024x1024|0.0493164|0.0449219|0.0493164|0.0449219|1.0978x|
|16|jit:uni|jit:blk|1024x1024|0.0256348|0.0234375|0.0256348|0.0234375|1.0938x|
|32|jit:uni|jit:blk|1024x1024|0.0217285|0.0151367|0.0217285|0.0151367|1.4355x|
|64|jit:uni|jit:blk|1024x1024|0.013916|0.0117188|0.013916|0.0117188|1.1875x|
|1|jit:uni|jit:blk|2048x2048|1.51978|1.40259|1.51978|1.40259|1.0836x|
|2|jit:uni|jit:blk|2048x2048|0.775879|0.687012|0.775879|0.687012|1.1294x|
|4|jit:uni|jit:blk|2048x2048|0.386475|0.344727|0.386475|0.344727|1.1211x|
|8|jit:uni|jit:blk|2048x2048|0.191406|0.17749|0.191406|0.17749|1.0784x|
|16|jit:uni|jit:blk|2048x2048|0.0961914|0.0905762|0.0961914|0.0905762|1.0620x|
|32|jit:uni|jit:blk|2048x2048|0.050293|0.0522461|0.050293|0.0522461|0.9626x|
|64|jit:uni|jit:blk|2048x2048|0.0441895|0.03125|0.0441895|0.03125|1.4141x|
