### PR TITLE
cpu: x64 brgemm: fix for destination data check

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -374,12 +374,14 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
             && (!one_of(dt_bias, data_type::undef, data_type::f32, dt_d)))
         return status::unimplemented;
     if (!IMPLICATION(brg->is_bf16,
-                one_of(dt_d, data_type::f32, data_type::bf16, data_type::f16)
+                one_of(dt_d, data_type::f32, data_type::bf16, data_type::f16,
+                        data_type::u8, data_type::s8)
                         && one_of(dt_bias, data_type::undef, data_type::f32,
                                 data_type::bf16, data_type::f16)))
         return status::unimplemented;
     if (!IMPLICATION(brg->is_f16,
-                one_of(dt_d, data_type::f32, data_type::f16)
+                one_of(dt_d, data_type::f32, data_type::f16, data_type::u8,
+                        data_type::s8)
                         && one_of(dt_bias, data_type::undef, data_type::f32,
                                 data_type::bf16, data_type::f16)))
         return status::unimplemented;

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
@@ -1,6 +1,6 @@
 --reset
 
---dt=bf16,bf16:bf16:f32,f32:bf16:f32
+--dt=bf16,bf16:bf16:f32,f32:bf16:f32,bf16:bf16:u8,bf16:bf16:s8
 --bia_dt=undef,f32,bf16
 --beta=0,1
 --attr-post-ops=,sum:2,relu

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_f16
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_f16
@@ -1,5 +1,5 @@
 --reset
---dt=f16,f16:f16:f32,f16:f32:f32,f32:f16:f32
+--dt=f16,f16:f16:f32,f16:f32:f32,f32:f16:f32,f16:f16:u8,f16:f16:s8
 --bia_dt=undef,f32,f16
 --beta=0,1
 --attr-post-ops=,sum:2,relu
@@ -8,7 +8,7 @@
 --batch=option_set_f32
 
 --reset
---dt=f16,f16:f16:f32,f16:f32:f32,f32:f16:f32
+--dt=f16,f16:f16:f32,f16:f32:f32,f32:f16:f32,f16:f16:u8,f16:f16:s8
 --bia_dt=undef,f32,f16
 --beta=0,1
 --attr-post-ops=,sum:2,relu


### PR DESCRIPTION
This fixes issue that brgemm will return unsupported when a post op results in a u8 or s8 data type for float16 and bfloat16 brgemm calculations.

This issue was reported in responce to earlyer fix that was published to catch unsupported data types.

The added check did not account for the fact that post ops could result in the destination data type being u8 or s8.

u8 and s8 has been added as a valid destination data type for float16 and bfloat16 brgemm operations. Only bf16 models are known to be affected by this issue.

this was validatated using the sde and following benchdnn tests.

benchdnn --brgemm --dt=bf16:bf16:u8 --attr-scales=dst:common:0.05 32x32:32x32
benchdnn --brgemm --dt=bf16:bf16:s8 --attr-scales=dst:common:0.05 32x32:32x32
benchdnn --brgemm --dt=f16:f16:u8 --attr-scales=dst:common:0.05 32x32:32x32
benchdnn --brgemm --dt=f16:f16:s8 --attr-scales=dst:common:0.05 32x32:32x32

this should resolve an issue reported by the OpenVINO team related to post-step affecting some known models.

see [PR#3887](https://github.com/uxlfoundation/oneDNN/pull/3887) to see original fix for [MFDNN-13836](https://jira.devtools.intel.com/browse/MFDNN-13836)



