### PR TITLE
cpu: x64: Xbyak x64 register manager

### DIFF
--- a/src/cpu/x64/xbyak_reg_manager.hpp
+++ b/src/cpu/x64/xbyak_reg_manager.hpp
@@ -1,0 +1,562 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#ifndef CPU_X64_XBYAK_REG_MANAGER_HPP
+#define CPU_X64_XBYAK_REG_MANAGER_HPP
+
+#include <cstdint>
+#include <set>
+#include <stdexcept>
+#include <vector>
+#include <type_traits>
+
+#define XBYAK64
+#define XBYAK_NO_OP_NAMES
+#include "xbyak/xbyak.h"
+#include "xbyak/xbyak_util.h"
+
+namespace Xbyak {
+// Static definitions for different types of registers in relation to which family they belong to.
+enum class RegFamily { GP, Vec, Opmask };
+
+template <class RegT>
+struct reg_family;
+
+// General Purpose register families (8-bit, 16-bit, 32-bit, 64-bit)
+template <>
+struct reg_family<Reg8> {
+    static constexpr RegFamily value = RegFamily::GP;
+};
+template <>
+struct reg_family<Reg16> {
+    static constexpr RegFamily value = RegFamily::GP;
+};
+template <>
+struct reg_family<Reg32> {
+    static constexpr RegFamily value = RegFamily::GP;
+};
+template <>
+struct reg_family<Reg64> {
+    static constexpr RegFamily value = RegFamily::GP;
+};
+
+// Vector register families (XMM, YMM, ZMM)
+template <>
+struct reg_family<Xmm> {
+    static constexpr RegFamily value = RegFamily::Vec;
+};
+template <>
+struct reg_family<Ymm> {
+    static constexpr RegFamily value = RegFamily::Vec;
+};
+template <>
+struct reg_family<Zmm> {
+    static constexpr RegFamily value = RegFamily::Vec;
+};
+
+// Opmask registers (k0-k7)
+template <>
+struct reg_family<Opmask> {
+    static constexpr RegFamily value = RegFamily::Opmask;
+};
+
+class RegPoolManager {
+public:
+    // Constructor - detects APX and AVX-512 support and sets up register pools accordingly
+    RegPoolManager() {
+        Xbyak::util::Cpu cpu;
+        uint64_t xcr0 = 0;
+        if (cpu.has(Xbyak::Util::Cpu::tOSXSAVE)) {
+            xcr0 = cpu.getXfeature();
+        }
+
+        // Detect APX for extended GP registers (r16-r31)
+        if (cpu.has(Xbyak::Util::Cpu::tAPX_F)) {
+            has_apx_ = ((xcr0 >> 19) & 1) == 1; // Check if XCR0[19] is set for APX support
+        }
+        max_gp_reg_idx_ = has_apx_ ? 31 : 15;
+
+        // Detect AVX-512 for extended vector registers (zmm16-zmm31)
+        if (cpu.has(Xbyak::Util::Cpu::tAVX512F)) {
+            has_avx512_ = ((xcr0 >> 7) & 1) == 1; // Check if XCR0[7] is set for AVX-512 support
+        }
+        max_vec_reg_idx_ = has_avx512_ ? 31 : 15;
+
+        // If APX is available, add r16-r31 to the free pool
+        // APX registers r16-r31 are caller-saved (call-clobbered)
+        if (has_apx_) {
+            for (int i = 16; i <= 31; ++i) {
+                free_gp_regs.insert(i);
+            }
+        }
+
+        // If AVX-512 is available, add zmm16-zmm31 to the free pool
+        // Extended vector registers are caller-saved (call-clobbered)
+        if (has_avx512_) {
+            for (int i = 16; i <= 31; ++i) {
+                free_vec_regs.insert(i);
+            }
+        }
+    }
+
+    // Usage:
+    // Reg64 rax = rm.alloc<Reg64>(); // Allocate next available 64-bit register (freed by user)
+    // rm.free(rax);                  // Free rax
+
+    // register allocation method - accepts int to specify an unused reg, or no arg to get next free reg
+    template <class RegT>
+    RegT alloc() {
+        switch (reg_family<RegT>::value) {
+            case RegFamily::GP: {
+                const int idx = next_gp_idx();
+                gp_reg(idx);
+                return RegT(idx);
+            }
+            case RegFamily::Vec: {
+                const int idx = next_vec_idx();
+                vec_reg(idx);
+                return RegT(idx);
+            }
+            case RegFamily::Opmask: {
+                const int idx = next_opmask_idx();
+                opmask_reg(idx);
+                return RegT(idx);
+            }
+            default: throw std::runtime_error("Unknown register family");
+        }
+    }
+
+    template <class RegT>
+    RegT alloc(int idx) {
+        switch (reg_family<RegT>::value) {
+            case RegFamily::GP: gp_reg(idx); return RegT(idx);
+            case RegFamily::Vec: vec_reg(idx); return RegT(idx);
+            case RegFamily::Opmask: opmask_reg(idx); return RegT(idx);
+            default: throw std::runtime_error("Unknown register family");
+        }
+    }
+
+    // takes register object and moves it from in use to free set
+    template <class RegT>
+    void free(RegT reg) {
+        const int idx = reg.getIdx();
+        switch (reg_family<RegT>::value) {
+            case RegFamily::GP: release_gp(idx); break;
+            case RegFamily::Vec: release_vec(idx); break;
+            case RegFamily::Opmask: release_opmask(idx); break;
+            default: throw std::runtime_error("Unknown register family");
+        }
+    }
+
+    // getter methods - return vectors of register indices representing a set
+    std::vector<int> get_free_gps() const {
+        return make_index_vector(free_gp_regs);
+    }
+    std::vector<int> get_in_use_gps() const {
+        return make_index_vector(in_use_gp);
+    }
+    std::vector<int> get_preserved_gps() const {
+        return make_index_vector(preserved_gp);
+    }
+    std::vector<int> get_used_gps() const { return make_index_vector(used_gp); }
+
+    std::vector<int> get_free_vecs() const {
+        return make_index_vector(free_vec_regs);
+    }
+    std::vector<int> get_in_use_vecs() const {
+        return make_index_vector(in_use_vec);
+    }
+    std::vector<int> get_preserved_vecs() const {
+        return make_index_vector(preserved_vec);
+    }
+    std::vector<int> get_used_vecs() const {
+        return make_index_vector(used_vec);
+    }
+
+    std::vector<int> get_free_opmasks() const {
+        return make_index_vector(free_opmask_regs);
+    }
+    std::vector<int> get_in_use_opmasks() const {
+        return make_index_vector(in_use_opmask);
+    }
+    std::vector<int> get_preserved_opmasks() const {
+        return make_index_vector(preserved_opmask);
+    }
+    std::vector<int> get_used_opmasks() const {
+        return make_index_vector(used_opmask);
+    }
+
+    // member function - add a register to the free pool of general registers
+    void add_to_gp_pool(const Reg64 &reg) { add_to_gp_pool(reg.getIdx()); }
+    void add_to_gp_pool(int idx) {
+        if ((idx < 0 || idx > max_gp_reg_idx_))
+            throw std::runtime_error("Register index out of range");
+        const bool in_free = free_gp_regs.count(idx) != 0;
+        const bool in_preserved = preserved_gp.count(idx) != 0;
+        const bool in_use = in_use_gp.count(idx) != 0;
+        if (in_free || in_preserved || in_use)
+            throw std::runtime_error("Register already tracked");
+        free_gp_regs.insert(idx);
+    }
+
+    // helper function - returns true if a register object is currently in the used set of registers
+    template <class RegT>
+    bool reg_in_use(const RegT &reg) const {
+        return reg_in_use_idx(reg.getIdx(), reg_family<RegT>::value);
+    }
+
+    // helper functions - returns true if an index in a given family is in use
+    bool gp_idx_in_use(int reg_idx) const {
+        return reg_in_use_idx(reg_idx, RegFamily::GP);
+    }
+    bool vec_idx_in_use(int reg_idx) const {
+        return reg_in_use_idx(reg_idx, RegFamily::Vec);
+    }
+    bool opmask_idx_in_use(int reg_idx) const {
+        return reg_in_use_idx(reg_idx, RegFamily::Opmask);
+    }
+
+    // scoped register handling with RAII
+    // usage: Reg64 r10 = rm.alloc<Reg64>(10);
+    //        auto scoped = rm.makeScoped(r10);
+    // or
+    //        auto scoped_reg = rm.makeScoped(rm.alloc<Reg64>());
+    // r10 & scoped_reg will free at end of scope when guards' dtors called.
+    template <class Reg>
+    class Scoped {
+    public:
+        explicit Scoped(RegPoolManager &rm, Reg r)
+            // pointer to allocator, allocate scoped reg at construction & track, unowned = nullptr
+            : rm_(&rm), reg_(r) {
+            validate_scoped_reg(rm_, reg_);
+        }
+
+        // if object is owner of scoped reg and goes out of scope, deallocate
+        ~Scoped() {
+            if (!rm_) return;
+            rm_->free(reg_);
+        }
+
+        // disable copy - scoped regs are move only to avoid ownership/double free issues as per RAII
+        Scoped(const Scoped &) = delete;
+        Scoped &operator=(const Scoped &) = delete;
+
+        // move constructor - used when scoped regs initialised from rvalue (incl. std::move)
+        Scoped(Scoped &&other) noexcept : rm_(other.rm_), reg_(other.reg_) {
+            other.rm_ = nullptr; // set previous owner to no longer own
+        }
+
+        // expose underlying register for implicit use in JIT helpers
+        operator const Reg &() const noexcept { return reg_; }
+        const Reg &get() const noexcept { return reg_; }
+
+    private:
+        RegPoolManager *rm_
+                = nullptr; // pointer to allocator, initialised as nullptr
+        Reg reg_ {};
+    };
+
+    // helper factory - calls Scoped ctor
+    template <class Reg>
+    inline Scoped<Reg> makeScoped(Reg r) & {
+        return Scoped<Reg>(*this, r);
+    }
+
+    // helper methods to query APX support
+    bool has_apx() const { return has_apx_; }
+    int max_gp_registers() const { return max_gp_reg_idx_ + 1; }
+
+    // helper methods to query AVX-512 support
+    bool has_avx512() const { return has_avx512_; }
+    int max_vec_registers() const { return max_vec_reg_idx_ + 1; }
+
+    // helper methods to return special registers as per x86-64 calling convention (System V AMD64 ABI)
+    // Stack pointer: rsp
+    inline Reg64 _stack_pointer() {
+        used_gp.insert(4); // rsp is index 4
+        return Reg64(4);
+    }
+    // Base pointer: rbp
+    inline Reg64 _base_pointer() {
+        used_gp.insert(5); // rbp is index 5
+        return Reg64(5);
+    }
+    // Opmask k0: special mask register that means "unmasked" (no masking)
+    // When k0 is used as a write mask, all elements are written (effectively no masking)
+    inline Opmask _opmask_k0() {
+        used_opmask.insert(0); // k0 is index 0
+        return Opmask(0);
+    }
+
+private:
+    // helper method - converts members of set to vector
+    static inline std::vector<int> make_index_vector(const std::set<int> &set) {
+        std::vector<int> indices;
+        indices.reserve(set.size());
+        for (int idx : set)
+            indices.emplace_back(idx);
+        return indices;
+    }
+
+    // helper method - checks reg in use before scoping
+    template <class RegT>
+    static void validate_scoped_reg(RegPoolManager *rm, RegT reg) {
+        const RegFamily family = reg_family<RegT>::value;
+        if (!rm->reg_in_use(reg))
+            throw std::runtime_error(scoped_reg_error(family));
+    }
+
+    // helper switch case for error messages
+    static const char *scoped_reg_error(RegFamily family) noexcept {
+        switch (family) {
+            case RegFamily::GP:
+                return "Cannot create GP scoped reg for a register that is not "
+                       "in use";
+            case RegFamily::Vec:
+                return "Cannot create Vec scoped reg for a register that is "
+                       "not in use";
+            case RegFamily::Opmask:
+                return "Cannot create Opmask scoped reg for a register that is "
+                       "not in use";
+            default: return "Cannot create scoped reg for unknown family";
+        }
+    }
+
+    // helper method - checks if a register index for a given family is currently in use
+    bool reg_in_use_idx(int idx, RegFamily family) const {
+        switch (family) {
+            case RegFamily::GP:
+                if (idx < 0 || idx > max_gp_reg_idx_) {
+                    throw std::runtime_error("GP register index out of range");
+                }
+                return in_use_gp.find(idx) != in_use_gp.end();
+            case RegFamily::Vec:
+                if (idx < 0 || idx > max_vec_reg_idx_) {
+                    throw std::runtime_error("Vec register index out of range");
+                }
+                return in_use_vec.find(idx) != in_use_vec.end();
+            case RegFamily::Opmask:
+                if (idx < 0 || idx > 7) {
+                    throw std::runtime_error(
+                            "Opmask register index out of range");
+                }
+                return in_use_opmask.find(idx) != in_use_opmask.end();
+            default: throw std::runtime_error("Unknown register family");
+        }
+    }
+
+    // helper method - finds next free register for a given family
+    int next_gp_idx() const {
+        if (!free_gp_regs.empty()) return *free_gp_regs.begin();
+        if (!preserved_gp.empty()) return *preserved_gp.begin();
+        throw std::runtime_error("No free GP registers available");
+    }
+    int next_vec_idx() const {
+        if (!free_vec_regs.empty()) return *free_vec_regs.begin();
+        if (!preserved_vec.empty()) return *preserved_vec.begin();
+        throw std::runtime_error("No free Vec registers available");
+    }
+    int next_opmask_idx() const {
+        if (!free_opmask_regs.empty()) return *free_opmask_regs.begin();
+        if (!preserved_opmask.empty()) return *preserved_opmask.begin();
+        throw std::runtime_error("No free Opmask registers available");
+    }
+
+    // tracking for in-use indices for a given register family
+    void gp_reg(int idx) {
+        if (reg_in_use_idx(idx, RegFamily::GP))
+            throw std::runtime_error("Specified GP register currently in use");
+        auto it = free_gp_regs.find(idx);
+        auto pres_it = preserved_gp.find(idx);
+        if (it != free_gp_regs.end()) {
+            in_use_gp.insert(idx);
+            free_gp_regs.erase(it);
+            used_gp.insert(idx);
+        } else if (pres_it != preserved_gp.end()) {
+            in_use_gp.insert(idx);
+            preserved_gp.erase(pres_it);
+            used_gp.insert(idx);
+        } else {
+            throw std::runtime_error(
+                    "Requested register not in free/preserved pools.");
+        }
+    }
+    void vec_reg(int idx) {
+        if (reg_in_use_idx(idx, RegFamily::Vec))
+            throw std::runtime_error("Specified Vec register currently in use");
+        auto it = free_vec_regs.find(idx);
+        auto pres_it = preserved_vec.find(idx);
+        if (it != free_vec_regs.end()) {
+            in_use_vec.insert(idx);
+            free_vec_regs.erase(it);
+            used_vec.insert(idx);
+        } else if (pres_it != preserved_vec.end()) {
+            in_use_vec.insert(idx);
+            preserved_vec.erase(pres_it);
+            used_vec.insert(idx);
+        } else {
+            throw std::runtime_error(
+                    "Requested register not in free/preserved/in-use sets.");
+        }
+    }
+    void opmask_reg(int idx) {
+        if (reg_in_use_idx(idx, RegFamily::Opmask))
+            throw std::runtime_error(
+                    "Specified Opmask register currently in use");
+        auto it = free_opmask_regs.find(idx);
+        auto pres_it = preserved_opmask.find(idx);
+        if (it != free_opmask_regs.end()) {
+            in_use_opmask.insert(idx);
+            free_opmask_regs.erase(it);
+            used_opmask.insert(idx);
+        } else if (pres_it != preserved_opmask.end()) {
+            in_use_opmask.insert(idx);
+            preserved_opmask.erase(pres_it);
+            used_opmask.insert(idx);
+        } else {
+            throw std::runtime_error(
+                    "Requested opmask register not in free/preserved pools.");
+        }
+    }
+
+    // member function - moves given index from in-use set to free set for given family
+    void release_gp(int idx) {
+        if ((idx < 0 || idx > max_gp_reg_idx_))
+            throw std::runtime_error("Register index out of range");
+        auto it = in_use_gp.find(idx);
+        if (it == in_use_gp.end())
+            throw std::runtime_error("GP register not in use");
+        in_use_gp.erase(it);
+        free_gp_regs.insert(idx);
+    }
+    void release_vec(int idx) {
+        if ((idx < 0 || idx > max_vec_reg_idx_))
+            throw std::runtime_error("Register index out of range");
+        auto it = in_use_vec.find(idx);
+        if (it == in_use_vec.end())
+            throw std::runtime_error("Vec register not in use");
+        in_use_vec.erase(it);
+        free_vec_regs.insert(idx);
+    }
+    void release_opmask(int idx) {
+        if ((idx < 0 || idx > 7))
+            throw std::runtime_error("Opmask register index out of range");
+        auto it = in_use_opmask.find(idx);
+        if (it == in_use_opmask.end())
+            throw std::runtime_error("Opmask register not in use");
+        in_use_opmask.erase(it);
+        free_opmask_regs.insert(idx);
+    }
+
+    // General Purpose registers (GP):
+    // Indices: rax=0, rcx=1, rdx=2, rbx=3, rsp=4, rbp=5, rsi=6, rdi=7, r8-r15=8-15
+    // Note: rsp (4) and rbp (5) are special and not typically allocated
+#ifdef _WIN32
+    // Windows x64 calling convention:
+    // Volatile (caller-saved): rax, rcx, rdx, r8-r11 (7 registers)
+    // Non-volatile (callee-saved): rbx, rbp, rdi, rsi, r12-r15 (8 registers)
+    static const std::set<int> &base_free_gp() {
+        static const std::set<int> s {0, 1, 2, 8, 9, 10, 11};
+        return s;
+    }
+    static const std::set<int> &base_preserved_gp() {
+        static const std::set<int> s {3, 6, 7, 12, 13, 14, 15};
+        return s;
+    }
+#else
+    // System V AMD64 ABI calling convention for Linux/macOS:
+    // Call-clobbered (caller-saved): rax, rcx, rdx, rsi, rdi, r8-r11 (9 registers)
+    // Call-preserved (callee-saved): rbx, r12-r15 (5 registers)
+    static const std::set<int> &base_free_gp() {
+        static const std::set<int> s {0, 1, 2, 6, 7, 8, 9, 10, 11};
+        return s;
+    }
+    static const std::set<int> &base_preserved_gp() {
+        static const std::set<int> s {3, 12, 13, 14, 15};
+        return s;
+    }
+#endif
+
+    std::set<int> used_gp;
+    std::set<int> in_use_gp;
+    std::set<int> free_gp_regs = base_free_gp();
+    std::set<int> preserved_gp = base_preserved_gp();
+
+    // Vector registers (XMM/YMM/ZMM):
+    // - SSE/AVX/AVX2: 0-15 (xmm0-xmm15, ymm0-ymm15)
+    // - AVX-512: 0-31 (xmm0-xmm31, ymm0-ymm31, zmm0-zmm31)
+    // Note: Only include 0-15 by default; extended registers (16-31) are added in constructor if AVX-512 is detected
+#ifdef _WIN32
+    // Windows x64 calling convention:
+    // Volatile (caller-saved): xmm0-xmm5 (6 registers)
+    // Non-volatile (callee-saved): xmm6-xmm15 (10 registers)
+    static const std::set<int> &base_free_vec() {
+        static const std::set<int> s {0, 1, 2, 3, 4, 5};
+        return s;
+    }
+    static const std::set<int> &base_preserved_vec() {
+        static const std::set<int> s {6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+        return s;
+    }
+#else
+    // System V AMD64 ABI (Linux/macOS):
+    // Call-clobbered: all vector registers are caller-saved
+    static const std::set<int> &base_free_vec() {
+        static const std::set<int> s {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+        return s;
+    }
+    static const std::set<int> &base_preserved_vec() {
+        static const std::set<int> s {};
+        return s;
+    }
+#endif
+
+    std::set<int> used_vec;
+    std::set<int> in_use_vec;
+    std::set<int> free_vec_regs = base_free_vec();
+    std::set<int> preserved_vec = base_preserved_vec();
+
+    // Opmask registers (k0-k7) for AVX-512
+    // k0 has special meaning (unmasked), typically k1-k7 are used
+    // All opmask registers are call-clobbered
+    static const std::set<int> &base_free_opmask() {
+        static const std::set<int> s {1, 2, 3, 4, 5, 6, 7};
+        return s;
+    }
+    // No preserved opmask registers
+    static const std::set<int> &base_preserved_opmask() {
+        static const std::set<int> s {};
+        return s;
+    }
+
+    std::set<int> used_opmask;
+    std::set<int> in_use_opmask;
+    std::set<int> free_opmask_regs = base_free_opmask();
+    std::set<int> preserved_opmask = base_preserved_opmask();
+
+    // APX feature support
+    bool has_apx_ = false;
+    int max_gp_reg_idx_ = 15; // 15 without APX, 31 with APX
+
+    // AVX-512 feature support
+    bool has_avx512_ = false;
+    // 15 without (SSE/AVX/AVX2), 31 with AVX-512
+    int max_vec_reg_idx_ = 15;
+};
+
+} // namespace Xbyak
+
+#endif // CPU_X64_XBYAK_REG_MANAGER_HPP

--- a/src/cpu/x64/xbyak_reg_manager_explained.md
+++ b/src/cpu/x64/xbyak_reg_manager_explained.md
@@ -1,0 +1,470 @@
+# Xbyak x86-64 Register Manager
+
+## Summary of Proposal
+
+This document serves as an overview and proposal for a user-level register manager to allow developers working with Xbyak on x86-64 to more easily track, manage and (de)allocate registers.
+
+This implementation is modeled after the [Xbyak_aarch64 Register Manager (PR #4587)](https://github.com/uxlfoundation/oneDNN/pull/4587) but adapted for x86-64 architecture and its specific characteristics.
+
+## Desired Outcomes
+
+1. Provide tracking and standardized, automatic allocate and free methods for registers.
+2. Guarantee unique ownership of registers for each of the three register families:
+   - General Purpose (GP): Reg8, Reg16, Reg32, Reg64
+   - Vector (Vec): Xmm, Ymm, Zmm
+   - Opmask: k0-k7 (AVX-512)
+3. Implement scoped registers following the RAII technique.
+4. Ensure compatibility & minimum friction with current register manager techniques in oneDNN.
+5. Support Intel APX extended registers (r16-r31) with automatic detection.
+6. Support AVX-512 extended vector registers (zmm16-zmm31) with automatic detection.
+
+## Context & Motivation
+
+The motivation for this project is to reduce the manual user-level register management for projects using Xbyak on x86-64 and to support both Windows x64 and System V AMD64 ABI calling conventions with automatic platform detection.
+
+### Key Differences from AArch64 Implementation
+
+| Aspect | x86-64 | AArch64 |
+|--------|--------|---------|
+| **GP Registers** | 16 (r0-r15), 32 with APX (r0-r31) | 31 (x0-x30) |
+| **Vector Registers** | 16 (zmm0-zmm15) SSE/AVX/AVX2, 32 (zmm0-zmm31) with AVX-512 | 32 (v0-v31) for FP/SIMD |
+| **Mask Registers** | 8 opmask (k0-k7) for AVX-512 | 16 predicate (p0-p15) for SVE |
+| **Special Registers** | rsp (r4), rbp (r5), k0 | x16/x17 (IPC), x18 (platform), x29 (FP), x30 (LR) |
+| **Register Aliasing** | RAX/EAX/AX/AL share same register<br>XMM/YMM/ZMM share same register | Different sizes access same register |
+| **Calling Convention** | Windows x64 / System V AMD64 ABI (auto-detected) | AAPCS64 |
+| **Extended Support** | Intel APX adds r16-r31, AVX-512 adds zmm16-zmm31 (runtime detection) | SVE scalable vectors |
+
+## Assumptions
+
+- Initially, the majority of kernels will continue to use the old method of register handling.
+- Calling convention automatically selected at compile time via `_WIN32` macro (Windows x64 vs System V AMD64).
+- Call-clobbered (volatile) registers are allocated first from the free pool.
+- There is no specific order that registers should be allocated in their respective sets.
+- Intel APX support is detected at runtime and extended GP registers (r16-r31) are automatically made available.
+- AVX-512 support is detected at runtime and extended vector registers (zmm16-zmm31) are automatically made available.
+- Register aliasing (e.g., RAX/EAX/AX/AL) is handled by tracking at the index level.
+
+## Implementation
+
+### Overview
+
+The register manager maintains three families of registers, each with three sets that hold indices representing the registers within the family. The `*` represents one of the three register families (GP, Vec, Opmask). Each family has these three sets that hold indices which represent the registers within the family. Further, each family has a used set, which simply tracks any register that has been touched by the manager up to this point.
+
+```
++-------------------------------------+
+|     RegPoolManager                  |
++-------------------------------------+
+| GP Registers (0-15 or 0-31)         |
+|  +-------------+                    |
+|  | free_regs   | ---alloc()-->      |
+|  +-------------+                    |
+|  +-------------+                    |
+|  | in_use      | <--alloc()---      |
+|  +-------------+    free()---->     |
+|  +-------------+                    |
+|  | preserved   | (callee-saved)     |
+|  +-------------+                    |
+|  +-------------+                    |
+|  | used        | (tracking)         |
+|  +-------------+                    |
++-------------------------------------+
+| Vec Registers (0-15 or 0-31)        |
+|  +-------------+                    |
+|  | free_regs   | ---alloc()-->      |
+|  +-------------+                    |
+|  +-------------+                    |
+|  | in_use      | <--alloc()---      |
+|  +-------------+    free()---->     |
+|  +-------------+                    |
+|  | preserved   | (empty)            |
+|  +-------------+                    |
+|  +-------------+                    |
+|  | used        | (tracking)         |
+|  +-------------+                    |
++-------------------------------------+
+| Opmask Registers (1-7)              |
+|  +-------------+                    |
+|  | free_regs   | ---alloc()-->      |
+|  +-------------+                    |
+|  +-------------+                    |
+|  | in_use      | <--alloc()---      |
+|  +-------------+    free()---->     |
+|  +-------------+                    |
+|  | preserved   | (empty)            |
+|  +-------------+                    |
+|  +-------------+                    |
+|  | used        | (tracking)         |
+|  +-------------+                    |
++-------------------------------------+
+```
+
+### Data Structures and Design Choices
+
+Used `std::set` to track register states as shown above. The manager aims to use STL-based data structures and functions to ensure the helper is as understandable and compatible as possible.
+
+### Register Priority and Management (System V AMD64 ABI)
+
+For information on design choices for registers discussed below, see the [System V AMD64 ABI](https://gitlab.com/x86-psABIs/x86-64-ABI).
+
+#### General Purpose Registers (16 or 32 registers)
+
+**Register Mapping:**
+- rax (0), rcx (1), rdx (2), rbx (3), rsp (4), rbp (5), rsi (6), rdi (7)
+- r8-r15 (8-15)
+- r16-r31 (16-31) - Intel APX only, detected at runtime
+
+**Register Name Helpers:**
+Use `Xbyak::Operand` to obtain register indices or construct register objects when allocating registers by name, or pass the numeric index directly (for example, `rm.alloc<Reg64>(10)`). Example:
+
+```cpp
+// get numeric index from the Xbyak enum
+Reg64 rax = rm.alloc<Reg64>(static_cast<int>(Xbyak::Operand::RAX));
+```
+
+This keeps allocation examples consistent with the Xbyak API.
+
+**Calling Convention (automatically selected via `_WIN32` macro):**
+
+*Windows x64:*
+- **Volatile (Caller-saved):** rax (0), rcx (1), rdx (2), r8-r11 (8-11) — 7 registers
+- **Non-volatile (Callee-saved):** rbx (3), rsi (6), rdi (7), r12-r15 (12-15) — 8 registers
+- **Parameter registers:** RCX, RDX, R8, R9 (4 integer parameters)
+
+*System V AMD64 ABI (Linux/Unix/macOS):*
+- **Call-Clobbered (Caller-saved):** rax (0), rcx (1), rdx (2), rsi (6), rdi (7), r8-r11 (8-11) — 9 registers
+- **Call-Preserved (Callee-saved):** rbx (3), r12-r15 (12-15) — 5 registers
+- **Parameter registers:** RDI, RSI, RDX, RCX, R8, R9 (6 integer parameters)
+
+*Extended Registers (APX):*
+- r16-r31 (16-31) automatically added as caller-saved when APX is detected
+
+**Special Registers (not auto-allocated):**
+- rsp (4) - Stack pointer
+- rbp (5) - Base/frame pointer
+
+**Key Difference:** Windows treats RSI/RDI as callee-saved (preserved), while System V treats them as caller-saved (volatile)
+
+**x86-64 Specific Note:**
+- Register aliasing (RAX/EAX/AX/AL) is handled by tracking at the index level
+- Writing to 32-bit registers (EAX) zero-extends to 64-bit (RAX)
+- APX detection uses `Xbyak::util::Cpu::tAPX_F` at construction time
+
+#### Vector Registers (16 or 32 registers)
+
+**Register Mapping:**
+- SSE/AVX/AVX2: xmm0-xmm15, ymm0-ymm15 (0-15)
+- AVX-512: xmm0-xmm31, ymm0-ymm31, zmm0-zmm31 (0-31)
+
+**Calling Convention (automatically selected via `_WIN32` macro):**
+
+*Windows x64:*
+- **Volatile (Caller-saved):** xmm0-xmm5 (0-5) — 6 registers
+- **Non-volatile (Callee-saved):** xmm6-xmm15 (6-15) — 10 registers
+- **Parameter registers:** xmm0-xmm3 (4 FP parameters)
+
+*System V AMD64 ABI (Linux/Unix/macOS):*
+- **Call-Clobbered (Caller-saved):** All vector registers (xmm0-xmm15 or zmm0-zmm31)
+- **Call-Preserved:** None
+- **Parameter registers:** xmm0-xmm7 (8 FP parameters)
+
+*Extended Registers (AVX-512):*
+- xmm16-xmm31/ymm16-ymm31/zmm16-zmm31 (16-31) automatically added as caller-saved when AVX-512 is detected
+
+**Key Difference:** Windows preserves xmm6-xmm15 (major impact for SIMD-heavy code), while System V treats all vector registers as volatile
+
+**x86-64 Specific Note:**
+- XMM, YMM, and ZMM registers are aliases of the same physical register
+- XMM uses lower 128 bits, YMM uses lower 256 bits, ZMM uses all 512 bits
+- Aliasing is automatically handled by index-based tracking
+- AVX-512 detection uses `Xbyak::util::Cpu::tAVX512F` at construction time
+- Extended registers (16-31) are only available when AVX-512 is detected
+
+#### Opmask Registers (8 registers for AVX-512)
+
+**Register Mapping:**
+- k0-k7 (0-7)
+
+**Call-Clobbered (Caller-saved):**
+- k1-k7 (1-7)
+
+**Special Register (not auto-allocated):**
+- k0 (0) - When used as write mask, means "unmasked" (no masking applied)
+
+### Scoped Registers (RAII)
+
+```cpp
+// Scoped register handling with RAII
+// Usage: Reg64 reg11 = rm.alloc<Reg64>(11);
+//        auto scoped = rm.makeScoped(reg11);
+// or
+//        auto scoped_reg = rm.makeScoped(rm.alloc<Reg64>());
+// reg11 & scoped_reg will free at end of scope when guards' dtors called.
+
+template<class Reg>
+class Scoped {
+public:
+    explicit Scoped(RegPoolManager& rm, Reg r)
+        : rm_(&rm), reg_(r) {
+        validate_scoped_reg(rm_, reg_);
+    }
+    
+    ~Scoped() {
+        if (!rm_) return;
+        rm_->free(reg_);
+    }
+    
+    // Disable copy - scoped regs are move only
+    Scoped(const Scoped&) = delete;
+    Scoped& operator=(const Scoped&) = delete;
+    
+    // Move constructor
+    Scoped(Scoped&& other) noexcept
+        : rm_(other.rm_), reg_(other.reg_) {
+        other.rm_ = nullptr;
+    }
+    
+    // Expose underlying register
+    operator const Reg &() const noexcept { return reg_; }
+    const Reg &get() const noexcept { return reg_; }
+
+private:
+    RegPoolManager* rm_ = nullptr;
+    Reg reg_{};
+};
+```
+
+**Note:** Scoped registers should not be manually freed, as this will lead to double-free errors and crashes. Users should use `std::move` to change the scoped guard of a register, and therefore its lifetime.
+
+### Special Register Helpers
+
+```cpp
+// Helper methods to return special registers
+// NOTE: These registers are excluded from automatic allocation
+
+// Stack pointer: rsp (index 4)
+inline Reg64 _stack_pointer() {
+    used_gp.insert(4);
+    return Reg64(4);
+}
+
+// Base/frame pointer: rbp (index 5)
+inline Reg64 _base_pointer() {
+    used_gp.insert(5);
+    return Reg64(5);
+}
+
+// Opmask k0: special mask that means "unmasked"
+inline Opmask _opmask_k0() {
+    used_opmask.insert(0);
+    return Opmask(0);
+}
+```
+
+### Extended ISA Support (APX and AVX-512)
+
+The register manager automatically detects Intel APX and AVX-512 support at construction time:
+
+```cpp
+RegPoolManager() {
+    Xbyak::util::Cpu cpu;
+    
+    // Detect APX for extended GP registers (r16-r31)
+    has_apx_ = cpu.has(Xbyak::util::Cpu::tAPX_F);
+    max_gp_reg_idx_ = has_apx_ ? 31 : 15;
+    
+    // Detect AVX-512 for extended vector registers (zmm16-zmm31)
+    has_avx512_ = cpu.has(Xbyak::util::Cpu::tAVX512F);
+    max_vec_reg_idx_ = has_avx512_ ? 31 : 15;
+    
+    // If APX is available, add r16-r31 to the free pool
+    if (has_apx_) {
+        for (int i = 16; i <= 31; ++i) {
+            free_gp_regs.insert(i);
+        }
+    }
+    
+    // If AVX-512 is available, add zmm16-zmm31 to the free pool
+    if (has_avx512_) {
+        for (int i = 16; i <= 31; ++i) {
+            free_vec_regs.insert(i);
+        }
+    }
+}
+```
+
+Query methods:
+```cpp
+bool has_apx() const;           // Returns true if APX is supported
+int max_gp_registers() const;   // Returns 16 or 32
+
+bool has_avx512() const;        // Returns true if AVX-512 is supported
+int max_vec_registers() const;  // Returns 16 or 32
+```
+
+**Extended ISA Implementation Notes:**
+- r16-r31 (APX) and zmm16-zmm31 (AVX-512) are automatically added as call-clobbered registers
+- All range checks use `max_gp_reg_idx_` and `max_vec_reg_idx_` instead of hardcoded values
+- Zero overhead: detection happens once at construction
+- Backward compatible: works seamlessly on systems without APX or AVX-512
+
+### Error Handling & Strictness
+
+The manager assumes that the user knows what they are doing, in so far that it will throw runtime errors if:
+
+- The user attempts to allocate a specific register when it is in use.
+- The user attempts to allocate a specific register that is not in the free or preserved sets.
+- The user frees a register that is not in the in-use set.
+- The user enters a register index outside the valid range:
+  - GP: 0-15 (without APX) or 0-31 (with APX)
+  - Vec: 0-16 (without AVX-512) or 0-31 (with AVX-512)
+  - Opmask: 0-7
+- The user attempts to add a register to the free GP pool when the register is already tracked.
+- There are no registers in free_regs or preserved when `alloc()` is called for a register type.
+- The user calls `makeScoped` on a register that is not in use.
+- The user tries to handle a register type whose `reg_family` is not GP/Vec/Opmask.
+
+### Usage Avoidance
+
+Further, it is important to note that the following should be avoided by users:
+
+**Manual freeing of scoped registers** can cause issues (double frees etc.)
+
+**Avoid alias issues** when handling registers:
+```cpp
+// BAD - creates aliasing issues
+Reg64 reg1 = rm.alloc<Reg64>();
+Reg64 reg2 = reg1;  // Both point to same register!
+rm.free(reg1);
+rm.free(reg2);      // Double free!
+
+// GOOD - use scoped or explicit tracking
+auto scoped = rm.makeScoped(rm.alloc<Reg64>());
+// or
+Reg64 reg1 = rm.alloc<Reg64>();
+// ... use reg1 ...
+rm.free(reg1);
+```
+
+## Using the Manager
+
+```cpp
+// Usage:
+RegPoolManager rm;
+
+// Allocate next available register
+Reg64 r1 = rm.alloc<Reg64>();
+Xmm xmm1 = rm.alloc<Xmm>();
+Opmask k1 = rm.alloc<Opmask>();
+
+// Free registers
+rm.free(r1);
+rm.free(xmm1);
+rm.free(k1);
+
+// Allocate specific register
+Reg64 r10 = rm.alloc<Reg64>(10);
+
+// Scoped registers (RAII)
+{
+    auto scoped = rm.makeScoped(rm.alloc<Reg64>());
+    // Use scoped.get() to access the register
+} // Automatically freed here
+
+// Special registers
+Reg64 rsp = rm._stack_pointer();
+Reg64 rbp = rm._base_pointer();
+Opmask k0 = rm._opmask_k0();
+
+// APX support
+if (rm.has_apx()) {
+    std::cout << "APX supported, " << rm.max_gp_registers() 
+              << " GP registers available" << std::endl;
+}
+
+// AVX-512 support
+if (rm.has_avx512()) {
+    std::cout << "AVX-512 supported, " << rm.max_vec_registers() 
+              << " vector registers available" << std::endl;
+}
+```
+
+## Helper Methods
+
+The manager includes minimal helpers to keep it lightweight:
+
+- `reg_in_use(reg)`: Returns true if a register object is in the in-use set
+- `gp_idx_in_use(idx)`, `vec_idx_in_use(idx)`, `opmask_idx_in_use(idx)`: Check if an index is in use for a given family
+- `makeScoped(reg)`: Creates an RAII guard for automatic deallocation
+- `add_to_gp_pool(idx)`: Adds a register to the free GP pool (for special use cases)
+- Special register helpers: `_stack_pointer()`, `_base_pointer()`, `_opmask_k0()`
+- APX query methods: `has_apx()`, `max_gp_registers()`
+- AVX-512 query methods: `has_avx512()`, `max_vec_registers()`
+- Getters for in-use, free, preserved, and used sets for each register family
+
+## Implementation Notes for x86-64
+
+### Key Architectural Differences
+
+1. **Register Count Variability**
+   - Base x86-64: 16 GP registers, 16 vector registers (SSE/AVX/AVX2)
+   - With APX: 32 GP registers (runtime detection required)
+   - With AVX-512: 32 vector registers (runtime detection required)
+   - AArch64 always has 31 GP registers and 32 vector registers
+
+2. **Register Aliasing**
+   - x86-64: RAX/EAX/AX/AL all refer to the same physical register
+   - x86-64: XMM/YMM/ZMM all refer to the same physical register
+   - Tracking by index automatically handles aliasing
+   - 32-bit writes (EAX) zero-extend to 64-bit (RAX)
+
+3. **Calling Convention Differences**
+
+   **Windows x64 vs System V AMD64:**
+
+   | Aspect | Windows x64 | System V AMD64 |
+   |--------|-------------|----------------|
+   | **GP Volatile** | rax, rcx, rdx, r8-r11 (7) | rax, rcx, rdx, rsi, rdi, r8-r11 (9) |
+   | **GP Non-volatile** | rbx, rbp, rsi, rdi, r12-r15 (8) | rbx, rbp, r12-r15 (5) |
+   | **Vec Volatile** | xmm0-xmm5 (6) | All xmm/zmm (16 or 32) |
+   | **Vec Non-volatile** | xmm6-xmm15 (10) | None |
+   | **Integer params** | RCX, RDX, R8, R9 (4) | RDI, RSI, RDX, RCX, R8, R9 (6) |
+   | **FP params** | xmm0-xmm3 (4) | xmm0-xmm7 (8) |
+   | **Shadow space** | 32 bytes required | Not required |
+
+   **Critical differences:**
+   - RSI/RDI: Windows treats as callee-saved, System V as caller-saved
+   - Vector preservation: Windows requires saving xmm6-xmm15 (major SIMD impact)
+   - Parameter passing: Completely different register sequences
+   - Implementation automatically selects correct convention via `_WIN32` macro
+
+4. **Special Registers**
+   - x86-64: rsp (stack), rbp (frame), k0 (unmasked)
+   - AArch64: x16, x17 (IPC), x18 (platform), x29 (frame), x30 (link)
+
+5. **Extended ISA Support**
+   - Intel APX adds 16 GP registers (r16-r31)
+   - AVX-512 adds 16 vector registers (zmm16-zmm31)
+   - Both require runtime detection via CPUID
+   - Automatically integrated when available
+   - All extended registers are caller-saved
+
+6. **Vector Register Differences**
+   - x86-64 SSE/AVX/AVX2: 16 XMM/YMM registers (xmm0-xmm15, ymm0-ymm15)
+   - x86-64 AVX-512: 32 ZMM registers (zmm0-zmm31)
+   - Runtime detection determines available count (16 or 32)
+   - All are caller-saved in System V ABI
+   - AArch64 always has 32 vector registers
+
+7. **Mask Registers**
+   - x86-64: 8 opmask registers (k0-k7) for AVX-512
+   - k0 is special (unmasked)
+   - AArch64: 16 predicate registers (p0-p15) for SVE
+
+## References
+
+- [System V AMD64 ABI](https://gitlab.com/x86-psABIs/x86-64-ABI)
+- [Microsoft x64 calling convention](https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention)
+- [Overview of x64 Calling Conventions](https://learn.microsoft.com/en-us/cpp/build/x64-software-conventions)
+- [Intel APX Specification](https://www.intel.com/content/www/us/en/developer/articles/technical/advanced-performance-extensions-apx.html)
+- [Xbyak Documentation](https://github.com/herumi/xbyak)
+- [AArch64 Register Manager (PR #4587)](https://github.com/uxlfoundation/oneDNN/pull/4587)


### PR DESCRIPTION
# Xbyak x86-64 Register Manager

## Summary of Proposal

This document serves as an overview and proposal for a user-level register manager to allow developers working with Xbyak on x86-64 to more easily track, manage and (de)allocate registers.

This implementation is modeled after the [Xbyak_aarch64 Register Manager (PR #4587)](https://github.com/uxlfoundation/oneDNN/pull/4587) but adapted for x86-64 architecture and its specific characteristics.

## Desired Outcomes

1. Provide tracking and standardized, automatic allocate and free methods for registers.
2. Guarantee unique ownership of registers for each of the three register families:
   - General Purpose (GP): Reg8, Reg16, Reg32, Reg64
   - Vector (Vec): Xmm, Ymm, Zmm
   - Opmask: k0-k7 (AVX-512)
3. Implement scoped registers following the RAII technique.
4. Ensure compatibility & minimum friction with current register manager techniques in oneDNN.
5. Support Intel APX extended registers (r16-r31) with automatic detection.
6. Support AVX-512 extended vector registers (zmm16-zmm31) with automatic detection.

## Context & Motivation

The motivation for this project is to reduce the manual user-level register management for projects using Xbyak on x86-64 and to support both Windows x64 and System V AMD64 ABI calling conventions with automatic platform detection.

### Key Differences from AArch64 Implementation

| Aspect | x86-64 | AArch64 |
|--------|--------|---------|
| **GP Registers** | 16 (r0-r15), 32 with APX (r0-r31) | 31 (x0-x30) |
| **Vector Registers** | 16 (zmm0-zmm15) SSE/AVX/AVX2, 32 (zmm0-zmm31) with AVX-512 | 32 (v0-v31) for FP/SIMD |
| **Mask Registers** | 8 opmask (k0-k7) for AVX-512 | 16 predicate (p0-p15) for SVE |
| **Special Registers** | rsp (r4), rbp (r5), k0 | x16/x17 (IPC), x18 (platform), x29 (FP), x30 (LR) |
| **Register Aliasing** | RAX/EAX/AX/AL share same register<br>XMM/YMM/ZMM share same register | Different sizes access same register |
| **Calling Convention** | Windows x64 / System V AMD64 ABI (auto-detected) | AAPCS64 |
| **Extended Support** | Intel APX adds r16-r31, AVX-512 adds zmm16-zmm31 (runtime detection) | SVE scalable vectors |

## Assumptions

- Initially, the majority of kernels will continue to use the old method of register handling.
- Calling convention automatically selected at compile time via `_WIN32` macro (Windows x64 vs System V AMD64).
- Call-clobbered (volatile) registers are allocated first from the free pool.
- There is no specific order that registers should be allocated in their respective sets.
- Intel APX support is detected at runtime and extended GP registers (r16-r31) are automatically made available.
- AVX-512 support is detected at runtime and extended vector registers (zmm16-zmm31) are automatically made available.
- Register aliasing (e.g., RAX/EAX/AX/AL) is handled by tracking at the index level.

## Implementation

### Overview

The register manager maintains three families of registers, each with three sets that hold indices representing the registers within the family. The `*` represents one of the three register families (GP, Vec, Opmask). Each family has these three sets that hold indices which represent the registers within the family. Further, each family has a used set, which simply tracks any register that has been touched by the manager up to this point.

```
+-------------------------------------+
|     RegPoolManager                  |
+-------------------------------------+
| GP Registers (0-15 or 0-31)         |
|  +-------------+                    |
|  | free_regs   | ---alloc()-->      |
|  +-------------+                    |
|  +-------------+                    |
|  | in_use      | <--alloc()---      |
|  +-------------+    free()---->     |
|  +-------------+                    |
|  | preserved   | (callee-saved)     |
|  +-------------+                    |
|  +-------------+                    |
|  | used        | (tracking)         |
|  +-------------+                    |
+-------------------------------------+
| Vec Registers (0-31)                |
|  +-------------+                    |
|  | free_regs   | ---alloc()-->      |
|  +-------------+                    |
|  +-------------+                    |
|  | in_use      | <--alloc()---      |
|  +-------------+    free()---->     |
|  +-------------+                    |
|  | preserved   | (empty)            |
|  +-------------+                    |
|  +-------------+                    |
|  | used        | (tracking)         |
|  +-------------+                    |
+-------------------------------------+
| Opmask Registers (1-7)              |
|  +-------------+                    |
|  | free_regs   | ---alloc()-->      |
|  +-------------+                    |
|  +-------------+                    |
|  | in_use      | <--alloc()---      |
|  +-------------+    free()---->     |
|  +-------------+                    |
|  | preserved   | (empty)            |
|  +-------------+                    |
|  +-------------+                    |
|  | used        | (tracking)         |
|  +-------------+                    |
+-------------------------------------+
```

### Data Structures and Design Choices

Used `std::set` to track register states as shown above. The manager aims to use STL-based data structures and functions to ensure the helper is as understandable and compatible as possible.

### Register Priority and Management (System V AMD64 ABI)

For information on design choices for registers discussed below, see the [System V AMD64 ABI](https://gitlab.com/x86-psABIs/x86-64-ABI).

#### General Purpose Registers (16 or 32 registers)

**Register Mapping:**
- rax (0), rcx (1), rdx (2), rbx (3), rsp (4), rbp (5), rsi (6), rdi (7)
- r8-r15 (8-15)
- r16-r31 (16-31) - Intel APX only, detected at runtime

**Register Name Enums:**
For convenience, three enums are provided to map register names to indices:
- `GpRegIdx`: rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi, r8-r15, r16-r31
- `VecRegIdx`: xmm0-xmm15, xmm16-xmm31 (AVX-512)
- `OpmaskRegIdx`: k0-k7

These allow allocating specific registers by name: `rm.alloc<Reg64>(rax)` instead of `rm.alloc<Reg64>(0)`.

**Calling Convention (automatically selected via `_WIN32` macro):**

*Windows x64:*
- **Volatile (Caller-saved):** rax (0), rcx (1), rdx (2), r8-r11 (8-11) — 7 registers
- **Non-volatile (Callee-saved):** rbx (3), rsi (6), rdi (7), r12-r15 (12-15) — 8 registers
- **Parameter registers:** RCX, RDX, R8, R9 (4 integer parameters)

*System V AMD64 ABI (Linux/Unix/macOS):*
- **Call-Clobbered (Caller-saved):** rax (0), rcx (1), rdx (2), rsi (6), rdi (7), r8-r11 (8-11) — 9 registers
- **Call-Preserved (Callee-saved):** rbx (3), r12-r15 (12-15) — 5 registers
- **Parameter registers:** RDI, RSI, RDX, RCX, R8, R9 (6 integer parameters)

*Extended Registers (APX):*
- r16-r31 (16-31) automatically added as caller-saved when APX is detected

**Special Registers (not auto-allocated):**
- rsp (4) - Stack pointer
- rbp (5) - Base/frame pointer

**Key Difference:** Windows treats RSI/RDI as callee-saved (preserved), while System V treats them as caller-saved (volatile)

**x86-64 Specific Note:**
- Register aliasing (RAX/EAX/AX/AL) is handled by tracking at the index level
- Writing to 32-bit registers (EAX) zero-extends to 64-bit (RAX)
- APX detection uses `Xbyak::util::Cpu::tAPX_F` at construction time

#### Vector Registers (16 or 32 registers)

**Register Mapping:**
- SSE/AVX/AVX2: xmm0-xmm15, ymm0-ymm15 (0-15)
- AVX-512: xmm0-xmm31, ymm0-ymm31, zmm0-zmm31 (0-31)

**Calling Convention (automatically selected via `_WIN32` macro):**

*Windows x64:*
- **Volatile (Caller-saved):** xmm0-xmm5 (0-5) — 6 registers
- **Non-volatile (Callee-saved):** xmm6-xmm15 (6-15) — 10 registers
- **Parameter registers:** xmm0-xmm3 (4 FP parameters)

*System V AMD64 ABI (Linux/Unix/macOS):*
- **Call-Clobbered (Caller-saved):** All vector registers (xmm0-xmm15 or zmm0-zmm31)
- **Call-Preserved:** None
- **Parameter registers:** xmm0-xmm7 (8 FP parameters)

*Extended Registers (AVX-512):*
- xmm16-xmm31/ymm16-ymm31/zmm16-zmm31 (16-31) automatically added as caller-saved when AVX-512 is detected

**Key Difference:** Windows preserves xmm6-xmm15 (major impact for SIMD-heavy code), while System V treats all vector registers as volatile

**x86-64 Specific Note:**
- XMM, YMM, and ZMM registers are aliases of the same physical register
- XMM uses lower 128 bits, YMM uses lower 256 bits, ZMM uses all 512 bits
- Aliasing is automatically handled by index-based tracking
- AVX-512 detection uses `Xbyak::util::Cpu::tAVX512F` at construction time
- Extended registers (16-31) are only available when AVX-512 is detected

#### Opmask Registers (8 registers for AVX-512)

**Register Mapping:**
- k0-k7 (0-7)

**Call-Clobbered (Caller-saved):**
- k1-k7 (1-7)

**Special Register (not auto-allocated):**
- k0 (0) - When used as write mask, means "unmasked" (no masking applied)

### Scoped Registers (RAII)

```cpp
// Scoped register handling with RAII
// Usage: Reg64 reg11 = rm.alloc<Reg64>(11);
//        auto scoped = rm.makeScoped(reg11);
// or
//        auto scoped_reg = rm.makeScoped(rm.alloc<Reg64>());
// reg11 & scoped_reg will free at end of scope when guards' dtors called.

template<class Reg>
class Scoped {
public:
    explicit Scoped(RegPoolManager& rm, Reg r)
        : rm_(&rm), reg_(r) {
        validate_scoped_reg(rm_, reg_);
    }
    
    ~Scoped() {
        if (!rm_) return;
        rm_->free(reg_);
    }
    
    // Disable copy - scoped regs are move only
    Scoped(const Scoped&) = delete;
    Scoped& operator=(const Scoped&) = delete;
    
    // Move constructor
    Scoped(Scoped&& other) noexcept
        : rm_(other.rm_), reg_(other.reg_) {
        other.rm_ = nullptr;
    }
    
    // Expose underlying register
    operator const Reg &() const noexcept { return reg_; }
    const Reg &get() const noexcept { return reg_; }

private:
    RegPoolManager* rm_ = nullptr;
    Reg reg_{};
};
```

**Note:** Scoped registers should not be manually freed, as this will lead to double-free errors and crashes. Users should use `std::move` to change the scoped guard of a register, and therefore its lifetime.

### Special Register Helpers

```cpp
// Helper methods to return special registers
// NOTE: These registers are excluded from automatic allocation

// Stack pointer: rsp (index 4)
inline Reg64 _stack_pointer() {
    used_gp.insert(4);
    return Reg64(4);
}

// Base/frame pointer: rbp (index 5)
inline Reg64 _base_pointer() {
    used_gp.insert(5);
    return Reg64(5);
}

// Opmask k0: special mask that means "unmasked"
inline Opmask _opmask_k0() {
    used_opmask.insert(0);
    return Opmask(0);
}
```

### Extended ISA Support (APX and AVX-512)

The register manager automatically detects Intel APX and AVX-512 support at construction time:

```cpp
RegPoolManager() {
    Xbyak::util::Cpu cpu;
    
    // Detect APX for extended GP registers (r16-r31)
    has_apx_ = cpu.has(Xbyak::util::Cpu::tAPX_F);
    max_gp_reg_idx_ = has_apx_ ? 31 : 15;
    
    // Detect AVX-512 for extended vector registers (zmm16-zmm31)
    has_avx512_ = cpu.has(Xbyak::util::Cpu::tAVX512F);
    max_vec_reg_idx_ = has_avx512_ ? 31 : 15;
    
    // If APX is available, add r16-r31 to the free pool
    if (has_apx_) {
        for (int i = 16; i <= 31; ++i) {
            free_gp_regs.insert(i);
        }
    }
    
    // If AVX-512 is available, add zmm16-zmm31 to the free pool
    if (has_avx512_) {
        for (int i = 16; i <= 31; ++i) {
            free_vec_regs.insert(i);
        }
    }
}
```

Query methods:
```cpp
bool has_apx() const;           // Returns true if APX is supported
int max_gp_registers() const;   // Returns 16 or 32

bool has_avx512() const;        // Returns true if AVX-512 is supported
int max_vec_registers() const;  // Returns 16 or 32
```

**Extended ISA Implementation Notes:**
- r16-r31 (APX) and zmm16-zmm31 (AVX-512) are automatically added as call-clobbered registers
- All range checks use `max_gp_reg_idx_` and `max_vec_reg_idx_` instead of hardcoded values
- Zero overhead: detection happens once at construction
- Backward compatible: works seamlessly on systems without APX or AVX-512

### Error Handling & Strictness

The manager assumes that the user knows what they are doing, in so far that it will throw runtime errors if:

- The user attempts to allocate a specific register when it is in use.
- The user attempts to allocate a specific register that is not in the free or preserved sets.
- The user frees a register that is not in the in-use set.
- The user enters a register index outside the valid range:
  - GP: 0-15 (without APX) or 0-31 (with APX)
  - Vec: 0-16 (without AVX-512) or 0-31 (with AVX-512)
  - Opmask: 0-7
- The user attempts to add a register to the free GP pool when the register is already tracked.
- There are no registers in free_regs or preserved when `alloc()` is called for a register type.
- The user calls `makeScoped` on a register that is not in use.
- The user tries to handle a register type whose `reg_family` is not GP/Vec/Opmask.

### Usage Avoidance

Further, it is important to note that the following should be avoided by users:

**Manual freeing of scoped registers** can cause issues (double frees etc.)

**Avoid alias issues** when handling registers:
```cpp
// BAD - creates aliasing issues
Reg64 reg1 = rm.alloc<Reg64>();
Reg64 reg2 = reg1;  // Both point to same register!
rm.free(reg1);
rm.free(reg2);      // Double free!

// GOOD - use scoped or explicit tracking
auto scoped = rm.makeScoped(rm.alloc<Reg64>());
// or
Reg64 reg1 = rm.alloc<Reg64>();
// ... use reg1 ...
rm.free(reg1);
```

## Using the Manager

```cpp
// Usage:
RegPoolManager rm;

// Allocate next available register
Reg64 r1 = rm.alloc<Reg64>();
Xmm xmm1 = rm.alloc<Xmm>();
Opmask k1 = rm.alloc<Opmask>();

// Free registers
rm.free(r1);
rm.free(xmm1);
rm.free(k1);

// Allocate specific register
Reg64 r10 = rm.alloc<Reg64>(10);

// Scoped registers (RAII)
{
    auto scoped = rm.makeScoped(rm.alloc<Reg64>());
    // Use scoped.get() to access the register
} // Automatically freed here

// Special registers
Reg64 rsp = rm._stack_pointer();
Reg64 rbp = rm._base_pointer();
Opmask k0 = rm._opmask_k0();

// APX support
if (rm.has_apx()) {
    std::cout << "APX supported, " << rm.max_gp_registers() 
              << " GP registers available" << std::endl;
}

// AVX-512 support
if (rm.has_avx512()) {
    std::cout << "AVX-512 supported, " << rm.max_vec_registers() 
              << " vector registers available" << std::endl;
}
```

## Helper Methods

The manager includes minimal helpers to keep it lightweight:

- `reg_in_use(reg)`: Returns true if a register object is in the in-use set
- `gp_idx_in_use(idx)`, `vec_idx_in_use(idx)`, `opmask_idx_in_use(idx)`: Check if an index is in use for a given family
- `makeScoped(reg)`: Creates an RAII guard for automatic deallocation
- `add_to_gp_pool(idx)`: Adds a register to the free GP pool (for special use cases)
- Special register helpers: `_stack_pointer()`, `_base_pointer()`, `_opmask_k0()`
- APX query methods: `has_apx()`, `max_gp_registers()`
- AVX-512 query methods: `has_avx512()`, `max_vec_registers()`
- Getters for in-use, free, preserved, and used sets for each register family

## Implementation Notes for x86-64

### Key Architectural Differences

1. **Register Count Variability**
   - Base x86-64: 16 GP registers, 16 vector registers (SSE/AVX/AVX2)
   - With APX: 32 GP registers (runtime detection required)
   - With AVX-512: 32 vector registers (runtime detection required)
   - AArch64 always has 31 GP registers and 32 vector registers

2. **Register Aliasing**
   - x86-64: RAX/EAX/AX/AL all refer to the same physical register
   - x86-64: XMM/YMM/ZMM all refer to the same physical register
   - Tracking by index automatically handles aliasing
   - 32-bit writes (EAX) zero-extend to 64-bit (RAX)

3. **Calling Convention Differences**

   **Windows x64 vs System V AMD64:**

   | Aspect | Windows x64 | System V AMD64 |
   |--------|-------------|----------------|
   | **GP Volatile** | rax, rcx, rdx, r8-r11 (7) | rax, rcx, rdx, rsi, rdi, r8-r11 (9) |
   | **GP Non-volatile** | rbx, rbp, rsi, rdi, r12-r15 (8) | rbx, rbp, r12-r15 (5) |
   | **Vec Volatile** | xmm0-xmm5 (6) | All xmm/zmm (16 or 32) |
   | **Vec Non-volatile** | xmm6-xmm15 (10) | None |
   | **Integer params** | RCX, RDX, R8, R9 (4) | RDI, RSI, RDX, RCX, R8, R9 (6) |
   | **FP params** | xmm0-xmm3 (4) | xmm0-xmm7 (8) |
   | **Shadow space** | 32 bytes required | Not required |

   **Critical differences:**
   - RSI/RDI: Windows treats as callee-saved, System V as caller-saved
   - Vector preservation: Windows requires saving xmm6-xmm15 (major SIMD impact)
   - Parameter passing: Completely different register sequences
   - Implementation automatically selects correct convention via `_WIN32` macro

4. **Special Registers**
   - x86-64: rsp (stack), rbp (frame), k0 (unmasked)
   - AArch64: x16, x17 (IPC), x18 (platform), x29 (frame), x30 (link)

5. **Extended ISA Support**
   - Intel APX adds 16 GP registers (r16-r31)
   - AVX-512 adds 16 vector registers (zmm16-zmm31)
   - Both require runtime detection via CPUID
   - Automatically integrated when available
   - All extended registers are caller-saved

6. **Vector Register Differences**
   - x86-64 SSE/AVX/AVX2: 16 XMM/YMM registers (xmm0-xmm15, ymm0-ymm15)
   - x86-64 AVX-512: 32 ZMM registers (zmm0-zmm31)
   - Runtime detection determines available count (16 or 32)
   - All are caller-saved in System V ABI
   - AArch64 always has 32 vector registers

7. **Mask Registers**
   - x86-64: 8 opmask registers (k0-k7) for AVX-512
   - k0 is special (unmasked)
   - AArch64: 16 predicate registers (p0-p15) for SVE

## References

- [System V AMD64 ABI](https://gitlab.com/x86-psABIs/x86-64-ABI)
- [Microsoft x64 calling convention](https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention)
- [Overview of x64 Calling Conventions](https://learn.microsoft.com/en-us/cpp/build/x64-software-conventions)
- [Intel APX Specification](https://www.intel.com/content/www/us/en/developer/articles/technical/advanced-performance-extensions-apx.html)
- [Xbyak Documentation](https://github.com/herumi/xbyak)
- [AArch64 Register Manager (PR #4587)](https://github.com/uxlfoundation/oneDNN/pull/4587)
