### PR TITLE
xe: gemm: fixup c-interleaving with post-ops

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm.cxx
@@ -526,6 +526,10 @@ void Generator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState
             add(1, state.j0, state.j0, -shiftJ0);
             divUp(state.j0, state.j0, strategy.cInterleaveChunk, strategy, state);
         }
+        if (problem.hasBinaryPostOp() && strategy.cInterleaveChunk > 1) {
+            state.ctiShiftJ0 = state.ra.alloc_sub<int32_t>();
+            mov(1, state.ctiShiftJ0, shiftJ0);
+        }
         mov(1, shiftJ0, 0);
 
         if (!strategy.persistentLoop()) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
@@ -307,6 +307,7 @@ struct GEMMState : public CommonState {
     ngen::Subregister i0, j0, h0;                           // d
     ngen::Subregister wgI0, wgJ0;                           // d
     ngen::Subregister unclampedI0;                          // d
+    ngen::Subregister ctiShiftJ0;                           // d
     ngen::Subregister threadK0, k0Rem, wgK;                 // ud
     ngen::Subregister remainders[3];                        // d (todo: w)
     ngen::Subregister remaindersFused[2];                   // w


### PR DESCRIPTION
Fixes [MFDNN-14597](https://jira.devtools.intel.com/browse/MFDNN-14597). The new C-interleave feature for GEMM strategies did not interact correctly with post-ops. We need to shift the binary post-op buffers and increase the leading dimensions to match the reordered C-tile dispatching.

Current behaviour on main:
```
./oneDNN/build/tests/benchdnn/benchdnn --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=wei --dt=f16:f16:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 3996x1280:1280x3420
[3421][DST][1:1] exp_f32:        -123 exp:        -123 got:         123 diff:     246 rdiff:       2
[3422][DST][1:2] exp_f32:         -23 exp:         -23 got:          46 diff:      69 rdiff:       3
[3423][DST][1:3] exp_f32:     13.9844 exp:     13.9844 got:    -6.99219 diff: 20.9766 rdiff:     1.5
[3426][DST][1:6] exp_f32:         188 exp:         188 got:         -94 diff:     282 rdiff:     1.5
[3429][DST][1:9] exp_f32:        -196 exp:        -196 got:           0 diff:     196 rdiff:       1
[3430][DST][1:10] exp_f32:         -20 exp:         -20 got:          10 diff:      30 rdiff:     1.5
[3434][DST][1:14] exp_f32:           0 exp:           0 got:         -22 diff:      22 rdiff:      22
[3436][DST][1:16] exp_f32:         -13 exp:         -13 got:          26 diff:      39 rdiff:       3
[3440][DST][1:20] exp_f32:          34 exp:          34 got:         -34 diff:      68 rdiff:       2
[3445][DST][1:25] exp_f32:           0 exp:           0 got:         278 diff:     278 rdiff:     278
[COMPARE_STATS][DST]: trh=0 err_max_diff:    1260 err_max_rdiff:     576 all_max_diff:    1260 all_max_rdiff:     576
[PRIM_REF][INFO]: L2_size:2097152 bytes; per_core_L3_size:1966080 bytes; nthr:224; impl_name:brg_matmul:avx10_1_512
0:FAILED (errors:5984138 total:13666320) (978 ms) __REPRO: --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=wei --dt=f16:f16:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 3996x1280:1280x3420
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:gemm:any : 1 (100%)                                  |
============================================================
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:FAILED (errors:5984138 total:13666320) (978 ms) __REPRO: --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=wei --dt=f16:f16:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 3996x1280:1280x3420
============================
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 1.00s; create_pd: 0.26s (26%); create_prim: 0.01s (1%); fill: 0.22s (22%); execute: 0.02s (2%); compute_ref: 0.02s (2%); compare: 0.13s (13%);
```

With PR:
```
./oneDNN/build/tests/benchdnn/benchdnn --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=wei --dt=f16:f16:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 3996x1280:1280x3420
0:PASSED (540 ms) __REPRO: --matmul --engine=gpu --allow-enum-tags-only=false --memory-kind=usm_device --cold-cache=wei --dt=f16:f16:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 3996x1280:1280x3420
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:gemm:any : 1 (100%)                                  |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.54s; create_pd: 0.13s (24%); create_prim: 0.00s (1%); fill: 0.18s (33%); execute: 0.01s (2%); compute_ref: 0.01s (2%); compare: 0.08s (14%);
```