### PR TITLE
cpu: aarch64: move acl ahead of jit_1x1:sve_128

### DIFF
--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
-* Copyright 2020-2025 Arm Ltd. and affiliates
+* Copyright 2020-2026 Arm Ltd. and affiliates
 * Copyright 2020-2025 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,13 +160,13 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_128,data_type::f32>)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64_ACL(acl_depthwise_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
+            CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_fwd_t)
             CPU_INSTANCE_RV64GCV(jit_rvv_1x1_convolution_fwd_t)


### PR DESCRIPTION
Partial revert of
cpu: aarch64: conv: enable jit_sve_1x1_conv for SVE128 (#4201)

This fixes a ~20% regression on Neoverse V2 cores, particularly for moderately sized and larger convolutions (>0.01 Gops). (See [conv regressions on performance dashboard](https://github.com/uxlfoundation/oneDNN/wiki/AArch64-status))

```
                                                                                                                                    time after / before
threads                                                                                                                             8     16     32    impl change
Gops         g    mb  ic   id ih  iw    oc   od oh  ow    kd kh kw sd sh sw pd ph pw dd dh dw name

1.179650e-03 1    1   64   1  16  16    36   1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv64                   2.29  2.41   2.17  jit_1x1:sve_128 -> gemm:acl
1.658880e-03 1    1   64   1  4   4     810  1  4   4     1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv67                   1.41  1.96   1.96  jit_1x1:sve_128 -> gemm:acl
2.097150e-03 1    1   64   1  16  16    64   1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv50*12                1.75  2.47   2.41  jit_1x1:sve_128 -> gemm:acl
4.718590e-03 1    1   64   1  32  32    36   1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv62                   1.45  1.46   1.63  jit_1x1:sve_128 -> gemm:acl
6.635520e-03 1    1   64   1  8   8     810  1  8   8     1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv65                   1.31  1.41   1.59  jit_1x1:sve_128 -> gemm:acl
8.388610e-03 1    1   64   1  32  32    64   1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv53*12                1.05  1.26   1.43  jit_1x1:sve_128 -> gemm:acl
1.048580e-02 1    1   320  1  16  16    64   1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv46*3                 1.11  1.26   1.46  jit_1x1:sve_128 -> gemm:acl
1.468010e-02 1    1   112  1  32  32    64   1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv51*2                  .92   .98   1.01  jit_1x1:sve_128 -> gemm:acl
1.887440e-02 1    1   64   1  64  64    36   1  64  64    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv60                   1.16  1.09   1.04  jit_1x1:sve_128 -> gemm:acl
2.097150e-02 1    1   40   1  64  64    64   1  64  64    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv54                    .90   .91    .89  jit_1x1:sve_128 -> gemm:acl
2.654210e-02 1    1   64   1  16  16    810  1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv63                   1.03   .97   1.00  jit_1x1:sve_128 -> gemm:acl
3.355440e-02 1    1   64   1  64  64    64   1  64  64    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv56*9                  .82   .81    .81  jit_1x1:sve_128 -> gemm:acl
3.932160e-02 1    1   240  1  32  32    80   1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv24                    .83   .80    .78  jit_1x1:sve_128 -> gemm:acl
4.718590e-02 1    1   144  1  64  64    40   1  64  64    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv17                    .92   .88    .86  jit_1x1:sve_128 -> gemm:acl
6.606030e-02 1    1   672  1  16  16    192  1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv38                    .88   .78    .80  jit_1x1:sve_128 -> gemm:acl
6.710890e-02 1    1   32   1  256 256   16   1  256 256   1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv5                     .74   .71    .75  jit_1x1:sve_128 -> gemm:acl
7.549750e-02 1    1   96   1  128 128   24   1  128 128   1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv10                   1.07   .90    .89  jit_1x1:sve_128 -> gemm:acl
7.864320e-02 1    1   40   1  64  64    240  1  64  64    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv18*2                  .80   .74    .79  jit_1x1:sve_128 -> gemm:acl
                      80   1  32  32    480  1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv25*3                  .79   .73    .80  jit_1x1:sve_128 -> gemm:acl
                      240  1  64  64    40   1  64  64    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv22                    .89   .83    .82  jit_1x1:sve_128 -> gemm:acl
                      480  1  32  32    80   1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv29*2                  .78   .72    .74  jit_1x1:sve_128 -> gemm:acl
1.061680e-01 1    1   64   1  32  32    810  1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv61                    .83   .76    .72  jit_1x1:sve_128 -> gemm:acl
1.101000e-01 1    1   480  1  32  32    112  1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv31                    .78   .70    .66  jit_1x1:sve_128 -> gemm:acl
1.132460e-01 1    1   24   1  128 128   144  1  128 128   1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv11*2                  .91   .79    .74  jit_1x1:sve_128 -> gemm:acl
                      144  1  128 128   24   1  128 128   1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv15                    .99   .80    .75  jit_1x1:sve_128 -> gemm:acl
                      192  1  16  16    1152 1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv39*4                  .90   .76    .72  jit_1x1:sve_128 -> gemm:acl
                      1152 1  16  16    192  1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv43*3                  .83   .79    .71  jit_1x1:sve_128 -> gemm:acl
1.541410e-01 1    1   112  1  32  32    672  1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv32*3                  .76   .70    .68  jit_1x1:sve_128 -> gemm:acl
                      672  1  32  32    112  1  32  32    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv36*2                  .73   .71    .66  jit_1x1:sve_128 -> gemm:acl
1.887440e-01 1    1   1152 1  16  16    320  1  16  16    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv45                    .81   .68    .71  jit_1x1:sve_128 -> gemm:acl
2.013270e-01 1    1   16   1  256 256   96   1  256 256   1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv6                     .90   .78    .73  jit_1x1:sve_128 -> gemm:acl
4.246730e-01 1    1   64   1  64  64    810  1  64  64    1  1  1  1  1  1  0  0  0  0  0  0  efficientdet:conv59                    .80   .70    .65  jit_1x1:sve_128 -> gemm:acl
1.284510e+00 1    50  64   1  56  56    64   1  56  56    1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res2a_branch2a               .85   .86    .85  jit_1x1:sve_128 -> gemm:acl
5.138020e+00 1    50  64   1  56  56    256  1  56  56    1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res2a_branch1*4              .94   .95    .88  jit_1x1:sve_128 -> gemm:acl
                      128  1  28  28    512  1  28  28    1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res3a_branch2c*4             .90   .90    .88  jit_1x1:sve_128 -> gemm:acl
                      256  1  14  14    1024 1  14  14    1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res4a_branch2c*6             .90   .90    .87  jit_1x1:sve_128 -> gemm:acl
                              56  56    64   1  56  56    1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res2b_branch2a*2             .80   .83    .81  jit_1x1:sve_128 -> gemm:acl
                      512  1  7   7     2048 1  7   7     1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res5a_branch2c*3             .86   .84    .81  jit_1x1:sve_128 -> gemm:acl
                              28  28    128  1  28  28    1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res3b_branch2a*3             .83   .85    .83  jit_1x1:sve_128 -> gemm:acl
                      1024 1  14  14    256  1  14  14    1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res4b_branch2a*5             .86   .88    .83  jit_1x1:sve_128 -> gemm:acl
                      2048 1  7   7     512  1  7   7     1  1  1  1  1  1  0  0  0  0  0  0  resnet_50:res5b_branch2a*2             .93   .93    .88  jit_1x1:sve_128 -> gemm:acl
```

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/uxlfoundation/oneDNN/blob/main/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
