### PR TITLE
cpu: pool: reduce verbose messages for templated arguments

### DIFF
--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -51,9 +51,15 @@ struct nchw_pooling_fwd_t : public primitive_t {
                             alg_kind::pooling_avg_include_padding,
                             alg_kind::pooling_avg_exclude_padding),
                     VERBOSE_BAD_ALGORITHM);
-            VDISPATCH_POOLING(utils::everyone_is(d_type, src_md()->data_type,
-                                      dst_md()->data_type),
-                    VERBOSE_UNSUPPORTED_DT);
+
+            // Disabling verbose dispatch messages for unsupported dt for better
+            // readability.
+            // TODO: restore once `d_type` template argument is removed.
+            if (!utils::everyone_is(
+                        d_type, src_md()->data_type, dst_md()->data_type)) {
+                return status::unimplemented;
+            }
+
             VDISPATCH_POOLING(platform::has_data_type_support(d_type),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_POOLING(

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -58,9 +58,15 @@ struct nhwc_pooling_fwd_t : public primitive_t {
                                       pooling_avg_include_padding,
                                       pooling_avg_exclude_padding),
                     VERBOSE_BAD_ALGORITHM);
-            VDISPATCH_POOLING(utils::everyone_is(d_type, src_md()->data_type,
-                                      dst_md()->data_type),
-                    VERBOSE_UNSUPPORTED_DT);
+
+            // Disabling verbose dispatch messages for unsupported dt for better
+            // readability.
+            // TODO: restore once `d_type` template argument is removed.
+            if (!utils::everyone_is(
+                        d_type, src_md()->data_type, dst_md()->data_type)) {
+                return status::unimplemented;
+            }
+
             VDISPATCH_POOLING(platform::has_data_type_support(d_type),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_POOLING(!is_dilated(), VERBOSE_UNSUPPORTED_FEATURE,

--- a/src/cpu/x64/jit_uni_pooling.hpp
+++ b/src/cpu/x64/jit_uni_pooling.hpp
@@ -54,9 +54,15 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
             VDISPATCH_POOLING(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_POOLING(
                     !has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "src");
-            VDISPATCH_POOLING(everyone_is(d_type, src_md()->data_type,
-                                      dst_md()->data_type),
-                    VERBOSE_UNSUPPORTED_DT);
+
+            // Disabling verbose dispatch messages for unsupported dt for better
+            // readability.
+            // TODO: restore once `d_type` template argument is removed.
+            if (!everyone_is(
+                        d_type, src_md()->data_type, dst_md()->data_type)) {
+                return status::unimplemented;
+            }
+
             VDISPATCH_POOLING(
                     attr()->has_default_values(
                             primitive_attr_t::skip_mask_t::post_ops, d_type),


### PR DESCRIPTION
Templated arguments create a lot of interfered messages that don't bring much value when debugging.
Switched off such messages for pooling and enabled actually meaningful one.