### PR TITLE
governance: added @Sqvid as maintainer for cpu-aarch64

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -161,6 +161,7 @@ Team: @uxlfoundation/onednn-cpu-aarch64
 | Name               | Github ID             | Affiliation       | Role       |
 | ------------------ | --------------------- | ----------------- | ---------- |
 | Hamza Butt         | @theComputeKid        | Arm Ltd           | Maintainer |
+| Siddhartha Menon   | @Sqvid                | Arm Ltd           | Maintainer |
 | Aditya Tewari      | @aditew01             | Arm Ltd           | Code Owner |
 | Crefeda Rodrigues  | @cfrod                | Arm Ltd           | Code Owner |
 | David Svantesson   | @davsva01             | Arm Ltd           | Code Owner |
@@ -169,7 +170,6 @@ Team: @uxlfoundation/onednn-cpu-aarch64
 | Radu Salavat       | @Radu2k               | Arm Ltd           | Code Owner |
 | Renato Arantes     | @renato-arantes       | Arm Ltd           | Code Owner |
 | Ryo Suzuki         | @Ryo-not-rio          | Arm Ltd           | Code Owner |
-| Siddhartha Menon   | @Sqvid                | Arm Ltd           | Code Owner |
 | Sunita Nadampalli  | @snadampal            | Amazon.com, Inc.  | Code Owner |
 
 ### OpenPOWER (PPC64)


### PR DESCRIPTION
I would like to nominate Siddhartha Mennon @Sqvid for the maintainer role of `cpu-arch64` component. Sid has over a year long [history of contributions](https://github.com/uxlfoundation/oneDNN/pulls?q=is%3Apr+author%3Asqvid+is%3Aclosed) to oneDNN and currently serves as a technical lead for oneDNN team at Arm.
