### PR TITLE
fixup: benchdnn: add stalling to trigger async issues with threadpool

### DIFF
--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -1277,7 +1277,14 @@ dnnl_data_type_t convert_dt(const dnnl::graph::logical_tensor::data_type dt) {
 
 stream_staller_t::stream_staller_t(graph::cpp_stream_t &stream) {
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    const auto &eng = stream.get_engine();
+    auto eng_kind = eng.get_kind();
+    if (eng_kind != dnnl::engine::kind::cpu) return;
+
     auto tp = dnnl::threadpool_interop::get_threadpool(stream);
+
+    // `tp` is not expected to be empty for CPU streams with threadpol runtime.
+    if (!tp) SAFE_V(FAIL);
 
     // Only relevant for asynchronous threadpool, synchronous will
     // deadlock.

--- a/tests/benchdnn/graph/utils.hpp
+++ b/tests/benchdnn/graph/utils.hpp
@@ -204,6 +204,7 @@ struct cpp_stream_t {
             void *interop_obj = nullptr);
     void wait() { stream_.wait(); }
     operator dnnl::stream &() { return stream_; }
+    dnnl::engine get_engine() const { return stream_.get_engine(); }
 
 private:
     BENCHDNN_DISALLOW_COPY_AND_ASSIGN(cpp_stream_t);

--- a/tests/benchdnn/utils/dnnl_query.cpp
+++ b/tests/benchdnn/utils/dnnl_query.cpp
@@ -73,6 +73,18 @@ dnnl_engine_t query_engine(const_dnnl_memory_t memory) {
     return engine;
 }
 
+dnnl_engine_t query_engine(const_dnnl_stream_t stream) {
+    dnnl_engine_t engine;
+    dnnl_stream_get_engine(stream, &engine);
+    return engine;
+}
+
+dnnl_engine_kind_t query_engine_kind(dnnl_engine_t engine) {
+    dnnl_engine_kind_t engine_kind = dnnl_any_engine;
+    dnnl_engine_get_kind(engine, &engine_kind);
+    return engine_kind;
+}
+
 int64_t query_mem_consumption(const_dnnl_primitive_desc_t pd) {
     int64_t size = 0;
     dnnl_primitive_desc_query(pd, dnnl_query_memory_consumption_s64, 0, &size);
@@ -135,12 +147,6 @@ const_dnnl_primitive_desc_t query_pd(dnnl_primitive_t prim) {
     const_dnnl_primitive_desc_t pd {};
     dnnl_primitive_get_primitive_desc(prim, &pd);
     return pd;
-}
-
-dnnl_engine_kind_t query_engine_kind(const dnnl_engine_t &engine) {
-    dnnl_engine_kind_t engine_kind = dnnl_any_engine;
-    dnnl_engine_get_kind(engine, &engine_kind);
-    return engine_kind;
 }
 
 dnnl_sparse_encoding_t query_md_sparse_encoding(const_dnnl_memory_desc_t md) {

--- a/tests/benchdnn/utils/dnnl_query.hpp
+++ b/tests/benchdnn/utils/dnnl_query.hpp
@@ -39,6 +39,8 @@ const_dnnl_memory_desc_t query_md(const_dnnl_memory_t memory);
 dnnl_engine_t query_engine(const_dnnl_primitive_desc_t pd,
         dnnl_query_t engine_type = dnnl_query_engine);
 dnnl_engine_t query_engine(const_dnnl_memory_t memory);
+dnnl_engine_t query_engine(const_dnnl_stream_t stream);
+dnnl_engine_kind_t query_engine_kind(dnnl_engine_t engine);
 
 int64_t query_mem_consumption(const_dnnl_primitive_desc_t pd);
 
@@ -55,8 +57,6 @@ const_dnnl_post_ops_t query_post_ops(const_dnnl_primitive_attr_t attr);
 const_dnnl_post_ops_t query_post_ops(const_dnnl_primitive_desc_t pd);
 const_dnnl_primitive_attr_t query_attr(const_dnnl_primitive_desc_t pd);
 const_dnnl_primitive_desc_t query_pd(dnnl_primitive_t prim);
-
-dnnl_engine_kind_t query_engine_kind(const dnnl_engine_t &engine);
 
 dnnl_sparse_encoding_t query_md_sparse_encoding(const_dnnl_memory_desc_t md);
 dnnl_dim_t query_md_nnz(const_dnnl_memory_desc_t md);


### PR DESCRIPTION
stream_staller expects a CPU stream with a non-empty threadpool ptr.