### PR TITLE
cpu: aarch64: remove branch target alignment

### DIFF
--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025, 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::icb_loop(const int icb,
         sub(reg_icb, reg_icb, 1);
         b(label_icb_loop);
     }
-    L_aligned(label_loop_end);
+    L(label_loop_end);
 
     if (icb_tail) compute(ic_step, mb_tail, n_block, icb_tail, true);
 }
@@ -172,13 +172,13 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::khw_loop(const int icb,
     ldr(reg_kh_l, ptr(param1, GET_OFF(kh_l)));
     mov(reg_aux_kh_in, reg_in);
 
-    L_aligned(label_kh_loop);
+    L(label_kh_loop);
     {
         cmp(reg_kh_l, 0);
         b(EQ, label_kh_end);
         ldr(reg_kw_l, ptr(param1, GET_OFF(kw_l)));
         mov(reg_aux_kw_in, reg_aux_kh_in);
-        L_aligned(label_kw_loop);
+        L(label_kw_loop);
         {
             cmp(reg_kw_l, 0);
             b(EQ, label_kw_end);
@@ -187,13 +187,13 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::khw_loop(const int icb,
             sub(reg_kw_l, reg_kw_l, 1);
             b(label_kw_loop);
         }
-        L_aligned(label_kw_end);
+        L(label_kw_end);
 
         add_imm(reg_aux_kh_in, reg_aux_kh_in, inp_kh_sz_, X_TMP_0);
         sub(reg_kh_l, reg_kh_l, 1);
         b(label_kh_loop);
     }
-    L_aligned(label_kh_end);
+    L(label_kh_end);
 }
 
 template <cpu_isa_t isa>
@@ -282,7 +282,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::generate() {
 
     zero_accumulators(m_block, n_block);
 
-    L_aligned(label_kd_loop);
+    L(label_kd_loop);
     {
         cmp(reg_kd_l, 0);
         b(EQ, label_loop_end);
@@ -291,7 +291,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::generate() {
         sub(reg_kd_l, reg_kd_l, 1);
         b(label_kd_loop);
     }
-    L_aligned(label_loop_end);
+    L(label_loop_end);
 
     store_accumulators(m_block, n_block);
 

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2024-2025 FUJITSU LIMITED
-* Copyright 2024-2025 Arm Ltd. and affiliates
+* Copyright 2024-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -603,7 +603,7 @@ private:
         cmp(reg_apply_comp, 0);
         b(EQ, label_apply_without_comp);
         apply_comp(m_block, n_block, tail);
-        L_aligned(label_apply_without_comp);
+        L(label_apply_without_comp);
 
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {


### PR DESCRIPTION
Remove branch target alignment from brgemm functions, reducing code size by ~10% and improving performance on Graviton 3/4 by ~0.5% (this required many repeated measurements to be confident of results). Branch alignment can affect performance, but it does not need to be the default, and it should be machine and kernel specific and evidence based.

As another point of reference, arm_gemm in ComputeLibrary only uses nops in a single kernel `a64_sgemm_asimd_8x12_a53`, written for a core which we do not specifically target (and only then sparingly).

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
