### PR TITLE
cpu: aarch64: reorder: remove direct_copy method

### DIFF
--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -152,9 +152,6 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     bool can_do_tr8x8();
 
     bool process_unroll_tr8x8(const int ndims, const int len);
-
-    template <cpu_isa_t isa>
-    bool process_direct_copy(const int ndims, const int len);
 
     void process_unroll_generic_step(int reg_unroll, const int *i_off,
             const int *o_off, const int *s_off, const int *c_off,


### PR DESCRIPTION
# Description

Benchmarking shows that this kernel does not offer significant benefits over the generic method. Additionally, its requirements are restrictive which makes it quite difficult to hit once the `prb` has been modified (e.g, for caching or threading reasons).

Below are my measurements. `generic` is just `jit:uni` without the `direct_copy` kernel. The last column is greater than 1 in cases where `direct_copy` is offering a speedup. `N/A` measurements indicate the problem was not applicable to that method.

|threads|sdt|ddt|old impl|new impl|shape|generic min|direct min|generic min / direct min (> 1 is better)|
|---------|---------|---------|---------|---------|---------|---------|---------|---------|
|1|f32|f32|jit:uni|jit:uni|2048|0.000488281|0.000244141|2.0000x|
|2|f32|f32|jit:uni|jit:uni|2048|0.000976562|0.000976562|1.0000x|
|4|f32|f32|jit:uni|jit:uni|2048|0.0012207|0.0012207|1.0000x|
|8|f32|f32|jit:uni|jit:uni|2048|0.00146484|0.00146484|1.0000x|
|16|f32|f32|jit:uni|jit:uni|2048|0.00219727|0.00219727|1.0000x|
|32|f32|f32|jit:uni|jit:uni|2048|0.00366211|0.00317383|1.1538x|
|64|f32|f32|jit:uni|jit:uni|2048|0.00683594|0.00683594|1.0000x|
|1|f32|f32|jit:uni|jit:uni|4096|0.000488281|0.000488281|1.0000x|
|2|f32|f32|jit:uni|jit:uni|4096|0.0012207|0.0012207|1.0000x|
|4|f32|f32|jit:uni|jit:uni|4096|0.0012207|0.0012207|1.0000x|
|8|f32|f32|jit:uni|jit:uni|4096|0.00146484|0.00170898|0.8571x|
|16|f32|f32|jit:uni|jit:uni|4096|0.00219727|0.00219727|1.0000x|
|32|f32|f32|jit:uni|jit:uni|4096|0.00341797|0.00341797|1.0000x|
|64|f32|f32|jit:uni|jit:uni|4096|0.00634766|0.00708008|0.8966x|
|1|f32|f32|jit:uni|jit:uni|65157176|9.71118|9.53687|1.0183x|
|2|f32|f32|jit:uni|jit:uni|65157176|5.21973|5.24536|0.9951x|
|4|f32|f32|jit:uni|jit:uni|65157176|3.60693|N/A|N/A|
|8|f32|f32|jit:uni|jit:uni|65157176|2.61816|N/A|N/A|
|16|f32|f32|jit:uni|jit:uni|65157176|2.37939|N/A|N/A|
|32|f32|f32|jit:uni|jit:uni|65157176|2.10596|N/A|N/A|
|64|f32|f32|jit:uni|jit:uni|65157176|2.67041|2.66992|1.0002x|

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
