### PR TITLE
cpu: rv64: gemm: switch f32 GEMM to mx7 RVV JIT

### DIFF
--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.cpp
@@ -25,8 +25,12 @@ namespace gemm_utils {
 
 using namespace Xbyak_riscv;
 
-jit_rvv_gemm_kernel_t::jit_rvv_gemm_kernel_t(dim_t m)
-    : jit_generator_t("rv64_gemm_kernel_f32_jit"), m_(m) {
+jit_rvv_gemm_kernel_t::jit_rvv_gemm_kernel_t(
+        dim_t n_cols, bool isTransA, bool isTransB)
+    : jit_generator_t("rv64_gemm_kernel_f32_jit")
+    , n_cols_(n_cols)
+    , isTransA_(isTransA)
+    , isTransB_(isTransB) {
     create_kernel();
 }
 
@@ -34,137 +38,116 @@ void jit_rvv_gemm_kernel_t::generate() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const Reg reg_param = a0;
 
-    // Persistent scalar parameters and pointers:
-    const Reg reg_A_ptr = a1; // running pointer over rows of A
+    const Reg reg_A_ptr = a1; // running pointer into A
+    const Reg reg_m = a2; // tile height (used for vsetvli)
     const Reg reg_C_base = a3; // base pointer to C(:, 0)
 
-    const Reg reg_lda_bytes = t0; // lda * sizeof(float)
-    const Reg reg_ldb_bytes = t1; // ldb * sizeof(float)
-    const Reg reg_ldc_bytes = t2; // ldc * sizeof(float)
-    const Reg reg_K = t3; // K
-    const Reg reg_alpha_bits
-            = t4; // holds raw alpha bits, loaded and then moved to freg_alpha for computation
-    const Reg reg_beta_bits = t5; // raw beta bits (0 means beta == 0.0f)
+    const Reg reg_lda_bytes = t0;
+    const Reg reg_ldb_bytes = t1;
+    const Reg reg_ldc_bytes = t2;
+    const Reg reg_K = t3;
+    const Reg reg_alpha_bits = t4;
+    const Reg reg_beta_bits = t5;
 
-    // Loop counters:
-    const Reg reg_k = a4; // current k
-    const Reg reg_K_main = a5; // K_main = (K / 4) * 4
-
-    // B row pointers for current k (used to access columns 0, 1, 2, and 3).
-    const Reg reg_B0_ptr = a6; // &B(k, 0)
-    const Reg reg_B1_ptr = a7; // &B(k, 1)
-
-    // Scratch temporaries used for address arithmetic.
-    const Reg reg_tmp0 = a0; // reused after initial parameter loads
-    const Reg reg_tmp1 = t6;
-
+    const Reg reg_k = a4; // current k counter
+    const Reg reg_K_main = a5; // (K / 4) * 4
+    const Reg reg_B0_ptr = a6; // running pointer into B
+    const Reg reg_tmp0 = a7;
     const FReg freg_alpha = fa0;
     const FReg freg_beta = fa1;
-    const FReg freg_b0 = fa2;
-    const FReg freg_b1 = fa3;
-    const FReg freg_b2 = fa4;
-    const FReg freg_b3 = fa5;
+    const FReg freg_b[7] = {fa2, fa3, fa4, fa5, fa6, fa7, ft0};
 
-    // Vector register layout depends on m_ (LMUL setting)
-    // For m=8 (LMUL=m2): each vreg occupies 2 vector registers
-    //   v_c0(0), v_c1(2), v_c2(4), v_c3(6), v_a0(8), v_tmp(10)
-    // For m=16 (LMUL=m4): each vreg occupies 4 vector registers
-    //   v_c0(0), v_c1(4), v_c2(8), v_c3(12), v_a0(16), v_tmp(20)
-    const VReg v_c0(0);
-    const VReg v_c1 = (m_ == 16) ? VReg(4) : VReg(2);
-    const VReg v_c2 = (m_ == 16) ? VReg(8) : VReg(4);
-    const VReg v_c3 = (m_ == 16) ? VReg(12) : VReg(6);
-    const VReg v_a0 = (m_ == 16) ? VReg(16) : VReg(8);
-    const VReg v_tmp = (m_ == 16) ? VReg(20) : VReg(10);
+    const VReg v_c[7] = {
+            VReg(0), VReg(4), VReg(8), VReg(12), VReg(16), VReg(20), VReg(24)};
+    const VReg v_a(28);
+
     // Layout of call_params_t:
-    //   0  : const float *A;
-    //   8  : const float *B;
-    //   16 : float *C;
-    //   24 : dim_t lda;
-    //   32 : dim_t ldb;
-    //   40 : dim_t ldc;
-    //   48 : dim_t K;
-    //   56 : float alpha;
-    //   60 : float beta;
+    //   0  : const float *A
+    //   8  : const float *B
+    //   16 : float *C
+    //   24 : dim_t lda
+    //   32 : dim_t ldb
+    //   40 : dim_t ldc
+    //   48 : dim_t K
+    //   56 : dim_t m
+    //   64 : float alpha
+    //   68 : float beta
     ld(reg_A_ptr, reg_param, 0);
-    ld(reg_B0_ptr, reg_param, 8); // B base
+    ld(reg_B0_ptr, reg_param, 8);
     ld(reg_C_base, reg_param, 16);
     ld(reg_lda_bytes, reg_param, 24);
     ld(reg_ldb_bytes, reg_param, 32);
     ld(reg_ldc_bytes, reg_param, 40);
     ld(reg_K, reg_param, 48);
+    ld(reg_m, reg_param, 56);
 
-    // Convert leading dimensions from elements to bytes.
+    lw(reg_alpha_bits, reg_param, 64);
+    fmv_w_x(freg_alpha, reg_alpha_bits);
+    lw(reg_beta_bits, reg_param, 68);
+    fmv_w_x(freg_beta, reg_beta_bits);
+
     slli(reg_lda_bytes, reg_lda_bytes, 2);
     slli(reg_ldb_bytes, reg_ldb_bytes, 2);
     slli(reg_ldc_bytes, reg_ldc_bytes, 2);
 
-    // Load alpha / beta as raw bits and as FP registers.
-    lw(reg_alpha_bits, reg_param, 56);
-    fmv_w_x(freg_alpha, reg_alpha_bits);
+    vsetvli(x0, reg_m, SEW::e32, LMUL::m4);
 
-    lw(reg_beta_bits, reg_param, 60);
-    fmv_w_x(freg_beta, reg_beta_bits);
+    const Reg &reg_tmp3 = reg_param;
 
-    // Set VL once for m_ rows; with LMUL = m2 (for m=8) or m4 (for m=16)
-    const LMUL lmul = (m_ == 16) ? LMUL::m4 : LMUL::m2;
-    li(reg_tmp0, m_);
-    vsetvli(x0, reg_tmp0, SEW::e32, lmul);
+    for (dim_t c = 0; c < n_cols_; c++)
+        vmv_v_i(v_c[c], 0);
 
-    // Initialize B row pointers for k = 0.
-    // B0_ptr = B base; B1_ptr = B + ldb_bytes
-    add(reg_B1_ptr, reg_B0_ptr, reg_ldb_bytes);
-
-    // Zero accumulators for 4 output columns.
-    vmv_v_i(v_c0, 0);
-    vmv_v_i(v_c1, 0);
-    vmv_v_i(v_c2, 0);
-    vmv_v_i(v_c3, 0);
-
-    // Base pointers for this 8-row micro-tile.
-    // A_ptr starts at A(:, 0) and advances by lda_bytes each FMA step.
-    // B0_ptr/B1_ptr start at B(k=0, 0/1) and advance by 4 bytes (next k).
-
-    // K_main = (K / 4) * 4
     mv(reg_K_main, reg_K);
-    srli(reg_tmp0, reg_K_main, 2);
-    slli(reg_K_main, reg_tmp0, 2);
+    srli(reg_tmp3, reg_K_main, 2);
+    slli(reg_K_main, reg_tmp3, 2);
 
-    // Helper lambda to emit one K-step of the unrolled micro-kernel.
-    // It keeps the exact instruction sequence as the inlined version:
-    //   - load A row vector
-    //   - load 4 B scalars (one per output column)
-    //   - 4 FMAs into v_c0..v_c3
-    //   - advance A_ptr and B0/B1 pointers
     auto emit_k_step = [&]() {
-        vle32_v(v_a0, reg_A_ptr);
-        flw(freg_b0, reg_B0_ptr, 0);
-        flw(freg_b1, reg_B1_ptr, 0);
-        mv(reg_tmp1, reg_B1_ptr);
-        add(reg_tmp1, reg_tmp1, reg_ldb_bytes);
-        flw(freg_b2, reg_tmp1, 0);
-        add(reg_tmp1, reg_tmp1, reg_ldb_bytes);
-        flw(freg_b3, reg_tmp1, 0);
-        vfmacc_vf(v_c0, freg_b0, v_a0);
-        vfmacc_vf(v_c1, freg_b1, v_a0);
-        vfmacc_vf(v_c2, freg_b2, v_a0);
-        vfmacc_vf(v_c3, freg_b3, v_a0);
-        add(reg_A_ptr, reg_A_ptr, reg_lda_bytes);
-        addi(reg_B0_ptr, reg_B0_ptr, 4);
-        addi(reg_B1_ptr, reg_B1_ptr, 4);
+        if (isTransA_) {
+            vlse32_v(v_a, reg_A_ptr, reg_lda_bytes);
+        } else {
+            vle32_v(v_a, reg_A_ptr);
+        }
+
+        if (isTransB_) {
+            for (dim_t c = 0; c < n_cols_; c++) {
+                flw(freg_b[c], reg_B0_ptr, static_cast<int32_t>(c * 4));
+            }
+        } else {
+            flw(freg_b[0], reg_B0_ptr, 0);
+            if (n_cols_ > 1) {
+                add(reg_tmp0, reg_B0_ptr, reg_ldb_bytes);
+                flw(freg_b[1], reg_tmp0, 0);
+                for (dim_t c = 2; c < n_cols_; c++) {
+                    add(reg_tmp0, reg_tmp0, reg_ldb_bytes);
+                    flw(freg_b[c], reg_tmp0, 0);
+                }
+            }
+        }
+
+        for (dim_t c = 0; c < n_cols_; c++)
+            vfmacc_vf(v_c[c], freg_b[c], v_a);
+
+        if (isTransA_) {
+            addi(reg_A_ptr, reg_A_ptr, 4);
+        } else {
+            add(reg_A_ptr, reg_A_ptr, reg_lda_bytes);
+        }
+
+        if (isTransB_) {
+            add(reg_B0_ptr, reg_B0_ptr, reg_ldb_bytes);
+        } else {
+            addi(reg_B0_ptr, reg_B0_ptr, 4);
+        }
     };
 
-    // k = 0
     mv(reg_k, x0);
 
     Label label_k_main_loop, label_k_main_end;
     Label label_k_tail_loop, label_k_tail_end;
 
-    // Main K loop: 4-way unrolled with pointer strength reduction.
     L(label_k_main_loop);
     bge(reg_k, reg_K_main, label_k_main_end);
 
-    // ---- k, k+1, k+2, k+3 ----
     emit_k_step();
     emit_k_step();
     emit_k_step();
@@ -175,7 +158,7 @@ void jit_rvv_gemm_kernel_t::generate() {
 
     L(label_k_main_end);
 
-    // Tail K loop for K % 4.
+    // Tail K loop for K % 4
     L(label_k_tail_loop);
     bge(reg_k, reg_K, label_k_tail_end);
 
@@ -186,62 +169,63 @@ void jit_rvv_gemm_kernel_t::generate() {
 
     L(label_k_tail_end);
 
-    // Combine accumulators with C: C = alpha * accum + beta * C.
-    auto emit_c_update = [&](int col_idx, const VReg &v_c) {
+    auto emit_c_update = [&](dim_t col_idx) {
         Label label_beta_zero, label_done;
-        Reg reg_c_col = reg_tmp0;
 
         if (col_idx == 0) {
-            // Column 0: C_base + 0 * ldc_bytes
-            mv(reg_c_col, reg_C_base);
+            mv(reg_tmp3, reg_C_base);
         } else {
-            // Column j: C_base + j * ldc_bytes
-            li(reg_tmp1, col_idx);
-            mul(reg_c_col, reg_ldc_bytes, reg_tmp1);
-            add(reg_c_col, reg_C_base, reg_c_col);
+            li(reg_tmp0, col_idx);
+            mul(reg_tmp3, reg_ldc_bytes, reg_tmp0);
+            add(reg_tmp3, reg_C_base, reg_tmp3);
         }
 
-        // beta == 0.0f
         beq(reg_beta_bits, x0, label_beta_zero);
 
-        // beta != 0: v_tmp = beta * C_old + alpha * v_c
-        vle32_v(v_tmp, reg_c_col);
-        vfmul_vf(v_tmp, v_tmp, freg_beta);
-        vfmul_vf(v_c, v_c, freg_alpha); // use in-place v_c update to save regs
-        vfadd_vv(v_tmp, v_tmp, v_c);
-        vse32_v(v_tmp, reg_c_col);
+        vle32_v(v_a, reg_tmp3);
+        vfmul_vf(v_a, v_a, freg_beta);
+        vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
+        vfadd_vv(v_a, v_a, v_c[col_idx]);
+        vse32_v(v_a, reg_tmp3);
         j_(label_done);
 
-        // beta == 0: v_c = alpha * v_c
         L(label_beta_zero);
-        vfmul_vf(v_c, v_c, freg_alpha);
-        vse32_v(v_c, reg_c_col);
+        vfmul_vf(v_c[col_idx], v_c[col_idx], freg_alpha);
+        vse32_v(v_c[col_idx], reg_tmp3);
 
         L(label_done);
     };
 
-    emit_c_update(0, v_c0);
-    emit_c_update(1, v_c1);
-    emit_c_update(2, v_c2);
-    emit_c_update(3, v_c3);
+    for (dim_t c = 0; c < n_cols_; c++)
+        emit_c_update(c);
+
     ret();
 #else
-    // RVV JIT is disabled, emit a stub. This kernel should never be used
-    // when RVV is not available at build time.
     ret();
 #endif
 }
 
-void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
-        dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m) {
-    static jit_rvv_gemm_kernel_t kernel_m8(8);
-    static jit_rvv_gemm_kernel_t kernel_m16(16);
+namespace {
 
-    // Print verbose message to indicate JIT kernel is being used for GEMM
+template <bool isTransA, bool isTransB>
+void jit_rvv_gemm_kernel_dispatch(const float *A, const float *B, float *C,
+        dim_t lda, dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta,
+        dim_t m, dim_t n_cols) {
+    static jit_rvv_gemm_kernel_t k1(1, isTransA, isTransB);
+    static jit_rvv_gemm_kernel_t k2(2, isTransA, isTransB);
+    static jit_rvv_gemm_kernel_t k3(3, isTransA, isTransB);
+    static jit_rvv_gemm_kernel_t k4(4, isTransA, isTransB);
+    static jit_rvv_gemm_kernel_t k5(5, isTransA, isTransB);
+    static jit_rvv_gemm_kernel_t k6(6, isTransA, isTransB);
+    static jit_rvv_gemm_kernel_t k7(7, isTransA, isTransB);
+
+    static jit_rvv_gemm_kernel_t *arr[]
+            = {nullptr, &k1, &k2, &k3, &k4, &k5, &k6, &k7};
+
     static bool verbose_printed = false;
     if (!verbose_printed) {
         VINFO(primitive, create, dispatch, rvv_gemm_jit,
-                "JIT gemm kernel taking over: m=%d, n=4", (int)m);
+                "JIT gemm kernel taking over: m=%d, n=%d", (int)m, (int)n_cols);
         verbose_printed = true;
     }
 
@@ -253,13 +237,30 @@ void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
     p.ldb = ldb;
     p.ldc = ldc;
     p.K = K;
+    p.m = m;
     p.alpha = alpha;
     p.beta = beta;
 
-    if (m == 8) {
-        kernel_m8(&p);
-    } else { // m == 16
-        kernel_m16(&p);
+    (*arr[n_cols])(&p);
+}
+
+} // namespace
+
+void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
+        dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m,
+        dim_t n_cols, bool isTransA, bool isTransB) {
+    if (!isTransA && !isTransB) {
+        jit_rvv_gemm_kernel_dispatch<false, false>(
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
+    } else if (isTransA && !isTransB) {
+        jit_rvv_gemm_kernel_dispatch<true, false>(
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
+    } else if (!isTransA && isTransB) {
+        jit_rvv_gemm_kernel_dispatch<false, true>(
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
+    } else {
+        jit_rvv_gemm_kernel_dispatch<true, true>(
+                A, B, C, lda, ldb, ldc, K, alpha, beta, m, n_cols);
     }
 }
 

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp
@@ -25,24 +25,31 @@ namespace cpu {
 namespace rv64 {
 namespace gemm_utils {
 
-// RVV JIT micro-kernel for f32 GEMM on RV64, implementing the same tile shape
-// as rvv_gemm_f32::kernel_mxn for the most important case:
-//   - isTransA = false
-//   - isTransB = false
+// RVV JIT micro-kernel for f32 GEMM on RV64.
 //
-// It computes a single mx4 block (m = 8 or 16 rows, n = 4 columns) of:
+// Computes an m x n_cols tile of:
+//   C[0:m, 0:n_cols] = alpha * A[0:m, 0:K] * B[0:K, 0:n_cols]
+//                    + beta * C[0:m, 0:n_cols]
 //
-//   C[0:m, 0:4] = alpha * A[0:m, 0:K] * B[0:K, 0:4] + beta * C[0:m, 0:4]
+// Design choices:
+//   - LMUL is fixed to m4 (4 vector registers per group)
+//   - n_cols is fixed at JIT compile time (1..7), determining the number
+//     of accumulator register groups emitted
+//   - m (tile height) is a runtime parameter; the JIT code uses vsetvli
+//     to set VL accordingly, so any m <= VLEN/32*4 is supported
+//   - isTransA/isTransB determine A/B memory access patterns
 //
-// using RVV vectorization over the M dimension and a 4-way unrolled K-loop
-// with a software-pipelined load/FMA schedule to better hide vector/FMA
-// latency.
+// Vector register layout (LMUL=m4, 8 groups of 4 regs):
+//   v0..v3   : accumulator c0 (column 0)
+//   v4..v7   : accumulator c1 (column 1)
+//   v8..v11  : accumulator c2 (column 2)
+//   v12..v15 : accumulator c3 (column 3)
+//   v16..v19 : accumulator c4 (column 4)
+//   v20..v23 : accumulator c5 (column 5)
+//   v24..v27 : accumulator c6 (column 6)
+//   v28..v31 : temporary for A loads and C update
 //
-// When m=8: uses LMUL=m2 for vector registers
-// When m=16: uses LMUL=m4 for vector registers
-//
-// The m parameter is provided at construction time, and the JIT code is
-// generated specifically for that m value (not as a runtime parameter).
+// When n_cols < 7, only the first n_cols accumulator groups are used.
 struct jit_rvv_gemm_kernel_t : public jit_generator_t {
     struct call_params_t {
         const float *A;
@@ -52,14 +59,15 @@ struct jit_rvv_gemm_kernel_t : public jit_generator_t {
         dim_t ldb;
         dim_t ldc;
         dim_t K;
+        dim_t m;
         float alpha;
         float beta;
     };
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_kernel_t)
 
-    // Construct a JIT kernel for a specific m value (8 or 16)
-    jit_rvv_gemm_kernel_t(dim_t m);
+    // Construct a JIT kernel for a specific n_cols (1..7) and transpose modes
+    jit_rvv_gemm_kernel_t(dim_t n_cols, bool isTransA, bool isTransB);
 
     void operator()(const call_params_t *p) const {
         jit_generator_t::operator()(p);
@@ -69,7 +77,9 @@ protected:
     void generate() override;
 
 private:
-    dim_t m_; // tile size in M dimension (8 or 16)
+    dim_t n_cols_;
+    bool isTransA_;
+    bool isTransB_;
 };
 
 } // namespace gemm_utils

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
@@ -15,6 +15,8 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <cstring>
+
 #include "common/dnnl_thread.hpp"
 #include "common/nstl.hpp"
 #include "common/utils.hpp"
@@ -24,10 +26,6 @@
 #include "cpu/rv64/gemm/jit_rvv_gemm_kernel.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
-
-#include "cpu/gemm/f32/ref_gemm_f32.hpp"
-
-#include <riscv_vector.h>
 
 namespace dnnl {
 namespace impl {
@@ -40,379 +38,20 @@ using gemm_f32_traits = gemm_utils::gemm_utils_traits<float>;
 
 namespace {
 
-#define STORE_C(C_PTR, V_C_REG, ALPHA, BETA, VL, LMUL) \
-    do { \
-        float *c_final_ptr = (C_PTR); \
-        if ((BETA) == 0.0f) { \
-            vfloat32##LMUL##_t v_res \
-                    = __riscv_vfmul_vf_f32##LMUL((V_C_REG), (ALPHA), (VL)); \
-            __riscv_vse32_v_f32##LMUL(c_final_ptr, v_res, (VL)); \
-        } else { \
-            vfloat32##LMUL##_t v_c_old \
-                    = __riscv_vle32_v_f32##LMUL(c_final_ptr, (VL)); \
-            vfloat32##LMUL##_t v_res \
-                    = __riscv_vfmul_vf_f32##LMUL(v_c_old, (BETA), (VL)); \
-            v_res = __riscv_vfmacc_vf_f32##LMUL( \
-                    v_res, (ALPHA), (V_C_REG), (VL)); \
-            __riscv_vse32_v_f32##LMUL(c_final_ptr, v_res, (VL)); \
-        } \
-    } while (0)
-
+// Scalar copy of A into workspace for cache-friendly access.
+// Copies m rows x K columns of A into a contiguous buffer ws.
+// After copy, ws is laid out as K blocks of m contiguous elements:
+//   ws[k * m + i] = A_logical[i, k]
 void copy_A(
-        bool isTransA, dim_t K, const float *A, const dim_t lda, float *ws) {
-    constexpr dim_t m = gemm_f32_traits::get_m_unroll_factor();
-
-    // Two-way software pipelining: overlap load and store
+        bool isTransA, dim_t K, const float *A, dim_t lda, float *ws, dim_t m) {
     for (dim_t k = 0; k < K; k++) {
-        dim_t i = 0;
         if (isTransA) {
-            ptrdiff_t stride = lda * sizeof(float);
-            if (i < m) {
-                size_t vl0 = __riscv_vsetvl_e32m4(m - i);
-                const float *a_ptr0 = A + i * lda + k;
-                vfloat32m4_t v_a0 = __riscv_vlse32_v_f32m4(a_ptr0, stride, vl0);
-                dim_t i0 = i;
-                i += vl0;
-
-                while (i < m) {
-                    size_t vl1 = __riscv_vsetvl_e32m4(m - i);
-                    const float *a_ptr1 = A + i * lda + k;
-                    vfloat32m4_t v_a1
-                            = __riscv_vlse32_v_f32m4(a_ptr1, stride, vl1);
-                    __riscv_vse32_v_f32m4(ws + i0, v_a0, vl0);
-
-                    i0 = i;
-                    vl0 = vl1;
-                    v_a0 = v_a1;
-                    i += vl1;
-                }
-                __riscv_vse32_v_f32m4(ws + i0, v_a0, vl0);
-            }
+            for (dim_t i = 0; i < m; i++)
+                ws[i] = A[i * lda + k];
         } else {
-            const float *a_ptr = A + k * lda;
-            if (i < m) {
-                size_t vl0 = __riscv_vsetvl_e32m4(m - i);
-                vfloat32m4_t v_a0 = __riscv_vle32_v_f32m4(a_ptr + i, vl0);
-                dim_t i0 = i;
-                i += vl0;
-
-                while (i < m) {
-                    size_t vl1 = __riscv_vsetvl_e32m4(m - i);
-                    vfloat32m4_t v_a1 = __riscv_vle32_v_f32m4(a_ptr + i, vl1);
-                    __riscv_vse32_v_f32m4(ws + i0, v_a0, vl0);
-
-                    i0 = i;
-                    vl0 = vl1;
-                    v_a0 = v_a1;
-                    i += vl1;
-                }
-                __riscv_vse32_v_f32m4(ws + i0, v_a0, vl0);
-            }
+            std::memcpy(ws, A + k * lda, m * sizeof(float));
         }
         ws += m;
-    }
-}
-
-template <bool isTransA, bool isTransB, int n_unroll>
-struct kernel_mxn_impl {
-    static void execute(dim_t K, const float *A, dim_t lda, const float *B,
-            dim_t ldb, float *C, dim_t ldc, float alpha, float beta,
-            int ithr = -1);
-};
-
-template <bool isTransA, bool isTransB>
-struct kernel_mxn_impl<isTransA, isTransB, 2> {
-    static void execute(dim_t K, const float *A, dim_t lda, const float *B,
-            dim_t ldb, float *C, dim_t ldc, float alpha, float beta,
-            int ithr = -1) {
-        constexpr dim_t m = gemm_f32_traits::get_m_unroll_factor();
-        constexpr dim_t n = 2;
-        MAYBE_UNUSED(ithr);
-        MAYBE_UNUSED(n);
-
-        dim_t i = 0;
-        while (i < m) {
-            size_t vl = __riscv_vsetvl_e32m8(m - i);
-
-            vfloat32m8_t v_c0 = __riscv_vfmv_v_f_f32m8(0.0f, vl);
-            vfloat32m8_t v_c1 = __riscv_vfmv_v_f_f32m8(0.0f, vl);
-
-            for (dim_t k = 0; k < K; ++k) {
-                vfloat32m8_t v_a;
-                if (isTransA) {
-                    ptrdiff_t stride_a = lda * sizeof(float);
-                    v_a = __riscv_vlse32_v_f32m8(A + i * lda + k, stride_a, vl);
-                } else {
-                    v_a = __riscv_vle32_v_f32m8(A + i + k * lda, vl);
-                }
-
-                const float *b_ptr = isTransB ? &B[k * ldb] : &B[k];
-                const dim_t b_stride = isTransB ? 1 : ldb;
-
-                v_c0 = __riscv_vfmacc_vf_f32m8(
-                        v_c0, b_ptr[0 * b_stride], v_a, vl);
-                v_c1 = __riscv_vfmacc_vf_f32m8(
-                        v_c1, b_ptr[1 * b_stride], v_a, vl);
-            }
-
-            STORE_C(C + 0 * ldc + i, v_c0, alpha, beta, vl, m8);
-            STORE_C(C + 1 * ldc + i, v_c1, alpha, beta, vl, m8);
-
-            i += vl;
-        }
-    }
-};
-
-template <bool isTransA, bool isTransB>
-struct kernel_mxn_impl<isTransA, isTransB, 4> {
-    static void execute(dim_t K, const float *A, dim_t lda, const float *B,
-            dim_t ldb, float *C, dim_t ldc, float alpha, float beta,
-            int ithr = -1) {
-        constexpr dim_t m = gemm_f32_traits::get_m_unroll_factor();
-        constexpr dim_t n = 4;
-        MAYBE_UNUSED(ithr);
-        MAYBE_UNUSED(n);
-
-        dim_t i = 0;
-        while (i < m) {
-            size_t vl = __riscv_vsetvl_e32m4(m - i);
-
-            vfloat32m4_t v_c0, v_c1, v_c2, v_c3;
-
-            v_c0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-            v_c1 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-            v_c2 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-            v_c3 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-
-            for (dim_t k = 0; k < K; ++k) {
-                vfloat32m4_t v_a;
-                if (isTransA) {
-                    ptrdiff_t stride_a = lda * sizeof(float);
-                    v_a = __riscv_vlse32_v_f32m4(A + i * lda + k, stride_a, vl);
-                } else {
-                    v_a = __riscv_vle32_v_f32m4(A + i + k * lda, vl);
-                }
-
-                const float *b_ptr = isTransB ? &B[k * ldb] : &B[k];
-                const dim_t b_stride = isTransB ? 1 : ldb;
-
-                v_c0 = __riscv_vfmacc_vf_f32m4(
-                        v_c0, b_ptr[0 * b_stride], v_a, vl);
-                v_c1 = __riscv_vfmacc_vf_f32m4(
-                        v_c1, b_ptr[1 * b_stride], v_a, vl);
-                v_c2 = __riscv_vfmacc_vf_f32m4(
-                        v_c2, b_ptr[2 * b_stride], v_a, vl);
-                v_c3 = __riscv_vfmacc_vf_f32m4(
-                        v_c3, b_ptr[3 * b_stride], v_a, vl);
-            }
-
-            STORE_C(C + 0 * ldc + i, v_c0, alpha, beta, vl, m4);
-            STORE_C(C + 1 * ldc + i, v_c1, alpha, beta, vl, m4);
-            STORE_C(C + 2 * ldc + i, v_c2, alpha, beta, vl, m4);
-            STORE_C(C + 3 * ldc + i, v_c3, alpha, beta, vl, m4);
-
-            i += vl;
-        }
-    }
-};
-
-template <bool isTransA, bool isTransB>
-struct kernel_mxn_impl<isTransA, isTransB, 8> {
-    static void execute(dim_t K, const float *A, dim_t lda, const float *B,
-            dim_t ldb, float *C, dim_t ldc, float alpha, float beta,
-            int ithr = -1) {
-        constexpr dim_t m = gemm_f32_traits::get_m_unroll_factor();
-        constexpr dim_t n = 8;
-        MAYBE_UNUSED(ithr);
-        MAYBE_UNUSED(n);
-
-        dim_t i = 0;
-        while (i < m) {
-            size_t vl = __riscv_vsetvl_e32m2(m - i);
-
-            vfloat32m2_t v_c0, v_c1, v_c2, v_c3, v_c4, v_c5, v_c6, v_c7;
-
-            v_c0 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-            v_c1 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-            v_c2 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-            v_c3 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-            v_c4 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-            v_c5 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-            v_c6 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-            v_c7 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
-
-            for (dim_t k = 0; k < K; ++k) {
-                vfloat32m2_t v_a;
-                if (isTransA) {
-                    ptrdiff_t stride_a = lda * sizeof(float);
-                    v_a = __riscv_vlse32_v_f32m2(A + i * lda + k, stride_a, vl);
-                } else {
-                    v_a = __riscv_vle32_v_f32m2(A + i + k * lda, vl);
-                }
-
-                const float *b_ptr = isTransB ? &B[k * ldb] : &B[k];
-                const dim_t b_stride = isTransB ? 1 : ldb;
-
-                v_c0 = __riscv_vfmacc_vf_f32m2(
-                        v_c0, b_ptr[0 * b_stride], v_a, vl);
-                v_c1 = __riscv_vfmacc_vf_f32m2(
-                        v_c1, b_ptr[1 * b_stride], v_a, vl);
-                v_c2 = __riscv_vfmacc_vf_f32m2(
-                        v_c2, b_ptr[2 * b_stride], v_a, vl);
-                v_c3 = __riscv_vfmacc_vf_f32m2(
-                        v_c3, b_ptr[3 * b_stride], v_a, vl);
-                v_c4 = __riscv_vfmacc_vf_f32m2(
-                        v_c4, b_ptr[4 * b_stride], v_a, vl);
-                v_c5 = __riscv_vfmacc_vf_f32m2(
-                        v_c5, b_ptr[5 * b_stride], v_a, vl);
-                v_c6 = __riscv_vfmacc_vf_f32m2(
-                        v_c6, b_ptr[6 * b_stride], v_a, vl);
-                v_c7 = __riscv_vfmacc_vf_f32m2(
-                        v_c7, b_ptr[7 * b_stride], v_a, vl);
-            }
-
-            STORE_C(C + 0 * ldc + i, v_c0, alpha, beta, vl, m2);
-            STORE_C(C + 1 * ldc + i, v_c1, alpha, beta, vl, m2);
-            STORE_C(C + 2 * ldc + i, v_c2, alpha, beta, vl, m2);
-            STORE_C(C + 3 * ldc + i, v_c3, alpha, beta, vl, m2);
-            STORE_C(C + 4 * ldc + i, v_c4, alpha, beta, vl, m2);
-            STORE_C(C + 5 * ldc + i, v_c5, alpha, beta, vl, m2);
-            STORE_C(C + 6 * ldc + i, v_c6, alpha, beta, vl, m2);
-            STORE_C(C + 7 * ldc + i, v_c7, alpha, beta, vl, m2);
-
-            i += vl;
-        }
-    }
-};
-
-template <bool isTransA, bool isTransB>
-struct kernel_mxn_impl<isTransA, isTransB, 16> {
-    static void execute(dim_t K, const float *A, dim_t lda, const float *B,
-            dim_t ldb, float *C, dim_t ldc, float alpha, float beta,
-            int ithr = -1) {
-        constexpr dim_t m = gemm_f32_traits::get_m_unroll_factor();
-        constexpr dim_t n = 16;
-        MAYBE_UNUSED(ithr);
-        MAYBE_UNUSED(n);
-
-        dim_t i = 0;
-        while (i < m) {
-            size_t vl = __riscv_vsetvl_e32m1(m - i);
-
-            vfloat32m1_t v_c0, v_c1, v_c2, v_c3, v_c4, v_c5, v_c6, v_c7;
-            vfloat32m1_t v_c8, v_c9, v_c10, v_c11, v_c12, v_c13, v_c14, v_c15;
-
-            v_c0 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c1 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c2 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c3 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c4 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c5 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c6 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c7 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c8 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c9 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c10 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c11 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c12 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c13 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c14 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-            v_c15 = __riscv_vfmv_v_f_f32m1(0.0f, vl);
-
-            for (dim_t k = 0; k < K; ++k) {
-                vfloat32m1_t v_a;
-                if (isTransA) {
-                    ptrdiff_t stride_a = lda * sizeof(float);
-                    v_a = __riscv_vlse32_v_f32m1(A + i * lda + k, stride_a, vl);
-                } else {
-                    v_a = __riscv_vle32_v_f32m1(A + i + k * lda, vl);
-                }
-
-                const float *b_ptr = isTransB ? &B[k * ldb] : &B[k];
-                const dim_t b_stride = isTransB ? 1 : ldb;
-
-                v_c0 = __riscv_vfmacc_vf_f32m1(
-                        v_c0, b_ptr[0 * b_stride], v_a, vl);
-                v_c1 = __riscv_vfmacc_vf_f32m1(
-                        v_c1, b_ptr[1 * b_stride], v_a, vl);
-                v_c2 = __riscv_vfmacc_vf_f32m1(
-                        v_c2, b_ptr[2 * b_stride], v_a, vl);
-                v_c3 = __riscv_vfmacc_vf_f32m1(
-                        v_c3, b_ptr[3 * b_stride], v_a, vl);
-                v_c4 = __riscv_vfmacc_vf_f32m1(
-                        v_c4, b_ptr[4 * b_stride], v_a, vl);
-                v_c5 = __riscv_vfmacc_vf_f32m1(
-                        v_c5, b_ptr[5 * b_stride], v_a, vl);
-                v_c6 = __riscv_vfmacc_vf_f32m1(
-                        v_c6, b_ptr[6 * b_stride], v_a, vl);
-                v_c7 = __riscv_vfmacc_vf_f32m1(
-                        v_c7, b_ptr[7 * b_stride], v_a, vl);
-                v_c8 = __riscv_vfmacc_vf_f32m1(
-                        v_c8, b_ptr[8 * b_stride], v_a, vl);
-                v_c9 = __riscv_vfmacc_vf_f32m1(
-                        v_c9, b_ptr[9 * b_stride], v_a, vl);
-                v_c10 = __riscv_vfmacc_vf_f32m1(
-                        v_c10, b_ptr[10 * b_stride], v_a, vl);
-                v_c11 = __riscv_vfmacc_vf_f32m1(
-                        v_c11, b_ptr[11 * b_stride], v_a, vl);
-                v_c12 = __riscv_vfmacc_vf_f32m1(
-                        v_c12, b_ptr[12 * b_stride], v_a, vl);
-                v_c13 = __riscv_vfmacc_vf_f32m1(
-                        v_c13, b_ptr[13 * b_stride], v_a, vl);
-                v_c14 = __riscv_vfmacc_vf_f32m1(
-                        v_c14, b_ptr[14 * b_stride], v_a, vl);
-                v_c15 = __riscv_vfmacc_vf_f32m1(
-                        v_c15, b_ptr[15 * b_stride], v_a, vl);
-            }
-
-            STORE_C(C + 0 * ldc + i, v_c0, alpha, beta, vl, m1);
-            STORE_C(C + 1 * ldc + i, v_c1, alpha, beta, vl, m1);
-            STORE_C(C + 2 * ldc + i, v_c2, alpha, beta, vl, m1);
-            STORE_C(C + 3 * ldc + i, v_c3, alpha, beta, vl, m1);
-            STORE_C(C + 4 * ldc + i, v_c4, alpha, beta, vl, m1);
-            STORE_C(C + 5 * ldc + i, v_c5, alpha, beta, vl, m1);
-            STORE_C(C + 6 * ldc + i, v_c6, alpha, beta, vl, m1);
-            STORE_C(C + 7 * ldc + i, v_c7, alpha, beta, vl, m1);
-            STORE_C(C + 8 * ldc + i, v_c8, alpha, beta, vl, m1);
-            STORE_C(C + 9 * ldc + i, v_c9, alpha, beta, vl, m1);
-            STORE_C(C + 10 * ldc + i, v_c10, alpha, beta, vl, m1);
-            STORE_C(C + 11 * ldc + i, v_c11, alpha, beta, vl, m1);
-            STORE_C(C + 12 * ldc + i, v_c12, alpha, beta, vl, m1);
-            STORE_C(C + 13 * ldc + i, v_c13, alpha, beta, vl, m1);
-            STORE_C(C + 14 * ldc + i, v_c14, alpha, beta, vl, m1);
-            STORE_C(C + 15 * ldc + i, v_c15, alpha, beta, vl, m1);
-
-            i += vl;
-        }
-    }
-};
-
-template <bool isTransA, bool isTransB>
-void kernel_mxn(dim_t K, const float *A, const dim_t lda, const float *B,
-        const dim_t ldb, float *C, const dim_t ldc, const float alpha,
-        const float beta, int ithr = -1) {
-    dim_t n_unroll = gemm_f32_traits::get_n_unroll_factor();
-
-    switch (n_unroll) {
-        case 2:
-            kernel_mxn_impl<isTransA, isTransB, 2>::execute(
-                    K, A, lda, B, ldb, C, ldc, alpha, beta, ithr);
-            break;
-        case 4:
-            kernel_mxn_impl<isTransA, isTransB, 4>::execute(
-                    K, A, lda, B, ldb, C, ldc, alpha, beta, ithr);
-            break;
-        case 8:
-            kernel_mxn_impl<isTransA, isTransB, 8>::execute(
-                    K, A, lda, B, ldb, C, ldc, alpha, beta, ithr);
-            break;
-        case 16:
-            kernel_mxn_impl<isTransA, isTransB, 16>::execute(
-                    K, A, lda, B, ldb, C, ldc, alpha, beta, ithr);
-            break;
-        default:
-            kernel_mxn_impl<isTransA, isTransB, 2>::execute(
-                    K, A, lda, B, ldb, C, ldc, alpha, beta, ithr);
     }
 }
 
@@ -421,136 +60,63 @@ void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
         const dim_t lda, const float *B, const dim_t ldb, float *C,
         const dim_t ldc, const float alpha, const float beta, float *ws,
         bool do_copy, int ithr = -1) {
+    MAYBE_UNUSED(ithr);
 
     const dim_t n_unroll = gemm_f32_traits::get_n_unroll_factor();
     const dim_t m_unroll = gemm_f32_traits::get_m_unroll_factor();
 
-    dim_t Nu = rnd_dn(N, n_unroll);
-    dim_t Mu = rnd_dn(M, m_unroll);
+    const dim_t Nu = rnd_dn(N, n_unroll);
+    const dim_t Mu = rnd_dn(M, m_unroll);
+    const dim_t n_tail = N - Nu;
+    const dim_t m_tail = M - Mu;
 
-    // JIT-optimized specialization for the most important case:
-    //   isTransA = false, isTransB = false, n_unroll = 4.
-    const bool use_jit_ker = !isTransA && !isTransB && (n_unroll == 4)
-            && (m_unroll == 8 || m_unroll == 16);
+    auto invoke_kernel = [&](const float *a_orig, const float *b, float *c,
+                                 dim_t tile_m, dim_t tile_n, dim_t j_col) {
+        const float *a_eff;
+        dim_t lda_eff;
+        bool trans_a_eff;
 
-    if (do_copy) {
-        if (use_jit_ker) {
-            for (dim_t i = 0; i < Mu; i += m_unroll) {
-                for (dim_t j = 0; j < Nu; j += n_unroll) {
-                    const float *b = isTransB ? &B[j] : &B[j * ldb];
-                    const float *a = isTransA ? &A[i * lda] : &A[i];
-                    if (j == 0) { copy_A(isTransA, K, a, lda, ws); }
-                    jit_rvv_gemm_kernel(a, b, &C[i + j * ldc], lda, ldb, ldc, K,
-                            alpha, beta, m_unroll);
-                }
-            }
+        if (do_copy && tile_m == m_unroll) {
+            if (j_col == 0) { copy_A(isTransA, K, a_orig, lda, ws, m_unroll); }
+            a_eff = ws;
+            lda_eff = m_unroll;
+            trans_a_eff = false;
         } else {
-            for (dim_t i = 0; i < Mu; i += m_unroll) {
-                for (dim_t j = 0; j < Nu; j += n_unroll) {
-                    const float *b = isTransB ? &B[j] : &B[j * ldb];
-                    const float *a = isTransA ? &A[i * lda] : &A[i];
-                    if (j == 0) { copy_A(isTransA, K, a, lda, ws); }
-                    kernel_mxn<false, isTransB>(K, ws, m_unroll, b, ldb,
-                            &C[i + j * ldc], ldc, alpha, beta, ithr);
-                }
-            }
+            a_eff = a_orig;
+            lda_eff = lda;
+            trans_a_eff = isTransA;
         }
-    } else {
-        if (use_jit_ker) {
-            for (dim_t i = 0; i < Mu; i += m_unroll) {
-                for (dim_t j = 0; j < Nu; j += n_unroll) {
-                    const float *b = isTransB ? &B[j] : &B[j * ldb];
-                    const float *a = isTransA ? &A[i * lda] : &A[i];
-                    jit_rvv_gemm_kernel(a, b, &C[i + j * ldc], lda, ldb, ldc, K,
-                            alpha, beta, m_unroll);
-                }
-            }
-        } else {
-            for (dim_t i = 0; i < Mu; i += m_unroll) {
-                for (dim_t j = 0; j < Nu; j += n_unroll) {
-                    const float *b = isTransB ? &B[j] : &B[j * ldb];
-                    const float *a = isTransA ? &A[i * lda] : &A[i];
-                    kernel_mxn<isTransA, isTransB>(K, a, lda, b, ldb,
-                            &C[i + j * ldc], ldc, alpha, beta, ithr);
-                }
-            }
+
+        jit_rvv_gemm_kernel(a_eff, b, c, lda_eff, ldb, ldc, K, alpha, beta,
+                tile_m, tile_n, trans_a_eff, isTransB);
+    };
+
+    for (dim_t i = 0; i < Mu; i += m_unroll) {
+        const float *a = isTransA ? &A[i * lda] : &A[i];
+        for (dim_t j = 0; j < Nu; j += n_unroll) {
+            const float *b = isTransB ? &B[j] : &B[j * ldb];
+            invoke_kernel(a, b, &C[i + j * ldc], m_unroll, n_unroll, j);
+        }
+
+        if (n_tail > 0) {
+            const float *b = isTransB ? &B[Nu] : &B[Nu * ldb];
+            invoke_kernel(a, b, &C[i + Nu * ldc], m_unroll, n_tail, Nu);
         }
     }
 
-    // tail processing: columns Nu to N (vectorized over i for contiguous C access)
-    // Process all M rows for the remaining (N-Nu) columns
-    for (dim_t j = Nu; j < N; j++) {
-        float *c_ptr = &C[j * ldc];
-        const float *b_col = isTransB ? &B[j] : &B[j * ldb];
+    if (m_tail > 0) {
+        const float *a_tail = isTransA ? &A[Mu * lda] : &A[Mu];
 
-        dim_t i = 0;
-        while (i < M) {
-            size_t vl = __riscv_vsetvl_e32m4(M - i);
-            vfloat32m4_t v_acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-
-            for (dim_t p = 0; p < K; p++) {
-                float b_val = isTransB ? b_col[p * ldb] : b_col[p];
-                vfloat32m4_t v_a;
-                if (isTransA) {
-                    // A(p, i:i+vl) - strided access
-                    ptrdiff_t stride_a = lda * sizeof(float);
-                    v_a = __riscv_vlse32_v_f32m4(&A[p + i * lda], stride_a, vl);
-                } else {
-                    // A(i:i+vl, p) - contiguous access
-                    v_a = __riscv_vle32_v_f32m4(&A[i + p * lda], vl);
-                }
-                v_acc = __riscv_vfmacc_vf_f32m4(v_acc, b_val, v_a, vl);
-            }
-
-            // Apply alpha and beta, store result (contiguous)
-            v_acc = __riscv_vfmul_vf_f32m4(v_acc, alpha, vl);
-            if (beta != 0.0f) {
-                vfloat32m4_t v_c_old = __riscv_vle32_v_f32m4(c_ptr + i, vl);
-                v_acc = __riscv_vfmacc_vf_f32m4(v_acc, beta, v_c_old, vl);
-            }
-            __riscv_vse32_v_f32m4(c_ptr + i, v_acc, vl);
-            i += vl;
+        for (dim_t j = 0; j < Nu; j += n_unroll) {
+            const float *b = isTransB ? &B[j] : &B[j * ldb];
+            jit_rvv_gemm_kernel(a_tail, b, &C[Mu + j * ldc], lda, ldb, ldc, K,
+                    alpha, beta, m_tail, n_unroll, isTransA, isTransB);
         }
-    }
 
-    // tail processing: rows Mu to M (vectorized over i for contiguous C access)
-    // Process remaining (M-Mu) rows for the first Nu columns
-    if (Mu < M) {
-        const dim_t m_tail = M - Mu;
-
-        for (dim_t j = 0; j < Nu; j++) {
-            float *c_ptr = &C[Mu + j * ldc];
-            const float *b_col = isTransB ? &B[j] : &B[j * ldb];
-
-            dim_t i = 0;
-            while (i < m_tail) {
-                size_t vl = __riscv_vsetvl_e32m4(m_tail - i);
-                vfloat32m4_t v_acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-
-                for (dim_t p = 0; p < K; p++) {
-                    float b_val = isTransB ? b_col[p * ldb] : b_col[p];
-                    vfloat32m4_t v_a;
-                    if (isTransA) {
-                        // A(p, Mu+i:Mu+i+vl) - strided access
-                        ptrdiff_t stride_a = lda * sizeof(float);
-                        v_a = __riscv_vlse32_v_f32m4(
-                                &A[p + (Mu + i) * lda], stride_a, vl);
-                    } else {
-                        // A(Mu+i:Mu+i+vl, p) - contiguous access
-                        v_a = __riscv_vle32_v_f32m4(&A[Mu + i + p * lda], vl);
-                    }
-                    v_acc = __riscv_vfmacc_vf_f32m4(v_acc, b_val, v_a, vl);
-                }
-
-                // Apply alpha and beta, store result (contiguous)
-                v_acc = __riscv_vfmul_vf_f32m4(v_acc, alpha, vl);
-                if (beta != 0.0f) {
-                    vfloat32m4_t v_c_old = __riscv_vle32_v_f32m4(c_ptr + i, vl);
-                    v_acc = __riscv_vfmacc_vf_f32m4(v_acc, beta, v_c_old, vl);
-                }
-                __riscv_vse32_v_f32m4(c_ptr + i, v_acc, vl);
-                i += vl;
-            }
+        if (n_tail > 0) {
+            const float *b = isTransB ? &B[Nu] : &B[Nu * ldb];
+            jit_rvv_gemm_kernel(a_tail, b, &C[Mu + Nu * ldc], lda, ldb, ldc, K,
+                    alpha, beta, m_tail, n_tail, isTransA, isTransB);
         }
     }
 }
@@ -764,9 +330,6 @@ status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
 
     return status::success;
 }
-
-#undef STORE_C
-
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -21,7 +21,8 @@
 #include "common/c_types_map.hpp"
 
 #include <cstddef>
-#include <unistd.h>
+
+#include "xbyak_riscv/xbyak_riscv_util.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -34,7 +35,7 @@ struct gemm_traits_t {};
 
 template <bool isTransA, bool isTransB>
 struct gemm_traits_t<float, isTransA, isTransB> {
-    static constexpr dim_t m = 16;
+    // m is determined by VLEN at runtime via get_m_unroll_factor()
     static constexpr dim_t BM = 4032;
     static constexpr dim_t BN = isTransA ? 96 : 256;
     static constexpr dim_t BK = isTransB ? 96 : 256;
@@ -45,28 +46,18 @@ struct gemm_utils_traits;
 
 template <>
 struct gemm_utils_traits<float> {
-    static constexpr dim_t get_m_unroll_factor() {
-        return gemm_traits_t<float, false, false>::m;
+    // m = VLEN / 32 * LMUL, where LMUL = 4 for f32
+    // VLEN=128 -> m=16, VLEN=256 -> m=32, VLEN=512 -> m=64
+    static dim_t get_m_unroll_factor() {
+        static const dim_t m = []() -> dim_t {
+            const uint32_t vlen = Xbyak_riscv::CPU::getInstance().getVlen();
+            return static_cast<dim_t>(vlen / 32 * 4);
+        }();
+        return m;
     }
 
-    static dim_t get_n_unroll_factor() {
-        long l1d_size = get_l1d_cache_size();
-        if (l1d_size >= 128 * 1024)
-            return 16;
-        else if (l1d_size >= 64 * 1024)
-            return 8;
-        else if (l1d_size >= 32 * 1024)
-            return 4;
-        else
-            return 2;
-    }
-
-private:
-    static long get_l1d_cache_size() {
-        static long l1d_size = sysconf(_SC_LEVEL1_DCACHE_SIZE);
-        if (l1d_size == -1) { l1d_size = 32 * 1024; }
-        return l1d_size;
-    }
+    // Fixed n = 7 for the mx7 micro-kernel
+    static constexpr dim_t get_n_unroll_factor() { return 7; }
 };
 
 // Sum the m*n values from p_src into p_dst, assuming the two-dimensional
@@ -88,12 +79,12 @@ void calc_nthr_nocopy_rvv(dim_t m, dim_t n, dim_t k, int nthrs, int *nthrs_m,
 void partition_unit_diff(
         int ithr, int nthr, dim_t n, dim_t *t_offset, dim_t *t_block);
 
-// RVV JIT micro-kernel used from rvv_gemm_f32.cpp to replace the hand-written
-// RVV intrinsics implementation of the 8x4 or 16x4 micro-kernel when
-//   isTransA = false, isTransB = false, n_unroll = 4.
-// The m parameter must be either 8 or 16.
+// RVV JIT micro-kernel for f32 GEMM.
+// Computes an m x n tile of C = alpha * A * B + beta * C.
+// n_cols must be 1..7, m can be any value (handled by vsetvl).
 void jit_rvv_gemm_kernel(const float *A, const float *B, float *C, dim_t lda,
-        dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m);
+        dim_t ldb, dim_t ldc, dim_t K, float alpha, float beta, dim_t m,
+        dim_t n_cols, bool isTransA, bool isTransB);
 
 } // namespace gemm_utils
 } // namespace rv64


### PR DESCRIPTION
# Summary
This PR switches the RV64 f32 GEMM path to an **mx7 RVV JIT kernel family**, replacing the previous mixed intrinsic/JIT microkernel structure with a unified JIT-based implementation for the main compute path.

The new kernel family blocks the N dimension by up to 7 columns and keeps the M tile size as a runtime parameter. It also supports all transpose combinations of A and B through the same JIT framework. The main motivation is to improve vector register utilization, increase the number of independent accumulators in flight, and provide a more uniform kernel structure across regular tiles and tail cases. 

The choice of `n_cols = 7` follows directly from RVV register allocation constraints for `f32` with `LMUL = 4`.

RVV provides 32 architectural vector registers. With `LMUL = 4`, one logical vector consumes 4 physical vector registers, so the kernel effectively has:

* 8 vector register groups total
* 7 groups available for C accumulators
* 1 remaining group used for the loaded A vector / temporary reuse during C update

That makes 7 the largest spill-free accumulator blocking factor for this configuration. A smaller N tile underutilizes the vector register file and leaves instruction-level parallelism on the table, while a larger tile would require spilling and would likely lose the intended compute-side benefit.

The existing A-packing / workspace logic is preserved. The main structural change is that the old mixed intrinsic/JIT microkernel organization in `rvv_gemm_f32.cpp` is replaced by a unified JIT-based kernel family, with the kernel interface extended to include runtime `m`, `n_cols`, and transpose-mode-aware dispatch. 

# Performance

The current result shows an average speedup of 1.20x on `sg2044` and 2.37x on `SpacemiT M1`.

In general, the new kernel provides clear gains on many larger and more compute-favorable GEMM shapes, where wider N blocking and higher accumulator count improve utilization of the RVV register file. At the same time, some shape-sensitive cases still show limited benefit or regressions, especially around tail-heavy, boundary-sensitive, or otherwise less favorable configurations.

## speedtest log files:
device: sg2044 VLEN=128 bit
batch: `perf_matmul_training`
[perf_matmul_training_opt.csv](https://github.com/user-attachments/files/26340022/perf_matmul_training_opt.csv)
[perf_matmul_training_raw.csv](https://github.com/user-attachments/files/26340024/perf_matmul_training_raw.csv)
[perf_matmul_training_speedup.csv](https://github.com/user-attachments/files/26340025/perf_matmul_training_speedup.csv)

device: muse pi pro (SpacemiT M1) VLEN=256 bit
batch: `perf_matmul_training`
[spacemit_m1_perf_matmul_training_opt.csv](https://github.com/user-attachments/files/26363604/spacemit_m1_perf_matmul_training_opt.csv)
[spacemit_m1_perf_matmul_training_raw.csv](https://github.com/user-attachments/files/26363605/spacemit_m1_perf_matmul_training_raw.csv)
[spacemit_m1_perf_matmul_training_speedup.csv](https://github.com/user-attachments/files/26363603/spacemit_m1_perf_matmul_training_speedup.csv)