### PR TITLE
ci: aarch64: fix update wiki failure

### DIFF
--- a/.github/actions/update-wiki/action.yml
+++ b/.github/actions/update-wiki/action.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2025 Arm Limited and affiliates.
+# Copyright 2025-2026 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ runs:
     - name: Checkout oneDNN wiki
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
-        persist-credentials: false
+        persist-credentials: true # needed in the 'Update the wiki page' step
         repository: "${{ github.repository }}.wiki"
         ref: master
         path: .wiki

--- a/.github/workflows/nightly-aarch64.yml
+++ b/.github/workflows/nightly-aarch64.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2024-2025 Arm Limited and affiliates.
+# Copyright 2024-2026 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -162,7 +162,7 @@ jobs:
         run: git bisect reset
 
       - name: Update wiki
-        if: ${{ (success() || failure()) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ryo-not-rio/wiki') }}
+        if: ${{ (success() || failure()) && github.ref == 'refs/heads/main' }}
         uses: ./oneDNN/.github/actions/update-wiki
         with:
           command: add-unit

--- a/.github/workflows/performance-aarch64.yml
+++ b/.github/workflows/performance-aarch64.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2024-2025 Arm Limited and affiliates.
+# Copyright 2024-2026 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -184,7 +184,7 @@ jobs:
           OMP_NUM_THREADS: ${{ inputs.num_threads || 16 }}
 
       - name: Update wiki
-        if: ${{ (success() || failure()) && inputs.benchdnn_command == '' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ryo-not-rio/wiki') }}
+        if: ${{ (success() || failure()) && inputs.benchdnn_command == '' && github.ref == 'refs/heads/main' }}
         uses: ./oneDNN/.github/actions/update-wiki
         with:
           command: add-perf


### PR DESCRIPTION
Fixes the failure in [Nightly AArch64](https://github.com/uxlfoundation/oneDNN/actions/runs/21236842205/job/61107409058) where the wiki update failed due to lack of write permissions