### PR TITLE
xe: sdpa: skip split-q barriers PTL onwards

### DIFF
--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -521,8 +521,8 @@ status_t micro_t::pd_t::init_conf(impl::engine_t *engine) {
         conf.prefetch_d_max = 0;
     }
 
-    const bool is_xe2 = pd->arch() == compute::gpu_arch_t::xe2;
-    conf.q_arrive_await_barrier = (Q > 1) && !is_xe2;
+    const bool arch_gte_xe2 = pd->arch() >= compute::gpu_arch_t::xe2;
+    conf.q_arrive_await_barrier = (Q > 1) && !arch_gte_xe2;
     conf.softmax_inf_as_zero
             = (d->softmax_alg == alg_kind::softmax_accurate_inf_as_zero);
     conf.use_systolic_ukernel = pd->use_systolic_ukernel();


### PR DESCRIPTION

Non-deterministic SDPA behavior has recently been observed on PTL. This PR extends an existing workaround to newer platforms.