### PR TITLE
cpu: rv64: cmake: fix gcc ice bug when specifying arch opt flags

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -160,26 +160,12 @@ if (DNNL_TARGET_ARCH STREQUAL "RV64")
         set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_SAVE})
 
         set(CAN_COMPILE_RVV_INTRINSICS TRUE)
-
-        # If explicitly passed DNNL_ARCH_OPT_FLAGS without V or Zvfh in the -march 
-        # string, disable their code paths even if the toolchain supports them.
-        if (DEFINED DNNL_ARCH_OPT_FLAGS AND DNNL_ARCH_OPT_FLAGS MATCHES "-march=")
-            string(FIND "${DNNL_ARCH_OPT_FLAGS}" "gcv" _dnnl_rv64_v_pos)
-            string(FIND "${DNNL_ARCH_OPT_FLAGS}" "zvfh" _dnnl_rv64_zvfh_pos)
-            if (_dnnl_rv64_v_pos EQUAL -1)
-                set(CAN_COMPILE_RVV_INTRINSICS FALSE)
-                set(CAN_COMPILE_ZVFH_INTRINSICS FALSE)
-            elseif (_dnnl_rv64_zvfh_pos EQUAL -1)
-                set(CAN_COMPILE_ZVFH_INTRINSICS FALSE)
-            endif()
-        endif()
-
         if (CAN_COMPILE_ZVFH_INTRINSICS)
+            set(CAN_COMPILE_ZVFH_INTRINSICS TRUE)
             set(RV64_MARCH_FLAG "-march=rv64gcv_zvfh")
-        elseif (CAN_COMPILE_RVV_INTRINSICS)
-            set(RV64_MARCH_FLAG "-march=rv64gcv")
         else()
-            set(RV64_MARCH_FLAG "-march=rv64gc")
+            set(CAN_COMPILE_ZVFH_INTRINSICS FALSE)
+            set(RV64_MARCH_FLAG "-march=rv64gcv")
         endif()
     else()
         # RVV is not supported, so Zvfh is also not supported


### PR DESCRIPTION
# Description

This PR fixes the gcc14.2 internal compiler error (ICE) bug that occurs when specifying `-DDNNL_ARCH_OPT_FLAGS="-march=rv64gcv"` to disable `zvfh` extension. 

I attempted to disable `zvfh` extension by adding `-DDNNL_ARCH_OPT_FLAGS="-march=rv64gcv"` in the cmake options. However, I found two bugs:
- In `platform.cmake`, the test that sets `DNNL_RISCV_USE_ZVFH_INTRINSICS` to `true` passed *before* `DDNNL_ARCH_OPT_FLAGS` overried the `CMAKE_CCXX_FLAGS`.
- `rvv_nhwc_pooling.hpp` uses `DNNL_RISCV_USE_ZVFH_INTRINSICS` flag for dispatch, but this flag can be undefined.

These issues together cause a GCC ICE during compilation.

<details>
<summary>See Log</summary>

