### PR TITLE
governance: Add RISC-V team as code owner for xbyak_riscv

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 /third_party/ngen/ @uxlfoundation/onednn-gpu-intel
 /third_party/xbyak/ @uxlfoundation/onednn-cpu-x64
 /third_party/xbyak_aarch64/ @uxlfoundation/onednn-cpu-aarch64
+/third_party/xbyak_riscv/ @uxlfoundation/onednn-cpu-rv64
 
 # Governance and process
 /.github/CODEOWNERS @uxlfoundation/onednn-maintain


### PR DESCRIPTION
# Description

In PR #4457, a simple version tag update in third_party/xbyak_riscv/README.md triggered a mandatory blocking review from the documentation team (onednn-doc), which the RISC-V team could not override.

This workflow seems suboptimal. The README.md in this directory is not user-facing documentation; it merely tracks upstream dependency information. Since the code in third_party/xbyak_riscv mirrors the upstream repository, where it has already undergone strict review, and updates here are typically just version bumps, I propose granting the RISC-V team ownership of this directory. This will allow the RISC-V team to approve these dependency updates efficiently without adding unnecessary load to the documentation team.