### PR TITLE
[GPU] revert swapab refactor

### DIFF
--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -226,6 +226,9 @@ struct gen_t : public primitive_t {
             VDISPATCH_GEMM(zp_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_GEMM(gs_ok(), VERBOSE_UNSUPPORTED_PR_CFG);
 
+            if (swap_ab_) std::swap(ao_dims_, bo_dims_);
+            if (swap_ab_) std::swap(ag_dims_, bg_dims_);
+
             VDISPATCH_GEMM_SC(init_post_ops(), VERBOSE_UNSUPPORTED_POSTOP);
 
             bool with_binary = (post_ops_.find(binary) != -1)
@@ -346,24 +349,14 @@ struct gen_t : public primitive_t {
             auto has_gs = [&](int idx) {
                 return !attr()->precomputed_reductions_.has_default_values(idx);
             };
-
-            // TODO: Refactor to contain all swap handling within pd.
-            jit::quant_params a_quant, b_quant;
-            if (swap_ab()) {
-                a_quant = {b_scales_type_, ao_type, ag_type, bsc_dims_,
-                        bo_dims_, bg_dims_, b_q2d_group_k(), b_q2d_group_n(), 0,
-                        has_gs(DNNL_ARG_B), false, b_zp_hostscalar()};
-                b_quant = {a_scales_type_, bo_type, bg_type, asc_dims_,
-                        ao_dims_, ag_dims_, a_q2d_group_k(), 0, a_q2d_group_m(),
-                        has_gs(DNNL_ARG_A), false, a_zp_hostscalar()};
-            } else {
-                a_quant = {a_scales_type_, ao_type, ag_type, asc_dims_,
-                        ao_dims_, ag_dims_, a_q2d_group_k(), a_q2d_group_m(), 0,
-                        has_gs(DNNL_ARG_A), false, a_zp_hostscalar()};
-                b_quant = {b_scales_type_, bo_type, bg_type, bsc_dims_,
-                        bo_dims_, bg_dims_, b_q2d_group_k(), 0, b_q2d_group_n(),
-                        has_gs(DNNL_ARG_B), false, b_zp_hostscalar()};
-            }
+            jit::quant_params a_quant
+                    = {a_scales_type_, ao_type, ag_type, asc_dims_, ao_dims_,
+                            ag_dims_, a_q2d_group_k(), a_q2d_group_m(), 0,
+                            has_gs(DNNL_ARG_A), false, a_zp_hostscalar()};
+            jit::quant_params b_quant
+                    = {b_scales_type_, bo_type, bg_type, bsc_dims_, bo_dims_,
+                            bg_dims_, b_q2d_group_k(), 0, b_q2d_group_n(),
+                            has_gs(DNNL_ARG_B), false, b_zp_hostscalar()};
             jit::quant_params c_quant = {c_scales_type_, co_type, bg_type,
                     csc_dims_, -1, -1, 0, c_q2d_group_m(), c_q2d_group_n(),
                     has_gs(DNNL_ARG_C), with_mx_scale(), false};

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -507,24 +507,46 @@ gen_nocopy_desc_t::select_kernel(compute::gpu_arch_t arch, int stepping,
         problem_.AO.setAlignment(int(types::data_type_size(a_quant.zp_type)));
     if (b_quant.zp_type != data_type::undef)
         problem_.BO.setAlignment(int(types::data_type_size(b_quant.zp_type)));
-
-    problem_.asPtrDims = a_quant.scale_ndims;
-    problem_.bsPtrDims = b_quant.scale_ndims;
-    problem_.aqGroupK = a_quant.group_k;
-    problem_.bqGroupK = b_quant.group_k;
-    problem_.aqGroupM = a_quant.group_m;
-    problem_.bqGroupN = b_quant.group_n;
-    if (a_quant.scales_type != data_type::undef) {
-        problem_.Ta_scale = convert_dnnl_to_kernel_type(a_quant.scales_type);
-        problem_.A_scale.layout = swap_ab ? MatrixLayout::T : MatrixLayout::N;
-        problem_.A_scale.setAlignment(
-                int(types::data_type_size(a_quant.scales_type)));
-    }
-    if (b_quant.scales_type != data_type::undef) {
-        problem_.Tb_scale = convert_dnnl_to_kernel_type(b_quant.scales_type);
-        problem_.B_scale.layout = swap_ab ? MatrixLayout::T : MatrixLayout::N;
-        problem_.B_scale.setAlignment(
-                int(types::data_type_size(b_quant.scales_type)));
+    if (!swap_ab) {
+        problem_.asPtrDims = a_quant.scale_ndims;
+        problem_.bsPtrDims = b_quant.scale_ndims;
+        problem_.aqGroupK = a_quant.group_k;
+        problem_.bqGroupK = b_quant.group_k;
+        problem_.aqGroupM = a_quant.group_m;
+        problem_.bqGroupN = b_quant.group_n;
+        if (a_quant.scales_type != data_type::undef) {
+            problem_.Ta_scale
+                    = convert_dnnl_to_kernel_type(a_quant.scales_type);
+            problem_.A_scale.setAlignment(
+                    int(types::data_type_size(a_quant.scales_type)));
+        }
+        if (b_quant.scales_type != data_type::undef) {
+            problem_.Tb_scale
+                    = convert_dnnl_to_kernel_type(b_quant.scales_type);
+            problem_.B_scale.layout = MatrixLayout::N;
+            problem_.B_scale.setAlignment(
+                    int(types::data_type_size(b_quant.scales_type)));
+        }
+    } else {
+        problem_.bsPtrDims = a_quant.scale_ndims;
+        problem_.asPtrDims = b_quant.scale_ndims;
+        problem_.bqGroupK = a_quant.group_k;
+        problem_.aqGroupK = b_quant.group_k;
+        problem_.bqGroupN = a_quant.group_m;
+        problem_.aqGroupM = b_quant.group_n;
+        if (a_quant.scales_type != data_type::undef) {
+            problem_.Tb_scale
+                    = convert_dnnl_to_kernel_type(a_quant.scales_type);
+            problem_.B_scale.setAlignment(
+                    int(types::data_type_size(a_quant.scales_type)));
+        }
+        if (b_quant.scales_type != data_type::undef) {
+            problem_.Ta_scale
+                    = convert_dnnl_to_kernel_type(b_quant.scales_type);
+            problem_.A_scale.layout = MatrixLayout::T;
+            problem_.A_scale.setAlignment(
+                    int(types::data_type_size(b_quant.scales_type)));
+        }
     }
 
     if (c_quant.scales_type != data_type::undef) {
@@ -1005,14 +1027,10 @@ void gen_kernel_t::init_interface() {
     if (problem.needsBGroupSums())
         interface_.newArgument(
                 "bg_ptr", ExternalArgumentType::GlobalPtr, bg_access);
-    if (problem.aOffset2D() || problem.aScale2D()
-            || problem.needsAGroupSums()) {
+    if (problem.aOffset2D() || problem.aScale2D() || problem.needsAGroupSums())
         interface_.newArgument("ldaq", DataType::d);
-    }
-    if (problem.bOffset2D() || problem.bScale2D()
-            || problem.needsBGroupSums()) {
+    if (problem.bOffset2D() || problem.bScale2D() || problem.needsBGroupSums())
         interface_.newArgument("ldbq", DataType::d);
-    }
     if (problem.hasCMXScale()) interface_.newArgument("ldcq", DataType::d);
     if (problem.cOffset != COffset::None || problem.sumA || problem.sumB) {
         interface_.newArgument(

--- a/src/gpu/intel/gemm/jit/pd.hpp
+++ b/src/gpu/intel/gemm/jit/pd.hpp
@@ -171,12 +171,8 @@ struct pd_t : public gemm::pd_t {
         return !attr()->scales_.has_default_values(DNNL_ARG_DST);
     }
 
-    bool with_a_zero_points() const {
-        return (swap_ab_ ? bo_dims_ >= 0 : ao_dims_ >= 0);
-    }
-    bool with_b_zero_points() const {
-        return (swap_ab_ ? ao_dims_ >= 0 : bo_dims_ >= 0);
-    }
+    bool with_a_zero_points() const { return (ao_dims_ >= 0); }
+    bool with_b_zero_points() const { return (bo_dims_ >= 0); }
     bool with_c_zero_points() const {
         return !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
     }


### PR DESCRIPTION
Addresses [MFDNN-14592](https://jira.devtools.intel.com/browse/MFDNN-14592). A refactor in #4541 caused segmentation faults due to improper handling of the `swap_ab` parameter. This reverts the change in question, and restores functionality.

> ./oneDNN/build/tests/benchdnn/benchdnn --matmul --mode=R --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_tensor:f16:1x128+wei:common:0.5:f16 --attr-zero-points=wei:common:1:u8 --attr-precomputed-reductions=src:per_tensor:s32:1x128 1824x1024:1024x1
Segmentation fault (core dumped)