### PR TITLE
tests: benchdnn: fix build with disabled primitive cache

### DIFF
--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -307,8 +307,8 @@ int test_persistent_cache_api(
 
             // If the operation is trivial, there may be no kernel in the cache.
             const auto dst_md = query_md(pd, DNNL_ARG_DST);
-            for (int i = 0; i < dst_md->ndims; ++i)
-                if (dst_md->padded_dims[i] == 0) return OK;
+            for (int i = 0; i < query_md_ndims(dst_md); ++i)
+                if (query_md_padded_dims(dst_md)[i] == 0) return OK;
 
             BENCHDNN_PRINT(
                     0, "error: %s\n", "cache blob is not expected to be empty");


### PR DESCRIPTION
The build fails if the primitive cache is disabled:
`cmake -DDNNL_ENABLE_PRIMITIVE_CACHE=OFF <path-to-src-root>`

The error message:
```
.../oneDNN/tests/benchdnn/dnnl_common.cpp: In function ‘int test_persistent_cache_api(benchdnn_dnnl_wrapper_t<dnnl_primitive*>&, res_t*)’:
.../oneDNN/tests/benchdnn/dnnl_common.cpp:312:39: error: invalid use of incomplete type ‘const struct dnnl_memory_desc’
  312 |             for (int i = 0; i < dst_md->ndims; ++i)
      |                                       ^~
```
Introduced here: [benchdnn: allow empty cache for trivial operations](https://github.com/uxlfoundation/oneDNN/commit/771345562adb2404c6cb1d692a0623ac22fdc72a), [PR #4469](https://github.com/uxlfoundation/oneDNN/pull/4469)

The fix uses query functions to access memory descriptor data.