```
zhangjian@localhost:~/oneDNN/build_rvv $ cmake .. -DDNNL_TARGET_ARCH="RV64" -DDNNL_ARCH_OPT_FLAGS="-march=rv64gcv"
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/zhangjian/tools/tool-gcc14.2/bin/riscv64-unknown-linux-gnu-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/zhangjian/tools/tool-gcc14.2/bin/riscv64-unknown-linux-gnu-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- DNNL_TARGET_ARCH: RV64
-- DNNL_LIBRARY_NAME: dnnl
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- Performing Test CAN_COMPILE_RVV_INTRINSICS
-- Performing Test CAN_COMPILE_RVV_INTRINSICS - Success
-- Performing Test CAN_COMPILE_ZVFH_INTRINSICS
-- Performing Test CAN_COMPILE_ZVFH_INTRINSICS - Success
-- Can compile RVV Intrinsics: TRUE
-- Can compile Zvfh Intrinsics: TRUE
-- DNNL_RISCV_USE_RVV_INTRINSICS: TRUE
-- DNNL_RISCV_USE_ZVFH_INTRINSICS: TRUE
-- Using RV64 march flag: -march=rv64gcv_zvfh
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Could NOT find Doxyrest (missing: DOXYREST_EXECUTABLE) 
-- Found Python: /usr/bin/python3.11 (found suitable version "3.11.7", minimum required is "3.7") found components: Interpreter 
-- Could NOT find Sphinx (missing: SPHINX_EXECUTABLE) 
-- Found Git: /usr/bin/git (found version "2.43.0") 
-- Enabled testing coverage: CI
-- Enabled workload: TRAINING
-- Enabled primitives: ALL
-- Enabled primitive CPU ISA: ALL
-- Enabled primitive GPU ISA: ALL
-- Enabled GeMM kernels ISA: ALL
-- Primitive cache is enabled
-- Graph component is enabled
-- Configuring done (1.8s)
-- Generating done (0.2s)
-- Build files have been written to: /home/zhangjian/oneDNN/build_rvv
zhangjian@localhost:~/oneDNN/build_rvv $ make -j8
...
/home/zhangjian/oneDNN/src/cpu/rv64/rvv_1x1_convolution.cpp: In member function 'dnnl::impl::status_t dnnl::impl::cpu::rv64::rvv_1x1_convolution_fwd_t::execute_forward_ncsp(const dnnl::impl::exec_ctx_t&) const':
/home/zhangjian/oneDNN/src/cpu/rv64/rvv_1x1_convolution.cpp:116:17: warning: unused variable 'wei_oc_stride' [-Wunused-variable]
  116 |     const dim_t wei_oc_stride = ic;
      |                 ^~~~~~~~~~~~~
/home/zhangjian/oneDNN/src/cpu/rv64/rvv_1x1_convolution.cpp: In member function 'dnnl::impl::status_t dnnl::impl::cpu::rv64::rvv_1x1_convolution_fwd_t::execute_forward_nspc(const dnnl::impl::exec_ctx_t&) const':
/home/zhangjian/oneDNN/src/cpu/rv64/rvv_1x1_convolution.cpp:272:17: warning: unused variable 'alpha' [-Wunused-variable]
  272 |     const float alpha = 1.0f;
      |                 ^~~~~
during RTL pass: expand
In lambda function,
    inlined from 'constexpr _Res std::__invoke_impl(__invoke_other, _Fn&&, _Args&& ...) [with _Res = void; _Fn = dnnl::impl::cpu::rv64::{anonymous}::AvgPoolingExcludePadding_f16(const void*, void*, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, const dnnl::impl::cpu::rv64::rvv_postops_t&)::<lambda(dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t)>&; _Args = {long int, long int, long int, long int}]' at /home/zhangjian/tools/tool-gcc14.2/riscv64-unknown-linux-gnu/include/c++/14.2.0/bits/invoke.h:61:36,
    inlined from 'std::__enable_if_t<((bool)std::is_void< <template-parameter-1-1> >::value), _Res> std::__invoke_r(_Callable&&, _Args&& ...) [with _Res = void; _Callable = dnnl::impl::cpu::rv64::{anonymous}::AvgPoolingExcludePadding_f16(const void*, void*, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, const dnnl::impl::cpu::rv64::rvv_postops_t&)::<lambda(dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t)>&; _Args = {long int, long int, long int, long int}]' at /home/zhangjian/tools/tool-gcc14.2/riscv64-unknown-linux-gnu/include/c++/14.2.0/bits/invoke.h:150:33,
    inlined from 'static _Res std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_invoke(const std::_Any_data&, _ArgTypes&& ...) [with _Res = void; _Functor = dnnl::impl::cpu::rv64::{anonymous}::AvgPoolingExcludePadding_f16(const void*, void*, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, const dnnl::impl::cpu::rv64::rvv_postops_t&)::<lambda(dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t, dnnl::impl::dim_t)>; _ArgTypes = {long int, long int, long int, long int}]' at /home/zhangjian/tools/tool-gcc14.2/riscv64-unknown-linux-gnu/include/c++/14.2.0/bits/std_function.h:290:30:
/home/zhangjian/oneDNN/src/cpu/rv64/rvv_nhwc_pooling.cpp:436:53: internal compiler error: in emit_move_insn, at expr.cc:4615
  436 |                         = __riscv_vfncvt_f_f_w_f16m1(vzero_f32, vl);
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```
</details>

## Bug Fix

We fix these bugs by:

- Adding detection logic for `DNNL_ARCH_OPT_FLAGS` to correctly determine the `CAN_COMPILE_ZVFH_INTRINSICS` flag.
- Fixing the `zvfh` runtime check by using the `cpu_isa_traits` for RV64.

## Tests

After this PR:

- The `DNNL_RISCV_USE_ZVFH_INTRINSICS` flag is set correctly and there are no compilation errors.

<details>
<summary>See log</summary>

