### PR TITLE
xe: gemm: fixup cinterleave strategy

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
@@ -522,9 +522,11 @@ void Generator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState
 
         emad(1, state.offsetB, state.offsetB, shiftJ0, state.inputs.ldb, strategy, state);
         emad(1, state.offsetC[0], state.offsetC[0], shiftJ0, state.inputs.ldc[0], strategy, state);
-        add(1, state.j0, state.j0, -shiftJ0);
-        if (state.wgJ0.isValid())
-            mov(1, state.wgJ0, 0);
+        if (state.wgJ0.isValid()) {
+            add(1, state.j0, state.j0, -shiftJ0);
+            divUp(state.j0, state.j0, strategy.cInterleaveChunk, strategy, state);
+        }
+        mov(1, shiftJ0, 0);
 
         if (!strategy.persistentLoop()) {
             state.ra.safeRelease(state.inputs.ldb);


### PR DESCRIPTION
Fixes [MFDNN-14491](https://jira.devtools.intel.com/browse/MFDNN-14491). One of the last changes I made when implementing the feature was fixing some indexing logic: originally I shifted B and C offsets to ignore any columns that came before the thread's `j0` column, setting `j0=0` afterward. The issue is when we use cooperation between threads, we need to offset each thread from the work group's initial j0, `wgJ0`. This logic doesn't handle this case correctly.

The fix was to ignore columns before the work group, setting `wgJ0=0` and `j0<-j0-wgJ0`. But I forgot to divide the nonzero `j0` by the interleave chunk size. This just adds the final `divUp` when we need to use `wgJ0`, otherwise goes back to the original simpler logic.