### PR TITLE
Fix perf regression in some brgemm convolutions

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -661,7 +661,12 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
                                        : brgemm_broadcast_t::none;
     }
     brgemm_attr_t brgattr;
-    brgattr.use_uker = use_uker;
+    // TODO: The current implementation uses regular brgemm kernel
+    // initialization to estimate the ur, regardless of the use_uker setting.
+    // This should be updated to:
+    //   1. Use unrolled kernel initialization when use_uker is true
+    //   2. Update brg_blocking_t::est_eff() to properly calculate
+    // brgemm_microkernel_eff
     brgattr.max_bs = max_batch;
     max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
     brgattr.max_top_vpad = max_vpad;


### PR DESCRIPTION
This PR revert part of changes from commit 719786c1dc54f841ec413eb060ab099d8a3e9a6c to fix [MFDNN-14568](https://jira.devtools.intel.com/browse/MFDNN-14568) - performance regression for some AMX convolutions.
Adding a TODO comment to clarify how the `estimate_brgemm_ur` function should handle kernel initialization for the `use_uker` setting. The comment outlines the need to update the logic to use unrolled kernel initialization when appropriate and to improve efficiency calculations.
