### PR TITLE
cpu: aarch64: reorder: re-add accidentally removed tag check

### DIFF
--- a/src/cpu/aarch64/reorder/acl_reorder.cpp
+++ b/src/cpu/aarch64/reorder/acl_reorder.cpp
@@ -94,6 +94,13 @@ status_t acl_reorder_fwd_t::pd_t::create(reorder_pd_t **reorder_pd,
     VDISPATCH_REORDER_IC(format_tag::undef != src_tag,
             "Only ab, ba or cdba source formats supported");
 
+    auto dst_tag = memory_desc_matches_one_of_tag(*dst_md, format_tag::BA8b4a,
+            format_tag::BA4b4a, format_tag::Ab4a, format_tag::Ab8a,
+            format_tag::Acdb8a, format_tag::Acdb4a);
+    ACL_CHECK_SUPPORT(format_tag::undef == dst_tag,
+            "Only Ab4a/Ab8a, BA8b4a/BA4b4a and Acdb8a/Acdb4a "
+            "destination formats supported");
+
     auto &transpose = _pd->app_.transpose;
     auto &dst_blocking = dst_md->format_desc.blocking;
 

--- a/src/cpu/aarch64/reorder/acl_reorder.hpp
+++ b/src/cpu/aarch64/reorder/acl_reorder.hpp
@@ -16,10 +16,8 @@
 #ifndef CPU_AARCH64_REORDER_ACL_REORDER_HPP
 #define CPU_AARCH64_REORDER_ACL_REORDER_HPP
 
-#include "arm_compute/core/Types.h"
 #include "common/utils.hpp"
 #include "cpu/aarch64/acl_utils.hpp"
-#include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/reorder/cpu_reorder_pd.hpp"
 
 namespace dnnl {


### PR DESCRIPTION
# Description

The check for the format tag was accidentally removed by 0f7a278170

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?