### PR TITLE
cpu: aarch64: reorder: restore node check for 256-bit blk kernel

### DIFF
--- a/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
@@ -70,9 +70,9 @@ bool jit_single_blk_kernel_t::applicable(const prb_t &p) {
 
     } else if (get_max_cpu_isa() == sve_256) {
         ok = (utils::one_of(n0, 8, 16, 32, 64)
-                     && (o0 == 1 && i1 == 1 && n0 == o1 && i0 == n1))
-                || (utils::one_of(n1, 8, 16, 32, 64)
-                        && (i0 == 1 && o1 == 1 && n0 == i1 && o0 == n1));
+                     || utils::one_of(n1, 8, 16, 32, 64))
+                && ((o0 == 1 && i1 == 1 && n0 == o1 && i0 == n1)
+                        || (i0 == 1 && o1 == 1 && n0 == i1 && o0 == n1));
     } else {
         assert(!"unsupported isa");
     }


### PR DESCRIPTION
# Description
The previous fixup cef7f125d6 fixed a correctness issue by making checks for jit:blk stricter on SVE-128 and SVE-256. However, the 256-bit kernel seems to be able to handle a wider array of cases due to predication, allowing us to restore the check to the previous behaviour on these platforms.

This fixes the following regression:
```sh
# Before
$ ./build-main/tests/benchdnn/benchdnn --reorder --mode=P --stag=aBx8b --dtag=abx 128x256x15x15
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,jit:uni,,--mode=P --reorder --sdt=f32 --ddt=f32 --stag=aBx8b --dtag=abx 128x256x15x15,0,0.563232,0.0537109,0,0.0554771,0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:uni : 1 (100%)                                       |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):0.0537109 avg(ms):0.0554771
total: 3.04s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.01s (0%); execute: 0.00s (0%);

# After
$ ./build/tests/benchdnn/benchdnn --reorder --mode=P --stag=aBx8b --dtag=abx 128x256x15x15
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,jit:blk,,--mode=P --reorder --sdt=f32 --ddt=f32 --stag=aBx8b --dtag=abx 128x256x15x15,0,0.503662,0.0375977,0,0.040977,0
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:blk : 1 (100%)                                       |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):0.0375977 avg(ms):0.040977
total: 3.04s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.01s (0%); execute: 0.00s (0%);
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?