```
zhangjian@localhost:~/oneDNN/build_rvv $ cmake .. -DDNNL_TARGET_ARCH="RV64" -DDNNL_ARCH_OPT_FLAGS="-march=rv64gcv"
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/zhangjian/tools/tool-gcc14.2/bin/riscv64-unknown-linux-gnu-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/zhangjian/tools/tool-gcc14.2/bin/riscv64-unknown-linux-gnu-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- DNNL_TARGET_ARCH: RV64
-- DNNL_LIBRARY_NAME: dnnl
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- Performing Test CAN_COMPILE_RVV_INTRINSICS
-- Performing Test CAN_COMPILE_RVV_INTRINSICS - Success
-- Performing Test CAN_COMPILE_ZVFH_INTRINSICS
-- Performing Test CAN_COMPILE_ZVFH_INTRINSICS - Success
-- Can compile RVV Intrinsics: TRUE
-- Can compile Zvfh Intrinsics: FALSE
-- DNNL_RISCV_USE_RVV_INTRINSICS: TRUE
-- DNNL_RISCV_USE_ZVFH_INTRINSICS: FALSE
-- Using RV64 march flag: -march=rv64gcv
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Could NOT find Doxyrest (missing: DOXYREST_EXECUTABLE) 
-- Found Python: /usr/bin/python3.11 (found suitable version "3.11.7", minimum required is "3.7") found components: Interpreter 
-- Could NOT find Sphinx (missing: SPHINX_EXECUTABLE) 
-- Found Git: /usr/bin/git (found version "2.43.0") 
-- Enabled testing coverage: CI
-- Enabled workload: TRAINING
-- Enabled primitives: ALL
-- Enabled primitive CPU ISA: ALL
-- Enabled primitive GPU ISA: ALL
-- Enabled GeMM kernels ISA: ALL
-- Primitive cache is enabled
-- Graph component is enabled
-- Configuring done (1.8s)
-- Generating done (0.2s)
-- Build files have been written to: /home/zhangjian/oneDNN/build_rvv
```
</details>


- `f16` tests are skipped on the `rv64gcv` platform as excepted.

<details>
<summary>See log</summary>

```
[root@localhost build_rvv]# LD_LIBRARY_PATH=$(pwd)/src:$LD_LIBRARY_PATH ./tests/benchdnn/benchdnn --pool --batch=tests/benchdnn/inputs/pool/test_pool_float16 
0:SKIPPED (Data type not supported) (128 ms) __REPRO: --pool --dt=f16:f16 ic64iw32ow16kw3sw2pw0
1:SKIPPED (Data type not supported) (17 ms) __REPRO: --pool --dt=f16:f16 --alg=avg_np ic64iw32ow16kw3sw2pw0
2:SKIPPED (Data type not supported) (4 ms) __REPRO: --pool --dt=f16:f16 --alg=avg_p ic64iw32ow16kw3sw2pw0
3:SKIPPED (Data type not supported) (4 ms) __REPRO: --pool --dt=f16:f16 --tag=axb ic64iw32ow16kw3sw2pw0
4:SKIPPED (Data type not supported) (4 ms) __REPRO: --pool --dt=f16:f16 --tag=axb --alg=avg_np ic64iw32ow16kw3sw2pw0
5:SKIPPED (Data type not supported) (4 ms) __REPRO: --pool --dt=f16:f16 --tag=axb --alg=avg_p ic64iw32ow16kw3sw2pw0
6:SKIPPED (Data type not supported) (5 ms) __REPRO: --pool --dir=BWD_D --dt=f16:f16 ic64iw32ow16kw3sw2pw0
7:SKIPPED (Data type not supported) (4 ms) __REPRO: --pool --dir=BWD_D --dt=f16:f16 --alg=avg_np ic64iw32ow16kw3sw2pw0
8:SKIPPED (Data type not supported) (4 ms) __REPRO: --pool --dir=BWD_D --dt=f16:f16 --alg=avg_p ic64iw32ow16kw3sw2pw0
9:SKIPPED (Data type not supported) (4 ms) __REPRO: --pool --dir=BWD_D --dt=f16:f16 --tag=axb ic64iw32ow16kw3sw2pw0
10:SKIPPED (Data type not supported) (5 ms) __REPRO: --pool --dir=BWD_D --dt=f16:f16 --tag=axb --alg=avg_np ic64iw32ow16kw3sw2pw0
...
tests:4014 passed:0 skipped:4014 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 21.54s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.00s (0%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```
</details>