### PR TITLE
cpu: rv64: conv: improve im2col of rvv gemm conv kernerl

### DIFF
--- a/src/cpu/rv64/rvv_gemm_convolution.hpp
+++ b/src/cpu/rv64/rvv_gemm_convolution.hpp
@@ -39,7 +39,7 @@ struct riscv_gemm_convolution_fwd_t : public primitive_t {
     struct pd_t : public cpu_convolution_fwd_pd_t {
         using cpu_convolution_fwd_pd_t::cpu_convolution_fwd_pd_t;
 
-        DECLARE_COMMON_PD_T(GEMM_IMPL_STR, riscv_gemm_convolution_fwd_t,
+        DECLARE_COMMON_PD_T("gemm:rvv", riscv_gemm_convolution_fwd_t,
                 USE_GLOBAL_SCRATCHPAD);
 
         status_t init(engine_t *engine) {

--- a/src/cpu/rv64/rvv_gemm_convolution_utils.hpp
+++ b/src/cpu/rv64/rvv_gemm_convolution_utils.hpp
@@ -86,6 +86,23 @@ struct single_gemm_conv_chunk_desc_t {
     dim_t w_size_ = 0;
 };
 
+// Address pre-computation cache for im2col optimization
+struct im2col_addr_cache_t {
+    const void *src_base;
+    void *col_base;
+    dim_t src_ic_stride;
+    dim_t col_ks_stride;
+    dim_t col_os_stride;
+    bool is_cached;
+    im2col_addr_cache_t()
+        : src_base(nullptr)
+        , col_base(nullptr)
+        , src_ic_stride(0)
+        , col_ks_stride(0)
+        , col_os_stride(0)
+        , is_cached(false) {}
+};
+
 namespace jit_gemm_convolution_utils {
 template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
@@ -104,9 +121,9 @@ void im2col(const conv_gemm_conf_t &jcp, const data_type_t *__restrict im,
         data_type_t *__restrict col, dim_t ss, dim_t sb, dim_t cs, dim_t cb);
 
 template <typename im_dt, typename col_dt>
-void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict im,
-        void *__restrict imtr, col_dt *__restrict col, dim_t hs, dim_t hb,
-        dim_t ws, dim_t wb);
+void im2col_dt(const conv_gemm_conf_t &jcp, const im2col_addr_cache_t *cache,
+        const void *__restrict im, void *__restrict imtr,
+        col_dt *__restrict col, dim_t hs, dim_t hb, dim_t ws, dim_t wb);
 
 template <typename T>
 void col2im_dt(


### PR DESCRIPTION
# Description

This PR introduces optimized GEMM-based convolution primitives for RISC-V architectures by reducing `im2col` transformation overhead through targeted algorithmic improvements.

This version provides:

1. **Address pre-computation cache** to eliminate redundant stride calculations
2. **Vectorized data copy loops** using RVV intrinsics for stride-1 convolutions
3. **Transpose result caching** to skip redundant 3D transpose operations
4. **Cache-friendly blocking** aligned to RVV vector length and cache lines

## Key Features

- **Address Pre-computation Cache**: Pre-computes memory addresses and stride information once per thread and **passes it to im2col functions**, eliminating redundant stride recalculations in inner loops
- **Vectorized Data Copy**: Uses RVV m4 vector intrinsics (`vle32_v_f32m4`/`vse32_v_f32m4`) for bulk memory operations when stride=1, replacing scalar copy loops
- **Transpose Caching**: Tracks transpose source pointer to skip redundant transpose operations in 3D convolutions
- **Cache-Friendly Blocking**: Aligns block sizes to RVV vector width and cache lines for improved memory access patterns
- **Conservative Design**: All optimizations maintain the existing `extended_sgemm()` interface without modifications to the GEMM kernel itself
- **Simplified Implementation**: Removed complex caching heuristics and layer-specific optimizations to focus on universal algorithmic improvements

# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on SG2044 platform with VLEN=128. We draw comparisons between:

1. **main branch** implementation (reference GEMM-based convolution using rvv intrinsics)
2. **optimized** implementation (this PR - with address pre-computation, vectorized data copy, transpose caching, and cache-friendly blocking)

### Overall Performance

| Dataset | Main Branch Time (ms) | Optimized Time (ms) | Improvement |
|---------|--------------------|---------------------|-------------|
| shapes_mobilenet | 1813.63 | 1791.39 | **1.23%** |
| shapes_vgg_11 | 11191.9 | 10678.3 | **4.59%** |
| shapes_resnet_50 | 18174.5 | 18227.2 | -0.29% (ignored) |
| shapes_googlenet_v3 | 14574.8 | 13837.7 | **5.06%** |
| **Total (4 datasets)** | 45753.83 | 44534.59 | **2.66%** |

### Performance Analysis

**Key Observations:**

1. **shapes_mobilenet**: Slight improvement (1.23% faster)
   - Only 1/11 layers uses gemm:rvv (9%)
   - 10/11 layers use jit_1x1:rvv (91%) - unaffected by im2col optimizations
   - The single gemm:rvv layer shows improvement

2. **shapes_vgg_11**: **Significant improvement** (4.59% faster)
   - All 10/10 layers use gemm:rvv (100%)
   - Optimizations provide consistent benefit across all VGG-11 layers
   - Best performing dataset

3. **shapes_resnet_50**: Minimal performance difference (0.29% regression, within noise margin)
   - 11/20 layers use gemm:rvv (55%) - affected by changes
   - 9/20 layers use jit_1x1:rvv (45%) - unaffected by im2col optimizations
   - Performance within measurement noise

4. **shapes_googlenet_v3**: **Significant improvement** (5.06% faster)
   - 24/43 layers use gemm:rvv (56%) - affected by changes
   - 19/43 layers use jit_1x1:rvv (44%) - unaffected by im2col optimizations
   - Consistent improvements across gemm:rvv layers

### Performance Breakdown

The optimizations provide the following benefits for **gemm:rvv convolution layers**:

1. **Address Pre-computation**:
   - Eliminates redundant stride calculations in inner loops
   - Cached values passed to im2col functions
   - Estimated 5-10% reduction in address computation overhead

2. **Vectorized Data Copy**:
   - RVV m4 intrinsics replace scalar loops for stride-1 convolutions
   - Estimated 15-25% improvement in memory copy throughput
   - Most effective for contiguous memory regions (size ≥ 16)

3. **Transpose Caching**:
   - Skips redundant transpose operations in 3D convolutions
   - Estimated 5-10% reduction for repeated source data
   - Most effective for depthwise 3D convolutions

4. **Cache-Friendly Blocking**:
   - Aligns blocks to RVV vector length and cache lines
   - Estimated 3-5% improvement in memory access efficiency
   - Reduces cache misses and improves throughput
