### PR TITLE
governance: added @vgvozdeva as maintainer for release management

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -264,3 +264,4 @@ Team: @uxlfoundation/onednn-devops
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Tatyana Primak     | @tprimak              | Intel Corporation | Maintainer |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
+| Viktoria Gvozdeva  | @vgvozdeva            | Intel Corporation | Maintainer |


### PR DESCRIPTION
I would like to nominate Viktoria Gvozdeva @vgvozdeva for the releases maintainer role. Viktoria was coordinating oneDNN releases throughout 2025 and completed several projects:
* Repository migration to UXL Foundation organization
* Implementing single year copyright scheme
* Enabling automatic copyright checker

Complete PR history: https://github.com/uxlfoundation/oneDNN/pulls?q=is%3Apr+author%3Avgvozdeva+is%3Aclosed
