### PR TITLE
cpu: x86: revert deconv fallback to non-brgemm kernel

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1457,10 +1457,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     const bool has_uneven_spatial = jcp.id % jcp.stride_d != 0
             || jcp.ih % jcp.stride_h != 0 || jcp.has_uneven_iw;
 
-    bool is_deconv_with_uneven_spatial = cd.use_inversion && has_uneven_spatial;
-    VDISPATCH_CONV_IC(!is_deconv_with_uneven_spatial,
-            VERBOSE_UNSUPPORTED_FEATURE,
-            "deconvolution with uneven spatial dimensions is not supported");
+    if (cd.use_inversion && has_uneven_spatial) return status::unimplemented;
 
     jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];

--- a/src/cpu/x64/jit_brgemm_deconv.cpp
+++ b/src/cpu/x64/jit_brgemm_deconv.cpp
@@ -199,34 +199,17 @@ status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                 reinterpret_cast<const op_desc_t *>(&conv_d), attr(), nullptr);
         if (!it.is_initialized()) return status::out_of_memory;
 
-        // First pass: try to find BRGEMM backward strided implementation
         while (++it != it.end()) {
             conv_pd_ = *it;
             if (check_embedded_impl_init<
                         typename brgemm_convolution_bwd_strided_t<isa>::pd_t>(
                         it)
-                    == status::success) {
+                    == status::success)
                 break;
-            }
         }
-
-        // Second pass: fallback to any other backward data convolution implementation
-        // This allows non-BRGEMM kernels (like jit_avx512_core_bf16) to handle
-        // cases with uneven spatial dimensions
-        if (it == it.end()) {
-            primitive_desc_iterator_t it2(engine,
-                    reinterpret_cast<const op_desc_t *>(&conv_d), attr(),
-                    nullptr);
-            if (!it2.is_initialized()) return status::out_of_memory;
-            while (++it2 != it2.end()) {
-                conv_pd_ = *it2;
-                if ((*it2)->kind() == primitive_kind::convolution) { break; }
-            }
-            if (it2 == it2.end())
-                VDISPATCH_DECONVOLUTION_IC(false,
-                        "no suitable implementation found for strided "
-                        "deconvolution");
-        }
+        if (it == it.end())
+            VDISPATCH_DECONVOLUTION_IC(false,
+                    "brgemm implementation not found for strided convolution");
     } else {
         CHECK(fwd_conv_desc_create(fwd_deconv_d, &conv_d));
 


### PR DESCRIPTION
This reverts commit fe3c5245a215b1227c00f99d83aafcd534c58c0e.

Nightly build caught failures that were missed by the CI build. No obvious quick fix so reverting the change.

this will revert https://github.com/uxlfoundation/oneDNN/pull/4598