### PR TITLE
xe: conv: v2: revert assertion

### DIFF
--- a/src/gpu/intel/conv/jit/v2/kernel_desc.hpp
+++ b/src/gpu/intel/conv/jit/v2/kernel_desc.hpp
@@ -430,7 +430,6 @@ public:
                 if (d == dim) return i;
             }
         }
-        gpu_error_not_expected();
         return -1;
     }
 


### PR DESCRIPTION
Reverts the recent addition of an assertion. The erroneous case is already otherwise properly guarded. Addresses [MFDNN-14593](https://jira.devtools.intel.com/browse/MFDNN-14593).