### PR TITLE
cpu: aarch64: move acl ahead of jit_1x1:sve_128 - v3.11 backport

### DIFF
--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
-* Copyright 2020-2025 Arm Ltd. and affiliates
+* Copyright 2020-2026 Arm Ltd. and affiliates
 * Copyright 2020-2025 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -159,13 +159,13 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(jit_uni_dw_convolution_fwd_t<sve_128,data_type::f32>)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_128>)
-            CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64_ACL(acl_depthwise_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_128>)
+            CPU_INSTANCE_AARCH64(jit_sve_1x1_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_convolution_fwd_t<f32,f32,f32,sve_128>)
             CPU_INSTANCE_X64(jit_uni_ncsp_convolution_fwd_t)
             CPU_INSTANCE_RV64GCV(riscv_gemm_convolution_fwd_t)


### PR DESCRIPTION
Partial revert of
cpu: aarch64: conv: enable jit_sve_1x1_conv for SVE128

This fixes a ~20% regression on Neoverse V2 cores, particularly for moderately sized and larger convolutions (>0.01 Gops).

Backport of #4586

Some cases change back to `gemm:acl` with speedups and none back to ref.
```
                                                                           time after / before       impl change
threads                                                                            16                16
Gops      g mb ic   ih  iw  oc   oh  ow  sd sh sw name
0.000010  1 1  1024 1   1   5    1   1   1  1  1  mobilenet:conv11*4               1.00              jit_1x1:sve_128
0.000328  1 32 1024 1   1   5    1   1   1  1  1  mobilenet:conv11*4                .83              jit_1x1:sve_128
0.025690  1 1  64   56  56  64   56  56  1  1  1  resnet_50:res2a_branch2a          .99  gemm:acl -> jit_1x1:sve_128
0.051380  1 1  32   112 112 64   112 112 1  1  1  mobilenet:conv2*4                1.00              jit_1x1:sve_128
               64   56  56  128  56  56  1  1  1  mobilenet:conv3*4                1.00              jit_1x1:sve_128
               128  28  28  256  28  28  1  1  1  mobilenet:conv5*4                1.00              jit_1x1:sve_128
               256  14  14  512  14  14  1  1  1  mobilenet:conv7*4                1.00              jit_1x1:sve_128
                    56  56  128  28  28  1  2  2  resnet_50:res3a_branch2a         1.00          brgconv_1x1:sve_128
               512  7   7   1024 7   7   1  1  1  mobilenet:conv9*4                1.00              jit_1x1:sve_128
                    28  28  256  14  14  1  2  2  resnet_50:res4a_branch2a         1.00          brgconv_1x1:sve_128
               1024 14  14  512  7   7   1  2  2  resnet_50:res5a_branch2a         1.00          brgconv_1x1:sve_128
0.094634  1 1  512  38  38  64   38  38  1  1  1  yolov2:conv12*9                  1.01              jit_1x1:sve_128
0.102760  1 1  64   56  56  256  56  56  1  1  1  resnet_50:res2a_branch1*4         .94  gemm:acl -> jit_1x1:sve_128
               128  28  28  512  28  28  1  1  1  resnet_50:res3a_branch2c*4        .76  gemm:acl -> jit_1x1:sve_128
                    56  56  128  56  56  1  1  1  mobilenet:conv4*4                1.00              jit_1x1:sve_128
               256  14  14  1024 14  14  1  1  1  resnet_50:res4a_branch2c*6        .88  gemm:acl -> jit_1x1:sve_128
                    28  28  256  28  28  1  1  1  mobilenet:conv6*4                1.00              jit_1x1:sve_128
                    56  56  64   56  56  1  1  1  resnet_50:res2b_branch2a*2        .80  gemm:acl -> jit_1x1:sve_128
               512  7   7   2048 7   7   1  1  1  resnet_50:res5a_branch2c*3        .83  gemm:acl -> jit_1x1:sve_128
                    14  14  512  14  14  1  1  1  mobilenet:conv8*20               1.00              jit_1x1:sve_128
                    28  28  128  28  28  1  1  1  resnet_50:res3b_branch2a*3        .72  gemm:acl -> jit_1x1:sve_128
               1024 7   7   1024 7   7   1  1  1  mobilenet:conv10*4               1.00              jit_1x1:sve_128
                    14  14  256  14  14  1  1  1  resnet_50:res4b_branch2a*5        .80  gemm:acl -> jit_1x1:sve_128
               2048 7   7   512  7   7   1  1  1  resnet_50:res5b_branch2a*2        .82  gemm:acl -> jit_1x1:sve_128
0.205521  1 1  256  56  56  512  28  28  1  2  2  resnet_50:res3a_branch1          1.00          brgconv_1x1:sve_128
               512  28  28  1024 14  14  1  2  2  resnet_50:res4a_branch1          1.00          brgconv_1x1:sve_128
               1024 14  14  2048 7   7   1  2  2  resnet_50:res5a_branch1          1.04          brgconv_1x1:sve_128
0.314214  1 1  1024 19  19  425  19  19  1  1  1  yolov2:conv14*9                  1.00              jit_1x1:sve_128
0.378536  1 1  128  152 152 64   152 152 1  1  1  yolov2:conv4*9                   1.01              jit_1x1:sve_128
               256  76  76  128  76  76  1  1  1  yolov2:conv6*9                   1.00              jit_1x1:sve_128
               512  38  38  256  38  38  1  1  1  yolov2:conv8*18                  1.00              jit_1x1:sve_128
               1024 19  19  512  19  19  1  1  1  yolov2:conv10*18                  .99              jit_1x1:sve_128
1.284510  1 50 64   56  56  64   56  56  1  1  1  resnet_50:res2a_branch2a          .86  gemm:acl -> jit_1x1:sve_128
1.514140  1 16 512  38  38  64   38  38  1  1  1  yolov2:conv12*9                  1.00              jit_1x1:sve_128
1.644170  1 32 32   112 112 64   112 112 1  1  1  mobilenet:conv2*4                1.00              jit_1x1:sve_128
               64   56  56  128  56  56  1  1  1  mobilenet:conv3*4                1.00              jit_1x1:sve_128
               128  28  28  256  28  28  1  1  1  mobilenet:conv5*4                1.00              jit_1x1:sve_128
               256  14  14  512  14  14  1  1  1  mobilenet:conv7*4                1.00              jit_1x1:sve_128
               512  7   7   1024 7   7   1  1  1  mobilenet:conv9*4                1.00              jit_1x1:sve_128
2.569010  1 50 256  56  56  128  28  28  1  2  2  resnet_50:res3a_branch2a         1.00          brgconv_1x1:sve_128
               512  28  28  256  14  14  1  2  2  resnet_50:res4a_branch2a         1.00          brgconv_1x1:sve_128
               1024 14  14  512  7   7   1  2  2  resnet_50:res5a_branch2a         1.00          brgconv_1x1:sve_128
3.288330  1 32 128  56  56  128  56  56  1  1  1  mobilenet:conv4*4                1.00              jit_1x1:sve_128
               256  28  28  256  28  28  1  1  1  mobilenet:conv6*4                1.00              jit_1x1:sve_128
               512  14  14  512  14  14  1  1  1  mobilenet:conv8*20               1.00              jit_1x1:sve_128
               1024 7   7   1024 7   7   1  1  1  mobilenet:conv10*4               1.00              jit_1x1:sve_128
5.027430  1 16 1024 19  19  425  19  19  1  1  1  yolov2:conv14*9                  1.00              jit_1x1:sve_128
5.138020  1 50 64   56  56  256  56  56  1  1  1  resnet_50:res2a_branch1*4         .94  gemm:acl -> jit_1x1:sve_128
               128  28  28  512  28  28  1  1  1  resnet_50:res3a_branch2c*4        .90  gemm:acl -> jit_1x1:sve_128
               256  14  14  1024 14  14  1  1  1  resnet_50:res4a_branch2c*6        .90  gemm:acl -> jit_1x1:sve_128
                    56  56  64   56  56  1  1  1  resnet_50:res2b_branch2a*2        .84  gemm:acl -> jit_1x1:sve_128
               512  7   7   2048 7   7   1  1  1  resnet_50:res5a_branch2c*3        .84  gemm:acl -> jit_1x1:sve_128
                    28  28  128  28  28  1  1  1  resnet_50:res3b_branch2a*3        .86  gemm:acl -> jit_1x1:sve_128
               1024 14  14  256  14  14  1  1  1  resnet_50:res4b_branch2a*5        .87  gemm:acl -> jit_1x1:sve_128
               2048 7   7   512  7   7   1  1  1  resnet_50:res5b_branch2a*2        .92  gemm:acl -> jit_1x1:sve_128
6.056570  1 16 128  152 152 64   152 152 1  1  1  yolov2:conv4*9                   1.00              jit_1x1:sve_128
               256  76  76  128  76  76  1  1  1  yolov2:conv6*9                   1.00              jit_1x1:sve_128
               512  38  38  256  38  38  1  1  1  yolov2:conv8*18                  1.00              jit_1x1:sve_128
               1024 19  19  512  19  19  1  1  1  yolov2:conv10*18                 1.00              jit_1x1:sve_128
10.276000 1 50 256  56  56  512  28  28  1  2  2  resnet_50:res3a_branch1          1.00          brgconv_1x1:sve_128
               512  28  28  1024 14  14  1  2  2  resnet_50:res4a_branch1          1.00          brgconv_1x1:sve_128
               1024 14  14  2048 7   7   1  2  2  resnet_50:res5a_branch1          1.00          brgconv_1x1:sve_128

```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?