### PR TITLE
[backport][rls-v3.11] benchdnn: inputs: work around false-positive hits

### DIFF
--- a/tests/benchdnn/inputs/rnn/harness_gru_regression
+++ b/tests/benchdnn/inputs/rnn/harness_gru_regression
@@ -1,4 +1,2 @@
 # int8 SIC != SLC
---reset
---trivial-strides=true --prop=FWD_I --alg=VANILLA_GRU --activation=UNDEF
---direction=left2right --cfg=u8u8u8f32 l1t47mb100sic128slc256dhc128dic128
+--reset --trivial-strides=true --prop=FWD_I --alg=VANILLA_GRU --activation=UNDEF --direction=left2right --cfg=u8u8u8f32 l1t32mb100sic128slc256dhc128dic128

--- a/tests/benchdnn/inputs/rnn/shapes_small
+++ b/tests/benchdnn/inputs/rnn/shapes_small
@@ -1,7 +1,7 @@
 # small shapes
 
 l8t3mb12_sic16_n"uniform"
-l4t3mb20_sic36_n"uniform:unroll_tail"
+l4t2mb20_sic36_n"uniform:unroll_tail"
 l1t2mb6_sic16_slc32_n"non-uniform:slc_neq_sic"
 l1t1mb7_sic17_dhc34_n"non-uniform:slc_neq_dhc_tail"
 l1t1mb3_sic16_slc32_dhc64_n"non-uniform:slc_neq_sic_neq_dhc"


### PR DESCRIPTION
Backport of #4546 