### PR TITLE
gpu: intel: gemmstone: guard #include <source_location>

### DIFF
--- a/src/gpu/intel/gemm/jit/include/internal/utils.hpp
+++ b/src/gpu/intel/gemm/jit/include/internal/utils.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <sstream>
 
-#if defined(__has_include) && __has_include("source_location")
+#if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
 #include <source_location>
 #endif
 


### PR DESCRIPTION
MSVC analysis generates a warning when including this file while compiling with C++ older than C++20. Guarding for a file existence is not enough and requires check for C++20 standard version (`__cplusplus >= 202002L || _MSVC_LANG >= 202002L` ) or a feature presence (via `__cpp_lib_source_location` macro).