### PR TITLE
[GPU] Simplify quantization attribute handling

### DIFF
--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -305,9 +305,9 @@ status_t gen_t::launch_nocopy(const exec_ctx_t &ctx,
         arg_list.set(argn++, slm, nullptr);
     }
 
-    if (pd()->ao_dims_ > 0 || problem->aScale2D())
+    if (pd()->a_quant.zp_ndims > 0 || problem->aScale2D())
         arg_list.set(argn++, offset_aq);
-    if (pd()->bo_dims_ > 0 || problem->bScale2D())
+    if (pd()->b_quant.zp_ndims > 0 || problem->bScale2D())
         arg_list.set(argn++, offset_bq);
 
     lws[0] *= nocopy_info()->subgroupSize;
@@ -589,8 +589,8 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
 
                 auto off_aq = off_aq0;
                 auto off_bq = off_bq0;
-                if (pd()->ao_dims_ >= 1 || a_scales) off_aq += Bm;
-                if (pd()->bo_dims_ >= 1 || b_scales) off_bq += Bn;
+                if (pd()->a_quant.zp_ndims >= 1 || a_scales) off_aq += Bm;
+                if (pd()->b_quant.zp_ndims >= 1 || b_scales) off_bq += Bn;
 
                 auto off_co = off_co0;
                 switch (cmask & 3) {

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -430,12 +430,12 @@ gen_nocopy_desc_t::select_kernel(compute::gpu_arch_t arch, int stepping,
         int eu_count, bool has_systolic, bool is_integrated, compute_mode mode,
         int batch_dims, bool trans_a, bool trans_b, bool trans_co, bool swap_ab,
         const quant_params &a_quant, const quant_params &b_quant,
-        const quant_params &c_quant, bool dst_sround, bool c_offset, bool bias,
-        sum_ab_t reduce_ab, float alpha, float beta, data_type_t a_type,
-        data_type_t b_type, data_type_t c_type, data_type_t co_type,
-        data_type_t acc_type, int align_a, int align_b, int align_c, dim_t m,
-        dim_t n, dim_t k, dim_t lda, dim_t ldb, dim_t ldc, dim_t batch,
-        gpu_post_ops_t &&post_ops) {
+        const quant_params &c_quant, bool mx_scales, bool dst_sround,
+        bool c_offset, bool bias, sum_ab_t reduce_ab, float alpha, float beta,
+        data_type_t a_type, data_type_t b_type, data_type_t c_type,
+        data_type_t co_type, data_type_t acc_type, int align_a, int align_b,
+        int align_c, dim_t m, dim_t n, dim_t k, dim_t lda, dim_t ldb, dim_t ldc,
+        dim_t batch, gpu_post_ops_t &&post_ops) {
     using namespace ngen;
     using namespace kcatalog;
 
@@ -529,7 +529,7 @@ gen_nocopy_desc_t::select_kernel(compute::gpu_arch_t arch, int stepping,
 
     if (c_quant.scales_type != data_type::undef) {
         problem_.csPtrDims = c_quant.scale_ndims;
-        problem_.cMXScale = c_quant.mx;
+        problem_.cMXScale = mx_scales;
         problem_.Tc_scale = convert_dnnl_to_kernel_type(c_quant.scales_type);
         problem_.cqGroupM = c_quant.group_m;
         problem_.cqGroupN = c_quant.group_n;

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -26,6 +26,7 @@
 #include "gemmstone/type.hpp"
 #include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/compute/kernel_arg_list.hpp"
+#include "gpu/intel/gemm/jit/pd.hpp"
 #include "gpu/intel/jit/generator_base.hpp"
 #include "gpu/intel/kernel_cache.hpp"
 
@@ -114,21 +115,6 @@ protected:
     void update_driver_info();
 };
 
-struct quant_params {
-    data_type_t scales_type;
-    data_type_t zp_type;
-    data_type_t gs_type;
-    int scale_ndims;
-    int zp_ndims;
-    int gs_ndims;
-    int group_k;
-    int group_m;
-    int group_n;
-    bool force_gs;
-    bool mx;
-    bool zp_host_scalar;
-};
-
 struct gen_nocopy_desc_t : public gen_desc_t {
     enum compute_mode {
         mode_default = 0,
@@ -151,12 +137,12 @@ struct gen_nocopy_desc_t : public gen_desc_t {
             int batch_dims, bool trans_a, bool trans_b, bool trans_co,
             bool swap_ab, const quant_params &a_quant,
             const quant_params &b_quant, const quant_params &c_quant,
-            bool dst_sround, bool c_offset, bool bias, sum_ab_t reduce_ab,
-            float alpha, float beta, data_type_t a_type, data_type_t b_type,
-            data_type_t c_type, data_type_t co_type, data_type_t acc_type,
-            int align_a, int align_b, int align_c, dim_t m, dim_t n, dim_t k,
-            dim_t lda, dim_t ldb, dim_t ldc, dim_t batch,
-            gpu_post_ops_t &&post_ops);
+            bool mx_scales, bool dst_sround, bool c_offset, bool bias,
+            sum_ab_t reduce_ab, float alpha, float beta, data_type_t a_type,
+            data_type_t b_type, data_type_t c_type, data_type_t co_type,
+            data_type_t acc_type, int align_a, int align_b, int align_c,
+            dim_t m, dim_t n, dim_t k, dim_t lda, dim_t ldb, dim_t ldc,
+            dim_t batch, gpu_post_ops_t &&post_ops);
 
     status_t finalize();
 

--- a/src/gpu/intel/gemm/jit/pd.hpp
+++ b/src/gpu/intel/gemm/jit/pd.hpp
@@ -33,6 +33,20 @@ namespace jit {
 
 #define GEMM_MAX_PO 36
 
+struct quant_params {
+    data_type_t scales_type = data_type::undef;
+    data_type_t zp_type = data_type::undef;
+    data_type_t gs_type = data_type::undef;
+    int scale_ndims = -1;
+    int zp_ndims = -1;
+    int gs_ndims = -1;
+    int group_k = 0;
+    int group_m = 0;
+    int group_n = 0;
+    bool force_gs = false;
+    bool zp_host_scalar = false;
+};
+
 struct pd_t : public gemm::pd_t {
     using gemm::pd_t::pd_t;
 
@@ -80,21 +94,11 @@ struct pd_t : public gemm::pd_t {
     bool wei_decomp_ = false;
     bool dy_quant_enabled_ = false;
     bool quant_enabled_ = false;
-    int a_scales_group_k_ = 0, a_scales_group_m_ = 0;
-    int b_scales_group_k_ = 0, b_scales_group_n_ = 0;
-    int c_scales_group_m_ = 0, c_scales_group_n_ = 0;
-    int a_zp_group_k_ = 0, a_zp_group_m_ = 0;
-    int b_zp_group_k_ = 0, b_zp_group_n_ = 0;
-    int a_gs_group_k_ = 0, a_gs_group_m_ = 0;
-    int b_gs_group_k_ = 0, b_gs_group_n_ = 0;
-    bool non_scale_po_ = false;
-    data_type_t a_scales_type_ = data_type::undef;
-    data_type_t b_scales_type_ = data_type::undef;
-    data_type_t c_scales_type_ = data_type::undef;
 
-    int ao_dims_ = -1, bo_dims_ = -1;
-    int ag_dims_ = -1, bg_dims_ = -1;
-    int asc_dims_ = -1, bsc_dims_ = -1, csc_dims_ = -1;
+    quant_params a_quant, b_quant, c_quant;
+
+    bool non_scale_po_ = false;
+
     post_ops_t post_ops_;
     std::vector<binary_src_t> binary_srcs_;
 
@@ -149,11 +153,11 @@ struct pd_t : public gemm::pd_t {
         return sum_ab();
     }
 
-    bool a_zp_2d() const { return ao_dims_ >= 2; }
-    bool b_zp_2d() const { return bo_dims_ >= 2; }
+    bool a_zp_2d() const { return a_quant.zp_ndims >= 2; }
+    bool b_zp_2d() const { return b_quant.zp_ndims >= 2; }
 
-    bool a_gs_2d() const { return ag_dims_ >= 2; }
-    bool b_gs_2d() const { return bg_dims_ >= 2; }
+    bool a_gs_2d() const { return a_quant.gs_ndims >= 2; }
+    bool b_gs_2d() const { return b_quant.gs_ndims >= 2; }
 
     bool with_sum_ab() const { return sum_ab() != sum_ab::sum_none; }
 
@@ -165,31 +169,31 @@ struct pd_t : public gemm::pd_t {
             case sum_ab::sum_b_col: return 2;
         }
     }
-    bool with_a_scales() const { return (asc_dims_ >= 0); }
-    bool with_b_scales() const { return (bsc_dims_ >= 0); }
+    bool with_a_scales() const { return (a_quant.scale_ndims >= 0); }
+    bool with_b_scales() const { return (b_quant.scale_ndims >= 0); }
     bool with_c_scales() const {
         return !attr()->scales_.has_default_values(DNNL_ARG_DST);
     }
 
     bool with_a_zero_points() const {
-        return (swap_ab_ ? bo_dims_ >= 0 : ao_dims_ >= 0);
+        return (swap_ab_ ? b_quant.zp_ndims >= 0 : a_quant.zp_ndims >= 0);
     }
     bool with_b_zero_points() const {
-        return (swap_ab_ ? ao_dims_ >= 0 : bo_dims_ >= 0);
+        return (swap_ab_ ? a_quant.zp_ndims >= 0 : b_quant.zp_ndims >= 0);
     }
     bool with_c_zero_points() const {
         return !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
     }
 
-    bool with_a_group_sums() const { return (ag_dims_ >= 0); }
-    bool with_b_group_sums() const { return (bg_dims_ >= 0); }
+    bool with_a_group_sums() const { return (a_quant.gs_ndims >= 0); }
+    bool with_b_group_sums() const { return (b_quant.gs_ndims >= 0); }
 
     bool with_sround() const { return with_sround_; }
     bool with_mx_scale() const { return with_mx_scale_; }
 
-    bool a_scales_2d() const { return asc_dims_ > 1; }
-    bool b_scales_2d() const { return bsc_dims_ > 1; }
-    bool c_scales_2d() const { return csc_dims_ > 1; }
+    bool a_scales_2d() const { return a_quant.scale_ndims > 1; }
+    bool b_scales_2d() const { return b_quant.scale_ndims > 1; }
+    bool c_scales_2d() const { return c_quant.scale_ndims > 1; }
 
     bool dy_quant_enabled();
     bool wei_decomp();
@@ -223,28 +227,14 @@ struct pd_t : public gemm::pd_t {
     dim_t eff_scale_stride(int idx, int arg) const;
     dim_t eff_zp_stride(int idx, int arg) const;
     dim_t eff_gs_stride(int idx, int arg) const;
-    bool a_scales_grouped() const {
-        bool k_grouped
-                = 1 < a_scales_group_k_ && a_scales_group_k_ < desc()->k();
-        bool m_grouped
-                = 1 < a_scales_group_m_ && a_scales_group_m_ < desc()->m();
+    bool a_grouped() const {
+        bool k_grouped = 1 < a_quant.group_k && a_quant.group_k < desc()->k();
+        bool m_grouped = 1 < a_quant.group_m && a_quant.group_m < desc()->m();
         return k_grouped || m_grouped;
     }
-    bool b_scales_grouped() const {
-        bool k_grouped
-                = 1 < b_scales_group_k_ && b_scales_group_k_ < desc()->k();
-        bool n_grouped
-                = 1 < b_scales_group_n_ && b_scales_group_n_ < desc()->n();
-        return k_grouped || n_grouped;
-    }
-    bool a_zp_grouped() const {
-        bool k_grouped = 1 < a_zp_group_k_ && a_zp_group_k_ < desc()->k();
-        bool m_grouped = 1 < a_zp_group_m_ && a_zp_group_m_ < desc()->m();
-        return k_grouped || m_grouped;
-    }
-    bool b_zp_grouped() const {
-        bool k_grouped = 1 < b_zp_group_k_ && b_zp_group_k_ < desc()->k();
-        bool n_grouped = 1 < b_zp_group_n_ && b_zp_group_n_ < desc()->n();
+    bool b_grouped() const {
+        bool k_grouped = 1 < b_quant.group_k && b_quant.group_k < desc()->k();
+        bool n_grouped = 1 < b_quant.group_n && b_quant.group_n < desc()->n();
         return k_grouped || n_grouped;
     }
     bool a_zp_host_scalar() const {
@@ -255,54 +245,12 @@ struct pd_t : public gemm::pd_t {
         auto attr_info = attr_info_t::create(attr());
         return attr_info.with_host_src_zp;
     }
-    int a_q2d_group_k() const {
-        if (a_zp_2d()) {
-            return a_zp_group_k_;
-        } else if (a_scales_2d()) {
-            return a_scales_group_k_;
-        } else if (with_a_group_sums()) {
-            return a_gs_group_k_;
-        }
-        return 0;
-    }
-    int a_q2d_group_m() const {
-        if (a_zp_2d()) {
-            return a_zp_group_m_;
-        } else if (a_scales_2d()) {
-            return a_scales_group_m_;
-        } else if (with_a_group_sums()) {
-            return a_gs_group_m_;
-        }
-        return 0;
-    }
-    int b_q2d_group_k() const {
-        if (b_zp_2d()) {
-            return b_zp_group_k_;
-        } else if (b_scales_2d()) {
-            return b_scales_group_k_;
-        } else if (with_b_group_sums()) {
-            return b_gs_group_k_;
-        }
-        return 0;
-    }
-    int b_q2d_group_n() const {
-        if (b_zp_2d()) {
-            return b_zp_group_n_;
-        } else if (b_scales_2d()) {
-            return b_scales_group_n_;
-        } else if (with_b_group_sums()) {
-            return b_gs_group_n_;
-        }
-        return 0;
-    }
-    int c_q2d_group_m() const {
-        if (c_scales_2d() || with_mx_scale()) { return c_scales_group_m_; }
-        return 0;
-    }
-    int c_q2d_group_n() const {
-        if (c_scales_2d() || with_mx_scale()) { return c_scales_group_n_; }
-        return 0;
-    }
+    int a_q2d_group_k() const { return a_quant.group_k; }
+    int a_q2d_group_m() const { return a_quant.group_m; }
+    int b_q2d_group_k() const { return b_quant.group_k; }
+    int b_q2d_group_n() const { return b_quant.group_n; }
+    int c_q2d_group_m() const { return c_quant.group_m; }
+    int c_q2d_group_n() const { return c_quant.group_n; }
     int eff_align_a() const {
         auto dt = eff_a_type();
         auto align


### PR DESCRIPTION
The `quant_params` struct duplicates many of the variables stored in `jit::pd_t`. By moving this struct up to this level, we can skip a lot of duplication and potential inconsistencies - particularly related to `swap_ab`. This gets us a good chunk of the way toward handling `swap_ab` more intentionally and consistently.