### PR TITLE
commit-msg: add verbosity for leading spaces

### DIFF
--- a/.github/automation/commit-msg-check.py
+++ b/.github/automation/commit-msg-check.py
@@ -38,6 +38,10 @@ def __scopeCheck(msg: str):
             )
             return False
 
+        if re.match("^Merge ", msg):
+            print(f"{status} FAILED: Merge commits are not allowed")
+            return False
+
         print(
             f"{status} FAILED: Commit message must follow the format "
             "<scope>:[ <scope>:] <short description>"


### PR DESCRIPTION
PR adds an extra message to remove confusion when there's a leading space but the scoping is correct and also applies `black` formatting.