### PR TITLE
cpu: rv64: jit: Fix Clang compilation error in jit_generator

### DIFF
--- a/src/cpu/rv64/jit_generator.hpp
+++ b/src/cpu/rv64/jit_generator.hpp
@@ -85,6 +85,8 @@ public:
     template <typename... kernel_args_t>
     void operator()(kernel_args_t... args) const {
         using jit_kernel_func_t = void (*)(const kernel_args_t...);
+        // This const_cast is required for Clang.
+        // Clang rejects reinterpret_cast from const uint8_t* to function pointer.
         auto *fptr = reinterpret_cast<jit_kernel_func_t>(
                 const_cast<uint8_t *>(jit_ker_));
         (*fptr)(std::forward<kernel_args_t>(args)...);


### PR DESCRIPTION
The JIT generator fails to compile with Clang due to a strict interpretation of `reinterpret_cast` rules.

Clang correctly identifies that casting from a `const uint8_t *` to a function pointer implicitly casts away the `const` qualifier, which is not allowed by the C++ standard for `reinterpret_cast`. While GCC is more permissive in this scenario, this behavior is non-standard.

This commit resolves the issue by introducing an explicit `const_cast` to remove the qualifier before the `reinterpret_cast`. This makes the developer's intent clear and ensures compatibility with both Clang and GCC.

**before the fix:**
```
xzz@MUSE-Pi-Pro ~/oneDNN/build1
 % export CC=clang CXX=clang++
xzz@MUSE-Pi-Pro ~/oneDNN/build1
 % cmake ..
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
-- The C compiler identification is Clang 18.1.8
-- The CXX compiler identification is Clang 18.1.8
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- DNNL_TARGET_ARCH: RV64
-- DNNL_LIBRARY_NAME: dnnl
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found OpenMP_C: -fopenmp=libomp (found version "5.1") 
-- Found OpenMP_CXX: -fopenmp=libomp (found version "5.1") 
-- Found OpenMP: TRUE (found version "5.1")  
-- Performing Test CAN_COMPILE_RVV_INTRINSICS
-- Performing Test CAN_COMPILE_RVV_INTRINSICS - Success
-- Performing Test CAN_COMPILE_ZVFH_INTRINSICS
-- Performing Test CAN_COMPILE_ZVFH_INTRINSICS - Success
-- Can compile RVV Intrinsics: TRUE
-- Can compile Zvfh Intrinsics: TRUE
-- DNNL_RISCV_USE_RVV_INTRINSICS: TRUE
-- DNNL_RISCV_USE_ZVFH_INTRINSICS: TRUE
-- Using RV64 march flag: -march=rv64gcv_zvfh
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Could NOT find Doxyrest (missing: DOXYREST_EXECUTABLE) 
-- Found Python: /usr/bin/python3 (found suitable version "3.12.3", minimum required is "3.7") found components: Interpreter 
-- Could NOT find Sphinx (missing: SPHINX_EXECUTABLE) 
-- Found Git: /usr/bin/git (found version "2.43.0") 
-- Enabled testing coverage: CI
-- Enabled workload: TRAINING
-- Enabled primitives: ALL
-- Enabled primitive CPU ISA: ALL
-- Enabled primitive GPU ISA: ALL
-- Enabled GeMM kernels ISA: ALL
-- Primitive cache is enabled
-- Graph component is enabled
-- Configuring done (17.0s)
-- Generating done (2.9s)
-- Build files have been written to: /home/xzz/oneDNN/build1
xzz@MUSE-Pi-Pro ~/oneDNN/build1
 % make -j 8
[  0%] Building CXX object src/graph/utils/CMakeFiles/dnnl_graph_utils.dir/alloc.cpp.o
[  0%] Building CXX object src/graph/backend/fake/CMakeFiles/dnnl_graph_backend_fake.dir/fake_backend.cpp.o
[  0%] Building CXX object src/cpu/rv64/CMakeFiles/dnnl_cpu_riscv.dir/cpu_isa_traits.cpp.o
[  0%] Building CXX object tests/gtests/gtest/CMakeFiles/dnnl_gtest.dir/src/gtest-all.cc.o
[  0%] Building CXX object src/common/CMakeFiles/dnnl_common.dir/batch_normalization.cpp.o
[  1%] Building CXX object src/cpu/CMakeFiles/dnnl_cpu.dir/bfloat16.cpp.o
[  1%] Building CXX object src/graph/interface/CMakeFiles/dnnl_graph_interface.dir/allocator.cpp.o
[  2%] Building CXX object src/graph/backend/dnnl/CMakeFiles/dnnl_graph_backend_dnnl.dir/common.cpp.o
[  2%] Building CXX object src/graph/utils/CMakeFiles/dnnl_graph_utils.dir/debug.cpp.o
[  2%] Building CXX object src/cpu/CMakeFiles/dnnl_cpu.dir/binary_injector_utils.cpp.o
[  2%] Building CXX object src/graph/utils/CMakeFiles/dnnl_graph_utils.dir/id.cpp.o
[  2%] Building CXX object src/graph/utils/CMakeFiles/dnnl_graph_utils.dir/ocl_usm_utils.cpp.o
[  2%] Building CXX object src/graph/utils/CMakeFiles/dnnl_graph_utils.dir/pm/nested_matcher.cpp.o
[  2%] Building CXX object src/graph/interface/CMakeFiles/dnnl_graph_interface.dir/backend.cpp.o
[  2%] Building CXX object src/cpu/rv64/CMakeFiles/dnnl_cpu_riscv.dir/gemm/jit_rvv_gemm_kernel.cpp.o
[  2%] Building CXX object src/common/CMakeFiles/dnnl_common.dir/bfloat16.cpp.o
[  2%] Building CXX object src/common/CMakeFiles/dnnl_common.dir/binary.cpp.o
[  2%] Building CXX object src/cpu/CMakeFiles/dnnl_cpu.dir/cpu_batch_normalization_list.cpp.o
In file included from /home/xzz/oneDNN/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp:17:
In file included from /home/xzz/oneDNN/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp:20:
/home/xzz/oneDNN/src/cpu/rv64/jit_generator.hpp:88:22: error: reinterpret_cast from 'const uint8_t *' (aka 'const unsigned char *') to 'jit_kernel_func_t' (aka 'void (*)(const dnnl::impl::cpu::rv64::gemm_utils::jit_rvv_gemm_kernel_t::call_params_t *const)') casts away qualifiers
   88 |         auto *fptr = reinterpret_cast<jit_kernel_func_t>(jit_ker_);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/xzz/oneDNN/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp:65:26: note: in instantiation of function template specialization 'dnnl::impl::cpu::rv64::jit_generator_t::operator()<const dnnl::impl::cpu::rv64::gemm_utils::jit_rvv_gemm_kernel_t::call_params_t *>' requested here
   65 |         jit_generator_t::operator()(p);
      |                          ^
1 error generated.
make[2]: *** [src/cpu/rv64/CMakeFiles/dnnl_cpu_riscv.dir/build.make:90：src/cpu/rv64/CMakeFiles/dnnl_cpu_riscv.dir/gemm/jit_rvv_gemm_kernel.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:895：src/cpu/rv64/CMakeFiles/dnnl_cpu_riscv.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```