### PR TITLE
xe: matmul, gemm: add dynamic dst scales support

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -277,7 +277,7 @@ enum {
     key_matmul_dst_cast_acc,
     key_matmul_dst_scales,
     key_matmul_sparse_tmp_ptr,
-    key_matmul_mx_scale_space,
+    key_matmul_dyn_scale_space,
     key_pool_dst_bf16cvt,
     key_pool_dst_plain2blocked_cvt,
     key_pool_ind_plain2blocked_cvt,

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -171,7 +171,7 @@ struct primitive_desc_t : public c_compatible {
         if (arg & DNNL_ARG_ATTR_SCALES) {
             int scale_arg = arg & ~DNNL_ARG_ATTR_SCALES;
             if (!attr()->scales_.has_default_values(scale_arg)) {
-                if (attr()->scales_.get(scale_arg).is_mx())
+                if (attr()->scales_.get(scale_arg).is_dynamic())
                     return arg_usage_t::output;
                 else
                     return arg_usage_t::input;

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -403,6 +403,8 @@ bool pd_t::scales_ok() {
             if (s == DNNL_ARG_C && with_mx_scale() && x_scales.get_group(0) != 1
                     && x_scales.get_group(1) != 32)
                 return false;
+            // Other dynamic quant unsupported
+            if (x_scales.is_dynamic()) return false;
         }
     }
 

--- a/src/gpu/intel/gemm/with_post_ops.cl
+++ b/src/gpu/intel/gemm/with_post_ops.cl
@@ -97,7 +97,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
         if (B_SCALES) load(&b_scale, b_scales + scale_stride * b_scale_dim);
         if (A_SCALES || B_SCALES) acc *= a_scale * b_scale;
         if (bias) {
-            ACC_DATA_T b = load(b, bias + BIAS_OFF(d0, d1, d2, d3, d4, d5));
+            ACC_DATA_T b = load(b, bias, BIAS_OFF(d0, d1, d2, d3, d4, d5));
             acc += b;
         }
 
@@ -106,7 +106,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
 
         accumulator = AS_POST_OP_DATA_T(acc);
         APPLY_POST_OPS_SERIAL(accumulator, sum_src, d0, d1, d2, d3, d4, d5);
-#if WITH_MX_DST_SCALE == 0
+#if WITH_DYN_DST_SCALE == 0
         if (C_SCALES) {
             POST_OP_DATA_T c_scale = load(c_scale, c_scales);
             accumulator /= c_scale;

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -60,7 +60,8 @@ status_t with_post_ops_t::pd_t::init(impl::engine_t *engine) {
         if (arg == DNNL_ARG_WEIGHTS && !wei_decomp) {
             VDISPATCH_GEMM((mask == 0 || mask == (1 << (dst_md()->ndims - 1))),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
-        } else if (arg == DNNL_ARG_DST && attr()->scales_.get(arg).is_mx()) {
+        } else if (arg == DNNL_ARG_DST
+                && attr()->scales_.get(arg).is_dynamic()) {
             VDISPATCH_GEMM(utils::one_of(d->a_type(), f4_e2m1, f8_e5m2, f8_e4m3)
                             && utils::one_of(
                                     d->b_type(), f4_e2m1, f8_e5m2, f8_e4m3),
@@ -90,15 +91,15 @@ status_t with_post_ops_t::pd_t::init(impl::engine_t *engine) {
                 sizeof(char), OCL_BUFFER_ALIGNMENT);
     }
 
-    mx_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_mx();
-    if (mx_scales_) {
+    dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
+    if (dynamic_scales_) {
         using namespace dnnl::impl::memory_tracking::names;
         const memory_desc_wrapper dst_mdw(dst_md(0));
         const auto &padded_dims = dst_mdw.padded_dims();
         const dim_t ndims = dst_mdw.ndims();
         const dim_t nelems = utils::array_product(padded_dims, ndims);
         auto scratchpad = scratchpad_registry().registrar();
-        scratchpad.book(memory_tracking::names::key_matmul_mx_scale_space,
+        scratchpad.book(memory_tracking::names::key_matmul_dyn_scale_space,
                 nelems, sizeof(float), OCL_BUFFER_ALIGNMENT);
     }
 
@@ -214,7 +215,7 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
 
     def_memory_desc_info(kernel_ctx, src_info, "SRC", false);
     def_memory_desc_info(kernel_ctx, bias_info, "BIAS", false);
-    if (mx_scales_) {
+    if (dynamic_scales_) {
         dnnl_memory_desc d_md(*dst_md(0));
         d_md.data_type = acc_type_;
         memory_desc_wrapper d_mdw(d_md);
@@ -226,7 +227,7 @@ status_t with_post_ops_t::pd_t::init_kernel_ctx(
     }
 
     int ndims = src_info.ndims;
-    kernel_ctx.set_data_type(mx_scales_ ? acc_type_ : c_type);
+    kernel_ctx.set_data_type(dynamic_scales_ ? acc_type_ : c_type);
     kernel_ctx.require_stateless_addressing(has_large_buffers());
 
     const auto &attr_scales = attr()->scales_;
@@ -299,13 +300,13 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
     CHECK(gemm(prim_)->execute(nested_ctx));
 
     const bool subbyte_pack = pd()->subbyte_pack_;
-    const bool mx_scales = pd()->mx_scales_;
+    const bool dyn_scales = pd()->dynamic_scales_;
 
     auto tmp = ctx.get_scratchpad_grantor().get_memory_storage(
             memory_tracking::names::key_matmul_pack_space);
 
     auto tmp_ds = ctx.get_scratchpad_grantor().get_memory_storage(
-            memory_tracking::names::key_matmul_mx_scale_space);
+            memory_tracking::names::key_matmul_dyn_scale_space);
 
     compute::kernel_arg_list_t arg_list;
     arg_list.set(0,
@@ -313,11 +314,10 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
                                    : GEMM_CTX_ARG_STORAGE(c));
     arg_list.set(1, GEMM_CTX_ARG_STORAGE(bias));
     arg_list.set(2,
-            mx_scales                     ? *tmp_ds
-                    : pd()->subbyte_pack_ ? *tmp
-                                          : GEMM_CTX_ARG_STORAGE(c));
+            dyn_scales             ? *tmp_ds
+                    : subbyte_pack ? *tmp
+                                   : GEMM_CTX_ARG_STORAGE(c));
     const auto &args = ctx.args();
-    int kidx = 0;
     int idx = append_post_ops_to_arg_list(args.exec_args, arg_list, 3,
             pd()->attr()->post_ops_, *pd()->dst_md());
     //a/b tensors are swapped for gemm
@@ -355,9 +355,11 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
         }
     }
     auto nd_range = pd()->dispatch_.nd_range();
-    CHECK(parallel_for(ctx, nd_range, kernels_[kidx++], arg_list));
+    CHECK(parallel_for(ctx, nd_range, kernels_[0], arg_list));
 
-    if (mx_scales) {
+    if (dyn_scales) {
+        const auto group_size
+                = pd()->attr()->scales_.get_group(DNNL_ARG_DST, -1);
         const auto c_d = nested_ctx.memory_mdw(DNNL_ARG_DST, pd()->dst_md());
         const int last = c_d.ndims() - 1;
         const dim_t D3 = c_d.ndims() > 5 ? c_d.dims()[last - 5] : 1;
@@ -371,27 +373,25 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
         for (int i = 0; i < c_d.ndims(); i++)
             if (c_d.dims()[last - i] > 1) { c_stride[i] = c_strides[last - i]; }
 
-        compute::kernel_arg_list_t mx_scale_arg_list;
+        compute::kernel_arg_list_t arg_list;
         int arg_idx = 0;
-        mx_scale_arg_list.set(arg_idx++, *tmp_ds);
-        mx_scale_arg_list.set(
-                arg_idx++, subbyte_pack ? *tmp : GEMM_CTX_ARG_STORAGE(c));
-        mx_scale_arg_list.set(arg_idx++, GEMM_CTX_ARG_STORAGE(c_scales));
-        mx_scale_arg_list.set(arg_idx++, 32);
-        mx_scale_arg_list.set(arg_idx++, D0);
-        mx_scale_arg_list.set(arg_idx++, D1);
-        mx_scale_arg_list.set(arg_idx++, D2);
-        mx_scale_arg_list.set(arg_idx++, c_stride[5]);
-        mx_scale_arg_list.set(arg_idx++, c_stride[4]);
-        mx_scale_arg_list.set(arg_idx++, c_stride[3]);
-        mx_scale_arg_list.set(arg_idx++, c_stride[2]);
-        mx_scale_arg_list.set(arg_idx++, c_stride[1]);
-        mx_scale_arg_list.set(arg_idx++, c_stride[0]);
-        compute::range_t mx_scale_gws(
-                {(size_t)M, (size_t)N / 32, (size_t)(D0 * D1 * D2 * D3)});
-        compute::nd_range_t mx_scale_nd_range(mx_scale_gws);
-        CHECK(parallel_for(
-                ctx, mx_scale_nd_range, kernels_[kidx++], mx_scale_arg_list));
+        arg_list.set(arg_idx++, *tmp_ds);
+        arg_list.set(arg_idx++, subbyte_pack ? *tmp : GEMM_CTX_ARG_STORAGE(c));
+        arg_list.set(arg_idx++, GEMM_CTX_ARG_STORAGE(c_scales));
+        arg_list.set(arg_idx++, group_size);
+        arg_list.set(arg_idx++, D0);
+        arg_list.set(arg_idx++, D1);
+        arg_list.set(arg_idx++, D2);
+        arg_list.set(arg_idx++, c_stride[5]);
+        arg_list.set(arg_idx++, c_stride[4]);
+        arg_list.set(arg_idx++, c_stride[3]);
+        arg_list.set(arg_idx++, c_stride[2]);
+        arg_list.set(arg_idx++, c_stride[1]);
+        arg_list.set(arg_idx++, c_stride[0]);
+        compute::range_t gws({(size_t)M, (size_t)N / group_size,
+                (size_t)(D0 * D1 * D2 * D3)});
+        compute::nd_range_t nd_range(gws);
+        CHECK(parallel_for(ctx, nd_range, kernels_[1], arg_list));
     }
     if (!subbyte_pack) return status_t::dnnl_success;
     memory_desc_wrapper dst_mdw(pd()->dst_md(0));
@@ -404,7 +404,7 @@ status_t with_post_ops_t::execute(const exec_ctx_t &ctx) const {
     compute::range_t repack_gws((nelems * 4 + 7) / 8);
     compute::nd_range_t repack_nd_range(repack_gws);
     return large_parallel_for(impl::exec_ctx_t(ctx.stream()), repack_nd_range,
-            kernels_[kidx++], repack_arg_list, 4);
+            kernels_[2], repack_arg_list, 4);
 }
 
 } // namespace gemm

--- a/src/gpu/intel/include/math_utils.h
+++ b/src/gpu/intel/include/math_utils.h
@@ -81,13 +81,15 @@ int __attribute__((overloadable)) rnd_down(long a, unsigned int b) {
 
 #if DT_F4_E2M1 || SRC_DT_F4_E2M1 || WEI_DT_F4_E2M1 || DST_DT_F4_E2M1 \
         || BIA_DT_F4_E2M1 || A_DT_F4_E2M1 || A_DT_F4_E2M1 || B_DT_F4_E2M1 \
-        || C_DT_F4_E2M1 || DATA_DT_F4_E2M1 || POST_OP_USING_F4_E2M1
+        || C_DT_F4_E2M1 || DATA_DT_F4_E2M1 || POST_OP_USING_F4_E2M1 \
+        || BIAS_DT_F4_E2M1
 #define MATH_UTILS_DECLARE_F4_E2M1 1
 #endif
 
 #if DT_F4_E3M0 || SRC_DT_F4_E3M0 || WEI_DT_F4_E3M0 || DST_DT_F4_E3M0 \
         || BIA_DT_F4_E3M0 || A_DT_F4_E3M0 || A_DT_F4_E3M0 || B_DT_F4_E3M0 \
-        || C_DT_F4_E3M0 || DATA_DT_F4_E3M0 || POST_OP_USING_F4_E3M0
+        || C_DT_F4_E3M0 || DATA_DT_F4_E3M0 || POST_OP_USING_F4_E3M0 \
+        || BIAS_DT_F4_E3M0
 #define MATH_UTILS_DECLARE_F4_E3M0 1
 #endif
 
@@ -126,12 +128,12 @@ float __attribute__((overloadable)) cvt_e8m0_to_f32(uchar f) {
     uint bits = f << 23;
     return as_float(bits);
 }
-#endif
 
 uchar __attribute__((overloadable)) cvt_f32_to_e8m0(float f) {
     uint bits = as_uint(f);
     return ((uchar4)((bits >> 23) & 0xff)).s0;
 }
+#endif
 
 #if MATH_UTILS_DECLARE_HF8
 // Emulation functions for f8_e4m3 <-> f16 conversion.

--- a/src/gpu/intel/include/types_specific.h
+++ b/src/gpu/intel/include/types_specific.h
@@ -771,14 +771,19 @@
 #ifdef DST_SCALES_DATA_T
 #if DST_SCALES_DT_HF8
 #define DST_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
+#define REF_TO_DST_SCALES(x) cvt_hf_to_f8_e4m3(convert_half(x))
 #elif DST_SCALES_DT_BF8
 #define DST_SCALES_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
+#define REF_TO_DST_SCALES(x) cvt_hf_to_f8_e5m2(convert_half(x))
 #elif DST_SCALES_DT_F16
 #define DST_SCALES_TO_REF(x) convert_float(x)
+#define REF_TO_DST_SCALES(x) convert_half(x)
 #elif DST_SCALES_DT_BF16
 #define DST_SCALES_TO_REF(x) cvt_bf16_to_f32(x)
+#define REF_TO_DST_SCALES(x) cvt_f32_to_bf16(x)
 #elif DST_SCALES_DT_E8M0
 #define DST_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
+#define REF_TO_DST_SCALES(x) cvt_f32_to_e8m0(x)
 #else
 #define DST_SCALES_TO_REF(x) (x)
 #endif
@@ -787,16 +792,19 @@
 #ifdef WEI_SCALES_DATA_T
 #if WEI_SCALES_DT_HF8
 #define WEI_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
+#define REF_TO_WEI_SCALES(x) cvt_hf_to_f8_e4m3(convert_half(x))
 #elif WEI_SCALES_DT_BF8
 #define WEI_SCALES_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#elif WEI_SCALES_DT_E8M0
-#define WEI_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
+#define REF_TO_WEI_SCALES(x) cvt_hf_to_f8_e5m2(convert_half(x))
 #elif WEI_SCALES_DT_F16
 #define WEI_SCALES_TO_REF(x) convert_float(x)
+#define REF_TO_WEI_SCALES(x) convert_half(x)
 #elif WEI_SCALES_DT_BF16
 #define WEI_SCALES_TO_REF(x) cvt_bf16_to_f32(x)
+#define REF_TO_WEI_SCALES(x) cvt_f32_to_bf16(x)
 #elif WEI_SCALES_DT_E8M0
 #define WEI_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
+#define REF_TO_WEI_SCALES(x) cvt_f32_to_e8m0(x)
 #else
 #define WEI_SCALES_TO_REF(x) (x)
 #endif
@@ -805,16 +813,19 @@
 #ifdef SRC_SCALES_DATA_T
 #if SRC_SCALES_DT_HF8
 #define SRC_SCALES_TO_REF(x) convert_float(cvt_f8_e4m3_to_hf(x))
+#define REF_TO_SRC_SCALES(x) cvt_hf_to_f8_e4m3(convert_half(x))
 #elif SRC_SCALES_DT_BF8
 #define SRC_SCALES_TO_REF(x) convert_float(cvt_f8_e5m2_to_hf(x))
-#elif SRC_SCALES_DT_E8M0
-#define SRC_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
+#define REF_TO_SRC_SCALES(x) cvt_hf_to_f8_e5m2(convert_half(x))
 #elif SRC_SCALES_DT_F16
 #define SRC_SCALES_TO_REF(x) convert_float(x)
+#define REF_TO_SRC_SCALES(x) convert_half(x)
 #elif SRC_SCALES_DT_BF16
 #define SRC_SCALES_TO_REF(x) cvt_bf16_to_f32(x)
+#define REF_TO_SRC_SCALES(x) cvt_f32_to_bf16(x)
 #elif SRC_SCALES_DT_E8M0
 #define SRC_SCALES_TO_REF(x) cvt_e8m0_to_f32(x)
+#define REF_TO_SRC_SCALES(x) cvt_f32_to_e8m0(x)
 #else
 #define SRC_SCALES_TO_REF(x) (x)
 #endif

--- a/src/gpu/intel/matmul/gemm.cpp
+++ b/src/gpu/intel/matmul/gemm.cpp
@@ -56,8 +56,9 @@ status_t gemm_t::execute(const exec_ctx_t &ctx) const {
     args.c_zero_point = c0;
     args.a_scales = &CTX_IN_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS);
     args.b_scales = &CTX_IN_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
-    bool mx_scales = gemm_->pd()->attr()->scales_.get(DNNL_ARG_DST).is_mx();
-    args.c_scales = mx_scales
+    bool dyn_scales
+            = gemm_->pd()->attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
+    args.c_scales = dyn_scales
             ? &CTX_OUT_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)
             : &CTX_IN_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
 

--- a/src/gpu/intel/matmul/ref.cl
+++ b/src/gpu/intel/matmul/ref.cl
@@ -312,19 +312,19 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
 #if WITH_DST_SCALES
 #if DST_SCALES_MASK == 0
         po_acc /= DST_SCALES_TO_REF(dst_scales[0]);
-#elif WITH_MX_DST_SCALE == 0
+#elif WITH_DYN_DST_SCALE == 0
         po_acc /= DST_SCALES_TO_REF(dst_scales[n]);
 #endif
 #endif
         po_acc += dst_zp;
 
-#if WITH_MX_DST_SCALE
+#if WITH_DYN_DST_SCALE
         ((__global ACC_DATA_T *)C)[dst_off] = po_acc;
 #else
         C[dst_off] = TO_DST(po_acc);
 #endif
 #else // WITH_BIAS || NON_DEFAULT_ATTRS
-#if WITH_MX_DST_SCALE
+#if WITH_DYN_DST_SCALE
         ((__global ACC_DATA_T *)C)[dst_off] = acc;
 #else
         C[dst_off] = TO_DST(acc);

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -68,7 +68,8 @@ struct ref_t : public primitive_t {
             VDISPATCH_MATMUL(attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS,
                                                     DNNL_ARG_DST},
                                      {quantization_mode::static_sazp,
-                                             quantization_mode::dynamic_mx}),
+                                             quantization_mode::dynamic_mx,
+                                             quantization_mode::dynamic_fp}),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_MATMUL(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_MATMUL(
@@ -121,8 +122,8 @@ struct ref_t : public primitive_t {
             CHECK(dropout_ok());
             subbyte_pack_ = utils::one_of(
                     dst_dt_, data_type::f4_e2m1, data_type::f4_e3m0);
-            mx_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_mx();
-            if (mx_scales_) {
+            dynamic_scales_ = attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
+            if (dynamic_scales_) {
                 using namespace dnnl::impl::memory_tracking::names;
                 const memory_desc_wrapper dst_mdw(dst_md(0));
                 const auto &padded_dims = dst_mdw.padded_dims();
@@ -130,7 +131,7 @@ struct ref_t : public primitive_t {
                 const dim_t nelems = utils::array_product(padded_dims, ndims);
                 auto scratchpad = scratchpad_registry().registrar();
                 scratchpad.book(
-                        memory_tracking::names::key_matmul_mx_scale_space,
+                        memory_tracking::names::key_matmul_dyn_scale_space,
                         nelems, sizeof(float), OCL_BUFFER_ALIGNMENT);
             }
             if (subbyte_pack_) {
@@ -152,7 +153,7 @@ struct ref_t : public primitive_t {
 
         bool non_default_attrs_ = false;
         bool subbyte_pack_ = false;
-        bool mx_scales_ = false;
+        bool dynamic_scales_ = false;
         data_type_t bia_dt_ = data_type::undef;
         data_type_t src_dt_ = data_type::undef;
         data_type_t dst_dt_ = data_type::undef;
@@ -276,8 +277,8 @@ struct ref_t : public primitive_t {
                     DNNL_ARG_SRC))
             kernel_ctx.define_int("WITH_SRC_GROUP_SUMS", 1);
 
-        bool mx_scales = pd()->attr()->scales_.get(DNNL_ARG_DST).is_mx();
-        kernel_ctx.define_int("DYN_SCALES", mx_scales);
+        bool dyn_scales = pd()->attr()->scales_.get(DNNL_ARG_DST).is_dynamic();
+        kernel_ctx.define_int("DYN_SCALES", dyn_scales);
 
         bool runtime_dims = pd()->has_runtime_dims_or_strides() || ndims > 5;
         if (!runtime_dims) {
@@ -331,19 +332,16 @@ struct ref_t : public primitive_t {
         def_data_type(kernel_ctx,
                 pd()->attr()->scales_.get_data_type(DNNL_ARG_DST),
                 "DST_SCALES");
-        int kidx = 0;
-        kernels_.resize(3);
-        CHECK(create_kernel(
-                engine, &kernels_[kidx++], "ref_matmul", kernel_ctx));
-        if (pd()->mx_scales_)
+        CHECK(create_kernel(engine, &kernels_[0], "ref_matmul", kernel_ctx));
+        if (pd()->dynamic_scales_)
             CHECK(create_kernel(
-                    engine, &kernels_[kidx++], "mx_scale_dst", kernel_ctx));
+                    engine, &kernels_[1], "dynamic_scale_dst", kernel_ctx));
         if (pd()->subbyte_pack_)
             CHECK(create_kernel(
-                    engine, &kernels_[kidx++], "subbyte_pack", kernel_ctx));
+                    engine, &kernels_[2], "subbyte_pack", kernel_ctx));
         if (!kernels_[0]) return status::runtime_error;
-        if ((pd()->subbyte_pack_ || pd()->mx_scales_) && !kernels_[1])
-            return status::runtime_error;
+        if (pd()->dynamic_scales_ && !kernels_[1]) return status::runtime_error;
+        if (pd()->subbyte_pack_ && !kernels_[2]) return status::runtime_error;
         return status::success;
     }
 
@@ -354,7 +352,7 @@ struct ref_t : public primitive_t {
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     status_t execute_ref(const exec_ctx_t &ctx) const;
-    std::vector<compute::kernel_t> kernels_;
+    std::array<compute::kernel_t, 3> kernels_ = {};
 };
 
 } // namespace matmul

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -141,7 +141,7 @@ attr_info_t attr_info_t::create(const primitive_attr_t *attr) {
     attr_info.with_host_src_scale = src_scales.is_host_scalar();
     attr_info.with_host_wei_scale = wei_scales.is_host_scalar();
     attr_info.with_host_dst_scale = dst_scales.is_host_scalar();
-    attr_info.with_mx_dst_scale = dst_scales.is_mx();
+    attr_info.with_dyn_dst_scale = dst_scales.is_dynamic();
     attr_info.with_host_src_zp = zp.get(DNNL_ARG_SRC).is_host_scalar();
     attr_info.with_host_wei_zp = zp.get(DNNL_ARG_WEIGHTS).is_host_scalar();
     attr_info.with_host_dst_zp = zp.get(DNNL_ARG_DST).is_host_scalar();
@@ -712,7 +712,7 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("WITH_HOST_SRC_SCALE", attr_info.with_host_src_scale);
     kernel_ctx.define_int("WITH_HOST_WEI_SCALE", attr_info.with_host_wei_scale);
     kernel_ctx.define_int("WITH_HOST_DST_SCALE", attr_info.with_host_dst_scale);
-    kernel_ctx.define_int("WITH_MX_DST_SCALE", attr_info.with_mx_dst_scale);
+    kernel_ctx.define_int("WITH_DYN_DST_SCALE", attr_info.with_dyn_dst_scale);
 
     return def_post_ops_cfg(kernel_ctx, post_ops, dst_md);
 }

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -103,7 +103,7 @@ struct attr_info_t {
     bool with_host_src_scale;
     bool with_host_wei_scale;
     bool with_host_dst_scale;
-    bool with_mx_dst_scale;
+    bool with_dyn_dst_scale;
     bool with_host_src_zp;
     bool with_host_wei_zp;
     bool with_host_dst_zp;


### PR DESCRIPTION
Adds dynamic FP (i.e., non-MX) scales support via OpenCL kernels.