### PR TITLE
cpu: platform: aarch64: query and calculate cache_per_core

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -266,6 +266,21 @@ unsigned get_per_core_cache_size(int level) {
         return cpu().getDataCacheSize(l) / cpu().getCoresSharingDataCache(l);
     } else
         return 0;
+#elif DNNL_AARCH64
+    const auto num_caches
+            = static_cast<int>(aarch64::cpu().getLastDataCacheLevel());
+
+    if (num_caches == 0) { return guess(level); }
+
+    if (level > 0 && level <= num_caches) {
+        const auto &cache_level
+                = static_cast<Xbyak_aarch64::util::Arm64CacheLevel>(level);
+
+        return aarch64::cpu().getDataCacheSize(cache_level)
+                / aarch64::cpu().getCoresSharingDataCache(cache_level);
+    } else {
+        return 0;
+    }
 #else
     return guess(level);
 #endif


### PR DESCRIPTION

# Description
Query the actual cache levels on the processor rather than returning a guess value.

There are several instances of heuristics depending on this function. So I will do some extra testing before we merge.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?