### PR TITLE
cpu: aarch64: reorder: restore node check for 256-bit blk kernel

### DIFF
--- a/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder_kernel.cpp
@@ -70,9 +70,9 @@ bool jit_single_blk_kernel_t::applicable(const prb_t &p) {
 
     } else if (get_max_cpu_isa() == sve_256) {
         ok = (utils::one_of(n0, 8, 16, 32, 64)
-                     && (o0 == 1 && i1 == 1 && n0 == o1 && i0 == n1))
-                || (utils::one_of(n1, 8, 16, 32, 64)
-                        && (i0 == 1 && o1 == 1 && n0 == i1 && o0 == n1));
+                     || utils::one_of(n1, 8, 16, 32, 64))
+                && ((o0 == 1 && i1 == 1 && n0 == o1 && i0 == n1)
+                        || (i0 == 1 && o1 == 1 && n0 == i1 && o0 == n1));
     } else {
         assert(!"unsupported isa");
     }


### PR DESCRIPTION
# Description
Backport of https://github.com/uxlfoundation/oneDNN/pull/4523
Fixes a performance regression.